### PR TITLE
Remove support for Tomcat 7.0.x

### DIFF
--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1150,12 +1150,9 @@ public abstract class SqlDialect
 
         public Integer getMaxTotal()
         {
-            // Need to invoke a different method on Tomcat 7 vs. Tomcat 8/9
-            String methodName = ModuleLoader.getInstance().getTomcatVersion().getMaxTotalMethodName();
-
             try
             {
-                return callGetter(methodName);
+                return callGetter("getMaxTotal");
             }
             catch (ServletException e)
             {

--- a/api/src/org/labkey/api/module/TomcatVersion.java
+++ b/api/src/org/labkey/api/module/TomcatVersion.java
@@ -32,60 +32,24 @@ import java.util.stream.Collectors;
  */
 public enum TomcatVersion
 {
-    TOMCAT_UNSUPPORTED(-1, true, null, null, null, null, null),
-    TOMCAT_7_0(70, true, "getMaxActive", "Connector", "keystoreFile", "keystorePass", "keystoreType"),
-    TOMCAT_8_5(85, false, "getMaxTotal", "SSLHostConfigCertificate", "certificateKeystoreFile", "certificateKeystorePassword", "certificateKeystoreType"),
-    TOMCAT_9_0(90, false, "getMaxTotal", "SSLHostConfigCertificate", "certificateKeystoreFile", "certificateKeystorePassword" , "certificateKeystoreType"),
-    TOMCAT_FUTURE(Integer.MAX_VALUE, true, null, null, null, null, null);
+    TOMCAT_UNSUPPORTED(-1, true),
+    TOMCAT_8_5(85, false),
+    TOMCAT_9_0(90, false),
+    TOMCAT_FUTURE(Integer.MAX_VALUE, true);
 
     private final int _version;
     private final boolean _deprecated;
-    private final String _maxTotalMethodName;
-    private final String _sslConfigPropName;
-    private final String _keystoreFilePropertyName;
-    private final String _keystorePasswordPropertyName;
-    private final String _keystoreTypePropertyName;
 
-    TomcatVersion(int version, boolean deprecated, String maxTotalMethodName, String sslConfigPropName, String keystoreFilePropertyName, String keystorePasswordPropertyName, String keystoreTypePropertyName)
+    TomcatVersion(int version, boolean deprecated)
     {
         _version = version;
         _deprecated = deprecated;
-        _maxTotalMethodName = maxTotalMethodName;
-        _sslConfigPropName = sslConfigPropName;
-        _keystoreFilePropertyName = keystoreFilePropertyName;
-        _keystorePasswordPropertyName = keystorePasswordPropertyName;
-        _keystoreTypePropertyName = keystoreTypePropertyName;
     }
 
     // Should LabKey warn administrators that support for this Tomcat version will be removed soon?
     public boolean isDeprecated()
     {
         return _deprecated;
-    }
-
-    public String getMaxTotalMethodName()
-    {
-        return _maxTotalMethodName;
-    }
-
-    public String getSslConfigPropName()
-    {
-        return _sslConfigPropName;
-    }
-
-    public String getKeystoreFilePropertyName()
-    {
-        return _keystoreFilePropertyName;
-    }
-
-    public String getKeystorePasswordPropertyName()
-    {
-        return _keystorePasswordPropertyName;
-    }
-
-    public String getKeystoreTypePropertyName()
-    {
-        return _keystoreTypePropertyName;
     }
 
     private static final String APACHE_TOMCAT_SERVER_NAME_PREFIX = "Apache Tomcat/";
@@ -141,7 +105,6 @@ public enum TomcatVersion
         public void test()
         {
             // Good
-            test(70, TOMCAT_7_0);
             test(85, TOMCAT_8_5);
             test(90, TOMCAT_9_0);
 
@@ -151,6 +114,7 @@ public enum TomcatVersion
             test(120, TOMCAT_FUTURE);
 
             // Bad
+            test(70, TOMCAT_UNSUPPORTED);
             test(60, TOMCAT_UNSUPPORTED);
             test(50, TOMCAT_UNSUPPORTED);
             test(40, TOMCAT_UNSUPPORTED);

--- a/pipeline/src/org/labkey/pipeline/mule/MuleListenerHelper.java
+++ b/pipeline/src/org/labkey/pipeline/mule/MuleListenerHelper.java
@@ -442,6 +442,12 @@ public class MuleListenerHelper implements ServletContext
 
     }
 
+// Allow building on Tomcat 7 for now    @Override
+    public String getVirtualServerName()
+    {
+        return null;
+    }
+
     @Override
     public ClassLoader getClassLoader()
     {


### PR DESCRIPTION
This PR removes the ability to run on Tomcat 7.0.x and adjusts platform classes to build with Tomcat 8.5.x. This needs to be merged before the SVN changes that will require building against Tomcat 8.5.x.