### PR TITLE
Issue 37217: Update download template to xlsx and provide metadata options

### DIFF
--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -1715,7 +1715,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         for (ImportTemplateType t : templates)
         {
             StringExpression url = StringExpressionFactory.createURL(t.getUrl());
-            list.add(Pair.of(t.getLabel(), url));
+            list.add(Pair.of(t.getLabel() == null ? "Download Template" : t.getLabel(), url));
         }
 
 

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -2393,13 +2393,7 @@ public class QueryView extends WebPartView<Object>
         }
     }
 
-    // Set up an ExcelWriter that exports no data -- used to export templates on upload pages
-    protected ExcelWriter getExcelTemplateWriter(boolean respectView)
-    {
-        return getExcelTemplateWriter(respectView, Collections.emptyList());
-    }
-
-    protected ExcelWriter getExcelTemplateWriter(boolean respectView, @NotNull List<FieldKey> includeCols)
+    protected ExcelWriter getExcelTemplateWriter(boolean respectView, @NotNull List<FieldKey> includeCols, ExcelWriter.ExcelDocumentType docType)
     {
         // The template should be based on the actual columns in the table, not the user's default view,
         // which may be hiding columns or showing values joined through lookups
@@ -2470,10 +2464,10 @@ public class QueryView extends WebPartView<Object>
             fieldKeys.addAll(requiredCols);
         }
 
-        return getExcelTemplateWriter(fieldKeys);
+        return getExcelTemplateWriter(fieldKeys, docType);
     }
 
-    protected ExcelWriter getExcelTemplateWriter(List<FieldKey> fieldKeys)
+    protected ExcelWriter getExcelTemplateWriter(List<FieldKey> fieldKeys, ExcelWriter.ExcelDocumentType docType)
     {
         // Force the view to use our special list
         getSettings().setFieldKeys(fieldKeys);
@@ -2506,7 +2500,7 @@ public class QueryView extends WebPartView<Object>
 
         // Need to remove special MV columns
         displayColumns.removeIf(col -> col.getColumnInfo() instanceof RawValueColumn);
-        return new ExcelWriter(null, displayColumns);
+        return new ExcelWriter(null, displayColumns, docType);
     }
 
     protected RenderContext configureForExcelExport(ExcelWriter.ExcelDocumentType docType, DataView view, DataRegion rgn)
@@ -2530,7 +2524,7 @@ public class QueryView extends WebPartView<Object>
 
     public void exportToExcel(HttpServletResponse response) throws IOException
     {
-        exportToExcel(response, getColumnHeaderType(), ExcelWriter.ExcelDocumentType.xls);
+        exportToExcel(response, getColumnHeaderType(), ExcelWriter.ExcelDocumentType.xlsx);
     }
 
     public void exportToExcel(HttpServletResponse response, ColumnHeaderType headerType, ExcelWriter.ExcelDocumentType docType) throws IOException
@@ -2538,18 +2532,7 @@ public class QueryView extends WebPartView<Object>
         exportToExcel(response, false, headerType, false, docType, false, Collections.emptyList(), null);
     }
 
-    public void exportToExcelTemplate(HttpServletResponse response, ColumnHeaderType headerType, boolean insertColumnsOnly) throws IOException
-    {
-        exportToExcelTemplate(response, headerType, insertColumnsOnly, false, Collections.emptyList(), null);
-    }
-
-    // Export with no data rows -- just captions
-    public void exportToExcelTemplate(HttpServletResponse response, ColumnHeaderType headerType, boolean insertColumnsOnly, boolean respectView, @NotNull List<FieldKey> includeColumns, @Nullable String prefix) throws IOException
-    {
-        exportToExcel(response, true, headerType, insertColumnsOnly, ExcelWriter.ExcelDocumentType.xls, respectView, includeColumns, prefix);
-    }
-
-    protected void exportToExcel(HttpServletResponse response,
+    public void exportToExcel(HttpServletResponse response,
                                  boolean templateOnly,
                                  ColumnHeaderType headerType,
                                  boolean insertColumnsOnly,
@@ -2563,7 +2546,7 @@ public class QueryView extends WebPartView<Object>
         TableInfo table = getTable();
         if (table != null)
         {
-            ExcelWriter ew = templateOnly ? getExcelTemplateWriter(respectView, includeColumns) : getExcelWriter(docType);
+            ExcelWriter ew = templateOnly ? getExcelTemplateWriter(respectView, includeColumns, docType) : getExcelWriter(docType);
             if (headerType == null)
                 headerType = getColumnHeaderType();
             ew.setCaptionType(headerType);

--- a/list/src/org/labkey/list/model/ListDefinitionImpl.java
+++ b/list/src/org/labkey/list/model/ListDefinitionImpl.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.RuntimeSQLException;
@@ -44,6 +45,7 @@ import org.labkey.api.query.QueryAction;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.SchemaKey;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.reader.DataLoader;
 import org.labkey.api.reader.MapLoader;
 import org.labkey.api.security.User;
@@ -636,13 +638,14 @@ public class ListDefinitionImpl implements ListDefinition
     @Nullable
     public TableInfo getTable(User user, Container c)
     {
-        ListTable table;
+        TableInfo table;
         try
         {
             if (null != getDomain())
             {
-                table = new ListTable(new ListQuerySchema(user, c), this, getDomain());
-                table.afterConstruct();
+                // Go through the schema so we always get all of the XML metadata applied
+                UserSchema schema = new ListQuerySchema(user, c);
+                table = schema.getTable(getDomain().getName(), null, true, false);
             }
             else
             {

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1569,6 +1569,7 @@ public class QueryController extends SpringActionController
         boolean insertColumnsOnly = true;
         String filenamePrefix;
         FieldKey[] includeColumn;
+        String fileType;
 
         public TemplateForm()
         {
@@ -1612,6 +1613,16 @@ public class QueryController extends SpringActionController
         {
             this.filenamePrefix = prefix;
         }
+
+        public String getFileType()
+        {
+            return fileType;
+        }
+
+        public void setFileType(String fileType)
+        {
+            this.fileType = fileType;
+        }
     }
 
 
@@ -1649,7 +1660,16 @@ public class QueryController extends SpringActionController
         void _export(TemplateForm form, QueryView view) throws Exception
         {
             boolean respectView = form.getViewName() != null;
-            view.exportToExcelTemplate(getViewContext().getResponse(), form.getHeaderType(), form.insertColumnsOnly, respectView, form.getIncludeColumns(), form.getFilenamePrefix());
+            ExcelWriter.ExcelDocumentType fileType = ExcelWriter.ExcelDocumentType.xlsx;
+            if (form.getFileType() != null)
+            {
+                try
+                {
+                    fileType = ExcelWriter.ExcelDocumentType.valueOf(form.getFileType().toLowerCase());
+                }
+                catch (IllegalArgumentException ignored) {}
+            }
+            view.exportToExcel(getViewContext().getResponse(), true, form.getHeaderType(), form.insertColumnsOnly, fileType, respectView, form.getIncludeColumns(), form.getFilenamePrefix());
         }
     }
 


### PR DESCRIPTION
Change default Excel template to be XLSX instead of XLS, but add parameter to let client choose

Make list import UI go through codepath that applies XML metadata, allowing override of template URL