### PR TITLE
Issue 37861: ExpData.getWebDavURL returns double encoded path in S3 folders

### DIFF
--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -437,7 +437,7 @@ public class FileUtil
         if (!FileUtil.hasCloudScheme(str))
             return new File(createUri(str, isEncoded)).toPath();
         else
-            return CloudStoreService.get().getPathFromUrl(container, decodeSpaces(str));
+            return CloudStoreService.get().getPathFromUrl(container, PageFlowUtil.decode(str)/*decode everything not just the space*/);
     }
 
     public static String getCloudRootPathString(String cloudName)

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -44,6 +44,7 @@ import org.labkey.api.exp.api.ExpDataClass;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.query.ExpDataClassDataTable;
+import org.labkey.api.files.FileContentService;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineService;
@@ -570,7 +571,15 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
                 if (relPath == null)
                     return null;
 
-                relPath = Path.parse(FilenameUtils.separatorsToUnix(relPath)).encode();
+                if(!FileContentService.get().isCloudRoot(getContainer()))
+                {
+                    relPath = Path.parse(FilenameUtils.separatorsToUnix(relPath)).encode();
+                }
+                else
+                {
+                    // Do not encode path from S3 folder.  It is already encoded.
+                    relPath = Path.parse(FilenameUtils.separatorsToUnix(relPath)).toString();
+                }
                 switch (type)
                 {
                     case folderRelative: return relPath;

--- a/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
@@ -786,6 +786,7 @@ public class ExpDataTableImpl extends ExpRunItemTableImpl<ExpDataTable.Column> i
         public WebDavUrlColumn (ColumnInfo colInfo, boolean relative)
         {
             super(colInfo);
+            setTextAlign("left");
             _relative = relative;
         }
 


### PR DESCRIPTION
Also, left-align URLs in UI (defaulted to right-aligned since the column wraps RowId, an integer)