### PR TITLE
Migrate more attributes() usages to new simple setters

### DIFF
--- a/api/src/org/labkey/api/jsp/taglib/ButtonTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/ButtonTag.java
@@ -18,35 +18,29 @@ package org.labkey.api.jsp.taglib;
 
 import org.labkey.api.util.Button;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 public class ButtonTag extends SimpleTagBase
 {
-    Boolean _disableOnClick;
-    String _text;
-    String _href;
-    String _alt;
-    String _onclick;
-    String _action;
-    String _name;
-    String _value;
-    String _id;
-    String _target;
-    Boolean _submit = true;
+    private String _text;
+    private String _href;
+    private String _onclick;
+    private String _action;
+    private String _name;
+    private String _id;
+    private Boolean _submit = true;
 
     @Override
     public void doTag() throws IOException
     {
-        Map<String, String> attributes = new HashMap<>();
         Button.ButtonBuilder button = PageFlowUtil.button(_text).id(_id);
 
         // TODO: This shouldn't have inconsistent logic from Button.java, should just be a pass through
         if (_href != null)
-            button.href(_href).onClick(_onclick).target(_target);
+            button.href(_href).onClick(_onclick);
         else
         {
             if (_onclick != null && _action != null)
@@ -57,27 +51,22 @@ public class ButtonTag extends SimpleTagBase
                 onClickScript = _onclick;
             if (_action != null)
                 onClickScript = ("this.form.action='" + _action + "';this.form.method='POST';");
-            if (_value != null)
-                attributes.put("value", _value);
 
-            button.submit(_submit).onClick(onClickScript).name(_name).attributes(attributes);
+            button.submit(_submit).onClick(onClickScript).name(_name);
         }
-
-        if (null != _disableOnClick)
-            button.disableOnClick(_disableOnClick);
 
         // TODO: HtmlString
         getOut().print(button.toString());
     }
 
-    public void setDisableOnClick(Boolean disableOnClick)
+    public void setHref(String href)
     {
-        _disableOnClick = disableOnClick;
+        _href = href;
     }
 
-    public void setHref(Object value)
+    public void setHref(URLHelper url)
     {
-        _href = value == null ? null : value.toString();
+        _href = url.toString();
     }
 
     public void setText(String text)
@@ -90,19 +79,9 @@ public class ButtonTag extends SimpleTagBase
         _onclick = onclick;
     }
 
-    public void setAction(String action)
-    {
-        _action = action;
-    }
-
     public void setAction(ActionURL action)
     {
         _action = action.toString();
-    }
-
-    public void setAction(Enum action)
-    {
-        _action = action.toString() + ".view";
     }
 
     public void setName(String name)
@@ -110,24 +89,9 @@ public class ButtonTag extends SimpleTagBase
         _name = name;
     }
 
-    public void setValue(String value)
-    {
-        _value = value;
-    }
-
     public void setId(String id)
     {
         _id = id;
-    }
-
-    public void setAlt(String alt)
-    {
-        _alt = alt;
-    }
-
-    public void setTarget(String target)
-    {
-        _target = target;
     }
 
     public void setSubmit(Boolean submit)

--- a/api/src/org/labkey/api/jsp/taglib/LinkTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/LinkTag.java
@@ -21,25 +21,15 @@ import org.labkey.api.util.URLHelper;
 
 import javax.servlet.jsp.JspWriter;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 public class LinkTag extends SimpleTagBase
 {
-    String _href;
-    String _text;
-    String _id;
-    String _onclick;
-    String _rel;
-
-    public void setHref(String href)
-    {
-        _href = href;
-    }
+    private URLHelper _href;
+    private String _text;
 
     public void setHref(URLHelper url)
     {
-        _href = url.toString();
+        _href = url;
     }
 
     public void setText(String text)
@@ -47,29 +37,10 @@ public class LinkTag extends SimpleTagBase
         _text = text;
     }
 
-    public void setId(String id)
-    {
-        _id = id;
-    }
-
-    public void setOnclick(String onclick)
-    {
-        _onclick = onclick;
-    }
-
-    public void setRel(String rel)
-    {
-        _rel = rel;
-    }
-
     @Override
     public void doTag() throws IOException
     {
-        Map<String, String> properties = new HashMap<>();
-        if (_rel != null)
-            properties.put("rel", _rel);
-
         JspWriter out = getOut();
-        out.print(PageFlowUtil.link(_text).href(_href).onClick(_onclick).id(_id).attributes(properties));
+        out.print(PageFlowUtil.link(_text).href(_href));
     }
 }

--- a/assay/src/org/labkey/assay/view/updateQCState.jsp
+++ b/assay/src/org/labkey/assay/view/updateQCState.jsp
@@ -146,5 +146,5 @@
     %>
     <labkey:input type="hidden" name="returnUrl" value="<%=h(form.getReturnUrl())%>"/>
     <labkey:button text="update" submit="false" onclick="saveState();"/>
-    <labkey:button text="cancel" href="<%=h(form.getReturnUrl())%>" onclick="LABKEY.setSubmit(true);"/>
+    <labkey:button text="cancel" href="<%=form.getReturnUrl()%>" onclick="LABKEY.setSubmit(true);"/>
 </labkey:form>

--- a/query/src/org/labkey/query/view/internalNewView.jsp
+++ b/query/src/org/labkey/query/view/internalNewView.jsp
@@ -34,5 +34,5 @@
     <p>View Name:<br><input type="text" name="ff_viewName" value="<%=h(form.ff_viewName)%>"></p>
     <p><input type="checkbox" name="ff_share" value="true"<%=checked(form.ff_share)%>> Share with other users</p>
     <p><input type="checkbox" name="ff_inherit" value="true"<%=checked(form.ff_share)%>> Inherit view in sub-projects</p>
-    <labkey:button text="Create" /> <labkey:button text="Cancel" href="<%=h(urlCancel)%>" />
+    <labkey:button text="Create" /> <labkey:button text="Cancel" href="<%=urlCancel%>" />
 </labkey:form>

--- a/study/src/org/labkey/study/assay/view/publishChooseStudy.jsp
+++ b/study/src/org/labkey/study/assay/view/publishChooseStudy.jsp
@@ -177,7 +177,7 @@
     %>
 
     <labkey:button text="Next" onclick="handleNext();" submit="false"/>
-    <labkey:button text="Cancel" href="<%=text(bean.getReturnURL())%>"/>
+    <labkey:button text="Cancel" href="<%=bean.getReturnURL()%>"/>
 
     <%
         for (Pair<String, String> parameter : parameters)


### PR DESCRIPTION
Slim down LinkTag and ButtonTag - remove unused (and NYI) setters plus corresponding handling

Remove double encoding (ButtonTag.setHref())