### PR TITLE
Issue 40011: run Query API calls within trigger scripts in same tx

### DIFF
--- a/api/src/org/labkey/api/action/ApiQueryResponse.java
+++ b/api/src/org/labkey/api/action/ApiQueryResponse.java
@@ -39,6 +39,7 @@ import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.ViewContext;
+import org.labkey.api.view.ViewServlet;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -268,7 +269,14 @@ public class ApiQueryResponse implements ApiResponse
         }
 
         _ctx = ctx;
-        _ctx.setCache(false);
+
+        // Issue 40011: Query API calls within trigger scripts run in separate transaction
+        // To handle large database result sets, we use non-caching connections by default.
+        // However, when inside the trigger script enviornment and making a Query API call back into the server we want
+        // to execute within the same transaction as the outer query insert/update/delete operation.
+        boolean cache = ViewServlet.isMockRequest(ctx.getRequest());
+
+        _ctx.setCache(cache);
     }
 
 

--- a/api/src/org/labkey/api/view/ViewServlet.java
+++ b/api/src/org/labkey/api/view/ViewServlet.java
@@ -612,6 +612,16 @@ public class ViewServlet extends HttpServlet
         }
     }
 
+    /**
+     * Returns true for mock requests. The Rhino trigger script enviornment uses
+     * mock requests when issuing API calls back into the server.
+     * See core/resources/scripts/labkey/adapter/bridge.js
+     */
+    public static boolean isMockRequest(HttpServletRequest request)
+    {
+        return request instanceof MockRequest;
+    }
+
     public void init(ServletConfig config) throws ServletException
     {
         super.init(config);


### PR DESCRIPTION
- regression introduced by fix for Issue 39888 in PR #915
- run trigger script in the same transaction as the outer query insert/update/delete