### PR TITLE
39891: optimize container filter when no special child folder types exist

### DIFF
--- a/api/src/org/labkey/api/data/ContainerFilter.java
+++ b/api/src/org/labkey/api/data/ContainerFilter.java
@@ -219,7 +219,7 @@ public abstract class ContainerFilter
         // have children that match the types. If there are no children that match
         // the set of included types, we can simplify the query to a simple IN clause
         // instead of joining to core.Containers and filtering by container type.
-        Set<String> finalIncludedChildTypes = includedChildTypes;
+        final Set<String> finalIncludedChildTypes = includedChildTypes;
         List<Container> containers = ids.stream()
                 .map(ContainerManager::getForId)
                 .filter(Objects::nonNull)

--- a/api/src/org/labkey/api/data/ContainerFilter.java
+++ b/api/src/org/labkey/api/data/ContainerFilter.java
@@ -214,13 +214,30 @@ public abstract class ContainerFilter
             return new SQLFragment("1 = 0");
         }
 
-        if (ids.size() == 1)
+        // Issue 39891: Biologics: slow page loads for sample/assay and assay/results
+        // When including child containers by type, check if any of the containers
+        // have children that match the types. If there are no children that match
+        // the set of included types, we can simplify the query to a simple IN clause
+        // instead of joining to core.Containers and filtering by container type.
+        Set<String> finalIncludedChildTypes = includedChildTypes;
+        List<Container> containers = ids.stream()
+                .map(ContainerManager::getForId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toUnmodifiableList());
+        boolean hasNoSpecialChildren = includedChildTypes.isEmpty() ||
+                containers.stream().noneMatch(c -> c.hasChildrenOfAnyType(finalIncludedChildTypes));
+
+        if (hasNoSpecialChildren)
         {
-            Container first = ContainerManager.getForId(ids.iterator().next());
-            if (null == first)
+            if (containers.isEmpty())
+            {
                 return new SQLFragment("1 = 0");
-            if (includedChildTypes.isEmpty() || !first.hasChildrenOfAnyType(includedChildTypes))
-                return new SQLFragment(containerColumnSQL).append("=").append(first);
+            }
+            else
+            {
+                // For optimization, turn off join to core.containers to filter by container type
+                includedChildTypes = Collections.emptySet();
+            }
         }
 
         SQLFragment list = new SQLFragment();


### PR DESCRIPTION
When no special container types exist in the set of containers, use a simple IN clause filter instead of joining to core.containers and filtering by type.