### PR TITLE
FacetedFilterCutoffTest.testFacetCutoff test fix-  issue 39727

### DIFF
--- a/api/webapp/clientapi/ext3/FilterDialog.js
+++ b/api/webapp/clientapi/ext3/FilterDialog.js
@@ -1217,7 +1217,10 @@ LABKEY.FilterDialog.View.Faceted = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
                     div.on('click', grid.onHeaderCellClick, grid);
                 }
 
-                if (numFacets > this.MAX_FILTER_CHOICES) {
+                // Issue 39727 - show a message if we've capped the number of options shown
+                Ext.getCmp(this.gridID + 'OverflowLabel').setVisible(this.overflow);
+
+                if (this.overflow) {
                     this.fireEvent('invalidfilter');
                 }
             }
@@ -1258,8 +1261,8 @@ LABKEY.FilterDialog.View.Faceted = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
                 if (d && d.values) {
                     var recs = [], v, i=0, hasBlank = false, isString, formattedValue;
 
-                    // Issue 39727. Do this here instead of onViewReady() so we know if we actually exceeded the max or not
-                    Ext.getCmp(this.gridID + 'OverflowLabel').setVisible(d.values.length > this.MAX_FILTER_CHOICES);
+                    // Issue 39727 - remember if we exceeded our cap so we can show a message
+                    this.overflow = d.values.length > this.MAX_FILTER_CHOICES;
 
                     for (; i < Math.min(d.values.length, this.MAX_FILTER_CHOICES); i++) {
                         v = d.values[i];


### PR DESCRIPTION
We used to add 251 items to the list, and then detect that it was too many and show the non-faceted filtering tab.

I switched it to only show 250 and warn that it was overflowed. Now we only show 250 (as we intended, I think) and both flip to the other tab AND show the warning on the list of values tab.

I additionally moved it into onViewReady() as you suggested, Cory.