### PR TITLE
Hide overflow of long display names

### DIFF
--- a/core/webapp/notification/Notification.css
+++ b/core/webapp/notification/Notification.css
@@ -45,6 +45,7 @@
     display: inline-block;
     white-space: nowrap;
     width: 300px;
+    overflow: hidden;
     text-overflow: ellipsis;
 }
 .labkey-notification-body


### PR DESCRIPTION
Long display names block the notification's "Mark as read" button.
This was causing intermittent test failures on TeamCity.
Not sure why it ever passes to be honest; I was not ever able to click the button locally.