### PR TITLE
Issue 38694: Links to deleted users cause NPEs and other problems fix

### DIFF
--- a/api/src/org/labkey/api/query/UserIdRenderer.java
+++ b/api/src/org/labkey/api/query/UserIdRenderer.java
@@ -75,8 +75,9 @@ public class UserIdRenderer extends DataColumn
     {
         var loggedInUser = ctx.getViewContext().getUser();
         Integer displayedUserId = (Integer)getBoundColumn().getValue(ctx);
+        boolean isDeletedUser = UserManager.getUser(displayedUserId) == null;
 
-        if (displayedUserId != null)
+        if (!isDeletedUser && displayedUserId != null)
         {
                ActionURL url = UserManager.getUserDetailsURL(ctx.getContainer(), loggedInUser, displayedUserId);
                if (url != null)

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -1654,7 +1654,7 @@ public class SecurityManager
     {
         Container proj = c.getProject();
 
-        if (null == proj)
+        if (null == proj || u == null)
             return "";
 
         int[] groupIds = u.getGroups();

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -1132,26 +1132,21 @@ public class UserManager
         User displayUser = getUser(displayedUserId);
 
         boolean isDeletedUser = displayUser == null;
-        String displayName;
 
-        if (!isDeletedUser)
-        {
-            displayName = displayUser.getDisplayName(currentUser);
-        }
-        else
-        {
-            displayName = String.valueOf(displayedUserId);
-        }
+        if (isDeletedUser)
+            return PageFlowUtil.filter("<" + displayedUserId + ">");
 
+        String displayName = displayUser.getDisplayName(currentUser);
         ActionURL url = getUserDetailsURL(container, currentUser, displayedUserId);
 
-        if (url != null && !isDeletedUser)
+        // currentUser has permissions to see user details of the displayed user
+        if (url != null)
         {
             return "<a class=\"labkey-link\" href=\"" + url +
                     "\">" + PageFlowUtil.filter(displayName) + "</a>";
         }
 
-        return "<" + PageFlowUtil.filter(displayName) + ">";
+        return PageFlowUtil.filter(displayName);
     }
 
     /**

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -1129,11 +1129,29 @@ public class UserManager
      */
     public static String getUserDetailsHTMLLink(Container container, User currentUser, int displayedUserId)
     {
-        String displayName = getUser(displayedUserId).getDisplayName(currentUser);
+        User displayUser = getUser(displayedUserId);
 
-        return "<a class=\"labkey-link\" href=\"" +
-                getUserDetailsURL(container, currentUser, displayedUserId) +
-                "\">" + PageFlowUtil.filter(displayName) + "</a>";
+        boolean isDeletedUser = displayUser == null;
+        String displayName;
+
+        if (!isDeletedUser)
+        {
+            displayName = displayUser.getDisplayName(currentUser);
+        }
+        else
+        {
+            displayName = String.valueOf(displayedUserId);
+        }
+
+        ActionURL url = getUserDetailsURL(container, currentUser, displayedUserId);
+
+        if (url != null && !isDeletedUser)
+        {
+            return "<a class=\"labkey-link\" href=\"" + url +
+                    "\">" + PageFlowUtil.filter(displayName) + "</a>";
+        }
+
+        return "<" + PageFlowUtil.filter(displayName) + ">";
     }
 
     /**


### PR DESCRIPTION
Deleted user has an ID of 3218. Pictures below show examples of how we would be using the ID.
Link is removed if there is no user or the user doesn't have access to see the link.

<img width="632" alt="Screen Shot 2019-10-15 at 3 28 58 PM" src="https://user-images.githubusercontent.com/32881015/66874929-77114f00-ef61-11e9-8f06-d890339f033c.png">
<img width="1539" alt="Screen Shot 2019-10-15 at 3 29 12 PM" src="https://user-images.githubusercontent.com/32881015/66874930-77a9e580-ef61-11e9-9f93-bfef9dc72669.png">
<img width="1538" alt="Screen Shot 2019-10-15 at 3 29 57 PM" src="https://user-images.githubusercontent.com/32881015/66874931-77a9e580-ef61-11e9-8559-125a475a6174.png">


When a user doesn't have permissions to see another user's details page (assigned to column):
<img width="1541" alt="Screen Shot 2019-10-16 at 9 38 38 AM" src="https://user-images.githubusercontent.com/32881015/66940035-103f7480-eff9-11e9-8ff2-cd4fbdebc758.png">