### PR TITLE
Issue 38677: NPE when running specimen refresh with legacy PHI settings

### DIFF
--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -713,19 +713,19 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
     @NotNull
     public Set<Class> getIntegrationTests()
     {
-        Set<Class> set = new HashSet<>();
-        set.add(SpecimenImporter.TestCase.class);
-        set.add(StudyManager.DatasetImportTestCase.class);
-        set.add(ParticipantGroupManager.ParticipantGroupTestCase.class);
-        set.add(StudyImpl.ProtocolDocumentTestCase.class);
-        set.add(DatasetDefinition.TestCleanupOrphanedDatasetDomains.class);
-        set.add(StudyManager.VisitCreationTestCase.class);
-        set.add(TreatmentManager.TreatmentDataTestCase.class);
-        set.add(StudyManager.AssayScheduleTestCase.class);
-        set.add(VisitImpl.TestCase.class);
-        set.add(StudyModule.TestCase.class);
-
-        return set;
+        return Set.of(
+            DatasetDefinition.TestCleanupOrphanedDatasetDomains.class,
+            ParticipantGroupManager.ParticipantGroupTestCase.class,
+            SpecimenImporter.TestCase.class,
+            StudyImpl.ProtocolDocumentTestCase.class,
+            StudyManager.AssayScheduleTestCase.class,
+            StudyManager.DatasetImportTestCase.class,
+            StudyManager.StudySnapshotTestCase.class,
+            StudyManager.VisitCreationTestCase.class,
+            StudyModule.TestCase.class,
+            TreatmentManager.TreatmentDataTestCase.class,
+            VisitImpl.TestCase.class
+        );
     }
 
     @Override

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -7635,7 +7635,7 @@ public class StudyController extends BaseStudyController
         public ModelAndView getView(SnapshotSettingsForm form, boolean reshow, BindException errors)
         {
             _study = getStudyRedirectIfNull();
-            StudySnapshot snapshot = StudyManager.getInstance().getRefreshStudySnapshot(_study.getStudySnapshot());
+            StudySnapshot snapshot = StudyManager.getInstance().getStudySnapshot(_study.getStudySnapshot());
 
             if (null == snapshot)
             {
@@ -7666,7 +7666,7 @@ public class StudyController extends BaseStudyController
         public boolean handlePost(SnapshotSettingsForm form, BindException errors)
         {
             StudyImpl study = getStudyRedirectIfNull();
-            StudySnapshot snapshot = StudyManager.getInstance().getRefreshStudySnapshot(study.getStudySnapshot());
+            StudySnapshot snapshot = StudyManager.getInstance().getStudySnapshot(study.getStudySnapshot());
             assert null != snapshot;
             snapshot.setRefresh(form.isRefresh());
             StudyManager.getInstance().updateStudySnapshot(snapshot, getUser());

--- a/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
@@ -25,7 +25,6 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.ColumnHeaderType;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerFilterable;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
@@ -295,7 +294,7 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
         StudySnapshot snapshot = null;
 
         if (optionsId != null)
-            snapshot = StudyManager.getInstance().getRefreshStudySnapshot(optionsId);
+            snapshot = StudyManager.getInstance().getStudySnapshot(optionsId);
 
         PHI snapshotPhiLevel = (snapshot != null) ? snapshot.getSnapshotSettings().getPhiLevel() : PHI.NotPHI;
         Collection<ColumnInfo> columns = DatasetDataWriter.getColumnsToExport(tinfo, def, false, snapshotPhiLevel);

--- a/study/src/org/labkey/study/model/StudyImpl.java
+++ b/study/src/org/labkey/study/model/StudyImpl.java
@@ -806,7 +806,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     {
         if (_studySnapshotType == null && getStudySnapshot() != null)
         {
-            StudySnapshot snapshot = StudyManager.getInstance().getRefreshStudySnapshot(getStudySnapshot());
+            StudySnapshot snapshot = StudyManager.getInstance().getStudySnapshot(getStudySnapshot());
             if (snapshot != null)
             {
                 _studySnapshotType = snapshot.getType();

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -146,6 +146,7 @@ import org.labkey.study.dataset.DatasetAuditProvider;
 import org.labkey.study.designer.StudyDesignManager;
 import org.labkey.study.importer.SchemaReader;
 import org.labkey.study.importer.StudyImportContext;
+import org.labkey.study.model.StudySnapshot.SnapshotSettings;
 import org.labkey.study.query.DatasetTableImpl;
 import org.labkey.study.query.StudyQuerySchema;
 import org.labkey.study.visitmanager.AbsoluteDateVisitManager;
@@ -204,8 +205,9 @@ public class StudyManager
     protected StudyManager()
     {
         // prevent external construction with a private default constructor
-        _studyHelper = new QueryHelper<StudyImpl>(() -> StudySchema.getInstance().getTableInfoStudy(), StudyImpl.class)
+        _studyHelper = new QueryHelper<>(() -> StudySchema.getInstance().getTableInfoStudy(), StudyImpl.class)
         {
+            @Override
             public List<StudyImpl> get(final Container c, SimpleFilter filterArg, final String sortString)
             {
                 assert filterArg == null && sortString == null;
@@ -4633,7 +4635,7 @@ public class StudyManager
 
     public List<StudyImpl> getAncillaryStudies(Container sourceStudyContainer)
     {
-        // in the upgrade case there  may not be any ancillary studyies
+        // in the upgrade case there may not be any ancillary studies
         TableInfo t = StudySchema.getInstance().getTableInfoStudy();
         ColumnInfo ssci = t.getColumn("SourceStudyContainerId");
         if (null == ssci || ssci.isUnselectable())
@@ -4645,18 +4647,26 @@ public class StudyManager
     // Return collection of current snapshots that are configured to refresh specimens
     public Collection<StudySnapshot> getRefreshStudySnapshots()
     {
+        return getStudySnapshots(new SQLFragment(" AND Refresh = ?", Boolean.TRUE));
+    }
+
+    // Return collection of all current snapshots
+    private Collection<StudySnapshot> getStudySnapshots(@Nullable SQLFragment filter)
+    {
         SQLFragment sql = new SQLFragment("SELECT ss.* FROM ");
         sql.append(StudySchema.getInstance().getTableInfoStudy(), "s");
         sql.append(" JOIN ");
         sql.append(StudySchema.getInstance().getTableInfoStudySnapshot(), "ss");
-        sql.append(" ON s.StudySnapshot = ss.RowId AND Source IS NOT NULL AND Destination IS NOT NULL AND Refresh = ?");
-        sql.add(Boolean.TRUE);
+        sql.append(" ON s.StudySnapshot = ss.RowId AND Source IS NOT NULL AND Destination IS NOT NULL");
+
+        if (null != filter)
+            sql.append(filter);
 
         return new SqlSelector(StudySchema.getInstance().getSchema(), sql).getCollection(StudySnapshot.class);
     }
 
     @Nullable
-    public StudySnapshot getRefreshStudySnapshot(Integer snapshotId)
+    public StudySnapshot getStudySnapshot(Integer snapshotId)
     {
         TableSelector selector = new TableSelector(StudySchema.getInstance().getTableInfoStudySnapshot(), new SimpleFilter(FieldKey.fromParts("RowId"), snapshotId), null);
 
@@ -6000,6 +6010,79 @@ public class StudyManager
             {
                 assertTrue(ContainerManager.delete(_junitStudy.getContainer(), _context.getUser()));
             }
+        }
+    }
+
+    public static class StudySnapshotTestCase extends Assert
+    {
+        @Test
+        public void testComplianceSettings()
+        {
+            // We load the SnapshotSettings bean from serialized JSON in the core.StudySnapshot.Settings column. This
+            // test ensures that we serialize using the latest compliance properties but continue to correctly load
+            // older snapshots that might specify "removeProtectedColumns":true instead of "phiLevel":<value>. This
+            // was broken shortly after we migrated to using phiLevel, see #xxxx.
+
+            // phiLevel property takes precedence over legacy properties
+            testComplianceSettings("\"removeProtectedColumns\":true,\"removePhiColumns\":false,\"phiLevel\":\"Limited\",\"shiftDates\":false,\"useAlternateParticipantIds\":false,\"maskClinic\":false", PHI.Limited);
+            testComplianceSettings("\"removeProtectedColumns\":false,\"removePhiColumns\":false,\"phiLevel\":\"Limited\",\"shiftDates\":false,\"useAlternateParticipantIds\":false,\"maskClinic\":false", PHI.Limited);
+            testComplianceSettings("\"phiLevel\":\"Restricted\"", PHI.Restricted);
+            testComplianceSettings("\"phiLevel\":\"PHI\"", PHI.PHI);
+            testComplianceSettings("\"phiLevel\":\"Limited\"", PHI.Limited);
+            testComplianceSettings("\"phiLevel\":\"NotPHI\"", PHI.NotPHI);
+
+            // removeProtectedColumns:true means include no PHI columns
+            testComplianceSettings("\"removeProtectedColumns\":true,\"shiftDates\":true,\"useAlternateParticipantIds\":true,\"maskClinic\":true", PHI.NotPHI);
+            testComplianceSettings("\"removeProtectedColumns\":false,\"shiftDates\":true,\"useAlternateParticipantIds\":true,\"maskClinic\":true", PHI.Restricted);
+
+            // removePhiColumns property should have no effect
+            testComplianceSettings("\"removeProtectedColumns\":true,\"removePhiColumns\":true", PHI.NotPHI);
+            testComplianceSettings("\"removeProtectedColumns\":true,\"removePhiColumns\":false", PHI.NotPHI);
+
+            // If no properties are specified then include all columns
+            testComplianceSettings("\"shiftDates\":true,\"useAlternateParticipantIds\":true,\"maskClinic\":true", PHI.Restricted);
+            testComplianceSettings("", PHI.Restricted);
+        }
+
+        private static final String JSON_PREFIX = "{\"description\":null,\"participantGroups\":[],\"participants\":null,\"datasets\":[5008,5024,5025,5026,5004,5006,5007],\"datasetRefresh\":true,\"datasetRefreshDelay\":30,\"visits\":null,\"specimenRequestId\":null,\"includeSpecimens\":true,\"specimenRefresh\":true,\"studyObjects\":[],\"lists\":[],\"views\":[],\"reports\":[],\"folderObjects\":[]";
+
+        private void testComplianceSettings(String settingsJson, PHI expectedLevel)
+        {
+            String json = JSON_PREFIX + (StringUtils.isNotEmpty(settingsJson) ? "," + settingsJson + "}" : "}");
+            StudySnapshot snapshot = new StudySnapshot();
+            snapshot.setSettings(json);
+
+            testSnapshot(snapshot, expectedLevel);
+        }
+
+        @Test
+        public void testStoredSnapshots()
+        {
+            Collection<StudySnapshot> snapshots = StudyManager.getInstance().getStudySnapshots(null);
+
+            for (StudySnapshot snapshot : snapshots)
+            {
+                PHI level = snapshot.getSnapshotSettings().getPhiLevel();
+                testSnapshot(snapshot, level);
+                StudySnapshot snapshotFromRowId = StudyManager.getInstance().getStudySnapshot(snapshot.getRowId());
+                testSnapshot(snapshotFromRowId, level);
+            }
+        }
+
+        private void testSnapshot(StudySnapshot snapshot, PHI expectedLevel)
+        {
+            assertNotNull(snapshot);
+            assertNotNull(expectedLevel);
+            SnapshotSettings settings = snapshot.getSnapshotSettings();
+            assertNotNull("getPhiLevel() returned null", settings.getPhiLevel());
+            assertEquals(expectedLevel, settings.getPhiLevel());
+
+            // Test the settings JSON that this snapshot generates
+            String serializedJson = snapshot.getSettings();
+            String expectedLevelJson = "\"phiLevel\":\"" + expectedLevel.name() + "\"";
+            assertTrue("Serialized JSON did not include " + expectedLevelJson, serializedJson.contains(expectedLevelJson));
+            assertFalse("Serialized JSON included removeProtectedColumns", serializedJson.contains("removeProtectedColumns"));
+            assertFalse("Serialized JSON included removePhiColumns", serializedJson.contains("removePhiColumns"));
         }
     }
 }

--- a/study/src/org/labkey/study/view/manageStudy.jsp
+++ b/study/src/org/labkey/study/view/manageStudy.jsp
@@ -128,7 +128,7 @@
 <%
         }
 
-        StudySnapshot snapshot = StudyManager.getInstance().getRefreshStudySnapshot(study.getStudySnapshot());
+        StudySnapshot snapshot = StudyManager.getInstance().getStudySnapshot(study.getStudySnapshot());
         assert null != snapshot;
         Container parent = null==snapshot.getSource() ? null : ContainerManager.getForId(snapshot.getSource());
 


### PR DESCRIPTION
Revamp SnapshotSettings to read & respect legacy property "removeProtectedColumns" if phiLevel is not present, but no longer write legacy properties going forward.

Add a unit test to ensure this continues to work correctly.

More accurate method name, getStudySnapshot(), since that code is not limited to refresh studies in any way.