### PR TITLE
Issue 37522: Sample Derive button only selects first page of samples

### DIFF
--- a/experiment/src/org/labkey/experiment/deriveSamplesChooseTarget.jsp
+++ b/experiment/src/org/labkey/experiment/deriveSamplesChooseTarget.jsp
@@ -39,7 +39,7 @@
 
 <labkey:form action="<%=h(buildURL(ExperimentController.DeriveSamplesAction.class))%>" method="get">
     <% if (bean.getDataRegionSelectionKey() != null) { %>
-    <labkey:input type="hidden" name="<%=text(DataRegionSelection.DATA_REGION_SELECTION_KEY)%>" value="<%=h(bean.getDataRegionSelectionKey())%>"/>
+    <input type="hidden" name="<%= h(DataRegionSelection.DATA_REGION_SELECTION_KEY) %>" value="<%=h(bean.getDataRegionSelectionKey())%>"/>
     <% } %>
 
     <table>

--- a/experiment/src/org/labkey/experiment/deriveSamplesChooseTarget.jsp
+++ b/experiment/src/org/labkey/experiment/deriveSamplesChooseTarget.jsp
@@ -24,7 +24,6 @@
 <%@ page import="java.util.Map" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib"%>
-<%@ taglib prefix="labke" uri="http://www.labkey.org/taglib" %>
 <%
     JspView<ExperimentController.DeriveSamplesChooseTargetBean> me = (JspView<ExperimentController.DeriveSamplesChooseTargetBean>) HttpView.currentView();
     ExperimentController.DeriveSamplesChooseTargetBean bean = me.getModelBean();

--- a/experiment/src/org/labkey/experiment/deriveSamplesChooseTarget.jsp
+++ b/experiment/src/org/labkey/experiment/deriveSamplesChooseTarget.jsp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 %>
+<%@ page import="org.labkey.api.data.DataRegionSelection" %>
 <%@ page import="org.labkey.api.exp.api.ExpMaterial" %>
 <%@ page import="org.labkey.api.exp.api.ExpSampleSet" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
@@ -37,6 +38,9 @@
 %>
 
 <labkey:form action="<%=h(buildURL(ExperimentController.DeriveSamplesAction.class))%>" method="get">
+    <% if (bean.getDataRegionSelectionKey() != null) { %>
+    <labkey:input type="hidden" name="<%=text(DataRegionSelection.DATA_REGION_SELECTION_KEY)%>" value="<%=h(bean.getDataRegionSelectionKey())%>"/>
+    <% } %>
 
     <table>
         <tr>
@@ -83,7 +87,7 @@
         <tr>
             <td class="labkey-form-label">Target sample set:</td>
             <td colspan="2">
-                <labkey:select name="tagetSampleSetId">
+                <labkey:select name="targetSampleSetId">
                     <labkey:options value="<%=bean.getTargetSampleSetId()%>" map="<%=sampleSetOptions%>"/>
                 </labkey:select>
             </td>


### PR DESCRIPTION
- merge session selection instead of just the current page selection if dataRegionSelectionKey present
- propagate dataRegionSelectionKey through sample derivation form
- clear selection after operation completes successfully
- default the target sample set when deriving samples to the current sample set
- more dataRegion selection cleanup