### PR TITLE
Issue 38911: exec task doesn't include same replacements as script task

### DIFF
--- a/api/src/org/labkey/api/pipeline/cmd/BooleanToCommandArgs.java
+++ b/api/src/org/labkey/api/pipeline/cmd/BooleanToCommandArgs.java
@@ -17,6 +17,7 @@ package org.labkey.api.pipeline.cmd;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -54,12 +55,12 @@ public class BooleanToCommandArgs extends JobParamToCommandArgs
         elseConverter.setParent(this);
     }
 
-    public List<String> toArgsInner(CommandTask task, Set<TaskToCommandArgs> visited) throws IOException
+    public List<String> toArgsInner(CommandTask task, Map<String, String> params, Set<TaskToCommandArgs> visited) throws IOException
     {
-        String value = getValue(task.getJob());
+        String value = getValue(params);
         if ("yes".equalsIgnoreCase(value))
-            return getIf().toArgs(task, visited);
+            return getIf().toArgs(task, params, visited);
         else
-            return getElse().toArgs(task, visited);
+            return getElse().toArgs(task, params, visited);
     }
 }

--- a/api/src/org/labkey/api/pipeline/cmd/EnumToCommandArgs.java
+++ b/api/src/org/labkey/api/pipeline/cmd/EnumToCommandArgs.java
@@ -52,14 +52,14 @@ public class EnumToCommandArgs extends JobParamToCommandArgs
         return _converters.get(value);
     }
 
-    public List<String> toArgsInner(CommandTask task, Set<TaskToCommandArgs> visited) throws IOException
+    public List<String> toArgsInner(CommandTask task, Map<String, String> params, Set<TaskToCommandArgs> visited) throws IOException
     {
-        String keyConverter = getValue(task.getJob());
+        String keyConverter = getValue(params);
         if (keyConverter != null)
         {
             TaskToCommandArgs converter = getConverter(keyConverter);
             if (converter != null)
-                return converter.toArgs(task, visited);
+                return converter.toArgs(task, params, visited);
         }
 
         return Collections.emptyList();

--- a/api/src/org/labkey/api/pipeline/cmd/ExeToCommandArgs.java
+++ b/api/src/org/labkey/api/pipeline/cmd/ExeToCommandArgs.java
@@ -73,7 +73,7 @@ public class ExeToCommandArgs extends ListToCommandArgs
         return (jobParams == null ? null : jobParams.get(_versionParamName));
     }
 
-    public List<String> toArgsInner(CommandTask task, Set<TaskToCommandArgs> visited) throws IOException
+    public List<String> toArgsInner(CommandTask task, Map<String, String> params, Set<TaskToCommandArgs> visited) throws IOException
     {
         if (_exePath == null || _exePath.length() == 0)
             return Collections.emptyList();
@@ -83,7 +83,7 @@ public class ExeToCommandArgs extends ListToCommandArgs
         RequiredInLine converterInline = new RequiredInLine();
         converterInline.setValue(PipelineJobService.get().getExecutablePath(_exePath,
                 task.getInstallPath(), _softwarePackage, getVersion(task), task.getJob().getLogger()));
-        args.addAll(converterInline.toArgs(task, visited));
+        args.addAll(converterInline.toArgs(task, params, visited));
 
         return args;
     }

--- a/api/src/org/labkey/api/pipeline/cmd/JarToCommandArgs.java
+++ b/api/src/org/labkey/api/pipeline/cmd/JarToCommandArgs.java
@@ -78,7 +78,7 @@ public class JarToCommandArgs extends ListToCommandArgs
         return (jobParams == null ? null : jobParams.get(_versionParamName));
     }
 
-    public List<String> toArgsInner(CommandTask task, Set<TaskToCommandArgs> visited) throws IOException
+    public List<String> toArgsInner(CommandTask task, Map<String, String> params, Set<TaskToCommandArgs> visited) throws IOException
     {
         if (_jarPath == null || _jarPath.length() == 0)
             return Collections.emptyList();
@@ -88,16 +88,16 @@ public class JarToCommandArgs extends ListToCommandArgs
         RequiredInLine converterInline = new RequiredInLine();
         converterInline.setParent(this);
         converterInline.setValue(PipelineJobService.get().getJavaPath());
-        args.addAll(converterInline.toArgs(task, visited));
+        args.addAll(converterInline.toArgs(task, params, visited));
 
         for (TaskToCommandArgs converter : getConverters())
-            args.addAll(converter.toArgs(task, visited));
+            args.addAll(converter.toArgs(task, params, visited));
 
         args.add("-jar");
 
         converterInline.setValue(PipelineJobService.get().getJarPath(_jarPath,
                 task.getInstallPath(), _softwarePackage, getVersion(task)));
-        args.addAll(converterInline.toArgs(task, visited));
+        args.addAll(converterInline.toArgs(task, params, visited));
 
         return args;
     }

--- a/api/src/org/labkey/api/pipeline/cmd/JobParamToCommandArgs.java
+++ b/api/src/org/labkey/api/pipeline/cmd/JobParamToCommandArgs.java
@@ -15,10 +15,8 @@
  */
 package org.labkey.api.pipeline.cmd;
 
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.ParamParser;
-import org.labkey.api.pipeline.PipelineJob;
 
 import java.util.Map;
 
@@ -73,16 +71,9 @@ abstract public class JobParamToCommandArgs extends TaskToCommandArgs
     }
 
     @Nullable
-    public String getValue(@NotNull PipelineJob job)
+    public String getValue(@Nullable Map<String, String> params)
     {
-        Map<String, String> jobParams = job.getParameters();
-        return getValue(jobParams);
-    }
-
-    @Nullable
-    public String getValue(@Nullable Map<String, String> jobParams)
-    {
-        String value = jobParams == null ? null : jobParams.get(getParameter());
+        String value = params == null ? null : params.get(getParameter());
         return value == null ? getDefault() : value;
     }
 

--- a/api/src/org/labkey/api/pipeline/cmd/JoinedBooleanToSwitch.java
+++ b/api/src/org/labkey/api/pipeline/cmd/JoinedBooleanToSwitch.java
@@ -15,10 +15,11 @@
  */
 package org.labkey.api.pipeline.cmd;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.io.IOException;
 
 /**
  * <code>JoinedBooleanToSwitch</code>
@@ -39,12 +40,12 @@ public class JoinedBooleanToSwitch extends TaskToCommandArgs
             converter.setParent(this);
     }
 
-    public List<String> toArgsInner(CommandTask task, Set<TaskToCommandArgs> visited) throws IOException
+    public List<String> toArgsInner(CommandTask task, Map<String, String> params, Set<TaskToCommandArgs> visited) throws IOException
     {
         StringBuilder switches = new StringBuilder();
         for (BooleanToSwitch converter : getConverters())
         {
-            if (converter.toArgs(task, visited).size() > 0)
+            if (converter.toArgs(task, params, visited).size() > 0)
                 switches.append(converter.getSwitchName());
         }
         if (switches.length() > 0)

--- a/api/src/org/labkey/api/pipeline/cmd/ListToCommandArgs.java
+++ b/api/src/org/labkey/api/pipeline/cmd/ListToCommandArgs.java
@@ -18,6 +18,7 @@ package org.labkey.api.pipeline.cmd;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -62,11 +63,11 @@ public class ListToCommandArgs extends TaskToCommandArgs
         _converters.add(converter);
     }
 
-    public List<String> toArgsInner(CommandTask task, Set<TaskToCommandArgs> visited) throws IOException
+    public List<String> toArgsInner(CommandTask task, Map<String, String> params, Set<TaskToCommandArgs> visited) throws IOException
     {
         ArrayList<String> args = new ArrayList<>();
         for (TaskToCommandArgs converter : getConverters())
-            args.addAll(converter.toArgs(task, visited));
+            args.addAll(converter.toArgs(task, params, visited));
         return args;
     }
 }

--- a/api/src/org/labkey/api/pipeline/cmd/PathToCommandArgs.java
+++ b/api/src/org/labkey/api/pipeline/cmd/PathToCommandArgs.java
@@ -17,6 +17,7 @@ package org.labkey.api.pipeline.cmd;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -24,7 +25,7 @@ import java.util.Set;
 */
 public abstract class PathToCommandArgs extends TaskPathToCommandArgs
 {
-    public List<String> toArgsInner(CommandTask task, Set<TaskToCommandArgs> visited) throws IOException
+    public List<String> toArgsInner(CommandTask task, Map<String, String> params, Set<TaskToCommandArgs> visited) throws IOException
     {
         return toArgs(getPaths(task));
     }

--- a/api/src/org/labkey/api/pipeline/cmd/RequiredInLine.java
+++ b/api/src/org/labkey/api/pipeline/cmd/RequiredInLine.java
@@ -89,7 +89,7 @@ public class RequiredInLine extends TaskToCommandArgs
         return isAddPipelineToolsDir() ? PipelineJobService.get().getToolPath(getValue(), null,  _softwarePackage, getVersion(task), task.getJob().getLogger()) : getValue();
     }
 
-    public List<String> toArgsInner(CommandTask task, Set<TaskToCommandArgs> visited) throws IOException
+    public List<String> toArgsInner(CommandTask task, Map<String, String> params, Set<TaskToCommandArgs> visited) throws IOException
     {
         return Collections.singletonList(getFullValue(task));
     }

--- a/api/src/org/labkey/api/pipeline/cmd/RequiredSwitch.java
+++ b/api/src/org/labkey/api/pipeline/cmd/RequiredSwitch.java
@@ -17,6 +17,7 @@ package org.labkey.api.pipeline.cmd;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -36,7 +37,7 @@ public class RequiredSwitch extends RequiredInLine
         _switchName = switchName;
     }
 
-    public List<String> toArgsInner(CommandTask task, Set<TaskToCommandArgs> visited) throws IOException
+    public List<String> toArgsInner(CommandTask task, Map<String, String> params, Set<TaskToCommandArgs> visited) throws IOException
     {
         // Ignore the key and job, and just return the switch.
         return getSwitchFormat().format(getSwitchName(), getFullValue(task));

--- a/api/src/org/labkey/api/pipeline/cmd/RequiredValueCommandArg.java
+++ b/api/src/org/labkey/api/pipeline/cmd/RequiredValueCommandArg.java
@@ -15,8 +15,8 @@
  */
 package org.labkey.api.pipeline.cmd;
 
-import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -47,7 +47,7 @@ public class RequiredValueCommandArg extends JobParamToCommandArgs
         _formatter = formatter;
     }
 
-    public List<String> toArgsInner(CommandTask task, Set<TaskToCommandArgs> visited)
+    public List<String> toArgsInner(CommandTask task, Map<String, String> params, Set<TaskToCommandArgs> visited)
     {
         return _formatter.toArgs(_value);
     }

--- a/api/src/org/labkey/api/pipeline/cmd/TaskToCommandArgs.java
+++ b/api/src/org/labkey/api/pipeline/cmd/TaskToCommandArgs.java
@@ -17,6 +17,7 @@ package org.labkey.api.pipeline.cmd;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -50,7 +51,7 @@ abstract public class TaskToCommandArgs
         _switchFormat = switchFormat;
     }
 
-    public final List<String> toArgs(CommandTask task, Set<TaskToCommandArgs> visited) throws IOException
+    public final List<String> toArgs(CommandTask task, Map<String, String> params, Set<TaskToCommandArgs> visited) throws IOException
     {
         if (visited.contains(this))
             throw new IllegalStateException("Circular logic in job to command args logic.");
@@ -59,7 +60,7 @@ abstract public class TaskToCommandArgs
         {
             visited.add(this);
 
-            return toArgsInner(task, visited);
+            return toArgsInner(task, params, visited);
         }
         finally
         {
@@ -67,5 +68,5 @@ abstract public class TaskToCommandArgs
         }
     }
 
-    abstract public List<String> toArgsInner(CommandTask task, Set<TaskToCommandArgs> visited) throws IOException;
+    abstract public List<String> toArgsInner(CommandTask task, Map<String, String> params, Set<TaskToCommandArgs> visited) throws IOException;
 }

--- a/api/src/org/labkey/api/pipeline/cmd/ValueToCommandArgs.java
+++ b/api/src/org/labkey/api/pipeline/cmd/ValueToCommandArgs.java
@@ -15,8 +15,8 @@
  */
 package org.labkey.api.pipeline.cmd;
 
-import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -29,9 +29,9 @@ import java.util.Set;
  */
 public abstract class ValueToCommandArgs extends JobParamToCommandArgs
 {
-    public List<String> toArgsInner(CommandTask task, Set<TaskToCommandArgs> visited)
+    public List<String> toArgsInner(CommandTask task, Map<String, String> params, Set<TaskToCommandArgs> visited)
     {
-        return toArgs(getValue(task.getJob()));
+        return toArgs(getValue(params));
     }
 
     abstract public List<String> toArgs(String value);

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1251,7 +1251,8 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                 ConvertHelper.TestCase.class,
                 RReport.TestCase.class,
                 CopyFileRootPipelineJob.TestCase.class,
-                MothershipReport.TestCase.class
+                MothershipReport.TestCase.class,
+                CommandLineTokenizer.TestCase.class
         ));
     }
 

--- a/internal/src/org/labkey/api/util/CommandLineTokenizer.java
+++ b/internal/src/org/labkey/api/util/CommandLineTokenizer.java
@@ -1,0 +1,297 @@
+package org.labkey.api.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public final class CommandLineTokenizer
+{
+    /**
+     * Tokenize a command line string into arguments.
+     *
+     * Splits on whitespace, preserves single- and double-quoted arguments as well
+     * arguments surrounded by ${ and }.  Backslash escapes the next character.
+     *
+     * @param str
+     * @return List of command line tokens.
+     * @throws IllegalArgumentException If the quotes are unbalanced.
+     */
+    @NotNull
+    public static List<String> tokenize(String str)
+    {
+        if (str == null || str.isBlank())
+            return Collections.emptyList();
+
+        List<String> tokens = new ArrayList<>(10);
+
+        StringBuilder current = new StringBuilder();
+
+        // true when we are backslash escaped
+        boolean escaped = false;
+        State state = State.NORMAL;
+        int startQuote = -1;
+
+        for (int i = 0; i < str.length(); i++)
+        {
+            char c = str.charAt(i);
+            if (escaped)
+            {
+                // Previous character was backslash, just append the current char
+                escaped = false;
+                current.append(c);
+            }
+            else
+            {
+                switch (state)
+                {
+                    case SINGLE_QUOTE:
+                        if (c == '\'')
+                        {
+                            // closing single-quote; continue until next whitespace is seen
+                            state = State.NORMAL;
+                            startQuote = -1;
+                        }
+                        else
+                        {
+                            current.append(c);
+                        }
+                        break;
+
+                    case DOUBLE_QUOTE:
+                        if (c == '"')
+                        {
+                            // closing double-quote; continue until next whitespace is seen
+                            state = State.NORMAL;
+                            startQuote = -1;
+                        }
+                        else if (c == '\\')
+                        {
+                            // backslash within double-quote string
+                            // peek ahead for backslash or double quote char and append the literal character
+                            if (i < str.length() && (str.charAt(i+1) == '\\' || str.charAt(i+1) == '"'))
+                            {
+                                i++;
+                                current.append(str.charAt(i));
+                            }
+                            else
+                            {
+                                current.append(c);
+                            }
+                        }
+                        else
+                        {
+                            current.append(c);
+                        }
+                        break;
+
+                    case DOLLAR_CURLY:
+                        if (c == '}')
+                        {
+                            // closing curly; continue until next whitespace is seen
+                            state = State.NORMAL;
+                            startQuote = -1;
+                            current.append(c);
+                        }
+                        else
+                        {
+                            current.append(c);
+                        }
+                        break;
+
+                    case NORMAL:
+                    default:
+                        if (c == '\\')
+                        {
+                            // backslash escape
+                            escaped = true;
+                        }
+                        else if (c == '\'')
+                        {
+                            // starting single quote
+                            state = State.SINGLE_QUOTE;
+                            startQuote = i;
+                        }
+                        else if (c == '"')
+                        {
+                            // starting double quote
+                            state = State.DOUBLE_QUOTE;
+                            startQuote = i;
+                        }
+                        else if (c == '$')
+                        {
+                            // peek ahead to see if we have '{'
+                            if (i < str.length() && str.charAt(i+1) == '{')
+                            {
+                                i++;
+                                state = State.DOLLAR_CURLY;
+                                startQuote = i;
+                                current.append("${");
+                            }
+                            else
+                            {
+                                current.append(c);
+                            }
+                        }
+                        else if (!Character.isWhitespace(c))
+                        {
+                            // any other character
+                            current.append(c);
+                            state = State.NORMAL;
+                        }
+                        else
+                        {
+                            // whitespace ends the token
+                            if (current.length() > 0)
+                                tokens.add(current.toString());
+                            current = new StringBuilder();
+                            state = State.NORMAL;
+                        }
+                        break;
+                }
+            }
+        }
+
+        // throw exception if quotes are unbalanced
+        if (state != State.NORMAL)
+        {
+            assert startQuote != -1;
+            throw new IllegalArgumentException("Mismatched " + state.name() + " starting at " + startQuote + ": " + str);
+        }
+
+        // append the dangling backslash
+        if (escaped)
+            current.append('\\');
+
+        if (current.length() > 0)
+            tokens.add(current.toString());
+
+        return tokens;
+    }
+
+    private enum State {
+        NORMAL,
+        SINGLE_QUOTE,
+        DOUBLE_QUOTE,
+        DOLLAR_CURLY
+    }
+
+    public static class TestCase
+    {
+        @Test
+        public void testEmpty()
+        {
+            assertThat(tokenize(null), equalTo(List.of()));
+            assertThat(tokenize(""), equalTo(List.of()));
+            assertThat(tokenize("   "), equalTo(List.of()));
+            assertThat(tokenize("\t\n "), equalTo(List.of()));
+        }
+
+        @Test
+        public void testSimple()
+        {
+            assertThat(tokenize("a b c"), equalTo(List.of("a", "b", "c")));
+            assertThat(tokenize("abc"), equalTo(List.of("abc")));
+
+            // backslash escaped character
+            assertThat(tokenize("a \\b c"), equalTo(List.of("a", "b", "c")));
+            assertThat(tokenize("a\\ b c"), equalTo(List.of("a b", "c")));
+            assertThat(tokenize("\\\\"), equalTo(List.of("\\")));
+
+            // trailing backslash included
+            assertThat(tokenize("\\"), equalTo(List.of("\\")));
+            assertThat(tokenize("c:\\\\path\\\\"), equalTo(List.of("c:\\path\\")));
+        }
+
+        @Test
+        public void testSingleQuote()
+        {
+            assertThat(tokenize("'a b c'"), equalTo(List.of("a b c")));
+
+            // quotes can be used within an argument
+            assertThat(tokenize("tr -d' '"), equalTo(List.of("tr", "-d ")));
+
+            // whitespace and double-quote within single-quote
+            assertThat(tokenize("'a  \"  b'"), equalTo(List.of("a  \"  b")));
+
+            // backslash within single-quote string
+            assertThat(tokenize("'\\'"), equalTo(List.of("\\")));
+
+            // mismatched quote
+            try
+            {
+                tokenize("Conan O'Brien");
+                fail("Expected mismatched quote exception");
+            }
+            catch (IllegalArgumentException e)
+            {
+                assertThat(e.getMessage(), startsWith("Mismatched SINGLE_QUOTE starting at 7:"));
+            }
+        }
+
+        @Test
+        public void testDoubleQuote()
+        {
+            assertThat(tokenize("\"a b c\""), equalTo(List.of("a b c")));
+
+            // whitespace and single-quote within double-quote string
+            assertThat(tokenize("\"a  '  b\""), equalTo(List.of("a  '  b")));
+
+            // whitespace and curly-quote within double-quote string
+            assertThat(tokenize("\"${foo bar}\""), equalTo(List.of("${foo bar}")));
+            assertThat(tokenize("\"test ${foo bar}\" blee"), equalTo(List.of("test ${foo bar}", "blee")));
+
+            // backslash escaped quote inside double-quote string
+            assertThat(tokenize("\"a \\\"b c\""), equalTo(List.of("a \"b c")));
+
+            // backslash escaped backslash inside double-quote string
+            assertThat(tokenize("\"a \\\\b c\""), equalTo(List.of("a \\b c")));
+
+            // mismatched quote
+            try
+            {
+                tokenize("\"foo");
+                fail("Expected mismatched quote exception");
+            }
+            catch (IllegalArgumentException e)
+            {
+                assertThat(e.getMessage(), startsWith("Mismatched DOUBLE_QUOTE starting at 0"));
+            }
+        }
+
+        @Test
+        public void testCurlyQuote()
+        {
+            // base $ passed through
+            assertThat(tokenize("a$b c"), equalTo(List.of("a$b", "c")));
+
+            assertThat(tokenize("foo ${pipeline, username} bar"),
+                    equalTo(List.of("foo", "${pipeline, username}", "bar")));
+
+            // whitespace and quotes within double-quote string
+            assertThat(tokenize("${a  '  b}"), equalTo(List.of("${a  '  b}")));
+
+            // closing curly
+            assertThat(tokenize("a}b"), equalTo(List.of("a}b")));
+
+            // mismatched quote
+            try
+            {
+                tokenize(" ${ ");
+                fail("Expected mismatched quote exception");
+            }
+            catch (IllegalArgumentException e)
+            {
+                assertThat(e.getMessage(), startsWith("Mismatched DOLLAR_CURLY starting at 2"));
+            }
+        }
+    }
+
+}

--- a/pipeline/src/org/labkey/pipeline/PipelineCommandTestCase.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineCommandTestCase.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.pipeline;
 
-import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.Assert;
@@ -132,11 +131,11 @@ public class PipelineCommandTestCase extends Assert
         RequiredSwitch test3 = new RequiredSwitch();
         test3.setSwitchFormat(new UnixNewSwitchFormat());
         test3.setSwitchName("c");
-        List<String> args3 = test3.toArgsInner(null, null);
+        List<String> args3 = test3.toArgsInner(null, null, null);
         assertEquals("Unexpected length for RequiredSwitch args", 1, args3.size());
         assertEquals("Unexpected arg for RequiredSwitch", "--c", args3.get(0));
         test3.setValue("Test3");
-        args3 = test3.toArgsInner(null, null);
+        args3 = test3.toArgsInner(null, null, null);
         assertEquals("Unexpected length for RequiredSwitch args", 1, args3.size());
         assertEquals("Unexpected arg for RequiredSwitch", "--c=Test3", args3.get(0));
 
@@ -205,19 +204,17 @@ public class PipelineCommandTestCase extends Assert
         commandList.addConverter(test5);
         commandList.addConverter(test6);
 
-        // expected param args to be : -a 100 -b -c testing -d testing2 100 -999
         final PipelineJob j = _context.mock(PipelineJob.class);
-        _context.checking(new Expectations() {{
-            allowing(j).getParameters();
-            Map<String, String> params = new HashMap<>();
-            params.put("test, boolean to switch", "yes");
-            params.put("test, value with switch", "testing");
-            params.put("test, value to switch with multi args", "testing2 100 -999");
-            params.put("test, inline value with default", "f");
-            will(returnValue(params));
-        }});
-        
-        List<String> args = commandList.toArgs(new CommandTaskImpl(j, new CommandTaskImpl.Factory()), new HashSet<TaskToCommandArgs>());
+        final CommandTaskImpl cmd = new CommandTaskImpl(j, new CommandTaskImpl.Factory());
+
+        // expected param args to be : -a 100 -b -c testing -d testing2 100 -999
+        Map<String, String> params = new HashMap<>();
+        params.put("test, boolean to switch", "yes");
+        params.put("test, value with switch", "testing");
+        params.put("test, value to switch with multi args", "testing2 100 -999");
+        params.put("test, inline value with default", "f");
+
+        List<String> args = commandList.toArgs(cmd, params, new HashSet<TaskToCommandArgs>());
         assertEquals("Unexpected length for args", 10, args.size());
         assertEquals("Unexpected arg for RequiredSwitch", "-a", args.get(0));
         assertEquals("Unexpected arg for RequiredSwitch", "100", args.get(1));
@@ -230,18 +227,17 @@ public class PipelineCommandTestCase extends Assert
         assertEquals("Unexpected arg for ValueToMultiCommandArgs", "-999", args.get(8));
         assertEquals("Unexpected arg for ValueInLine", "f", args.get(9));
 
-        // expected param args to be : -a 100
         final PipelineJob j2 = _context.mock(PipelineJob.class, "job2");
-        _context.checking(new Expectations() {{
-            allowing(j2).getParameters();
-            Map<String, String> params = new HashMap<>();
-            params.put("test, boolean to switch", "no");
-            params.put("test, value with switch", null);
-            params.put("test, value to switch with multi args", "");
-            params.put("test, inline value with default", null);
-            will(returnValue(params));
-        }});
-        List<String> args2 = commandList.toArgs(new CommandTaskImpl(j2, new CommandTaskImpl.Factory()), new HashSet<TaskToCommandArgs>());
+        final CommandTaskImpl cmd2 = new CommandTaskImpl(j2, new CommandTaskImpl.Factory());
+
+        // expected param args to be : -a 100
+        Map<String, String> params2 = new HashMap<>();
+        params.put("test, boolean to switch", "no");
+        params.put("test, value with switch", null);
+        params.put("test, value to switch with multi args", "");
+        params.put("test, inline value with default", null);
+
+        List<String> args2 = commandList.toArgs(cmd2, params2, new HashSet<TaskToCommandArgs>());
         assertEquals("Unexpected length for args2", 3, args2.size());
         assertEquals("Unexpected arg for RequiredSwitch", "-a", args2.get(0));
         assertEquals("Unexpected arg for RequiredSwitch", "100", args2.get(1));

--- a/pipeline/src/org/labkey/pipeline/api/ExecTaskFactory.java
+++ b/pipeline/src/org/labkey/pipeline/api/ExecTaskFactory.java
@@ -43,6 +43,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.labkey.api.util.CommandLineTokenizer.tokenize;
+
 /**
  * User: kevink
  * Date: 12/30/13
@@ -125,11 +127,9 @@ public class ExecTaskFactory extends SimpleTaskFactory
     {
         List<TaskToCommandArgs> ret = new ArrayList<>();
 
-        // TODO: Better parsing: handle quoting and whitespace in tokens
-        String[] parts = command.split(" ");
+        List<String> parts = tokenize(command);
         for (String part : parts)
         {
-            part = part.trim();
             if (part.length() == 0)
                 continue;
 

--- a/pipeline/src/org/labkey/pipeline/api/ScriptTaskFactory.java
+++ b/pipeline/src/org/labkey/pipeline/api/ScriptTaskFactory.java
@@ -207,7 +207,7 @@ public class ScriptTaskFactory extends SimpleTaskFactory
     }
 
     @Override
-    public List<String> toArgs(CommandTask task)
+    public List<String> toArgs(CommandTask task, Map<String, String> replacements)
     {
         throw new IllegalStateException();
     }


### PR DESCRIPTION
- tokenize command line, preserve space within quotes and curly ${tokens}
- include additional replacements in CommandTaskImpl generated command line