### PR TITLE
Allow sort of search results by container

### DIFF
--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -302,6 +302,8 @@ public interface SearchService
 
     SearchResult search(String queryString, @Nullable List<SearchCategory> categories, User user, Container current, SearchScope scope, @Nullable String sortField, int offset, int limit) throws IOException;
 
+    SearchResult search(String queryString, @Nullable List<SearchCategory> categories, User user, Container current, SearchScope scope, @Nullable String sortField, int offset, int limit, boolean invertResults) throws IOException;
+
     @Nullable SearchHit find(String docId) throws IOException;
 
     String escapeTerm(String term);

--- a/core/src/org/labkey/core/search/NoopSearchService.java
+++ b/core/src/org/labkey/core/search/NoopSearchService.java
@@ -243,6 +243,12 @@ public class NoopSearchService implements SearchService
     }
 
     @Override
+    public SearchResult search(String queryString, @Nullable List<SearchCategory> categories, User user, Container current, SearchScope scope, @Nullable String sortField, int offset, int limit, boolean invertResults)
+    {
+        return null;
+    }
+
+    @Override
     public SearchResult search(String queryString, @Nullable List<SearchCategory> categories, User user, Container current, SearchScope scope, @Nullable String sortField, int offset, int limit)
     {
         return null;

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -598,7 +598,7 @@ public class SearchController extends SpringActionController
                     //UNDONE: paging, rowlimit etc
                     int limit = form.getLimit() < 0 ? 1000 : form.getLimit();
                     result = ss.search(query, ss.getCategories(form.getCategory()), getUser(), getContainer(), form.getSearchScope(),
-                        form.getSortField(), form.getOffset(), limit);
+                        form.getSortField(), form.getOffset(), limit, form.isInvertSort());
                 }
                 catch (Exception x)
                 {
@@ -701,7 +701,7 @@ public class SearchController extends SpringActionController
     {
         ActionURL getPostURL(Container c);    // Search does not actually post
         String getDescription(Container c);
-        SearchResult getSearchResult(String queryString, @Nullable String category, User user, Container currentContainer, SearchScope scope, @Nullable String sortField, int offset, int limit) throws IOException;
+        SearchResult getSearchResult(String queryString, @Nullable String category, User user, Container currentContainer, SearchScope scope, @Nullable String sortField, int offset, int limit, boolean invertSort) throws IOException;
         boolean includeAdvancedUI();
         boolean includeNavigationLinks();
     }
@@ -728,9 +728,9 @@ public class SearchController extends SpringActionController
         }
 
         @Override
-        public SearchResult getSearchResult(String queryString, @Nullable String category, User user, Container currentContainer, SearchScope scope, String sortField, int offset, int limit) throws IOException
+        public SearchResult getSearchResult(String queryString, @Nullable String category, User user, Container currentContainer, SearchScope scope, String sortField, int offset, int limit, boolean invertSort) throws IOException
         {
-            return _ss.search(queryString, _ss.getCategories(category), user, currentContainer, scope, sortField, offset, limit);
+            return _ss.search(queryString, _ss.getCategories(category), user, currentContainer, scope, sortField, offset, limit, invertSort);
         }
 
         @Override
@@ -860,6 +860,7 @@ public class SearchController extends SpringActionController
         private boolean _includeHelpLink = true;
         private boolean _webpart = false;
         private boolean _showAdvanced = false;
+        private boolean _invertSort = false;
         private SearchConfiguration _config = new InternalSearchConfiguration();    // Assume internal search (for webparts, etc.)
         private String _template = null;
         private SearchScope _scope = SearchScope.All;
@@ -1014,6 +1015,16 @@ public class SearchController extends SpringActionController
         public void setShowAdvanced(boolean showAdvanced)
         {
             _showAdvanced = showAdvanced;
+        }
+
+        public boolean isInvertSort()
+        {
+            return _invertSort;
+        }
+
+        public void setInvertSort(boolean invertSort)
+        {
+            _invertSort = invertSort;
         }
 
         public String getTemplate()

--- a/search/src/org/labkey/search/SearchModule.java
+++ b/search/src/org/labkey/search/SearchModule.java
@@ -66,7 +66,7 @@ public class SearchModule extends DefaultModule
     @Override
     public double getVersion()
     {
-        return 19.20;
+        return 19.21;
     }
 
     @Override

--- a/search/src/org/labkey/search/view/search.jsp
+++ b/search/src/org/labkey/search/view/search.jsp
@@ -225,6 +225,7 @@
     String safeCategories = categories == null ? "" : categories.toLowerCase();
     String queryString = form.getQueryString();
     String sortField = form.getSortField();
+    boolean invertSort = form.isInvertSort();
 
     SearchConfiguration searchConfig = form.getConfig();
     boolean includeNavigationResults = !form.isWebPart() && searchConfig.includeNavigationLinks() && template.includeNavigationLinks() && scope != SearchScope.Folder;
@@ -248,11 +249,11 @@
     {
         try
         {
-            result = searchConfig.getSearchResult(template.reviseQuery(ctx, queryString), categories, user, c, scope, sortField, offset, hitsPerPage);
+            result = searchConfig.getSearchResult(template.reviseQuery(ctx, queryString), categories, user, c, scope, sortField, offset, hitsPerPage, invertSort);
 
             if (includeNavigationResults)
             {
-                navResult = SearchService.get().search(queryString, Arrays.asList(SearchService.navigationCategory), user, c, scope, sortField, offset, hitsPerPage);
+                navResult = SearchService.get().search(queryString, Arrays.asList(SearchService.navigationCategory), user, c, scope, sortField, offset, hitsPerPage, invertSort);
                 hasNavResults = navResult != null && navResult.hits.size() > 0;
             }
         }
@@ -285,6 +286,7 @@
             <% if (showAdvancedUI) { %>
             <labkey:input type="hidden" name="category" value="<%=h(categories)%>"/>
             <labkey:input type="hidden" name="sortField" value="<%=h(form.getSortField())%>"/>
+            <labkey:input type="hidden" name="invertSort" value="<%=h(form.isInvertSort())%>"/>
             <labkey:input type="hidden" name="showAdvanced" value="<%=h(form.isShowAdvanced())%>"/>
             <% } %>
             <% if (null == template.getSearchScope()) { %>
@@ -393,7 +395,7 @@
                 <div class="form-group">
                     <div class="col-sm-4">
                         <h5>Sort
-                            <%= helpPopup("Sort", "Sort the results by the relevance, created, or modified date")%>
+                            <%= helpPopup("Sort", "Sort the results by the relevance, created/modified date, or folder path")%>
                         </h5>
                         <div style="padding-top: 1px;">
                             <div class="radio">
@@ -409,6 +411,16 @@
                             <div class="radio">
                                 <label>
                                     <input type="radio" name="sortField" value="<%=text("modified")%>" <%=checked("modified".equals(sortField))%>> Modified
+                                </label>
+                            </div>
+                            <div class="radio">
+                                <label>
+                                    <input type="radio" name="sortField" value="<%=text("container")%>" <%=checked("container".equals(sortField))%>> Folder Path
+                                </label>
+                            </div>
+                            <div class="checkbox">
+                                <label>
+                                    <input type="checkbox" name="invertSort" value="true" <%=checked(invertSort)%>> Reverse Sort Results
                                 </label>
                             </div>
                         </div>
@@ -603,6 +615,7 @@
 
             advForm.change(function() {
                 var category = '', sep = '';
+                var doInvert = false;
                 advForm.serializeArray().forEach(function(p) {
                     if (p.name.toLowerCase() === 'scope') {
                         form.find('input[name="scope"]').val(p.value);
@@ -610,11 +623,16 @@
                     else if (p.name.toLowerCase() === "sortfield") {
                         form.find('input[name="sortField"]').val(p.value);
                     }
-                    else {
+                    else if (p.name.toLowerCase() === "invertsort" && p.value === "true") {
+                        doInvert = true;
+                    }
+                    else if (p.name.toLowerCase() === "category") {
                         category += sep + p.value;
                         sep = '+';
                     }
                 });
+
+                form.find('input[name="invertSort"]').val(doInvert);
                 form.find('input[name="category"]').val(category);
             });
 
@@ -625,6 +643,9 @@
                     }
                     else if (e.name === 'showAdvanced' && e.value.toLowerCase() === 'false') {
                         e.value = '';
+                    }
+                    else if (e.name === 'invertSort' && e.value.toLowerCase() === 'false') {
+                            e.value = '';
                     }
                     else if (e.name === 'sortField' && e.value.toLocaleLowerCase() === 'score') {
                         e.value = '';

--- a/study/test/src/org/labkey/test/tests/search/SearchTest.java
+++ b/study/test/src/org/labkey/test/tests/search/SearchTest.java
@@ -52,6 +52,8 @@ public abstract class SearchTest extends StudyBaseTest
     private static final String FOLDER_A = "Folder Apple";
     private static final String FOLDER_B = "Folder Banana"; // Folder move destination
     private static final String FOLDER_C = "Folder Cherry"; // Folder rename name.
+    private static final String FOLDER_D = "Subfolder Date";
+    private static final String FOLDER_E = "Subfolder Eggfruit";
     private static final String GROUP_NAME = "Test Group";
     private static final String USER1 = "user1_searchtest@search.test";
 
@@ -158,9 +160,73 @@ public abstract class SearchTest extends StudyBaseTest
     protected void doVerifySteps()
     {
         _searchHelper.verifySearchResults("/" + getProjectName() + "/" + getFolderName(), false);
+        testAdvancedSearchUI();
         renameFolderAndReSearch();
         moveFolderAlterListsAndReSearch();
         deleteFolderAndVerifyNoResults();
+    }
+
+    private void testAdvancedSearchUI()
+    {
+        final String searchTerm = "Sample";
+
+        goToProjectHome();
+        _searchHelper.searchFor(searchTerm, false);  //already waited above
+
+        expandAdvancedOptions();
+
+        waitAndClick(Locator.radioButtonByNameAndValue("scope", "Project"));
+        _searchHelper.searchFor(searchTerm);
+        waitForElement(Locator.tagWithText("div", "Found 5 results"));
+
+        waitAndClick(Locator.radioButtonByNameAndValue("scope", "Folder"));
+        _searchHelper.searchFor(searchTerm);
+        waitForElement(Locator.tagWithText("div", "Found 0 results"));
+
+        waitAndClick(Locator.radioButtonByNameAndValue("scope", "FolderAndSubfolders"));
+        _searchHelper.searchFor(searchTerm);
+        waitForElement(Locator.tagWithText("div", "Found 5 results"));
+
+        //Now create subfolders:
+        goToProjectHome();
+        _containerHelper.createSubfolder(getProjectName(), FOLDER_D);
+        _containerHelper.createSubfolder(getProjectName(), FOLDER_E);
+        goToProjectHome();
+        final String searchTerm2 = "Subfolder";
+        _searchHelper.searchFor(searchTerm2, true);
+
+        expandAdvancedOptions();
+
+        waitAndClick(Locator.radioButtonByNameAndValue("scope", "Project"));
+        _searchHelper.searchFor(searchTerm2);
+        waitForElement(Locator.tagWithText("div", "Found 2 results"));
+
+        waitAndClick(Locator.radioButtonByNameAndValue("scope", "Folder"));
+        _searchHelper.searchFor(searchTerm2);
+        waitForElement(Locator.tagWithText("div", "Found 0 results"));
+
+        waitAndClick(Locator.radioButtonByNameAndValue("scope", "FolderAndSubfolders"));
+        _searchHelper.searchFor(searchTerm2);
+        waitForElement(Locator.tagWithText("div", "Found 2 results"));
+
+        //test folder sort:
+        waitAndClick(Locator.radioButtonByNameAndValue("sortField", "container"));
+        _searchHelper.searchFor(searchTerm2);
+
+        assertTextBefore("Folder -- " + FOLDER_D, "Folder -- " + FOLDER_E);
+
+        waitAndClick(Locator.checkboxByName("invertSort"));
+        _searchHelper.searchFor(searchTerm2);
+        assertTextBefore("Folder -- " + FOLDER_E, "Folder -- " + FOLDER_D);
+
+        _containerHelper.deleteFolder(getProjectName(), FOLDER_D);
+        _containerHelper.deleteFolder(getProjectName(), FOLDER_E);
+    }
+
+    private void expandAdvancedOptions()
+    {
+        waitAndClick(Locator.tagWithText("a", "advanced options"));
+        waitForElement(Locator.tag("input").withAttribute("name", "invertSort").notHidden());
     }
 
     private void renameFolderAndReSearch()


### PR DESCRIPTION
This allows sorting of search results by container, and allows search order to be inverted.  It also adds a test for this and expands coverage on the existing search UI