### PR TITLE
Issue 38299: Email template UI doesn't show HTML/plain text separator help

### DIFF
--- a/core/src/org/labkey/core/admin/customizeEmail.jsp
+++ b/core/src/org/labkey/core/admin/customizeEmail.jsp
@@ -183,7 +183,7 @@
                 message.value = this.emailTemplates[i].message;
                 Ext4.get("siteResetButton").dom.style.display = this.emailTemplates[i].showSiteReset ? "" : "none";
                 Ext4.get("folderResetButton").dom.style.display = this.emailTemplates[i].showFolderReset ? "" : "none";
-                Ext4.get("helpMultipleContentTypes").dom.style.display = this.emailTemplates[i].supportsMultipleContentTypes ? "" : "none";
+                Ext4.get("helpMultipleContentTypes").dom.style.display = this.emailTemplates[i].hasMultipleContentTypes ? "" : "none";
 
                 changeValidSubstitutions(this.emailTemplates[i]);
                 return;


### PR DESCRIPTION
The JSON property names we used to set and get the values got out of sync.