### PR TITLE
 Issue 39135: InputForeignKey slow with many material inputs

### DIFF
--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -924,7 +924,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     public boolean safeAddColumn(BaseColumnInfo column)
     {
         checkLocked();
-        if (getColumn(column.getName()) != null)
+        if (getColumn(column.getName(), false) != null)
             return false;
         addColumn(column);
         return true;

--- a/experiment/src/org/labkey/experiment/api/InputForeignKey.java
+++ b/experiment/src/org/labkey/experiment/api/InputForeignKey.java
@@ -16,16 +16,20 @@
 
 package org.labkey.experiment.api;
 
-import org.labkey.api.query.LookupForeignKey;
-import org.labkey.api.exp.api.*;
-import org.labkey.api.exp.query.ExpSchema;
-import org.labkey.api.exp.query.ExpProtocolApplicationTable;
-import org.labkey.api.exp.query.SamplesSchema;
-import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.api.ExpSampleSet;
+import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.SampleSetService;
+import org.labkey.api.exp.query.ExpProtocolApplicationTable;
+import org.labkey.api.exp.query.ExpSchema;
+import org.labkey.api.exp.query.SamplesSchema;
+import org.labkey.api.query.LookupForeignKey;
 
-import java.util.*;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * This class is a foreign key which has columns for data and material inputs of various types.
@@ -35,6 +39,7 @@ public class InputForeignKey extends LookupForeignKey
     private final ExpSchema _schema;
     private final ExpProtocol.ApplicationType _type;
     private final ContainerFilter _filter;
+
     private Set<String> _dataInputs;
     private Map<String, ExpSampleSet> _materialInputs;
 
@@ -46,10 +51,15 @@ public class InputForeignKey extends LookupForeignKey
         _filter = filter == null ? ContainerFilter.Type.Current.create(schema.getUser()) : filter;
     }
 
-
+    @Override
     public TableInfo getLookupTableInfo()
     {
-        // TODO ContainerFilter
+        String key = getClass().getName() + "/" + _type.toString() + "/" + _filter.getCacheKey(_schema.getContainer());
+        return _schema.getCachedLookupTableInfo(key, this::createLookupTableInfo);
+    }
+
+    private TableInfo createLookupTableInfo()
+    {
         ExpProtocolApplicationTable ret = ExperimentService.get().createProtocolApplicationTable(ExpSchema.TableType.ProtocolApplications.toString(), _schema, null);
         ret.setContainerFilter(_filter);
         SamplesSchema samplesSchema = _schema.getSamplesSchema();
@@ -63,9 +73,11 @@ public class InputForeignKey extends LookupForeignKey
             ExpSampleSet sampleSet = entry.getValue();
             ret.safeAddColumn(ret.createMaterialInputColumn(role, samplesSchema, sampleSet, role));
         }
+        ret.setLocked(true);
         return ret;
     }
 
+    @Override
     protected ColumnInfo getPkColumn(TableInfo table)
     {
         assert table instanceof ExpProtocolApplicationTable;
@@ -86,7 +98,7 @@ public class InputForeignKey extends LookupForeignKey
     {
         if (_materialInputs == null)
         {
-            _materialInputs = ExperimentService.get().getSampleSetsForRoles(_schema.getContainer(), _filter, _type);
+            _materialInputs = SampleSetService.get().getSampleSetsForRoles(_schema.getContainer(), _filter, _type);
         }
         return _materialInputs;
     }

--- a/experiment/src/org/labkey/experiment/api/SampleSetServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleSetServiceImpl.java
@@ -241,7 +241,7 @@ public class SampleSetServiceImpl implements SampleSetService
     public Map<String, ExpSampleSet> getSampleSetsForRoles(Container container, ContainerFilter filter, ExpProtocol.ApplicationType type)
     {
         SQLFragment sql = new SQLFragment();
-        sql.append("SELECT mi.Role, MAX(m.CpasType) AS SampleSetLSID, COUNT (DISTINCT m.CpasType) AS SampleSetCount FROM ");
+        sql.append("SELECT mi.Role, MAX(m.CpasType) AS MaxSampleSetLSID, MIN (m.CpasType) AS MinSampleSetLSID FROM ");
         sql.append(getTinfoMaterial(), "m");
         sql.append(", ");
         sql.append(getTinfoMaterialInput(), "mi");
@@ -267,26 +267,19 @@ public class SampleSetServiceImpl implements SampleSetService
         sql.append(filter.getSQLFragment(getExpSchema(), new SQLFragment("r.Container"), container));
         sql.append(" GROUP BY mi.Role ORDER BY mi.Role");
 
-        Map<String, Object>[] queryResults = new SqlSelector(getExpSchema(), sql).getMapArray();
-        Map<String, ExpSampleSet> lsidToSampleSet = new HashMap<>();
-
         Map<String, ExpSampleSet> result = new LinkedHashMap<>();
-        for (Map<String, Object> queryResult : queryResults)
+        for (Map<String, Object> queryResult : new SqlSelector(getExpSchema(), sql).getMapCollection())
         {
             ExpSampleSet sampleSet = null;
-            Number sampleSetCount = (Number) queryResult.get("SampleSetCount");
-            if (sampleSetCount.intValue() == 1)
+            String maxSampleSetLSID = (String) queryResult.get("MaxSampleSetLSID");
+            String minSampleSetLSID = (String) queryResult.get("MinSampleSetLSID");
+
+            // Check if we have a sample set that was being referenced
+            if (maxSampleSetLSID != null && maxSampleSetLSID.equalsIgnoreCase(minSampleSetLSID))
             {
-                String sampleSetLSID = (String) queryResult.get("SampleSetLSID");
-                if (!lsidToSampleSet.containsKey(sampleSetLSID))
-                {
-                    sampleSet = getSampleSet(sampleSetLSID);
-                    lsidToSampleSet.put(sampleSetLSID, sampleSet);
-                }
-                else
-                {
-                    sampleSet = lsidToSampleSet.get(sampleSetLSID);
-                }
+                // If the min and the max are the same, it means all rows share the same value so we know that there's
+                // a single sample set being targeted
+                sampleSet = getSampleSet(container, maxSampleSetLSID);
             }
             result.put((String) queryResult.get("Role"), sampleSet);
         }


### PR DESCRIPTION
- don't resolve columns when using safeAddColumn
- cache the InputForeignKey lookup table
- avoid count distinct when querying for SampleSets by input role name