### PR TITLE
Issue 37268: experiment-derive.api doesn't include parents in name expression

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -404,19 +404,23 @@ public class NameGenerator
                     if (value == null)
                         continue;
 
-                    if (colName.startsWith(ExpData.DATA_INPUT_PARENT))
+                    String[] parts = colName.split("/", 2);
+                    if (parts.length == 2)
                     {
-                        parentNames(value, colName).forEach(parentName -> {
-                            allInputs.add(parentName);
-                            dataInputs.add(parentName);
-                        });
-                    }
-                    else if (colName.startsWith(ExpMaterial.MATERIAL_INPUT_PARENT))
-                    {
-                        parentNames(value, colName).forEach(parentName -> {
-                            allInputs.add(parentName);
-                            materialInputs.add(parentName);
-                        });
+                        if (parts[0].equalsIgnoreCase(ExpData.DATA_INPUT_PARENT))
+                        {
+                            parentNames(value, colName).forEach(parentName -> {
+                                allInputs.add(parentName);
+                                dataInputs.add(parentName);
+                            });
+                        }
+                        else if (parts[0].equalsIgnoreCase(ExpMaterial.MATERIAL_INPUT_PARENT))
+                        {
+                            parentNames(value, colName).forEach(parentName -> {
+                                allInputs.add(parentName);
+                                materialInputs.add(parentName);
+                            });
+                        }
                     }
                 }
 


### PR DESCRIPTION
- case-insensitive check for MaterialInputs parent column name
- don't bother joining by ',' just to split it apart again later