### PR TITLE
Changed variable type LockPropertyType to StringProperty in GWTPropertyDescriptor

### DIFF
--- a/api/gwtsrc/org/labkey/api/gwt/client/LockedPropertyType.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/LockedPropertyType.java
@@ -6,19 +6,7 @@ package org.labkey.api.gwt.client;
 **/
 public enum LockedPropertyType
 {
-    FullyLocked("Fully Locked"), // can't change any properties
-    PartiallyLocked("Partially Locked"), // can't change name and type, for example, but can change other properties
-    NotLocked("Not Locked"); // not locked, can change all properties
-
-    private String _label;
-
-    LockedPropertyType(String label)
-    {
-        _label = label;
-    }
-
-    public String getLabel()
-    {
-        return _label;
-    }
+    FullyLocked, // can't change any properties
+    PartiallyLocked, // can't change name and type, for example, but can change other properties
+    NotLocked // not locked, can change all properties
 }

--- a/api/gwtsrc/org/labkey/api/gwt/client/LockedPropertyType.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/LockedPropertyType.java
@@ -10,8 +10,6 @@ public enum LockedPropertyType
     PartiallyLocked("Partially Locked"), // can't change name and type, for example, but can change other properties
     NotLocked("Not Locked"); // not locked, can change all properties
 
-    LockedPropertyType() {}
-
     private String _label;
 
     LockedPropertyType(String label)

--- a/api/gwtsrc/org/labkey/api/gwt/client/LockedPropertyType.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/LockedPropertyType.java
@@ -1,12 +1,10 @@
 package org.labkey.api.gwt.client;
 
-import com.google.gwt.user.client.rpc.IsSerializable;
-
 /**
  * Enum to set a type of lock on a column, since binary values of either fully locked or not locked is not sufficient to handle
  * combined cases of various domain designs, esp. when a column is partially locked.
 **/
-public enum LockedPropertyType implements IsSerializable
+public enum LockedPropertyType
 {
     FullyLocked("Fully Locked"), // can't change any properties
     PartiallyLocked("Partially Locked"), // can't change name and type, for example, but can change other properties

--- a/api/gwtsrc/org/labkey/api/gwt/client/LockedPropertyType.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/LockedPropertyType.java
@@ -8,9 +8,21 @@ import com.google.gwt.user.client.rpc.IsSerializable;
 **/
 public enum LockedPropertyType implements IsSerializable
 {
-    FULLY_LOCKED, // can't change any properties
-    PARTIALLY_LOCKED, // can't change name and type, for example, but can change other properties
-    NOT_LOCKED; // not locked, can change all properties
+    FullyLocked("Fully Locked"), // can't change any properties
+    PartiallyLocked("Partially Locked"), // can't change name and type, for example, but can change other properties
+    NotLocked("Not Locked"); // not locked, can change all properties
 
     LockedPropertyType() {}
+
+    private String _label;
+
+    LockedPropertyType(String label)
+    {
+        _label = label;
+    }
+
+    public String getLabel()
+    {
+        return _label;
+    }
 }

--- a/api/gwtsrc/org/labkey/api/gwt/client/model/GWTPropertyDescriptor.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/model/GWTPropertyDescriptor.java
@@ -78,7 +78,7 @@ public class GWTPropertyDescriptor implements IsSerializable
     private IntegerProperty scale = new IntegerProperty(4000);
     private StringProperty redactedText = new StringProperty();
     private BooleanProperty isPrimaryKey = new BooleanProperty(false);
-    private LockedPropertyType lockType = LockedPropertyType.NOT_LOCKED;
+    private StringProperty lockType = new StringProperty(LockedPropertyType.NotLocked.name());
 
     // for controlling the property editor (not persisted or user settable)
 //    private boolean isEditable = true;
@@ -138,6 +138,7 @@ public class GWTPropertyDescriptor implements IsSerializable
         setScale(s.getScale());
         setRedactedText(s.getRedactedText());
         setPrimaryKey(s.isPrimaryKey());
+        setLockType(s.getLockType());
 
         for (GWTPropertyValidator v : s.getPropertyValidators())
         {
@@ -544,24 +545,23 @@ public class GWTPropertyDescriptor implements IsSerializable
         this.isPrimaryKey.setBool(isPrimaryKey);
     }
 
-    public LockedPropertyType getLockType()
+    public String getLockType()
     {
-        return this.lockType;
+        return lockType.getString();
     }
 
     /** This method is for informational purpose only so that the client can identify column's locked type.
      * Setting lock type on a column via this method will not get preserved in the domain's table.
      */
-    public void setLockType(LockedPropertyType lockType)
+    public void setLockType(String lockType)
     {
-        this.lockType = lockType;
+        this.lockType.set(lockType);
     }
 
     public String debugString()
     {
         return getName() + " " + getLabel() + " " + getRangeURI() + " " + isRequired() + " " + getDescription();
     }
-
 
     public boolean equals(Object o)
     {

--- a/internal/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/internal/src/org/labkey/api/exp/property/DomainUtil.java
@@ -225,12 +225,12 @@ public class DomainUtil
             //fully lock shared columns or columns not in the same container (ex. for dataset domain)
             if (!p.getContainer().equalsIgnoreCase(container.getId()))
             {
-                p.setLockType(LockedPropertyType.FULLY_LOCKED);
+                p.setLockType(LockedPropertyType.FullyLocked.name());
             }
             //partially lock mandatory properties (ex. for issues, specimen domains)
             if (mandatoryProperties.contains(p.getName()))
             {
-                p.setLockType(LockedPropertyType.PARTIALLY_LOCKED);
+                p.setLockType(LockedPropertyType.PartiallyLocked.name());
             }
 
             list.add(p);
@@ -651,7 +651,7 @@ public class DomainUtil
         Map<String, ? extends GWTPropertyDescriptor> updatedFieldsMap = updatedFields.stream().collect(Collectors.toMap(GWTPropertyDescriptor::getName, e -> e));
         Set<String> updatedFieldNames = new CaseInsensitiveHashSet(updatedFieldsMap.keySet());
 
-        Map<String, ? extends GWTPropertyDescriptor> origFieldsMap = origFields.stream().filter(e -> e.getLockType() == LockedPropertyType.PARTIALLY_LOCKED).collect(Collectors.toMap(GWTPropertyDescriptor::getName, e -> e));
+        Map<String, ? extends GWTPropertyDescriptor> origFieldsMap = origFields.stream().filter(e -> e.getLockType().equalsIgnoreCase(LockedPropertyType.PartiallyLocked.name())).collect(Collectors.toMap(GWTPropertyDescriptor::getName, e -> e));
         Set<String> origMandatoryFieldNames = new CaseInsensitiveHashSet(origFieldsMap.keySet());
 
         for (String mandatoryField : origMandatoryFieldNames)
@@ -670,7 +670,7 @@ public class DomainUtil
         for (GWTPropertyDescriptor pd : origFields)
         {
             //if a column is fully locked
-            if (pd.getLockType() == LockedPropertyType.FULLY_LOCKED)
+            if (pd.getLockType().equalsIgnoreCase(LockedPropertyType.FullyLocked.name()))
             {
                 locked.add(pd);
             }


### PR DESCRIPTION
To avoid serialization issues on teamcity postgres.