### PR TITLE
getQueryDetails performance

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProviderSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProviderSchema.java
@@ -172,9 +172,11 @@ public class AssayProviderSchema extends AssaySchema
             //if (protocolSchema == null)
             //    protocolSchema = new AssayProtocolSchema(_user, _container, protocol, provider);
             if (protocolSchema != null)
+            {
+                protocolSchema.setDefaultSchema(getDefaultSchema());
                 _protocolSchemas.put(protocol, protocolSchema);
+            }
         }
-        protocolSchema.setDefaultSchema(getDefaultSchema());
         return protocolSchema;
     }
 

--- a/api/src/org/labkey/api/assay/AssayProviderSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProviderSchema.java
@@ -174,6 +174,7 @@ public class AssayProviderSchema extends AssaySchema
             if (protocolSchema != null)
                 _protocolSchemas.put(protocol, protocolSchema);
         }
+        protocolSchema.setDefaultSchema(getDefaultSchema());
         return protocolSchema;
     }
 

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -575,6 +575,8 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Column
     {
         if (_displayField != null)
             return _displayField;
+        if (isUnselectable())
+            return null;
         ForeignKey fk = getFk();
         if (fk == null)
             return null;

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -711,6 +711,14 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Column
         return getFk().getLookupTableInfo();
     }
 
+    @Override
+    public TableDescription getFkTableDescription()
+    {
+        if (null == getFk())
+            return null;
+        return getFk().getLookupTableDescription();
+    }
+
 
     @Override
     public boolean isUserEditable()

--- a/api/src/org/labkey/api/data/ColumnInfo.java
+++ b/api/src/org/labkey/api/data/ColumnInfo.java
@@ -168,6 +168,8 @@ public interface ColumnInfo extends ColumnRenderProperties
 
     TableInfo getFkTableInfo();
 
+    TableDescription getFkTableDescription();
+
     boolean isUserEditable();
 
     DisplayColumnFactory getDisplayColumnFactory();

--- a/api/src/org/labkey/api/data/ForeignKey.java
+++ b/api/src/org/labkey/api/data/ForeignKey.java
@@ -52,6 +52,12 @@ public interface ForeignKey
     @Nullable
     TableInfo getLookupTableInfo();
 
+    @Nullable
+    default TableDescription getLookupTableDescription()
+    {
+        return getLookupTableInfo();
+    }
+
     /**
      * Return an URL expression for what the hyperlink for this column should be.  The hyperlink must be able to be
      * constructed knowing only the foreign key value, as other columns may not be available in the ResultSet.

--- a/api/src/org/labkey/api/data/TableDescription.java
+++ b/api/src/org/labkey/api/data/TableDescription.java
@@ -1,0 +1,26 @@
+package org.labkey.api.data;
+
+
+import java.util.List;
+
+/* This is a small subset of TableInfo that gives only basic information about a table, this might be provided by xml or a foreignkey.
+ * Importantly, it does not require generating any column lists or ColumnInfo objects.
+ */
+public interface TableDescription
+{
+    boolean isPublic();
+
+    String getPublicName();
+
+    // TODO replace with (or add) getPublicSchemaKey()
+    String getPublicSchemaName();
+
+    String getName();
+
+    /* TODO this is called by JsonWriter, but is this actually useful? */
+    String getSchemaName();  // same as ((TableInfo)this).getSchema().getName()
+
+    String getTitleColumn();
+
+    List<String> getPkColumnNames();
+}

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -57,9 +57,9 @@ import java.util.Set;
  * User: Matthew
  * Date: Apr 27, 2006
  */
-public interface TableInfo extends HasPermission, SchemaTreeNode
+public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNode
 {
-
+    @Override
     String getName();
 
     /** Get title, falling back to the name if title is null **/
@@ -174,6 +174,7 @@ public interface TableInfo extends HasPermission, SchemaTreeNode
     String getVersionColumnName();
 
     /** @return the default display value for this table if it's the target of a foreign key */
+    @Override
     String getTitleColumn();
 
     boolean hasDefaultTitleColumn();
@@ -328,12 +329,21 @@ public interface TableInfo extends HasPermission, SchemaTreeNode
      */
     List<Pair<String, StringExpression>> getRawImportTemplates();
 
+    @Override
     boolean isPublic();
 
+    @Override
     String getPublicName();
 
     /** @return The public (queryable) schema name in SchemaKey encoding. */
+    @Override
     String getPublicSchemaName();
+
+    /* TODO this is called by JsonWriter, but is this actually useful? */
+    default String getSchemaName()
+    {
+        return getSchema().getName();
+    }
 
     // Most datasets do not have a container column
     boolean hasContainerColumn();

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -32,7 +32,6 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.Lookup;
 import org.labkey.api.module.Module;
-import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.LookupForeignKey;
@@ -385,9 +384,7 @@ public class ExpSchema extends AbstractExpSchema
         {
             public TableInfo getLookupTableInfo()
             {
-                ExpProtocolTable protocolTable = (ExpProtocolTable)TableType.Protocols.createTable(ExpSchema.this, TableType.Protocols.toString(), cf);
-                protocolTable.setContainerFilter(ContainerFilter.EVERYTHING);
-                return protocolTable;
+                return getTable(TableType.Protocols.toString(), ContainerFilter.EVERYTHING);
             }
         };
     }
@@ -418,9 +415,13 @@ public class ExpSchema extends AbstractExpSchema
     {
         return new LookupForeignKey("RowId", "RowId")
         {
+            @Override
             public TableInfo getLookupTableInfo()
             {
-                return PipelineService.get().getJobsTable(getUser(), getContainer());
+                QuerySchema pipeline = getDefaultSchema().getSchema("pipeline");
+                if (null == pipeline)
+                    return null;
+                return pipeline.getTable("Jobs", getDefaultContainerFilter());
             }
 
             public StringExpression getURL(ColumnInfo parent)
@@ -458,11 +459,25 @@ public class ExpSchema extends AbstractExpSchema
     {
         return new ExperimentLookupForeignKey(null, null, ExpSchema.SCHEMA_NAME, TableType.RunGroups.name(), "RowId", null)
         {
+            @Override
             public TableInfo getLookupTableInfo()
             {
+                ContainerFilter cf = getLookupContainerFilter();
+                String key = getClass().getName() + "/RunGroupIdForeignKey/" + includeBatches + "/" + cf.getCacheKey(ExpSchema.this.getContainer());
+                // since getTable(forWrite=true) does not cache, cache this tableinfo using getCachedLookupTableInfo()
+                return ExpSchema.this.getCachedLookupTableInfo(key, this::createLookupTableInfo);
+            }
+
+            @Override
+            protected ContainerFilter getLookupContainerFilter()
+            {
+                return Objects.requireNonNullElse(cf, new ContainerFilter.CurrentPlusProjectAndShared(getUser()));
+            }
+
+            private TableInfo createLookupTableInfo()
+            {
                 // CONSIDER: I wonder if this shouldn't be using UnionContainerFilter(cf, CurrentPlusProjectAndShared)
-                ExpExperimentTable result = (ExpExperimentTable)getTable(TableType.RunGroups.name(),
-                        Objects.requireNonNullElse(cf, new ContainerFilter.CurrentPlusProjectAndShared(getUser())), true, true);
+                ExpExperimentTable result = (ExpExperimentTable) getTable(TableType.RunGroups.name(), getLookupContainerFilter(), true, true);
                 if (!includeBatches)
                 {
                     result.setBatchProtocol(null);

--- a/api/src/org/labkey/api/query/UserIdQueryForeignKey.java
+++ b/api/src/org/labkey/api/query/UserIdQueryForeignKey.java
@@ -38,7 +38,7 @@ public class UserIdQueryForeignKey extends QueryForeignKey
      * no longer have permission to access the container */
     public UserIdQueryForeignKey(QuerySchema sourceSchema, boolean includeAllUsers)
     {
-        super(sourceSchema, null,"core", sourceSchema.getContainer(), null, sourceSchema.getUser(), includeAllUsers ? "SiteUsers" : "Users", "UserId", "DisplayName");
+        super(sourceSchema, null, "core", sourceSchema.getContainer(), null, sourceSchema.getUser(), includeAllUsers ? "SiteUsers" : "Users", "UserId", "DisplayName");
         _includeAllUsers = includeAllUsers;
     }
 
@@ -59,22 +59,29 @@ public class UserIdQueryForeignKey extends QueryForeignKey
     {
         if (_table == null && getSchema() != null)
         {
-            _table = ((UserSchema) getSchema()).getTable(_tableName, getLookupContainerFilter(), true, true);
-
-            if (_includeAllUsers)
-            {
-                // Clear out the filter that might be preventing us from resolving the lookup if the user list is being filtered
-                FilteredTable table = (FilteredTable) _table;
-                if (table == null)
-                {
-                    // Exception 23740
-                    throw new IllegalStateException("Failed to find lookup target " + getLookupSchemaName() + "." + getLookupTableName() + " in container " + getLookupContainer());
-                }
-                table.clearConditions(FieldKey.fromParts("UserId"));
-            }
-            _table.setLocked(true);
+            String cacheKey = this.getClass().getName() + "/" + _includeAllUsers;
+            _table = ((UserSchema) getSchema()).getCachedLookupTableInfo(cacheKey, this::createLookupTableInfo);
         }
         return _table;
+    }
+
+    private TableInfo createLookupTableInfo()
+    {
+        TableInfo ret = ((UserSchema) getSchema()).getTable(_tableName, getLookupContainerFilter(), true, true);
+
+        if (_includeAllUsers)
+        {
+            // Clear out the filter that might be preventing us from resolving the lookup if the user list is being filtered
+            FilteredTable table = (FilteredTable) ret;
+            if (table == null)
+            {
+                // Exception 23740
+                throw new IllegalStateException("Failed to find lookup target " + getLookupSchemaName() + "." + getLookupTableName() + " in container " + getLookupContainer());
+            }
+            table.clearConditions(FieldKey.fromParts("UserId"));
+        }
+        ret.setLocked(true);
+        return ret;
     }
 
     /* set foreign key and display column */

--- a/assay/src/org/labkey/assay/query/AssaySchemaImpl.java
+++ b/assay/src/org/labkey/assay/query/AssaySchemaImpl.java
@@ -84,7 +84,9 @@ public class AssaySchemaImpl extends AssaySchema
         @Override
         public QuerySchema createSchema(DefaultSchema schema, Module module)
         {
-            return new AssaySchemaImpl(schema.getUser(), schema.getContainer(), null);
+            var ret = new AssaySchemaImpl(schema.getUser(), schema.getContainer(), null);
+            ret.setDefaultSchema(schema);
+            return ret;
         }
     }
 
@@ -120,6 +122,7 @@ public class AssaySchemaImpl extends AssaySchema
         return _protocols;
     }
 
+    // CONSIDER add DefaultSchema parameter to getSchema()!
     @Override
     public QuerySchema getSchema(String name)
     {
@@ -130,7 +133,9 @@ public class AssaySchemaImpl extends AssaySchema
         {
             if (name.equalsIgnoreCase(provider.getResourceName()))
             {
-                return getProviderSchema(provider);
+                var ret = getProviderSchema(provider);
+                ret.setDefaultSchema(getDefaultSchema());
+                return ret;
             }
         }
 
@@ -138,10 +143,17 @@ public class AssaySchemaImpl extends AssaySchema
         for (AssayProvider provider : getAllProviders())
         {
             if (name.equalsIgnoreCase(provider.getName()))
-                return getProviderSchema(provider);
+            {
+                var ret = getProviderSchema(provider);
+                ret.setDefaultSchema(getDefaultSchema());
+                return ret;
+            }
         }
 
-        return super.getSchema(name);
+        var ret = super.getSchema(name);
+        if (null != ret)
+            ret.setDefaultSchema(getDefaultSchema());
+        return ret;
     }
 
     // Get the cached AssayProviderSchema for a provider or create a new one.

--- a/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
@@ -463,6 +463,7 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
         ret.setDescription("Contains pointers to all of the different kinds of inputs (both materials and data files) that could be used for this run");
         ret.setFk(new InputForeignKey(getExpSchema(), ExpProtocol.ApplicationType.ExperimentRun, getContainerFilter()));
         ret.setIsUnselectable(true);
+        ret.setDisplayColumnFactory(ColumnInfo.NOLOOKUP_FACTORY);
         return ret;
     }
 
@@ -475,6 +476,7 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
         ret.setDescription("Contains pointers to all of the different kinds of outputs (both materials and data files) that could be produced by this run");
         ret.setFk(new InputForeignKey(getExpSchema(), ExpProtocol.ApplicationType.ExperimentRunOutput, getContainerFilter()));
         ret.setIsUnselectable(true);
+        ret.setDisplayColumnFactory(ColumnInfo.NOLOOKUP_FACTORY);
         return ret;
     }
 
@@ -561,8 +563,8 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
         addColumn(Column.Protocol).setFk(schema.getProtocolForeignKey(getContainerFilter(), "LSID"));
         addColumn(Column.RunGroups);
         addColumn(Column.RunGroupToggle);
-        addColumn(Column.Input);
-        addColumn(Column.Output);
+//        addColumn(Column.Input);
+//        addColumn(Column.Output);
         addColumn(Column.DataInputs);
         addColumn(Column.DataOutputs);
 

--- a/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
@@ -563,8 +563,8 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
         addColumn(Column.Protocol).setFk(schema.getProtocolForeignKey(getContainerFilter(), "LSID"));
         addColumn(Column.RunGroups);
         addColumn(Column.RunGroupToggle);
-//        addColumn(Column.Input);
-//        addColumn(Column.Output);
+        addColumn(Column.Input);
+        addColumn(Column.Output);
         addColumn(Column.DataInputs);
         addColumn(Column.DataOutputs);
 

--- a/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
@@ -336,10 +336,20 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
                     @Override
                     public TableInfo getLookupTableInfo()
                     {
+                        ContainerFilter cf = getLookupContainerFilter();
+                        UserSchema schema = getUserSchema();
+                        String key = getClass().getName() + "/RunGroups.RowId.fk/" + cf.getCacheKey(schema.getContainer());
+                        // since getTable(forWrite=true) does not cache, cache this tableinfo using getCachedLookupTableInfo()
+                        return schema.getCachedLookupTableInfo(key, this::createLookupTableInfo);
+                    }
+
+                    private TableInfo createLookupTableInfo()
+                    {
                         // TODO ContainerFilter: getLookupTableInfo() should not mutate table
                         // for now use forWrite==true to get mutable tableinfo
                         ExpTable result = (ExpTable)getExpSchema().getTable(ExpSchema.TableType.RunGroupMap.name(), getLookupContainerFilter(), true, true);
                         result.getMutableColumn(ExpRunGroupMapTable.Column.RunGroup).setFk(getExpSchema().getRunGroupIdForeignKey(getContainerFilter(), false));
+                        result.setLocked(true);
                         return result;
                     }
                 }, ExpRunGroupMapTable.Column.RunGroup.toString()));

--- a/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
@@ -60,6 +60,7 @@ abstract public class ExpTableImpl<C extends Enum> extends FilteredTable<UserSch
     private final ExpObjectImpl _objectType;
     private Set<Class<? extends Permission>> _allowablePermissions = new HashSet<>();
     private Domain _domain;
+    private ExpSchema _expSchema = null;
 
     // The populated flag indicates all standard columns have been added to the table, but metadata override have not yet been added
     protected boolean _populated;
@@ -344,11 +345,14 @@ abstract public class ExpTableImpl<C extends Enum> extends FilteredTable<UserSch
 
     public ExpSchema getExpSchema()
     {
-        if (_userSchema instanceof ExpSchema)
+        if (_expSchema == null)
         {
-            return (ExpSchema)_userSchema;
+            if (_userSchema instanceof ExpSchema)
+                _expSchema = (ExpSchema)_userSchema;
+            else
+                _expSchema = (ExpSchema)_userSchema.getDefaultSchema().getSchema("exp");
         }
-        return new ExpSchema(_userSchema.getUser(), _userSchema.getContainer());
+        return _expSchema;
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
@@ -350,7 +350,7 @@ abstract public class ExpTableImpl<C extends Enum> extends FilteredTable<UserSch
             if (_userSchema instanceof ExpSchema)
                 _expSchema = (ExpSchema)_userSchema;
             else
-                _expSchema = (ExpSchema)_userSchema.getDefaultSchema().getSchema("exp");
+                _expSchema = (ExpSchema)_userSchema.getDefaultSchema().getSchema(ExpSchema.SCHEMA_NAME);
         }
         return _expSchema;
     }

--- a/experiment/src/org/labkey/experiment/api/InputForeignKey.java
+++ b/experiment/src/org/labkey/experiment/api/InputForeignKey.java
@@ -51,6 +51,7 @@ public class InputForeignKey extends LookupForeignKey
     {
         // TODO ContainerFilter
         ExpProtocolApplicationTable ret = ExperimentService.get().createProtocolApplicationTable(ExpSchema.TableType.ProtocolApplications.toString(), _schema, null);
+        ((ExpProtocolApplicationTableImpl)ret).setPublic(false);
         ret.setContainerFilter(_filter);
         SamplesSchema samplesSchema = _schema.getSamplesSchema();
         for (String role : getDataInputs())

--- a/experiment/src/org/labkey/experiment/api/InputForeignKey.java
+++ b/experiment/src/org/labkey/experiment/api/InputForeignKey.java
@@ -16,8 +16,10 @@
 
 package org.labkey.experiment.api;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.TableDescription;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpSampleSet;
@@ -28,6 +30,7 @@ import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.query.LookupForeignKey;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -56,6 +59,61 @@ public class InputForeignKey extends LookupForeignKey
     {
         String key = getClass().getName() + "/" + _type.toString() + "/" + _filter.getCacheKey(_schema.getContainer());
         return _schema.getCachedLookupTableInfo(key, this::createLookupTableInfo);
+    }
+
+    @Override
+    public String getLookupColumnName()
+    {
+        return "RowId";
+    }
+
+    @Override
+    public @Nullable TableDescription getLookupTableDescription()
+    {
+        return new TableDescription()
+        {
+            @Override
+            public boolean isPublic()
+            {
+                return false;
+            }
+
+            @Override
+            public String getPublicName()
+            {
+                return null;
+            }
+
+            @Override
+            public String getPublicSchemaName()
+            {
+                return null;
+            }
+
+            @Override
+            public String getName()
+            {
+                return "ProtocolApplications";
+            }
+
+            @Override
+            public String getSchemaName()
+            {
+                return "exp";
+            }
+
+            @Override
+            public String getTitleColumn()
+            {
+                return "LSID";
+            }
+
+            @Override
+            public List<String> getPkColumnNames()
+            {
+                return List.of("RowId");
+            }
+        };
     }
 
     private TableInfo createLookupTableInfo()

--- a/experiment/src/org/labkey/experiment/api/SampleSetServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleSetServiceImpl.java
@@ -267,9 +267,6 @@ public class SampleSetServiceImpl implements SampleSetService
         sql.append(filter.getSQLFragment(getExpSchema(), new SQLFragment("r.Container"), container));
         sql.append(" GROUP BY mi.Role ORDER BY mi.Role");
 
-        Collection<Map<String, Object>> queryResults = new SqlSelector(getExpSchema(), sql).getMapCollection();
-        Map<String, ExpSampleSet> lsidToSampleSet = new HashMap<>();
-
         Map<String, ExpSampleSet> result = new LinkedHashMap<>();
         for (Map<String, Object> queryResult : queryResults)
         {


### PR DESCRIPTION
avoid redundant calls to createTable() and other table constructors