### PR TITLE
Restore serialized GWTProperty.rangeURI behavior

### DIFF
--- a/internal/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/internal/src/org/labkey/api/exp/property/DomainUtil.java
@@ -297,7 +297,7 @@ public class DomainUtil
         gwtProp.setName(prop.getName());
         gwtProp.setPropertyURI(prop.getPropertyURI());
         gwtProp.setContainer(prop.getContainer().getId());
-        gwtProp.setRangeURI(prop.getRangeURI());
+        gwtProp.setRangeURI(prop.getPropertyType() != null ? prop.getPropertyType().getTypeUri() : prop.getRangeURI());
         gwtProp.setRequired(prop.isRequired());
         gwtProp.setHidden(prop.isHidden());
         gwtProp.setShownInInsertView(prop.isShownInInsertView());


### PR DESCRIPTION
PropertyDescriptor's rangeURI could be stored as a simple type name (e.g. "int") instead of a full property type URI.
Use the resolved PropertyType's typeURI if possible, otherwise the stored rangeURI.