### PR TITLE
UX Domain Designer experimental feature flag

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -775,6 +775,8 @@ public interface ExperimentService extends ExperimentRunTypeSource
      */
     List<ExpRun> getDeletableRunsFromMaterials(Collection<? extends ExpMaterial> materials);
 
+    boolean useUXDomainDesigner();
+
     public static class XarExportOptions
     {
         String _lsidRelativizer = LSID_OPTION_FOLDER_RELATIVE;

--- a/api/src/org/labkey/api/exp/api/ExperimentUrls.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentUrls.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.UrlProvider;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.ExperimentRunType;
+import org.labkey.api.exp.property.Domain;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 
@@ -65,6 +66,8 @@ public interface ExperimentUrls extends UrlProvider
     ActionURL getAddRunsToExperimentURL(Container container, ExpExperiment expExperiment);
 
     ActionURL getDomainEditorURL(Container container, String domainURI, boolean allowAttachmentProperties, boolean allowFileLinkProperties, boolean showDefaultValueSettings);
+
+    ActionURL getDomainEditorURL(Container container, Domain domain, boolean allowAttachmentProperties, boolean allowFileLinkProperties, boolean showDefaultValueSettings);
 
     ActionURL getShowDataClassURL(Container container, int rowId);
 

--- a/core/src/org/labkey/core/query/UsersDomainKind.java
+++ b/core/src/org/labkey/core/query/UsersDomainKind.java
@@ -27,6 +27,7 @@ import org.labkey.api.exp.Handler;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.TemplateInfo;
+import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
@@ -109,7 +110,10 @@ public class UsersDomainKind extends SimpleTableDomainKind
     @Override
     public ActionURL urlEditDefinition(Domain domain, ContainerUser containerUser)
     {
-        return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain.getTypeURI(), false, false, false);
+        if (ExperimentService.get().useUXDomainDesigner())
+            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(ContainerManager.getSharedContainer(), domain, false, false, false);
+        else
+            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain.getTypeURI(), false, false, false);
     }
 
     @Override

--- a/core/src/org/labkey/core/query/UsersDomainKind.java
+++ b/core/src/org/labkey/core/query/UsersDomainKind.java
@@ -110,10 +110,7 @@ public class UsersDomainKind extends SimpleTableDomainKind
     @Override
     public ActionURL urlEditDefinition(Domain domain, ContainerUser containerUser)
     {
-        if (ExperimentService.get().useUXDomainDesigner())
-            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(ContainerManager.getSharedContainer(), domain, false, false, false);
-        else
-            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain.getTypeURI(), false, false, false);
+        return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(ContainerManager.getSharedContainer(), domain, false, false, false);
     }
 
     @Override

--- a/experiment/src/client/DomainDesigner/DomainDesigner.tsx
+++ b/experiment/src/client/DomainDesigner/DomainDesigner.tsx
@@ -38,10 +38,7 @@ export class App extends React.PureComponent<any, StateProps> {
     {
         super(props);
 
-        const schemaName = ActionURL.getParameter('schemaName');
-        const queryName = ActionURL.getParameter('queryName');
-        const domainId = ActionURL.getParameter('domainId');
-        const returnUrl = ActionURL.getParameter('returnUrl');
+        const { domainId, schemaName, queryName, returnUrl } = ActionURL.getParameters();
 
         this.state = {
             schemaName,
@@ -96,19 +93,8 @@ export class App extends React.PureComponent<any, StateProps> {
         // saveDomain(domain, 'VarList', options, name )
         saveDomain(domain)
             .then((savedDomain) => {
-                const newDomain = clearFieldDetails(savedDomain);
-
-                this.setState(() => ({
-                    domain: newDomain,
-                    submitting: false,
-                    message: 'Domain saved successfully.',
-                    messageType: 'success',
-                    dirty: false
-                }));
-
-                window.setTimeout(() => {
-                    this.dismissAlert();
-                }, 5000);
+                //const newDomain = clearFieldDetails(savedDomain);
+                this.navigate();
             })
             .catch(error => {
                 this.setState(() => ({
@@ -135,13 +121,14 @@ export class App extends React.PureComponent<any, StateProps> {
             this.setState(() => ({showConfirm: true}));
         }
         else {
-            this.onConfirm();
+            this.navigate();
         }
     };
 
-    onConfirm = () => {
+    navigate = () => {
         const { returnUrl } = this.state;
         this.setState(() => ({dirty: false}), () => {
+            // TODO if we don't have a returnUrl, should we just do a goBack()?
             window.location.href = returnUrl || ActionURL.buildURL('project', 'begin');
         });
     };
@@ -156,7 +143,7 @@ export class App extends React.PureComponent<any, StateProps> {
                 title='Confirm Leaving Page'
                 msg='You have unsaved changes. Are you sure you would like to leave this page before saving your changes?'
                 confirmVariant='success'
-                onConfirm={this.onConfirm}
+                onConfirm={this.navigate}
                 onCancel={this.hideConfirm}
             />
         )

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -177,6 +177,9 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
 
         AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_RESOLVE_PROPERTY_URI_COLUMNS, "Resolve property URIs as columns on experiment tables",
                 "If a column is not found on an experiment table, attempt to resolve the column name as a Property URI and add it as a property column", false);
+
+        AdminConsole.addExperimentalFeatureFlag(ExperimentServiceImpl.EXPERIMENTAL_DOMAIN_DESIGNER, "UX Domain Designer",
+                "Directs UI to the new UX Domain Designer view for those domain kinds which are supported.", false);
     }
 
     public boolean hasScripts()

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -133,7 +133,10 @@ public class DataClassDomainKind extends AbstractDomainKind
     @Override
     public ActionURL urlEditDefinition(Domain domain, ContainerUser containerUser)
     {
-        return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain.getTypeURI(), true, false, false);
+        if (ExperimentService.get().useUXDomainDesigner())
+            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain, true, false, false);
+        else
+            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain.getTypeURI(), true, false, false);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -133,10 +133,7 @@ public class DataClassDomainKind extends AbstractDomainKind
     @Override
     public ActionURL urlEditDefinition(Domain domain, ContainerUser containerUser)
     {
-        if (ExperimentService.get().useUXDomainDesigner())
-            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain, true, false, false);
-        else
-            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain.getTypeURI(), true, false, false);
+        return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain, true, false, false);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -184,6 +184,7 @@ public class ExperimentServiceImpl implements ExperimentService
 
     public static final String EXPERIMENTAL_LEGACY_LINEAGE = "legacy-lineage";
     public static final String DEFAULT_MATERIAL_SOURCE_NAME = "Unspecified";
+    public static final String EXPERIMENTAL_DOMAIN_DESIGNER = "experimental-uxdomaindesigner";
 
     private List<ExperimentRunTypeSource> _runTypeSources = new CopyOnWriteArrayList<>();
     private Set<ExperimentDataHandler> _dataHandlers = new HashSet<>();
@@ -6589,6 +6590,12 @@ public class ExperimentServiceImpl implements ExperimentService
         }
 
         return new ArrayList<>(runsDeletedWithInput(runsUsingItems));
+    }
+
+    @Override
+    public boolean useUXDomainDesigner()
+    {
+        return AppProps.getInstance().isExperimentalFeatureEnabled(EXPERIMENTAL_DOMAIN_DESIGNER);
     }
 
     public static class TestCase extends Assert

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -6158,6 +6158,9 @@ public class ExperimentController extends SpringActionController
         @Override
         public ActionURL getDomainEditorURL(Container container, Domain domain, boolean allowAttachmentProperties, boolean allowFileLinkProperties, boolean showDefaultValueSettings)
         {
+            if (!ExperimentService.get().useUXDomainDesigner())
+                return getDomainEditorURL(container, domain.getTypeURI(), allowAttachmentProperties, allowFileLinkProperties, showDefaultValueSettings);
+
             ActionURL url = new ActionURL("experiment", "domainDesigner", container);
             url.addParameter("domainId", domain.getTypeId());
             applyDomainEditorUrlParams(allowAttachmentProperties, allowFileLinkProperties, showDefaultValueSettings, url);

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -6146,18 +6146,32 @@ public class ExperimentController extends SpringActionController
             return new ActionURL(BeginAction.class, container);
         }
 
+        @Override
         public ActionURL getDomainEditorURL(Container container, String domainURI, boolean allowAttachmentProperties, boolean allowFileLinkProperties, boolean showDefaultValueSettings)
         {
             ActionURL url = new ActionURL(PropertyController.EditDomainAction.class, container);
             url.addParameter("domainURI", domainURI);
+            applyDomainEditorUrlParams(allowAttachmentProperties, allowFileLinkProperties, showDefaultValueSettings, url);
+            return url;
+        }
+
+        @Override
+        public ActionURL getDomainEditorURL(Container container, Domain domain, boolean allowAttachmentProperties, boolean allowFileLinkProperties, boolean showDefaultValueSettings)
+        {
+            ActionURL url = new ActionURL("experiment", "domainDesigner", container);
+            url.addParameter("domainId", domain.getTypeId());
+            applyDomainEditorUrlParams(allowAttachmentProperties, allowFileLinkProperties, showDefaultValueSettings, url);
+            return url;
+        }
+
+        private void applyDomainEditorUrlParams(boolean allowAttachmentProperties, boolean allowFileLinkProperties, boolean showDefaultValueSettings, ActionURL url)
+        {
             if (allowAttachmentProperties)
                 url.addParameter("allowAttachmentProperties", "1");
             if (allowFileLinkProperties)
                 url.addParameter("allowFileLinkProperties", "1");
             if (showDefaultValueSettings)
                 url.addParameter("showDefaultValueSettings", "1");
-            return url;
-
         }
 
         @Override

--- a/internal/src/org/labkey/api/query/SimpleTableDomainKind.java
+++ b/internal/src/org/labkey/api/query/SimpleTableDomainKind.java
@@ -194,10 +194,7 @@ public class SimpleTableDomainKind extends AbstractDomainKind
         if (!containerUser.getContainer().isContainerFor(ContainerType.DataType.domainDefinitions))
             return null;
 
-        if (ExperimentService.get().useUXDomainDesigner())
-            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain, true, true, true);
-        else
-            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain.getTypeURI(), true, true, true);
+        return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain, true, true, true);
     }
 
     @Override

--- a/internal/src/org/labkey/api/query/SimpleTableDomainKind.java
+++ b/internal/src/org/labkey/api/query/SimpleTableDomainKind.java
@@ -28,6 +28,7 @@ import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.TemplateInfo;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.XarFormatException;
+import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.property.AbstractDomainKind;
 import org.labkey.api.exp.property.Domain;
@@ -193,7 +194,10 @@ public class SimpleTableDomainKind extends AbstractDomainKind
         if (!containerUser.getContainer().isContainerFor(ContainerType.DataType.domainDefinitions))
             return null;
 
-        return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain.getTypeURI(), true, true, true);
+        if (ExperimentService.get().useUXDomainDesigner())
+            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain, true, true, true);
+        else
+            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain.getTypeURI(), true, true, true);
     }
 
     @Override

--- a/internal/src/org/labkey/experiment/api/SampleSetDomainKind.java
+++ b/internal/src/org/labkey/experiment/api/SampleSetDomainKind.java
@@ -155,7 +155,10 @@ public class SampleSetDomainKind extends AbstractDomainKind
 
     public ActionURL urlEditDefinition(Domain domain, ContainerUser containerUser)
     {
-        return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain.getTypeURI(), false, true, false);
+        if (ExperimentService.get().useUXDomainDesigner())
+            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain, false, true, false);
+        else
+            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain.getTypeURI(), false, true, false);
     }
 
     @Override

--- a/internal/src/org/labkey/experiment/api/SampleSetDomainKind.java
+++ b/internal/src/org/labkey/experiment/api/SampleSetDomainKind.java
@@ -155,10 +155,7 @@ public class SampleSetDomainKind extends AbstractDomainKind
 
     public ActionURL urlEditDefinition(Domain domain, ContainerUser containerUser)
     {
-        if (ExperimentService.get().useUXDomainDesigner())
-            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain, false, true, false);
-        else
-            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain.getTypeURI(), false, true, false);
+        return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain, false, true, false);
     }
 
     @Override

--- a/study/src/org/labkey/study/controllers/StudyDefinitionController.java
+++ b/study/src/org/labkey/study/controllers/StudyDefinitionController.java
@@ -18,6 +18,7 @@ package org.labkey.study.controllers;
 import org.labkey.api.action.FormHandlerAction;
 import org.labkey.api.action.QueryViewAction;
 import org.labkey.api.action.ReturnUrlForm;
+import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.PropertyService;
@@ -84,7 +85,13 @@ public class StudyDefinitionController extends BaseStudyController
         @Override
         public URLHelper getSuccessURL(ReturnUrlForm form)
         {
-            ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(getContainer(), _domain.getTypeURI(), false, false, false);
+            ActionURL url;
+
+            if (ExperimentService.get().useUXDomainDesigner())
+                url = PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(getContainer(), _domain, false, false, false);
+            else
+                url = PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(getContainer(), _domain.getTypeURI(), false, false, false);
+
             form.propagateReturnURL(url);
             return url;
         }

--- a/study/src/org/labkey/study/controllers/StudyDefinitionController.java
+++ b/study/src/org/labkey/study/controllers/StudyDefinitionController.java
@@ -85,13 +85,7 @@ public class StudyDefinitionController extends BaseStudyController
         @Override
         public URLHelper getSuccessURL(ReturnUrlForm form)
         {
-            ActionURL url;
-
-            if (ExperimentService.get().useUXDomainDesigner())
-                url = PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(getContainer(), _domain, false, false, false);
-            else
-                url = PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(getContainer(), _domain.getTypeURI(), false, false, false);
-
+            ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(getContainer(), _domain, false, false, false);
             form.propagateReturnURL(url);
             return url;
         }

--- a/study/src/org/labkey/study/query/studydesign/AbstractStudyDesignDomainKind.java
+++ b/study/src/org/labkey/study/query/studydesign/AbstractStudyDesignDomainKind.java
@@ -176,10 +176,7 @@ public abstract class AbstractStudyDesignDomainKind extends AbstractDomainKind
     @Override
     public ActionURL urlEditDefinition(Domain domain, ContainerUser containerUser)
     {
-        if (ExperimentService.get().useUXDomainDesigner())
-            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain, false, false, false);
-        else
-            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain.getTypeURI(), false, false, false);
+        return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain, false, false, false);
     }
 
     @Override

--- a/study/src/org/labkey/study/query/studydesign/AbstractStudyDesignDomainKind.java
+++ b/study/src/org/labkey/study/query/studydesign/AbstractStudyDesignDomainKind.java
@@ -26,6 +26,7 @@ import org.labkey.api.exp.Handler;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.XarFormatException;
+import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.property.AbstractDomainKind;
 import org.labkey.api.exp.property.Domain;
@@ -175,7 +176,10 @@ public abstract class AbstractStudyDesignDomainKind extends AbstractDomainKind
     @Override
     public ActionURL urlEditDefinition(Domain domain, ContainerUser containerUser)
     {
-        return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain.getTypeURI(), false, false, false);
+        if (ExperimentService.get().useUXDomainDesigner())
+            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain, false, false, false);
+        else
+            return PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(containerUser.getContainer(), domain.getTypeURI(), false, false, false);
     }
 
     @Override


### PR DESCRIPTION
Currently supported for the following domains: site users props, study add. props, extensible tables, sample sets, data classes