### PR TITLE
Issue 30769: Consolidate dirty handling

### DIFF
--- a/wiki/resources/web/wiki/internal/wikiEdit.js
+++ b/wiki/resources/web/wiki/internal/wikiEdit.js
@@ -357,7 +357,8 @@ function tinyMceHandleEvent(evt) {
 
     var onCancel = function() {
         // per bug 5957, don't prompt about losing changes if the user clicks cancel
-        setClean();
+        // setClean();
+        LABKEY.setDirty(false);
         _finished = true;
         window.location = _cancelUrl ? _cancelUrl : getRedirUrl();
     };
@@ -373,7 +374,8 @@ function tinyMceHandleEvent(evt) {
                     icon: Ext4.MessageBox.WARNING,
                     fn: function(btnId) {
                         if (btnId == "yes") {
-                            setWikiDirty();
+                            // setWikiDirty();
+                            LABKEY.setDirty(true);
                             _redirUrl = ''; // clear the redir URL since it will be referring to the old name
                             onSave();
                         }
@@ -385,7 +387,8 @@ function tinyMceHandleEvent(evt) {
             });
         }
         else {
-            setWikiDirty();
+            // setWikiDirty();
+            LABKEY.setDirty(true);
         }
     };
 
@@ -407,7 +410,8 @@ function tinyMceHandleEvent(evt) {
             updateControl("body", respJson.body);
         }
 
-        setWikiDirty();
+        // setWikiDirty();
+        LABKEY.setDirty(true);
 
         // hide the convert window
         if (_convertWin) {
@@ -485,7 +489,7 @@ function tinyMceHandleEvent(evt) {
         _doingSave = true;
 
 
-        if (!isDirty() && _wikiProps.entityId && !LABKEY.isDirty()) {
+        if (_wikiProps.entityId && !LABKEY.isDirty()) {
             onSaveComplete();
             return;
         }
@@ -501,7 +505,8 @@ function tinyMceHandleEvent(evt) {
     };
 
     var onSaveComplete = function(statusMessage) {
-        setClean();
+        // setClean();
+        LABKEY.setDirty(false);
         _doingSave = false;
         if (!statusMessage) {
             statusMessage = "Saved.";
@@ -601,6 +606,7 @@ function tinyMceHandleEvent(evt) {
         });
     };
 
+    //delete
     var setClean = function() {
         _wikiProps.isDirty = false;
         _attachments.isDirty = false;

--- a/wiki/resources/web/wiki/internal/wikiEdit.js
+++ b/wiki/resources/web/wiki/internal/wikiEdit.js
@@ -530,7 +530,7 @@ function tinyMceHandleEvent(evt) {
             }
 
             if (isDirty()) {
-                setStatus("Saving file attachments...");
+                setStatus("Saving...");
                 getExt4(function() {
                     // bah, for now we have to use Ext4 to do this post since it is an upload
                     Ext4.Ajax.request({


### PR DESCRIPTION
Moved much of wikiEdit.js's own isDirty checking to labkey.js's isDirty functions.
Note that dirty state of the body field has to be handled separately. I tried to implement a nicer jQuery way to detect keystrokes, but they didn't work. I'm assuming this is why the original author had to use the tinyMCE detection methods in the first place.

(Also, the deleted line '$(_idSel + 'body').keypress(setWikiDirty).change(setWikiDirty);' that was ostensibly setting body dirtiness with jQuery was actually not doing anything functional at all.)

I waffled as to whether to modularize calls to LABKEY.setDirty(false) and then setBodyClean() into their own function. Doing it would be /slightly/ more modular, but also introduce another non-labkey.js dirtiness handling function. 