### PR TITLE
Issue 39805: uq_plate_container_name violation when upgrading

### DIFF
--- a/assay/resources/schemas/dbscripts/postgresql/assay-20.001-20.002.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-20.001-20.002.sql
@@ -19,9 +19,10 @@ ALTER TABLE assay.well
 ALTER TABLE assay.wellgroup
     ADD CONSTRAINT uq_wellgroup_lsid UNIQUE (lsid);
 
--- plate names are unique in each container
-ALTER TABLE assay.plate
-    ADD CONSTRAINT uq_plate_container_name UNIQUE (container, name);
+-- Issue 39805: uq_plate_container_name violation when upgrading via assay-20.001-20.002.sql
+-- plate template names are unique in each container
+--ALTER TABLE assay.plate
+--  ADD CONSTRAINT uq_plate_container_name UNIQUE (container, name);
 
 -- each well position is unique on the plate
 ALTER TABLE assay.well

--- a/assay/resources/schemas/dbscripts/postgresql/assay-20.002-20.003.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-20.002-20.003.sql
@@ -1,0 +1,5 @@
+-- Issue 39805: uq_plate_container_name violation when upgrading via assay-20.001-20.002.sql
+SELECT core.fn_dropifexists('plate', 'assay', 'CONSTRAINT', 'uq_plate_container_name');
+
+-- plate template (not instances) names are unique in each container
+CREATE UNIQUE INDEX uq_plate_container_name_template ON assay.plate (container, name) WHERE template=true;

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-20.001-20.002.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-20.001-20.002.sql
@@ -20,9 +20,10 @@ ALTER TABLE assay.well
 ALTER TABLE assay.wellgroup
     ADD CONSTRAINT uq_wellgroup_lsid UNIQUE (lsid);
 
+-- Issue 39805: uq_plate_container_name violation when upgrading via assay-20.001-20.002.sql
 -- plate names are unique in each container
-ALTER TABLE assay.plate
-    ADD CONSTRAINT uq_plate_container_name UNIQUE (container, name);
+--ALTER TABLE assay.plate
+--    ADD CONSTRAINT uq_plate_container_name UNIQUE (container, name);
 
 -- each well position is unique on the plate
 ALTER TABLE assay.well

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-20.002-20.003.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-20.002-20.003.sql
@@ -1,0 +1,5 @@
+-- Issue 39805: uq_plate_container_name violation when upgrading via assay-20.001-20.002.sql
+EXEC core.fn_dropifexists 'plate', 'assay', 'CONSTRAINT', 'uq_plate_container_name';
+
+-- plate template (not instances) names are unique in each container
+CREATE UNIQUE INDEX uq_plate_container_name_template ON assay.plate (container, name) WHERE template=1;

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -92,7 +92,7 @@ public class AssayModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 20.002;
+        return 20.003;
     }
 
     @Override


### PR DESCRIPTION
- plate templates must have unique names, but plate instances may not
- use filtered unique index over assay.plate (container, name) for plate templates