### PR TITLE
Sample details container filtering issues

### DIFF
--- a/api/src/org/labkey/api/data/ContainerFilter.java
+++ b/api/src/org/labkey/api/data/ContainerFilter.java
@@ -587,10 +587,15 @@ public abstract class ContainerFilter
 
         public CurrentPlusExtras(User user, Container... extraContainers)
         {
+            this(user, Arrays.asList(extraContainers));
+        }
+
+        public CurrentPlusExtras(User user, Collection<Container> extraContainers)
+        {
             super(user);
 
             //Note: dont force upstream code to consider this
-            _extraContainers = new ArrayList<>(Arrays.asList(extraContainers));
+            _extraContainers = new ArrayList<>(extraContainers);
             _extraContainers.removeIf(c -> c.getContainerType().isDuplicatedInContainerFilter());
         }
 

--- a/experiment/src/org/labkey/experiment/ParentChildView.java
+++ b/experiment/src/org/labkey/experiment/ParentChildView.java
@@ -145,6 +145,9 @@ public class ParentChildView extends VBox
         }
 
         QueryView queryView = new QueryView(schema, settings, null);
+        // Issue 38018: Sample Set: Multiple data inputs from different containers are not shown in the Parent Data grid
+        // Use ContainerFilter.EVERYTHING - We've already set an IN clause that restricts us to showing just data that we have permission to view
+        queryView.setContainerFilter(ContainerFilter.EVERYTHING);
         TableInfo table = queryView.getTable();
 
         CustomView v = queryView.getCustomView();
@@ -222,12 +225,10 @@ public class ParentChildView extends VBox
         {
             protected TableInfo createTable()
             {
-                ExpMaterialTable table = ExperimentServiceImpl.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), getSchema(), getContainerFilter());
+                // Use ContainerFilter.EVERYTHING - We've already set an IN clause that restricts us to showing just data that we have permission to view
+                ExpMaterialTable table = ExperimentServiceImpl.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), getSchema(), ContainerFilter.EVERYTHING);
                 table.setMaterials(materials);
                 table.populate(ss, false);
-                // We've already set an IN clause that restricts us to showing just data that we have permission
-                // to view
-                table.setContainerFilter(ContainerFilter.EVERYTHING);
 
                 List<FieldKey> defaultVisibleColumns = new ArrayList<>();
                 if (ss == null)

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -412,29 +412,27 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         addColumn(Column.Description);
 
         var typeColumnInfo = addColumn(Column.SampleSet);
-        ContainerFilter sampleSetFkContainerFilter;
-        if (ss != null)
+        typeColumnInfo.setFk(new QueryForeignKey(_userSchema, null, ExpSchema.SCHEMA_NAME, getContainer(), null, getUserSchema().getUser(), ExpSchema.TableType.SampleSets.name(), "lsid", null)
         {
-            // Be sure that we can resolve the sample set if it's defined in a separate container.
-            // Same as CurrentPlusProjectAndShared but includes SampleSet's container as well.
-            // Issue 37982: Sample Set: Link to precursor sample set does not resolve correctly if sample has parents in current sample set and a sample set in the parent container
-            Set<Container> containers = new HashSet<>();
-            containers.add(ss.getContainer());
-            containers.add(getContainer());
-            if (getContainer().getProject() != null)
-                containers.add(getContainer().getProject());
-            containers.add(ContainerManager.getSharedContainer());
-            sampleSetFkContainerFilter = new ContainerFilter.CurrentPlusExtras(_userSchema.getUser(), containers);
-        }
-        else
-        {
-            sampleSetFkContainerFilter = new ContainerFilter.CurrentPlusProjectAndShared(_userSchema.getUser());
-        }
+            @Override
+            protected ContainerFilter getLookupContainerFilter()
+            {
+                if (ss == null)
+                    return new ContainerFilter.CurrentPlusProjectAndShared(_userSchema.getUser());
 
-        typeColumnInfo.setFk(QueryForeignKey.from(_userSchema, sampleSetFkContainerFilter)
-                .schema(ExpSchema.SCHEMA_NAME)
-                .table(ExpSchema.TableType.SampleSets.name())
-                .key("lsid"));
+                // Be sure that we can resolve the sample set if it's defined in a separate container.
+                // Same as CurrentPlusProjectAndShared but includes SampleSet's container as well.
+                // Issue 37982: Sample Set: Link to precursor sample set does not resolve correctly if sample has parents in current sample set and a sample set in the parent container
+                Set<Container> containers = new HashSet<>();
+                containers.add(ss.getContainer());
+                containers.add(getContainer());
+                if (getContainer().getProject() != null)
+                    containers.add(getContainer().getProject());
+                containers.add(ContainerManager.getSharedContainer());
+                return new ContainerFilter.CurrentPlusExtras(_userSchema.getUser(), containers);
+            }
+        });
+
         typeColumnInfo.setReadOnly(true);
         typeColumnInfo.setShownInInsertView(false);
 


### PR DESCRIPTION
- Issue 37982: Sample Set: Link to precursor sample set does not resolve correctly if sample has parents in current sample set and a sample set in the parent container
- Issue 38018: Sample Set: Multiple data inputs from different containers are not shown in the Parent Data grid