### PR TITLE
Issue 40109:  When merging sample records on import, don't change parents for which no column is provided

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -525,8 +525,6 @@ public class ExpDataIterators
                         String lsid = entry.getKey();
                         Set<Pair<String, String>> parentNames = entry.getValue();
 
-                        Set<Pair<String, String>> nonEmptyParentNames = parentNames.stream().filter((pair) -> !StringUtils.isEmpty(pair.second)).collect(Collectors.toSet());
-
                         ExpRunItem runItem = _isSample ? ExperimentService.get().getExpMaterial(lsid) : ExperimentService.get().getExpData(lsid);
                         if (runItem == null) // nothing to do if the item does not exist
                             continue;
@@ -562,7 +560,7 @@ public class ExpDataIterators
                             {
                                 ExpMaterial sample = (ExpMaterial) runItem;
 
-                               if (_context.getInsertOption().mergeRows)
+                                if (_context.getInsertOption().mergeRows)
                                 {
                                     // TODO always clear? or only when parentcols is in input? or only when new derivation is specified?
                                     // Since this entry was (maybe) already in the database, we may need to delete old derivation info

--- a/experiment/src/org/labkey/experiment/api/ExpSampleSetTestCase.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleSetTestCase.java
@@ -226,7 +226,7 @@ public class ExpSampleSetTestCase extends ExpProvisionedTableTestHelper
     }
 
     // idCols all null, nameExpression not null, has 'name' property -- ok
-//    @Test
+    @Test
     public void idColsUnset_nameExpression_hasNameProperty() throws Exception
     {
         final User user = TestContext.get().getUser();
@@ -468,7 +468,7 @@ public class ExpSampleSetTestCase extends ExpProvisionedTableTestHelper
 
 
     // Issue 33682: Calling insertRows on SampleSet with empty values will not insert new samples
-//    @Test
+    @Test
     public void testBlankRows() throws Exception
     {
         final User user = TestContext.get().getUser();

--- a/experiment/src/org/labkey/experiment/controllers/exp/RunInputOutputBean.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/RunInputOutputBean.java
@@ -30,11 +30,18 @@ public class RunInputOutputBean
 {
     private final Map<ExpMaterial, String> _materials;
     private final Map<ExpData, String> _datas;
+    private final boolean _doUpdate;
 
     public RunInputOutputBean(@NotNull Map<ExpMaterial, String> materials, @NotNull Map<ExpData, String> datas)
     {
+        this(materials, datas, false);
+    }
+
+    public RunInputOutputBean(@NotNull Map<ExpMaterial, String> materials, @NotNull Map<ExpData, String> datas, boolean doUpdate)
+    {
         _materials = materials;
         _datas = datas;
+        _doUpdate = doUpdate;
     }
 
     @NotNull
@@ -47,5 +54,10 @@ public class RunInputOutputBean
     public Map<ExpData, String> getDatas()
     {
         return _datas;
+    }
+
+    public boolean doClear()
+    {
+        return _materials.isEmpty() && _datas.isEmpty() && _doUpdate;
     }
 }

--- a/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
+++ b/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
@@ -16,7 +16,6 @@
 
 package org.labkey.experiment.samples;
 
-import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -26,8 +25,6 @@ import org.labkey.api.collections.Sets;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.NameGenerator;
 import org.labkey.api.data.RemapCache;
@@ -50,6 +47,7 @@ import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpProtocolApplication;
 import org.labkey.api.exp.api.ExpRun;
+import org.labkey.api.exp.api.ExpRunItem;
 import org.labkey.api.exp.api.ExpSampleSet;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.SampleSetService;
@@ -59,12 +57,9 @@ import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.Lookup;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.query.ExpMaterialTable;
-import org.labkey.api.exp.query.ExpSchema;
-import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryKey;
-import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.util.Pair;
@@ -77,6 +72,7 @@ import org.labkey.experiment.controllers.exp.RunInputOutputBean;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -292,20 +288,25 @@ public abstract class UploadSamplesHelper
      * support for mapping DataClass or SampleSet objects as a parent input using the column name format:
      * DataInputs/<data class name> or MaterialInputs/<sample set name>. Either / or . works as a delimiter
      *
-     * @param parentNames - set of (parent column name, parent value) pairs
+     * @param parentNames set of (parent column name, parent value) pairs.  Parent values that are empty
+     *                    indicate tha parent should be removed.
+     * @param runItem the item whose parents are being modified.  If provided, existing parents of the item
+     *                will be incorporated into the resolved inputs and outputs
      * @throws ExperimentException
      */
     @NotNull
-    public static Pair<RunInputOutputBean, RunInputOutputBean> resolveInputsAndOutputs(User user, Container c,
-                                                                         Set<Pair<String, String>> parentNames,
-                                                                         @Nullable MaterialSource source,
-                                                                         RemapCache cache,
-                                                                         Map<Integer, ExpMaterial> materialMap,
-                                                                         Map<Integer, ExpData> dataMap)
-            throws ExperimentException, ValidationException
+    public static Pair<RunInputOutputBean, RunInputOutputBean> resolveInputsAndOutputs(User user, Container c, @Nullable ExpRunItem runItem,
+                                                                                       Set<Pair<String, String>> parentNames,
+                                                                                       @Nullable MaterialSource source,
+                                                                                       RemapCache cache,
+                                                                                       Map<Integer, ExpMaterial> materialMap,
+                                                                                       Map<Integer, ExpData> dataMap)
+            throws ValidationException, ExperimentException
     {
         Map<ExpMaterial, String> parentMaterials = new HashMap<>();
         Map<ExpData, String> parentData = new HashMap<>();
+        Set<String> parentDataTypesToRemove = new HashSet<>();
+        Set<String> parentSampleTypesToRemove = new HashSet<>();
 
         Map<ExpMaterial, String> childMaterials = new HashMap<>();
         Map<ExpData, String> childData = new HashMap<>();
@@ -314,22 +315,23 @@ public abstract class UploadSamplesHelper
         {
             String parentColName = pair.first;
             String parentValue = pair.second;
+            boolean isEmptyParent = StringUtils.isEmpty(parentValue);
 
             String[] parts = parentColName.split("\\.|/");
             if (parts.length == 1)
             {
                 if (parts[0].equalsIgnoreCase("parent"))
                 {
-                    ExpMaterial sample = findMaterial(c, user, null, parentValue, cache, materialMap);
-                    if (sample != null)
-                        parentMaterials.put(sample, sampleRole(sample));
-                    else
+                    if (!isEmptyParent)
                     {
-                        String message = "Sample input '" + parentValue + "'";
-                        if (parts.length > 1)
-                            message += " in SampleSet '" + parts[1] + "'";
-                        message += " not found";
-                        throw new ValidationException(message);
+                        ExpMaterial sample = findMaterial(c, user, null, parentValue, cache, materialMap);
+                        if (sample != null)
+                            parentMaterials.put(sample, sampleRole(sample));
+                        else
+                        {
+                            String message = "Sample input '" + parentValue + "' not found";
+                            throw new ValidationException(message);
+                        }
                     }
                 }
             }
@@ -341,44 +343,90 @@ public abstract class UploadSamplesHelper
                     if (!findMaterialSource(c, user, namePart))
                         throw new ValidationException(String.format("Invalid import alias: parent SampleSet [%1$s] does not exist or may have been deleted", namePart));
 
-                    ExpMaterial sample = findMaterial(c, user, namePart, parentValue, cache, materialMap);
-                    if (sample != null)
-                        parentMaterials.put(sample, sampleRole(sample));
+                    if (isEmptyParent)
+                    {
+                        parentSampleTypesToRemove.add(namePart);
+                    }
                     else
-                        throw new ValidationException("Sample input '" + parentValue + "' in SampleSet '" + namePart + "' not found");
-                }
+                    {
+                        ExpMaterial sample = findMaterial(c, user, namePart, parentValue, cache, materialMap);
+                        if (sample != null)
+                            parentMaterials.put(sample, sampleRole(sample));
+                        else
+                            throw new ValidationException("Sample input '" + parentValue + "' in SampleSet '" + namePart + "' not found");
+
+                    }
+                 }
                 else if (parts[0].equalsIgnoreCase(ExpMaterial.MATERIAL_OUTPUT_CHILD))
                 {
-                    ExpMaterial sample = findMaterial(c, user, namePart, parentValue, cache, materialMap);
-                    if (sample != null)
-                        childMaterials.put(sample, sampleRole(sample));
-                    else
-                        throw new ValidationException("Sample output '" + parentValue + "' in SampleSet '" + namePart + "' not found");
+                    if (!isEmptyParent)
+                    {
+                        ExpMaterial sample = findMaterial(c, user, namePart, parentValue, cache, materialMap);
+                        if (sample != null)
+                            childMaterials.put(sample, sampleRole(sample));
+                        else
+                            throw new ValidationException("Sample output '" + parentValue + "' in SampleSet '" + namePart + "' not found");
+                    }
                 }
                 else if (parts[0].equalsIgnoreCase(ExpData.DATA_INPUT_PARENT))
                 {
                     if (source != null)
                         ensureTargetColumnLookup(user, c, source, parentColName, "exp.data", namePart);
-                    ExpData data = findData(c, user, namePart, parentValue, cache, dataMap);
-                    if (data != null)
-                        parentData.put(data, dataRole(data, user));
+                    if (isEmptyParent)
+                    {
+                        parentDataTypesToRemove.add(parentValue);
+                    }
                     else
-                        throw new ValidationException("Data input '" + parentValue + "' in DataClass '" + namePart + "' not found");
+                    {
+                        ExpData data = findData(c, user, namePart, parentValue, cache, dataMap);
+                        if (data != null)
+                            parentData.put(data, dataRole(data, user));
+                        else
+                            throw new ValidationException("Data input '" + parentValue + "' in DataClass '" + namePart + "' not found");
+                    }
                 }
                 else if (parts[0].equalsIgnoreCase(ExpData.DATA_OUTPUT_CHILD))
                 {
-                    ExpData data = findData(c, user, namePart, parentValue, cache, dataMap);
-                    if (data != null)
-                        childData.put(data, dataRole(data, user));
-                    else
-                        throw new ValidationException("Data output '" + parentValue + "' in DataClass '" + namePart + "' not found");
+                    if (!isEmptyParent)
+                    {
+                        ExpData data = findData(c, user, namePart, parentValue, cache, dataMap);
+                        if (data != null)
+                            childData.put(data, dataRole(data, user));
+                        else
+                            throw new ValidationException("Data output '" + parentValue + "' in DataClass '" + namePart + "' not found");
+                    }
                 }
             }
         }
 
+
+        if (runItem != null)
+        {
+            Pair<Set<ExpData>, Set<ExpMaterial>> currentParents = ExperimentService.get().getParents(c, user, runItem);
+            if (currentParents.first != null)
+            {
+                currentParents.first.forEach((dataParent) -> {
+                    ExpDataClass dataClass = dataParent.getDataClass(user);
+                    if (dataClass != null && !parentData.containsValue(dataClass.getName()) && !parentDataTypesToRemove.contains(dataClass.getName()))
+                    {
+                        parentData.put(dataParent, dataRole(dataParent, user));
+                    }
+                });
+            }
+            if (currentParents.second != null)
+            {
+                currentParents.second.forEach((materialParent) -> {
+                    ExpSampleSet sampleSet = materialParent.getSampleSet();
+                    if (sampleSet != null && !parentMaterials.containsValue(sampleSet.getName()) && !parentSampleTypesToRemove.contains(sampleSet.getName()))
+                        parentMaterials.put(materialParent, sampleRole(materialParent));
+                });
+            }
+        }
+
         RunInputOutputBean parents = null;
-        if (!parentMaterials.isEmpty() || !parentData.isEmpty())
-            parents = new RunInputOutputBean(parentMaterials, parentData);
+
+        if (!parentMaterials.isEmpty() || !parentData.isEmpty() || !parentDataTypesToRemove.isEmpty() || !parentSampleTypesToRemove.isEmpty())
+            parents = new RunInputOutputBean(parentMaterials, parentData, !parentDataTypesToRemove.isEmpty() || !parentSampleTypesToRemove.isEmpty());
 
         RunInputOutputBean children = null;
         if (!childMaterials.isEmpty() || !childData.isEmpty())
@@ -386,6 +434,7 @@ public abstract class UploadSamplesHelper
 
         return Pair.of(parents, children);
     }
+
 
     public static String sampleRole(ExpMaterial material)
     {
@@ -398,7 +447,6 @@ public abstract class UploadSamplesHelper
         ExpDataClass dc = data.getDataClass(user);
         return dc != null ? dc.getName() : ExpDataRunInput.DEFAULT_ROLE;
     }
-
 
     public static Lsid.LsidBuilder generateSampleLSID(MaterialSource source)
     {

--- a/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
+++ b/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
@@ -377,7 +377,7 @@ public abstract class UploadSamplesHelper
                     if (isEmptyParent)
                     {
                         if (isMerge)
-                            parentDataTypesToRemove.add(parentValue);
+                            parentDataTypesToRemove.add(namePart);
                     }
                     else
                     {
@@ -408,21 +408,27 @@ public abstract class UploadSamplesHelper
             Pair<Set<ExpData>, Set<ExpMaterial>> currentParents = ExperimentService.get().getParents(c, user, runItem);
             if (currentParents.first != null)
             {
+                Map<ExpData, String> existingParentData = new HashMap<>();
                 currentParents.first.forEach((dataParent) -> {
                     ExpDataClass dataClass = dataParent.getDataClass(user);
-                    if (dataClass != null && !parentData.containsValue(dataClass.getName()) && !parentDataTypesToRemove.contains(dataClass.getName()))
+                    String role = dataRole(dataParent, user);
+                    if (dataClass != null && !parentData.containsValue(role) && !parentDataTypesToRemove.contains(role))
                     {
-                        parentData.put(dataParent, dataRole(dataParent, user));
+                        existingParentData.put(dataParent, role);
                     }
                 });
+                parentData.putAll(existingParentData);
             }
             if (currentParents.second != null)
             {
+                Map<ExpMaterial, String> existingParentMaterials = new HashMap<>();
                 currentParents.second.forEach((materialParent) -> {
                     ExpSampleSet sampleSet = materialParent.getSampleSet();
-                    if (sampleSet != null && !parentMaterials.containsValue(sampleSet.getName()) && !parentSampleTypesToRemove.contains(sampleSet.getName()))
-                        parentMaterials.put(materialParent, sampleRole(materialParent));
+                    String role = sampleRole(materialParent);
+                    if (sampleSet != null && !parentMaterials.containsValue(role) && !parentSampleTypesToRemove.contains(role))
+                        existingParentMaterials.put(materialParent, role);
                 });
+                parentMaterials.putAll(existingParentMaterials);
             }
         }
 

--- a/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
+++ b/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
@@ -310,6 +310,7 @@ public abstract class UploadSamplesHelper
 
         Map<ExpMaterial, String> childMaterials = new HashMap<>();
         Map<ExpData, String> childData = new HashMap<>();
+        boolean isMerge = runItem != null;
 
         for (Pair<String, String> pair : parentNames)
         {
@@ -345,7 +346,8 @@ public abstract class UploadSamplesHelper
 
                     if (isEmptyParent)
                     {
-                        parentSampleTypesToRemove.add(namePart);
+                        if (isMerge)
+                            parentSampleTypesToRemove.add(namePart);
                     }
                     else
                     {
@@ -374,7 +376,8 @@ public abstract class UploadSamplesHelper
                         ensureTargetColumnLookup(user, c, source, parentColName, "exp.data", namePart);
                     if (isEmptyParent)
                     {
-                        parentDataTypesToRemove.add(parentValue);
+                        if (isMerge)
+                            parentDataTypesToRemove.add(parentValue);
                     }
                     else
                     {
@@ -400,7 +403,7 @@ public abstract class UploadSamplesHelper
         }
 
 
-        if (runItem != null)
+        if (isMerge)
         {
             Pair<Set<ExpData>, Set<ExpMaterial>> currentParents = ExperimentService.get().getParents(c, user, runItem);
             if (currentParents.first != null)


### PR DESCRIPTION
**Rationale**
When importing samples data to be merged with existing samples, we generally use the tactic that if a field is not provided in the input, its value will not be changed.  This should also be true for parent columns and was true if a sample had a parent of only one type, but if more than one type of parent was provided, since we implement the changing of parentage by removing the derivation run and replacing it with a new one, we need to be sure to pick up the existing parents that are not mentioned in the data being imported (and thus assumed to not be changing).

This is needed for 20.4 since we have introduced the ability to edit data class parents for a sample within the Sample Manager application and need to be sure we don't remove any existing sample parents when doing this editing.

