### PR TITLE
Match file separators in test

### DIFF
--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -969,7 +969,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
             String javaHome = System.getenv("JAVA_HOME");
             if (javaHome != null)
             {
-                javaHome = javaHome.replace("/", File.separator); // Match normalized file separators from `getExecutablePath`
+                javaHome = javaHome.replaceAll("[/\\\\]", File.separator); // Match normalized file separators from `getExecutablePath`
                 String installPath = "${JAVA_HOME}/bin";
                 String found = _impl.getExecutablePath("jar", installPath, null, null, null);
                 assertEquals("Failed to expand environment variable correctly.", javaHome + File.separator + "bin" + File.separator + "jar", found);

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -84,6 +84,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
 public class PipelineJobServiceImpl implements PipelineJobService
@@ -969,7 +970,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
             String javaHome = System.getenv("JAVA_HOME");
             if (javaHome != null)
             {
-                javaHome = javaHome.replaceAll("[/\\\\]", File.separator); // Match normalized file separators from `getExecutablePath`
+                javaHome = javaHome.replaceAll("[/\\\\]", Matcher.quoteReplacement(File.separator)); // Match normalized file separators from `getExecutablePath`
                 String installPath = "${JAVA_HOME}/bin";
                 String found = _impl.getExecutablePath("jar", installPath, null, null, null);
                 assertEquals("Failed to expand environment variable correctly.", javaHome + File.separator + "bin" + File.separator + "jar", found);

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -969,6 +969,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
             String javaHome = System.getenv("JAVA_HOME");
             if (javaHome != null)
             {
+                javaHome = javaHome.replace("/", File.separator); // Match normalized file separators from `getExecutablePath`
                 String installPath = "${JAVA_HOME}/bin";
                 String found = _impl.getExecutablePath("jar", installPath, null, null, null);
                 assertEquals("Failed to expand environment variable correctly.", javaHome + File.separator + "bin" + File.separator + "jar", found);


### PR DESCRIPTION
The way we pass `JAVA_HOME` to Tomcat has changed slightly in the latest gradle plugin, causing this test to fail on TeamCity Windows agents.
Tomcat starts just fine with mixed `/` and `\` in `JAVA_HOME` so the test should be fine with either.