### PR TITLE
Issue39726: Fix Troubleshooter's Top-level Button Options

### DIFF
--- a/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
+++ b/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
@@ -256,10 +256,10 @@ export class App extends PureComponent<{}, State> {
                             Save and Finish
                         </Button>
 
-                        < Button
+                        <Button
                             className="labkey-button parent-panel__cancel-button"
                             onClick={this.onCancel}
-                            >
+                        >
                             Cancel
                         </Button>
                     </>

--- a/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
+++ b/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
@@ -261,7 +261,7 @@ export class App extends PureComponent<{}, State> {
                             onClick={this.onCancel}
                             >
                             Cancel
-                            </Button>
+                        </Button>
                     </>
                     :
                     < Button

--- a/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
+++ b/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
@@ -250,16 +250,27 @@ export class App extends PureComponent<{}, State> {
 
                 {this.state.dirty && <Alert> {alertText} </Alert>}
 
-                <Button className="labkey-button primary parent-panel__save-button" onClick={this.saveChanges}>
-                    Save and Finish
-                </Button>
+                {this.state.canEdit ?
+                    <>
+                        <Button className="labkey-button primary parent-panel__save-button" onClick={this.saveChanges}>
+                            Save and Finish
+                        </Button>
 
-                <Button
-                    className="labkey-button parent-panel__cancel-button"
-                    onClick={this.onCancel}
-                >
-                    Cancel
-                </Button>
+                        < Button
+                            className="labkey-button parent-panel__cancel-button"
+                            onClick={this.onCancel}
+                            >
+                            Cancel
+                            </Button>
+                    </>
+                    :
+                    < Button
+                        className="labkey-button"
+                        onClick={this.onCancel}
+                    >
+                        Done
+                    </Button>
+                }
             </div>
         );
     }


### PR DESCRIPTION
A brief fix—the troubleshooter role should only see a 'Done' button that navigates them back to Admin Console.