### PR TITLE
Fix ExternalSchemaTest - don't special case-check for "queryName" parameter

### DIFF
--- a/api/src/org/labkey/api/query/QueryForm.java
+++ b/api/src/org/labkey/api/query/QueryForm.java
@@ -77,11 +77,6 @@ public class QueryForm extends ReturnUrlForm implements HasViewContext, HasBindP
 
     public QueryView getQueryView(BindException errors)
     {
-        if (StringUtils.isEmpty(getQueryName()))
-        {
-            throw new NotFoundException("Query not specified");
-        }
-
         if (_queryView == null)
         {
             UserSchema schema = getSchema();


### PR DESCRIPTION
Let other, existing error handling catch the fact that we're missing "query.queryName" and "query"