### PR TITLE
Use correct type in ConditionalFormat.validateFormat

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -913,7 +913,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                     Object remapped = cache.remap(lookupTable, (String)o);
                     if (remapped == null)
                     {
-                        errors.add(new PropertyValidationError("Failed to convert '" + pd.getName() + "': " + o, pd.getName()));
+                        errors.add(new PropertyValidationError("Failed to convert '" + pd.getName() + "': Could not translate value: " + o, pd.getName()));
                     }
                     else if (o != remapped)
                     {

--- a/api/src/org/labkey/api/data/ConditionalFormat.java
+++ b/api/src/org/labkey/api/data/ConditionalFormat.java
@@ -33,6 +33,7 @@ import org.labkey.data.xml.ConditionalFormatType;
 import org.labkey.data.xml.ConditionalFormatsType;
 
 import java.awt.*;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -119,7 +120,7 @@ public class ConditionalFormat extends GWTConditionalFormat
     {
         try
         {
-            _meetsCriteria(col, "ignored");
+            _meetsCriteria(col, newValue(col));
             return null;
         }
         catch (RuntimeSQLException e)
@@ -134,6 +135,19 @@ public class ConditionalFormat extends GWTConditionalFormat
             {
                 throw e;
             }
+        }
+    }
+
+    private Object newValue(ColumnRenderProperties col)
+    {
+        try
+        {
+            return col.getJavaClass().getDeclaredConstructor().newInstance();
+        }
+        catch (ReflectiveOperationException e)
+        {
+            // ok
+            return null;
         }
     }
 

--- a/api/src/org/labkey/api/data/ConditionalFormat.java
+++ b/api/src/org/labkey/api/data/ConditionalFormat.java
@@ -138,6 +138,7 @@ public class ConditionalFormat extends GWTConditionalFormat
         }
     }
 
+    // best-effort to create new value instance for validating conditional format parameters
     private Object newValue(ColumnRenderProperties col)
     {
         try


### PR DESCRIPTION
- create a default object value of the right type when validating the format
- fixes ClassCastException in CompareType.GTE.meetsCriteria