### PR TITLE
Issue 37308: add xmlSchemas jar as api dependency so it will be included in pom file

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -130,6 +130,8 @@ sourceSets {
 dependencies {
   BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: BuildUtils.getRemoteApiProjectPath(gradle))
   BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: BuildUtils.getBootstrapProjectPath(gradle))
+  BuildUtils.addLabKeyDependency(project: project, config: "api", depProjectPath: project.path, depProjectConfig: "xmlSchema")
+
   compile project.files(project.tasks.schemasJar)
 
   implementation fileTree(dir: "$tomcatDir/lib", includes: ['*.jar'], excludes: ['servlet-api.jar', 'mail.jar'])


### PR DESCRIPTION
This change will cause no harm with the current gradlePlugin release, but requires gradlePlugins > 1.4.4, which has a fix for the PomFile task, in order for the pom file to include the labkey dependency with the proper classifier for the schemas jar.