### PR TITLE
Prevent ConcurrentModificationException in ClrAssemblyManager

### DIFF
--- a/api/src/org/labkey/api/data/bigiron/ClrAssemblyManager.java
+++ b/api/src/org/labkey/api/data/bigiron/ClrAssemblyManager.java
@@ -18,8 +18,8 @@ package org.labkey.api.data.bigiron;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.view.template.Warnings;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
  * User: tgaluhn
@@ -32,7 +32,7 @@ import java.util.Set;
  */
 public class ClrAssemblyManager
 {
-    private static final Set<AbstractClrInstallationManager> _managers = new LinkedHashSet<>();
+    private static final Set<AbstractClrInstallationManager> _managers = new CopyOnWriteArraySet<>();
 
     private ClrAssemblyManager()
     {


### PR DESCRIPTION
Should fix an error that happened during server startup on a TeamCity run:
```
ERROR WebPartView              2019-07-12 02:14:22,117     http-nio-8111-exec-2 : renderView() exception in org.labkey.api.view.JspView while responding to /labkey/admin-moduleStatus.view?returnUrl=%2Flabkey%2FHome%2Fproject-begin.view%3F
java.util.ConcurrentModificationException
	at java.base/java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:719)
	at java.base/java.util.LinkedHashMap$LinkedKeyIterator.next(LinkedHashMap.java:741)
	at org.labkey.api.data.bigiron.ClrAssemblyManager.addAdminWarningMessages(ClrAssemblyManager.java:48)
	at org.labkey.bigiron.mssql.BaseMicrosoftSqlServerDialect.addAdminWarningMessages(BaseMicrosoftSqlServerDialect.java:1653)
	at org.labkey.bigiron.mssql.MicrosoftSqlServer2008R2Dialect.addAdminWarningMessages(MicrosoftSqlServer2008R2Dialect.java:25)
	at org.labkey.core.view.template.bootstrap.CoreWarningProvider.addStaticWarnings(CoreWarningProvider.java:53)
	at org.labkey.api.view.template.PageConfig.lambda$getStaticAdminWarnings$0(PageConfig.java:419)
	at java.base/java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:803)
	at org.labkey.core.view.template.bootstrap.WarningServiceImpl.forEachProvider(WarningServiceImpl.java:38)
	at org.labkey.api.view.template.PageConfig.getStaticAdminWarnings(PageConfig.java:419)
	at org.labkey.api.view.template.PageConfig.renderSiteMessages(PageConfig.java:473)
```