### PR TITLE
Support PostgreSQL 12 (currently in beta)

### DIFF
--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -31,6 +31,7 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.AliasManager;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.MemTracker;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.SystemMaintenance;
 import org.labkey.api.view.template.Warnings;
 import org.springframework.dao.ConcurrencyFailureException;
@@ -798,10 +799,10 @@ public abstract class SqlDialect
         }
 
         if (!shouldAdd.isEmpty())
-            throw new IllegalStateException("Need to add " + shouldAdd.size() + " keywords to " + getProductName() + " reserved word list: " + shouldAdd);
+            throw new IllegalStateException("Need to add " + StringUtilsLabKey.pluralize(shouldAdd.size(), "keyword") + " to " + getProductName() + " reserved word list: " + shouldAdd);
 
         if (!shouldRemove.isEmpty())
-            LOG.info("Should remove " + shouldRemove.size() + " keywords from " + getClass().getName() + " reserved word list: " + shouldRemove);
+            LOG.info("Should remove " + StringUtilsLabKey.pluralize(shouldRemove.size(), "keyword") + " from " + getClass().getName() + " reserved word list: " + shouldRemove);
     }
 
 

--- a/api/src/org/labkey/api/data/dialect/sqlKeywords.txt
+++ b/api/src/org/labkey/api/data/dialect/sqlKeywords.txt
@@ -479,6 +479,7 @@ issuer
 iterate
 join
 json
+json_table
 k
 key
 key_block_size
@@ -1028,6 +1029,7 @@ successful
 sum
 super
 superuser
+support
 suspend
 swaps
 switches

--- a/bigiron/src/org/labkey/bigiron/mysql/MySql80Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySql80Dialect.java
@@ -30,9 +30,9 @@ public class MySql80Dialect extends MySql57Dialect
         Set<String> words = super.getReservedWords();
 
         words.remove("sql_cache");
-        words.addAll(new CsvSet("admin, columns, cube, cume_dist, dense_rank, empty, events, except, first_value, " +
-                "function, grouping, groups, indexes, lag, last_value, lead, nth_value, ntile, of, over, parameters, percent_rank, " +
-                "rank, recursive, routines, row, row_number, rows, system, tables, triggers, window"));
+        words.addAll(new CsvSet("admin, columns, cube, cume_dist, dense_rank, empty, events, except, first_value, function, " +
+                "grouping, groups, indexes, json_table, lag, last_value, lateral, lead, nth_value, ntile, of, over, parameters, " +
+                "percent_rank, rank, recursive, routines, row, row_number, rows, system, tables, triggers, window"));
 
         return words;
     }

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -54,7 +54,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
     }
 
     final static String PRODUCT_NAME = "PostgreSQL";
-    final static String RECOMMENDED = PRODUCT_NAME + " 10.x is the recommended version.";
+    final static String RECOMMENDED = PRODUCT_NAME + " 11.x is the recommended version.";
     final static String JDBC_PREFIX = "jdbc:postgresql:";
 
     @Override
@@ -128,13 +128,14 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
             if (logWarnings)
                 _log.warn("LabKey Server has not been tested against " + PRODUCT_NAME + " version " + databaseProductVersion + ". " + RECOMMENDED);
 
-            return new PostgreSql_11_Dialect();
+            return new PostgreSql_12_Dialect();
         }
 
         throw new DatabaseNotSupportedException(PRODUCT_NAME + " version " + databaseProductVersion + " is not supported. You must upgrade your database server installation; " + RECOMMENDED);
     }
 
 
+    @Override
     public Collection<? extends Class> getJUnitTests()
     {
         return Arrays.<Class>asList(DialectRetrievalTestCase.class, InlineProcedureTestCase.class, JdbcHelperTestCase.class);
@@ -152,6 +153,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
 
     public static class DialectRetrievalTestCase extends AbstractDialectRetrievalTestCase
     {
+        @Override
         public void testDialectRetrieval()
         {
             final String connectionUrl = "jdbc:postgresql:";
@@ -168,7 +170,8 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
             good("PostgreSQL", 9.6, 9.7, "", connectionUrl, null, PostgreSql96Dialect.class);
             good("PostgreSQL", 10.0, 11.0, "", connectionUrl, null, PostgreSql_10_Dialect.class);
             good("PostgreSQL", 11.0, 12.0, "", connectionUrl, null, PostgreSql_11_Dialect.class);
-            good("PostgreSQL", 12.0, 13.0, "", connectionUrl, null, PostgreSql_11_Dialect.class);
+            good("PostgreSQL", 12.0, 13.0, "", connectionUrl, null, PostgreSql_12_Dialect.class);
+            good("PostgreSQL", 13.0, 14.0, "", connectionUrl, null, PostgreSql_12_Dialect.class);
         }
     }
 

--- a/core/src/org/labkey/core/dialect/PostgreSql_12_Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql_12_Dialect.java
@@ -1,0 +1,5 @@
+package org.labkey.core.dialect;
+
+public class PostgreSql_12_Dialect extends PostgreSql_11_Dialect
+{
+}


### PR DESCRIPTION
Add PostgreSQL 12 dialect, adjust dialect retrieval tests.

Recommend PostreSQL 11.x.

Adjust MySQL reserved word list to match recent changes. Fix messages.