### PR TITLE
Revert back to using compileInProductionMode setting from lib.xml when set

### DIFF
--- a/api/src/org/labkey/api/view/template/LibClientDependency.java
+++ b/api/src/org/labkey/api/view/template/LibClientDependency.java
@@ -90,7 +90,7 @@ public class LibClientDependency extends FilePathClientDependency
                 // <library> is an optional parameter
                 if (library != null)
                 {
-                    boolean compileInProductionMode = library.isSetCompileInProductionMode();
+                    boolean compileInProductionMode = !library.isSetCompileInProductionMode() || library.getCompileInProductionMode();
 
                     for (DependencyType s : library.getScriptArray())
                     {


### PR DESCRIPTION
- with default to "true" for libraries that do not set this property