### PR TITLE
Introduce core.executeJavaInitializationCode() no-op stored procedure…

### DIFF
--- a/api/src/org/labkey/api/data/SqlScriptExecutor.java
+++ b/api/src/org/labkey/api/data/SqlScriptExecutor.java
@@ -140,7 +140,7 @@ public class SqlScriptExecutor
             }
 
             if (start < trimmed.length())
-                blocks.add(new Block(trimmed.substring(start, trimmed.length())));
+                blocks.add(new Block(trimmed.substring(start)));
         }
 
         return blocks;

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -876,7 +876,7 @@ public abstract class PostgreSql91Dialect extends SqlDialect
             return super.getSelectNameFromMetaDataName(metaDataName);
     }
 
-    private static final Pattern PROC_PATTERN = Pattern.compile("^\\s*SELECT\\s+core\\.((executeJavaUpgradeCode\\s*\\(\\s*'(.+)'\\s*\\))|(bulkImport\\s*\\(\\s*'(.+)'\\s*,\\s*'(.+)'\\s*,\\s*'(.+)'\\s*,?\\s*(\\w*)\\)))\\s*;\\s*$", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+    private static final Pattern PROC_PATTERN = Pattern.compile("^\\s*SELECT\\s+core\\.((executeJava(?:Upgrade|Initialization)Code\\s*\\(\\s*'(.+)'\\s*\\))|(bulkImport\\s*\\(\\s*'(.+)'\\s*,\\s*'(.+)'\\s*,\\s*'(.+)'\\s*,?\\s*(\\w*)\\)))\\s*;\\s*$", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
     @Override
     // No need to split up PostgreSQL scripts; execute all statements in a single block (unless we have a special stored proc call).

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -919,7 +919,7 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     }
 
     private static final Pattern GO_PATTERN = Pattern.compile("^\\s*GO\\s*$", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
-    private static final Pattern PROC_PATTERN = Pattern.compile("^\\s*EXEC(?:UTE)?\\s+core\\.((executeJavaUpgradeCode\\s*'(.+)')|(bulkImport\\s*'(.+)'\\s*,\\s*'(.+)'\\s*,\\s*'(.+)'))\\s*,?\\s*(\\d)?;?\\s*$", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+    private static final Pattern PROC_PATTERN = Pattern.compile("^\\s*EXEC(?:UTE)?\\s+core\\.((executeJava(?:Upgrade|Initialization)Code\\s*'(.+)')|(bulkImport\\s*'(.+)'\\s*,\\s*'(.+)'\\s*,\\s*'(.+)'))\\s*,?\\s*(\\d)?;?\\s*$", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
     @Override
     // Split Microsoft SQL scripts on GO statements

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
@@ -206,6 +206,11 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
                     "EXEC core.executeJavaUpgradeCode 'upgradeCode'\n" +                       // Normal
                     "EXECUTE core.executeJavaUpgradeCode 'upgradeCode'\n" +                    // EXECUTE
                     "execute core.executeJavaUpgradeCode'upgradeCode'\n" +                     // execute
+
+                    "EXEC core.executeJavaInitializationCode 'upgradeCode'\n" +                // executeJavaInitializationCode works as a synonym
+                    "EXECUTE core.executeJavaInitializationCode 'upgradeCode'\n" +             // EXECUTE
+                    "execute core.executeJavaInitializationCode'upgradeCode'\n" +              // execute
+
                     "    EXEC     core.executeJavaUpgradeCode    'upgradeCode'         \n" +   // Lots of whitespace
                     "exec CORE.EXECUTEJAVAUPGRADECODE 'upgradeCode'\n" +                       // Case insensitive
                     "execute core.executeJavaUpgradeCode'upgradeCode';\n" +                    // execute (with ;)
@@ -213,6 +218,7 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
                     "exec CORE.EXECUTEJAVAUPGRADECODE 'upgradeCode';     \n" +                 // Case insensitive (with ;)
                     "EXEC core.executeJavaUpgradeCode 'upgradeCode'     ;\n" +                 // Lots of whitespace with ; at end
                     "EXEC core.executeJavaUpgradeCode 'upgradeCode'";                          // No line ending
+
 
             String badSql =
                     "/* EXEC core.executeJavaUpgradeCode 'upgradeCode'\n" +           // Inside block comment
@@ -230,7 +236,7 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
             SqlDialect dialect = getEarliestSqlDialect();
             TestUpgradeCode good = new TestUpgradeCode();
             dialect.runSql(null, goodSql, good, null, null);
-            assertEquals(10, good.getCounter());
+            assertEquals(13, good.getCounter());
 
             TestUpgradeCode bad = new TestUpgradeCode();
             dialect.runSql(null, badSql, bad, null, null);

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-Version: 19.20
+Version: 19.22
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/core-19.21-19.22.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-19.21-19.22.sql
@@ -1,0 +1,10 @@
+-- This empty stored procedure is a synonym for core.executeJavaUpgradeCode(), but is meant to denote Java code that is used to
+-- initialize data in a schema (e.g., pre-populating a table with values), not transform existing data. We mark these cases with
+-- a different procedure name because our bootstrap scripts still need to invoke them, as opposed to invocations of upgrade code
+-- which we remove from bootstrap scripts. See implementations of the UpgradeCode interface to find the initialization code.
+CREATE FUNCTION core.executeJavaInitializationCode(text) RETURNS void AS $$
+DECLARE note TEXT := 'Empty function that signals script runner to execute Java initialization code. See implementations of UpgradeCode.java.';
+BEGIN
+END
+$$ LANGUAGE plpgsql;
+

--- a/core/resources/schemas/dbscripts/postgresql/obsolete/core-16.30-17.10.sql
+++ b/core/resources/schemas/dbscripts/postgresql/obsolete/core-16.30-17.10.sql
@@ -36,7 +36,7 @@ $BODY$
      objname    Required. For TABLE, VIEW, PROCEDURE, FUNCTION, AGGREGATE, SYNONYM, this is the name of the object to be dropped
                  for SCHEMA, specify '*' to drop all dependent objects, or NULL to drop an empty schema
                  for INDEX, CONSTRAINT, DEFAULT, or COLUMN, specify the name of the table
-     objschema  Requried. The name of the schema for the object, or the schema being dropped
+     objschema  Required. The name of the schema for the object, or the schema being dropped
      objtype    Required. The type of object being dropped. Valid values are TABLE, VIEW, INDEX, CONSTRAINT, DEFAULT, SCHEMA, PROCEDURE, FUNCTION, AGGREGATE, SYNONYM, COLUMN
      subobjtype Required. When dropping INDEX, CONSTRAINT, DEFAULT, or COLUMN, the name of the object being dropped. Otherwise NULL
  */

--- a/core/resources/schemas/dbscripts/postgresql/obsolete/core-16.31-16.32.sql
+++ b/core/resources/schemas/dbscripts/postgresql/obsolete/core-16.31-16.32.sql
@@ -30,7 +30,7 @@ $BODY$
      objname    Required. For TABLE, VIEW, PROCEDURE, FUNCTION, AGGREGATE, SYNONYM, this is the name of the object to be dropped
                  for SCHEMA, specify '*' to drop all dependent objects, or NULL to drop an empty schema
                  for INDEX, CONSTRAINT, DEFAULT, or COLUMN, specify the name of the table
-     objschema  Requried. The name of the schema for the object, or the schema being dropped
+     objschema  Required. The name of the schema for the object, or the schema being dropped
      objtype    Required. The type of object being dropped. Valid values are TABLE, VIEW, INDEX, CONSTRAINT, DEFAULT, SCHEMA, PROCEDURE, FUNCTION, AGGREGATE, SYNONYM, COLUMN
      subobjtype Required. When dropping INDEX, CONSTRAINT, DEFAULT, or COLUMN, the name of the object being dropped. Otherwise NULL
  */

--- a/core/resources/schemas/dbscripts/sqlserver/core-19.21-19.22.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-19.21-19.22.sql
@@ -1,0 +1,11 @@
+-- This empty stored procedure is a synonym for core.executeJavaUpgradeCode(), but is meant to denote Java code that is used to
+-- initialize data in a schema (e.g., pre-populating a table with values), not transform existing data. We mark these cases with
+-- a different procedure name because our bootstrap scripts still need to invoke them, as opposed to invocations of upgrade code
+-- which we remove from bootstrap scripts. See implementations of the UpgradeCode interface to find the initialization code.
+CREATE PROCEDURE core.executeJavaInitializationCode(@Name VARCHAR(255)) AS
+BEGIN
+DECLARE @notice VARCHAR(255)
+SET @notice = 'Empty function that signals script runner to execute initialization Java code. See implementations of UpgradeCode.java.'
+END;
+
+GO

--- a/core/resources/schemas/dbscripts/sqlserver/obsolete/core-16.30-17.10.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/obsolete/core-16.30-17.10.sql
@@ -35,7 +35,7 @@ BEGIN
        objname    Required. For TABLE, VIEW, PROCEDURE, FUNCTION, AGGREGATE, SYNONYM, this is the name of the object to be dropped
                    for SCHEMA, specify '*' to drop all dependent objects, or NULL to drop an empty schema
                    for INDEX, CONSTRAINT, DEFAULT, or COLUMN, specify the name of the table
-       objschema  Requried. The name of the schema for the object, or the schema being dropped
+       objschema  Required. The name of the schema for the object, or the schema being dropped
        objtype    Required. The type of object being dropped. Valid values are TABLE, VIEW, INDEX, CONSTRAINT, DEFAULT, SCHEMA, PROCEDURE, FUNCTION, AGGREGATE, SYNONYM, COLUMN
        subobjtype Optional. When dropping INDEX, CONSTRAINT, DEFAULT, or COLUMN, the name of the object being dropped
        printCmds  Optional, 1 or 0. If 1, the cascading drop commands for SCHEMA and COLUMN will be printed for debugging purposes

--- a/core/resources/schemas/dbscripts/sqlserver/obsolete/core-16.31-16.32.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/obsolete/core-16.31-16.32.sql
@@ -27,7 +27,7 @@ BEGIN
        objname    Required. For TABLE, VIEW, PROCEDURE, FUNCTION, AGGREGATE, SYNONYM, this is the name of the object to be dropped
                    for SCHEMA, specify '*' to drop all dependent objects, or NULL to drop an empty schema
                    for INDEX, CONSTRAINT, DEFAULT, or COLUMN, specify the name of the table
-       objschema  Requried. The name of the schema for the object, or the schema being dropped
+       objschema  Required. The name of the schema for the object, or the schema being dropped
        objtype    Required. The type of object being dropped. Valid values are TABLE, VIEW, INDEX, CONSTRAINT, DEFAULT, SCHEMA, PROCEDURE, FUNCTION, AGGREGATE, SYNONYM, COLUMN
        subobjtype Optional. When dropping INDEX, CONSTRAINT, DEFAULT, or COLUMN, the name of the object being dropped
        printCmds  Optional, 1 or 0. If 1, the cascading drop commands for SCHEMA and COLUMN will be printed for debugging purposes

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -182,10 +182,10 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
         {
             String goodSql =
                     "SELECT core.executeJavaUpgradeCode('upgradeCode');\n" +                       // Normal
+                    "SELECT core.executeJavaInitializationCode('upgradeCode');\n" +                // executeJavaInitializationCode works as a synonym
                     "    SELECT     core.executeJavaUpgradeCode    ('upgradeCode')    ;     \n" +  // Lots of whitespace
                     "select CORE.EXECUTEJAVAUPGRADECODE('upgradeCode');\n" +                       // Case insensitive
                     "SELECT core.executeJavaUpgradeCode('upgradeCode');";                          // No line ending
-
 
             String badSql =
                     "/* SELECT core.executeJavaUpgradeCode('upgradeCode');\n" +       // Inside block comment
@@ -201,7 +201,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
             SqlDialect dialect = new PostgreSql94Dialect();
             TestUpgradeCode good = new TestUpgradeCode();
             dialect.runSql(null, goodSql, good, null, null);
-            assertEquals(4, good.getCounter());
+            assertEquals(5, good.getCounter());
 
             TestUpgradeCode bad = new TestUpgradeCode();
             dialect.runSql(null, badSql, bad, null, null);


### PR DESCRIPTION
… as a synonym for core.executeJavaUpgradeCode(). Allows script writers to declare their intent, which will streamline bootstrap script consolidation steps in the future.

Remove unnecessary create + drop of core.fn_dropIfExists() and core.bulkImport() in bootstrap script. Clarify and correct some comments.