### PR TITLE
Issue 39090: Escape usernames in email notifications.

### DIFF
--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -962,7 +962,7 @@ public class AnnouncementManager
             super(NAME, DEFAULT_SUBJECT, loadBody(), DEFAULT_DESCRIPTION, ContentType.HTML);
             setEditableScopes(EmailTemplate.Scope.SiteOrFolder);
 
-            _replacements.add(new ReplacementParam<>("createdByUser", String.class, "User that generated the message", ContentType.Plain)
+            _replacements.add(new ReplacementParam<>("createdByUser", String.class, "User that generated the message", ContentType.HTML)
             {
                 public String getValue(Container c)
                 {


### PR DESCRIPTION
Tested this on a 19.3 enlistment with dumbster, confirmed that usernames with special characters are no longer double-encoded, and now display properly.