### PR TITLE
Add cache-busting param to URL for custom CSS on admin page

### DIFF
--- a/core/src/org/labkey/core/admin/lookAndFeelResources.jsp
+++ b/core/src/org/labkey/core/admin/lookAndFeelResources.jsp
@@ -24,6 +24,8 @@
 <%@ page import="org.labkey.core.admin.AdminController.DeleteCustomStylesheetAction" %>
 <%@ page import="org.labkey.core.admin.AdminController.ResetFaviconAction" %>
 <%@ page import="org.labkey.core.admin.AdminController.ResetLogoAction" %>
+<%@ page import="org.labkey.api.util.PageFlowUtil" %>
+<%@ page import="org.labkey.api.admin.CoreUrls" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
@@ -79,7 +81,7 @@
     <td>
         <% if (null != bean.customStylesheet)
         { %>
-            Currently using a custom stylesheet. <%=link("view CSS", CoreController.CustomStylesheetAction.class)%> <%=link("delete custom stylesheet", DeleteCustomStylesheetAction.class).usePost()%>
+            Currently using a custom stylesheet. <%=link("view CSS", PageFlowUtil.urlProvider(CoreUrls.class).getCustomStylesheetURL(getContainer()))%> <%=link("delete custom stylesheet", DeleteCustomStylesheetAction.class).usePost()%>
         <% } else { %>
             No custom stylesheet.
         <% } %>


### PR DESCRIPTION
This matches how we actually reference the CSS in the <head> of each page, and makes sure the user doesn't see a cached copy