### PR TITLE
More appropriate response for attempting to view/edit guest user details

### DIFF
--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -2286,7 +2286,7 @@ public class UserController extends SpringActionController
         if (null == user)
             throw new NotFoundException("User not found :" + userId);
         if (user.isGuest())
-            throw new UnauthorizedException("Unable to modify Guest user details");
+            throw new NotFoundException("Action not valid for Guest user");
         return user;
     }
 


### PR DESCRIPTION
`UnauthorizedException` doesn't really make sense because nobody can view or edit details for the guest user; it isn't a matter of insufficient permission