### PR TITLE
Avoid errors about unknown schemas for modules that were filtered out…

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -529,13 +529,15 @@ public class ModuleLoader implements Filter, MemTrackerListener
             for (ModuleContext context : getAllModuleContexts())
                 _moduleContextMap.put(context.getName(), context);
 
-            //Make sure we have a context for all modules, even ones we haven't seen before
+            // Refresh our list of modules as some may have been filtered out based on dependencies or DB platform
+            modules = getModules();
             for (Module module : modules)
             {
                 ModuleContext context = _moduleContextMap.get(module.getName());
 
                 if (null == context)
                 {
+                    // Make sure we have a context for all modules, even ones we haven't seen before
                     context = new ModuleContext(module);
                     _moduleContextMap.put(module.getName(), context);
                 }


### PR DESCRIPTION
… based on missing dependencies

Example: run with onprcEhrModules on a Postgres DB

ERROR ModuleLoader             2020-03-16 16:21:16,720    localhost-startStop-1 : Failure occurred during ModuleLoader init.
java.lang.RuntimeException: java.lang.IllegalStateException: Schema "onprc_ssu" is not claimed by any module.
	at org.labkey.api.data.DbSchemaCache$DbSchemaLoader.load(DbSchemaCache.java:118)
	at org.labkey.api.data.DbSchemaCache$DbSchemaLoader.load(DbSchemaCache.java:106)
	at org.labkey.api.cache.BlockingCache.get(BlockingCache.java:147)
	at org.labkey.api.cache.BlockingCache.get(BlockingCache.java:83)
	at org.labkey.api.data.DbSchemaCache.get(DbSchemaCache.java:65)
	at org.labkey.api.data.DbScope.getSchema(DbScope.java:1144)
	at org.labkey.api.data.DbSchema.get(DbSchema.java:100)
	at org.labkey.api.data.FileSqlScriptProvider.getSchemas(FileSqlScriptProvider.java:86)
	at org.labkey.api.module.ModuleLoader.additionalSchemasRequiringUpgrade(ModuleLoader.java:722)
