### PR TITLE
Issue 32048: Query$QueryInternalException caused by NPE

### DIFF
--- a/query/src/org/labkey/query/sql/QueryTable.java
+++ b/query/src/org/labkey/query/sql/QueryTable.java
@@ -419,7 +419,7 @@ public class QueryTable extends QueryRelation
         {
             assert ref.count() > 0;
             assert null != _generateSelectSQL : "Select SQL has not been generated";
-            if (_generateSelectSQL)
+            if (null != _generateSelectSQL && _generateSelectSQL.booleanValue())
                 return super.getValueSql();
             else
                 return _col.getValueSql(_innerAlias);


### PR DESCRIPTION
Boolean object could be null.