### PR TITLE
When adding assay modules, also include dependencies

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -27,6 +27,8 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.admin.ImportContext;
+import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.assay.AssayService;
 import org.labkey.api.collections.Sets;
 import org.labkey.api.data.PropertyManager.PropertyMap;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -54,8 +56,6 @@ import org.labkey.api.security.roles.Role;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.study.StudyService;
-import org.labkey.api.assay.AssayProvider;
-import org.labkey.api.assay.AssayService;
 import org.labkey.api.util.ContainerContext;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.FileUtil;
@@ -1206,7 +1206,13 @@ public class Container implements Serializable, Comparable<Container>, Securable
                     AssayProvider ap = AssayService.get().getProvider(p);
                     if (ap != null && !ap.getRequiredModules().isEmpty())
                     {
-                        withDependencies.addAll(ap.getRequiredModules());
+                        Set<Module> toAdd = new HashSet<>();
+                        for (Module m : ap.getRequiredModules())
+                        {
+                            toAdd.add(m);
+                            toAdd.addAll(m.getResolvedModuleDependencies());
+                        }
+                        withDependencies.addAll(toAdd);
                     }
                 }
             }


### PR DESCRIPTION
In Container.getActiveModules(), it attempts to look at available assays and automatically add the modules they declare as active. That's great, but if the assay declares a dependency on module1, and this module depends on module2, that's not added. If we only turn on Module1 but not module2, we can get errors. One could argue that's the developer's mistake; however, it seems like we could do a check here and avoid it. there's no way for the user to go to the UI and turn on module1 w/o module2 automatically being added, so I'd argue we ought to do the same thing here.