### PR TITLE
Tomcat 8.5 cleanup: move JDBC drivers into webapp, eliminate unnecess…

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -100,7 +100,10 @@ List others = [
         "org.apache.tika:tika-core:${tikaVersion}",
         "cglib:cglib-nodep:${cglibNodepVersion}",
         "xerces:xercesImpl:${xercesImplVersion}",
-        "org.imca_cat.pollingwatchservice:pollingwatchservice:${pollingWatchVersion}"
+        "org.imca_cat.pollingwatchservice:pollingwatchservice:${pollingWatchVersion}",
+        "net.sourceforge.jtds:jtds:${jtdsVersion}", // MS SQLServer JDBC Driver
+        "org.postgresql:postgresql:${postgresqlDriverVersion}",
+        "mysql:mysql-connector-java:${mysqlDriverVersion}"
 ]
 
 List javax = [

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -101,9 +101,7 @@ List others = [
         "cglib:cglib-nodep:${cglibNodepVersion}",
         "xerces:xercesImpl:${xercesImplVersion}",
         "org.imca_cat.pollingwatchservice:pollingwatchservice:${pollingWatchVersion}",
-        "net.sourceforge.jtds:jtds:${jtdsVersion}", // MS SQLServer JDBC Driver
-        "org.postgresql:postgresql:${postgresqlDriverVersion}",
-        "mysql:mysql-connector-java:${mysqlDriverVersion}"
+        "org.postgresql:postgresql:${postgresqlDriverVersion}"
 ]
 
 List javax = [

--- a/api/resources/credits/jars.txt
+++ b/api/resources/credits/jars.txt
@@ -38,11 +38,13 @@ jfreechart-1.0.14.jar|JFreeChart|1.0.14|{link:JFreeChart|http://www.jfree.org/jf
 jmock-2.6.0.jar|jMock|2.6.0|{link:jMock|http://www.jmock.org/}|{link:jMock Project License|http://www.jmock.org/license.html}|jeckels|jMock mock object testing framework
 jmock-legacy-2.6.0.jar|jMock|2.6.0|{link:jMock|http://www.jmock.org/}|{link:jMock Project License|http://www.jmock.org/license.html}|jeckels|jMock mock object testing framework
 json-simple-1.1.jar|JSON.simple - A Simple Java toolkit for JSON|Version 1.1|{link:JSON.simple|https://code.google.com/p/json-simple/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|klum|JSON parser for remoteapi
+jtds-1.3.1.jar|jTDS JDBC Driver|1.3.1|{link:SourceForge|http://jtds.sourceforge.net}|{link:LGPL|http://jtds.sourceforge.net/license.html}|adam|Connect with Microsoft SQL Server database servers
 jtidy-r918.jar|Java Tidy|r918|{link:SourceForge|http://jtidy.sourceforge.net/}|{link:Custom|http://www.labkey.org/download/jtidy-LICENSE.txt}|mbellew|Validating HTML content
 junit-4.12.jar|JUnit|4.12|{link:Junit|http://www.junit.org}|{link:CPL 1.0|http://www.opensource.org/licenses/cpl1.0.php}|jeckels|Unit testing
 jxl-2.6.3.jar|API|2.6.3|{link:jexcelapi|http://www.jexcelapi.org/}|{link:LGPL|http://www.opensource.org/licenses/lgpl-license.php}|jeckels|Java Excel library
 kaptcha-2.3.jar|Captcha generator|2.3|{link:kaptcha|http://code.google.com/p/kaptcha/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|nicka|User signup forms
 log4j-1.2.17.jar|Log4j|1.2.17|{link:Apache|http://logging.apache.org/log4j/1.2/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|mbellew|Logging
+mysql-connector-java-8.0.18.jar|MySQL JDBC Driver|8.0.18|{link:MySQL|http://www.mysql.com/downloads/connector/j}|{link:GPL v2|http://www.gnu.org/licenses/gpl-2.0.html} with {link:Universal FOSS Exception|https://oss.oracle.com/licenses/universal-foss-exception/}|adam|Connect with MySQL database servers
 objenesis-1.0.jar|Objenesis|1.0|{link:Objenesis|http://code.google.com/p/objenesis/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jeckels|Library for instantiating Java objects, dependency of jMock
 opencsv-2.3.jar|OpenCSV|2.3|{link:OpenCSV|http://opencsv.sourceforge.net/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|adam|Parsing CSV Files
 patricia-trie-0.6.jar|PATRICIA Trie|0.6|{link:PATRICIA Trie|http://code.google.com/p/patricia-trie/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jeckels|PATRICIA Trie data structure implementation
@@ -50,6 +52,7 @@ pdfbox-2.0.11.jar|Apache PDFBox®|2.0.11|{link:PDFBox|https://pdfbox.apache.org/
 poi-4.0.0.jar|Apache POI|4.0.0|{link:Apache|https://poi.apache.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|adam|Extracting text from and exporting to Microsoft document formats (Excel, Word, PowerPoint, etc.)
 poi-ooxml-4.0.0.jar|Apache POI OOXML|4.0.0|{link:Apache|https://poi.apache.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|adam|POI support for OOXML formats
 pollingwatchservice-0.2.0.jar|Polling Watch Service|0.2.0|{link:imca|https://www.imca.aps.anl.gov/~jlmuir/sw/pollingwatchservice.html}|{link:BSD 2-Clause license|https://www.imca.aps.anl.gov/~jlmuir/repo/bsd-2-clause-license.txt}|klum|Provide polling file watcher for cifs file systems
+postgresql-42.2.10.jar|PostgreSQL JDBC Driver|42.2.10|{link:jdbc.postgresql.org|http://jdbc.postgresql.org/index.html}|{link:BSD|https://jdbc.postgresql.org/about/license.html}|adam|Connect with PostgreSQL database servers
 quartz-2.1.7.jar|quartz|2.1.7|{link:quartz|http://quartz-scheduler.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jeckels|Scheduling
 rengine-0.6-8.jar|Rengine|0.6-8|{link:Rserve|http://www.rforge.net/Rserve}|{link:LGPL|http://www.gnu.org/licenses/lgpl.html}|cnathe|R client classes
 rome-1.7.1.jar|ROME|1.7.1|{link:ROME|https://github.com/rometools/rome}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|nicka|Support for RSS and Atom aggregation

--- a/api/resources/credits/jars.txt
+++ b/api/resources/credits/jars.txt
@@ -38,13 +38,11 @@ jfreechart-1.0.14.jar|JFreeChart|1.0.14|{link:JFreeChart|http://www.jfree.org/jf
 jmock-2.6.0.jar|jMock|2.6.0|{link:jMock|http://www.jmock.org/}|{link:jMock Project License|http://www.jmock.org/license.html}|jeckels|jMock mock object testing framework
 jmock-legacy-2.6.0.jar|jMock|2.6.0|{link:jMock|http://www.jmock.org/}|{link:jMock Project License|http://www.jmock.org/license.html}|jeckels|jMock mock object testing framework
 json-simple-1.1.jar|JSON.simple - A Simple Java toolkit for JSON|Version 1.1|{link:JSON.simple|https://code.google.com/p/json-simple/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|klum|JSON parser for remoteapi
-jtds-1.3.1.jar|jTDS JDBC Driver|1.3.1|{link:SourceForge|http://jtds.sourceforge.net}|{link:LGPL|http://jtds.sourceforge.net/license.html}|adam|Connect with Microsoft SQL Server database servers
 jtidy-r918.jar|Java Tidy|r918|{link:SourceForge|http://jtidy.sourceforge.net/}|{link:Custom|http://www.labkey.org/download/jtidy-LICENSE.txt}|mbellew|Validating HTML content
 junit-4.12.jar|JUnit|4.12|{link:Junit|http://www.junit.org}|{link:CPL 1.0|http://www.opensource.org/licenses/cpl1.0.php}|jeckels|Unit testing
 jxl-2.6.3.jar|API|2.6.3|{link:jexcelapi|http://www.jexcelapi.org/}|{link:LGPL|http://www.opensource.org/licenses/lgpl-license.php}|jeckels|Java Excel library
 kaptcha-2.3.jar|Captcha generator|2.3|{link:kaptcha|http://code.google.com/p/kaptcha/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|nicka|User signup forms
 log4j-1.2.17.jar|Log4j|1.2.17|{link:Apache|http://logging.apache.org/log4j/1.2/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|mbellew|Logging
-mysql-connector-java-8.0.18.jar|MySQL JDBC Driver|8.0.18|{link:MySQL|http://www.mysql.com/downloads/connector/j}|{link:GPL v2|http://www.gnu.org/licenses/gpl-2.0.html} with {link:Universal FOSS Exception|https://oss.oracle.com/licenses/universal-foss-exception/}|adam|Connect with MySQL database servers
 objenesis-1.0.jar|Objenesis|1.0|{link:Objenesis|http://code.google.com/p/objenesis/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jeckels|Library for instantiating Java objects, dependency of jMock
 opencsv-2.3.jar|OpenCSV|2.3|{link:OpenCSV|http://opencsv.sourceforge.net/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|adam|Parsing CSV Files
 patricia-trie-0.6.jar|PATRICIA Trie|0.6|{link:PATRICIA Trie|http://code.google.com/p/patricia-trie/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jeckels|PATRICIA Trie data structure implementation

--- a/api/schemas/module.xsd
+++ b/api/schemas/module.xsd
@@ -9,7 +9,7 @@
 	<xsd:annotation>
 
     <xsd:documentation xml:lang="en">
-        Describes module properties.  Currently experimental and not in active use.
+        Describes module properties.
     </xsd:documentation>
 	</xsd:annotation>
 

--- a/api/src/org/labkey/api/jsp/RecompilingJspClassLoader.java
+++ b/api/src/org/labkey/api/jsp/RecompilingJspClassLoader.java
@@ -15,9 +15,12 @@
  */
 package org.labkey.api.jsp;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jasper.JspC;
+import org.apache.jasper.servlet.JspCServletContext;
+import org.apache.jasper.servlet.TldScanner;
 import org.apache.log4j.Logger;
+import org.apache.tomcat.JarScanner;
+import org.apache.tomcat.util.scan.StandardJarScanner;
 import org.labkey.api.annotations.JavaRuntimeVersion;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.module.ResourceFinder;
@@ -114,28 +117,30 @@ public class RecompilingJspClassLoader extends JspClassLoader
 
                     ClassPath cp = new ClassPath();
                     cp.addDirectory(new File(finder.getBuildPath(), "/explodedModule/lib"));
-                    // N.B.  Our build references specific tomcat versions (set in the root-level gradle.properties file), whereas
-                    // here we add the tomcat libraries for the local installation to the classpath.  This should mostly be OK, but if seeing
-                    // different behavior between the JSPs from the Gradle build and those compiled while in dev mode, this may
-                    // be a culprit.
-                    cp.addDirectory(getTomcatLib());
-                    // With the Gradle build, api and internal are first-class modules and their libraries are no longer put into WEB-INF/lib
-                    // so we include their individual lib directories in the classpath for the JSPs.
+                    // N.B. Our build references specific tomcat versions (set in the root-level gradle.properties file),
+                    // whereas here we add the tomcat libraries for the local installation to the classpath. This should
+                    // mostly be OK, but if seeing different behavior between the JSPs from the Gradle build and those
+                    // compiled while in dev mode, this may be a culprit.
+                    File tomcatLib = ModuleLoader.getInstance().getTomcatLib();
+                    if (null != tomcatLib)
+                        cp.addDirectory(tomcatLib);
+                    // With the Gradle build, api and internal are first-class modules and their libraries are no longer
+                    // put into WEB-INF/lib so we include their individual lib directories in the classpath for the JSPs.
                     for (ResourceFinder apiFinder : apiResourceFinders)
                         cp.addDirectory(new File(apiFinder.getBuildPath(), "/explodedModule/lib"));
                     cp.addDirectory(getModulesApiLib());
 
                     // Compile the .jsp file
                     JspC jasper = new JspC() {
-//                        This override eliminates the unnecessary TLD scanning during recompile. Commented out for now since it doesn't work with Tomcat 7.x.
-//                        @Override
-//                        protected TldScanner newTldScanner(JspCServletContext context, boolean namespaceAware, boolean validate, boolean blockExternal)
-//                        {
-//                            StandardJarScanner scanner = new StandardJarScanner();
-//                            scanner.setJarScanFilter((jarScanType, s) -> false);
-//                            context.setAttribute(JarScanner.class.getName(), scanner);
-//                            return super.newTldScanner(context, namespaceAware, validate, blockExternal);
-//                        }
+                        // This override eliminates unnecessary TLD scanning during recompile
+                        @Override
+                        protected TldScanner newTldScanner(JspCServletContext context, boolean namespaceAware, boolean validate, boolean blockExternal)
+                        {
+                            StandardJarScanner scanner = new StandardJarScanner();
+                            scanner.setJarScanFilter((jarScanType, s) -> false);
+                            context.setAttribute(JarScanner.class.getName(), scanner);
+                            return super.newTldScanner(context, namespaceAware, validate, blockExternal);
+                        }
                     };
                     jasper.setUriroot(jspJavaFileBuildDirectory.getParent() + "/webapp");
                     jasper.setOutputDir(jspJavaFileBuildDirectory.getAbsolutePath());
@@ -199,7 +204,6 @@ public class RecompilingJspClassLoader extends JspClassLoader
         return ret.toString();
     }
 
-
     private void compileJavaFile(String filePath, String classPath, String jspFilename, String classDirPath) throws Exception
     {
         ByteArrayOutputStream errorStream = new ByteArrayOutputStream();
@@ -209,7 +213,6 @@ public class RecompilingJspClassLoader extends JspClassLoader
         if (0 != ret)
             throw new JspCompilationException(jspFilename, errorStream.toString());
     }
-
 
     private static class JspCompilationException extends ServletException implements HideConfigurationDetails
     {
@@ -229,11 +232,10 @@ public class RecompilingJspClassLoader extends JspClassLoader
         }
     }
 
-
     private static class ClassPath
     {
         private final String SEP = System.getProperty("path.separator");
-        private StringBuilder _path = new StringBuilder();
+        private final StringBuilder _path = new StringBuilder();
 
         private void addFile(String filePath)
         {
@@ -265,32 +267,6 @@ public class RecompilingJspClassLoader extends JspClassLoader
         {
             return _path.toString();
         }
-    }
-
-
-    private File getTomcatLib()
-    {
-        String classPath = System.getProperty("java.class.path", ".");
-
-        for (String path : StringUtils.split(classPath, File.pathSeparatorChar))
-        {
-            if (path.endsWith("/bin/bootstrap.jar"))
-            {
-                path = path.substring(0, path.length() - "/bin/bootstrap.jar".length());
-                if (new File(path, "lib").isDirectory())
-                    return new File(path, "lib");
-            }
-        }
-
-        String tomcat = System.getenv("CATALINA_HOME");
-
-        if (null == tomcat)
-            tomcat = System.getenv("TOMCAT_HOME");
-
-        if (null == tomcat)
-            _log.warn("Could not find CATALINA_HOME environment variable, unlikely to be successful recompiling JSPs");
-
-        return new File(tomcat, "lib");
     }
 
     private String getModulesApiLib()

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -128,6 +128,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 
@@ -453,12 +454,12 @@ public class ModuleLoader implements Filter, MemTrackerListener
         File webinfModulesDir = new File(_webappDir, "WEB-INF/modules");
         if (!webinfModulesDir.isDirectory() && null == service)
             throw new ConfigurationException("Could not find required class LabKeyBootstrapClassLoader. You probably need to copy labkeyBootstrap.jar into $CATALINA_HOME/lib and/or edit your " + AppProps.getInstance().getWebappConfigurationFilename() + " to include <Loader loaderClass=\"org.labkey.bootstrap.LabKeyBootstrapClassLoader\" />");
-        File[] webInfModules = webinfModulesDir.listFiles(pathname -> pathname.isDirectory());
+        File[] webInfModules = webinfModulesDir.listFiles(File::isDirectory);
         if (null != webInfModules)
         {
             Arrays.stream(webInfModules)
-                    .map(m -> new AbstractMap.SimpleEntry<File,File>(m,null))
-                    .forEach(e -> explodedModuleDirs.add(e));
+                .map(m -> new AbstractMap.SimpleEntry<File,File>(m,null))
+                .forEach(explodedModuleDirs::add);
         }
 
         doInitWithSourceModule(explodedModuleDirs);
@@ -1096,6 +1097,8 @@ public class ModuleLoader implements Filter, MemTrackerListener
     // Enumerate each jdbc DataSource in labkey.xml and tell DbScope to initialize them
     private void initializeDataSources()
     {
+        verifyJdbcDrivers();
+
         _log.debug("Ensuring that all databases specified by datasources in webapp configuration xml are present");
 
         Map<String, DataSource> dataSources = new TreeMap<>(String::compareTo);
@@ -1133,6 +1136,51 @@ public class ModuleLoader implements Filter, MemTrackerListener
         }
 
         DbScope.initializeScopes(labkeyDsName, dataSources);
+    }
+
+    // Verify that old JDBC drivers are not present in <tomcat>/lib -- they are now provided by the API module
+    private void verifyJdbcDrivers()
+    {
+        File lib = getTomcatLib();
+
+        if (null != lib)
+        {
+            List<String> existing = Stream.of("jtds.jar", "mysql.jar", "postgresql.jar")
+                .filter(name->new File(lib, name).exists())
+                .collect(Collectors.toList());
+
+            if (!existing.isEmpty())
+//                throw new ConfigurationException("You must delete the following JDBC drivers from " + lib.getAbsolutePath() + ": " + existing);
+                _log.warn("You must delete the following JDBC drivers from " + lib.getAbsolutePath() + ": " + existing);
+        }
+    }
+
+    public @Nullable File getTomcatLib()
+    {
+        String classPath = System.getProperty("java.class.path", ".");
+
+        for (String path : StringUtils.split(classPath, File.pathSeparatorChar))
+        {
+            if (path.endsWith("/bin/bootstrap.jar"))
+            {
+                path = path.substring(0, path.length() - "/bin/bootstrap.jar".length());
+                if (new File(path, "lib").isDirectory())
+                    return new File(path, "lib");
+            }
+        }
+
+        String tomcat = System.getenv("CATALINA_HOME");
+
+        if (null == tomcat)
+            tomcat = System.getenv("TOMCAT_HOME");
+
+        if (null == tomcat)
+        {
+            _log.warn("Could not find CATALINA_HOME environment variable");
+            return null;
+        }
+
+        return new File(tomcat, "lib");
     }
 
     // For each name, look for a matching data source in labkey.xml. If found, attempt a connection and

--- a/api/src/org/labkey/api/security/AuthenticationProvider.java
+++ b/api/src/org/labkey/api/security/AuthenticationProvider.java
@@ -19,7 +19,6 @@ package org.labkey.api.security;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
-import org.labkey.api.annotations.RemoveIn20_7;
 import org.labkey.api.attachments.Attachment;
 import org.labkey.api.attachments.AttachmentCache;
 import org.labkey.api.attachments.AttachmentFile;
@@ -85,12 +84,6 @@ public interface AuthenticationProvider
 
     // Most providers don't have a test action
     default @Nullable ActionURL getTestLink()
-    {
-        return null;
-    }
-
-    @RemoveIn20_7  // Not used -- but need to remove usages in compliance and CDS, which don't have a multiAuthUI branch
-    default @Nullable ActionURL getConfigurationLink()
     {
         return null;
     }

--- a/bigiron/build.gradle
+++ b/bigiron/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    external "net.sourceforge.jtds:jtds:${jtdsVersion}" // MS SQLServer JDBC Driver
+    external ("mysql:mysql-connector-java:${mysqlDriverVersion}")
+    {
+        exclude group: "com.google.protobuf", module: "protobuf-java" // We haven't needed this in the past...
+    }
+}

--- a/bigiron/resources/credits/jars.txt
+++ b/bigiron/resources/credits/jars.txt
@@ -1,0 +1,5 @@
+{table}
+Filename|Component|Version|Source|License|LabKey Dev|Purpose
+jtds-1.3.1.jar|jTDS JDBC Driver|1.3.1|{link:SourceForge|http://jtds.sourceforge.net}|{link:LGPL|http://jtds.sourceforge.net/license.html}|adam|Connect with Microsoft SQL Server database servers
+mysql-connector-java-8.0.18.jar|MySQL JDBC Driver|8.0.18|{link:MySQL|http://www.mysql.com/downloads/connector/j}|{link:GPL v2|http://www.gnu.org/licenses/gpl-2.0.html} with {link:Universal FOSS Exception|https://oss.oracle.com/licenses/universal-foss-exception/}|adam|Connect with MySQL database servers
+{table}

--- a/core/resources/credits/tomcat_jars.txt
+++ b/core/resources/credits/tomcat_jars.txt
@@ -1,8 +1,5 @@
 {table}
 Filename|Component|Version|Source|License|LabKey Dev|Purpose
 javax.activation.jar|JavaBeans Activation Framework (JAF)|1.2.1|{link:Eclipse Project for JAF|https://projects.eclipse.org/projects/ee4j.jaf}|{link:Eclipse Public License 2.0|https://www.eclipse.org/legal/epl-2.0/}|adam|JavaMail and Workflow dependency
-jtds.jar|jTDS JDBC Driver|1.3.1|{link:SourceForge|http://jtds.sourceforge.net}|{link:LGPL|http://jtds.sourceforge.net/license.html}|adam|Connect with Microsoft SQL Server database servers
 mail.jar|Jakarta Mail|1.6.5|{link:Eclipse Project for Jakarta Mail|https://projects.eclipse.org/projects/ee4j.mail}|{link:Eclipse Public License 2.0|https://www.eclipse.org/legal/epl-2.0/}|adam|Send email from LabKey Server
-mysql.jar|MySQL JDBC Driver|8.0.18|{link:MySQL|http://www.mysql.com/downloads/connector/j}|{link:GPL v2|http://www.gnu.org/licenses/gpl-2.0.html} with {link:Universal FOSS Exception|https://oss.oracle.com/licenses/universal-foss-exception/}|adam|Connect with MySQL database servers
-postgresql.jar|PostgreSQL JDBC Driver|42.2.10|{link:jdbc.postgresql.org|http://jdbc.postgresql.org/index.html}|{link:BSD|https://jdbc.postgresql.org/about/license.html}|adam|Connect with PostgreSQL database servers
 {table}

--- a/pipeline/src/org/labkey/pipeline/mule/MuleListenerHelper.java
+++ b/pipeline/src/org/labkey/pipeline/mule/MuleListenerHelper.java
@@ -58,12 +58,12 @@ import java.util.Set;
  */
 public class MuleListenerHelper implements ServletContext
 {
-    private MuleXmlBuilderContextListener _muleContextListener;
-
-    private ServletContext _parentContext = null;
-    private HashMap<String,Object> _attributes = new HashMap<>();
-    private HashMap<String,String> _initParameters = new HashMap<>();
     private static final Logger _log = Logger.getLogger(MuleListenerHelper.class);
+
+    private final MuleXmlBuilderContextListener _muleContextListener;
+    private final ServletContext _parentContext;
+    private final HashMap<String, Object> _attributes = new HashMap<>();
+    private final HashMap<String, String> _initParameters = new HashMap<>();
 
     public MuleListenerHelper(ServletContext parentContext, String muleConfigPaths)
     {
@@ -77,7 +77,7 @@ public class MuleListenerHelper implements ServletContext
         // HACK: Fix for MULE-2289
         final Converter conv = ConvertUtils.lookup(Integer.TYPE);
         ConvertUtils.register(new Converter() {
-            private final Map POOL_EXHAUSTED_ACTIONS = new CaseInsensitiveHashMap<Integer>()
+            private final Map<String, Integer> POOL_EXHAUSTED_ACTIONS = new CaseInsensitiveHashMap<>()
             {
                 // static initializer
                 {
@@ -103,6 +103,7 @@ public class MuleListenerHelper implements ServletContext
                 }
             };
 
+            @Override
             public Object convert(Class clazz, Object obj)
             {
                 // MULE-2289: Threading-profile tag always sets poolExhaustedAction to WAIT.
@@ -110,7 +111,7 @@ public class MuleListenerHelper implements ServletContext
                 //            this conversion.  Our registered converter will throw an
                 //            exception in this case, so we catch it, and do what Mule
                 //            intends but fails to do.
-                Integer val = (Integer) POOL_EXHAUSTED_ACTIONS.get(obj);
+                Integer val = POOL_EXHAUSTED_ACTIONS.get(obj);
                 if (val != null)
                 {
                     _log.info("Hack for MULE-2289, converting " + obj + " to integer value " + val);
@@ -146,36 +147,43 @@ public class MuleListenerHelper implements ServletContext
         _muleContextListener.contextDestroyed(null);
     }
 
+    @Override
     public ServletContext getContext(String string)
     {
         return null;
     }
 
+    @Override
     public int getMajorVersion()
     {
         return 0;
     }
 
+    @Override
     public int getMinorVersion()
     {
         return 0;
     }
 
+    @Override
     public String getMimeType(String string)
     {
         return "text/html";
     }
 
+    @Override
     public Set<String> getResourcePaths(String string)
     {
         return _parentContext.getResourcePaths(string);
     }
 
+    @Override
     public URL getResource(String string) throws MalformedURLException
     {
         return _parentContext.getResource(string);
     }
 
+    @Override
     public InputStream getResourceAsStream(String string)
     {
         InputStream is = _parentContext.getResourceAsStream(string);
@@ -205,56 +213,67 @@ public class MuleListenerHelper implements ServletContext
         return is;
     }
 
+    @Override
     public RequestDispatcher getRequestDispatcher(String string)
     {
         return _parentContext.getRequestDispatcher(string);
     }
 
+    @Override
     public RequestDispatcher getNamedDispatcher(String string)
     {
         return _parentContext.getNamedDispatcher(string);
     }
 
+    @Override
     public Servlet getServlet(String string) throws ServletException
     {
         return _parentContext.getServlet(string);
     }
 
+    @Override
     public Enumeration<Servlet> getServlets()
     {
         return _parentContext.getServlets();
     }
 
+    @Override
     public Enumeration<String> getServletNames()
     {
         return _parentContext.getServletNames();
     }
 
+    @Override
     public void log(String string)
     {
         _log.info(string);
     }
 
+    @Override
     public void log(Exception exception, String string)
     {
         _log.error(string, exception);
     }
 
+    @Override
     public void log(String string, Throwable throwable)
     {
         _log.error(string, throwable);
     }
 
+    @Override
     public String getRealPath(String string)
     {
         return _parentContext.getRealPath(string);
     }
 
+    @Override
     public String getServerInfo()
     {
         return _parentContext.getServerInfo();
     }
 
+    @Override
     public String getInitParameter(String string)
     {
         String param = _initParameters.get(string);
@@ -263,36 +282,43 @@ public class MuleListenerHelper implements ServletContext
         return param;
     }
 
+    @Override
     public Enumeration<String> getInitParameterNames()
     {
         return null;
     }
 
+    @Override
     public Object getAttribute(String string)
     {
         return _attributes.get(string);
     }
 
+    @Override
     public Enumeration<String> getAttributeNames()
     {
         return null;
     }
 
+    @Override
     public void setAttribute(String string, Object object)
     {
         _attributes.put(string,object);
     }
 
+    @Override
     public void removeAttribute(String string)
     {
         _attributes.remove(string);
     }
 
+    @Override
     public String getServletContextName()
     {
         return null;
     }
 
+    @Override
     public String getContextPath()
     {
         return AppProps.getInstance().getContextPath();
@@ -442,12 +468,6 @@ public class MuleListenerHelper implements ServletContext
 
     }
 
-//    @Override
-    public String getVirtualServerName()
-    {
-        return null;
-    }
-
     @Override
     public ClassLoader getClassLoader()
     {
@@ -456,6 +476,12 @@ public class MuleListenerHelper implements ServletContext
 
     @Override
     public JspConfigDescriptor getJspConfigDescriptor()
+    {
+        return null;
+    }
+
+    @Override
+    public String getVirtualServerName()
     {
         return null;
     }


### PR DESCRIPTION
…ary TLD scan during JSP recompilation, etc.

Pairs nicely with an SVN server/build.gradle change that removes special copying of JDBC driver jars