### PR TITLE
Prevent NPE from bad reportId

### DIFF
--- a/study/src/org/labkey/study/view/assayProgressReport.jsp
+++ b/study/src/org/labkey/study/view/assayProgressReport.jsp
@@ -15,17 +15,17 @@
      * limitations under the License.
      */
 %>
-<%@ page import="org.labkey.api.util.UniqueID"%>
+<%@ page import="com.fasterxml.jackson.databind.ObjectMapper"%>
+<%@ page import="org.labkey.api.reports.Report" %>
+<%@ page import="org.labkey.api.reports.report.ReportDescriptor" %>
+<%@ page import="org.labkey.api.reports.report.ReportIdentifier" %>
+<%@ page import="org.labkey.api.util.UniqueID" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.study.controllers.reports.ReportsController" %>
-<%@ page import="com.fasterxml.jackson.databind.ObjectMapper" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
-<%@ page import="org.labkey.api.reports.report.ReportIdentifier" %>
-<%@ page import="org.labkey.api.reports.Report" %>
-<%@ page import="org.labkey.api.reports.report.ReportDescriptor" %>
 <%@ page extends="org.labkey.study.view.BaseStudyPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -47,10 +47,13 @@
     if (reportIdentifier != null)
     {
         Report report = reportIdentifier.getReport(getViewContext());
-        ReportDescriptor descriptor = report.getDescriptor();
+        if (report != null)
+        {
+            ReportDescriptor descriptor = report.getDescriptor();
 
-        reportConfig.putAll(descriptor.getProperties());
-        reportConfig.put("shared", descriptor.isShared());
+            reportConfig.putAll(descriptor.getProperties());
+            reportConfig.put("shared", descriptor.isShared());
+        }
     }
 %>
 <labkey:panel>


### PR DESCRIPTION
NPE triggered by crawler: `study-reports-assayProgressReport.view?RowId=<injection string>`
```
java.lang.NullPointerException
       at org.labkey.jsp.compiled.org.labkey.study.view.assayProgressReport_jsp._jspService(assayProgressReport_jsp.java:177)
       at org.labkey.api.view.JspView.renderView(JspView.java:170)
       at org.labkey.api.view.WebPartView.renderInternal(WebPartView.java:371)
```