### PR TITLE
Issue 36980: Assay getProtocol getting NPE if assay definition not found

### DIFF
--- a/study/src/org/labkey/study/assay/AssayServiceImpl.java
+++ b/study/src/org/labkey/study/assay/AssayServiceImpl.java
@@ -19,6 +19,7 @@ package org.labkey.study.assay;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.fhcrc.cpas.exp.xml.SimpleTypeNames;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
@@ -89,21 +90,25 @@ public class AssayServiceImpl extends DomainEditorServiceBase implements AssaySe
         super(context);
     }
 
+    @Nullable
     public GWTProtocol getAssayDefinition(int rowId, boolean copy)
     {
         ExpProtocol protocol = ExperimentService.get().getExpProtocol(rowId);
-        if (protocol == null)
-            return null;
-        else
+        if (protocol != null)
         {
             Pair<ExpProtocol, List<Pair<Domain, Map<DomainProperty, Object>>>> assayInfo;
             AssayProvider provider = org.labkey.api.study.assay.AssayService.get().getProvider(protocol);
-            if (copy)
-                assayInfo = provider.getAssayTemplate(getUser(), getContainer(), protocol);
-            else
-                assayInfo = new Pair<>(protocol, provider.getDomains(protocol));
-            return getAssayTemplate(provider, assayInfo, copy);
+            if (provider != null)
+            {
+                if (copy)
+                    assayInfo = provider.getAssayTemplate(getUser(), getContainer(), protocol);
+                else
+                    assayInfo = new Pair<>(protocol, provider.getDomains(protocol));
+                return getAssayTemplate(provider, assayInfo, copy);
+            }
         }
+
+        return null;
     }
 
     public GWTProtocol getAssayTemplate(String providerName)

--- a/study/src/org/labkey/study/controllers/assay/actions/GetProtocolAction.java
+++ b/study/src/org/labkey/study/controllers/assay/actions/GetProtocolAction.java
@@ -39,12 +39,16 @@ public class GetProtocolAction extends ReadOnlyApiAction<GWTProtocol>
             ExpProtocol expProtocol = ExperimentService.get().getExpProtocol(protocol.getProtocolId());
             if (expProtocol == null)
             {
-                return new NotFoundException("Could not locate Experiment Protocol for id: " + protocol.getProtocolId().toString());
+                throw new NotFoundException("Could not locate Experiment Protocol for id: " + protocol.getProtocolId().toString());
             }
             else if (expProtocol.getContainer().hasPermission(getUser(), ReadPermission.class))
             {
                 AssayServiceImpl svc = new AssayServiceImpl(getViewContext());
                 GWTProtocol ret = svc.getAssayDefinition(protocol.getProtocolId(), false);
+                if (ret == null)
+                {
+                    throw new NotFoundException("Could not locate Assay Definition for id: " + protocol.getProtocolId().toString());
+                }
                 return success("Assay protocol " + protocol.getName() + "'", ret);
             }
             else


### PR DESCRIPTION
Updated getAssayDefinition to return null if AssayProvider not found.  Throw NotFoundException in GetProtocolAction if getAssayDefinition returns null.