### PR TITLE
Add empty clean task so npmRunClean doesn't complain

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "setup": "npm install"
+    "setup": "npm install",
+    "clean": ""
   },
   "devDependencies": {
     "@babel/core": "7.4.5",


### PR DESCRIPTION
This little change is needed so we can run npmRunClean at the root level to clean out all generated npm artifacts.  it does nothing in this case because platform does not generate any artifacts.