### PR TITLE
Don't show link to parent from WebDav root

### DIFF
--- a/core/src/org/labkey/core/webdav/list.jsp
+++ b/core/src/org/labkey/core/webdav/list.jsp
@@ -110,7 +110,7 @@
     }
 
     boolean shade = true;
-    if (parent != null)
+    if (parent != null && parent.getPath().size() > 0)
     {
         String name = "[ up ]";
         WebdavResource info = parent;


### PR DESCRIPTION
At the top level webdav HTML view, we still display the `[ up ]` link. No nasty behavior; it just navigates away from the WebDav listing. The existing `null` check implies that this isn't expected, however.