### PR TITLE
Log stacks of concurrent threads immediately after a SQL deadlock exception

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExpData.java
+++ b/api/src/org/labkey/api/exp/api/ExpData.java
@@ -16,12 +16,14 @@
 
 package org.labkey.api.exp.api;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.exp.ExperimentDataHandler;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.XarSource;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.security.User;
+import org.labkey.api.util.URLHelper;
 
 import java.io.File;
 import java.net.URI;
@@ -85,4 +87,10 @@ public interface ExpData extends ExpRunItem
     /** Override to signal that we never throw BatchValidationExceptions */
     @Override
     void save(User user);
+
+    enum PathType { full, serverRelative, folderRelative }
+
+    /** If this file is under the file root for its parent container, return the WebDAV URL that can be used to interact with it */
+    @Nullable
+    String getWebDavURL(@NotNull PathType type);
 }

--- a/api/src/org/labkey/api/pipeline/PipeRoot.java
+++ b/api/src/org/labkey/api/pipeline/PipeRoot.java
@@ -87,6 +87,8 @@ public interface PipeRoot extends SecurableResource
 
     /** @return relative path to the file from the root. null if the file isn't under the root. Does not include a leading slash */
     String relativePath(File file);
+
+    /** @return relative path to the file from the root. null if the path isn't under the root. Does not include a leading slash */
     String relativePath(Path file);
 
     /** @return whether the file specified is a child of the pipeline root */

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -1405,7 +1405,7 @@ public class PageFlowUtil
         return link(text).href(url).onClick(onClickScript).id(id).attributes(properties).build().toString();
     }
 
-    public static String iconLink(String iconCls, String tooltip, String url, @Nullable String onClickScript, @Nullable String id, Map<String, String> properties)
+    public static String iconLink(String iconCls, String tooltip, @Nullable String url, @Nullable String onClickScript, @Nullable String id, Map<String, String> properties)
     {
         return new LinkBuilder().iconCls(iconCls).tooltip(tooltip).href(url).onClick(onClickScript).id(id).attributes(properties).build().toString();
     }

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -8957,7 +8957,7 @@ public class AdminController extends SpringActionController
                         new SQLException("Intentional exception for testing purposes", "400"),
                         (String)getViewContext().getRequest().getAttribute(ViewServlet.ORIGINAL_URL_STRING),
                         target,
-                        ExceptionReportingLevel.valueOf(form.getLevel()), null);
+                        ExceptionReportingLevel.valueOf(form.getLevel()), null, null, null);
             }
             Map<String, Object> result = new LinkedHashMap<>();
             if (null != report)

--- a/core/src/org/labkey/core/junit/JunitController.java
+++ b/core/src/org/labkey/core/junit/JunitController.java
@@ -142,7 +142,7 @@ public class JunitController extends SpringActionController
 
         public NavTree appendNavTrail(NavTree root)
         {
-            return null;
+            return root.addChild("Unit and integration tests");
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -16,7 +16,9 @@
 
 package org.labkey.experiment.api;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
@@ -71,6 +73,7 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -88,8 +91,9 @@ import java.util.stream.Collectors;
 
 public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
 {
-    public static final SearchService.SearchCategory expDataCategory = new SearchService.SearchCategory("data", "ExpData");
+    private static final Logger LOG = Logger.getLogger(ExpDataImpl.class);
 
+    public static final SearchService.SearchCategory expDataCategory = new SearchService.SearchCategory("data", "ExpData");
 
     /**
      * Temporary mapping until experiment.xml contains the mime type
@@ -524,6 +528,56 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
             return ExperimentServiceImpl.get().getExpData(dc, rowId);
         else
             return ExperimentServiceImpl.get().getExpData(rowId);
+    }
+
+    @Nullable
+    public String getWebDavURL(@NotNull PathType type)
+    {
+        if (getFilePath() == null)
+            return null;
+
+        if (getContainer() == null)
+        {
+            return null;
+        }
+
+        PipeRoot root = PipelineService.get().getPipelineRootSetting(getContainer());
+        if (root == null)
+            return null;
+
+        try
+        {
+            java.nio.file.Path path = getFilePath();
+            if (path == null)
+            {
+                return null;
+            }
+
+            path = path.toAbsolutePath();
+
+            //currently only report if the file is under the container for this ExpData
+            if (root.isUnderRoot(path))
+            {
+                String relPath = root.relativePath(path);
+                if (relPath == null)
+                    return null;
+
+                relPath = Path.parse(FilenameUtils.separatorsToUnix(relPath)).encode();
+                switch (type)
+                {
+                    case folderRelative: return relPath;
+                    case serverRelative: return root.getWebdavURL() + relPath;
+                    case full: return AppProps.getInstance().getBaseServerUrl() + root.getWebdavURL() + relPath;
+                    default:
+                        throw new IllegalArgumentException("Unexpected path type: " + type);
+                }
+            }
+        }
+        catch (InvalidPathException e)
+        {
+            LOG.error("Invalid path for expData: " + getRowId(), e);
+        }
+        return null;
     }
 
     public void index(SearchService.IndexTask task)

--- a/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
@@ -784,47 +784,10 @@ public class ExpDataTableImpl extends ExpRunItemTableImpl<ExpDataTable.Column> i
         @Override
         public Object getJsonValue(ExpData data)
         {
-            if (data == null || data.getFile() == null)
+            if (data == null)
                 return null;
 
-            Container c = data.getContainer();
-            if (c == null)
-            {
-                return null;
-            }
-
-            PipeRoot root = PipelineService.get().getPipelineRootSetting(c);
-            if (root == null)
-                return null;
-
-            try
-            {
-                java.nio.file.Path path = data.getFilePath();
-                if (path == null)
-                {
-                    return null;
-                }
-
-                path = path.toAbsolutePath();
-
-                //currently only report if the file is under the container for this ExpData
-                if (root.isUnderRoot(path))
-                {
-                    String relPath = root.relativePath(path);
-                    if (relPath == null)
-                        return null;
-
-                    relPath = Path.parse(FilenameUtils.separatorsToUnix(relPath)).encode();
-                    return _relative ? relPath : root.getWebdavURL() + relPath;
-                }
-            }
-            catch (InvalidPathException e)
-            {
-                _log.error("Invalid path for expData: " + data.getRowId(), e);
-            }
-
-            //NOTE: should we try to see if this is under the site root and resolve across folders?
-            return null;
+            return data.getWebDavURL(_relative ? ExpData.PathType.folderRelative : ExpData.PathType.serverRelative);
         }
 
         @Override


### PR DESCRIPTION
We already include this in mothership exception reports. This is a refactor so that we generate the info once and log it locally as well.