### PR TITLE
Item 6571: Change to support Sample Manager new user email content and hosted server setup

### DIFF
--- a/api/webapp/clientapi/core/Security.js
+++ b/api/webapp/clientapi/core/Security.js
@@ -1509,6 +1509,7 @@ LABKEY.Security = new function()
          * @param config A configuration object with the following properties:
          * @param {String} config.email The new user's email address, or a semicolon separated list of email addresses.
          * @param {Boolean} config.sendEmail Set to false to stop the server from sending a welcome email to the user.
+         * @param {String} config.optionalMessage An optional message to include in the new user registration email.
          * @param {Function} config.success A reference to a function to call with the API results. This
          * function will be passed the following parameters:
          * <ul>
@@ -1533,7 +1534,8 @@ LABKEY.Security = new function()
         {
             var params = {
                 email: config.email,
-                sendEmail: config.sendEmail
+                sendEmail: config.sendEmail,
+                optionalMessage: config.optionalMessage
             };
             return LABKEY.Ajax.request({
                 url: LABKEY.ActionURL.buildURL("security", "createNewUser", config.containerPath),

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -931,21 +931,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.0.29",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.29.tgz",
-      "integrity": "sha1-7jaO+W8s3fuTQL5VCFovXpoeyTM="
+      "version": "0.0.30",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.30.tgz",
+      "integrity": "sha1-liK5XkZ8TSE5VbU0nEOvzyWY3w0="
     },
     "@labkey/components": {
-      "version": "0.12.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.12.0.tgz",
-      "integrity": "sha1-OgLug7UgtS+tFHUakv6pj/43/uE=",
+      "version": "0.13.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.13.0.tgz",
+      "integrity": "sha1-tkAShEctOam+qfFZbOg8pN+BxqY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.0.29",
+        "@labkey/api": "0.0.30",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -936,9 +936,9 @@
       "integrity": "sha1-uQRoHmkGsWlLjS/ziNN1a0GvAxc="
     },
     "@labkey/components": {
-      "version": "0.10.0-fb-smUserEmailContent.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.10.0-fb-smUserEmailContent.0.tgz",
-      "integrity": "sha1-EBui1rWW/upNife/aogLuN6r2P4=",
+      "version": "0.10.0-fb-smUserEmailContent.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.10.0-fb-smUserEmailContent.1.tgz",
+      "integrity": "sha1-kgXpTWpTTzOxCzrT96hMHSwsPKc=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -931,21 +931,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.0.26",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.26.tgz",
-      "integrity": "sha1-TSogzf1a345nYpaocYtO2Ne+QkM="
+      "version": "0.0.29-fb-smUserEmailContent.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.29-fb-smUserEmailContent.0.tgz",
+      "integrity": "sha1-uQRoHmkGsWlLjS/ziNN1a0GvAxc="
     },
     "@labkey/components": {
-      "version": "0.8.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.8.0.tgz",
-      "integrity": "sha1-7WOIfaDuyI64QUocfNlDKQvU90c=",
+      "version": "0.10.0-fb-smUserEmailContent.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.10.0-fb-smUserEmailContent.0.tgz",
+      "integrity": "sha1-EBui1rWW/upNife/aogLuN6r2P4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.0.26",
+        "@labkey/api": "0.0.29-fb-smUserEmailContent.0",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",
@@ -2831,9 +2831,9 @@
       }
     },
     "date-fns": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.8.1.tgz",
-      "integrity": "sha512-EL/C8IHvYRwAHYgFRse4MGAPSqlJVlOrhVYZ75iQBKrnv+ZedmYsgwH3t+BCDuZDXpoo07+q9j4qgSSOa7irJg=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.9.0.tgz",
+      "integrity": "sha512-khbFLu/MlzLjEzy9Gh8oY1hNt/Dvxw3J6Rbc28cVoYWQaC1S3YI4xwkF9ZWcjDLscbZlY9hISMr66RFzZagLsA=="
     },
     "date-now": {
       "version": "0.1.4",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -803,17 +803,17 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
-      "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.0.tgz",
+      "integrity": "sha512-Z7ti+HB0puCcLmFE3x90kzaVgbx6TRrYIReaygW6EkBEnJh1ajS4/inhF7CypzWeDV3NFl1AfWj0eMtdihojxw==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.7.tgz",
-      "integrity": "sha512-P91T3dFYQL7aj44PxOMIAbo66Ag3NbmXG9fseSYaXxapp3K9XTct5HU9IpTOm2D0AoktKusgqzN5YcSxZXEKBQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.8.0.tgz",
+      "integrity": "sha512-GsSb5MFUX2Q+zVUa7d4/8EXz7KPDuw0uNzY1sdBV7kvzdHzotxqi0HQlqesDRcffpvqcr+ZX8N+mMnb7/osExw==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
@@ -936,9 +936,9 @@
       "integrity": "sha1-uQRoHmkGsWlLjS/ziNN1a0GvAxc="
     },
     "@labkey/components": {
-      "version": "0.10.0-fb-smUserEmailContent.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.10.0-fb-smUserEmailContent.1.tgz",
-      "integrity": "sha1-kgXpTWpTTzOxCzrT96hMHSwsPKc=",
+      "version": "0.10.0-fb-smUserEmailContent.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.10.0-fb-smUserEmailContent.2.tgz",
+      "integrity": "sha1-4jTrjoRjw5ajmLCAKhmm4Qq4dwY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",

--- a/assay/package.json
+++ b/assay/package.json
@@ -27,7 +27,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.10.0-fb-smUserEmailContent.0"
+    "@labkey/components": "0.10.0-fb-smUserEmailContent.1"
   },
   "devDependencies": {
     "@babel/core": "7.4.5",

--- a/assay/package.json
+++ b/assay/package.json
@@ -27,7 +27,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.10.0-fb-smUserEmailContent.1"
+    "@labkey/components": "0.10.0-fb-smUserEmailContent.2"
   },
   "devDependencies": {
     "@babel/core": "7.4.5",

--- a/assay/package.json
+++ b/assay/package.json
@@ -27,7 +27,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.12.0"
+    "@labkey/components": "0.13.0"
   },
   "devDependencies": {
     "@babel/core": "7.4.5",

--- a/assay/package.json
+++ b/assay/package.json
@@ -27,7 +27,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.8.0"
+    "@labkey/components": "0.10.0-fb-smUserEmailContent.0"
   },
   "devDependencies": {
     "@babel/core": "7.4.5",

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -920,7 +920,7 @@ public class LoginController extends SpringActionController
     }
 
     // Generic message that we display to users for most success and failure situations, to avoid revealing whether an account exists or not, #33907
-    private static final String GENERIC_RESET_PASSWORD_MESSAGE = "Password reset was attempted. If an active account with this email address exists on the server then you will receive an email message with password reset instructions.";
+    private static final String GENERIC_RESET_PASSWORD_MESSAGE = "Password reset was attempted. If an active account with this email address exists on the server, you will receive an email message with password reset instructions.";
 
     private Pair<Boolean, String> resetPasswordResponse(User user, @Nullable String failureEmailMessage, @Nullable String failureLogMessage)
     {

--- a/core/src/org/labkey/core/login/PasswordRule.java
+++ b/core/src/org/labkey/core/login/PasswordRule.java
@@ -49,7 +49,7 @@ public enum PasswordRule
         @Override
         public String getSummaryRuleHTML()
         {
-            return getFullRuleHTML();
+            return "Your password must be at least six characters and cannot contain spaces or match your email address.";
         }
         
         @Override
@@ -64,7 +64,7 @@ public enum PasswordRule
             if (!passwordPattern.matcher(password).matches())
             {
                 if (null != messages)
-                    messages.add("Your password must be six non-whitespace characters or more.");
+                    messages.add("Your password must be at least six characters and cannot contain spaces.");
 
                 return false;
             }
@@ -106,7 +106,7 @@ public enum PasswordRule
         @Override
         public String getSummaryRuleHTML()
         {
-            return "Passwords must be at least eight characters, include a mix of letters, digits, and symbols, and cannot include your email address.";
+            return "Your password must be at least eight characters, include a mix of letters, digits, and symbols, and cannot include your email address.";
         }
         @Override
         boolean isValidForLogin(@NotNull String password, @NotNull User user, @Nullable Collection<String> messages)

--- a/core/src/org/labkey/core/login/setPassword.jsp
+++ b/core/src/org/labkey/core/login/setPassword.jsp
@@ -17,6 +17,7 @@
 %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page import="org.labkey.api.collections.NamedObject" %>
+<%@ page import="org.labkey.api.util.URLHelper" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
@@ -24,6 +25,8 @@
 <%@ page import="org.labkey.core.login.DbLoginManager" %>
 <%@ page import="org.labkey.core.login.LoginController" %>
 <%@ page import="org.labkey.core.portal.ProjectController" %>
+<%@ page import="org.labkey.api.data.Container" %>
+<%@ page import="org.labkey.api.data.ContainerManager" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
     @Override
@@ -112,6 +115,15 @@
             <%= button(bean.buttonText).submit(true).name("set") %>
             <%=unsafe(bean.cancellable ? button("Cancel").href(bean.form.getReturnURLHelper() != null ? bean.form.getReturnURLHelper() : new ActionURL(ProjectController.HomeAction.class, getContainer())).toString() : "")%>
         </div>
+    <% }
+       else
+       {
+           Container c = getContainer().isRoot() ? ContainerManager.getHomeContainer() : getContainer();
+           URLHelper homeURL = bean.form.getReturnURLHelper() != null ? bean.form.getReturnURLHelper() : new ActionURL(ProjectController.StartAction.class, c);
+    %>
+            <div class="auth-item">
+                <%= unsafe(button("Home").href(homeURL).toString()) %>
+            </div>
     <% } %>
     </div>
 </labkey:form>

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -1994,6 +1994,7 @@ public class SecurityApiActions
         private String _email; // supports a semicolon list of email addresses
         private boolean _sendEmail = true;
         private boolean _skipFirstLogin = false;
+        private String _optionalMessage;
 
         public String getEmail()
         {
@@ -2024,6 +2025,16 @@ public class SecurityApiActions
         {
             _skipFirstLogin = skipFirstLogin;
         }
+
+        public String getOptionalMessage()
+        {
+            return _optionalMessage;
+        }
+
+        public void setOptionalMessage(String optionalMessage)
+        {
+            _optionalMessage = optionalMessage;
+        }
     }
 
     @RequiresPermission(AdminPermission.class)
@@ -2052,7 +2063,7 @@ public class SecurityApiActions
 
             for (ValidEmail email : validEmails)
             {
-                String msg = SecurityManager.addUser(getViewContext(), email, form.isSendEmail(), null);
+                String msg = SecurityManager.addUser(getViewContext(), email, form.isSendEmail(), form.getOptionalMessage());
                 User user = UserManager.getUser(email);
                 if (null == user)
                     throw new IllegalArgumentException(null != msg ? msg : "Error creating new user account.");

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -931,21 +931,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.0.29",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.29.tgz",
-      "integrity": "sha1-7jaO+W8s3fuTQL5VCFovXpoeyTM="
+      "version": "0.0.30",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.30.tgz",
+      "integrity": "sha1-liK5XkZ8TSE5VbU0nEOvzyWY3w0="
     },
     "@labkey/components": {
-      "version": "0.12.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.12.0.tgz",
-      "integrity": "sha1-OgLug7UgtS+tFHUakv6pj/43/uE=",
+      "version": "0.13.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.13.0.tgz",
+      "integrity": "sha1-tkAShEctOam+qfFZbOg8pN+BxqY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.0.29",
+        "@labkey/api": "0.0.30",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -936,9 +936,9 @@
       "integrity": "sha1-uQRoHmkGsWlLjS/ziNN1a0GvAxc="
     },
     "@labkey/components": {
-      "version": "0.10.0-fb-smUserEmailContent.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.10.0-fb-smUserEmailContent.0.tgz",
-      "integrity": "sha1-EBui1rWW/upNife/aogLuN6r2P4=",
+      "version": "0.10.0-fb-smUserEmailContent.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.10.0-fb-smUserEmailContent.1.tgz",
+      "integrity": "sha1-kgXpTWpTTzOxCzrT96hMHSwsPKc=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -931,21 +931,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.0.26",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.26.tgz",
-      "integrity": "sha1-TSogzf1a345nYpaocYtO2Ne+QkM="
+      "version": "0.0.29-fb-smUserEmailContent.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.29-fb-smUserEmailContent.0.tgz",
+      "integrity": "sha1-uQRoHmkGsWlLjS/ziNN1a0GvAxc="
     },
     "@labkey/components": {
-      "version": "0.8.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.8.0.tgz",
-      "integrity": "sha1-7WOIfaDuyI64QUocfNlDKQvU90c=",
+      "version": "0.10.0-fb-smUserEmailContent.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.10.0-fb-smUserEmailContent.0.tgz",
+      "integrity": "sha1-EBui1rWW/upNife/aogLuN6r2P4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.0.26",
+        "@labkey/api": "0.0.29-fb-smUserEmailContent.0",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",
@@ -2831,9 +2831,9 @@
       }
     },
     "date-fns": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.8.1.tgz",
-      "integrity": "sha512-EL/C8IHvYRwAHYgFRse4MGAPSqlJVlOrhVYZ75iQBKrnv+ZedmYsgwH3t+BCDuZDXpoo07+q9j4qgSSOa7irJg=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.9.0.tgz",
+      "integrity": "sha512-khbFLu/MlzLjEzy9Gh8oY1hNt/Dvxw3J6Rbc28cVoYWQaC1S3YI4xwkF9ZWcjDLscbZlY9hISMr66RFzZagLsA=="
     },
     "date-now": {
       "version": "0.1.4",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -803,17 +803,17 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
-      "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.0.tgz",
+      "integrity": "sha512-Z7ti+HB0puCcLmFE3x90kzaVgbx6TRrYIReaygW6EkBEnJh1ajS4/inhF7CypzWeDV3NFl1AfWj0eMtdihojxw==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.7.tgz",
-      "integrity": "sha512-P91T3dFYQL7aj44PxOMIAbo66Ag3NbmXG9fseSYaXxapp3K9XTct5HU9IpTOm2D0AoktKusgqzN5YcSxZXEKBQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.8.0.tgz",
+      "integrity": "sha512-GsSb5MFUX2Q+zVUa7d4/8EXz7KPDuw0uNzY1sdBV7kvzdHzotxqi0HQlqesDRcffpvqcr+ZX8N+mMnb7/osExw==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
@@ -936,9 +936,9 @@
       "integrity": "sha1-uQRoHmkGsWlLjS/ziNN1a0GvAxc="
     },
     "@labkey/components": {
-      "version": "0.10.0-fb-smUserEmailContent.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.10.0-fb-smUserEmailContent.1.tgz",
-      "integrity": "sha1-kgXpTWpTTzOxCzrT96hMHSwsPKc=",
+      "version": "0.10.0-fb-smUserEmailContent.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.10.0-fb-smUserEmailContent.2.tgz",
+      "integrity": "sha1-4jTrjoRjw5ajmLCAKhmm4Qq4dwY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -27,7 +27,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.10.0-fb-smUserEmailContent.0"
+    "@labkey/components": "0.10.0-fb-smUserEmailContent.1"
   },
   "devDependencies": {
     "@babel/core": "7.4.5",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -27,7 +27,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.10.0-fb-smUserEmailContent.1"
+    "@labkey/components": "0.10.0-fb-smUserEmailContent.2"
   },
   "devDependencies": {
     "@babel/core": "7.4.5",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -27,7 +27,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.12.0"
+    "@labkey/components": "0.13.0"
   },
   "devDependencies": {
     "@babel/core": "7.4.5",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -27,7 +27,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.8.0"
+    "@labkey/components": "0.10.0-fb-smUserEmailContent.0"
   },
   "devDependencies": {
     "@babel/core": "7.4.5",


### PR DESCRIPTION
- add SiteSettings.homeProjectResetPermissions startup property to reset/remove guest access from home project SecurityPolicy
- allow optionalMessage param for CreateNewUserAction (this was already supported in the new user email template)
- add optionalMessage param to the LABKEY.Security.createNewUser config object