### PR TITLE
Issue 39442: Slow performance exporting large assays

### DIFF
--- a/api/src/org/labkey/api/assay/TsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/TsvDataHandler.java
@@ -102,8 +102,6 @@ public class TsvDataHandler extends AbstractAssayTsvDataHandler implements Trans
     @Override
     public String getFileName(ExpData data, String defaultName)
     {
-        ExpRun run = data.getRun();
-
         if (!data.isFinalRunOutput())
             return defaultName;
 

--- a/api/src/org/labkey/api/exp/api/ExpRun.java
+++ b/api/src/org/labkey/api/exp/api/ExpRun.java
@@ -34,6 +34,7 @@ public interface ExpRun extends ExpObject, ExpLineageItem
     @Nullable ExpExperiment getBatch();
     ExpProtocol getProtocol();
 
+    /** @return true if the data is an output from the run, and not an intermediate/temporary file within the run */
     boolean isFinalOutput(ExpData data);
 
     /**

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -96,6 +96,9 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
 
     public static final SearchService.SearchCategory expDataCategory = new SearchService.SearchCategory("data", "ExpData");
 
+    /** Cache this because it can be expensive to recompute */
+    private Boolean _finalRunOutput;
+
     /**
      * Temporary mapping until experiment.xml contains the mime type
      */
@@ -346,11 +349,12 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
     @Override
     public boolean isFinalRunOutput()
     {
-        ExpRun run = getRun();
-        if (run == null)
-            return false;
-        else
-            return run.isFinalOutput(this);
+        if (_finalRunOutput == null)
+        {
+            ExpRun run = getRun();
+            _finalRunOutput = run != null && run.isFinalOutput(this);
+        }
+        return _finalRunOutput.booleanValue();
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
@@ -181,7 +181,8 @@ public class ExpRunImpl extends ExpIdentifiableEntityImpl<ExperimentRun> impleme
     @Override
     public boolean isFinalOutput(ExpData data)
     {
-        return data.getSourceApplication().getActionSequence() == getMaxOutputActionSequence();
+        ExpProtocolApplication sourceApplication = data.getSourceApplication();
+        return sourceApplication != null && sourceApplication.getActionSequence() == getMaxOutputActionSequence();
     }
 
     private int getMaxOutputActionSequence()

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1450,6 +1450,7 @@ public class ExperimentServiceImpl implements ExperimentService
 
         try
         {
+            List<ExpRun> runs = new ArrayList<>();
             for (int id : runIds)
             {
                 ExpRun run = ExperimentService.get().getExpRun(id);
@@ -1457,6 +1458,7 @@ public class ExperimentServiceImpl implements ExperimentService
                 {
                     throw new NotFoundException("Could not find run " + id);
                 }
+                runs.add(run);
             }
 
             XarExportSelection selection = new XarExportSelection();
@@ -1469,7 +1471,7 @@ public class ExperimentServiceImpl implements ExperimentService
                 }
                 selection.addExperimentIds(experiment.getRowId());
             }
-            selection.addRunIds(runIds);
+            selection.addRuns(runs);
             // NOTE: selection distinguishes between null and empty (careful)
             // TODO have ArchiveURLRewriter() differentiate between input and output roles
             // TODO using Set<roles> is adequate for now (as long as the caller knows all the roles of interest)

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4459,13 +4459,37 @@ public class ExperimentController extends SpringActionController
 
         public ModelAndView getView(ExportOptionsForm form, boolean reshow, BindException errors) throws Exception
         {
-            handlePost(form, errors);
+            // FormViewAction can reinvoke getView() in response to a POST if we're not redirecting the browser,
+            // so avoid double-creating the export
+            if ("get".equalsIgnoreCase(getViewContext().getRequest().getMethod()))
+                handlePost(form, errors);
             return null;
         }
 
         public NavTree appendNavTrail(NavTree root)
         {
             return null;
+        }
+
+        public List<ExpRun> lookupRuns(ExportOptionsForm form)
+        {
+            Set<Integer> runIds = DataRegionSelection.getSelectedIntegers(getViewContext(), form.getDataRegionSelectionKey(), false);
+            if (runIds.isEmpty())
+            {
+                throw new NotFoundException();
+            }
+            List<ExpRun> result = new ArrayList<>();
+
+            for (int id : runIds)
+            {
+                ExpRun run = ExperimentService.get().getExpRun(id);
+                if (run == null || !run.getContainer().hasPermission(getUser(), ReadPermission.class))
+                {
+                    throw new NotFoundException("Could not find run " + id);
+                }
+                result.add(run);
+            }
+            return result;
         }
     }
 
@@ -4474,44 +4498,22 @@ public class ExperimentController extends SpringActionController
     {
         public boolean handlePost(ExportOptionsForm form, BindException errors) throws Exception
         {
-            Set<Integer> runIds = DataRegionSelection.getSelectedIntegers(getViewContext(), form.getDataRegionSelectionKey(), false);
-            if (runIds.isEmpty())
+            XarExportSelection selection = new XarExportSelection();
+            if (form.getExpRowId() != null)
             {
-                throw new NotFoundException();
-            }
-
-            try
-            {
-                for (int id : runIds)
+                ExpExperiment experiment = ExperimentService.get().getExpExperiment(form.getExpRowId());
+                if (experiment != null && !experiment.getContainer().hasPermission(getUser(), ReadPermission.class))
                 {
-                    ExpRun run = ExperimentService.get().getExpRun(id);
-                    if (run == null || !run.getContainer().hasPermission(getUser(), ReadPermission.class))
-                    {
-                        throw new NotFoundException("Could not find run " + id);
-                    }
+                    throw new NotFoundException("Run group " + form.getExpRowId());
                 }
-
-                XarExportSelection selection = new XarExportSelection();
-                if (form.getExpRowId() != null)
-                {
-                    ExpExperiment experiment = ExperimentService.get().getExpExperiment(form.getExpRowId());
-                    if (experiment != null && !experiment.getContainer().hasPermission(getUser(), ReadPermission.class))
-                    {
-                        throw new NotFoundException("Run group " + form.getExpRowId());
-                    }
-                    selection.addExperimentIds(experiment.getRowId());
-                }
-                selection.addRunIds(runIds);
-
-                _resultURL = exportXAR(selection, form.getLsidOutputType(), form.getExportType(), form.getXarFileName());
-                if (form.getDataRegionSelectionKey() != null)
-                    DataRegionSelection.clearAll(getViewContext(), form.getDataRegionSelectionKey());
-                return true;
+                selection.addExperimentIds(experiment.getRowId());
             }
-            catch (NumberFormatException e)
-            {
-                throw new NotFoundException(runIds.toString());
-            }
+            selection.addRuns(lookupRuns(form));
+
+            _resultURL = exportXAR(selection, form.getLsidOutputType(), form.getExportType(), form.getXarFileName());
+            if (form.getDataRegionSelectionKey() != null)
+                DataRegionSelection.clearAll(getViewContext(), form.getDataRegionSelectionKey());
+            return true;
         }
     }
 
@@ -4548,40 +4550,18 @@ public class ExperimentController extends SpringActionController
     {
         public boolean handlePost(ExportOptionsForm form, BindException errors) throws Exception
         {
-            Set<Integer> runIds = DataRegionSelection.getSelectedIntegers(getViewContext(), form.getDataRegionSelectionKey(), false);
-            if (runIds.isEmpty())
+            XarExportSelection selection = new XarExportSelection();
+            selection.setIncludeXarXml(false);
+            if ("role".equalsIgnoreCase(form.getFileExportType()))
             {
-                throw new NotFoundException();
+                selection.addRoles(form.getRoles());
             }
+            selection.addRuns(lookupRuns(form));
 
-            try
-            {
-                for (int id : runIds)
-                {
-                    ExpRun run = ExperimentService.get().getExpRun(id);
-                    if (run == null || !run.getContainer().hasPermission(getUser(), ReadPermission.class))
-                    {
-                        throw new NotFoundException("Could not find run " + id);
-                    }
-                }
-
-                XarExportSelection selection = new XarExportSelection();
-                selection.setIncludeXarXml(false);
-                if ("role".equalsIgnoreCase(form.getFileExportType()))
-                {
-                    selection.addRoles(form.getRoles());
-                }
-                selection.addRunIds(runIds);
-
-                _resultURL = exportXAR(selection, null, null, form.getZipFileName());
-                if (form.getDataRegionSelectionKey() != null)
-                    DataRegionSelection.clearAll(getViewContext(), form.getDataRegionSelectionKey());
-                return true;
-            }
-            catch (NumberFormatException e)
-            {
-                throw new NotFoundException(runIds.toString());
-            }
+            _resultURL = exportXAR(selection, null, null, form.getZipFileName());
+            if (form.getDataRegionSelectionKey() != null)
+                DataRegionSelection.clearAll(getViewContext(), form.getDataRegionSelectionKey());
+            return true;
         }
     }
 

--- a/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
@@ -99,11 +99,7 @@ public class FolderXarWriterFactory implements FolderWriterFactory
             }
 
             List<? extends ExpRun> expRuns = ExperimentService.get().getExpRuns(ctx.getContainer(), null, null);
-            // Add runs.
-            for (ExpRun run: expRuns)
-            {
-                selection.addRunId(run.getRowId());
-            }
+            selection.addRuns(expRuns);
 
             ctx.getXml().addNewXar().setDir(XAR_DIRECTORY);
             VirtualFile xarDir = vf.getDir(XAR_DIRECTORY);

--- a/experiment/src/org/labkey/experiment/xar/XarExportSelection.java
+++ b/experiment/src/org/labkey/experiment/xar/XarExportSelection.java
@@ -18,6 +18,7 @@ package org.labkey.experiment.xar;
 
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExpSampleSet;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.experiment.ArchiveURLRewriter;
@@ -30,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -40,7 +42,7 @@ import java.util.Set;
 public class XarExportSelection implements Serializable
 {
     private List<Integer> _expIds = new ArrayList<>();
-    private List<Integer> _runIds = new ArrayList<>();
+    private Set<ExpRun> _runs = new LinkedHashSet<>();
     private List<Integer> _dataIds = new ArrayList<>();
     private List<Integer> _sampleSetIds = new ArrayList<>();
     private List<Integer> _protocolIds = new ArrayList<>();
@@ -55,17 +57,9 @@ public class XarExportSelection implements Serializable
         }
     }
 
-    public void addRunId(int runId)
+    public void addRuns(Collection<? extends ExpRun> runs)
     {
-        _runIds.add(runId);
-    }
-
-    public void addRunIds(Collection<Integer> runIds)
-    {
-        for (int runId : runIds)
-        {
-            _runIds.add(runId);
-        }
+        _runs.addAll(runs);
     }
 
     public void addDataIds(int... dataIds)
@@ -119,9 +113,9 @@ public class XarExportSelection implements Serializable
             exporter.addExperiment(ExperimentServiceImpl.get().getExpExperiment(expId));
         }
 
-        for (int runId : _runIds)
+        for (ExpRun run : _runs)
         {
-            exporter.addExperimentRun(ExperimentServiceImpl.get().getExpRun(runId));
+            exporter.addExperimentRun(run);
         }
 
         for (int protocolId : _protocolIds)


### PR DESCRIPTION
Avoid doing so many redundant queries to fetch exp.data, exp.experimentruns, etc

Don't double-export after the initial XAR creation is successful