### PR TITLE
Issue 39022: GWT refuses to serialize exception when resizing column …

### DIFF
--- a/internal/src/org/labkey/api/exp/property/AbstractDomainKind.java
+++ b/internal/src/org/labkey/api/exp/property/AbstractDomainKind.java
@@ -279,7 +279,7 @@ public abstract class AbstractDomainKind extends DomainKind
     @Override
     public boolean exceedsMaxLength(Domain domain, DomainProperty prop)
     {
-        if (prop.getPropertyDescriptor().isStringType())
+        if (!prop.getPropertyDescriptor().isStringType())
             return false;
 
         String schema = getStorageSchemaName();


### PR DESCRIPTION
…on SQL Server 2019

Fix check in exceedsMaxLength() to avoid SQLExceptions when resizing too small