### PR TITLE
Issue 39354: ReturnURLString.getActionURL regression

### DIFF
--- a/api/src/org/labkey/api/util/ReturnURLString.java
+++ b/api/src/org/labkey/api/util/ReturnURLString.java
@@ -21,15 +21,12 @@ import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ConvertHelper;
-import org.labkey.api.settings.AppProps;
 import org.labkey.api.view.ActionURL;
-import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewServlet;
 
-import javax.servlet.http.HttpServletRequest;
-import java.net.MalformedURLException;
 import java.net.URISyntaxException;
-import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -129,6 +126,13 @@ public class ReturnURLString
         }
         catch (URISyntaxException e)
         {
+            StringBuilder sb = new StringBuilder("Bad returnUrl");
+            if (e.getIndex() >= 0)
+            {
+                char c = s.charAt(e.getIndex());
+                sb.append(" at char '" + c + "'");
+            }
+            LOG.error(sb.append(": ").append(e.getMessage().toString()));
             return null;
         }
     }

--- a/api/src/org/labkey/api/util/URLHelper.java
+++ b/api/src/org/labkey/api/util/URLHelper.java
@@ -320,22 +320,17 @@ public class URLHelper implements Cloneable, Serializable, Taintable, HasHtmlStr
     /**
      * The path argument is not URL encoded.
      */
-    public URLHelper setPath(Path path)
+    public URLHelper setPath(String path)
     {
-        if (_readOnly) throw new java.lang.IllegalStateException();
-        _path = path;
-        return this;
+        return setParsedPath(_parsePath(path, false));
     }
-
 
     /**
      * The path argument is not URL encoded.
      */
-    public URLHelper setPath(String path)
+    public URLHelper setPath(Path path)
     {
-        if (_readOnly) throw new java.lang.IllegalStateException();
-        _path = _parsePath(path, false);
-        return this;
+        return setParsedPath(path);
     }
 
 
@@ -411,6 +406,13 @@ public class URLHelper implements Cloneable, Serializable, Taintable, HasHtmlStr
     public Path getParsedPath()
     {
         return null == _path ? Path.rootPath : _path;
+    }
+
+    public URLHelper setParsedPath(Path path)
+    {
+        if (_readOnly) throw new java.lang.IllegalStateException();
+        _path = path;
+        return this;
     }
 
 

--- a/api/src/org/labkey/api/view/ActionURL.java
+++ b/api/src/org/labkey/api/view/ActionURL.java
@@ -455,16 +455,15 @@ public class ActionURL extends URLHelper implements Cloneable
 
     public ActionURL setContainer(Container c)
     {
-        _path = null == c ? Path.rootPath : c.getParsedPath();
+        setParsedPath(null == c ? Path.rootPath : c.getParsedPath());
         return this;
     }
 
 
     public ActionURL setExtraPath(String extraPath)
     {
-        if (_readOnly) throw new java.lang.IllegalStateException();
         if (null == extraPath) extraPath = "";
-        _path = Path.parse(extraPath);
+        setParsedPath(Path.parse(extraPath));
         return this;
     }
 
@@ -479,15 +478,17 @@ public class ActionURL extends URLHelper implements Cloneable
 
     /**
      * The path argument is not URL encoded.
+     * The controller, action, and remaining path are extracted from the path.
      */
     @Override
     public ActionURL setPath(String pathStr)
     {
-        return this.setPath(Path.parse(pathStr));
+        return this.setPath(_parsePath(pathStr, false));
     }
 
     /**
      * The path argument is not URL encoded.
+     * The controller, action, and remaining path are extracted from the path.
      */
     @Override
     public ActionURL setPath(Path path)

--- a/api/src/org/labkey/api/view/ActionURL.java
+++ b/api/src/org/labkey/api/view/ActionURL.java
@@ -39,6 +39,8 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.containsString;
+
 /**
  * Encapsulates URL generation and parsing based on controller/container/action conventions.
  * This class has to be kept in sync with ViewServlet.
@@ -173,7 +175,8 @@ public class ActionURL extends URLHelper implements Cloneable
 
         try
         {
-            setPath(request.getServletPath());
+            // NOTE: request.getServletPath() is already decoded unlike request.getRequestURI()
+            setPath(_parsePath(request.getServletPath(), false));
         }
         catch (IllegalArgumentException x)
         {
@@ -434,7 +437,7 @@ public class ActionURL extends URLHelper implements Cloneable
             throw new IllegalArgumentException(use.getMessage(), use);
         }
 
-        String path = uri.getPath();
+        String path = uri.getRawPath();
         if (path == null)
         {
             throw new IllegalArgumentException("No path found in URI: " + p);
@@ -445,7 +448,7 @@ public class ActionURL extends URLHelper implements Cloneable
                 path = path.substring(context.length());
         }
 
-        setPath(path);
+        setPath(_parsePath(path, true));
         setRawQuery(q);
         setFragment(f);
     }
@@ -474,18 +477,28 @@ public class ActionURL extends URLHelper implements Cloneable
         return path;
     }
 
-
+    /**
+     * The path argument is not URL encoded.
+     */
     @Override
     public ActionURL setPath(String pathStr)
+    {
+        return this.setPath(Path.parse(pathStr));
+    }
+
+    /**
+     * The path argument is not URL encoded.
+     */
+    @Override
+    public ActionURL setPath(Path path)
     {
         if (_readOnly)
             throw new java.lang.IllegalStateException();
 
         String controller = null;
-        Path path = Path.parse(pathStr);
 
         if (path.size() < 1)
-            throw new IllegalArgumentException(pathStr);
+            throw new IllegalArgumentException(path.toString());
         String action = path.get(path.size()-1);
         path = path.getParent();
 
@@ -508,7 +521,7 @@ public class ActionURL extends URLHelper implements Cloneable
         if (null == controller)
         {
             if (path.size() < 1)
-                throw new IllegalArgumentException(pathStr);
+                throw new IllegalArgumentException(path.toString());
             controller = path.get(0);
             path = path.subpath(1, path.size());
         }
@@ -626,6 +639,19 @@ public class ActionURL extends URLHelper implements Cloneable
                 assertEquals(parse.getContextPath() + "/path/controller-action.view?foo=bar", toString);
             else
                 assertEquals(parse.getContextPath() + "/controller/path/action.view?foo=bar", toString);
+        }
+
+        @Test
+        public void testDecode() throws URISyntaxException
+        {
+            // The original fix for Issue 39354 changed returnUrl to be parsed using
+            // the URLHelper(String) constructor.  This revealed a subtle inconsistency
+            // between URLHelper and ActionURL decoding of '+' character.
+            String s = AppProps.getInstance().getContextPath() + "/path+space%2Bplus/controller-action.view";
+            URLHelper a = new URLHelper(s);
+            ActionURL b = new ActionURL(s);
+            assertThat(a.getLocalURIString(), containsString("/path%20space%2Bplus/controller-action.view"));
+            assertEquals(a.getLocalURIString(), b.getLocalURIString());
         }
     }
 }

--- a/api/src/org/labkey/api/view/ViewServlet.java
+++ b/api/src/org/labkey/api/view/ViewServlet.java
@@ -419,7 +419,7 @@ public class ViewServlet extends HttpServlet
                 {
                     c = cFixUp;
                     path = pathFixUp;
-                    url.setPath(path);
+                    url.setParsedPath(path);
                     if ("GET".equals(request.getMethod()))
                         throw new RedirectException(url);
                 }

--- a/api/src/org/labkey/api/view/menu/NavTreeMenu.java
+++ b/api/src/org/labkey/api/view/menu/NavTreeMenu.java
@@ -154,7 +154,7 @@ public class NavTreeMenu extends WebPartView implements Collapsible
         if (!c.isInFolderNav())
         {
             currentUrl = currentUrl.clone();
-            currentUrl.setPath(currentUrl.getParsedPath().getParent());
+            currentUrl.setParsedPath(currentUrl.getParsedPath().getParent());
         }
         if (!c.isInFolderNav())
             c = c.getParent();


### PR DESCRIPTION
#815 broke ReturnURLString.getActionURL for URLs containing a '+' in the path part.  Originally, the raw returnUrl string was used to create the ActionURL, but my change to use the parsed URLHelper to construct the ActionURL revealed that URLHelper and ActionURL were inconsistent in how the URL string was decoded.

Fixes LabModulesTest