### PR TITLE
Issue 33909: Suppress some Messages menu content when not in Page Admin Mode

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -2104,7 +2104,6 @@ public class AnnouncementsController extends SpringActionController
 
     private static void addAdminMenus(LinkBarBean bean, NavTree menu, ViewContext context)
     {
-
         NavTree email = new NavTree("Email", "", context.getContextPath() + "/_images/email.png");
         if (bean.emailPrefsURL != null)
             email.addChild("Preferences", bean.emailPrefsURL);
@@ -2114,36 +2113,10 @@ public class AnnouncementsController extends SpringActionController
             email.addChild("Site-Wide Email Template", bean.siteEmailTemplateURL);
         if (bean.containerEmailTemplateURL != null)
             email.addChild(StringUtils.capitalize(context.getContainer().getContainerNoun()) + " Email Template", bean.containerEmailTemplateURL);
-
         if (email.hasChildren())
             menu.addChild(email);
 
-        if (PageFlowUtil.isPageAdminMode(context))
-            menu.addChild("Admin", bean.adminURL);
-
-
-
-        // this is all the email sub-menu
-//        NavTree email = new NavTree("Email", "", context.getContextPath() + "/_images/email.png");
-//        if (bean.emailPrefsURL != null)
-//            email.addChild("Preferences", bean.emailPrefsURL);
-//        if (bean.emailManageURL != null)
-//            email.addChild("Administration", bean.emailManageURL);
-//        if (bean.siteEmailTemplateURL != null)
-//            email.addChild("Site-Wide Email Template", bean.siteEmailTemplateURL);
-//        if (bean.containerEmailTemplateURL != null)
-//            email.addChild(StringUtils.capitalize(context.getContainer().getContainerNoun()) + " Email Template", bean.containerEmailTemplateURL);
-//
-//        if (email.hasChildren())
-//            menu.addChild(email);
-//
-////        this is adminBLARGL in particular. Why is it picked out?
-////        this doesn't contain any info on whether or not admin mode is turned on
-////        old: bean.adminURL != null
-//        if (PageFlowUtil.isPageAdminMode(context))
-//            menu.addChild("AdminBLARGL", bean.adminURL);
-
-
+        menu.addChild("Admin", bean.adminURL);
     }
 
 
@@ -2207,7 +2180,6 @@ public class AnnouncementsController extends SpringActionController
                 menu.addChild("View List", bean.listURL);
             if ((bean.listURL != null) && !isAdmin)
                 menu.addChild("Email Preferences", bean.emailPrefsURL);
-
 
             if (isAdmin)
                 addAdminMenus(bean, menu, context);

--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -2116,7 +2116,8 @@ public class AnnouncementsController extends SpringActionController
         if (email.hasChildren())
             menu.addChild(email);
 
-        menu.addChild("Admin", bean.adminURL);
+        if (bean.adminURL != null)
+            menu.addChild("Admin", bean.adminURL);
     }
 
 
@@ -2178,7 +2179,7 @@ public class AnnouncementsController extends SpringActionController
                 menu.addChild("New", bean.insertURL);
             if (bean.listURL != null)
                 menu.addChild("View List", bean.listURL);
-            if ((bean.listURL != null) && !isAdmin)
+            if ((bean.emailPrefsURL != null) && !isAdmin)
                 menu.addChild("Email Preferences", bean.emailPrefsURL);
 
             if (isAdmin)

--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -2172,7 +2172,7 @@ public class AnnouncementsController extends SpringActionController
             setTitleHref(getBeginURL(c));
 
             ViewContext context = getViewContext();
-            boolean isAdmin = PageFlowUtil.isPageAdminMode(context);
+            boolean isAdminMode = PageFlowUtil.isPageAdminMode(context);
             MessagesBean bean = getModelBean(); 
             NavTree menu = new NavTree("");
             if (bean.insertURL != null)

--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -2104,11 +2104,7 @@ public class AnnouncementsController extends SpringActionController
 
     private static void addAdminMenus(LinkBarBean bean, NavTree menu, ViewContext context)
     {
-        boolean thing = PageFlowUtil.isPageAdminMode(context);
 
-
-
-        // this is all the email sub-menu
         NavTree email = new NavTree("Email", "", context.getContextPath() + "/_images/email.png");
         if (bean.emailPrefsURL != null)
             email.addChild("Preferences", bean.emailPrefsURL);
@@ -2122,11 +2118,30 @@ public class AnnouncementsController extends SpringActionController
         if (email.hasChildren())
             menu.addChild(email);
 
-//        this is adminBLARGL in particular. Why is it picked out?
-//        this doesn't contain any info on whether or not admin mode is turned on
-//        old: bean.adminURL != null
         if (PageFlowUtil.isPageAdminMode(context))
-            menu.addChild("AdminBLARGL", bean.adminURL);
+            menu.addChild("Admin", bean.adminURL);
+
+
+
+        // this is all the email sub-menu
+//        NavTree email = new NavTree("Email", "", context.getContextPath() + "/_images/email.png");
+//        if (bean.emailPrefsURL != null)
+//            email.addChild("Preferences", bean.emailPrefsURL);
+//        if (bean.emailManageURL != null)
+//            email.addChild("Administration", bean.emailManageURL);
+//        if (bean.siteEmailTemplateURL != null)
+//            email.addChild("Site-Wide Email Template", bean.siteEmailTemplateURL);
+//        if (bean.containerEmailTemplateURL != null)
+//            email.addChild(StringUtils.capitalize(context.getContainer().getContainerNoun()) + " Email Template", bean.containerEmailTemplateURL);
+//
+//        if (email.hasChildren())
+//            menu.addChild(email);
+//
+////        this is adminBLARGL in particular. Why is it picked out?
+////        this doesn't contain any info on whether or not admin mode is turned on
+////        old: bean.adminURL != null
+//        if (PageFlowUtil.isPageAdminMode(context))
+//            menu.addChild("AdminBLARGL", bean.adminURL);
 
 
     }
@@ -2182,14 +2197,20 @@ public class AnnouncementsController extends SpringActionController
             setTitle(settings.getBoardName());
             setTitleHref(getBeginURL(c));
 
+            ViewContext context = getViewContext();
+            boolean isAdmin = PageFlowUtil.isPageAdminMode(context);
             MessagesBean bean = getModelBean(); 
             NavTree menu = new NavTree("");
             if (bean.insertURL != null)
                 menu.addChild("New", bean.insertURL);
             if (bean.listURL != null)
                 menu.addChild("View List", bean.listURL);
+            if ((bean.listURL != null) && !isAdmin)
+                menu.addChild("Email Preferences", bean.emailPrefsURL);
 
-            addAdminMenus(bean, menu, getViewContext());
+
+            if (isAdmin)
+                addAdminMenus(bean, menu, context);
 
             setIsWebPart(asWebPart);
             setNavMenu(menu);

--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -2104,6 +2104,11 @@ public class AnnouncementsController extends SpringActionController
 
     private static void addAdminMenus(LinkBarBean bean, NavTree menu, ViewContext context)
     {
+        boolean thing = PageFlowUtil.isPageAdminMode(context);
+
+
+
+        // this is all the email sub-menu
         NavTree email = new NavTree("Email", "", context.getContextPath() + "/_images/email.png");
         if (bean.emailPrefsURL != null)
             email.addChild("Preferences", bean.emailPrefsURL);
@@ -2114,11 +2119,16 @@ public class AnnouncementsController extends SpringActionController
         if (bean.containerEmailTemplateURL != null)
             email.addChild(StringUtils.capitalize(context.getContainer().getContainerNoun()) + " Email Template", bean.containerEmailTemplateURL);
 
-        if (bean.adminURL != null)
-            menu.addChild("Admin", bean.adminURL);
-
         if (email.hasChildren())
             menu.addChild(email);
+
+//        this is adminBLARGL in particular. Why is it picked out?
+//        this doesn't contain any info on whether or not admin mode is turned on
+//        old: bean.adminURL != null
+        if (PageFlowUtil.isPageAdminMode(context))
+            menu.addChild("AdminBLARGL", bean.adminURL);
+
+
     }
 
 


### PR DESCRIPTION
'Admin' dropdown option now only available in Page Admin Mode.
'Email' sub-menu option now only available in Page Admin Mode. When not in Page Admin Mode, only 'Email Preferences' is available. 