### PR TITLE
Fixes for Biologics introduced by #758

### DIFF
--- a/api/src/org/labkey/api/data/JsonWriter.java
+++ b/api/src/org/labkey/api/data/JsonWriter.java
@@ -343,13 +343,15 @@ public class JsonWriter
             //Issue 20092: the target column specified by the FK does not necessarily need to be a true PK
             // PERF computing getLookupColumnName() can be expensive, but we only want to do this work when it is not == default pk
             // suggest having fk.getLookupColumnName() which returns explicitly set LookupColumnName, and fk.computeLookupColumnName()
-            if (fk.getLookupColumnName() != null)
+            // NOTE: Don't try to resolve the lookup column on the lookup table because
+            // the MVFK lookup column is on the junction table instead of the far-right lookup table.
+            if (fk.getLookupColumnName() != null && !(fk instanceof MultiValuedForeignKey))
             {
                 key = fk.getLookupColumnName();
                 if (lookupTable instanceof TableInfo)
                 {
                     //NOTE: the XML could specify a column with different casing than the canonical name.  this could be problematic for client side JS.  \
-                    ColumnInfo targetCol = ((TableInfo)lookupTable).getColumn(fk.getLookupColumnName());
+                    ColumnInfo targetCol = ((TableInfo)lookupTable).getColumn(key);
                     if (targetCol != null)
                         key = targetCol.getName();
                 }

--- a/experiment/src/org/labkey/experiment/api/LineageForeignKey.java
+++ b/experiment/src/org/labkey/experiment/api/LineageForeignKey.java
@@ -137,7 +137,7 @@ class LineageForeignKey extends AbstractForeignKey
         abstract List<? extends ExpObject> getItems(UserSchema s);
     }
 
-    public ColumnInfo _createLookupColumn(ColumnInfo parent, TableInfo table, String displayField)
+    public ColumnInfo _createLookupColumn(ColumnInfo parent, TableInfo table, String displayField, boolean unselectable)
     {
         if (table == null)
         {
@@ -164,6 +164,7 @@ class LineageForeignKey extends AbstractForeignKey
         col.setFk(lookup.getFk());
         col.setUserEditable(false);
         col.setReadOnly(true);
+        col.setIsUnselectable(unselectable);
         col.setDisplayColumnFactory(lookup.getDisplayColumnFactory());
         return col;
     }
@@ -171,7 +172,7 @@ class LineageForeignKey extends AbstractForeignKey
     @Override
     public ColumnInfo createLookupColumn(ColumnInfo parent, String displayField)
     {
-        return _createLookupColumn(parent, getLookupTableInfo(), displayField);
+        return _createLookupColumn(parent, getLookupTableInfo(), displayField, true);
     }
 
     public void applyDisplayColumn(BaseColumnInfo column, Integer depth, String expType, String cpasType, @Nullable String lookupColumnName)
@@ -281,6 +282,7 @@ class LineageForeignKey extends AbstractForeignKey
             col.setFk(new ByTypeLineageForeignKey(requireNonNull(getUserSchema()), level, cacheKeyPrefix));
             col.setUserEditable(false);
             col.setReadOnly(true);
+            col.setIsUnselectable(true);
             applyDisplayColumn(col, 0, level.expType, null, null);
             addColumn(col);
         }
@@ -424,7 +426,7 @@ class LineageForeignKey extends AbstractForeignKey
         @Override
         public ColumnInfo createLookupColumn(ColumnInfo parent, String displayField)
         {
-            return _createLookupColumn(parent, getLookupTableInfo(), displayField);
+            return _createLookupColumn(parent, getLookupTableInfo(), displayField, false);
         }
 
         @Override


### PR DESCRIPTION
- don't attempt to resolve the lookup column of a MultiValueFK
- mark the SampleSet and DataClass lineage lookup columns as selectable (eg. Inputs/Data/CellLine)