### PR TITLE
Fix for DomainDesignerTest failures related to List Designer changes

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2580,7 +2580,7 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
@@ -6794,7 +6794,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -11093,7 +11093,7 @@
     },
     "rgba-regex": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
     },

--- a/experiment/src/client/DomainDesigner/DomainDesigner.tsx
+++ b/experiment/src/client/DomainDesigner/DomainDesigner.tsx
@@ -103,7 +103,7 @@ export class App extends React.PureComponent<any, Partial<IAppState>> {
 
         this.setState(() => ({submitting: true}));
 
-        saveDomain(domain, undefined, undefined, undefined,  includeWarnings)
+        saveDomain(domain, undefined, {domainId: domain.domainId}, undefined,  includeWarnings)
             .then((savedDomain) => {
                 this.setState(() => ({
                     domain: savedDomain,


### PR DESCRIPTION
- this test uses the DomainDesigner.tsx action directly for editing a list domain and since the list updateDomain now has some extra validation, we need to pass along the domainId in the options object