### PR TITLE
36673: Copy-paste tab of assay upload fails to resolve sample lookup to exp.Materials

### DIFF
--- a/api/src/org/labkey/api/qc/DataLoaderSettings.java
+++ b/api/src/org/labkey/api/qc/DataLoaderSettings.java
@@ -26,7 +26,7 @@ public class DataLoaderSettings
     private boolean _allowEmptyData;
     private boolean _throwOnErrors;
     private boolean _allowUnexpectedColumns;    // don't load columns not in target domain
-    private boolean _allowLookupByAlternateKey; // import lookup column by unique index on target column or by title display column (if unique)
+    private boolean _allowLookupByAlternateKey = true; // import lookup column by unique index on target column or by title display column (if unique)
 
     public boolean isBestEffortConversion()
     {

--- a/api/src/org/labkey/api/qc/TsvDataSerializer.java
+++ b/api/src/org/labkey/api/qc/TsvDataSerializer.java
@@ -98,7 +98,6 @@ public class TsvDataSerializer implements DataExchangeHandler.DataSerializer
         Domain dataDomain = provider.getResultsDomain(protocol);
         DataLoaderSettings loaderSettings = new DataLoaderSettings();
         loaderSettings.setAllowUnexpectedColumns(true);
-        loaderSettings.setAllowLookupByAlternateKey(true);
 
         try (DataLoader loader = AbstractAssayTsvDataHandler.createLoaderForImport(runData, dataDomain, loaderSettings, shouldInferTypes))
         {

--- a/api/src/org/labkey/api/study/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/study/assay/AbstractAssayTsvDataHandler.java
@@ -122,7 +122,6 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         AssayProvider provider = AssayService.get().getProvider(protocol);
 
         DataLoaderSettings settings = new DataLoaderSettings();
-        settings.setAllowLookupByAlternateKey(true);
 
         Map<DataType, List<Map<String, Object>>> rawData = getValidationDataMap(data, dataFile, info, log, context, settings);
         assert(rawData.size() <= 1);
@@ -141,7 +140,6 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         try
         {
             DataLoaderSettings settings = new DataLoaderSettings();
-            settings.setAllowLookupByAlternateKey(true);
             importRows(data, context.getUser(), run, context.getProtocol(), context.getProvider(), dataMap, settings);
         }
         catch (ValidationException e)

--- a/api/src/org/labkey/api/study/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/study/assay/DefaultAssayRunCreator.java
@@ -559,19 +559,8 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
         if (lookup == null)
             return false;
 
-        String schemaName = lookup.getSchemaName();
-        String queryName = lookup.getQueryName();
-        boolean isExpSchema = ExpSchema.SCHEMA_NAME.equalsIgnoreCase(schemaName);
-        boolean isMaterialsQuery = ExpSchema.TableType.Materials.name().equalsIgnoreCase(queryName);
-        boolean isExpMaterialsLookup = isExpSchema && isMaterialsQuery;
-        boolean isExpMaterialsSchema = "exp.materials".equalsIgnoreCase(schemaName);
-        boolean isSamplesQuery = "samples".equalsIgnoreCase(queryName);
-        boolean isExpMaterialsSamplesLookup = isExpMaterialsSchema && isSamplesQuery;
-
-        if (!(isExpMaterialsLookup || isExpMaterialsSamplesLookup))
-        {
+        if (!(ExpSchema.SCHEMA_NAME.equalsIgnoreCase(lookup.getSchemaName()) && ExpSchema.TableType.Materials.name().equalsIgnoreCase(lookup.getQueryName())))
             return false;
-        }
 
         JdbcType type = dp.getPropertyType().getJdbcType();
         if (!(type.isText() || type.isInteger()))

--- a/api/src/org/labkey/api/study/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/study/assay/DefaultAssayRunCreator.java
@@ -559,8 +559,19 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
         if (lookup == null)
             return false;
 
-        if (!(ExpSchema.SCHEMA_NAME.equalsIgnoreCase(lookup.getSchemaName()) && ExpSchema.TableType.Materials.name().equalsIgnoreCase(lookup.getQueryName())))
+        String schemaName = lookup.getSchemaName();
+        String queryName = lookup.getQueryName();
+        boolean isExpSchema = ExpSchema.SCHEMA_NAME.equalsIgnoreCase(schemaName);
+        boolean isMaterialsQuery = ExpSchema.TableType.Materials.name().equalsIgnoreCase(queryName);
+        boolean isExpMaterialsLookup = isExpSchema && isMaterialsQuery;
+        boolean isExpMaterialsSchema = "exp.materials".equalsIgnoreCase(schemaName);
+        boolean isSamplesQuery = "samples".equalsIgnoreCase(queryName);
+        boolean isExpMaterialsSamplesLookup = isExpMaterialsSchema && isSamplesQuery;
+
+        if (!(isExpMaterialsLookup || isExpMaterialsSamplesLookup))
+        {
             return false;
+        }
 
         JdbcType type = dp.getPropertyType().getJdbcType();
         if (!(type.isText() || type.isInteger()))


### PR DESCRIPTION
This PR fixes Issue 36673. This fix makes it so that during assay import we convert sample names to sample IDs when you have a lookup to schema: exp.materials query: samples.

Note: For some reason the line endings setting I have configured conflicts with the repo, so it looks like I changed _entire_ files, which I did not. I am going to investigate this and hopefully push a set of changes that _do not change entire files_.