### PR TITLE
Add "START_MESSAGE" to ModuleLoader's doInit

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -161,6 +161,8 @@ public class ModuleLoader implements Filter, MemTrackerListener
     private static TomcatVersion _tomcatVersion = null;
     private static JavaVersion _javaVersion = null;
 
+    private static final String START_MESSAGE = "Starting LabKey"
+
     private static final String BANNER = "\n" +
             "   __                                   \n" +
             "   ||  |  _ |_ |/ _     (\u00af _  _   _  _\n" +
@@ -426,6 +428,8 @@ public class ModuleLoader implements Filter, MemTrackerListener
     /** Full web-server initialization */
     private void doInit(ServletContext servletCtx, boolean terminateAfterStartup) throws Exception
     {
+        _log.info(START_MESSAGE);
+
         _log.info(BANNER);
 
         _servletContext = servletCtx;


### PR DESCRIPTION
This'll give me something predictable to look for in LabKey logs.
I was just pattern matching the banner, so if there's a better place for this, let me know.