### PR TITLE
Issue 38206: FilePathRoot in exp.Runs table gets mangled when sibling folders are moved

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -621,13 +621,13 @@ public class DbScope
 
     public interface RetryFn<ReturnType>
     {
-        ReturnType exec(DbScope.Transaction tx) throws DeadlockLoserDataAccessException;
+        ReturnType exec(DbScope.Transaction tx) throws DeadlockLoserDataAccessException, RuntimeSQLException;
     }
 
-    /* can be used to conveniently throw a typed exception out of executeWithRetry */
-    public static class RetryException extends RuntimeException
+    /** Can be used to conveniently throw a typed exception out of executeWithRetry */
+    public static class RetryPassthroughException extends RuntimeException
     {
-        public RetryException(@NotNull Exception x)
+        public RetryPassthroughException(@NotNull Exception x)
         {
             super(x);
         }
@@ -644,8 +644,9 @@ public class DbScope
         }
     }
 
-    /** Won't retry if we're already in a transaction
-     * fn() should throw DeadlockLoserDataAccessException, not generic SQLException
+    /**
+     * If there's a deadlock exception, retry two more times after a delay. Won't retry if we're already in a transaction
+     * fn() should throw DeadlockLoserDataAccessException or RuntimeSQLException to get the retry behavior
      */
     public <ReturnType> ReturnType executeWithRetry(RetryFn<ReturnType> fn, Lock... extraLocks)
     {
@@ -653,7 +654,7 @@ public class DbScope
         ReturnType ret = null;
         int tries = isTransactionActive() ? 1 : 3;
         long delay = 100;
-        DeadlockLoserDataAccessException lastException = null;
+        RuntimeException lastException = null;
         for (var tri=0 ; tri < tries ; tri++ )
         {
             lastException = null;
@@ -666,7 +667,17 @@ public class DbScope
             catch (DeadlockLoserDataAccessException dldae)
             {
                 lastException = dldae;
-                try { Thread.sleep((tri+1)*delay); } catch (InterruptedException ie) {}
+                try { Thread.sleep((tri+1)*delay); } catch (InterruptedException ignored) {}
+                LOG.info("Retrying operation after deadlock", new Throwable());
+            }
+            catch (RuntimeSQLException e)
+            {
+                lastException = e;
+                if (!SqlDialect.isTransactionException(e))
+                {
+                    break;
+                }
+                try { Thread.sleep((tri+1)*delay); } catch (InterruptedException ignored) {}
                 LOG.info("Retrying operation after deadlock", new Throwable());
             }
         }
@@ -2765,7 +2776,7 @@ public class DbScope
         @Test
         public void testRetryException()
         {
-            var r = new RetryException(new IllegalArgumentException());
+            var r = new RetryPassthroughException(new IllegalArgumentException());
             try
             {
                 r.rethrow(IllegalArgumentException.class);

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -545,6 +545,7 @@ public abstract class SqlDialect
 
     public abstract String getClobLengthFunction();
 
+    /** Literal string search, no wildcards supported */
     public abstract SQLFragment getStringIndexOfFunction(SQLFragment toFind, SQLFragment toSearch);
 
     public abstract String getSubstringFunction(String s, String start, String length);

--- a/api/src/org/labkey/api/files/TableUpdaterFileListener.java
+++ b/api/src/org/labkey/api/files/TableUpdaterFileListener.java
@@ -66,11 +66,7 @@ public class TableUpdaterFileListener implements FileListener
         String get(File f);
         String get(Path f);
         /** @return the file path separator (typically '/' or '\') */
-        String getSeparatorSuffix();
-        default boolean matchParentAndFileName()
-        {
-            return Type.fileRootPath.equals(this);
-        }
+        String getSeparatorSuffix(Path path);
     }
 
     public enum Type implements PathGetter
@@ -91,7 +87,7 @@ public class TableUpdaterFileListener implements FileListener
             }
 
             @Override
-            public String getSeparatorSuffix()
+            public String getSeparatorSuffix(Path path)
             {
                 return "/";
             }
@@ -116,13 +112,13 @@ public class TableUpdaterFileListener implements FileListener
             }
 
             @Override
-            public String getSeparatorSuffix()
+            public String getSeparatorSuffix(Path path)
             {
-                return File.separator;
+                return FileUtil.hasCloudScheme(path) ? "/" : File.separator;
             }
         },
 
-        /** field has root of file path, but need to match with filename in "name" field */
+        /** field has root of file path */
         fileRootPath
         {
             @Override
@@ -138,9 +134,9 @@ public class TableUpdaterFileListener implements FileListener
             }
 
             @Override
-            public String getSeparatorSuffix()
+            public String getSeparatorSuffix(Path path)
             {
-                return File.separator;
+                return FileUtil.hasCloudScheme(path) ? "/" : File.separator;
             }
         },
 
@@ -163,7 +159,7 @@ public class TableUpdaterFileListener implements FileListener
             }
 
             @Override
-            public String getSeparatorSuffix()
+            public String getSeparatorSuffix(Path path)
             {
                 return "/";
             }
@@ -192,11 +188,7 @@ public class TableUpdaterFileListener implements FileListener
     @Override
     public String getSourceName()
     {
-        StringBuilder name = new StringBuilder();
-        name.append(_table.getSchema().getName()).append(".");
-        name.append(_table.getName()).append(".");
-        name.append(_pathColumn);
-        return name.toString();
+        return _table.getSchema().getName() + "." + _table.getName() + "." + _pathColumn;
     }
 
     @Override
@@ -242,129 +234,81 @@ public class TableUpdaterFileListener implements FileListener
 
         String srcPath = getSourcePath(src, container);
         String destPath = _pathGetter.get(dest);
+        String srcPathWithout = null;
 
-        if (!_pathGetter.matchParentAndFileName() || !Files.isDirectory(src))
+        // If it's a directory, prep versions with and without a trailing slash. Check the dest because it's already moved by the time this fires
+        if (srcPath.endsWith("/") || srcPath.endsWith("\\") || Files.isDirectory(dest))
         {
-            // For fileRootPath, we need the parent of the files
-            String srcPathWithout = null;
-            if (_pathGetter.matchParentAndFileName())
-            {
-                srcPath = getParentWithSeparator(src);
-                srcPathWithout = getParentWithoutSeparator(src);
-                destPath = getParentWithoutSeparator(dest);
-                if (null == srcPath || null == destPath)
-                    return;     // Nothing to do
-            }
-
-            // Now build up the SQL to handle this specific path
-            SQLFragment singleEntrySQL = new SQLFragment(sharedSQL);
-            singleEntrySQL.append("? WHERE ");
-            singleEntrySQL.append(dbColumnName);
-            singleEntrySQL.append(" = ?");
-            singleEntrySQL.add(destPath);
-            singleEntrySQL.add(srcPath);
-            if (null != srcPathWithout)
-            {
-                singleEntrySQL.append(" OR ");
-                singleEntrySQL.append(dbColumnName);
-                singleEntrySQL.append(" = ?");
-                singleEntrySQL.add(srcPathWithout);
-            }
-
-            if (_pathGetter.matchParentAndFileName())
-            {
-                String fileName = FileUtil.getFileName(src);
-                if (null != fileName)
-                    singleEntrySQL.append(" AND Name = ?").add(fileName);
-            }
-
-            int rows = -1;
-            for (int retry = 0; retry < 2; retry++)
-            {
-                try
-                {
-                    rows = new SqlExecutor(schema).execute(singleEntrySQL);
-                    break;
-                }
-                catch (RuntimeException x)
-                {
-                    if (retry > 0 || _table.getSchema().getScope().isTransactionActive() || !SqlDialect.isTransactionException(x))
-                        throw x;
-                }
-            }
-            LOG.info("Updated " + rows + " row in " + _table + " for move from " + src + " to " + dest);
+            srcPath = getWithSeparator(src, container);
+            srcPathWithout = getWithoutSeparator(srcPath);
+            destPath = getWithoutSeparator(destPath);
         }
 
-        // Skip attempting to fix up child paths if we know that the entry is a file. If it's not (either it's a
+        // Now build up the SQL to handle this specific path
+        SQLFragment singleEntrySQL = new SQLFragment(sharedSQL);
+        singleEntrySQL.append("? WHERE (");
+        singleEntrySQL.append(dbColumnName);
+        singleEntrySQL.append(" = ?");
+        singleEntrySQL.add(destPath);
+        singleEntrySQL.add(srcPath);
+        if (null != srcPathWithout)
+        {
+            singleEntrySQL.append(" OR ");
+            singleEntrySQL.append(dbColumnName);
+            singleEntrySQL.append(" = ?");
+            singleEntrySQL.add(srcPathWithout);
+        }
+        singleEntrySQL.append(")");
+
+        int rows = schema.getScope().executeWithRetry(tx -> new SqlExecutor(schema).execute(singleEntrySQL));
+        LOG.info("Updated " + rows + " row in " + _table + " for move from " + src + " to " + dest);
+
+        // Handle updating child paths, unless we know that the entry is a file. If it's not (either it's a
         // directory or it doesn't exist), then try to fix up child records
         if ((!Files.exists(dest) || Files.isDirectory(dest)))
         {
-            if (!srcPath.endsWith(_pathGetter.getSeparatorSuffix()))
+            String separatorSuffix = _pathGetter.getSeparatorSuffix(dest);
+            if (!srcPath.endsWith(separatorSuffix))
             {
-                srcPath = srcPath + _pathGetter.getSeparatorSuffix();
+                srcPath = srcPath + separatorSuffix;
             }
-            if (!destPath.endsWith(_pathGetter.getSeparatorSuffix()))
+            if (!destPath.endsWith(separatorSuffix))
             {
-                destPath = destPath + _pathGetter.getSeparatorSuffix();
+                destPath = destPath + separatorSuffix;
             }
 
             int childRowsUpdated = 0;
 
+            // Consider paths with file:///...
             if (srcPath.startsWith("file:"))
             {
-                // Consider paths with file:///...
-                String srcPath2 = "file://" + srcPath.replaceFirst("^file:/+", "/");;
-                SQLFragment whereClause2 = new SQLFragment(" WHERE ");
-                whereClause2.append(dialect.getStringIndexOfFunction(new SQLFragment("?", srcPath2), new SQLFragment(dbColumnName))).append(" = 1");
-                SQLFragment childPathsSQL2 = new SQLFragment(sharedSQL);
-                childPathsSQL2.append(dialect.concatenate(new SQLFragment("?", destPath), new SQLFragment(dialect.getSubstringFunction(dbColumnName, Integer.toString(srcPath2.length() + 1), "5000"))));
-                childPathsSQL2.append(whereClause2);
-
-                childRowsUpdated += new SqlExecutor(schema).execute(childPathsSQL2);
+                srcPath = "file://" + srcPath.replaceFirst("^file:/+", "/");
             }
-            else
-            {
-                SQLFragment whereClause = new SQLFragment(" WHERE ");
-                whereClause.append(dialect.getStringIndexOfFunction(new SQLFragment("?", srcPath), new SQLFragment(dbColumnName))).append(" = 1");
+            SQLFragment whereClause = new SQLFragment(" WHERE ");
+            whereClause.append(dialect.getStringIndexOfFunction(new SQLFragment("?", srcPath), new SQLFragment(dbColumnName))).append(" = 1");
 
-                // Make the SQL to handle children
-                SQLFragment childPathsSQL = new SQLFragment(sharedSQL);
-                childPathsSQL.append(dialect.concatenate(new SQLFragment("?", destPath), new SQLFragment(dialect.getSubstringFunction(dbColumnName, Integer.toString(srcPath.length() + 1), "5000"))));
-                childPathsSQL.append(whereClause);
-
-                childRowsUpdated += new SqlExecutor(schema).execute(childPathsSQL);
-            }
+            // Make the SQL to handle children
+            SQLFragment childPathsSQL = new SQLFragment(sharedSQL);
+            childPathsSQL.append(dialect.concatenate(new SQLFragment("?", destPath), new SQLFragment(dialect.getSubstringFunction(dbColumnName, Integer.toString(srcPath.length() + 1), "5000"))));
+            childPathsSQL.append(whereClause);
+            childRowsUpdated += new SqlExecutor(schema).execute(childPathsSQL);
 
             LOG.info("Updated " + childRowsUpdated + " child paths in " + _table + " rows for move from " + src + " to " + dest);
         }
     }
 
-    @Nullable
-    private String getParentWithSeparator(Path path)
+    @NotNull
+    private String getWithSeparator(Path path, Container container)
     {
-        Path parent = path.getParent();
-        if (null != parent)
-        {
-            if (FileUtil.hasCloudScheme(parent))
-                return FileUtil.pathToString(parent) + File.separator;
-            else
-                return parent.toFile().getPath() + File.separator;
-        }
-        return null;
+        String result = getSourcePath(path, container);
+        String separator = _pathGetter.getSeparatorSuffix(path);
+        return result + (result.endsWith(separator) ? "" : separator);
     }
 
-    @Nullable
-    private String getParentWithoutSeparator(Path path)
+    @NotNull
+    private String getWithoutSeparator(String path)
     {
-        Path parent = path.getParent();
-        if (null != parent)
-        {
-            if (FileUtil.hasCloudScheme(parent))
-                return FileUtil.pathToString(parent);
-            else
-                return parent.toFile().getPath();
-        }
-        return null;
+        return (path.endsWith("/") || path.endsWith("\\")) ? path.substring(0, path.length() - 1): path;
     }
 
     @Override
@@ -372,7 +316,7 @@ public class TableUpdaterFileListener implements FileListener
     {
         Set<String> columns = Collections.singleton(_pathColumn);
         SimpleFilter filter = new SimpleFilter();
-        filter.addCondition(_pathColumn, null, CompareType.NONBLANK);
+        filter.addCondition(FieldKey.fromParts(_pathColumn), null, CompareType.NONBLANK);
         if (container != null)
         {
             ColumnInfo containerColumn = _table.getColumn("container");

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -563,9 +563,10 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     @Override
     public SQLFragment getStringIndexOfFunction(SQLFragment toFind, SQLFragment toSearch)
     {
-        SQLFragment result = new SQLFragment("patindex('%' + ");
+        // Use CHARINDEX instead of PATINDEX, which does wildcard matching
+        SQLFragment result = new SQLFragment("CHARINDEX(");
         result.append(toFind);
-        result.append(" + '%', ");
+        result.append(", ");
         result.append(toSearch);
         result.append(")");
         return result;

--- a/experiment/src/org/labkey/experiment/api/SampleSetServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleSetServiceImpl.java
@@ -717,11 +717,11 @@ public class SampleSetServiceImpl implements SampleSetService
                 }
                 catch (ExperimentException eex)
                 {
-                    throw new DbScope.RetryException(eex);
+                    throw new DbScope.RetryPassthroughException(eex);
                 }
             });
         }
-        catch (DbScope.RetryException x)
+        catch (DbScope.RetryPassthroughException x)
         {
             x.rethrow(ExperimentException.class);
             throw x;

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -48,6 +48,8 @@ import org.labkey.api.data.WorkbookContainerType;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.api.DataType;
 import org.labkey.api.exp.api.ExpData;
+import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.query.ExpDataTable;
 import org.labkey.api.files.DirectoryPattern;
@@ -79,6 +81,7 @@ import org.labkey.api.util.Path;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
+import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.api.webdav.WebdavResource;
 import org.labkey.api.webdav.WebdavService;
 
@@ -1519,6 +1522,7 @@ public class FileContentServiceImpl implements FileContentService
         private static final String PROJECT1_SUBFOLDER1 = "Subfolder1";
         private static final String PROJECT1_SUBFOLDER2 = "Subfolder2" + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
         private static final String PROJECT1_SUBSUBFOLDER = "SubSubfolder";
+        private static final String PROJECT1_SUBSUBFOLDER_SIBLING = "SubSubfolderSibling";
         private static final String PROJECT2 = "FileRootTestProject2";
 
         private static final String FILE_ROOT_SUFFIX = "_FileRootTest";
@@ -1628,6 +1632,7 @@ public class FileContentServiceImpl implements FileContentService
             _expectedPaths.put(subfolder2, null);
 
             Container subsubfolder = ContainerManager.createContainer(subfolder1, PROJECT1_SUBSUBFOLDER);
+            Container subsubfolderSibling = ContainerManager.createContainer(subfolder1, PROJECT1_SUBSUBFOLDER_SIBLING);
             _expectedPaths.put(subsubfolder, null);
 
             //create a test file that we will follow
@@ -1640,7 +1645,25 @@ public class FileContentServiceImpl implements FileContentService
             ExpData data = ExperimentService.get().createData(subsubfolder, new DataType("FileContentTest"));
             data.setDataFileURI(childFile.toPath().toUri());
             data.save(TestContext.get().getUser());
-            int rowId = data.getRowId();
+
+            ExpProtocol protocol = ExperimentService.get().createExpProtocol(subsubfolder, ExpProtocol.ApplicationType.ProtocolApplication, "DummyProtocol");
+            protocol = ExperimentService.get().insertSimpleProtocol(protocol, TestContext.get().getUser());
+
+            ExpRun expRun = ExperimentService.get().createExperimentRun(subsubfolder, "DummyRun");
+            expRun.setProtocol(protocol);
+            expRun.setFilePathRootPath(childFile.getParentFile().toPath());
+
+            ViewBackgroundInfo info = new ViewBackgroundInfo(subsubfolder, TestContext.get().getUser(), null);
+            ExpRun run = ExperimentService.get().saveSimpleExperimentRun(
+                    expRun,
+                    Collections.emptyMap(),
+                    Collections.singletonMap(data, "Data"),
+                    Collections.emptyMap(),
+                    Collections.emptyMap(),
+                    Collections.emptyMap(),
+                    info,
+                    _log,
+                    false);
 
             Assert.assertTrue("File not found: " + childFile.getPath(), childFile.exists());
             ContainerManager.move(subsubfolder, subfolder2, TestContext.get().getUser());
@@ -1653,10 +1676,21 @@ public class FileContentServiceImpl implements FileContentService
             File expectedFile = new File(svc.getFileRoot(movedSubfolder, ContentType.files), TXT_FILE);
             Assert.assertTrue("File was not moved, expected: " + expectedFile.getPath(), expectedFile.exists());
 
-            ExpData movedData = ExperimentService.get().getExpData(rowId);
+            ExpData movedData = ExperimentService.get().getExpData(data.getRowId());
             Assert.assertNotNull(movedData);
 
-            assertPathsEqual("Incorrect file path", expectedFile, FileUtil.stringToPath(movedSubfolder, movedData.getDataFileUrl()).toFile());
+            // Reload the run after it's path has hopefully been updated
+            expRun = ExperimentService.get().getExpRun(expRun.getRowId());
+
+            assertPathsEqual("Incorrect data file path", expectedFile, FileUtil.stringToPath(movedSubfolder, movedData.getDataFileUrl()).toFile());
+            assertPathsEqual("Incorrect run root path", expectedFile.getParentFile(), expRun.getFilePathRoot());
+
+            // Issue 38206 - file paths get mangled with multiple folder moves
+            ContainerManager.move(subsubfolderSibling, subfolder2, TestContext.get().getUser());
+
+            // Reload the run after it's path has hopefully NOT been updated
+            expRun = ExperimentService.get().getExpRun(expRun.getRowId());
+            assertPathsEqual("Incorrect run root path", expectedFile.getParentFile(), expRun.getFilePathRoot());
         }
 
         @Test
@@ -1727,34 +1761,27 @@ public class FileContentServiceImpl implements FileContentService
             FileContentService svc = FileContentService.get();
             Assert.assertNotNull(svc);
 
-            Container project1 = ContainerManager.getForPath(PROJECT1);
-            if (project1 != null)
-            {
-                ContainerManager.deleteAll(project1, TestContext.get().getUser());
-
-                File file1 = svc.getFileRoot(project1);
-                if (file1 != null && file1.exists())
-                {
-                    FileUtil.deleteDir(file1);
-                }
-            }
-
-            Container project2 = ContainerManager.getForPath(PROJECT2);
-            if (project2 != null)
-            {
-                ContainerManager.deleteAll(project2, TestContext.get().getUser());
-
-                File file2 = svc.getFileRoot(project2);
-                if (file2 != null && file2.exists())
-                {
-                    FileUtil.deleteDir(file2);
-                }
-            }
+            deleteContainerAndFiles(svc, ContainerManager.getForPath(PROJECT1));
+            deleteContainerAndFiles(svc, ContainerManager.getForPath(PROJECT2));
 
             File testRoot = getTestRoot();
             if (testRoot.exists())
             {
                 FileUtil.deleteDir(testRoot);
+            }
+        }
+
+        private void deleteContainerAndFiles(FileContentService svc, @Nullable Container c)
+        {
+            if (c != null)
+            {
+                ContainerManager.deleteAll(c, TestContext.get().getUser());
+
+                File file1 = svc.getFileRoot(c);
+                if (file1 != null && file1.exists())
+                {
+                    FileUtil.deleteDir(file1);
+                }
             }
         }
     }

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2404,11 +2404,11 @@ public class QueryController extends SpringActionController
                     }
                     // need to throw here to avoid committing tx
                     if (errors.hasErrors())
-                        throw new DbScope.RetryException(errors);
+                        throw new DbScope.RetryPassthroughException(errors);
                     return true;
                 });
             }
-            catch (DbScope.RetryException x)
+            catch (DbScope.RetryPassthroughException x)
             {
                 if (x.getCause() != errors)
                     x.throwRuntimeException();


### PR DESCRIPTION
Recreated against 20.3 after fixing a test failure that's been hanging out in the develop version - need to use CHARINDEX instead of PATINDEX for path fixup on SQL Server.

https://github.com/LabKey/platform/pull/863