### PR TITLE
39247 : Don't block the entire schema browser while waiting for query dependencies

### DIFF
--- a/query/webapp/query/browser/view/QueryDetails.js
+++ b/query/webapp/query/browser/view/QueryDetails.js
@@ -699,10 +699,12 @@ Ext4.define('LABKEY.query.browser.view.QueryDetails', {
      */
     setQueryDependencies : function(cmp){
         this.remove(cmp);
-        this.add({
-            xtype : 'box',
-            html : this.formatDependencies()
-        });
+        var dependencies = this.formatDependencies();
+        if (dependencies)
+            this.add({
+                xtype : 'box',
+                html : dependencies
+            });
     },
 
     setQueryDetails : function(queryDetails) {


### PR DESCRIPTION
Add a small placeholder component to the query details tab and replace with the dependency report once the query analysis returns.