### PR TITLE
Issue 39413: ETL ignores source container

### DIFF
--- a/api/src/org/labkey/api/dataiterator/AbstractDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/AbstractDataIterator.java
@@ -16,7 +16,7 @@
 
 package org.labkey.api.dataiterator;
 
-import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.ValidationException;
@@ -133,5 +133,11 @@ public abstract class AbstractDataIterator implements DataIterator
     protected boolean preserveEmptyString()
     {
         return _context.getConfigParameterBoolean(QueryUpdateService.ConfigParameters.PreserveEmptyString);
+    }
+
+    @Nullable
+    protected String getDataSource()
+    {
+        return _context.getDataSource();
     }
 }

--- a/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
@@ -49,6 +49,7 @@ public class DataIteratorContext
     private final Set<String> _passThroughBuiltInColumnNames = new CaseInsensitiveHashSet();
     private final Set<String> _dontUpdateColumnNames = new CaseInsensitiveHashSet();
     private final Set<String> _alternateKeys = new CaseInsensitiveHashSet();
+    private String _dataSource;
 
     int _maxRowErrors = 1;
 
@@ -82,6 +83,17 @@ public class DataIteratorContext
     public void setSelectIds(Boolean selectIds)
     {
         _selectIds = selectIds;
+    }
+
+    @Nullable
+    public String getDataSource()
+    {
+        return _dataSource;
+    }
+
+    public void setDataSource(@Nullable String dataSource)
+    {
+        _dataSource = dataSource;
     }
 
     public boolean isFailFast()

--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -65,6 +65,8 @@ import java.util.stream.StreamSupport;
  */
 public class DataIteratorUtil
 {
+    public static final String DATA_SOURCE = "dataSource";
+    public static final String ETL_DATA_SOURCE = "etl";
 
     private static final Logger LOG = Logger.getLogger(DataIteratorUtil.class);
 

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -460,7 +460,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                     return rowContainerVal;
                 }
 
-                Container rowContainer = UserSchema.translateRowSuppliedContainer(rowContainerVal, us.getContainer(), us.getUser(), tableInfo, UpdatePermission.class);
+                Container rowContainer = UserSchema.translateRowSuppliedContainer(rowContainerVal, us.getContainer(), us.getUser(), tableInfo, UpdatePermission.class, getDataSource());
                 if (rowContainer != null)
                 {
                     if (!this.us.getContainer().allowRowMutationForContainer(rowContainer))

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -216,7 +216,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         context.getErrors().setExtraContext(extraScriptContext);
         if (extraScriptContext != null)
         {
-            context.setDataSource((String) extraScriptContext.get("dataSource"));
+            context.setDataSource((String) extraScriptContext.get(DataIteratorUtil.DATA_SOURCE));
         }
 
         in = preTriggerDataIterator(in, context);

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -208,12 +208,16 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
     }
 
 
-    protected int _importRowsUsingDIB(User user, Container container, DataIteratorBuilder in, @Nullable final ArrayList<Map<String, Object>> outputRows, DataIteratorContext context, Map<String, Object> extraScriptContext)
+    protected int _importRowsUsingDIB(User user, Container container, DataIteratorBuilder in, @Nullable final ArrayList<Map<String, Object>> outputRows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
     {
         if (!hasPermission(user, InsertPermission.class))
             throw new UnauthorizedException("You do not have permission to insert data into this table.");
 
         context.getErrors().setExtraContext(extraScriptContext);
+        if (extraScriptContext != null)
+        {
+            context.setDataSource((String) extraScriptContext.get("dataSource"));
+        }
 
         in = preTriggerDataIterator(in, context);
 
@@ -320,7 +324,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
 
 
     protected @Nullable List<Map<String, Object>> _insertRowsUsingDIB(User user, Container container, List<Map<String, Object>> rows,
-                                                      DataIteratorContext context, Map<String, Object> extraScriptContext)
+                                                      DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
     {
         if (!hasPermission(user, InsertPermission.class))
             throw new UnauthorizedException("You do not have permission to insert data into this table.");

--- a/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
@@ -415,14 +415,14 @@ public class DefaultQueryUpdateService extends AbstractQueryUpdateService
 
         if (row.get("container") != null)
         {
-            Container rowContainer = UserSchema.translateRowSuppliedContainer(row.get("container"), container, user, getQueryTable(), UpdatePermission.class);
+            Container rowContainer = UserSchema.translateRowSuppliedContainer(row.get("container"), container, user, getQueryTable(), UpdatePermission.class, null);
             if (rowContainer == null)
             {
                 throw new ValidationException("Unknown container: " + row.get("container"));
             }
             else
             {
-                Container oldContainer = UserSchema.translateRowSuppliedContainer(new CaseInsensitiveHashMap<>(oldRow).get("container"), container, user, getQueryTable(), UpdatePermission.class);
+                Container oldContainer = UserSchema.translateRowSuppliedContainer(new CaseInsensitiveHashMap<>(oldRow).get("container"), container, user, getQueryTable(), UpdatePermission.class, null);
                 if (null != oldContainer && !rowContainer.equals(oldContainer))
                     throw new UnauthorizedException("The row is from the wrong container.");
             }
@@ -611,7 +611,7 @@ public class DefaultQueryUpdateService extends AbstractQueryUpdateService
         if (container != null && getDbTable().getColumn("container") != null)
         {
             // UNDONE: 9077: check container permission on each row before delete
-            Container rowContainer = UserSchema.translateRowSuppliedContainer(new CaseInsensitiveHashMap<>(oldRowMap).get("container"), container, user, getQueryTable(), DeletePermission.class);
+            Container rowContainer = UserSchema.translateRowSuppliedContainer(new CaseInsensitiveHashMap<>(oldRowMap).get("container"), container, user, getQueryTable(), DeletePermission.class, null);
             if (null != rowContainer && !container.equals(rowContainer))
             {
                 //Issue 15301: allow workbooks records to be deleted/updated from the parent container
@@ -760,7 +760,7 @@ public class DefaultQueryUpdateService extends AbstractQueryUpdateService
             //Issue 15301: allow workbooks records to be deleted/updated from the parent container
             if (row.get("container") != null)
             {
-                Container rowContainer = UserSchema.translateRowSuppliedContainer(row.get("container"), container, user, getQueryTable(), clazz);
+                Container rowContainer = UserSchema.translateRowSuppliedContainer(row.get("container"), container, user, getQueryTable(), clazz, null);
                 if (rowContainer != null && container.allowRowMutationForContainer(rowContainer))
                 {
                     row.put("container", rowContainer.getId()); //normalize to container ID

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -760,7 +760,7 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
      * If a value is supplied but cannot be resolved to a valid container then null is returned.
      */
     @Nullable
-    public static Container translateRowSuppliedContainer(Object rowContainerVal, Container c, User u, TableInfo ti, Class<? extends Permission> clazz)
+    public static Container translateRowSuppliedContainer(Object rowContainerVal, Container c, User u, TableInfo ti, Class<? extends Permission> clazz, @Nullable String dataSource)
     {
         Container ret;
         if (rowContainerVal == null)
@@ -780,8 +780,9 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
         {
             // Issue 39413: If incoming container is not a workbook container or a sub-container of the current container
             // then ignore the incoming container. This was an issue when queries for ETLs contained a different container
-            // than the current container, verify permissions was looking for destination target in incoming container
-            if (!ret.isWorkbook() || !ret.hasAncestor(c))
+            // than the current container, verify permissions was looking for destination target in incoming container.
+            // This function is used a little differently for ETLs vs QUS usage so scope this behavior only to ETLs.
+            if ((dataSource != null && dataSource.equals("etl")) && (!ret.isWorkbook() || !ret.hasAncestor(c)))
             {
                 return null;
             }

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -29,6 +29,7 @@ import org.labkey.api.data.CrosstabTableInfo;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.UserSchemaCustomizer;
+import org.labkey.api.dataiterator.DataIteratorUtil;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.reports.report.view.ReportUtil;
 import org.labkey.api.security.User;
@@ -782,7 +783,7 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
             // then ignore the incoming container. This was an issue when queries for ETLs contained a different container
             // than the current container, verify permissions was looking for destination target in incoming container.
             // This function is used a little differently for ETLs vs QUS usage so scope this behavior only to ETLs.
-            if ((dataSource != null && dataSource.equals("etl")) && (!ret.isWorkbook() || !ret.hasAncestor(c)))
+            if ((dataSource != null && dataSource.equals(DataIteratorUtil.ETL_DATA_SOURCE)) && (!ret.isWorkbook() || !ret.hasAncestor(c)))
             {
                 return null;
             }

--- a/internal/src/org/labkey/api/query/SimpleQueryUpdateService.java
+++ b/internal/src/org/labkey/api/query/SimpleQueryUpdateService.java
@@ -66,7 +66,7 @@ public class SimpleQueryUpdateService extends DefaultQueryUpdateService
 
 
     @Override
-    public List<Map<String, Object>> insertRows(User user, Container container, List<Map<String, Object>> rows, BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext) throws DuplicateKeyException, QueryUpdateServiceException, SQLException
+    public List<Map<String, Object>> insertRows(User user, Container container, List<Map<String, Object>> rows, BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, @Nullable Map<String, Object> extraScriptContext) throws DuplicateKeyException, QueryUpdateServiceException, SQLException
     {
         List<Map<String, Object>> result = super._insertRowsUsingDIB(user, container, rows, getDataIteratorContext(errors, InsertOption.INSERT, configParameters), extraScriptContext);
         return result;


### PR DESCRIPTION
If the source query for an ETL contains a container column, ignore the incoming container.  The only exception is if the container is a workbook container and a sub-container of the current container.  Passing the data source through the data iterator context in order to determine if it is an ETL doing the update.