### PR TITLE
Ticket 39463: Add manifest as .view.xml dependency

### DIFF
--- a/api/schemas/clientLibrary.xsd
+++ b/api/schemas/clientLibrary.xsd
@@ -30,7 +30,16 @@
     </xsd:complexType>
 
     <xsd:complexType name="dependencyType">
-        <xsd:attribute name="path" type="xsd:string" use="required"/>
+        <xsd:attribute name="path" type="xsd:string" use="required">
+            <xsd:annotation>
+                <xsd:documentation>
+                    Supported dependency file types are JS, CSS and manifest. These will be added to the HTML head
+                    element as appropriate for the file type (script tag for JS and link tags for CSS and manifest).
+                    File type is determined by the file extensions .js, .css and .webmanifest. See Progressive Web App
+                    documentation for information on manifest files.
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
         <xsd:attribute name="mode" type="lib:modeTypeEnum" use="optional"/>
     </xsd:complexType>
 

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -1622,6 +1622,7 @@ public class PageFlowUtil
         StringBuilder sb = getFaviconIncludes(c);
         sb.append(getLabkeyJS(context, config, resources, includePostParameters));
         sb.append(getStylesheetIncludes(c, resources, includeDefaultResources));
+        sb.append(getManifestIncludes(c, resources));
         sb.append(getJavaScriptIncludes(c, resources));
 
         return sb.toString();
@@ -1770,6 +1771,43 @@ public class PageFlowUtil
             }
             sb.append(");\n</script>\n");
         }
+    }
+
+    // Manifest files are included as links in the HTML head.  These files are used to identify resources for progressive
+    // web apps like flash page and home page link icons.  There can be multiple on the same page.
+    private static String getManifestIncludes(Container c, @Nullable LinkedHashSet<ClientDependency> resources)
+    {
+        StringBuilder sb = new StringBuilder();
+
+        if (resources != null)
+        {
+            Set<String> manifestFiles = new HashSet<>();
+            for (ClientDependency r : resources)
+            {
+                for (String manifest : r.getManifestPaths(c))
+                {
+                    if (!manifestFiles.contains(manifest))
+                    {
+                        sb.append("<link href=\"");
+                        if (ClientDependency.isExternalDependency(manifest))
+                        {
+                            sb.append(filter(manifest));
+                        }
+                        else
+                        {
+                            sb.append(AppProps.getInstance().getContextPath());
+                            sb.append("/");
+                            sb.append(filter(manifest));
+                        }
+                        sb.append("\" rel=\"manifest\">");
+
+                        manifestFiles.add(manifest);
+                    }
+                }
+            }
+        }
+
+        return sb.toString();
     }
 
     public static final String extJsRoot()

--- a/api/src/org/labkey/api/view/template/ClientDependency.java
+++ b/api/src/org/labkey/api/view/template/ClientDependency.java
@@ -60,7 +60,8 @@ public abstract class ClientDependency
         sass(".sass"),
         jsb2(".jsb2"),
         context(".context"),
-        lib(".lib.xml");
+        lib(".lib.xml"),
+        manifest(".webmanifest");
 
         TYPE(String extension)
         {
@@ -249,6 +250,19 @@ public abstract class ClientDependency
             scripts.addAll(function.apply(r));
 
         return scripts;
+    }
+
+    public @NotNull Set<String> getManifestPaths(Container c)
+    {
+        return getManifestPaths(c, AppProps.getInstance().isDevMode());
+    }
+
+    public @NotNull Set<String> getManifestPaths(Container c, boolean devMode)
+    {
+        if (devMode)
+            return getDevModeScripts(c, TYPE.manifest);
+        else
+            return getProductionScripts(c, TYPE.manifest);
     }
 
     public @NotNull Set<String> getCssPaths(Container c)


### PR DESCRIPTION
Dependencies defined in .view.xml files with .webmanifest file extension will be linked in HTML head as a manifest.  These are read automatically by all browsers to make a web page installable.  Used for PWA install.