### PR TITLE
Update integration test to account for change to pipelinetest module

### DIFF
--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -1055,8 +1055,8 @@ public class PipelineJobServiceImpl implements PipelineJobService
 
                 if (null != pipelinetest)
                 {
-                    assertEquals("Task pipelines from pipelinetest module", 9, TASK_PIPELINE_CACHE.getResourceMap(pipelinetest).size());
-                    assertEquals("Task factories from pipelinetest module", 3, TASK_FACTORY_CACHE.getResourceMap(pipelinetest).size());
+                    assertEquals("Task pipelines from pipelinetest module", 10, TASK_PIPELINE_CACHE.getResourceMap(pipelinetest).size());
+                    assertEquals("Task factories from pipelinetest module", 2, TASK_FACTORY_CACHE.getResourceMap(pipelinetest).size());
                 }
 
                 Module pipelinetest2 = ModuleLoader.getInstance().getModule("pipelinetest2");

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -1056,7 +1056,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
                 if (null != pipelinetest)
                 {
                     assertEquals("Task pipelines from pipelinetest module", 10, TASK_PIPELINE_CACHE.getResourceMap(pipelinetest).size());
-                    assertEquals("Task factories from pipelinetest module", 2, TASK_FACTORY_CACHE.getResourceMap(pipelinetest).size());
+                    assertEquals("Task factories from pipelinetest module", 3, TASK_FACTORY_CACHE.getResourceMap(pipelinetest).size());
                 }
 
                 Module pipelinetest2 = ModuleLoader.getInstance().getModule("pipelinetest2");


### PR DESCRIPTION
I think this commit (https://github.com/LabKey/testAutomation/commit/6c9fb4befdfd53c4ca5d159f6b91b3692352a477#diff-ff11edf87ffbf4025704442af895726d) caused the pipeline to get cached differently.