### PR TITLE
Item 5864: Type-Dependent Layout (Domain Designer)

### DIFF
--- a/api/gwtsrc/org/labkey/api/gwt/client/ui/property/FormatItem.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/ui/property/FormatItem.java
@@ -38,6 +38,7 @@ public class FormatItem<DomainType extends GWTDomain<FieldType>, FieldType exten
     // Update the below constant whenever we add support for a new major Java version so we always point at the current docs.
     // Why is this global constant defined in such an obscure class? Ideally, we would define it in HelpTopic, but that class
     // is not available to GWT client code. Defining it here allows us to use it in both GWT and server code.
+    // TODO: When the GWT domain designer is removed, move this constant to HelpTopic.java
     public static final String JDK_JAVADOC_BASE_URL = "https://docs.oracle.com/en/java/javase/12/docs/api/java.base/";
 
     // Should match Formats.getDecimalFormatDocumentationURL()

--- a/api/src/org/labkey/api/util/HelpTopic.java
+++ b/api/src/org/labkey/api/util/HelpTopic.java
@@ -58,6 +58,11 @@ public class HelpTopic
         return HELP_LINK_PREFIX;
     }
 
+    public static String getJdkJavaDocLinkPrefix()
+    {
+        return FormatItem.JDK_JAVADOC_BASE_URL;
+    }
+
     public String getHelpTopicHref()
     {
         return HELP_LINK_PREFIX + _topic;

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -2158,6 +2158,7 @@ public class PageFlowUtil
         json.put("serverName", StringUtils.isNotEmpty(serverName) ? serverName : "Labkey Server");
         json.put("versionString", appProps.getLabKeyVersionString());
         json.put("helpLinkPrefix", HelpTopic.getHelpLinkPrefix());
+        json.put("jdkJavaDocLinkPrefix", HelpTopic.getJdkJavaDocLinkPrefix());
 
         if (AppProps.getInstance().isExperimentalFeatureEnabled(NotificationMenuView.EXPERIMENTAL_NOTIFICATION_MENU))
         json.put("notifications", getNotificationJson(user));


### PR DESCRIPTION
Make JDK JavaDoc base URL available to client code via LABKEY.jdkJavaDocLinkPrefix

Dependency for https://github.com/LabKey/glass-components/pull/35

Simple example:
```javascript
<script type="text/javascript">
document.write('<a href="' + LABKEY.jdkJavaDocLinkPrefix + 'java/text/DecimalFormat.html"/>My Page</a>');
</script>
```