### PR TITLE
Migrate from @Deprecated PageFlowUtil.textLink() static methods to di…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1265,7 +1265,6 @@ api/src/org/labkey/api/reports/report/view/ReportDesignBean.java -text
 api/src/org/labkey/api/reports/report/view/ReportQueryView.java -text
 api/src/org/labkey/api/reports/report/view/ReportUtil.java -text
 api/src/org/labkey/api/reports/report/view/rReportDesignerSyntaxRef.jsp -text
-api/src/org/labkey/api/reports/report/view/rReportTabHandler.jsp -text
 api/src/org/labkey/api/reports/report/view/RunChartReportView.java -text
 api/src/org/labkey/api/reports/report/view/RunReportView.java -text
 api/src/org/labkey/api/reports/report/view/ScriptReportBean.java -text
@@ -1919,7 +1918,6 @@ assay/src/org/labkey/assay/plate/query/PlateSchema.java -text
 assay/src/org/labkey/assay/plate/query/PlateTable.java -text
 assay/src/org/labkey/assay/plate/query/WellGroupTable.java -text
 assay/src/org/labkey/assay/plate/view/copyTemplate.jsp -text
-assay/src/org/labkey/assay/plate/view/plateTemplate.jsp -text
 assay/src/org/labkey/assay/plate/view/plateTemplateList.jsp -text
 assay/src/org/labkey/assay/plate/WellGroupCurveImpl.java -text
 assay/src/org/labkey/assay/plate/WellGroupImpl.java -text
@@ -2249,7 +2247,6 @@ core/src/org/labkey/core/admin/TestNetworkDriveBean.java -text
 core/src/org/labkey/core/admin/threads.jsp -text
 core/src/org/labkey/core/admin/usageMetrics/UsageMetricsServiceImpl.java -text
 core/src/org/labkey/core/admin/ValidateDomainsPipelineJob.java -text
-core/src/org/labkey/core/admin/view/filesNotifySettings.jsp -text
 core/src/org/labkey/core/admin/view/filesProjectSettings.jsp -text
 core/src/org/labkey/core/admin/view/filesSiteSettings.jsp -text
 core/src/org/labkey/core/admin/view/folderSettingsHeader.jsp -text
@@ -2809,7 +2806,6 @@ internal/src/org/labkey/api/util/HashHelpers.java -text
 internal/src/org/labkey/api/util/SortHelpers.java -text
 internal/src/org/labkey/api/util/TextExtractor.java -text
 internal/src/org/labkey/api/util/wiki_markup.properties -text
-internal/src/org/labkey/api/view/addWebPart.jsp -text
 internal/src/org/labkey/api/view/DefaultWebPartFactory.java -text
 internal/src/org/labkey/api/view/FileServlet.java -text
 internal/src/org/labkey/api/view/LinkBarView.java -text
@@ -3547,7 +3543,6 @@ query/src/org/labkey/query/reports/view/ReportsWebPart.java -text
 query/src/org/labkey/query/reports/view/ReportsWebPartConfig.java -text
 query/src/org/labkey/query/reports/view/reportsWebPartConfig.jsp -text
 query/src/org/labkey/query/reports/view/ReportUIProvider.java -text
-query/src/org/labkey/query/reports/view/rReportTabHeader.jsp -text
 query/src/org/labkey/query/reports/view/shareReport.jsp -text
 query/src/org/labkey/query/sql/Builder.java -text
 query/src/org/labkey/query/sql/IConstant.java -text
@@ -4213,7 +4208,6 @@ study/src/org/labkey/study/view/customizeParticipantView.jsp -text
 study/src/org/labkey/study/view/customizeParticipantWebPart.jsp -text
 study/src/org/labkey/study/view/datasetDetails.jsp -text
 study/src/org/labkey/study/view/datasetDisplayOrder.jsp -text
-study/src/org/labkey/study/view/datasetInfo.jsp -text
 study/src/org/labkey/study/view/datasets.jsp -text
 study/src/org/labkey/study/view/DatasetsWebPartView.java -text
 study/src/org/labkey/study/view/datasetVisibility.jsp -text
@@ -4222,7 +4216,6 @@ study/src/org/labkey/study/view/demoMode.jsp -text
 study/src/org/labkey/study/view/editSnapshot.jsp -text
 study/src/org/labkey/study/view/editVisit.jsp -text
 study/src/org/labkey/study/view/externalReportDesigner.jsp -text
-study/src/org/labkey/study/view/importDataset.jsp -text
 study/src/org/labkey/study/view/importDataType.jsp -text
 study/src/org/labkey/study/view/importStudyBatch.jsp -text
 study/src/org/labkey/study/view/importVisitAliases.jsp -text
@@ -4231,7 +4224,6 @@ study/src/org/labkey/study/view/manageCohortsBottom.jsp -text
 study/src/org/labkey/study/view/manageCohortsTop.jsp -text
 study/src/org/labkey/study/view/manageComments.jsp -text
 study/src/org/labkey/study/view/manageFilewatchers.jsp -text
-study/src/org/labkey/study/view/manageLocations.jsp -text
 study/src/org/labkey/study/view/manageMasterPatientConfig.jsp -text
 study/src/org/labkey/study/view/manageParticipantCategories.jsp -text
 study/src/org/labkey/study/view/manageReports.jsp -text
@@ -4247,12 +4239,10 @@ study/src/org/labkey/study/view/overview.jsp -text
 study/src/org/labkey/study/view/participantAll.jsp -text
 study/src/org/labkey/study/view/participantCharacteristics.jsp -text
 study/src/org/labkey/study/view/participantReport.jsp -text
-study/src/org/labkey/study/view/pipelineSetup.jsp -text
 study/src/org/labkey/study/view/renderAssayProgressReport.jsp -text
 study/src/org/labkey/study/view/reportPermission.jsp -text
 study/src/org/labkey/study/view/requirePipeline.jsp -text
 study/src/org/labkey/study/view/saveReportView.jsp -text
-study/src/org/labkey/study/view/securityTabHeader.jsp -text
 study/src/org/labkey/study/view/sendParticipantGroup.jsp -text
 study/src/org/labkey/study/view/snapshotSettings.jsp -text
 study/src/org/labkey/study/view/specimen/autoReportList.jsp -text

--- a/api/src/org/labkey/api/action/RedirectAction.java
+++ b/api/src/org/labkey/api/action/RedirectAction.java
@@ -19,6 +19,7 @@ package org.labkey.api.action;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.annotations.RemoveIn20_1;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.RedirectException;
 import org.labkey.api.view.template.PageConfig;
@@ -31,15 +32,13 @@ import static org.labkey.api.action.SpringActionController.ERROR_MSG;
 
 
 /**
- * Base class for action that always redirects the client to a different URL.
- * TODO: Subclasses should extend FormHandlerAction or SimpleRedirectAction instead, and this class should be deleted.
- *
- * TODO: This class is deprecated in favor of SimpleRedirectAction.
+ * Use SimpleRedirectAction instead. This base action class will be removed in LabKey Server 20.1
  *
  * User: adamr
  * Date: September 19, 2007
  */
 @Deprecated
+@RemoveIn20_1
 public abstract class RedirectAction<FORM> extends BaseViewAction<FORM>
 {
     @Override

--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -1819,7 +1819,7 @@ public class DataRegion extends DisplayElement
                 props = Collections.emptyMap();
             }
 
-            out.write(PageFlowUtil.iconLink(iconCls, value.toString(), url, null, null, props));
+            out.write(PageFlowUtil.iconLink(iconCls, value.toString()).href(url).attributes(props).toString());
         }
     }
 

--- a/api/src/org/labkey/api/data/UrlColumn.java
+++ b/api/src/org/labkey/api/data/UrlColumn.java
@@ -39,6 +39,7 @@ public class UrlColumn extends SimpleDisplayColumn
         setURL(url);
     }
 
+    @Override
     public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
     {
         Object value = getValue(ctx);
@@ -55,7 +56,7 @@ public class UrlColumn extends SimpleDisplayColumn
             {
                 props = Collections.emptyMap();
             }
-            out.write(PageFlowUtil.textLink(value.toString(), url, null, null, props));
+            out.write(PageFlowUtil.link(value.toString()).href(url).attributes(props).toString());
         }
     }
 }

--- a/api/src/org/labkey/api/jsp/JspBase.java
+++ b/api/src/org/labkey/api/jsp/JspBase.java
@@ -135,9 +135,26 @@ public abstract class JspBase extends JspContext implements HasViewContext
         return HtmlString.unsafe(s);
     }
 
+    /**
+     * Convenience method for asserting that a String contains valid, properly encoded HTML.
+     *
+     * @param s Valid, properly encoded HTML
+     * @return An HtmlString that wraps the parameter without encoding
+     */
     public HtmlString unsafe(String s)
     {
         return HtmlString.unsafe(s);
+    }
+
+    /**
+     * Convenience method for asserting that a CharSequence contains valid, properly encoded HTML.
+     *
+     * @param cs Valid, properly encoded HTML
+     * @return An HtmlString that wraps the parameter without encoding
+     */
+    public HtmlString unsafe(CharSequence cs)
+    {
+        return HtmlString.unsafe(cs.toString());
     }
 
     /**
@@ -381,11 +398,9 @@ public abstract class JspBase extends JspContext implements HasViewContext
         return new ButtonBuilder(html);
     }
 
-    // TODO: Switch to real impl in PageFlowUtil after merging it from CSRF branch
     public @NotNull HtmlString makeHtmlId(@Nullable String s)
     {
-        return null == s ? HtmlString.EMPTY_STRING : HtmlString.unsafe(s.replaceAll(" ", ""));
-//        return PageFlowUtil.makeHtmlId(s);
+        return PageFlowUtil.makeHtmlId(s);
     }
 
     public HtmlString generateReturnUrlFormField(URLHelper returnURL)

--- a/api/src/org/labkey/api/jsp/JspContext.java
+++ b/api/src/org/labkey/api/jsp/JspContext.java
@@ -33,10 +33,12 @@ public abstract class JspContext extends HttpJspBase
         MemTracker.getInstance().put(this);
     }
 
+    @Override
     public void jspInit()
     {
     }
 
+    @Override
     public void jspDestroy()
     {
     }

--- a/api/src/org/labkey/api/jsp/LabKeyJspWriter.java
+++ b/api/src/org/labkey/api/jsp/LabKeyJspWriter.java
@@ -81,7 +81,7 @@ public class LabKeyJspWriter extends JspWriterWrapper
                     if (null == obj)
                         LOG.info("A JSP is attempting to render a null object!", new Throwable());
                     else
-                        LOG.info("A JSP is rendering an object of class " + obj.getClass().getSimpleName(), new Throwable());
+                        LOG.info("A JSP is rendering an object of class " + obj.getClass().getName(), new Throwable());
                 }
             }
         }

--- a/api/src/org/labkey/api/jsp/taglib/CheckboxTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/CheckboxTag.java
@@ -26,9 +26,8 @@ public class CheckboxTag extends SimpleTagBase
 {
     protected String _id;
     protected String _name;
-    protected Object _value;
+    protected String _value;
     protected Boolean _checked;
-    protected Set _checkedSet;
 
     @Override
     public void doTag() throws IOException
@@ -45,10 +44,6 @@ public class CheckboxTag extends SimpleTagBase
         out.print("\"");
 
         if (_checked != null && _checked)
-        {
-            out.print(" checked");
-        }
-        else if (_checkedSet != null && _checkedSet.contains(_value))
         {
             out.print(" checked");
         }
@@ -69,7 +64,7 @@ public class CheckboxTag extends SimpleTagBase
         _name = name;
     }
 
-    public void setValue(Object value)
+    public void setValue(String value)
     {
         _value = value;
     }
@@ -77,10 +72,5 @@ public class CheckboxTag extends SimpleTagBase
     public void setChecked(Boolean checked)
     {
         _checked = checked;
-    }
-
-    public void setCheckedSet(Set set)
-    {
-        _checkedSet = set;
     }
 }

--- a/api/src/org/labkey/api/jsp/taglib/HelpPopupTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/HelpPopupTag.java
@@ -16,12 +16,15 @@
 
 package org.labkey.api.jsp.taglib;
 
+import org.labkey.api.annotations.RemoveIn20_1;
 import org.labkey.api.util.PageFlowUtil;
 
 import javax.servlet.jsp.tagext.BodyTagSupport;
 import javax.servlet.jsp.JspException;
 import java.io.IOException;
 
+@Deprecated // Use JspBase.helpPopup()
+@RemoveIn20_1
 public class HelpPopupTag extends BodyTagSupport
 {
     private String title;

--- a/api/src/org/labkey/api/jsp/taglib/LinkTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/LinkTag.java
@@ -70,6 +70,6 @@ public class LinkTag extends SimpleTagBase
             properties.put("rel", _rel);
 
         JspWriter out = getOut();
-        out.print(PageFlowUtil.textLink(_text, _href, _onclick, _id, properties));
+        out.print(PageFlowUtil.link(_text).href(_href).onClick(_onclick).id(_id).attributes(properties));
     }
 }

--- a/api/src/org/labkey/api/jsp/taglib/SimpleTagBase.java
+++ b/api/src/org/labkey/api/jsp/taglib/SimpleTagBase.java
@@ -28,6 +28,11 @@ public class SimpleTagBase extends SimpleTagSupport
         return PageFlowUtil.filter(o);
     }
 
+    protected String h(String s)
+    {
+        return PageFlowUtil.filter(s);
+    }
+
     protected JspWriter getOut()
     {
         return getJspContext().getOut();

--- a/api/src/org/labkey/api/qc/view/manageQCStates.jsp
+++ b/api/src/org/labkey/api/qc/view/manageQCStates.jsp
@@ -40,7 +40,7 @@
     ActionURL baseDeleteStateURL = new ActionURL(bean.getDeleteAction(), container);
 %>
 <labkey:errors/><br>
-<labkey:form action="<%=h(buildURL(manageAction.getClass()))%>" name="manageQCStates" method="POST">
+<labkey:form action="<%=buildURL(manageAction.getClass())%>" name="manageQCStates" method="POST">
 <input type="hidden" name="reshowPage" value="true">
 <input type="hidden" name="returnUrl" value="<%= h(bean.getReturnUrl()) %>">
     <labkey:panel title="<%=currentQCPanelTitle%>">

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -358,7 +358,7 @@ public class QueryView extends WebPartView<Object>
                     if (getUser().isPlatformDeveloper())
                     {
                         out.write(" ");
-                        out.print(PageFlowUtil.textLink(StringUtils.defaultString(resolveText, "resolve"), resolveURL));
+                        out.print(PageFlowUtil.link(StringUtils.defaultString(resolveText, "resolve")).href(resolveURL));
                     }
                 }
                 out.write("<br>");
@@ -1928,18 +1928,6 @@ public class QueryView extends WebPartView<Object>
     protected boolean canViewReport(User user, Container c, Report report)
     {
         return true;
-    }
-
-    protected String textLink(String text, ActionURL url, String anchorElementId)
-    {
-        if (url == null)
-            return null;
-        return PageFlowUtil.textLink(text, url, anchorElementId).concat("&nbsp;");
-    }
-
-    protected String textLink(String text, ActionURL url)
-    {
-        return textLink(text, url, null);
     }
 
     public void addCustomizeViewItems(MenuButton button)

--- a/api/src/org/labkey/api/util/Button.java
+++ b/api/src/org/labkey/api/util/Button.java
@@ -52,7 +52,7 @@ public class Button extends DisplayElement implements HasHtmlString
     private final String href;
     private final String onClick;
     private final String id;
-    private final Map<String,String> attributes;
+    private final Map<String, String> attributes;
     private final String unsafeAttributes;
     private final String tooltip;
     private final String typeCls;

--- a/api/src/org/labkey/api/util/DisplayElementBuilder.java
+++ b/api/src/org/labkey/api/util/DisplayElementBuilder.java
@@ -32,7 +32,7 @@ public abstract class DisplayElementBuilder<T extends DisplayElement & HasHtmlSt
     String href;
     String id;
     String onClick;
-    Map<String,String> attributes;
+    Map<String, String> attributes;
     String cssClass;
     String tooltip;
     String iconCls;
@@ -128,7 +128,7 @@ public abstract class DisplayElementBuilder<T extends DisplayElement & HasHtmlSt
         return build().getHtmlString();
     }
 
-    @Override // TODO: HtmlString - remove
+    @Override
     public String toString()
     {
         return getHtmlString().toString();

--- a/api/src/org/labkey/api/util/ErrorRenderer.java
+++ b/api/src/org/labkey/api/util/ErrorRenderer.java
@@ -120,7 +120,7 @@ public class ErrorRenderer
 
             if (!showDetails)
             {
-                out.println("<p><div id='togglePanel' style='cursor:pointer' onclick='document.getElementById(\"contentPanel\").style.display=\"block\";document.getElementById(\"togglePanel\").style.display=\"none\";'>" + PageFlowUtil.textLink("Show more details", "#details") + "</div>\n" +
+                out.println("<p><div id='togglePanel' style='cursor:pointer' onclick='document.getElementById(\"contentPanel\").style.display=\"block\";document.getElementById(\"togglePanel\").style.display=\"none\";'>" + PageFlowUtil.link("Show more details").href("#details") + "</div>\n" +
                         "<div id=\"contentPanel\" style=\"display:none;\">");
             }
 

--- a/api/src/org/labkey/api/util/HasHtmlString.java
+++ b/api/src/org/labkey/api/util/HasHtmlString.java
@@ -19,6 +19,11 @@ import java.io.IOException;
 
 public interface HasHtmlString extends DOM.Renderable
 {
+    /**
+     * Must be consistent with {@code toString()}! JSP rendering of objects will call {@code obj.getHtmlString().toString()}
+     * in dev mode but {@code obj.toString()} in production mode. Most implementations will either implement {@code toString()}
+     * as {@code return getHtmlString.toString()} or implement {@code getHtmlString()} as {@code HtmlString.unsafe(toString);}.
+     */
     HtmlString getHtmlString();
 
     @Override

--- a/api/src/org/labkey/api/util/Link.java
+++ b/api/src/org/labkey/api/util/Link.java
@@ -26,7 +26,7 @@ import static org.labkey.api.util.DOM.at;
 
 public class Link extends DisplayElement implements HasHtmlString
 {
-    private LinkBuilder lb;
+    private final LinkBuilder lb;
 
     public Link(LinkBuilder linkBuilder)
     {

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -37,6 +37,7 @@ import org.labkey.api.action.UrlProvider;
 import org.labkey.api.admin.CoreUrls;
 import org.labkey.api.admin.notification.Notification;
 import org.labkey.api.admin.notification.NotificationService;
+import org.labkey.api.annotations.RemoveIn20_1;
 import org.labkey.api.announcements.api.Tour;
 import org.labkey.api.announcements.api.TourService;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
@@ -168,8 +169,6 @@ public class PageFlowUtil
     private static final String NONPRINTING_ALTCHAR = "~";
 
     public static final String SESSION_PAGE_ADMIN_MODE = "session-page-admin-mode";
-
-    public static final String XML_ENCODING_DECLARATION = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
 
     public static boolean useExperimentalCoreUI()
     {
@@ -1260,7 +1259,8 @@ public class PageFlowUtil
     /**
      *  Returns an onClick handler that posts to the specified url, providing a CSRF token.
      */
-    @Deprecated // TODO: Remove soon
+    @Deprecated
+    @RemoveIn20_1  // TODO: Unused -- all callers now delegate to builder methods that implement post-on-click
     public static String postOnClickJavaScript(ActionURL url)
     {
         return postOnClickJavaScript(url.getLocalURIString());
@@ -1274,6 +1274,11 @@ public class PageFlowUtil
     public static LinkBuilder link(String text)
     {
         return new LinkBuilder(text);
+    }
+
+    public static LinkBuilder iconLink(String iconCls, @Nullable String tooltip)
+    {
+        return new LinkBuilder().iconCls(iconCls).tooltip(tooltip);
     }
 
     private static final String ARBITRARY_LETTER = "Q";
@@ -1327,6 +1332,7 @@ public class PageFlowUtil
         return button(text).href("#").onClick("LABKEY.setDirty(false); window.history.back(); return false;").getHtmlString();
     }
 
+    @RemoveIn20_1 // No usages
     public static String generateDropDownButton(String text, String href, String onClick, @Nullable Map<String, String> attributes)
     {
         return button(text)
@@ -1338,6 +1344,7 @@ public class PageFlowUtil
     }
 
     /* Renders a span and a drop down arrow image wrapped in a link */
+    @RemoveIn20_1 // No usages
     public static String generateDropDownButton(String text, String href, String onClick)
     {
         return generateDropDownButton(text, href, onClick, null);
@@ -1397,11 +1404,6 @@ public class PageFlowUtil
         return attributes.toString();
     }
 
-    public static String generateDisabledButton(String text)
-    {
-        return button(text).enabled(false).toString();
-    }
-
     /**
      * If the provided text uses ", return '. If it uses ', return ".
      * This is useful to quote javascript.
@@ -1426,62 +1428,80 @@ public class PageFlowUtil
         return '"';
     }
 
+    @Deprecated    // Use LinkBuilder directly - see PageFlowUtil.link(). 42 usages.
     public static String textLink(String text, URLHelper url)
     {
-        return link(text).href(url).build().toString();
+        return link(text).href(url).toString();
     }
 
+    @Deprecated    // Use LinkBuilder directly - no usages
+    @RemoveIn20_1
     public static String textLink(String text, URLHelper url, String id)
     {
         return link(text).href(url).id(id).build().toString();
     }
 
+    @Deprecated    // Use LinkBuilder directly - no usages
+    @RemoveIn20_1
     public static String textLink(String text, URLHelper url, @Nullable String onClickScript, @Nullable String id)
     {
         return link(text).href(url).onClick(onClickScript).id(id).build().toString();
     }
 
+    @Deprecated    // Use LinkBuilder directly - no usages
+    @RemoveIn20_1
     public static String textLink(String text, URLHelper url, @Nullable String onClickScript, @Nullable String id, Map<String, String> properties)
     {
         return link(text).href(url).onClick(onClickScript).id(id).attributes(properties).build().toString();
     }
 
+    @Deprecated    // Use LinkBuilder directly - no usages
+    @RemoveIn20_1
     public static String textLink(String text, String href, String id)
     {
         return link(text).href(href).id(id).build().toString();
     }
 
+    @Deprecated    // Use LinkBuilder directly - no usages
+    @RemoveIn20_1
     public static String textLink(String text, String href)
     {
         return link(text).href(href).build().toString();
     }
 
-    @Deprecated
+    @Deprecated    // Use LinkBuilder directly - no usages
+    @RemoveIn20_1
     public static String textLink(String text, String href, @Nullable String onClickScript, @Nullable String id)
     {
         return link(text).href(href).onClick(onClickScript).id(id).build().toString();
     }
 
-    @Deprecated
+    @Deprecated    // Use LinkBuilder directly - no usages
+    @RemoveIn20_1
     public static String textLink(String text, String href, @Nullable String onClickScript, @Nullable String id, Map<String, String> properties)
     {
         return link(text).href(href).onClick(onClickScript).id(id).attributes(properties).build().toString();
     }
 
+    @Deprecated    // Use LinkBuilder directly - no usages
+    @RemoveIn20_1
     public static String unstyledTextLink(String text, String href, String onClickScript, String id)
     {
         return link(text).href(href).onClick(onClickScript).id(id).clearClasses().toString();
     }
 
+    @Deprecated    // Use LinkBuilder directly - no usages
+    @RemoveIn20_1
     public static String unstyledTextLink(String text, URLHelper url)
     {
         return link(text).href(url).clearClasses().toString();
     }
 
-
+    @Deprecated    // Use LinkBuilder directly - no usages
+    @RemoveIn20_1
     public static String iconLink(String iconCls, String tooltip, @Nullable String url, @Nullable String onClickScript, @Nullable String id, Map<String, String> properties)
     {
-        return new LinkBuilder().iconCls(iconCls).tooltip(tooltip).href(url).onClick(onClickScript).id(id).attributes(properties).build().toString();
+        return iconLink(iconCls, tooltip).href(url).onClick(onClickScript).id(id).attributes(properties).build().toString();
     }
 
     public static String helpPopup(String title, String helpText)
@@ -1538,7 +1558,7 @@ public class PageFlowUtil
             // Finally, since this is script inside of an attribute, it must be HTML escaped again.
             showHelpDivArgs.append(filter(jsString(htmlHelpText ? helpText : filter(helpText, true))));
             if (width != 0)
-                showHelpDivArgs.append(", ").append(filter(jsString(filter(String.valueOf(width) + "px"))));
+                showHelpDivArgs.append(", ").append(filter(jsString(filter(width + "px"))));
             if (onClickScript == null)
             {
                 onClickScript = "return showHelpDiv(" + showHelpDivArgs + ");";

--- a/api/src/org/labkey/api/view/DataView.java
+++ b/api/src/org/labkey/api/view/DataView.java
@@ -256,7 +256,7 @@ public abstract class DataView extends WebPartView<RenderContext>
                     if (user.hasSiteAdminPermission() || user.isPlatformDeveloper())
                     {
                         out.write("&nbsp;");
-                        out.write(PageFlowUtil.textLink(StringUtils.defaultString(resolveText, "resolve"), resolveURL));
+                        out.write(PageFlowUtil.link(StringUtils.defaultString(resolveText, "resolve")).href(resolveURL).toString());
                     }
                 }
                 out.write("<br>");

--- a/api/src/org/labkey/api/view/JspTemplate.java
+++ b/api/src/org/labkey/api/view/JspTemplate.java
@@ -66,7 +66,7 @@ public class JspTemplate<ModelClass> extends JspView<ModelClass>
             assertEquals("This is a JSP used by the JspTemplate.TestCase", test);
 
             RReport r = new RReport();
-            assertTrue("".equals(r.getDefaultScript()));
+            assertEquals("", r.getDefaultScript());
             assertTrue(r.getDesignerHelpHtml().length() > 1000);
 
             JavaScriptReport js = new JavaScriptReport();

--- a/api/src/org/labkey/api/view/PopupMenu.java
+++ b/api/src/org/labkey/api/view/PopupMenu.java
@@ -139,7 +139,7 @@ public class PopupMenu extends DisplayElement
         if (_buttonStyle == ButtonStyle.TEXTBUTTON)
         {
             assert !requiresSelection : "Only button-style popups can require selection.";
-            out.append(PageFlowUtil.textLink(_navTree.getText(), "javascript:void(0)", onClickScript, "", attributes));
+            out.append(PageFlowUtil.link(_navTree.getText()).onClick(onClickScript).attributes(attributes).toString());
         }
         else if (_buttonStyle == ButtonStyle.MENUBUTTON)
         {

--- a/assay/api-src/org/labkey/api/assay/dilution/query/DilutionResultsQueryView.java
+++ b/assay/api-src/org/labkey/api/assay/dilution/query/DilutionResultsQueryView.java
@@ -146,7 +146,7 @@ public abstract class DilutionResultsQueryView extends ResultsQueryView
 
                     Map<String, String> title = new HashMap<>();
                     title.put("title", "View run details");
-                    out.write(PageFlowUtil.textLink("run details", url, "", "", title));
+                    out.write(PageFlowUtil.link("run details").href(url).attributes(title).toString());
                 }
             }
 

--- a/assay/api-src/org/labkey/api/assay/query/RunListDetailsQueryView.java
+++ b/assay/api-src/org/labkey/api/assay/query/RunListDetailsQueryView.java
@@ -69,7 +69,7 @@ public class RunListDetailsQueryView extends RunListQueryView
 
                     Map<String, String> map = new HashMap<>();
                     map.put("title", "View run details");
-                    out.write(PageFlowUtil.textLink("run details", url, null, null, map));
+                    out.write(PageFlowUtil.link("run details").href(url).attributes(map).toString());
                 }
             }
         });

--- a/assay/src/org/labkey/assay/plate/view/copyTemplate.jsp
+++ b/assay/src/org/labkey/assay/plate/view/copyTemplate.jsp
@@ -36,7 +36,7 @@
     <tr>
         <td>
             <br>
-            <labkey:form action="<%=h(buildURL(PlateController.HandleCopyAction.class))%>" method="POST">
+            <labkey:form action="<%=buildURL(PlateController.HandleCopyAction.class)%>" method="POST">
                 <input type="hidden" name="destination" value="<%= h(bean.getSelectedDestination()) %>">
                 <input type="hidden" name="templateName" value="<%= h(bean.getTemplateName()) %>">
                 <%= button("Cancel").href(PlateController.PlateTemplateListAction.class, getContainer()) %>

--- a/audit/src/org/labkey/audit/AuditLogImpl.java
+++ b/audit/src/org/labkey/audit/AuditLogImpl.java
@@ -75,6 +75,7 @@ public class AuditLogImpl implements AuditLogService, StartupListener
         return "Audit Log";
     }
 
+    @Override
     public void moduleStartupComplete(ServletContext servletContext)
     {
         synchronized (STARTUP_LOCK)
@@ -89,11 +90,13 @@ public class AuditLogImpl implements AuditLogService, StartupListener
         }
     }
 
+    @Override
     public boolean isViewable()
     {
         return true;
     }
 
+    @Override
     public <K extends AuditTypeEvent> K addEvent(User user, K type)
     {
         return _addEvent(user, type);
@@ -149,7 +152,7 @@ public class AuditLogImpl implements AuditLogService, StartupListener
                         LogManager.get()._insertEvent(user, event);
                     }
                     else
-                        _eventTypeQueue.add(new Pair<>(user, (AuditTypeEvent)event));
+                        _eventTypeQueue.add(new Pair<>(user, event));
                 }
             }
             else
@@ -166,17 +169,20 @@ public class AuditLogImpl implements AuditLogService, StartupListener
         return null;
     }
 
+    @Override
     public String getTableName()
     {
         return AuditQuerySchema.AUDIT_TABLE_NAME;
     }
 
+    @Override
     public TableInfo getTable(ViewContext context, String name)
     {
         UserSchema schema = createSchema(context.getUser(), context.getContainer());
         return schema.getTable(name);
     }
 
+    @Override
     public UserSchema createSchema(User user, Container container)
     {
         return new AuditQuerySchema(user, container);

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -26,9 +26,9 @@
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.core.admin.AdminController" %>
 <%@ page import="java.io.File" %>
-<%@ page import="static org.labkey.api.security.SecurityManager.SECONDS_PER_DAY" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Objects" %>
+<%@ page import="static org.labkey.api.security.SecurityManager.SECONDS_PER_DAY" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%=formatMissedErrors("form")%>
@@ -448,11 +448,8 @@ Click the Save button at any time to accept the current settings and continue.</
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
     <td class="labkey-form-label">
-        Always include inaccessible parent folders in project menu when child folder is accessible
-        <labkey:helpPopup title="Project menu access">
-            Unchecking this will only allow users to see folders in the project menu
-            where they have permissions to see the root project and all parent folders.
-        </labkey:helpPopup>
+        Always include inaccessible parent folders in project menu when child folder is accessible<%=helpPopup("Project menu access",
+            "Unchecking this will only allow users to see folders in the project menu where they have permissions to see the root project and all parent folders.")%>
     </td>
     <td><input type="checkbox" name="navAccessOpen" id="navAccessOpen" <%=checked(appProps.isNavigationAccessOpen())%>></td>
 </tr>

--- a/core/src/org/labkey/core/admin/sql/SqlScriptController.java
+++ b/core/src/org/labkey/core/admin/sql/SqlScriptController.java
@@ -522,7 +522,7 @@ public class SqlScriptController extends SpringActionController
             if (0 == html.length())
                 html.append("No schemas require consolidation in this range");
             else
-                html.append(PageFlowUtil.textLink("Create batch file from current settings", getConsolidateBatchActionURL(form), null, null, Collections.singletonMap("target", "batchFile")));
+                html.append(PageFlowUtil.link("Create batch file from current settings").href(getConsolidateBatchActionURL(form)).attributes(Collections.singletonMap("target", "batchFile")).toString());
 
             html.insert(0, formHtml);
 

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -2587,7 +2587,7 @@ public class LoginController extends SpringActionController
                 html.append("<td id=\"").append(id1).append("\">");
                 html.append(logo);
                 html.append("</td><td id=\"").append(id2).append("\" width=\"100%\">");
-                html.append(PageFlowUtil.textLink("delete", "javascript:{}", "deleteLogo('" + prefix + "');", "")); // RE_CHECK
+                html.append(PageFlowUtil.link("delete").onClick("deleteLogo('" + prefix + "');").toString()); // RE_CHECK
                 html.append("</td>\n");
 
                 return html.toString();

--- a/core/src/org/labkey/core/security/apiKey.jsp
+++ b/core/src/org/labkey/core/security/apiKey.jsp
@@ -71,13 +71,13 @@
             %>API keys are currently disabled on this site. <%
         }
 %>
-As a site administrator, you can configure API keys on the <%=PageFlowUtil.unstyledTextLink("Site Settings page", urlProvider(AdminUrls.class).getCustomizeSiteURL())%>.
+As a site administrator, you can configure API keys on the <%=link("Site Settings page", urlProvider(AdminUrls.class).getCustomizeSiteURL()).clearClasses()%>.
 
 <%
         if (apiKeys)
         {
 %>
-You can manage API keys generated on the server via <%=PageFlowUtil.unstyledTextLink("this query", urlProvider(QueryUrls.class).urlExecuteQuery(ContainerManager.getRoot(), "core", "APIKeys"))%>.
+You can manage API keys generated on the server via <%=link("this query", urlProvider(QueryUrls.class).urlExecuteQuery(ContainerManager.getRoot(), "core", "APIKeys")).clearClasses()%>.
 <%
         }
 %>

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -751,6 +751,7 @@ public class ExperimentController extends SpringActionController
     {
         protected ExpMaterialImpl _material;
 
+        @Override
         public VBox getView(ExpObjectForm form, BindException errors) throws Exception
         {
             Container c = getContainer();
@@ -792,6 +793,7 @@ public class ExperimentController extends SpringActionController
             return new VBox(new StandardAndCustomPropertiesView(detailsView, cpv));
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             setHelpTopic("sampleSets");
@@ -810,6 +812,7 @@ public class ExperimentController extends SpringActionController
     @RequiresPermission(ReadPermission.class)
     public class ShowMaterialAction extends ShowMaterialSimpleAction
     {
+        @Override
         public VBox getView(ExpObjectForm form, BindException errors) throws Exception
         {
             VBox vbox = super.getView(form, errors);
@@ -849,7 +852,7 @@ public class ExperimentController extends SpringActionController
                     // container context on the generated expr.
                     ((DetailsURL) expr).setContainerContext(ss.getContainer());
                     String url = expr.eval(Collections.singletonMap(new FieldKey(null, "RowId"), _material.getRowId()));
-                    updateLinks.append(PageFlowUtil.textLink("edit", url) + " ");
+                    updateLinks.append(PageFlowUtil.link("edit").href(url)).append(" ");
                 }
             }
 
@@ -860,7 +863,7 @@ public class ExperimentController extends SpringActionController
                 if (ss != null)
                     deriveURL.addParameter("targetSampleSetId", ss.getRowId());
 
-                updateLinks.append(PageFlowUtil.textLink("derive samples from this sample", deriveURL) + " ");
+                updateLinks.append(PageFlowUtil.link("derive samples from this sample").href(deriveURL)).append(" ");
             }
 
             vbox.addView(new HtmlView(updateLinks.toString()));
@@ -878,7 +881,6 @@ public class ExperimentController extends SpringActionController
 
             return vbox;
         }
-
     }
 
 

--- a/experiment/src/org/labkey/experiment/types/types.jsp
+++ b/experiment/src/org/labkey/experiment/types/types.jsp
@@ -38,7 +38,7 @@
 <table>
     <% for (Domain type : bean.locals.values()) { %>
 <tr>
-    <td><%=PageFlowUtil.unstyledTextLink(type.getName(), new ActionURL(TypesController.TypeDetailsAction.class, getContainer()).addParameter("type", type.getTypeURI()))%></td>
+    <td><%=link(type.getName(), new ActionURL(TypesController.TypeDetailsAction.class, getContainer()).addParameter("type", type.getTypeURI())).clearClasses()%></td>
     <%
         DomainKind kind = type.getDomainKind();
         if (kind != null)
@@ -60,7 +60,7 @@
 <table>
     <% for (Domain type : bean.project.values()) { %>
     <tr>
-        <td><%=PageFlowUtil.unstyledTextLink(type.getName(), new ActionURL(TypesController.TypeDetailsAction.class, type.getContainer()).addParameter("type", type.getTypeURI()))%></td>
+        <td><%=link(type.getName(), new ActionURL(TypesController.TypeDetailsAction.class, type.getContainer()).addParameter("type", type.getTypeURI())).clearClasses()%></td>
         <%
             DomainKind kind = type.getDomainKind();
             if (kind != null)
@@ -82,7 +82,7 @@
 <table>
     <% for (Domain type : bean.globals.values()) { %>
     <tr>
-        <td><%=PageFlowUtil.unstyledTextLink(type.getName(), new ActionURL(TypesController.TypeDetailsAction.class, type.getContainer()).addParameter("type", type.getTypeURI()))%></td>
+        <td><%=link(type.getName(), new ActionURL(TypesController.TypeDetailsAction.class, type.getContainer()).addParameter("type", type.getTypeURI())).clearClasses()%></td>
         <%
             DomainKind kind = type.getDomainKind();
             if (kind != null)

--- a/internal/src/org/labkey/api/view/LinkBarView.java
+++ b/internal/src/org/labkey/api/view/LinkBarView.java
@@ -48,7 +48,7 @@ public class LinkBarView extends WebPartView
         out.write("<table width=\"100%\" cellpadding=0><tr><td>");
         for (Pair<String, String> link : _links)
         {
-            out.write(PageFlowUtil.textLink(link.first, link.second) + "&nbsp;");
+            out.write(PageFlowUtil.link(link.first).href(link.second) + "&nbsp;");
         }
         out.write("</td></tr>");
         if (_drawLine)

--- a/issues/src/org/labkey/issue/view/issueListWebPartConfig.jsp
+++ b/issues/src/org/labkey/issue/view/issueListWebPartConfig.jsp
@@ -44,7 +44,7 @@
         titleLabel = "Optional title for the Issues Summary web part.";
     }
 %>
-<labkey:form method="post" action="<%=h(webPart.getCustomizePostURL(context))%>">
+<labkey:form method="post" action="<%=webPart.getCustomizePostURL(context)%>">
     <table class="lk-fields-table">
         <tr>
             <td class="labkey-form-label">Issue List Definition:</td>

--- a/mothership/src/org/labkey/mothership/view/createIssue.jsp
+++ b/mothership/src/org/labkey/mothership/view/createIssue.jsp
@@ -20,7 +20,7 @@
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <% Map<String, String> ctx = (Map)getModelBean(); %>
 
-<labkey:form method="POST" id="CreateIssue" action='<%=h(ctx.get("action"))%>'>
+<labkey:form method="POST" id="CreateIssue" action='<%=ctx.get("action")%>'>
     <input type="hidden" name="callbackURL" value="<%=h(ctx.get("callbackURL"))%>"/>
     <input type="hidden" name="body" value="<%=h(ctx.get("body"))%>"/>
     <input type="hidden" name="title" value="<%=h(ctx.get("title"))%>"/>

--- a/pipeline/src/org/labkey/pipeline/mule/EPipelineContextListener.java
+++ b/pipeline/src/org/labkey/pipeline/mule/EPipelineContextListener.java
@@ -36,6 +36,7 @@ public class EPipelineContextListener implements StartupListener, ShutdownListen
         return "EPipeline";
     }
 
+    @Override
     public void moduleStartupComplete(ServletContext servletContext)
     {
         // The Enterprise Pipeline is currently the only thing that uses Mule,
@@ -47,10 +48,12 @@ public class EPipelineContextListener implements StartupListener, ShutdownListen
         }
     }
 
+    @Override
     public void shutdownPre()
     {
     }
 
+    @Override
     public void shutdownStarted()
     {
         if (_muleListenerHelper != null)

--- a/pipeline/src/org/labkey/pipeline/status/enterprisePipelineAdmin.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/enterprisePipelineAdmin.jsp
@@ -30,8 +30,8 @@
 <p>You are running the Enterprise Pipeline.</p>
 <p>
     <labkey:button text="Force Status Refresh" href="<%= new ActionURL(StatusController.ForceRefreshAction.class, ContainerManager.getRoot()) %>" />
-    <labkey:helpPopup title="Force Status Refresh">Under normal operations, this should not be required, but if there were network problems
-    that prevented a callback with status information, this can update a job.</labkey:helpPopup>
+    <%=helpPopup("Force Status Refresh",
+        "Under normal operations, this should not be required, but if there were network problems that prevented a callback with status information, this can update a job.")%>
 </p>
 Your configuration references the following execution locations:
 <ul>

--- a/search/src/org/labkey/search/umls/concept.jsp
+++ b/search/src/org/labkey/search/umls/concept.jsp
@@ -78,7 +78,7 @@ String CUI = StringUtils.trimToNull(form.getCUI());
 
 Set<String> preferredSAB = PageFlowUtil.set("SNOMEDCT","LCN","MSH","NCI");
 %>
-<labkey:form action="<%=h(buildURL(UmlsController.ConceptAction.class))%>" method="GET"><input name=CUI value="<%=h(CUI)%>"><input type="submit" value="FIND"></labkey:form>
+<labkey:form action="<%=buildURL(UmlsController.ConceptAction.class)%>" method="GET"><input name=CUI value="<%=h(CUI)%>"><input type="submit" value="FIND"></labkey:form>
 <%
 if (null != CUI)
 {

--- a/search/src/org/labkey/search/view/indexerAdmin.jsp
+++ b/search/src/org/labkey/search/view/indexerAdmin.jsp
@@ -43,7 +43,7 @@ if (null == ss)
 }
 else
 {
-    %><p><labkey:form method="POST" action="<%=h(buildURL(SearchController.AdminAction.class))%>">
+    %><p><labkey:form method="POST" action="<%=buildURL(SearchController.AdminAction.class)%>">
         <table>
             <tr>
                 <td>Path to full-text search index:&nbsp;</td>
@@ -76,7 +76,7 @@ else
 </table>
 </p>
 
-    <p><labkey:form method="POST" action="<%=h(buildURL(SearchController.AdminAction.class))%>">
+    <p><labkey:form method="POST" action="<%=buildURL(SearchController.AdminAction.class)%>">
         <table><%
 
     if (ss.isRunning())
@@ -107,7 +107,7 @@ else
     if (hasAdminOpsPerms)
     {
     %>
-    <p><labkey:form method="POST" action="<%=h(buildURL(SearchController.AdminAction.class))%>">
+    <p><labkey:form method="POST" action="<%=buildURL(SearchController.AdminAction.class)%>">
         <table>
             <tr><td>Deleting the search index isn't usually necessary; it causes re-indexing of all data.</td></tr>
             <tr><td><input type="hidden" name="delete" value="1"></td></tr>
@@ -117,7 +117,7 @@ else
     <%
     }
     %>
-    <p><labkey:form method="POST" action="<%=h(buildURL(SearchController.AdminAction.class))%>">
+    <p><labkey:form method="POST" action="<%=buildURL(SearchController.AdminAction.class)%>">
         <table>
             <tr><td width="800">You can change the search indexing directory type below, but this is generally not recommended. Contact
                 LabKey for assistance if full-text indexing or searching seems to have difficulty with the default setting.<br><br></td></tr>
@@ -141,7 +141,7 @@ else
             %>
         </table>
     </labkey:form></p>
-    <p><labkey:form method="POST" action="<%=h(buildURL(SearchController.AdminAction.class))%>">
+    <p><labkey:form method="POST" action="<%=buildURL(SearchController.AdminAction.class)%>">
         <table>
             <tr><td width="800">You can change the maximum file size limit below, but this is generally not recommended and will result in additional system memory usage. We further limit <b>xlsx</b> files at 1/5 the normal max, as they are compressed at rest.<br><br></td></tr>
             <tr><td>Indexed file size limit: <input type="number" name="fileLimitMB" value="<%=h(SearchPropertyManager.getFileSizeLimitMB())%>" /> MB</td></tr><%

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -2676,7 +2676,7 @@ public class StudyController extends BaseStudyController
                 @Override
                 public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
                 {
-                    out.write(PageFlowUtil.textLink("Download Data File", "downloadTsv.view?id=" + ctx.get("RowId")));
+                    out.write(PageFlowUtil.link("Download Data File").href("downloadTsv.view?id=" + ctx.get("RowId")).toString());
                 }
             };
             dr.addDisplayColumn(dc);
@@ -3602,7 +3602,7 @@ public class StudyController extends BaseStudyController
             if ("POST".equalsIgnoreCase(getViewContext().getRequest().getMethod()))
                 lsids = DataRegionSelection.getSelected(getViewContext(), updateQCForm.getDataRegionSelectionKey(), true, false);
             if (lsids == null || lsids.isEmpty())
-                return new HtmlView("No data rows selected.  " + PageFlowUtil.textLink("back", "javascript:back()"));
+                return new HtmlView("No data rows selected.  " + PageFlowUtil.link("back").href("javascript:back()"));
 
             StudyQuerySchema querySchema = StudyQuerySchema.createSchema(study, getUser(), true);
             DatasetQuerySettings qs = new DatasetQuerySettings(getViewContext().getBindPropertyValues(), DatasetQueryView.DATAREGION);

--- a/study/src/org/labkey/study/controllers/specimen/SpecimenController.java
+++ b/study/src/org/labkey/study/controllers/specimen/SpecimenController.java
@@ -3698,7 +3698,7 @@ public class SpecimenController extends BaseStudyController
                     }
                 }
                 if (selectedVials == null || selectedVials.size() == 0)
-                    return new HtmlView("No vials selected.  " + PageFlowUtil.textLink("back", "javascript:back()"));
+                    return new HtmlView("No vials selected.  " + PageFlowUtil.link("back").href("javascript:back()"));
             }
 
             return new JspView<>("/org/labkey/study/view/specimen/updateComments.jsp",

--- a/study/src/org/labkey/study/designer/view/StudyDesignsWebPart.java
+++ b/study/src/org/labkey/study/designer/view/StudyDesignsWebPart.java
@@ -74,7 +74,7 @@ public class StudyDesignsWebPart extends GridView
                 {
                     Map<String, String> style = new HashMap<>();
                     style.put("style", "white-space:nowrap");
-                    out.write(PageFlowUtil.textLink("Go To Study Folder", renderURL(ctx), "", "", style));
+                    out.write(PageFlowUtil.link("Go To Study Folder").href(renderURL(ctx)).attributes(style).toString());
                 }
                 else
                 {

--- a/study/src/org/labkey/study/query/SpecimenQueryView.java
+++ b/study/src/org/labkey/study/query/SpecimenQueryView.java
@@ -164,7 +164,7 @@ public class SpecimenQueryView extends BaseStudyQueryView
 
                 out.write(PageFlowUtil.helpPopup("Specimen Unavailable",
                         (reason instanceof String ? reason : "Specimen Unavailable.") + "<br><br>" +
-                                "Click " + PageFlowUtil.textLink("history", getHistoryLink(ctx)) + " for more information.", true));
+                                "Click " + PageFlowUtil.link("history").href(getHistoryLink(ctx)) + " for more information.", true));
             }
         }
 

--- a/wiki/src/org/labkey/wiki/WikiTOC.java
+++ b/wiki/src/org/labkey/wiki/WikiTOC.java
@@ -286,8 +286,8 @@ public class WikiTOC extends NavTreeMenu
             if (showExpandOption)
             {
                 out.println("</td></tr><tr><td>&nbsp;</td></tr><tr><td>");
-                out.println(PageFlowUtil.textLink("expand all", "javascript:void(0);", "LABKEY.wiki.internal.Wiki.adjustAllTocEntries('NavTree-" + getId() + "', true, true)", ""));
-                out.println(PageFlowUtil.textLink("collapse all", "javascript:void(0);", "LABKEY.wiki.internal.Wiki.adjustAllTocEntries('NavTree-" + getId() + "', true, false)", ""));
+                out.println(PageFlowUtil.link("expand all").onClick("LABKEY.wiki.internal.Wiki.adjustAllTocEntries('NavTree-" + getId() + "', true, true)"));
+                out.println(PageFlowUtil.link("collapse all").onClick("LABKEY.wiki.internal.Wiki.adjustAllTocEntries('NavTree-" + getId() + "', true, false)"));
             }
 
             out.println("</td>\n</tr>\n</table>");

--- a/wiki/src/org/labkey/wiki/renderer/ClientDependencySubstitutionHandler.java
+++ b/wiki/src/org/labkey/wiki/renderer/ClientDependencySubstitutionHandler.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 public class ClientDependencySubstitutionHandler implements HtmlRenderer.SubstitutionHandler
 {
+    @Override
     @NotNull
     public FormattedHtml getSubstitution(Map<String, String> params)
     {

--- a/wiki/src/org/labkey/wiki/renderer/WebPartSubstitutionHandler.java
+++ b/wiki/src/org/labkey/wiki/renderer/WebPartSubstitutionHandler.java
@@ -46,6 +46,7 @@ public class WebPartSubstitutionHandler implements HtmlRenderer.SubstitutionHand
     private static final ThreadLocal<Stack<Map>> _paramsStack = ThreadLocal.withInitial(Stack::new);
 
 
+    @Override
     @NotNull
     public FormattedHtml getSubstitution(Map<String, String> params)
     {


### PR DESCRIPTION
…rect use of LinkBuilder. Mark most PageFlowUtil.textLink() methods for removal in 20.1. Add PageFlowUtil.iconLink() helper to provide a LinkBuilder pre-populated with key icon link properties.

Correctly handle pre-encoded action parameter in FormTag. Red squiggle confusion and the acceptance of Object has led to a mix of action parameter types: unencoded strings, encoded strings, and ActionURLs. By adding a setAction(HtmlString) variant and adjusting the internal logic, we can detect and handle all cases. This also highlights the encoded usages to allow future migration toward unencoded (our convention for tag properties).

Mark now unused RedirectAction for removal in 20.1

Add JspBase.unsafe(CharSequence) for convenience (e.g., HTML built using a StringBuilder)