### PR TITLE
Issue 30769: use standard file picker on wiki edit page

### DIFF
--- a/core/resources/styles/themeVariables/_variables.scss
+++ b/core/resources/styles/themeVariables/_variables.scss
@@ -1,0 +1,1 @@
+// this is the default theme

--- a/experiment/resources/views/fileUploadPreview.html
+++ b/experiment/resources/views/fileUploadPreview.html
@@ -1,0 +1,2 @@
+<div id="app"></div>
+

--- a/experiment/resources/views/fileUploadPreview.view.xml
+++ b/experiment/resources/views/fileUploadPreview.view.xml
@@ -1,0 +1,11 @@
+<view xmlns="http://labkey.org/data/xml/view" frame="none" title="File Upload Preview">
+    <permissions>
+        <permission name="insert"/>
+    </permissions>
+    <dependencies>
+        <dependency path="experiment/gen/experiment-styles.css" />
+        
+         <dependency path="experiment/gen/fileUploadPreview.js"/>
+        
+    </dependencies>
+</view>

--- a/experiment/resources/views/fileUploadPreviewDev.html
+++ b/experiment/resources/views/fileUploadPreviewDev.html
@@ -1,0 +1,4 @@
+<div id="app"></div>
+
+<script src="http://localhost:3020/fileUploadPreview.js"></script>
+

--- a/experiment/resources/views/fileUploadPreviewDev.view.xml
+++ b/experiment/resources/views/fileUploadPreviewDev.view.xml
@@ -1,0 +1,9 @@
+<view xmlns="http://labkey.org/data/xml/view" frame="none" title="File Upload Preview">
+    <permissions>
+        <permission name="insert"/>
+    </permissions>
+    <dependencies>
+        <dependency path="experiment/gen/experiment-styles.css" />
+        
+    </dependencies>
+</view>

--- a/wiki/resources/web/wiki/internal/wikiEdit.js
+++ b/wiki/resources/web/wiki/internal/wikiEdit.js
@@ -75,7 +75,6 @@ function tinyMceHandleEvent(evt) {
 }
 
 (function($) {
-
     //
     // CONSTANTS
     //
@@ -317,6 +316,8 @@ function tinyMceHandleEvent(evt) {
         });
     };
 
+
+
     var onAddAttachment = function(fileInput, index) {
         // update the name column
         var cell = $('#wiki-na-name-' + index).attr('nobreak', '1').html('<a class="labkey-button"><span>remove</span></a>&nbsp;' + getFileName(fileInput.value));
@@ -325,6 +326,8 @@ function tinyMceHandleEvent(evt) {
         // mark the attachments as dirty
         _attachments.isDirty = true;
     };
+
+
 
     var onAttachmentSuccess = function(response) {
         //parse the response JSON
@@ -422,18 +425,24 @@ function tinyMceHandleEvent(evt) {
     };
 
     // TODO: We shouldn't need to expose either of these methods, rather hookup the onclicks after appending the elements
-    var onDeleteAttachment = function(index) {
+        onDeleteAttachment = function(index) {
         var row = getExistingAttachmentRow(index);
 
         getExistingAttachmentIconImg(index).src = LABKEY.ActionURL.getContextPath() + "/_icons/_deleted.gif";
         row.cells[1].style.textDecoration = "line-through";
-        row.cells[2].innerHTML = "<a class='labkey-button' onclick='LABKEY._wiki.onUndeleteAttachment(" + index + ")'><span>undelete</span></a>"
-        + "<input type='hidden' name='toDelete' value=\"" + LABKEY.Utils.encodeHtml(_attachments[index].name) + "\"/>";
+        // row.cells[2].innerHTML = "<a class='labkey-button' onclick='LABKEY._wiki.onUndeleteAttachment(" + index + ")'><span>undelete</span></a>"
+        // + "<input type='hidden' name='toDelete' value=\"" + LABKEY.Utils.encodeHtml(_attachments[index].name) + "\"/>";
 
-        //add a prop so we know we need to save the attachments
+        row.cells[2].innerHTML = "<a onclick='LABKEY._wiki.onUndeleteAttachment(" + index + ")'><span>&nbsp; un-delete</span></a>"
+                + "<input type='hidden' name='toDelete' value=\"" + LABKEY.Utils.encodeHtml(_attachments[index].name) + "\"/>";
+
+
+
+            //add a prop so we know we need to save the attachments
         _attachments.isDirty = true;
     };
 
+    //    candelete
     var onRemoveNewAttachment = function(index)
     {
         //delete the entire table row
@@ -454,7 +463,10 @@ function tinyMceHandleEvent(evt) {
 
         getExistingAttachmentIconImg(index).src = _attachments[index].iconUrl;
         row.cells[1].style.textDecoration = "";
-        row.cells[2].innerHTML = "<a class='labkey-button' onclick='LABKEY._wiki.onDeleteAttachment(" + index + ")'><span>delete</span></a>";
+        row.cells[2].innerHTML = "<a href='javascript:onDeleteAttachment("+ index +")'>&nbsp; delete</a>";
+
+
+
     };
 
     var onDeletePage = function() {
@@ -494,7 +506,8 @@ function tinyMceHandleEvent(evt) {
             return;
         _doingSave = true;
 
-        if (!isDirty() && _wikiProps.entityId) {
+
+        if (!isDirty() && _wikiProps.entityId && !LABKEY.isDirty()) {
             onSaveComplete();
             return;
         }
@@ -537,7 +550,7 @@ function tinyMceHandleEvent(evt) {
                 updateControls(_wikiProps);
             }
 
-            if (_attachments.isDirty) {
+            if (_attachments.isDirty || LABKEY.isDirty()) {
                 setStatus("Saving file attachments...");
                 getExt4(function() {
                     // bah, for now we have to use Ext4 to do this post since it is an upload
@@ -823,11 +836,11 @@ function tinyMceHandleEvent(evt) {
                 cell = row.insertCell(1);
                 cell.id = "wiki-ea-name-" + idx;
                 cell.innerHTML = "<a target='_blank' href='" + attachments[idx].downloadUrl + "'>"
-                + (encodeNames ? LABKEY.Utils.encodeHtml(attachments[idx].name) : attachments[idx].name) + "</a>";
+                + "&nbsp;" + (encodeNames ? LABKEY.Utils.encodeHtml( attachments[idx].name) : attachments[idx].name) + "</a>";
 
                 cell = row.insertCell(2);
                 cell.id = "wiki-ea-del-" + idx;
-                cell.innerHTML = "<a class='labkey-button' onclick='LABKEY._wiki.onDeleteAttachment(" + idx + ")'><span>delete</span></a>";
+                cell.innerHTML = "<a href='javascript:LABKEY._wiki.onDeleteAttachment(" + idx + ")'>&nbsp; delete</a>";
             }
         }
     };

--- a/wiki/resources/web/wiki/internal/wikiEdit.js
+++ b/wiki/resources/web/wiki/internal/wikiEdit.js
@@ -316,18 +316,13 @@ function tinyMceHandleEvent(evt) {
         });
     };
 
-
-
     var onAddAttachment = function(fileInput, index) {
         // update the name column
         var cell = $('#wiki-na-name-' + index).attr('nobreak', '1').html('<a class="labkey-button"><span>remove</span></a>&nbsp;' + getFileName(fileInput.value));
-        cell.click(function() { onRemoveNewAttachment(index); });
 
         // mark the attachments as dirty
         _attachments.isDirty = true;
     };
-
-
 
     var onAttachmentSuccess = function(response) {
         //parse the response JSON
@@ -425,30 +420,16 @@ function tinyMceHandleEvent(evt) {
     };
 
     // TODO: We shouldn't need to expose either of these methods, rather hookup the onclicks after appending the elements
-        onDeleteAttachment = function(index) {
+    var onDeleteAttachment = function(index) {
         var row = getExistingAttachmentRow(index);
 
         getExistingAttachmentIconImg(index).src = LABKEY.ActionURL.getContextPath() + "/_icons/_deleted.gif";
         row.cells[1].style.textDecoration = "line-through";
-        // row.cells[2].innerHTML = "<a class='labkey-button' onclick='LABKEY._wiki.onUndeleteAttachment(" + index + ")'><span>undelete</span></a>"
-        // + "<input type='hidden' name='toDelete' value=\"" + LABKEY.Utils.encodeHtml(_attachments[index].name) + "\"/>";
-
         row.cells[2].innerHTML = "<a onclick='LABKEY._wiki.onUndeleteAttachment(" + index + ")'><span>&nbsp; un-delete</span></a>"
                 + "<input type='hidden' name='toDelete' value=\"" + LABKEY.Utils.encodeHtml(_attachments[index].name) + "\"/>";
 
-
-
-            //add a prop so we know we need to save the attachments
+        //add a prop so we know we need to save the attachments
         _attachments.isDirty = true;
-    };
-
-    //    candelete
-    var onRemoveNewAttachment = function(index)
-    {
-        //delete the entire table row
-        var row = document.getElementById("wiki-na-" + index);
-        if (row)
-            getNewAttachmentsTable().deleteRow(row.rowIndex);
     };
 
     var getNewAttachmentsTable = function() {
@@ -464,9 +445,6 @@ function tinyMceHandleEvent(evt) {
         getExistingAttachmentIconImg(index).src = _attachments[index].iconUrl;
         row.cells[1].style.textDecoration = "";
         row.cells[2].innerHTML = "<a href='javascript:onDeleteAttachment("+ index +")'>&nbsp; delete</a>";
-
-
-
     };
 
     var onDeletePage = function() {
@@ -836,7 +814,7 @@ function tinyMceHandleEvent(evt) {
                 cell = row.insertCell(1);
                 cell.id = "wiki-ea-name-" + idx;
                 cell.innerHTML = "<a target='_blank' href='" + attachments[idx].downloadUrl + "'>"
-                + "&nbsp;" + (encodeNames ? LABKEY.Utils.encodeHtml( attachments[idx].name) : attachments[idx].name) + "</a>";
+                    + "&nbsp;" + (encodeNames ? LABKEY.Utils.encodeHtml( attachments[idx].name) : attachments[idx].name) + "</a>";
 
                 cell = row.insertCell(2);
                 cell.id = "wiki-ea-del-" + idx;

--- a/wiki/src/org/labkey/wiki/view/wikiEdit.jsp
+++ b/wiki/src/org/labkey/wiki/view/wikiEdit.jsp
@@ -187,8 +187,9 @@
                         </table>
                         <labkey:form action="<%=h(buildURL(WikiController.AttachFilesAction.class))%>" method="POST" enctype="multipart/form-data" id="form-files">
                             <table id="wiki-existing-attachments"></table>
+                            <br>
                             <table id="wiki-new-attachments"></table>
-                            <a id="wiki-file-link"><img src="<%=getWebappURL("_images/paperclip.gif")%>">Attach a file</a>
+                            <a href="javascript:addFilePicker('wiki-new-attachments','filePickerLink')" id="filePickerLink"><img src="<%=getWebappURL("_images/paperclip.gif")%>">&nbsp;Attach a file</a>
                         </labkey:form>
                     </td>
                 </tr>


### PR DESCRIPTION
Here it is!
I kept the strikeout and red X styling upon deleting a file, but most everything else is standardized to the regular file picker.
A small difference --  In most file pickers, the file name of an existing attachment is rendered in regular text. On the edit wiki page, the file name is rendered as a link. I think this looks a bit odd, and I can take it out, but I left it for now in case there's a good reason for this functionality.