### PR TITLE
38885: ExpProtocolAttachmentType breaks attachment query on SQL Server

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExpProtocolAttachmentType.java
+++ b/api/src/org/labkey/api/exp/api/ExpProtocolAttachmentType.java
@@ -41,6 +41,6 @@ public class ExpProtocolAttachmentType implements AttachmentType
     @Override
     public void addWhereSql(SQLFragment sql, String parentColumn, String documentNameColumn)
     {
-        sql.append(parentColumn).append(" IN (SELECT lsid FROM ").append(ExperimentService.get().getTinfoProtocol(), "p").append(")");
+        sql.append(parentColumn).append(" IN (SELECT EntityId FROM ").append(ExperimentService.get().getTinfoProtocol(), "ep").append(")");
     }
 }


### PR DESCRIPTION
Changing SQL to match `ExpRunAttachmentType`

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=38885