### PR TITLE
Fix problem where container filter wasn't getting applied in SelectRows, and NPEs around QueryForm.getQueryDef()

### DIFF
--- a/api/src/org/labkey/api/query/QueryForm.java
+++ b/api/src/org/labkey/api/query/QueryForm.java
@@ -335,18 +335,11 @@ public class QueryForm extends ReturnUrlForm implements HasViewContext, HasBindP
         return getQuerySettings() != null ? getQuerySettings().getQueryName() : _queryName;
     }
 
-    @Nullable
+    /** @throws NotFoundException if the query can't be resolved */
+    @NotNull
     public QueryDefinition getQueryDef()
     {
-        try
-        {
-            QueryView view = getQueryView();
-            return view.getQueryDef();
-        }
-        catch (NotFoundException e)
-        {
-            return null;
-        }
+        return getQueryView().getQueryDef();
     }
 
     public @Nullable ActionURL urlFor(QueryAction action)
@@ -355,7 +348,7 @@ public class QueryForm extends ReturnUrlForm implements HasViewContext, HasBindP
         UserSchema schema = getSchema();
         QueryDefinition def = getQueryDef();
 
-        if (null != schema && null != def)
+        if (null != schema)
         {
             ret = schema.urlFor(action, def);
             if (ret != null && _customView != null && _customView.getName() != null)
@@ -393,10 +386,6 @@ public class QueryForm extends ReturnUrlForm implements HasViewContext, HasBindP
             return null;
         String columnListName = getViewName();
         QueryDefinition querydef = getQueryDef();
-        if (null == querydef)
-        {
-            throw new NotFoundException();
-        }
         _customView = querydef.getCustomView(getUser(), getViewContext().getRequest(), columnListName);
         return _customView;
     }
@@ -414,7 +403,7 @@ public class QueryForm extends ReturnUrlForm implements HasViewContext, HasBindP
 
     public boolean canEdit()
     {
-        return null != getQueryDef() && getQueryDef().canEdit(getUser());
+        return getQueryDef().canEdit(getUser());
     }
 
     public String getQueryViewActionURL()

--- a/api/src/org/labkey/api/query/UserSchemaAction.java
+++ b/api/src/org/labkey/api/query/UserSchemaAction.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.query;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.FormViewAction;
 import org.labkey.api.action.NullSafeBindException;
 import org.labkey.api.action.SpringActionController;
@@ -58,6 +59,7 @@ public abstract class UserSchemaAction extends FormViewAction<QueryUpdateForm>
     protected UserSchema _schema;
     protected TableInfo _table;
 
+    @Override
     public BindException bindParameters(PropertyValues m) throws Exception
     {
         _form = createQueryForm(getViewContext());
@@ -88,6 +90,7 @@ public abstract class UserSchemaAction extends FormViewAction<QueryUpdateForm>
         return form;
     }
 
+    @Override
     public void validateCommand(QueryUpdateForm target, Errors errors)
     {
     }
@@ -127,11 +130,14 @@ public abstract class UserSchemaAction extends FormViewAction<QueryUpdateForm>
      *
      * I changed getSuccessURL(null) to return cancelUrl if it is provided.
      */
+    @Override
     public ActionURL getSuccessURL(QueryUpdateForm form)
     {
-        ActionURL returnURL = null;
-        if (null == form)
-            returnURL = getActionURLParam(ActionURL.Param.cancelUrl);
+        return resolveReturnUrl(form == null ? getActionURLParam(ActionURL.Param.cancelUrl) : null, form);
+    }
+
+    private ActionURL resolveReturnUrl(@Nullable ActionURL returnURL, QueryUpdateForm form)
+    {
         if (null == returnURL)
             returnURL = getActionURLParam(ActionURL.Param.returnUrl);
         if (null == returnURL)
@@ -147,18 +153,10 @@ public abstract class UserSchemaAction extends FormViewAction<QueryUpdateForm>
     public ActionURL getCancelURL(QueryUpdateForm form)
     {
         ActionURL cancelURL = getActionURLParam(ActionURL.Param.cancelUrl);
-        if (cancelURL == null)
-            cancelURL = getActionURLParam(ActionURL.Param.returnUrl);
-        if (cancelURL == null)
-        {
-            if (_schema != null && _table != null)
-                cancelURL = _schema.urlFor(QueryAction.executeQuery, _form.getQueryDef());
-            else
-                cancelURL = QueryService.get().urlDefault(form.getContainer(), QueryAction.executeQuery, null, null);
-        }
-        return cancelURL;
+        return resolveReturnUrl(cancelURL, form);
     }
 
+    @Override
     public NavTree appendNavTrail(NavTree root)
     {
         if (_table != null)

--- a/api/src/org/labkey/api/query/snapshot/AbstractSnapshotProvider.java
+++ b/api/src/org/labkey/api/query/snapshot/AbstractSnapshotProvider.java
@@ -86,40 +86,36 @@ public abstract class AbstractSnapshotProvider implements QuerySnapshotService.P
     protected QuerySnapshotDefinition createSnapshotDef(QuerySnapshotForm form)
     {
         QueryDefinition queryDef = form.getQueryDef();
-        if (queryDef != null)
+        QuerySnapshotDefinition snapshot = QueryService.get().createQuerySnapshotDef(queryDef,  form.getSnapshotName());
+
+        snapshot.setColumns(form.getFieldKeyColumns());
+        snapshot.setUpdateDelay(form.getUpdateDelay());
+
+        ViewContext context = form.getViewContext();
+        CustomView mergedFilterTempView = queryDef.createCustomView(context.getUser(), "tempCustomView");
+
+        if (form.getViewName() != null)
         {
-            QuerySnapshotDefinition snapshot = QueryService.get().createQuerySnapshotDef(queryDef,  form.getSnapshotName());
-
-            snapshot.setColumns(form.getFieldKeyColumns());
-            snapshot.setUpdateDelay(form.getUpdateDelay());
-
-            ViewContext context = form.getViewContext();
-            CustomView mergedFilterTempView = queryDef.createCustomView(context.getUser(), "tempCustomView");
-
-            if (form.getViewName() != null)
+            CustomView customSrc = queryDef.getCustomView(context.getUser(), context.getRequest(), form.getViewName());
+            if (customSrc != null)
             {
-                CustomView customSrc = queryDef.getCustomView(context.getUser(), context.getRequest(), form.getViewName());
-                if (customSrc != null)
-                {
-                    snapshot.setColumns(customSrc.getColumns());
+                snapshot.setColumns(customSrc.getColumns());
 
-                    if (customSrc.hasFilterOrSort())
-                        mergedFilterTempView.setFilterAndSort(customSrc.getFilterAndSort());
-                }
+                if (customSrc.hasFilterOrSort())
+                    mergedFilterTempView.setFilterAndSort(customSrc.getFilterAndSort());
             }
-
-            // Merge the custom view and URL filters together
-            ActionURL mergedFilterURL = context.cloneActionURL();
-            mergedFilterTempView.applyFilterAndSortToURL(mergedFilterURL, QueryView.DATAREGIONNAME_DEFAULT);
-
-            // The combined filters is what we want in this custom view
-            mergedFilterTempView.setFilterAndSortFromURL(mergedFilterURL, QueryView.DATAREGIONNAME_DEFAULT);
-
-            snapshot.setFilter(mergedFilterTempView.getFilterAndSort());
-
-            return snapshot;
         }
-        return null;
+
+        // Merge the custom view and URL filters together
+        ActionURL mergedFilterURL = context.cloneActionURL();
+        mergedFilterTempView.applyFilterAndSortToURL(mergedFilterURL, QueryView.DATAREGIONNAME_DEFAULT);
+
+        // The combined filters is what we want in this custom view
+        mergedFilterTempView.setFilterAndSortFromURL(mergedFilterURL, QueryView.DATAREGIONNAME_DEFAULT);
+
+        snapshot.setFilter(mergedFilterTempView.getFilterAndSort());
+
+        return snapshot;
     }
 
     public static DomainProperty addAsDomainProperty(Domain domain, ColumnInfo column)

--- a/api/src/org/labkey/api/study/actions/PublishConfirmAction.java
+++ b/api/src/org/labkey/api/study/actions/PublishConfirmAction.java
@@ -313,11 +313,10 @@ public class PublishConfirmAction extends FormViewAction<PublishConfirmAction.Pu
         QuerySettings settings = schema.getSettings(context, AssayProtocolSchema.DATA_TABLE_NAME, AssayProtocolSchema.DATA_TABLE_NAME);
         settings.setAllowChooseView(false);
         settings.setSelectionKey(publishConfirmForm.getDataRegionSelectionKey());
+        if (publishConfirmForm.getContainerFilterName() != null)
+            settings.setContainerFilterName(publishConfirmForm.getContainerFilterName());
         PublishResultsQueryView queryView = new PublishResultsQueryView(provider, _protocol, schema, settings,
                 _allObjects, _targetStudy, _postedTargetStudies, _postedVisits, _postedDates, _postedPtids, publishConfirmForm.getDefaultValueSourceEnum(), mismatched);
-
-        if (publishConfirmForm.getContainerFilterName() != null)
-            queryView.getSettings().setContainerFilterName(publishConfirmForm.getContainerFilterName());
 
         List<ActionButton> buttons = new ArrayList<>();
         URLHelper returnURL = publishConfirmForm.getReturnURLHelper();

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3589,15 +3589,12 @@ public class ExperimentController extends SpringActionController
         protected void initRequest(QueryForm form) throws ServletException
         {
             QueryDefinition query = form.getQueryDef();
-            if (query != null)
-            {
-                List<QueryException> qpe = new ArrayList<>();
-                TableInfo t = query.getTable(form.getSchema(), qpe, true);
-                if (!qpe.isEmpty())
-                    throw qpe.get(0);
-                if (null != t)
-                    setTarget(t);
-            }
+            List<QueryException> qpe = new ArrayList<>();
+            TableInfo t = query.getTable(form.getSchema(), qpe, true);
+            if (!qpe.isEmpty())
+                throw qpe.get(0);
+            if (null != t)
+                setTarget(t);
         }
 
         @Override

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2112,10 +2112,6 @@ public class QueryController extends SpringActionController
             // assertQueryExists requires that it be well-formed
             // assertQueryExists(form);
             QueryDefinition queryDef = form.getQueryDef();
-            if (queryDef == null)
-			{
-                throw new NotFoundException("Query not found");
-			}
             _form = form;
             _form.setDescription(queryDef.getDescription());
             _form.setInheritable(queryDef.canInherit());
@@ -2136,7 +2132,7 @@ public class QueryController extends SpringActionController
             }
             QueryDefinition queryDef = form.getQueryDef();
             _queryName = form.getQueryName();
-            if (queryDef == null || !queryDef.getDefinitionContainer().getId().equals(getContainer().getId()))
+            if (!queryDef.getDefinitionContainer().getId().equals(getContainer().getId()))
                 throw new NotFoundException("Query not found");
 
 			_form = form;

--- a/query/src/org/labkey/query/controllers/TableInfoForm.java
+++ b/query/src/org/labkey/query/controllers/TableInfoForm.java
@@ -39,6 +39,7 @@ public class TableInfoForm extends QueryForm
     {
     }
 
+    @Override
     protected @NotNull BindException doBindParameters(PropertyValues in)
     {
         BindException errors = super.doBindParameters(in);
@@ -107,7 +108,7 @@ public class TableInfoForm extends QueryForm
         List<String> parts;
         if (target == null)
         {
-            parts = Collections.EMPTY_LIST;
+            parts = Collections.emptyList();
         }
         else
         {

--- a/query/src/org/labkey/query/controllers/ViewQuerySourceAction.java
+++ b/query/src/org/labkey/query/controllers/ViewQuerySourceAction.java
@@ -46,8 +46,6 @@ public class ViewQuerySourceAction extends SimpleViewAction<QueryForm>
     {
         _form = form;
         QueryDefinition qdef = form.getQueryDef();
-        if (null == qdef)
-                throw new NotFoundException("Could not find a custom query named '" + form.getQueryName() + "' in schema '" + form.getSchemaName() + "'!");
 
         StringBuilder html = new StringBuilder("<div class='labkey-query-source'><pre>");
         html.append(qdef.getSql());


### PR DESCRIPTION
Now propagating containerFilter setting into QuerySettings before the QueryView creates the TableInfo, which must knows its ContainerFilter instance at construction time

Also, make QueryForm.getQueryDef() throw NotFoundException instead of return null. This simplifies many callers, and prevents NPEs