### PR TITLE
Remove enumeration of modules in search of footer views. Just use cor…

### DIFF
--- a/api/src/org/labkey/api/premium/PremiumService.java
+++ b/api/src/org/labkey/api/premium/PremiumService.java
@@ -40,8 +40,6 @@ public interface PremiumService
 
     boolean isFileWatcherSupported();
 
-    ActionURL getConfCustomPageElements(Container c);
-
     default CommonsMultipartResolver getMultipartResolver(ViewBackgroundInfo info)
     {
         return new CommonsMultipartResolver();
@@ -92,12 +90,5 @@ public interface PremiumService
         {
             return false;
         }
-
-        @Override
-        public ActionURL getConfCustomPageElements(Container c)
-        {
-            return null;
-        }
     }
-
 }

--- a/api/src/org/labkey/api/settings/BannerProperties.java
+++ b/api/src/org/labkey/api/settings/BannerProperties.java
@@ -1,16 +1,11 @@
 package org.labkey.api.settings;
 
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 
 public class BannerProperties implements TemplateProperties
 {
-    private final String BANNER_CONFIGS = "BannerProperties";
-    private final String SHOW_BANNER_PROPERTY_NAME = "ShowBanner";
-    private final String BANNER_MODULE_PROPERTY_NAME = "BannerModule";
-    private final String FILE_NAME = "_banner";
-    private final String PROPERTY_DISPLAY_TYPE = "Banner";
-
-    private Container _container;
+    private final Container _container;
 
     public BannerProperties(Container container)
     {
@@ -26,36 +21,42 @@ public class BannerProperties implements TemplateProperties
     @Override
     public String getDisplayConfigs()
     {
-        return BANNER_CONFIGS;
+        return "BannerProperties";
     }
 
     @Override
     public String getDisplayPropertyName()
     {
-        return SHOW_BANNER_PROPERTY_NAME;
+        return "ShowBanner";
     }
 
     @Override
     public String getModulePropertyName()
     {
-        return BANNER_MODULE_PROPERTY_NAME;
+        return "BannerModule";
     }
 
     @Override
     public String getFileName()
     {
-        return FILE_NAME;
-    }
-
-    @Override
-    public String getShowByDefault()
-    {
-        return String.valueOf(false);
+        return "_banner";
     }
 
     @Override
     public String getPropertyDisplayType()
     {
-        return PROPERTY_DISPLAY_TYPE;
+        return "Banner";
+    }
+
+    @Override
+    public String getDefaultModule()
+    {
+        return null;
+    }
+
+    @Override
+    public TemplateProperties getRootProperties()
+    {
+        return new BannerProperties(ContainerManager.getRoot());
     }
 }

--- a/api/src/org/labkey/api/settings/FooterProperties.java
+++ b/api/src/org/labkey/api/settings/FooterProperties.java
@@ -17,16 +17,11 @@
 package org.labkey.api.settings;
 
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 
 public class FooterProperties implements TemplateProperties
 {
-    private final String FOOTER_CONFIGS = "FooterProperties";
-    private final String SHOW_FOOTER_PROPERTY_NAME = "ShowFooter";
-    private final String FOOTER_MODULE_PROPERTY_NAME = "FooterModule";
-    private final String FILE_NAME = "_footer";
-    private final String PROPERTY_DISPLAY_TYPE = "Footer";
-
-    private Container _container;
+    private final Container _container;
 
     public FooterProperties(Container container)
     {
@@ -42,33 +37,42 @@ public class FooterProperties implements TemplateProperties
     @Override
     public String getDisplayConfigs()
     {
-        return FOOTER_CONFIGS;
+        return "FooterProperties";
     }
 
     @Override
     public String getDisplayPropertyName()
     {
-        return SHOW_FOOTER_PROPERTY_NAME;
+        return "ShowFooter";
     }
 
     @Override
     public String getModulePropertyName()
     {
-        return FOOTER_MODULE_PROPERTY_NAME;
+        return "FooterModule";
     }
 
     @Override
     public String getFileName()
     {
-        return FILE_NAME;
+        return "_footer";
     }
-
-    @Override
-    public String getShowByDefault() { return "TRUE";}
 
     @Override
     public String getPropertyDisplayType()
     {
-        return PROPERTY_DISPLAY_TYPE;
+        return "Footer";
+    }
+
+    @Override
+    public String getDefaultModule()
+    {
+        return "Core";
+    }
+
+    @Override
+    public TemplateProperties getRootProperties()
+    {
+        return new FooterProperties(ContainerManager.getRoot());
     }
 }

--- a/api/src/org/labkey/api/settings/HeaderProperties.java
+++ b/api/src/org/labkey/api/settings/HeaderProperties.java
@@ -16,19 +16,14 @@
 package org.labkey.api.settings;
 
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 
 /**
  * Created by marty on 7/5/2017.
  */
 public class HeaderProperties implements TemplateProperties
 {
-    private final String HEADER_CONFIGS = "HeaderProperties";
-    private final String SHOW_HEADER_PROPERTY_NAME = "ShowHeader";
-    private final String HEADER_MODULE_PROPERTY_NAME = "HeaderModule";
-    private final String FILE_NAME = "_header";
-    private final String PROPERTY_DISPLAY_TYPE = "Header";
-
-    private Container _container;
+    private final Container _container;
 
     public HeaderProperties(Container container)
     {
@@ -44,33 +39,42 @@ public class HeaderProperties implements TemplateProperties
     @Override
     public String getDisplayConfigs()
     {
-        return HEADER_CONFIGS;
+        return "HeaderProperties";
     }
 
     @Override
     public String getDisplayPropertyName()
     {
-        return SHOW_HEADER_PROPERTY_NAME;
+        return "ShowHeader";
     }
 
     @Override
     public String getModulePropertyName()
     {
-        return HEADER_MODULE_PROPERTY_NAME;
+        return "HeaderModule";
     }
 
     @Override
     public String getFileName()
     {
-        return FILE_NAME;
+        return "_header";
     }
-
-    @Override
-    public String getShowByDefault() { return "FALSE";}
 
     @Override
     public String getPropertyDisplayType()
     {
-        return PROPERTY_DISPLAY_TYPE;
+        return "Header";
+    }
+
+    @Override
+    public String getDefaultModule()
+    {
+        return null;
+    }
+
+    @Override
+    public TemplateProperties getRootProperties()
+    {
+        return new HeaderProperties(ContainerManager.getRoot());
     }
 }

--- a/api/src/org/labkey/api/settings/TemplateProperties.java
+++ b/api/src/org/labkey/api/settings/TemplateProperties.java
@@ -172,12 +172,12 @@ public interface TemplateProperties
             throw new IllegalStateException("Container is null for this TemplateProperty");
     }
 
-    private String getNotDisplayedSetting()
+    private @NotNull String getNotDisplayedSetting()
     {
         return "No " + getPropertyDisplayType() + " Displayed";
     }
 
-    private String getInheritSetting()
+    private @NotNull String getInheritSetting()
     {
         TemplateProperties rootProperties = getRootProperties();
         return "Inherit from site settings (" + rootProperties.getCurrentSetting() + ")";
@@ -185,7 +185,7 @@ public interface TemplateProperties
 
     private @NotNull String getCurrentSetting()
     {
-        String currentSetting;
+        String currentSetting = null;
 
         if (getContainer().isRoot())
         {
@@ -196,21 +196,18 @@ public interface TemplateProperties
         {
             Boolean isDisplayObj = isDisplay(false);
 
-            if (isDisplayObj != null && !isDisplayObj)
-            {
-                currentSetting = getNotDisplayedSetting();
-            }
-            else
-            {
-                currentSetting = getModuleName(false);
-            }
-
-            if (currentSetting == null)
+            if (isDisplayObj == null)
             {
                 currentSetting = getInheritSetting();
             }
+            else
+            {
+                if (isDisplayObj)
+                    currentSetting = getModuleName(false);
 
-            return currentSetting;
+                if (null == currentSetting)
+                   currentSetting = getNotDisplayedSetting();
+            }
         }
 
         return currentSetting;

--- a/api/src/org/labkey/api/settings/TemplateProperties.java
+++ b/api/src/org/labkey/api/settings/TemplateProperties.java
@@ -16,10 +16,22 @@
 package org.labkey.api.settings;
 
 import org.apache.commons.lang3.BooleanUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.PropertyManager;
+import org.labkey.api.module.Module;
+import org.labkey.api.module.ModuleHtmlView;
+import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.util.element.Option;
+import org.labkey.api.util.element.Option.OptionBuilder;
+import org.labkey.api.view.HtmlView;
+import org.labkey.api.view.WebPartView;
 
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Created by marty on 7/5/2017.
@@ -27,21 +39,18 @@ import java.util.Map;
 public interface TemplateProperties
 {
     String SHOW_ONLY_IN_PROJECT_ROOT_PROPERTY_NAME = "ShowOnlyInProjectRoot";
+    String NONE = "none";
 
     String getDisplayConfigs();
     String getDisplayPropertyName();
     String getModulePropertyName();
     String getFileName();
-    String getShowByDefault();
     String getPropertyDisplayType();
     Container getContainer();
+    String getDefaultModule();
+    TemplateProperties getRootProperties();
 
-    default Boolean isDisplay()
-    {
-        return isDisplay(true);
-    }
-
-    default Boolean isDisplay(boolean inherit)
+    private Boolean isDisplay(boolean inherit)
     {
         String displayProp = getProperty(getDisplayPropertyName(), inherit);
         return BooleanUtils.toBooleanObject(displayProp);
@@ -52,14 +61,42 @@ public interface TemplateProperties
         setProperty(getDisplayPropertyName(), isDisplay != null ? String.valueOf(isDisplay) : null);
     }
 
-    default String getModule()
+    private @Nullable Module getModule()
     {
-        return getModule(true);
+        return ModuleLoader.getInstance().getModule(getModuleName());
     }
 
-    default String getModule(boolean inherit)
+    default @Nullable HtmlView getView()
     {
-        return getProperty(getModulePropertyName(), inherit);
+        Module module = getModule();
+        HtmlView view = null;
+
+        if (null != module)
+        {
+            view = ModuleHtmlView.get(module, getFileName());
+
+            if (null != view)
+            {
+                view.setFrame(WebPartView.FrameType.NONE);
+            }
+        }
+
+        return view;
+    }
+
+    private @Nullable String getModuleName()
+    {
+        return getModuleName(true);
+    }
+
+    private @Nullable String getModuleName(boolean inherit)
+    {
+        Boolean isDisplay = isDisplay(inherit);
+
+        if (null == isDisplay)
+            return getDefaultModule();
+
+        return isDisplay ? getProperty(getModulePropertyName(), inherit) : null;
     }
 
     default void setModule(String module)
@@ -100,6 +137,7 @@ public interface TemplateProperties
             map.remove(propName);
         else
             map.put(propName, value);
+
         map.save();
     }
 
@@ -111,8 +149,7 @@ public interface TemplateProperties
     /**
      * Helper to pull property values from the appropriate scopes
      *
-     * @param inherit if true will inherit from the site root if the property is not defined in the
-     *                container
+     * @param inherit if true will inherit from the site root if the property is not defined in the container
      */
     private String getProperty(String propName, boolean inherit)
     {
@@ -133,5 +170,78 @@ public interface TemplateProperties
         }
         else
             throw new IllegalStateException("Container is null for this TemplateProperty");
+    }
+
+    private String getNotDisplayedSetting()
+    {
+        return "No " + getPropertyDisplayType() + " Displayed";
+    }
+
+    private String getInheritSetting()
+    {
+        TemplateProperties rootProperties = getRootProperties();
+        return "Inherit from site settings (" + rootProperties.getCurrentSetting() + ")";
+    }
+
+    private @NotNull String getCurrentSetting()
+    {
+        String currentSetting;
+
+        if (getContainer().isRoot())
+        {
+            String moduleName = getModuleName(false);
+            currentSetting = null == moduleName ? getNotDisplayedSetting() : moduleName;
+        }
+        else
+        {
+            Boolean isDisplayObj = isDisplay(false);
+
+            if (isDisplayObj != null && !isDisplayObj)
+            {
+                currentSetting = getNotDisplayedSetting();
+            }
+            else
+            {
+                currentSetting = getModuleName(false);
+            }
+
+            if (currentSetting == null)
+            {
+                currentSetting = getInheritSetting();
+            }
+
+            return currentSetting;
+        }
+
+        return currentSetting;
+    }
+
+    default List<Option> getOptions()
+    {
+        Map<String, String> modules = new LinkedHashMap<>();  // Keep the options in insertion order
+
+        // Add the inherit option with appropriate text
+        if (getContainer().isProject())
+            modules.put(null, getInheritSetting());
+
+        // Add the "No XXX Displayed" option
+        modules.put(NONE, getNotDisplayedSetting());
+
+        // Add all modules that contain the appropriate view, in alphabetical order
+        ModuleLoader.getInstance().getModules().stream()
+            .filter(m->ModuleHtmlView.exists(m, getFileName()))
+            .map(Module::getName)
+            .sorted(String.CASE_INSENSITIVE_ORDER)
+            .forEach(name->modules.put(name, name));
+
+        String currentSetting = getCurrentSetting();
+
+        return modules.entrySet().stream()
+            .map(e->new OptionBuilder()
+                .value(e.getKey())
+                .label(e.getValue())
+                .selected(e.getValue().equals(currentSetting))
+                .build())
+            .collect(Collectors.toList());
     }
 }

--- a/api/src/org/labkey/api/view/FolderManagement.java
+++ b/api/src/org/labkey/api/view/FolderManagement.java
@@ -261,8 +261,6 @@ public class FolderManagement
             TabProvider provider = TYPE_ACTION_TAB_PROVIDER.get(type).get(action.getClass());
             String tabId = provider.getTabId();
 
-            assert null == ctx.get("tabId");
-
             return new ManagementTabStrip(c, tabId, errors)
             {
                 @Override

--- a/api/src/org/labkey/api/view/FolderManagement.java
+++ b/api/src/org/labkey/api/view/FolderManagement.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.api.view;
 
-import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.action.BaseViewAction;
 import org.labkey.api.action.FormViewAction;
 import org.labkey.api.action.SimpleViewAction;
@@ -51,7 +50,27 @@ public class FolderManagement
             @Override
             NavTree appendNavTrail(BaseViewAction action, NavTree root, Container c, User user)
             {
-                return folderManagementNavTrail(root, c, user);
+                // In the root, view is rendered as a standalone page (no tab strip). Create an appropriate nav trail.
+                if (c.isRoot())
+                {
+                    TabProvider provider = TYPE_ACTION_TAB_PROVIDER.get(this).get(action.getClass());
+                    return PageFlowUtil.urlProvider(AdminUrls.class).appendAdminNavTrail(root, provider.getText(), null);
+                }
+
+                if (c.isContainerTab())
+                    root.addChild(c.getParent().getName(), c.getParent().getStartURL(user));
+
+                root.addChild(c.getName(), c.getStartURL(user));
+                root.addChild("Folder Management");
+
+                return root;
+            }
+
+            @Override
+            boolean shouldRenderTabStrip(Container container)
+            {
+                // In the root, render as standalone page (no tab strip)
+                return !container.isRoot();
             }
         },
         ProjectSettings
@@ -73,9 +92,17 @@ public class FolderManagement
 
                 return root;
             }
+
+            @Override
+            boolean shouldRenderTabStrip(Container container)
+            {
+                return true;
+            }
         };
 
         abstract NavTree appendNavTrail(BaseViewAction action, NavTree root, Container c, User user);
+
+        abstract boolean shouldRenderTabStrip(Container container);
     }
 
     // Using two data structures lets us maintain the list of tab providers in registration order AND look up container predicates quickly, with reasonable concurrency behavior
@@ -123,10 +150,7 @@ public class FolderManagement
         ManagementTabStrip(Container c, String tabId, BindException errors)
         {
             _container = c;
-
-            // Stay on same tab if there are errors
-            if (errors.hasErrors() && null != StringUtils.trimToNull(tabId))
-                setSelectedTabId(tabId);
+            setSelectedTabId(tabId);
         }
 
         @Override
@@ -167,28 +191,15 @@ public class FolderManagement
         @Override
         public ModelAndView handleRequest() throws Exception
         {
-            validateContainer(getType(), this.getClass(), getContainer());
+            validateContainer(getType(), getClass(), getContainer());
 
             return super.handleRequest();
         }
 
         @Override
-        public ModelAndView getView(Void form, BindException errors)
+        public ModelAndView getView(Void form, BindException errors) throws Exception
         {
-            return new ManagementTabStrip(getContainer(), (String)getViewContext().get("tabId"), errors)
-            {
-                @Override
-                public HttpView getTabView(String tabId) throws Exception
-                {
-                    return ManagementViewAction.this.getTabView();
-                }
-
-                @Override
-                protected List<TabProvider> getTabProviders()
-                {
-                    return TYPE_TAB_PROVIDER.get(getType());
-                }
-            };
+            return wrapViewInTabStrip(this, getType(), getTabView(), errors);
         }
 
         protected abstract TYPE getType();
@@ -210,26 +221,13 @@ public class FolderManagement
         @Override
         public ModelAndView getView(FORM form, boolean reshow, BindException errors) throws Exception
         {
-            return new ManagementTabStrip(getContainer(), (String)getViewContext().get("tabId"), errors)
-            {
-                @Override
-                public HttpView getTabView(String tabId) throws Exception
-                {
-                    return ManagementViewPostAction.this.getTabView(form, reshow, errors);
-                }
-
-                @Override
-                protected List<TabProvider> getTabProviders()
-                {
-                    return TYPE_TAB_PROVIDER.get(getType());
-                }
-            };
+            return wrapViewInTabStrip(this, getType(), getTabView(form, reshow, errors), errors);
         }
 
         @Override
         public ModelAndView handleRequest(FORM form, BindException errors) throws Exception
         {
-            validateContainer(getType(), this.getClass(), getContainer());
+            validateContainer(getType(), getClass(), getContainer());
 
             return super.handleRequest(form, errors);
         }
@@ -249,6 +247,39 @@ public class FolderManagement
         {
             return getType().appendNavTrail(this, root, getContainer(), getUser());
         }
+    }
+
+
+    /** Wrap the provided view in a tab strip, if that's what the type desires **/
+    private static HttpView wrapViewInTabStrip(BaseViewAction action, TYPE type, HttpView view, BindException errors)
+    {
+        ViewContext ctx = action.getViewContext();
+        Container c = ctx.getContainer();
+
+        if (type.shouldRenderTabStrip(c))
+        {
+            TabProvider provider = TYPE_ACTION_TAB_PROVIDER.get(type).get(action.getClass());
+            String tabId = provider.getTabId();
+
+            assert null == ctx.get("tabId");
+
+            return new ManagementTabStrip(c, tabId, errors)
+            {
+                @Override
+                public HttpView getTabView(String tabId)
+                {
+                    return view;
+                }
+
+                @Override
+                protected List<TabProvider> getTabProviders()
+                {
+                    return TYPE_TAB_PROVIDER.get(type);
+                }
+            };
+        }
+
+        return view;
     }
 
 
@@ -308,21 +339,6 @@ public class FolderManagement
     }
 
 
-    private static NavTree folderManagementNavTrail(NavTree root, Container c, User user)
-    {
-        if (c.isRoot())
-            return PageFlowUtil.urlProvider(AdminUrls.class).appendAdminNavTrail(root, "Admin Console", null);
-
-        if (c.isContainerTab())
-            root.addChild(c.getParent().getName(), c.getParent().getStartURL(user));
-
-        root.addChild(c.getName(), c.getStartURL(user));
-        root.addChild("Folder Management");
-
-        return root;
-    }
-
-
     private static class TabProvider
     {
         private final String _text;
@@ -338,12 +354,19 @@ public class FolderManagement
             _filter = filter;
         }
 
+        private String getText()
+        {
+            return _text;
+        }
+
+        private String getTabId()
+        {
+            return _id;
+        }
+
         private ActionURL getActionURL(Container c)
         {
-            ActionURL url = new ActionURL(_actionClass, c);
-            url.addParameter("tabId", _id);
-
-            return url;
+            return new ActionURL(_actionClass, c);
         }
 
         private boolean shouldRender(Container c)

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -73,7 +73,6 @@ import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.Lookup;
 import org.labkey.api.files.FileContentService;
-import org.labkey.api.jsp.LabKeyJspWriter;
 import org.labkey.api.message.settings.MessageConfigService;
 import org.labkey.api.message.settings.MessageConfigService.ConfigTypeProvider;
 import org.labkey.api.miniprofiler.RequestInfo;
@@ -213,7 +212,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
-import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -468,25 +466,19 @@ public class AdminController extends SpringActionController
 
         ActionURL getLookAndFeelResourcesURL(Container c)
         {
-            ActionURL url = new ActionURL(ResourcesAction.class, LookAndFeelProperties.getSettingsContainer(c));
-            url.addParameter("tabId", "resources");
-            return url;
+            return new ActionURL(ResourcesAction.class, LookAndFeelProperties.getSettingsContainer(c));
         }
 
         @Override
         public ActionURL getProjectSettingsMenuURL(Container c)
         {
-            ActionURL url = new ActionURL(MenuBarAction.class, LookAndFeelProperties.getSettingsContainer(c));
-            url.addParameter("tabId", "menubar");
-            return url;
+            return new ActionURL(MenuBarAction.class, LookAndFeelProperties.getSettingsContainer(c));
         }
 
         @Override
         public ActionURL getProjectSettingsFileURL(Container c)
         {
-            ActionURL url = new ActionURL(FilesAction.class, LookAndFeelProperties.getSettingsContainer(c));
-            url.addParameter("tabId", "files");
-            return url;
+            return new ActionURL(FilesAction.class, LookAndFeelProperties.getSettingsContainer(c));
         }
 
         @Override
@@ -526,19 +518,19 @@ public class AdminController extends SpringActionController
         @Override
         public ActionURL getManageFoldersURL(Container c)
         {
-            return getFolderManagementURL(ManageFoldersAction.class, c, "folderTree");
+            return new ActionURL(ManageFoldersAction.class, c);
         }
 
         @Override
         public ActionURL getExportFolderURL(Container c)
         {
-            return getFolderManagementURL(ExportFolderAction.class, c, "export");
+            return new ActionURL(ExportFolderAction.class, c);
         }
 
         @Override
         public ActionURL getImportFolderURL(Container c)
         {
-            return getFolderManagementURL(ImportFolderAction.class, c, "import");
+            return new ActionURL(ImportFolderAction.class, c);
         }
 
         @Override
@@ -579,31 +571,31 @@ public class AdminController extends SpringActionController
         @Override
         public ActionURL getFileRootsURL(Container c)
         {
-            return getFolderManagementURL(FileRootsAction.class, c, "files");
+            return new ActionURL(FileRootsAction.class, c);
         }
 
         @Override
         public ActionURL getFolderSettingsURL(Container c)
         {
-            return getFolderManagementURL(FolderSettingsAction.class, c, "settings");
+            return new ActionURL(FolderSettingsAction.class, c);
         }
 
         @Override
         public ActionURL getNotificationsURL(Container c)
         {
-            return getFolderManagementURL(NotificationsAction.class, c, "messages");
+            return new ActionURL(NotificationsAction.class, c);
         }
 
         @Override
         public ActionURL getModulePropertiesURL(Container c)
         {
-            return getFolderManagementURL(ModulePropertiesAction.class, c, "props");
+            return new ActionURL(ModulePropertiesAction.class, c);
         }
 
         @Override
         public ActionURL getMissingValuesURL(Container c)
         {
-            return getFolderManagementURL(MissingValuesAction.class, c, "mvIndicators");
+            return new ActionURL(MissingValuesAction.class, c);
         }
 
         public ActionURL getInitialFolderSettingsURL(Container c)
@@ -638,11 +630,6 @@ public class AdminController extends SpringActionController
         public ActionURL getTrackedAllocationsViewerURL()
         {
             return new ActionURL(TrackedAllocationsViewerAction.class, ContainerManager.getRoot());
-        }
-
-        public static ActionURL getFolderManagementURL(Class<? extends Controller> actionClass, Container c, String tabId)
-        {
-            return new ActionURL(actionClass, c).addParameter("tabId", tabId);
         }
     }
 
@@ -10120,12 +10107,6 @@ public class AdminController extends SpringActionController
         public final HtmlString helpLink = new HelpTopic("customizeLook").getSimpleLinkHtml("more info...");
         public final HtmlString welcomeLink = new HelpTopic("customizeLook").getSimpleLinkHtml("more info...");
         public final HtmlString customColumnRestrictionHelpLink = new HelpTopic("chartTrouble").getSimpleLinkHtml("more info...");
-
-
-        public static ActionURL getCustomPageElementLink(Container c)
-        {
-            return PremiumService.get().getConfCustomPageElements(c);
-        }
     }
 
 

--- a/core/src/org/labkey/core/admin/folderType.jsp
+++ b/core/src/org/labkey/core/admin/folderType.jsp
@@ -236,7 +236,6 @@ function validate()
 }
 </script>
 <labkey:form name="folderModules" id="folderModules" method="POST" action="<%=h(buildURL(FolderTypeAction.class))%>" onsubmit="return validate();">
-    <input type="hidden" name="tabId" value="folderType">
     <table width="100%">
         <tr>
             <td valign="top"><%

--- a/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
+++ b/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
@@ -114,34 +114,27 @@
             "that are scoped directly to that report or wiki page. Administrators can disable this feature.";
 %>
 <tr>
-    <td class="labkey-form-label">Enable Object-Level Discussions
-        <%=helpPopup("Enable Discussion", enableDiscussionHelp, true)%></td>
+    <td class="labkey-form-label">Enable Object-Level Discussions<%=helpPopup("Enable Discussion", enableDiscussionHelp, true)%></td>
     <td><input type="checkbox" name="enableDiscussion" size="50"<%=checked(laf.isDiscussionEnabled())%>></td>
 </tr>
 <tr>
     <td class="labkey-form-label">Logo link (specifies page that header logo links to)</td>
-    <td><input type="text" name="logoHref" size="50" value="<%= h(laf.getUnsubstitutedLogoHref()) %>"></td>
+    <td><input type="text" name="logoHref" size="50" value="<%=h(laf.getUnsubstitutedLogoHref())%>"></td>
 </tr>
 <tr>
     <td class="labkey-form-label">Support link (specifies page where users can request support)</td>
-    <td><input type="text" name="reportAProblemPath" size="50" value="<%= h(laf.getUnsubstitutedReportAProblemPath()) %>"></td>
+    <td><input type="text" name="reportAProblemPath" size="50" value="<%=h(laf.getUnsubstitutedReportAProblemPath())%>"></td>
 </tr>
 <tr>
     <td class="labkey-form-label">Support email (shown to users if they don't have permission<br/>to see a page, or are having trouble logging in)</td>
-    <td style="vertical-align: top;"><input type="text" name="supportEmail" size="50" value="<%= h(laf.getSupportEmail()) %>"></td>
+    <td style="vertical-align: top;"><input type="text" name="supportEmail" size="50" value="<%=h(laf.getSupportEmail())%>"></td>
 </tr>
-<% if (bean.getCustomPageElementLink(c) != null) { %>
-    <tr>
-        <td class="labkey-form-label" ><%=link("Configure Custom Page Elements", bean.getCustomPageElementLink(c))%></td>
-    </tr>
-<%}%>
 <tr>
     <td colspan=2>Customize settings used in system emails (<%=bean.helpLink%>)</td>
 </tr>
 <tr>
     <td class="labkey-form-label">
-        System email address (<i>from</i> address for system notification emails)
-        <%=helpPopup("System email address", "Requires AdminOperationsPermission to update.", false)%>
+        System email address (<i>from</i> address for system notification emails)<%=helpPopup("System email address", "Requires AdminOperationsPermission to update.", false)%>
     </td>
     <td><input type="text" name="systemEmailAddress" size="50" value="<%= h(laf.getSystemEmailAddress()) %>" <%=h(!hasAdminOpsPerm ? "disabled" : "")%>></td>
 </tr>

--- a/core/src/org/labkey/core/view/template/bootstrap/PageTemplate.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/PageTemplate.java
@@ -21,8 +21,6 @@ import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.module.FolderType;
-import org.labkey.api.module.Module;
-import org.labkey.api.module.ModuleHtmlView;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.module.MultiPortalFolderType;
 import org.labkey.api.security.User;
@@ -50,7 +48,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.ListIterator;
 
 public class PageTemplate extends JspView<PageConfig>
 {
@@ -103,7 +100,7 @@ public class PageTemplate extends JspView<PageConfig>
         page.setAppBar(generateAppBarModel(context, page));
 
         setView("navigation", getNavigationView(context, page));
-        setView("footer", getTemplateResource(new FooterProperties(c)));
+        setView("footer", new FooterProperties(c).getView());
     }
 
     private AppBar generateAppBarModel(ViewContext context, PageConfig page)
@@ -157,7 +154,6 @@ public class PageTemplate extends JspView<PageConfig>
         }
         page.setMetaTag("authenticatedUser", null == authenticatedUser ? "-" : StringUtils.defaultString(authenticatedUser.getEmail(),user.getDisplayName(user)));
         page.setMetaTag("impersonatedUser", null == impersonatedUser ? "-" : StringUtils.defaultString(impersonatedUser.getEmail(),user.getDisplayName(user)));
-
     }
 
     protected ModelAndView getBodyTemplate(PageConfig page, ModelAndView body)
@@ -167,7 +163,7 @@ public class PageTemplate extends JspView<PageConfig>
         Container c = this.getViewContext().getContainer();
         TemplateProperties banner = new BannerProperties(c);
         if (!banner.isShowOnlyInProjectRoot() || (c.equals(c.getProject())))
-            view.setView("banner", getTemplateResource(banner));
+            view.setView("banner", banner.getView());
 
         view.setBody(body);
         view.setFrame(FrameType.NONE);
@@ -320,36 +316,6 @@ public class PageTemplate extends JspView<PageConfig>
     {
         ActionURL url = getViewContext().cloneActionURL();
         return url.setExtraPath("__r" + getViewContext().getContainer().getRowId());
-    }
-
-    public static HtmlView getTemplateResource(TemplateProperties prop)
-    {
-        HtmlView view = null;
-        if (prop.isDisplay() != null && prop.isDisplay())
-        {
-            Module coreModule = ModuleLoader.getInstance().getCoreModule();
-            List<Module> modules = new ArrayList<>(ModuleLoader.getInstance().getModules());
-            if (null != ModuleLoader.getInstance().getModule(prop.getModule()))
-            {
-                modules.add(ModuleLoader.getInstance().getModule(prop.getModule()));
-            }
-            ListIterator<Module> i = modules.listIterator(modules.size());
-            while (i.hasPrevious())
-            {
-                view = ModuleHtmlView.get(i.previous(), prop.getFileName());
-                if (null != view)
-                    break;
-            }
-            if (null == view)
-            {
-                view = ModuleHtmlView.get(coreModule, prop.getFileName());
-            }
-            if (null != view)
-            {
-                view.setFrame(FrameType.NONE);
-            }
-        }
-        return view;
     }
 
     public static String getTemplatePrefix(PageConfig page)

--- a/core/src/org/labkey/core/view/template/bootstrap/header.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/header.jsp
@@ -60,7 +60,7 @@
     LookAndFeelProperties laf = LookAndFeelProperties.getInstance(c);
     boolean showSearch = hasUrlProvider(SearchUrls.class);
 
-    HtmlView headerHtml = PageTemplate.getTemplateResource(new HeaderProperties(getContainer()));
+    HtmlView headerHtml = new HeaderProperties(getContainer()).getView();
     String siteShortName = (laf.getShortName() != null && laf.getShortName().length() > 0) ? laf.getShortName() : null;
 
     final NavTree optionsMenu = PopupAdminView.createNavTree(context);

--- a/filecontent/src/org/labkey/filecontent/view/configure.jsp
+++ b/filecontent/src/org/labkey/filecontent/view/configure.jsp
@@ -51,7 +51,7 @@
     if (getContainer().hasPermission(getUser(), AdminOperationsPermission.class))
     {
         Path rootPath = service.getFileRootPath(getContainer());
-        ActionURL configureHelper = urlProvider(AdminUrls.class).getProjectSettingsURL(getContainer()).addParameter("tabId", "files");
+        ActionURL configureHelper = urlProvider(AdminUrls.class).getProjectSettingsURL(getContainer());
         if (null == rootPath)
         { %>
             There is no file root for this folder.


### PR DESCRIPTION
…e footer by default with ability to override in premium.

Push all the inheritance, null-handling, and options logic for footers, headers, and banners into TemplateProperties. This simplifies callers such as the configuration JSP, the form, PageTemplate, etc.

Fixes: "Powered by LabKey" footer appears again on initial bootstrap. Use alphabetical order in module drop-down. Clean up configuration wording.

Move header/banner/footer configuration to a Project Settings / Look & Feel Settings tab.

Improve folder management tabs: Remove tab strip when actions are shown in root. Eliminate need to pass around tabId parameter - we know which tab to highlight based on the current action class.