### PR TITLE
Attempt to fix issues with LabKeyJspWriter and taglibs

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -35,6 +35,7 @@ import org.labkey.api.security.ApiKeyManager;
 import org.labkey.api.security.ApiKeyManager.ApiKeyMaintenanceTask;
 import org.labkey.api.security.AuthenticationLogoType;
 import org.labkey.api.security.AvatarType;
+import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.SystemMaintenance;
 import org.labkey.api.view.WebPartFactory;
 
@@ -64,8 +65,9 @@ public class ApiModule extends CodeOnlyModule
             AttachmentService.get().registerAttachmentType(ExpRunAttachmentType.get());
 
         // Replace the default JspFactory with a custom factory that injects our own JspWriter implementation
-        JspFactory factory = JspFactory.getDefaultFactory();
-        JspFactory.setDefaultFactory(new LabKeyJspFactory(factory));
+        LabKeyJspFactory factory = new LabKeyJspFactory(JspFactory.getDefaultFactory());
+        JspFactory.setDefaultFactory(factory);
+        ContextListener.addShutdownListener(factory);
     }
 
     @NotNull

--- a/api/src/org/labkey/api/jsp/LabKeyJspFactory.java
+++ b/api/src/org/labkey/api/jsp/LabKeyJspFactory.java
@@ -1,5 +1,7 @@
 package org.labkey.api.jsp;
 
+import org.labkey.api.util.ShutdownListener;
+
 import javax.servlet.Servlet;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletRequest;
@@ -9,7 +11,7 @@ import javax.servlet.jsp.JspEngineInfo;
 import javax.servlet.jsp.JspFactory;
 import javax.servlet.jsp.PageContext;
 
-public class LabKeyJspFactory extends JspFactory
+public class LabKeyJspFactory extends JspFactory implements ShutdownListener
 {
     private final JspFactory _factory;
 
@@ -42,5 +44,23 @@ public class LabKeyJspFactory extends JspFactory
     public JspApplicationContext getJspApplicationContext(ServletContext servletContext)
     {
         return _factory.getJspApplicationContext(servletContext);
+    }
+
+    @Override
+    public String getName()
+    {
+        return "LabKeyJspFactory";
+    }
+
+    @Override
+    public void shutdownPre()
+    {
+    }
+
+    @Override
+    public void shutdownStarted()
+    {
+        // Restore the default JspFactory so a Tomcat reload doesn't result in multiple wrappings
+        JspFactory.setDefaultFactory(_factory);
     }
 }

--- a/api/src/org/labkey/api/jsp/LabKeyPageContext.java
+++ b/api/src/org/labkey/api/jsp/LabKeyPageContext.java
@@ -20,6 +20,8 @@ public class LabKeyPageContext extends PageContext
 {
     private final PageContext _pageContext;
 
+    private JspWriter _out = null;
+
     LabKeyPageContext(PageContext pageContext)
     {
         _pageContext = pageContext;
@@ -142,7 +144,10 @@ public class LabKeyPageContext extends PageContext
 
     public JspWriter getOut()
     {
-        return new LabKeyJspWriter(_pageContext.getOut());
+        if (null == _out)
+            _out = new LabKeyJspWriter(_pageContext.getOut());
+
+        return _out;
     }
 
     public ExpressionEvaluator getExpressionEvaluator()
@@ -164,5 +169,11 @@ public class LabKeyPageContext extends PageContext
     public BodyContent pushBody()
     {
         return _pageContext.pushBody();
+    }
+
+    @Override
+    public JspWriter popBody()
+    {
+        return _pageContext.popBody();
     }
 }

--- a/api/src/org/labkey/api/jsp/taglib/FormTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/FormTag.java
@@ -26,6 +26,7 @@ import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
 
 import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.tagext.BodyTagSupport;
 import java.io.IOException;
 
@@ -206,7 +207,8 @@ public class FormTag extends BodyTagSupport
         sb.append(">");
         try
         {
-            pageContext.getOut().write(sb.toString());
+            JspWriter out = pageContext.getOut();
+            out.write(sb.toString());
         }
         catch (IOException e)
         {
@@ -220,12 +222,13 @@ public class FormTag extends BodyTagSupport
     {
         try
         {
+            JspWriter out = pageContext.getOut();
             String csrf = CSRFUtil.getExpectedToken(pageContext);
             if (StringUtils.equals("POST", method))
             {
-                pageContext.getOut().write("<input type=\"hidden\" name=\"" + CSRFUtil.csrfName + "\" value=\"" + PageFlowUtil.filter(csrf) + "\">");
+                out.write("<input type=\"hidden\" name=\"" + CSRFUtil.csrfName + "\" value=\"" + PageFlowUtil.filter(csrf) + "\">");
             }
-            pageContext.getOut().write("</form>");
+            out.write("</form>");
         }
         catch (IOException e)
         {


### PR DESCRIPTION
We're seeing intermittent problems where FormTag.doEnd() output sometimes goes nowhere. For example, the </form> tag and csrf token might not get output on the site settings page. Attempt to fix by stashing our wrapped JspWriter and implementing popBody().

Also, register a ShutdownListener that reverts back to the default JspFactory; this prevents us from wrapping our own LabKeyJspFactory on every Tomcat reload.