### PR TITLE
Fix test with lastModified date fix for webDav

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
@@ -43,6 +43,7 @@ import org.labkey.test.util.DataRegionTable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -207,6 +208,14 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
         checkExpectedErrors(numExpectedErrors);
     }
 
+    public File getModifiedStudyReloadTxt()
+    {
+        File file = TestFileUtils.getSampleData("study/StudyVisitManagement.folder/studyload.txt");
+        file.setLastModified((new Date()).getTime());
+
+        return file;
+    }
+
     @Test
     public void testFailForUndefinedVisitsReload() throws IOException
     {
@@ -240,7 +249,7 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
         // test reload again with the failure bit unset
         goToModule("Pipeline");
         clickButton("Process and Import Data");
-        _fileBrowserHelper.uploadFile(EXPLODED_FOLDER_STUDYLOAD_TXT, null, null, true);
+        _fileBrowserHelper.uploadFile(getModifiedStudyReloadTxt(), null, null, true);
         attemptStudyReloadNow("Reloading Study 001", false);
 
         // verify undefined visits now created


### PR DESCRIPTION
Targeting develop since it's test bug instead of app bug. Let me know if that needs to be changed.

StudyVisitManagementTest.testFailForUndefinedVisitsReload started to fail after lastModified for uploaded file has been corrected to actual file's modified timestamp, instead of upload timestamp. 

This test has been relying on upload timestamp as file's last modified, hence it started to fail. 

Change made to update file's modified prior to upload. 

https://teamcity.labkey.org/project.html?projectId=LabkeyTrunk&testNameId=8683724906803122396&tab=testDetails