### PR TITLE
Issue 38218 Print preview bug for grids.

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1468,8 +1468,8 @@ public class QueryController extends SpringActionController
     {
         public ModelAndView getView(QueryForm form, BindException errors) throws Exception
         {
-            ModelAndView result = super.getView(form, errors);
             _print = true;
+            ModelAndView result = super.getView(form, errors);
             String title = form.getQueryName();
             if (StringUtils.isEmpty(title))
                 title = form.getSchemaName();


### PR DESCRIPTION
Print preview was not appearing because _print variable was set too late and seen as false in the `super.getView()`.