### PR TITLE
Change SortOrder default to MAX_INT to ensure that new configurations…

### DIFF
--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-Version: 19.33
+Version: 19.34
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/core-19.33-19.34.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-19.33-19.34.sql
@@ -1,0 +1,4 @@
+-- Change SortOrder type to SMALLINT and default to MAX_SMALL_INT to ensure that new configurations appear at the bottom of the list by default
+SELECT core.fn_dropifexists('AuthenticationConfigurations', 'core', 'DEFAULT', 'SortOrder');
+ALTER TABLE core.AuthenticationConfigurations ALTER COLUMN SortOrder TYPE SMALLINT;
+ALTER TABLE core.AuthenticationConfigurations ALTER COLUMN SortOrder SET DEFAULT 32767;

--- a/core/resources/schemas/dbscripts/sqlserver/core-19.33-19.34.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-19.33-19.34.sql
@@ -1,0 +1,4 @@
+-- Change SortOrder type to SMALLINT and default to MAX_SMALL_INT to ensure that new configurations appear at the bottom of the list by default
+EXEC core.fn_dropifexists 'AuthenticationConfigurations', 'core', 'DEFAULT', 'SortOrder';
+ALTER TABLE core.AuthenticationConfigurations ALTER COLUMN SortOrder SMALLINT;
+ALTER TABLE core.AuthenticationConfigurations ADD CONSTRAINT DF_SortOrder DEFAULT 32767 FOR SortOrder;


### PR DESCRIPTION
… appear at the bottom of the list by default. Also, switch its type to SMALLINT -- let's not suggest that we support 2 billion authentication configurations.