### PR TITLE
Throw correct exception for failed GUID conversion

### DIFF
--- a/api/src/org/labkey/api/data/ConvertHelper.java
+++ b/api/src/org/labkey/api/data/ConvertHelper.java
@@ -463,7 +463,14 @@ public class ConvertHelper implements PropertyEditorRegistrar
                 return null;
             if (value instanceof GUID)
                 return value;
-            return new GUID(String.valueOf(value));
+            try
+            {
+                return new GUID(String.valueOf(value));
+            }
+            catch (Exception e)
+            {
+                throw new ConversionException("Could not convert '" + value + "' to a GUID", e);
+            }
         }
     }
 


### PR DESCRIPTION
Converter interface indicates a `ConversionException` for such an error