### PR TITLE
Rename SeeUserDetailsRole -> SeeUserAndGroupDetailsRole

### DIFF
--- a/api/src/org/labkey/api/data/BeanObjectFactory.java
+++ b/api/src/org/labkey/api/data/BeanObjectFactory.java
@@ -169,7 +169,7 @@ public class BeanObjectFactory<K> implements ObjectFactory<K> // implements Resu
                 }
                 catch (IllegalArgumentException | ConversionException x)
                 {
-                    _log.warn("Bean [" + bean.getClass().getName() + "] could not set property: " + prop + "=" + String.valueOf(value) + ": " + x.getMessage());
+                    _log.warn("Bean [" + bean.getClass().getName() + "] could not set property: " + prop + "=" + value + ": " + x.getMessage());
                 }
             }
         }

--- a/api/src/org/labkey/api/security/roles/Role.java
+++ b/api/src/org/labkey/api/security/roles/Role.java
@@ -49,9 +49,11 @@ public interface Role extends Parameter.JdbcParameterValue
 
     /**
      * Returns serialization aliases, additional names that should resolve to this role for serialization purposes.
-     * Typically empty, this is useful in cases where a role is renamed or repackaged. If an old name is returned
-     * here, then roles that have been serialized to the database or a folder archive with that name will continue
-     * to resolve to the intended role.
+     * Typically empty, this is useful in cases where a role or permission class is renamed or repackaged. If an old
+     * name is returned here, then roles/permissions that have been serialized with that name will continue to resolve
+     * to the intended class. Note that Roles are typically persisted in the database (core.RoleAssignments table) and
+     * with assignments exported to folder archives. Permissions are persisted as part of the webpart permissions
+     * feature, both to core.PortalWebParts.Permissions in the database and pages.xml in folder archives.
      * @return A collection of aliases that can be used to deserialize this role
      */
     @NotNull

--- a/api/src/org/labkey/api/security/roles/RoleManager.java
+++ b/api/src/org/labkey/api/security/roles/RoleManager.java
@@ -70,7 +70,7 @@ public class RoleManager
         registerRole(new NoPermissionsRole());
         registerRole(new OwnerRole());
         registerRole(new TroubleshooterRole());
-        registerRole(new SeeUserDetailsRole());
+        registerRole(new SeeUserAndGroupDetailsRole());
         registerRole(new CanSeeAuditLogRole());
         registerRole(new SharedViewEditorRole());
         registerRole(new EmailNonUsersRole(), false);

--- a/api/src/org/labkey/api/security/roles/SeeUserAndGroupDetailsRole.java
+++ b/api/src/org/labkey/api/security/roles/SeeUserAndGroupDetailsRole.java
@@ -15,25 +15,37 @@
  */
 package org.labkey.api.security.roles;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.permissions.SeeGroupDetailsPermission;
 import org.labkey.api.security.permissions.SeeUserDetailsPermission;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /*
 * User: adam
 * Date: Jan 22, 2010
 * Time: 1:22:04 PM
 */
-public class SeeUserDetailsRole extends AbstractRootContainerRole
+public class SeeUserAndGroupDetailsRole extends AbstractRootContainerRole
 {
     public static final String NAME = "See User and Group Details";
 
-    public SeeUserDetailsRole()
+    public SeeUserAndGroupDetailsRole()
     {
         super(NAME, "Allows viewing email addresses and contact information of other users as well as information about security groups.",
                 SeeUserDetailsPermission.class, SeeGroupDetailsPermission.class);
 
         addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));
+    }
+
+    @Override
+    public @NotNull Collection<String> getSerializationAliases()
+    {
+        // This role previously provided access to just user details; it was later expanded to add group details and renamed.
+        // Treat old name as a valid serialization alias to continue resolving old assignments in the database and folder archives.
+        return Collections.singleton("org.labkey.api.security.roles.SeeUserDetailsRole");
     }
 }

--- a/assay/src/org/labkey/assay/security/AssayDesignerRole.java
+++ b/assay/src/org/labkey/assay/security/AssayDesignerRole.java
@@ -47,7 +47,7 @@ public class AssayDesignerRole extends AbstractRole
     public @NotNull Collection<String> getSerializationAliases()
     {
         // This class was repackaged when the assay framework was moved out of study into a separate assay module.
-        // Add an alias for the old package to allow import of serialized role assignments in old folder archives
+        // Add an alias for the previous package to allow import of serialized role assignments in old folder archives
         // (e.g., QC Trend Report Testing.folder.zip).
         return Collections.singleton("org.labkey.study.security.roles.AssayDesignerRole");
     }

--- a/core/src/org/labkey/core/query/CoreQuerySchema.java
+++ b/core/src/org/labkey/core/query/CoreQuerySchema.java
@@ -43,7 +43,7 @@ import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.SeeGroupDetailsPermission;
 import org.labkey.api.security.permissions.UserManagementPermission;
-import org.labkey.api.security.roles.SeeUserDetailsRole;
+import org.labkey.api.security.roles.SeeUserAndGroupDetailsRole;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ViewContext;
 import org.labkey.core.workbook.WorkbookQueryView;
@@ -230,7 +230,7 @@ public class CoreQuerySchema extends UserSchema
             addNullSetFilter(groups);
 
         groups.setDescription("Contains all site groups and groups defined in the current project." +
-            " This table is available only to administrators plus users who have been granted the '" + SeeUserDetailsRole.NAME + "' site role.");
+            " This table is available only to administrators plus users who have been granted the '" + SeeUserAndGroupDetailsRole.NAME + "' site role.");
         
         return groups;
     }

--- a/core/src/org/labkey/core/query/UsersTable.java
+++ b/core/src/org/labkey/core/query/UsersTable.java
@@ -50,7 +50,7 @@ import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.UserManagementPermission;
-import org.labkey.api.security.roles.SeeUserDetailsRole;
+import org.labkey.api.security.roles.SeeUserAndGroupDetailsRole;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.UnauthorizedException;
@@ -96,7 +96,7 @@ public class UsersTable extends SimpleUserSchema.SimpleTable<UserSchema>
         setDescription("Contains all users who are members of the current project." +
             " The data in this table are available only to users who are signed-in (not guests). Guests see no rows." +
             " Signed-in users see the columns UserId, EntityId, and DisplayName." +
-            " Users granted the '" + SeeUserDetailsRole.NAME + "' role see all standard and custom columns.");
+            " Users granted the '" + SeeUserAndGroupDetailsRole.NAME + "' role see all standard and custom columns.");
 
         setImportURL(LINK_DISABLER);
         if (schema.getUser().hasRootPermission(UserManagementPermission.class))


### PR DESCRIPTION
Reflect expanded purpose of role. Use getSerializationAliases() to maintain backward compatibility with previous name.