### PR TITLE
Recognize a couple more keywords ("ANALYZE", "{call")

### DIFF
--- a/api/src/org/labkey/api/data/MaterializedQueryHelper.java
+++ b/api/src/org/labkey/api/data/MaterializedQueryHelper.java
@@ -22,6 +22,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.labkey.api.action.SpringActionController;
 import org.labkey.api.cache.CacheListener;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.test.TestWhen;
@@ -365,9 +366,13 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
             selectInto.append(selectQuery);
             selectInto.append("\n) _sql_");
             new SqlExecutor(_scope).execute(selectInto);
-            for (String index : _indexes)
+
+            try (var ignored = SpringActionController.ignoreSqlUpdates())
             {
-                new SqlExecutor(_scope).execute(StringUtils.replace(index,"${NAME}",name));
+                for (String index : _indexes)
+                {
+                    new SqlExecutor(_scope).execute(StringUtils.replace(index, "${NAME}", name));
+                }
             }
 
             synchronized (this)

--- a/api/src/org/labkey/api/data/dialect/StatementWrapper.java
+++ b/api/src/org/labkey/api/data/dialect/StatementWrapper.java
@@ -2741,18 +2741,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
 
     private boolean isMutatingSql(String sql)
     {
-        // The original approach used to detect mutating SQL. It can encounter false positives and negatives, since it
-        // doesn't handle block comments or quoted strings.
-        String firstLine = Arrays.stream(sql.split("\n")).map(StringUtils::trimToEmpty).filter(s -> !s.isEmpty() && !startsWith(s,"--")).findFirst().orElse("").toUpperCase();
-        boolean oldWay = (contains(firstLine,"INSERT ") || contains(firstLine, "UPDATE ") || contains(firstLine, "DELETE "));
-
-        var detector = new MutatingSqlDetector(sql);
-        boolean newWay = detector.isMutating();
-
-        if (oldWay && !newWay)
-            _log.warn("Previous mutating SQL detection approach flagged this statement, but new approach did not: " + sql);
-
-        return newWay;
+        return new MutatingSqlDetector(sql).isMutating();
     }
 
 


### PR DESCRIPTION
Stop flagging creation of temp table indexes as "mutating"

Remove old mutating SQL detection approach

Pass through and log SQL along with unrecognized keyword message