### PR TITLE
Issue 37564: Duplicate conditions in ExpSchema.java

### DIFF
--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -293,12 +293,6 @@ public class ExpSchema extends AbstractExpSchema
             }
         }
 
-        // Support "Experiments" as a legacy name for the RunGroups table
-        if ("Experiments".equalsIgnoreCase(name))
-        {
-            ExpExperimentTable ret = ExperimentService.get().createExperimentTable(name, this, cf);
-            return setupTable(ret);
-        }
         if ("Experiments".equalsIgnoreCase(name))
         {
             // Support "Experiments" as a legacy name for the RunGroups table


### PR DESCRIPTION
I must have intended to delete the original check in a refactor. The two different approaches route through the same code and produce identical results.