### PR TITLE
Add null checks to consumers of `QueryForm.getQueryDef`

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1806,6 +1806,10 @@ public class QueryController extends SpringActionController
             _form = form;
 
             _query = _form.getQueryDef();
+            if (_query == null)
+            {
+                throw new NotFoundException();
+            }
             Map<String, String> props = new HashMap<>();
             props.put("schemaName", form.getSchemaName());
             props.put("queryName", form.getQueryName());
@@ -2328,9 +2332,10 @@ public class QueryController extends SpringActionController
 
             if (_schema != null && _table != null)
             {
-                if (_table.hasPermission(getUser(), UpdatePermission.class))
+                QueryDefinition queryDef = _form.getQueryDef();
+                if (queryDef != null && _table.hasPermission(getUser(), UpdatePermission.class))
                 {
-                    StringExpression updateExpr = _form.getQueryDef().urlExpr(QueryAction.updateQueryRow, _schema.getContainer());
+                    StringExpression updateExpr = queryDef.urlExpr(QueryAction.updateQueryRow, _schema.getContainer());
                     if (updateExpr != null)
                     {
                         String url = updateExpr.eval(tableForm.getTypedValues());
@@ -2344,16 +2349,16 @@ public class QueryController extends SpringActionController
                 }
 
 
-                ActionURL gridUrl;
+                ActionURL gridUrl = null;
                 if (_form.getReturnActionURL() != null)
                 {
                     // If we have a specific return URL requested, use that
                     gridUrl = _form.getReturnActionURL();
                 }
-                else
+                else if (queryDef != null)
                 {
                     // Otherwise go back to the default grid view
-                    gridUrl = _schema.urlFor(QueryAction.executeQuery, _form.getQueryDef());
+                    gridUrl = _schema.urlFor(QueryAction.executeQuery, queryDef);
                 }
                 if (gridUrl != null)
                 {
@@ -3241,6 +3246,10 @@ public class QueryController extends SpringActionController
             _form = form;
 
             QueryDefinition query = form.getQueryDef();
+            if (query == null)
+            {
+                throw new NotFoundException();
+            }
             List<QueryException> qpe = new ArrayList<>();
             TableInfo t = query.getTable(form.getSchema(), qpe, true);
             if (!qpe.isEmpty())

--- a/query/src/org/labkey/query/controllers/TableInfoForm.java
+++ b/query/src/org/labkey/query/controllers/TableInfoForm.java
@@ -17,11 +17,13 @@
 package org.labkey.query.controllers;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.query.QueryDefinition;
 import org.labkey.api.query.QueryForm;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ForeignKey;
+import org.labkey.api.view.NotFoundException;
 import org.labkey.query.sql.Query;
 import org.labkey.query.QueryDefinitionImpl;
 import org.springframework.validation.BindException;
@@ -86,13 +88,18 @@ public class TableInfoForm extends QueryForm
     public Map<FieldKey, TableInfo> getTableInfoMap()
     {
         Map<FieldKey, TableInfo> ret = new HashMap<>();
+        QueryDefinition queryDef = getQueryDef();
+        if (queryDef == null)
+        {
+            throw new NotFoundException();
+        }
         if (!isDesign())
         {
-            ret.put(null, getQueryDef().getTable(getSchema(), null, true));
+            ret.put(null, queryDef.getTable(getSchema(), null, true));
         }
         else
         {
-            Query query = ((QueryDefinitionImpl) getQueryDef()).getQuery(getSchema());
+            Query query = ((QueryDefinitionImpl) queryDef).getQuery(getSchema());
             for (FieldKey key : query.getFromTables())
             {
                 ret.put(key, query.getFromTable(key));


### PR DESCRIPTION
Hoping to prevent crawler errors before they happen