### PR TITLE
Don't remove selection when changing DataRegion filters

### DIFF
--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -561,7 +561,6 @@ if (!LABKEY.DataRegions) {
      * @see LABKEY.DataRegion.addFilter static method.
      */
     LABKEY.DataRegion.prototype.addFilter = function(filter) {
-        this.clearSelected();
         _updateFilter(this, filter);
     };
 
@@ -569,7 +568,6 @@ if (!LABKEY.DataRegions) {
      * Removes all filters from the DataRegion
      */
     LABKEY.DataRegion.prototype.clearAllFilters = function() {
-        this.clearSelected();
         if (this.async) {
             this.offset = 0;
             this.userFilters = {};
@@ -583,7 +581,6 @@ if (!LABKEY.DataRegions) {
      * @param {string|FieldKey} fieldKey the name of the field from which all filters should be removed
      */
     LABKEY.DataRegion.prototype.clearFilter = function(fieldKey) {
-        this.clearSelected();
         var fk = _resolveFieldKey(this, fieldKey);
 
         if (fk) {
@@ -707,7 +704,6 @@ if (!LABKEY.DataRegions) {
      * @param {LABKEY.Filter} filter
      */
     LABKEY.DataRegion.prototype.removeFilter = function(filter) {
-        this.clearSelected();
         if (LABKEY.Utils.isObject(filter) && LABKEY.Utils.isFunction(filter.getColumnName)) {
             _updateFilter(this, null, [this.name + '.' + filter.getColumnName() + '~']);
         }

--- a/api/webapp/clientapi/ext3/FilterDialog.js
+++ b/api/webapp/clientapi/ext3/FilterDialog.js
@@ -188,7 +188,6 @@ LABKEY.FilterDialog = Ext.extend(Ext.Window, {
                     }
                     else
                         dr.replaceFilter(filters[0]);
-                    dr.clearSelected();
                 }
                 else {
                     this.clearFilter();


### PR DESCRIPTION
This new behavior is causing numerous test failures. I'd like to revert it temporarily to make the tests happy while we work out a solution.