### PR TITLE
37524: use unescaped value on URL for CONTAINS

### DIFF
--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -1624,6 +1624,13 @@ public abstract class CompareType
             sb.replace(i, i + 1, _unescapedValue);
         }
 
+        // Issue 37524: QueryWebPart with CONTAINS filter and value that includes an underscore will generate incorrect filter on the "select all" url
+        @Override
+        protected String toURLParamValue()
+        {
+            return _unescapedValue;
+        }
+
         abstract String toWhereClause(SqlDialect dialect, String alias);
     }
 


### PR DESCRIPTION
Issue 37524: QueryWebPart with CONTAINS filter and value that includes an underscore will generate incorrect filter on the "select all" url