### PR TITLE
Recursive query headers are added to the SQL dialects.

### DIFF
--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -1874,4 +1874,10 @@ public abstract class PostgreSql91Dialect extends SqlDialect
 
         return super.formatJdbcFunction("timestampdiff", arguments);
     }
+    
+    public SQLFragment getRecursiveQueryHeader(String tableAlias, List<String> columnAliases){
+        return new SQLFragment("WITH RECURSIVE ").append(tableAlias)
+                .append("(" + StringUtils.join(columnAliases, ", ") + ")")
+                .append(" AS ");
+    }	    
 }

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1252,9 +1252,9 @@ public abstract class SqlDialect
     /**
      * Returns header of a recursive CTE query: WITH alias AS or WITH RECURSIVE alias AS
      * depending on the SQL engine.
-     * @param tableAlias
-     * @param columnAliases
-     * @return
+     * @param tableAlias - alias of the CTE to create
+     * @param columnAliases - list of aliases for the CTE columns
+     * @return SQLFragment with the CTE declaration. 
      */
     public SQLFragment getRecursiveQueryHeader(String tableAlias, List<String> columnAliases){
         return new SQLFragment("WITH ").append(tableAlias)

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1249,7 +1249,19 @@ public abstract class SqlDialect
         return t;
     }
 
-
+    /**
+     * Returns header of a recursive CTE query: WITH alias AS or WITH RECURSIVE alias AS
+     * depending on the SQL engine.
+     * @param tableAlias
+     * @param columnAliases
+     * @return
+     */
+    public SQLFragment getRecursiveQueryHeader(String tableAlias, List<String> columnAliases){
+        return new SQLFragment("WITH ").append(tableAlias)
+                .append("(" + StringUtils.join(columnAliases, ", ") + ")")
+                .append(" AS ");
+    }
+	
     public SQLFragment implicitConvertToString(JdbcType from, SQLFragment sql)
     {
         if (from == JdbcType.GUID)


### PR DESCRIPTION
Two new methods added to simplify creation of recursive CTE queries in database-agnostic fashion. This should not affect any existing code.