### PR TITLE
Add "serialization aliases" mechanism to Role

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-* text=auto
 
+* text=auto
 announcements/module.properties -text
 announcements/resources/schemas/comm.xml -text
 announcements/resources/schemas/dbscripts/postgresql/comm-18.10-18.20.sql -text
@@ -1809,7 +1809,10 @@ assay/api-src/org/labkey/api/assay/nab/view/RunDetailOptions.java -text
 assay/api-src/org/labkey/api/assay/nab/view/RunDetailsAction.java -text
 assay/api-src/org/labkey/api/assay/nab/view/RunDetailsHeaderView.java -text
 assay/api-src/org/labkey/api/assay/PlateBasedRunCreator.java -text
+assay/api-src/org/labkey/api/exp/property/AssayBatchDomainKind.java -text
 assay/api-src/org/labkey/api/exp/property/AssayDomainKind.java -text
+assay/api-src/org/labkey/api/exp/property/AssayResultDomainKind.java -text
+assay/api-src/org/labkey/api/exp/property/AssayRunDomainKind.java -text
 assay/api-src/org/labkey/api/nab/NabUrls.java -text
 assay/api-src/org/labkey/api/qc/PlateBasedDataExchangeHandler.java -text
 assay/api-src/org/labkey/api/study/AbstractPlateTypeHandler.java -text
@@ -1890,14 +1893,11 @@ assay/src/org/labkey/assay/actions/PipelineDataCollectorRedirectAction.java -tex
 assay/src/org/labkey/assay/actions/SaveAssayBatchAction.java -text
 assay/src/org/labkey/assay/actions/TemplateAction.java -text
 assay/src/org/labkey/assay/actions/TsvImportAction.java -text
-assay/src/org/labkey/assay/AssayBatchDomainKind.java -text
 assay/src/org/labkey/assay/AssayFolderType.java -text
 assay/src/org/labkey/assay/AssayImportServiceImpl.java -text
 assay/src/org/labkey/assay/AssayListPortalView.java -text
 assay/src/org/labkey/assay/AssayListQueryView.java -text
 assay/src/org/labkey/assay/AssayManager.java -text
-assay/src/org/labkey/assay/AssayResultDomainKind.java -text
-assay/src/org/labkey/assay/AssayRunDomainKind.java -text
 assay/src/org/labkey/assay/AssayServiceImpl.java -text
 assay/src/org/labkey/assay/DefaultAssayDomainKind.java -text
 assay/src/org/labkey/assay/FileBasedModuleDataHandler.java -text

--- a/api/src/org/labkey/api/data/BeanObjectFactory.java
+++ b/api/src/org/labkey/api/data/BeanObjectFactory.java
@@ -151,7 +151,7 @@ public class BeanObjectFactory<K> implements ObjectFactory<K> // implements Resu
             }
             catch (IllegalArgumentException | ConversionException x)
             {
-                _log.warn("Bean [" + bean.getClass().getName() + "] could not set property: " + prop + "=" + value + ": " + x.getMessage());
+                _log.warn("Bean [" + bean.getClass().getName() + "] could not set property: " + prop + "=" + String.valueOf(value) + ": " + x.getMessage());
             }
         }
 

--- a/api/src/org/labkey/api/data/BeanObjectFactory.java
+++ b/api/src/org/labkey/api/data/BeanObjectFactory.java
@@ -109,6 +109,7 @@ public class BeanObjectFactory<K> implements ObjectFactory<K> // implements Resu
             return name;
     }
 
+    @Override
     public K fromMap(Map<String, ?> m)
     {
         try
@@ -150,7 +151,7 @@ public class BeanObjectFactory<K> implements ObjectFactory<K> // implements Resu
             }
             catch (IllegalArgumentException | ConversionException x)
             {
-                _log.warn("Bean [" + bean.getClass().getName() + "] could not set property: " + prop + "=" + String.valueOf(value) + ": " + x.getMessage());
+                _log.warn("Bean [" + bean.getClass().getName() + "] could not set property: " + prop + "=" + value + ": " + x.getMessage());
             }
         }
 

--- a/api/src/org/labkey/api/security/roles/Role.java
+++ b/api/src/org/labkey/api/security/roles/Role.java
@@ -23,6 +23,8 @@ import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.UserPrincipal;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Set;
 
 /*
@@ -44,6 +46,19 @@ public interface Role extends Parameter.JdbcParameterValue
      */
     @NotNull
     String getUniqueName();
+
+    /**
+     * Returns serialization aliases, additional names that should resolve to this role for serialization purposes.
+     * Typically empty, this is useful in cases where a role is renamed or repackaged. If an old name is returned
+     * here, then roles that have been serialized to the database or a folder archive with that name will continue
+     * to resolve to the intended role.
+     * @return A collection of aliases that can be used to deserialize this role
+     */
+    @NotNull
+    default Collection<String> getSerializationAliases()
+    {
+        return Collections.emptyList();
+    }
 
     /**
      * @return The role's name.

--- a/api/src/org/labkey/api/security/roles/RoleManager.java
+++ b/api/src/org/labkey/api/security/roles/RoleManager.java
@@ -132,6 +132,10 @@ public class RoleManager
     public static void registerRole(Role role, boolean addPermissionsToAdminRoles)
     {
         _nameToRoleMap.put(role.getUniqueName(), role);
+
+        role.getSerializationAliases()
+            .forEach(alias->_nameToRoleMap.put(alias, role));
+
         _classToRoleMap.put(role.getClass(), role);
         _roles.add(role);
 
@@ -140,7 +144,7 @@ public class RoleManager
                 || role instanceof FolderAdminRole);
 
         //register all exposed permissions in the name and class maps
-        for(Class<? extends Permission> permClass : role.getPermissions())
+        for (Class<? extends Permission> permClass : role.getPermissions())
         {
             try
             {
@@ -182,6 +186,10 @@ public class RoleManager
     public static void registerPermission(Permission perm, boolean addToAdminRoles)
     {
         _nameToRoleMap.put(perm.getUniqueName(), perm);
+
+        perm.getSerializationAliases()
+            .forEach(alias->_nameToRoleMap.put(alias, perm));
+
         _classToRoleMap.put(perm.getClass(), perm);
         if (addToAdminRoles)
             addPermissionToAdminRoles(perm.getClass());

--- a/api/src/org/labkey/api/util/GUID.java
+++ b/api/src/org/labkey/api/util/GUID.java
@@ -16,7 +16,6 @@
 package org.labkey.api.util;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -223,10 +222,10 @@ public class GUID implements Serializable, Parameter.JdbcParameterValue
     public static final String guidRegEx = "\\p{XDigit}{8}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{12}";
     public static final Pattern guidPattern = Pattern.compile(guidRegEx);
 
-    public static boolean isGUID(String s)
+    public static boolean isGUID(@Nullable String s)
     {
         // quick check
-        if (s.length() != 36 || s.charAt(8) != '-' || s.charAt(13) != '-' || s.charAt(18) != '-' || s.charAt(23) != '-')
+        if (null == s || s.length() != 36 || s.charAt(8) != '-' || s.charAt(13) != '-' || s.charAt(18) != '-' || s.charAt(23) != '-')
             return false;
         return guidPattern.matcher(s).find();
     }

--- a/api/src/org/labkey/api/view/Portal.java
+++ b/api/src/org/labkey/api/view/Portal.java
@@ -415,6 +415,7 @@ public class Portal
             super(WebPart.class);
         }
 
+        @Override
         protected void fixupBean(WebPart part)
         {
             if (null == part.location || part.location.length() == 0)

--- a/assay/src/org/labkey/assay/security/AssayDesignerRole.java
+++ b/assay/src/org/labkey/assay/security/AssayDesignerRole.java
@@ -15,10 +15,14 @@
  */
 package org.labkey.assay.security;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.lists.permissions.DesignListPermission;
 import org.labkey.api.security.roles.AbstractRole;
 import org.labkey.api.study.permissions.DesignAssayPermission;
 import org.labkey.assay.AssayModule;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /*
 * User: Dave
@@ -37,5 +41,14 @@ public class AssayDesignerRole extends AbstractRole
         );
 
         excludeGuests();
+    }
+
+    @Override
+    public @NotNull Collection<String> getSerializationAliases()
+    {
+        // This class was repackaged when the assay framework was moved out of study into a separate assay module.
+        // Add an alias for the old package to allow import of serialized role assignments in old folder archives
+        // (e.g., QC Trend Report Testing.folder.zip).
+        return Collections.singleton("org.labkey.study.security.roles.AssayDesignerRole");
     }
 }


### PR DESCRIPTION
This allows us to rename and repackage roles and permissions but still resolve the old names that may be serialized in the database or folder archives.

Add "org.labkey.study.security.roles.AssayDesignerRole" as an alias for org.labkey.assay.security.AssayDesignerRole to fix QC Trend Report tests. These tests import a folder archive (QC Trend Report Testing.folder.zip) that includes role assignments with the old role name.