### PR TITLE
Issue 38504: Update Run properties fails to resolve string lookups

### DIFF
--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -655,7 +655,15 @@ public class DataColumn extends DisplayColumn
             String textInputValue = strVal;
             if (ExperimentalFeatureService.get().isFeatureEnabled(EXPERIMENTAL_RESOLVE_LOOKUPS_BY_VALUE))
             {
-                Object displayValue = getDisplayValue(ctx);
+                Object displayValue = null;
+                TableViewForm viewForm = ctx.getForm();
+                if (viewForm != null && viewForm.contains(this, ctx))
+                {
+                    // On error reshow, use the user supplied form value
+                    displayValue = viewForm.get(formFieldName);
+                }
+                if (displayValue == null)
+                    displayValue = getDisplayValue(ctx);
                 textInputValue = Objects.toString(displayValue, strVal);
             }
             renderTextFormInput(ctx, out, formFieldName, value, textInputValue, disabledInput);


### PR DESCRIPTION
- When the lookup column is not the PK column, don't attempt to
  convert the new and old values for the audit log message.

- On update form reshow, use the submitted form value instead of
  the stringified id value.