### PR TITLE
Issue 39223: conditional format filters don't support ~me~ value replacement

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -204,6 +204,7 @@ public class ApiModule extends CodeOnlyModule
             ContainerDisplayColumn.TestCase.class,
             ContainerFilter.TestCase.class,
             ContainerManager.TestCase.class,
+            CompareType.TestCase.class,
             DbSchema.CachingTestCase.class,
             DbSchema.DDLMethodsTestCase.class,
             DbSchema.SchemaCasingTestCase.class,

--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -1277,8 +1277,8 @@ public abstract class CompareType
         if (fk instanceof UserIdForeignKey || fk instanceof UserIdQueryForeignKey)
             return true;
 
-        if (lookupSchemaName.equalsIgnoreCase("core") &&
-                (lookupQueryName.equalsIgnoreCase("users") || lookupQueryName.equalsIgnoreCase("usersdata")))
+        if ("core".equalsIgnoreCase(lookupSchemaName) &&
+                ("users".equalsIgnoreCase(lookupQueryName) || "usersdata".equalsIgnoreCase(lookupQueryName)))
             return true;
 
         return false;
@@ -1294,7 +1294,7 @@ public abstract class CompareType
             return false;
 
         String propertyURI = col.getPropertyURI();
-        if (propertyURI.endsWith("core#UsersData.DisplayName") || propertyURI.endsWith("core#Users.DisplayName"))
+        if (propertyURI != null && (propertyURI.endsWith("core#UsersData.DisplayName") || propertyURI.endsWith("core#Users.DisplayName")))
             return true;
 
         return false;

--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -85,7 +85,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
         {
             if (value == null)
             {
@@ -113,7 +113,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             FilterClause clause = createFilterClause(FieldKey.fromParts("unused"), paramVals.length > 0 ? paramVals[0] : null);
             return clause.meetsCriteria(col, value);
@@ -129,7 +129,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
         {
             return !CompareType.EQUAL.meetsCriteria(col, value, filterValues);
         }
@@ -148,7 +148,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             FilterClause clause = createFilterClause(FieldKey.fromParts("unused"), paramVals.length > 0 ? paramVals[0] : null);
             return clause.meetsCriteria(col, value);
@@ -164,7 +164,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
         {
             return value == null || !CompareType.EQUAL.meetsCriteria(col, value, filterValues);
         }
@@ -173,7 +173,7 @@ public abstract class CompareType
     public static final CompareType GT = new CompareType("Is Greater Than", "gt", "GREATER_THAN", true, " > ?", OperatorType.GT)
     {
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
         {
             if (!(value instanceof Comparable))
             {
@@ -197,7 +197,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             CompareClause clause = createFilterClause(FieldKey.fromParts("unused"), paramVals.length > 0 ? paramVals[0] : null);
             return clause.meetsCriteria(col, value);
@@ -207,7 +207,7 @@ public abstract class CompareType
     public static final CompareType LT = new CompareType("Is Less Than", "lt", "LESS_THAN", true, " < ?", OperatorType.LT)
     {
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
         {
             if (!(value instanceof Comparable))
             {
@@ -231,7 +231,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             CompareClause clause = createFilterClause(FieldKey.fromParts("unused"), paramVals.length > 0 ? paramVals[0] : null);
             return clause.meetsCriteria(col, value);
@@ -241,7 +241,7 @@ public abstract class CompareType
     public static final CompareType GTE = new CompareType("Is Greater Than or Equal To", "gte", "GREATER_THAN_OR_EQUAL", true, " >= ?", OperatorType.GTE)
     {
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
         {
             if (!(value instanceof Comparable))
             {
@@ -265,7 +265,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             CompareClause clause = createFilterClause(FieldKey.fromParts("unused"), paramVals.length > 0 ? paramVals[0] : null);
             return clause.meetsCriteria(col, value);
@@ -275,7 +275,7 @@ public abstract class CompareType
     public static final CompareType LTE = new CompareType("Is Less Than or Equal To", "lte", "LESS_THAN_OR_EQUAL", true, " <= ?", OperatorType.LTE)
     {
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
         {
             if (!(value instanceof Comparable))
             {
@@ -299,7 +299,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             CompareClause clause = createFilterClause(FieldKey.fromParts("unused"), paramVals.length > 0 ? paramVals[0] : null);
             return clause.meetsCriteria(col, value);
@@ -315,7 +315,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
         {
             return value != null && value.toString().startsWith((String)filterValues[0]);
         }
@@ -330,7 +330,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
         {
             return value == null || !value.toString().startsWith((String)filterValues[0]);
         }
@@ -345,7 +345,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
         {
             return value != null && value.toString().contains((String) filterValues[0]);
         }
@@ -360,7 +360,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
         {
             return value == null || !value.toString().contains((String) filterValues[0]);
         }
@@ -388,7 +388,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             FilterClause clause = createFilterClause(FieldKey.fromParts("unused"), Arrays.asList(paramVals));
             return clause.meetsCriteria(col, value);
@@ -420,7 +420,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             FilterClause clause = createFilterClause(FieldKey.fromParts("unused"), Arrays.asList(paramVals));
             return !clause.meetsCriteria(col, value);
@@ -462,7 +462,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             FilterClause clause = new SimpleFilter.InClause(FieldKey.fromParts("unused"), Arrays.asList(paramVals));
             return clause.meetsCriteria(col, value);
@@ -504,7 +504,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             FilterClause clause = new SimpleFilter.InClause(FieldKey.fromParts("unused"), Arrays.asList(paramVals));
             return !clause.meetsCriteria(col, value);
@@ -530,7 +530,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             throw new UnsupportedOperationException("Should be handled inside of " + SimpleFilter.InClause.class);
         }
@@ -549,7 +549,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             throw new UnsupportedOperationException("Should be handled inside of " + SimpleFilter.InClause.class);
         }
@@ -580,7 +580,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             FieldKey fieldKey = FieldKey.fromParts("unused");
             FilterClause clause;
@@ -631,7 +631,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             FieldKey fieldKey = FieldKey.fromParts("unused");
             FilterClause clause;
@@ -666,7 +666,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             throw new UnsupportedOperationException("Conditional formatting not yet supported for MEMBER_OF");
         }
@@ -685,7 +685,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
         {
             return value == null;
         }
@@ -707,7 +707,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] filterValues)
         {
             return value != null;
         }
@@ -729,7 +729,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             throw new UnsupportedOperationException("Conditional formatting not yet supported for MV indicators");
         }
@@ -744,7 +744,7 @@ public abstract class CompareType
         }
 
         @Override
-        protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+        public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
         {
             throw new UnsupportedOperationException("Conditional formatting not yet supported for MV indicators");
         }
@@ -1023,7 +1023,7 @@ public abstract class CompareType
         return _valueSeparator;
     }
 
-    protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+    public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
     {
         // if not implemented, but be implemented by the FilterClause
         throw new UnsupportedOperationException();

--- a/api/src/org/labkey/api/data/ConditionalFormat.java
+++ b/api/src/org/labkey/api/data/ConditionalFormat.java
@@ -18,7 +18,10 @@ package org.labkey.api.data;
 import org.apache.log4j.Logger;
 import org.fhcrc.cpas.exp.xml.PropertyDescriptorType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.SimpleFilter.FilterClause;
+import org.labkey.api.exp.PropertyColumn;
+import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.gwt.client.model.GWTConditionalFormat;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.URLHelper;
@@ -67,16 +70,71 @@ public class ConditionalFormat extends GWTConditionalFormat
         return result;
     }
 
-    public boolean meetsCriteria(Object value)
+    /**
+     * Checks if the conditional format applies to the value.
+     * @throws RuntimeSQLException if the filter parameters are invalid.
+     */
+    private boolean _meetsCriteria(ColumnRenderProperties col, Object value)
     {
         for (FilterClause filterClause : getSimpleFilter().getClauses())
         {
-            if (!filterClause.meetsCriteria(value))
+            if (!filterClause.meetsCriteria(col, value))
             {
                 return false;
             }
         }
         return true;
+    }
+
+    /**
+     * Checks if the conditional format applies to the value.
+     */
+    public boolean meetsCriteria(ColumnInfo col, Object value)
+    {
+        try
+        {
+            return _meetsCriteria(col, value);
+        }
+        catch (RuntimeSQLException e)
+        {
+            // CompareType.convertParamValue will throw if the filter clause parameter(s) can't be converted
+            if (e.getSQLException() instanceof SQLGenerationException)
+            {
+                // Error message should have already been reported by <code>validateFormat</code>
+                return false;
+            }
+            else
+            {
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Validates the conditional format filter parameter values.
+     * @return An error message if the format is invalid, otherwise null
+     */
+    @Nullable
+    public String validateFormat(@NotNull ColumnRenderProperties col)
+    {
+        try
+        {
+            _meetsCriteria(col, "ignored");
+            return null;
+        }
+        catch (RuntimeSQLException e)
+        {
+            // Deal with unparseable filter values - see issue 23321
+            // CompareType.convertParamValue will throw if the filter clause parameter(s) can't be converted
+            if (e.getSQLException() instanceof SQLGenerationException)
+            {
+                return "Invalid conditional format filter: " + e.getMessage();
+            }
+            else
+            {
+                throw e;
+            }
+        }
     }
 
     @NotNull

--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -454,7 +454,7 @@ public class DataColumn extends DisplayColumn
         for (ConditionalFormat format : getBoundColumn().getConditionalFormats())
         {
             Object value = ctx.get(_displayColumn.getFieldKey());
-            if (format.meetsCriteria(value))
+            if (format.meetsCriteria(_displayColumn, value))
             {
                 return format;
             }
@@ -467,7 +467,7 @@ public class DataColumn extends DisplayColumn
             for (ConditionalFormat format : _displayColumn.getConditionalFormats())
             {
                 Object value = ctx.get(_displayColumn.getFieldKey());
-                if (format.meetsCriteria(value))
+                if (format.meetsCriteria(_displayColumn, value))
                 {
                     return format;
                 }

--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -2627,6 +2627,49 @@ public class DataRegion extends DisplayElement
     }
 
     /**
+     * Add a DataRegion message for invalid conditional formats.
+     */
+    private void prepareConditionalFormats(RenderContext ctx)
+    {
+        for (DisplayColumn dc : getDisplayColumns())
+        {
+            String msg = prepareConditionalFormats(dc);
+            if (msg != null)
+                addMessage(new Message(PageFlowUtil.filter(msg), MessageType.WARNING, "filter"));
+        }
+    }
+
+    /**
+     * Check for invalid conditional formats.
+     */
+    private String prepareConditionalFormats(DisplayColumn dc)
+    {
+        ColumnInfo col = dc.getColumnInfo();
+        if (col == null)
+            return null;
+
+        for (ConditionalFormat format : col.getConditionalFormats())
+        {
+            String msg = format.validateFormat(col);
+            if (msg != null)
+                return msg;
+        }
+
+        ColumnInfo displayCol = dc.getDisplayColumnInfo();
+        if (displayCol != null && col != displayCol)
+        {
+            for (ConditionalFormat format : displayCol.getConditionalFormats())
+            {
+                String msg = format.validateFormat(displayCol);
+                if (msg != null)
+                    return msg;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * @param fieldKey The fieldKey to match a DisplayColumn against.
      * @return DisplayColumn associated with the fieldKey if it is shown in this DataRegion, otherwise, null
      */
@@ -2748,6 +2791,7 @@ public class DataRegion extends DisplayElement
         {
             prepareParameters(ctx);
             prepareFilters(ctx);
+            prepareConditionalFormats(ctx);
         }
 
         prepareView(ctx);

--- a/api/src/org/labkey/api/data/ExcelColumn.java
+++ b/api/src/org/labkey/api/data/ExcelColumn.java
@@ -545,7 +545,7 @@ public class ExcelColumn extends RenderColumn
 
         for (ConditionalFormat format : columnInfo.getConditionalFormats())
         {
-            if (format.meetsCriteria(o))
+            if (format.meetsCriteria(columnInfo, o))
             {
                 CellStyle excelFormat = _formats.get(format);
                 if (excelFormat == null)

--- a/api/src/org/labkey/api/security/SecurityPolicy.java
+++ b/api/src/org/labkey/api/security/SecurityPolicy.java
@@ -516,7 +516,7 @@ public class SecurityPolicy implements HasPermission
     }
 
     @NotNull
-    protected Set<Role> getContextualRoles(UserPrincipal principal)
+    protected Set<Role> getContextualRoles(@NotNull UserPrincipal principal)
     {
         return principal.getContextualRoles(this);
     }

--- a/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
@@ -666,7 +666,7 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
             String value = buildString(ctx, false);
             for (ConditionalFormat format : getBoundColumn().getConditionalFormats())
             {
-                if (format.meetsCriteria(value))
+                if (format.meetsCriteria(getBoundColumn(), value))
                 {
                     return format.getCssStyle();
                 }

--- a/experiment/src/org/labkey/experiment/api/VocabularyDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/VocabularyDomainKind.java
@@ -138,9 +138,9 @@ public class VocabularyDomainKind extends AbstractDomainKind
 
         if (!container.isContainerFor(ContainerType.DataType.domainDefinitions))
         {
-            throw new IllegalArgumentException("Vocabulary  can not be created in this Container type.");
+            throw new IllegalArgumentException("Vocabulary can not be created in this Container type.");
         }
-        String domainURI = generateDomainURI( name, container);
+        String domainURI = generateDomainURI(name, container);
 
         List<GWTPropertyDescriptor> properties = domain.getFields();
         Domain vocabularyDomain = PropertyService.get().createDomain(container, domainURI, domain.getName(), templateInfo);

--- a/experiment/src/org/labkey/experiment/api/data/ChildOfCompareType.java
+++ b/experiment/src/org/labkey/experiment/api/data/ChildOfCompareType.java
@@ -16,6 +16,7 @@
 package org.labkey.experiment.api.data;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.ColumnRenderProperties;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.query.FieldKey;
@@ -39,7 +40,7 @@ public class ChildOfCompareType extends CompareType
     }
 
     @Override
-    public boolean meetsCriteria(Object value, Object[] paramVals)
+    protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
     {
         throw new UnsupportedOperationException("Conditional formatting not yet supported for EXP_CHILD_OF");
     }

--- a/experiment/src/org/labkey/experiment/api/data/ChildOfCompareType.java
+++ b/experiment/src/org/labkey/experiment/api/data/ChildOfCompareType.java
@@ -40,7 +40,7 @@ public class ChildOfCompareType extends CompareType
     }
 
     @Override
-    protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+    public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
     {
         throw new UnsupportedOperationException("Conditional formatting not yet supported for EXP_CHILD_OF");
     }

--- a/experiment/src/org/labkey/experiment/api/data/ParentOfCompareType.java
+++ b/experiment/src/org/labkey/experiment/api/data/ParentOfCompareType.java
@@ -16,6 +16,7 @@
 package org.labkey.experiment.api.data;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.ColumnRenderProperties;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.query.FieldKey;
@@ -39,7 +40,7 @@ public class ParentOfCompareType extends CompareType
     }
 
     @Override
-    public boolean meetsCriteria(Object value, Object[] paramVals)
+    protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
     {
         throw new UnsupportedOperationException("Conditional formatting not yet supported for EXP_PARENT_OF");
     }

--- a/experiment/src/org/labkey/experiment/api/data/ParentOfCompareType.java
+++ b/experiment/src/org/labkey/experiment/api/data/ParentOfCompareType.java
@@ -40,7 +40,7 @@ public class ParentOfCompareType extends CompareType
     }
 
     @Override
-    protected boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+    public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
     {
         throw new UnsupportedOperationException("Conditional formatting not yet supported for EXP_PARENT_OF");
     }

--- a/internal/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/internal/src/org/labkey/api/exp/property/DomainUtil.java
@@ -810,9 +810,19 @@ public class DomainUtil
         List<ConditionalFormat> formats = new ArrayList<>();
         for (GWTConditionalFormat format : from.getConditionalFormats())
         {
-            formats.add(new ConditionalFormat(format));
+            ConditionalFormat fmt = new ConditionalFormat(format);
+            String msg = fmt.validateFormat(to.getPropertyDescriptor());
+            if (msg != null)
+            {
+                if (errors == null)
+                    throw new RuntimeException(msg);
+                errors.addError(new PropertyValidationError(msg, from.getName(), from.getPropertyId()));
+                return;
+            }
+            formats.add(fmt);
         }
         to.setConditionalFormats(formats);
+
         // If the incoming DomainProperty specifies its dimension/measure state, respect that value.  Otherwise we need
         // to infer the correct value. This is necessary for code paths like the dataset creation wizard which does not
         // (and should not, for simplicity reasons) provide the user with the option to specify dimension/measure status
@@ -851,7 +861,7 @@ public class DomainUtil
         if (from.isExcludeFromShifting())
             to.setExcludeFromShifting(from.isExcludeFromShifting());
 
-        if(from.getScale() != null)
+        if (from.getScale() != null)
             to.setScale(from.getScale());
     }
 

--- a/internal/src/org/labkey/api/query/ExtendedTableDomainKind.java
+++ b/internal/src/org/labkey/api/query/ExtendedTableDomainKind.java
@@ -58,7 +58,7 @@ public abstract class ExtendedTableDomainKind extends SimpleTableDomainKind
         updatedDomain.setName(gwtDomain.getName());
 
         ValidationException errors = updateDomain(existingDomain, updatedDomain, container, user);
-        if(errors.hasErrors())
+        if (errors.hasErrors())
         {
             throw new RuntimeException(errors);
         }
@@ -76,7 +76,7 @@ public abstract class ExtendedTableDomainKind extends SimpleTableDomainKind
         Domain domain = PropertyService.get().getDomain(container, domainURI);
 
         // First check if this should be an update
-        if( null != domain )
+        if (null != domain)
         {
             updateDomain(container, user, gwtDomain);
         }


### PR DESCRIPTION
- validate conditional formats when saving domain and before rendering DataRegion
- support '~me~' in conditional filter value for user columns
- support relative date parsing of conditional format filter value
- use date parsing when matching BETWEEN filter of a conditional format of a date column
  e.g, to highlight dates for today use a conditional format like query.dateColumn~between=-0d,+0d