### PR TITLE
Issue 37826: Lookup from linked schema query to a non-linked schema target fails to apply proper ContainerFilter

### DIFF
--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -2769,19 +2769,23 @@ public class DataRegion extends DisplayElement
 
     protected void prepareParameters(RenderContext ctx)
     {
-        Map<String, Object> parameters = getQueryParameters();
-
-        if (!parameters.isEmpty())
+        // Treat parameters like filters in terms of showing them or not in the header of the grid
+        if (isShowFilterDescription())
         {
-            for (Map.Entry<String, Object> entry : parameters.entrySet())
+            Map<String, Object> parameters = getQueryParameters();
+
+            if (!parameters.isEmpty())
             {
-                String text = entry.getKey() + " = " + entry.getValue();
+                for (Map.Entry<String, Object> entry : parameters.entrySet())
+                {
+                    String text = entry.getKey() + " = " + entry.getValue();
 
-                ContextAction.Builder action = new ContextAction.Builder()
-                        .iconCls("question")
-                        .text(text);
+                    ContextAction.Builder action = new ContextAction.Builder()
+                            .iconCls("question")
+                            .text(text);
 
-                _contextActions.add(action.build());
+                    _contextActions.add(action.build());
+                }
             }
         }
     }

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -372,6 +372,8 @@ if (!LABKEY.DataRegions) {
 
                 showRecordSelectors: false,
 
+                showFilterDescription: true,
+
                 showReports: undefined,
 
                 /**
@@ -3648,6 +3650,7 @@ if (!LABKEY.DataRegions) {
                 'showPaginationCount',
                 'showReports',
                 'showSurroundingBorder',
+                'showFilterDescription',
                 'showUpdateColumn',
                 'showViewPanel',
                 'timeout',
@@ -4449,6 +4452,7 @@ if (!LABKEY.DataRegions) {
      * @param {boolean} [config.showRStudioButton] Show the export to RStudio button menu in the button bar.  Requires export button to work. (default false).
      * @param {boolean} [config.showBorders] Render the table with borders (default true).
      * @param {boolean} [config.showSurroundingBorder] Render the table with a surrounding border (default true).
+     * @param {boolean} [config.showFilterDescription] Include filter and parameter values in the grid header, if present (default true).
      * @param {boolean} [config.showRecordSelectors] Render the select checkbox column (default undefined, meaning they will be shown if the query is updatable by the current user).
      *  If 'showDeleteButton' is true, the checkboxes will be  included regardless of the 'showRecordSelectors' config option.
      * @param {boolean} [config.showPagination] Show the pagination links and count (default true).

--- a/query/src/org/labkey/query/LinkedSchema.java
+++ b/query/src/org/labkey/query/LinkedSchema.java
@@ -283,8 +283,9 @@ public class LinkedSchema extends ExternalSchema
     @Override
     public @NotNull ContainerFilter getDefaultContainerFilter()
     {
+        return super.getDefaultContainerFilter();
         // NOTE: The source table ContainerFilter is already set by _sourceSchema.getTable()
-        return new ContainerFilter.InternalNoContainerFilter(getUser());
+//        return new ContainerFilter.InternalNoContainerFilter(getUser());
     }
 
     @Override

--- a/query/src/org/labkey/query/LinkedTableInfo.java
+++ b/query/src/org/labkey/query/LinkedTableInfo.java
@@ -38,8 +38,11 @@ import org.labkey.api.query.UserIdForeignKey;
 import org.labkey.api.query.UserIdQueryForeignKey;
 import org.labkey.api.query.UserSchema;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -194,9 +197,11 @@ public class LinkedTableInfo extends SimpleUserSchema.SimpleTable<UserSchema>
     public Collection<QueryService.ParameterDecl> getNamedParameters()
     {
         // LinkedTableInfo only exposes named parameters defined in the original TableInfo
-        // and removes named parameters that are added to the generated LinkedSchema.createQueryDef() query.
-        //return super.getNamedParameters();
-        return Collections.emptyList();
+        // and named parameters already have a value supplied via the template
+        List<QueryService.ParameterDecl> result = new ArrayList<>(getRealTable().getNamedParameters());
+        Map<String, Object> values = fireCustomizeParameterValues();
+        result.removeIf(param -> values.get(param.getName()) != null);
+        return result;
     }
 
     @NotNull


### PR DESCRIPTION
Also, prompt for parameters on linked schema queries that include them

New QueryWebPart option to suppress filters and parameter values in the header