### PR TITLE
6937: Replace Graphviz with Lineage Graph Component

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2298,6 +2298,7 @@ experiment/src/org/labkey/experiment/controllers/exp/ExperimentRunGraphView.java
 experiment/src/org/labkey/experiment/controllers/exp/ExperimentRunGroupsView.java -text
 experiment/src/org/labkey/experiment/controllers/exp/ExperimentUpdateView.java -text
 experiment/src/org/labkey/experiment/controllers/exp/exportSampleSetAsXar.jsp -text
+experiment/src/org/labkey/experiment/controllers/exp/experimentRunGraphView.jsp -text
 experiment/src/org/labkey/experiment/controllers/exp/GraphMoreGrid.java -text
 experiment/src/org/labkey/experiment/controllers/exp/ProtocolListView.java -text
 experiment/src/org/labkey/experiment/controllers/exp/ProtocolParametersView.java -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -2298,7 +2298,6 @@ experiment/src/org/labkey/experiment/controllers/exp/ExperimentRunGraphView.java
 experiment/src/org/labkey/experiment/controllers/exp/ExperimentRunGroupsView.java -text
 experiment/src/org/labkey/experiment/controllers/exp/ExperimentUpdateView.java -text
 experiment/src/org/labkey/experiment/controllers/exp/exportSampleSetAsXar.jsp -text
-experiment/src/org/labkey/experiment/controllers/exp/experimentRunGraphView.jsp -text
 experiment/src/org/labkey/experiment/controllers/exp/GraphMoreGrid.java -text
 experiment/src/org/labkey/experiment/controllers/exp/ProtocolListView.java -text
 experiment/src/org/labkey/experiment/controllers/exp/ProtocolParametersView.java -text

--- a/api/webapp/clientapi/core/Experiment.js
+++ b/api/webapp/clientapi/core/Experiment.js
@@ -49,7 +49,7 @@ LABKEY.Experiment = new function()
 
     function _saveBatches(config, createExps)
     {
-        LABKEY.Ajax.request({
+        return LABKEY.Ajax.request({
             url: LABKEY.ActionURL.buildURL("assay", "saveAssayBatch", LABKEY.ActionURL.getContainer()),
             method: 'POST',
             jsonData: {
@@ -147,7 +147,8 @@ LABKEY.Experiment = new function()
             {
                 throw "Either the runIds or the selectionKey config parameter is required.";
             }
-            LABKEY.Ajax.request(
+
+            return LABKEY.Ajax.request(
             {
                 url : LABKEY.ActionURL.buildURL("experiment", "createHiddenRunGroup", config.containerPath),
                 method : 'POST',
@@ -192,7 +193,7 @@ LABKEY.Experiment.loadBatch({
                 return new LABKEY.Exp.RunGroup(json.batch);
             }
 
-            LABKEY.Ajax.request({
+            return LABKEY.Ajax.request({
                 url: LABKEY.ActionURL.buildURL("assay", "getAssayBatch", LABKEY.ActionURL.getContainer()),
                 method: 'POST',
                 success: getSuccessCallbackWrapper(createExp, LABKEY.Utils.getOnSuccess(config), config.scope),
@@ -244,7 +245,7 @@ LABKEY.Experiment.loadBatch({
                 return batches;
             }
 
-            LABKEY.Ajax.request({
+            return LABKEY.Ajax.request({
                 url: LABKEY.ActionURL.buildURL("assay", "getAssayBatches", LABKEY.ActionURL.getContainer()),
                 method: 'POST',
                 success: getSuccessCallbackWrapper(createExp, LABKEY.Utils.getOnSuccess(config), config.scope),
@@ -311,7 +312,7 @@ LABKEY.Experiment.loadBatch({
             if (config.includeRunSteps !== undefined)
                 jsonData.includeRunSteps = config.includeRunSteps;
 
-            LABKEY.Ajax.request({
+            return LABKEY.Ajax.request({
                 url: LABKEY.ActionURL.buildURL("assay", "getAssayRuns.api", LABKEY.ActionURL.getContainer()),
                 method: 'POST',
                 success: getSuccessCallbackWrapper(createExp, LABKEY.Utils.getOnSuccess(config), config.scope),
@@ -390,11 +391,11 @@ LABKEY.Experiment.saveBatch({
          */
         saveBatch : function (config)
         {
-            _saveBatches(getSaveBatchesConfig(config), function(json) {
+            return _saveBatches(getSaveBatchesConfig(config), function(json) {
                 if (json.batches) {
                     return new LABKEY.Exp.RunGroup(json.batches[0])
                 }
-             });
+            });
         },
 
         saveRuns: function (config)
@@ -410,7 +411,7 @@ LABKEY.Experiment.saveBatch({
                 return runs;
             }
 
-            LABKEY.Ajax.request({
+            return LABKEY.Ajax.request({
                 url: LABKEY.ActionURL.buildURL("assay", "saveAssayRuns.api", LABKEY.ActionURL.getContainer()),
                 method: 'POST',
                 success: getSuccessCallbackWrapper(createExp, LABKEY.Utils.getOnSuccess(config), config.scope),
@@ -453,7 +454,7 @@ LABKEY.Experiment.saveBatch({
          */
         saveBatches : function (config)
         {
-            _saveBatches(getSaveBatchesConfig(config), function(json){
+            return _saveBatches(getSaveBatchesConfig(config), function(json) {
                 var batches = [];
                 if (json.batches) {
                     for (var i = 0; i < json.batches.length; i++) {
@@ -487,7 +488,7 @@ LABKEY.Experiment.saveBatch({
          */
         saveMaterials : function (config)
         {
-            LABKEY.Query.insertRows({
+            return LABKEY.Query.insertRows({
                 schemaName: 'Samples',
                 queryName: config.name,
                 rows: config.materials,
@@ -541,7 +542,7 @@ LABKEY.Experiment.saveBatch({
             if (config.cpasType)
                 params.cpasType = config.cpasType;
 
-            LABKEY.Ajax.request({
+            return LABKEY.Ajax.request({
                 method: 'GET',
                 url: LABKEY.ActionURL.buildURL("experiment", "lineage.api"),
                 params: params,
@@ -585,7 +586,7 @@ LABKEY.Experiment.saveBatch({
             if (config.includeRunSteps !== undefined)
                 params.includeRunSteps = config.includeRunSteps;
 
-            LABKEY.Ajax.request({
+            return LABKEY.Ajax.request({
                 method: 'GET',
                 url: LABKEY.ActionURL.buildURL("experiment", "resolve.api"),
                 params: params,

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.0.41",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.41.tgz",
-      "integrity": "sha1-GrDXiCUEqvJD5SL5fQjlt+W/0Ig="
+      "version": "0.0.45",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.45.tgz",
+      "integrity": "sha1-F1ertkYwErJ3J4Q9aEam//2UtTQ="
     },
     "@labkey/components": {
-      "version": "0.42.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.42.1.tgz",
-      "integrity": "sha1-zhQ/doBNSIum/RCPMmrf4g/XoOY=",
+      "version": "0.44.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.44.0.tgz",
+      "integrity": "sha1-Ohd00Hc9L74ZhAmKfswrL7RA4Oc=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.0.41",
+        "@labkey/api": "0.0.45",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",
@@ -285,7 +285,7 @@
         "react-sticky": "6.0.3",
         "react-treebeard": "3.2.4",
         "reactn": "2.2.6",
-        "vis": "4.21.0"
+        "vis-network": "6.5.2"
       }
     },
     "@types/events": {
@@ -751,9 +751,9 @@
       "dev": true
     },
     "babel-plugin-emotion": {
-      "version": "10.0.29",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.29.tgz",
-      "integrity": "sha512-7Jpi1OCxjyz0k163lKtqP+LHMg5z3S6A7vMBfHnF06l2unmtsOmFDzZBpGf0CWo1G4m8UACfVcDJiSiRuu/cSw==",
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@emotion/hash": "0.8.0",
@@ -1823,11 +1823,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
       }
-    },
-    "emitter-component": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
-      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -3140,11 +3135,6 @@
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
-    },
     "handle-thing": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
@@ -3747,11 +3737,6 @@
       "requires": {
         "minimist": "^1.2.0"
       }
-    },
-    "keycharm": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.2.0.tgz",
-      "integrity": "sha1-+m6i5DuQpoAohD0n8gddNajD5vk="
     },
     "keycode": {
       "version": "2.2.0",
@@ -4740,14 +4725,6 @@
             "loose-envify": "^1.0.0"
           }
         }
-      }
-    },
-    "propagating-hammerjs": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/propagating-hammerjs/-/propagating-hammerjs-1.4.7.tgz",
-      "integrity": "sha512-oW9Wd+W2Tp5uOz6Fh4mEU7p+FoyU85smLH/mPga83Loh0pHa6AH4ZHGywvwMk3TWP31l7iUsvJyW265p4Ipwrg==",
-      "requires": {
-        "hammerjs": "^2.0.8"
       }
     },
     "proxy-addr": {
@@ -6454,17 +6431,10 @@
         "velocity-animate": "^1.4.0"
       }
     },
-    "vis": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/vis/-/vis-4.21.0.tgz",
-      "integrity": "sha1-3XFji/9/ZJXQC8n0DCU1JhM97Ws=",
-      "requires": {
-        "emitter-component": "^1.1.1",
-        "hammerjs": "^2.0.8",
-        "keycharm": "^0.2.0",
-        "moment": "^2.18.1",
-        "propagating-hammerjs": "^1.4.6"
-      }
+    "vis-network": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-6.5.2.tgz",
+      "integrity": "sha512-Dj5oEtZMUWuhq7D7dwdmxmtJgrK3kwfV4Ov/ePSrhPZgNdJlXzpeDZU/Eq0pKGyOAPLClemgVImc0bZpZ4Yafw=="
     },
     "vm-browserify": {
       "version": "1.1.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.42.1"
+    "@labkey/components": "0.44.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -934,21 +934,21 @@
       }
     },
     "@labkey/api": {
-      "version": "0.0.43",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.43.tgz",
-      "integrity": "sha1-kHZXM52TxpxN/VFVjidM4dGbcUc="
+      "version": "0.0.45",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.45.tgz",
+      "integrity": "sha1-F1ertkYwErJ3J4Q9aEam//2UtTQ="
     },
     "@labkey/components": {
-      "version": "0.42.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.42.1.tgz",
-      "integrity": "sha1-zhQ/doBNSIum/RCPMmrf4g/XoOY=",
+      "version": "0.44.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.44.0.tgz",
+      "integrity": "sha1-Ohd00Hc9L74ZhAmKfswrL7RA4Oc=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.0.41",
+        "@labkey/api": "0.0.45",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",
@@ -975,14 +975,7 @@
         "react-sticky": "6.0.3",
         "react-treebeard": "3.2.4",
         "reactn": "2.2.6",
-        "vis": "4.21.0"
-      },
-      "dependencies": {
-        "@labkey/api": {
-          "version": "0.0.41",
-          "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.41.tgz",
-          "integrity": "sha1-GrDXiCUEqvJD5SL5fQjlt+W/0Ig="
-        }
+        "vis-network": "6.5.2"
       }
     },
     "@labkey/eslint-config-base": {
@@ -1853,9 +1846,9 @@
       }
     },
     "babel-plugin-emotion": {
-      "version": "10.0.29",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.29.tgz",
-      "integrity": "sha512-7Jpi1OCxjyz0k163lKtqP+LHMg5z3S6A7vMBfHnF06l2unmtsOmFDzZBpGf0CWo1G4m8UACfVcDJiSiRuu/cSw==",
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@emotion/hash": "0.8.0",
@@ -3758,11 +3751,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
       }
-    },
-    "emitter-component": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
-      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -5876,11 +5864,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
-    },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
     },
     "handle-thing": {
       "version": "2.0.0",
@@ -8118,11 +8101,6 @@
         "object.assign": "^4.1.0"
       }
     },
-    "keycharm": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.2.0.tgz",
-      "integrity": "sha1-+m6i5DuQpoAohD0n8gddNajD5vk="
-    },
     "keycode": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
@@ -10178,14 +10156,6 @@
             "loose-envify": "^1.0.0"
           }
         }
-      }
-    },
-    "propagating-hammerjs": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/propagating-hammerjs/-/propagating-hammerjs-1.4.7.tgz",
-      "integrity": "sha512-oW9Wd+W2Tp5uOz6Fh4mEU7p+FoyU85smLH/mPga83Loh0pHa6AH4ZHGywvwMk3TWP31l7iUsvJyW265p4Ipwrg==",
-      "requires": {
-        "hammerjs": "^2.0.8"
       }
     },
     "proxy-addr": {
@@ -12928,17 +12898,10 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "vis": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/vis/-/vis-4.21.0.tgz",
-      "integrity": "sha1-3XFji/9/ZJXQC8n0DCU1JhM97Ws=",
-      "requires": {
-        "emitter-component": "^1.1.1",
-        "hammerjs": "^2.0.8",
-        "keycharm": "^0.2.0",
-        "moment": "^2.18.1",
-        "propagating-hammerjs": "^1.4.6"
-      }
+    "vis-network": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-6.5.2.tgz",
+      "integrity": "sha512-Dj5oEtZMUWuhq7D7dwdmxmtJgrK3kwfV4Ov/ePSrhPZgNdJlXzpeDZU/Eq0pKGyOAPLClemgVImc0bZpZ4Yafw=="
     },
     "vm-browserify": {
       "version": "1.1.2",

--- a/core/package.json
+++ b/core/package.json
@@ -77,8 +77,8 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "0.0.43",
-    "@labkey/components": "0.42.1",
+    "@labkey/api": "0.0.45",
+    "@labkey/components": "0.44.0",
     "@labkey/eslint-config-react": "0.0.5",
     "react-toggle-button": "2.2.0"
   },

--- a/core/src/client/LabKeyUIComponentsPage/LineagePage.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/LineagePage.tsx
@@ -2,16 +2,15 @@
  * Copyright (c) 2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React from 'react'
-import {List} from 'immutable'
-import { Col, FormControl, Row, Tab, Tabs } from "react-bootstrap";
+import React, { PureComponent } from 'react'
+import { FormControl, Tab, Tabs } from "react-bootstrap";
 import {Alert, LINEAGE_GROUPING_GENERATIONS, LineageFilter, LineageGraph, LineageGrid, VisGraphNode} from "@labkey/components";
 
 interface StateProps {
     lsid: string
 }
 
-export class LineagePage extends React.Component<any, StateProps> {
+export class LineagePage extends PureComponent<any, StateProps> {
 
     constructor(props: any) {
         super(props);
@@ -48,7 +47,7 @@ export class LineagePage extends React.Component<any, StateProps> {
                             <LineageGraph
                                 lsid={lsid}
                                 grouping={{generations: LINEAGE_GROUPING_GENERATIONS.Specific}}
-                                filters={List([new LineageFilter('type', ['Sample', 'Data'])])}
+                                filters={[new LineageFilter('type', ['Sample', 'Data'])]}
                                 navigate={this.onLineageNodeDblClick}
                             />
                         </div>

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.0.41",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.41.tgz",
-      "integrity": "sha1-GrDXiCUEqvJD5SL5fQjlt+W/0Ig="
+      "version": "0.0.45",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.45.tgz",
+      "integrity": "sha1-F1ertkYwErJ3J4Q9aEam//2UtTQ="
     },
     "@labkey/components": {
-      "version": "0.42.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.42.1.tgz",
-      "integrity": "sha1-zhQ/doBNSIum/RCPMmrf4g/XoOY=",
+      "version": "0.44.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.44.0.tgz",
+      "integrity": "sha1-Ohd00Hc9L74ZhAmKfswrL7RA4Oc=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.0.41",
+        "@labkey/api": "0.0.45",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",
@@ -285,7 +285,7 @@
         "react-sticky": "6.0.3",
         "react-treebeard": "3.2.4",
         "reactn": "2.2.6",
-        "vis": "4.21.0"
+        "vis-network": "6.5.2"
       }
     },
     "@types/events": {
@@ -751,9 +751,9 @@
       "dev": true
     },
     "babel-plugin-emotion": {
-      "version": "10.0.29",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.29.tgz",
-      "integrity": "sha512-7Jpi1OCxjyz0k163lKtqP+LHMg5z3S6A7vMBfHnF06l2unmtsOmFDzZBpGf0CWo1G4m8UACfVcDJiSiRuu/cSw==",
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@emotion/hash": "0.8.0",
@@ -1823,11 +1823,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
       }
-    },
-    "emitter-component": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
-      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -3140,11 +3135,6 @@
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
-    },
     "handle-thing": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
@@ -3747,11 +3737,6 @@
       "requires": {
         "minimist": "^1.2.0"
       }
-    },
-    "keycharm": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.2.0.tgz",
-      "integrity": "sha1-+m6i5DuQpoAohD0n8gddNajD5vk="
     },
     "keycode": {
       "version": "2.2.0",
@@ -4740,14 +4725,6 @@
             "loose-envify": "^1.0.0"
           }
         }
-      }
-    },
-    "propagating-hammerjs": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/propagating-hammerjs/-/propagating-hammerjs-1.4.7.tgz",
-      "integrity": "sha512-oW9Wd+W2Tp5uOz6Fh4mEU7p+FoyU85smLH/mPga83Loh0pHa6AH4ZHGywvwMk3TWP31l7iUsvJyW265p4Ipwrg==",
-      "requires": {
-        "hammerjs": "^2.0.8"
       }
     },
     "proxy-addr": {
@@ -6454,17 +6431,10 @@
         "velocity-animate": "^1.4.0"
       }
     },
-    "vis": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/vis/-/vis-4.21.0.tgz",
-      "integrity": "sha1-3XFji/9/ZJXQC8n0DCU1JhM97Ws=",
-      "requires": {
-        "emitter-component": "^1.1.1",
-        "hammerjs": "^2.0.8",
-        "keycharm": "^0.2.0",
-        "moment": "^2.18.1",
-        "propagating-hammerjs": "^1.4.6"
-      }
+    "vis-network": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-6.5.2.tgz",
+      "integrity": "sha512-Dj5oEtZMUWuhq7D7dwdmxmtJgrK3kwfV4Ov/ePSrhPZgNdJlXzpeDZU/Eq0pKGyOAPLClemgVImc0bZpZ4Yafw=="
     },
     "vm-browserify": {
       "version": "1.1.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.42.1"
+    "@labkey/components": "0.44.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/experiment/src/client/RunGraph/RunGraph.tsx
+++ b/experiment/src/client/RunGraph/RunGraph.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { getGlobal } from 'reactn';
 import {
     initQueryGridState,
     LineageGraph,
@@ -11,10 +10,6 @@ import { AppContext } from './util'
 import '@labkey/components/dist/components.css';
 
 initQueryGridState();
-
-// window['GG'] = () => {
-//     return getGlobal()['QueryGrid_lineageResults'].toJS();
-// };
 
 interface RunGraphProps {
     context: AppContext

--- a/experiment/src/client/RunGraph/RunGraph.tsx
+++ b/experiment/src/client/RunGraph/RunGraph.tsx
@@ -8,6 +8,8 @@ import {
 
 import { AppContext } from './util'
 
+import '@labkey/components/dist/components.css';
+
 initQueryGridState();
 
 // window['GG'] = () => {

--- a/experiment/src/client/RunGraph/RunGraph.tsx
+++ b/experiment/src/client/RunGraph/RunGraph.tsx
@@ -23,6 +23,11 @@ export class RunGraph extends React.Component<RunGraphProps> {
                 filterIn={false}
                 lsid={this.props.context.lsid}
                 urlResolver={LineageURLResolvers.Server}
+                navigate={(node) => {
+                    if (node && node.lineageNode && node.lineageNode.links.lineage) {
+                        window.location.href = node.lineageNode.links.lineage;
+                    }
+                }}
             />
         );
     }

--- a/experiment/src/client/RunGraph/RunGraph.tsx
+++ b/experiment/src/client/RunGraph/RunGraph.tsx
@@ -3,7 +3,7 @@ import { getGlobal } from 'reactn';
 import {
     initQueryGridState,
     LineageGraph,
-    VisGraphNode,
+    LineageURLResolvers,
 } from '@labkey/components';
 
 import { AppContext } from './util'
@@ -21,16 +21,13 @@ interface RunGraphProps {
 }
 
 export class RunGraph extends React.Component<RunGraphProps> {
-
-    navigate = (node: VisGraphNode): void => {};
-
     render() {
         return (
             <LineageGraph
                 distance={1}
                 filterIn={false}
                 lsid={this.props.context.lsid}
-                navigate={this.navigate}
+                urlResolver={LineageURLResolvers.Server}
             />
         );
     }

--- a/experiment/src/client/RunGraph/RunGraph.tsx
+++ b/experiment/src/client/RunGraph/RunGraph.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { getGlobal } from 'reactn';
+import {
+    initQueryGridState,
+    LineageGraph,
+    VisGraphNode,
+} from '@labkey/components';
+
+import { AppContext } from './util'
+
+initQueryGridState();
+
+// window['GG'] = () => {
+//     return getGlobal()['QueryGrid_lineageResults'].toJS();
+// };
+
+interface RunGraphProps {
+    context: AppContext
+}
+
+export class RunGraph extends React.Component<RunGraphProps> {
+
+    navigate = (node: VisGraphNode): void => {};
+
+    render() {
+        return (
+            <LineageGraph
+                distance={1}
+                filterIn={false}
+                lsid={this.props.context.lsid}
+                navigate={this.navigate}
+            />
+        );
+    }
+}

--- a/experiment/src/client/RunGraph/app.tsx
+++ b/experiment/src/client/RunGraph/app.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { RunGraph } from './RunGraph';
+import { AppContext, registerApp } from './util';
+
+registerApp<AppContext>('runGraph', (target, ctx) => {
+    ReactDOM.render(<RunGraph context={ctx} />, document.getElementById(target));
+});

--- a/experiment/src/client/RunGraph/dev.tsx
+++ b/experiment/src/client/RunGraph/dev.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { AppContainer } from 'react-hot-loader';
+
+import { RunGraph } from './RunGraph';
+import { AppContext, registerApp } from './util';
+
+const render = (target: string, ctx: AppContext) => {
+    ReactDOM.render(
+        <AppContainer>
+            <RunGraph context={ctx}/>
+        </AppContainer>,
+        document.getElementById(target)
+    );
+};
+
+registerApp<AppContext>('runGraph', render, true);
+
+declare const module: any;
+
+if (module.hot) {
+    module.hot.accept();
+}

--- a/experiment/src/client/RunGraph/util.ts
+++ b/experiment/src/client/RunGraph/util.ts
@@ -1,0 +1,73 @@
+export interface AppContext {
+    lsid: string
+    rowId: number
+    target: string
+}
+
+export interface InitAppEventDetail<T> {
+    appName: string
+    appContext: T
+    appTarget: string
+}
+
+interface AppRegistryItem {
+    appName: string
+    contexts: any[]
+    hot: boolean
+    onInit: Function
+    targets: string[]
+}
+
+let appRegistry: {[appName:string]: AppRegistryItem} = {};
+let isDOMContentLoaded = false;
+
+// Global listener for initializing apps
+window.addEventListener('initApp', (event: CustomEvent<InitAppEventDetail<any>>) => {
+    const { appContext, appName, appTarget } = event.detail;
+
+    if (appRegistry.hasOwnProperty(appName)) {
+        if (appRegistry[appName].hot) {
+            appRegistry[appName].contexts.push(appContext);
+            appRegistry[appName].targets.push(appTarget);
+        }
+
+        if (isDOMContentLoaded) {
+            appRegistry[appName].onInit(appTarget, appContext);
+        } else {
+            window.addEventListener('DOMContentLoaded', () => {
+                isDOMContentLoaded = true;
+                appRegistry[appName].onInit(appTarget, appContext);
+            }, { once: true });
+        }
+    } else {
+        throw Error(`Application "${appName}" is not a registered application. Unable to initialize.`);
+    }
+});
+
+export function registerApp<T>(appName: string, onInit: (target: string, ctx: T) => any, hot?: boolean): void {
+    if (!appRegistry.hasOwnProperty(appName)) {
+        appRegistry[appName] = {
+            appName,
+            contexts: [],
+            hot: hot === true,
+            onInit,
+            targets: [],
+        };
+    } else if (appRegistry[appName].hot) {
+        runHot(appRegistry[appName]);
+    }
+}
+
+function runHot(item: AppRegistryItem): void {
+    if (!item.hot) {
+        throw Error(`Attempting to run application ${item.appName} hot when hot is not enabled.`);
+    }
+
+    if (item.targets.length !== item.contexts.length) {
+        throw Error(`Application registry for "${item.appName}" is in an invalid state. Expected targets and contexts to align.`);
+    }
+
+    for (let i=0; i < item.targets.length; i++) {
+        item.onInit(item.targets[i], item.contexts[i]);
+    }
+}

--- a/experiment/src/client/entryPoints.js
+++ b/experiment/src/client/entryPoints.js
@@ -22,7 +22,7 @@ module.exports = {
     },{
         name: 'runGraph',
         title: 'Experiment Run Graph',
-        permission: 'read',
-        path: './src/client/RunGraph'
+        path: './src/client/RunGraph',
+        generateViews: false // used by experimentRunGraphView.jsp
     }]
 };

--- a/experiment/src/client/entryPoints.js
+++ b/experiment/src/client/entryPoints.js
@@ -19,5 +19,10 @@ module.exports = {
         title: 'Data Class Designer',
         permission: 'admin', // this is admin so that direct access to this view has highest level perm, see <View Action TBD> for main usage
         path: './src/client/DataClassDesigner'
+    },{
+        name: 'runGraph',
+        title: 'Experiment Run Graph',
+        permission: 'read',
+        path: './src/client/RunGraph'
     }]
 };

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentRunGraphModel.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentRunGraphModel.java
@@ -1,0 +1,51 @@
+package org.labkey.experiment.controllers.exp;
+
+import org.labkey.experiment.api.ExpRunImpl;
+
+public class ExperimentRunGraphModel
+{
+    private boolean _detail;
+    private String _focus;
+    private String _focusType;
+    private ExpRunImpl _run;
+
+    public boolean isDetail()
+    {
+        return _detail;
+    }
+
+    public String getFocus()
+    {
+        return _focus;
+    }
+
+    public void setFocus(String focus)
+    {
+        _focus = focus;
+    }
+
+    public void setDetail(boolean detail)
+    {
+        _detail = detail;
+    }
+
+    public String getFocusType()
+    {
+        return _focusType;
+    }
+
+    public void setFocusType(String focusType)
+    {
+        _focusType = focusType;
+    }
+
+    public ExpRunImpl getRun()
+    {
+        return _run;
+    }
+
+    public void setRun(ExpRunImpl run)
+    {
+        _run = run;
+    }
+}

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentRunGraphView.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentRunGraphView.java
@@ -16,93 +16,41 @@
 
 package org.labkey.experiment.controllers.exp;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
-import org.labkey.api.exp.ExperimentException;
-import org.labkey.api.reader.Readers;
-import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.view.ViewContext;
+import org.labkey.api.view.JspView;
 import org.labkey.api.view.WebPartView;
-import org.labkey.experiment.ExperimentRunGraph;
 import org.labkey.experiment.api.ExpRunImpl;
 
-import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.Reader;
 
 /**
  * User: jeckels
  * Date: Dec 18, 2007
  */
-public class ExperimentRunGraphView extends WebPartView
+public class ExperimentRunGraphView extends WebPartView<ExperimentRunGraphModel>
 {
-    private static final Logger _log = Logger.getLogger(ExperimentRunGraphView.class);
-
-    private ExpRunImpl _run;
-    private boolean _detail;
-    private String _focus;
-    private String _focusType;
-
     public ExperimentRunGraphView(ExpRunImpl run, boolean detail)
     {
-        super(FrameType.DIV);
-        _run = run;
-        _detail = detail;
+        super(new ExperimentRunGraphModel());
+        setFrame(FrameType.NONE);
+
+        getModelBean().setRun(run);
+        getModelBean().setDetail(detail);
     }
 
     public void setFocus(String f)
     {
         if (null != f && !"null".equals(f))
-            _focus = f;
-    }
-
-    @Override
-    protected void renderView(Object model, PrintWriter out)
-    {
-        try
-        {
-            ViewContext context = getViewContext();
-
-            out.println("<p>Click on a node in the graph below for details. Run outputs have a bold outline.</p>");
-
-            ExperimentRunGraph.RunGraphFiles files = ExperimentRunGraph.generateRunGraph(context, _run, _detail, _focus, _focusType);
-            out.println("<img src=\"" + ExperimentController.ExperimentUrlsImpl.get().getDownloadGraphURL(_run, _detail, _focus, _focusType) + "\" usemap=\"#graphmap\" >");
-            
-            if (files.getMapFile().exists())
-            {
-                out.println("<map name=\"graphmap\">");
-
-                try (Reader reader = Readers.getReader(files.getMapFile()))
-                {
-                    IOUtils.copy(reader, out);
-                }
-                finally
-                {
-                    files.release();
-                }
-
-                out.write("</map>");
-            }
-        }
-        catch (ExperimentException | InterruptedException e)
-        {
-            out.println("<p>" + e.getMessage() + "</p>");
-        }
-        catch (IOException e)
-        {
-            out.println("<p> Error in generating graph:</p>");
-            out.println("<pre>" + PageFlowUtil.filter(e.getMessage()) + "</pre>");
-            _log.error("Error generating graph", e);
-        }
+            getModelBean().setFocus(f);
     }
 
     public void setFocusType(String focusType)
     {
-        _focusType = focusType;
+        getModelBean().setFocusType(focusType);
     }
 
-    public String getFocusType()
+    @Override
+    protected void renderView(ExperimentRunGraphModel model, PrintWriter out) throws Exception
     {
-        return _focusType;
+        include(new JspView<>("/org/labkey/experiment/controllers/exp/experimentRunGraphView.jsp", model));
     }
 }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentRunGraphView.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentRunGraphView.java
@@ -17,20 +17,17 @@
 package org.labkey.experiment.controllers.exp;
 
 import org.labkey.api.view.JspView;
-import org.labkey.api.view.WebPartView;
 import org.labkey.experiment.api.ExpRunImpl;
-
-import java.io.PrintWriter;
 
 /**
  * User: jeckels
  * Date: Dec 18, 2007
  */
-public class ExperimentRunGraphView extends WebPartView<ExperimentRunGraphModel>
+public class ExperimentRunGraphView extends JspView<ExperimentRunGraphModel>
 {
     public ExperimentRunGraphView(ExpRunImpl run, boolean detail)
     {
-        super(new ExperimentRunGraphModel());
+        super("/org/labkey/experiment/controllers/exp/experimentRunGraphView.jsp", new ExperimentRunGraphModel());
         setFrame(FrameType.NONE);
 
         getModelBean().setRun(run);
@@ -46,11 +43,5 @@ public class ExperimentRunGraphView extends WebPartView<ExperimentRunGraphModel>
     public void setFocusType(String focusType)
     {
         getModelBean().setFocusType(focusType);
-    }
-
-    @Override
-    protected void renderView(ExperimentRunGraphModel model, PrintWriter out) throws Exception
-    {
-        include(new JspView<>("/org/labkey/experiment/controllers/exp/experimentRunGraphView.jsp", model));
     }
 }

--- a/experiment/src/org/labkey/experiment/controllers/exp/experimentRunGraphView.jsp
+++ b/experiment/src/org/labkey/experiment/controllers/exp/experimentRunGraphView.jsp
@@ -35,6 +35,7 @@
     {
          // dependencies.add("http://localhost:3001/runGraph.js");
          dependencies.add("experiment/gen/runGraph.js");
+         dependencies.add("experiment/gen/runGraph.css");
     }
 %>
 <%

--- a/experiment/src/org/labkey/experiment/controllers/exp/experimentRunGraphView.jsp
+++ b/experiment/src/org/labkey/experiment/controllers/exp/experimentRunGraphView.jsp
@@ -1,0 +1,79 @@
+<%
+/*
+ * Copyright (c) 2020 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+%>
+<%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.api.view.ViewContext" %>
+<%@ page import="org.labkey.api.exp.ExperimentException" %>
+<%@ page import="org.labkey.experiment.ExperimentRunGraph" %>
+<%@ page import="org.labkey.experiment.controllers.exp.ExperimentRunGraphModel" %>
+<%@ page import="org.labkey.api.reader.Readers" %>
+<%@ page import="org.apache.commons.io.IOUtils" %>
+<%@ page import="org.labkey.experiment.controllers.exp.ExperimentController" %>
+<%@ page import="java.io.IOException" %>
+<%@ page import="java.io.Reader" %>
+<%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%
+    try
+    {
+        ViewContext context = getViewContext();
+        ExperimentRunGraphModel model = (ExperimentRunGraphModel)HttpView.currentModel();
+
+        ExperimentRunGraph.RunGraphFiles files = ExperimentRunGraph.generateRunGraph(context,
+                                                                                     model.getRun(),
+                                                                                     model.isDetail(),
+                                                                                     model.getFocus(),
+                                                                                     model.getFocusType());
+
+        ActionURL imgSrc = ExperimentController.ExperimentUrlsImpl.get().getDownloadGraphURL(model.getRun(),
+                                                                                             model.isDetail(),
+                                                                                             model.getFocus(),
+                                                                                             model.getFocusType());
+%>
+<img alt="Run Graph" src="<%=imgSrc%>" usemap="#graphmap"/>
+<%
+        if (files.getMapFile().exists())
+        {
+%>
+<map name="graphmap">
+<%
+            try (Reader reader = Readers.getReader(files.getMapFile()))
+            {
+                IOUtils.copy(reader, out);
+%>
+</map>
+<%
+            }
+            finally
+            {
+                files.release();
+            }
+        }
+    }
+    catch (ExperimentException | InterruptedException e)
+    {
+%><p><%=h(e.getMessage())%></p><%
+    }
+    catch (IOException e)
+    {
+%>
+<p> Error in generating graph:</p>
+<pre><%=h(e.getMessage())%></pre>
+<%
+
+    }
+%>

--- a/internal/webapp/_images/run.svg
+++ b/internal/webapp/_images/run.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="65px" height="64px" viewBox="0 0 65 64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+    <title>run_square_blue_64x64_svg</title>
+    <desc>Created with Sketch.</desc>
+    <g id="run_square_blue_64x64" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(1.000000, 0.000000)">
+        <g transform="translate(5.000000, 5.000000)" stroke-width="2">
+            <rect id="Background" stroke="#0067C5" fill="#99C9E8" x="0" y="0" width="54" height="54" rx="2"></rect>
+            <rect id="Rectangle" stroke="#0067C5" fill="#FFFFFF" x="10" y="7" width="18" height="8" rx="1"></rect>
+            <rect id="Rectangle" stroke="#0067C5" fill="#FFFFFF" x="4" y="38" width="18" height="8" rx="1"></rect>
+            <rect id="Rectangle" stroke="#0067C5" fill="#FFFFFF" x="32" y="23" width="18" height="8" rx="1"></rect>
+            <path d="M33,11 L40,11 C40.5522847,11 41,11.4477153 41,12 L41,18 L41,18" id="Path" stroke="#FFFFFF" stroke-linecap="round"></path>
+            <path d="M27,36 L40,36 C40.5522847,36 41,36.4477153 41,37 L41,42 L41,42" id="Path" stroke="#FFFFFF" stroke-linecap="round" transform="translate(34.000000, 39.000000) scale(1, -1) translate(-34.000000, -39.000000) "></path>
+            <line x1="26" y1="44" x2="28" y2="42" id="Path" stroke="#FFFFFF" stroke-linecap="round" transform="translate(27.000000, 43.000000) scale(-1, 1) translate(-27.000000, -43.000000) "></line>
+            <line x1="26" y1="42" x2="28" y2="40" id="Path" stroke="#FFFFFF" stroke-linecap="round"></line>
+            <line x1="41" y1="19" x2="43" y2="17" id="Path" stroke="#FFFFFF" stroke-linecap="round"></line>
+            <line x1="39" y1="19" x2="41" y2="17" id="Path" stroke="#FFFFFF" stroke-linecap="round" transform="translate(40.000000, 18.000000) scale(-1, 1) translate(-40.000000, -18.000000) "></line>
+        </g>
+    </g>
+</svg>

--- a/internal/webapp/_images/run_gray.svg
+++ b/internal/webapp/_images/run_gray.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64px" height="64px" viewBox="0 0 64 64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+    <title>run_square_gray_64x64_svg</title>
+    <desc>Created with Sketch.</desc>
+    <g id="run_square_gray_64x64" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(5.000000, 5.000000)" stroke-width="2">
+            <rect id="Background" stroke="#808080" fill="#D3D3D3" x="0" y="0" width="54" height="54" rx="2"></rect>
+            <rect id="Rectangle" stroke="#808080" fill="#FFFFFF" x="10" y="7" width="18" height="8" rx="1"></rect>
+            <rect id="Rectangle" stroke="#808080" fill="#FFFFFF" x="4" y="38" width="18" height="8" rx="1"></rect>
+            <rect id="Rectangle" stroke="#808080" fill="#FFFFFF" x="32" y="23" width="18" height="8" rx="1"></rect>
+            <path d="M33,11 L40,11 C40.5522847,11 41,11.4477153 41,12 L41,18 L41,18" id="Path" stroke="#FFFFFF" stroke-linecap="round"></path>
+            <path d="M27,36 L40,36 C40.5522847,36 41,36.4477153 41,37 L41,42 L41,42" id="Path" stroke="#FFFFFF" stroke-linecap="round" transform="translate(34.000000, 39.000000) scale(1, -1) translate(-34.000000, -39.000000) "></path>
+            <line x1="26" y1="44" x2="28" y2="42" id="Path" stroke="#FFFFFF" stroke-linecap="round" transform="translate(27.000000, 43.000000) scale(-1, 1) translate(-27.000000, -43.000000) "></line>
+            <line x1="26" y1="42" x2="28" y2="40" id="Path" stroke="#FFFFFF" stroke-linecap="round"></line>
+            <line x1="41" y1="19" x2="43" y2="17" id="Path" stroke="#FFFFFF" stroke-linecap="round"></line>
+            <line x1="39" y1="19" x2="41" y2="17" id="Path" stroke="#FFFFFF" stroke-linecap="round" transform="translate(40.000000, 18.000000) scale(-1, 1) translate(-40.000000, -18.000000) "></line>
+        </g>
+    </g>
+</svg>

--- a/internal/webapp/_images/run_light.svg
+++ b/internal/webapp/_images/run_light.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64px" height="64px" viewBox="0 0 64 64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+    <title>run_square_outline_64x64_svg</title>
+    <desc>Created with Sketch.</desc>
+    <g id="run_square_outline_64x64" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="run_square_blue_64x64" transform="translate(5.000000, 5.000000)" stroke="#FFFFFF" stroke-width="2">
+            <rect id="Background" x="0" y="0" width="54" height="54" rx="2"></rect>
+            <rect id="Rectangle" fill="#FFFFFF" x="10" y="7" width="18" height="8" rx="1"></rect>
+            <rect id="Rectangle" fill="#FFFFFF" x="4" y="38" width="18" height="8" rx="1"></rect>
+            <rect id="Rectangle" fill="#FFFFFF" x="32" y="23" width="18" height="8" rx="1"></rect>
+            <path d="M33,11 L40,11 C40.5522847,11 41,11.4477153 41,12 L41,18 L41,18" id="Path" stroke-linecap="round"></path>
+            <path d="M27,36 L40,36 C40.5522847,36 41,36.4477153 41,37 L41,42 L41,42" id="Path" stroke-linecap="round" transform="translate(34.000000, 39.000000) scale(1, -1) translate(-34.000000, -39.000000) "></path>
+            <line x1="26" y1="44" x2="28" y2="42" id="Path" stroke-linecap="round" transform="translate(27.000000, 43.000000) scale(-1, 1) translate(-27.000000, -43.000000) "></line>
+            <line x1="26" y1="42" x2="28" y2="40" id="Path" stroke-linecap="round"></line>
+            <line x1="41" y1="19" x2="43" y2="17" id="Path" stroke-linecap="round"></line>
+            <line x1="39" y1="19" x2="41" y2="17" id="Path" stroke-linecap="round" transform="translate(40.000000, 18.000000) scale(-1, 1) translate(-40.000000, -18.000000) "></line>
+        </g>
+    </g>
+</svg>

--- a/internal/webapp/_images/run_orange.svg
+++ b/internal/webapp/_images/run_orange.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="65px" height="64px" viewBox="0 0 65 64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+    <title>run_square_orange_64x64_svg</title>
+    <desc>Created with Sketch.</desc>
+    <g id="run_square_orange_64x64" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(1.000000, 0.000000)">
+        <g transform="translate(5.000000, 5.000000)" stroke-width="2">
+            <rect id="Background" stroke="#FFA500" fill="#FFCC81" x="0" y="0" width="54" height="54" rx="2"></rect>
+            <rect id="Rectangle" stroke="#FFA500" fill="#FFFFFF" x="10" y="7" width="18" height="8" rx="1"></rect>
+            <rect id="Rectangle" stroke="#FFA500" fill="#FFFFFF" x="4" y="38" width="18" height="8" rx="1"></rect>
+            <rect id="Rectangle" stroke="#FFA500" fill="#FFFFFF" x="32" y="23" width="18" height="8" rx="1"></rect>
+            <path d="M33,11 L40,11 C40.5522847,11 41,11.4477153 41,12 L41,18 L41,18" id="Path" stroke="#FFFFFF" stroke-linecap="round"></path>
+            <path d="M27,36 L40,36 C40.5522847,36 41,36.4477153 41,37 L41,42 L41,42" id="Path" stroke="#FFFFFF" stroke-linecap="round" transform="translate(34.000000, 39.000000) scale(1, -1) translate(-34.000000, -39.000000) "></path>
+            <line x1="26" y1="44" x2="28" y2="42" id="Path" stroke="#FFFFFF" stroke-linecap="round" transform="translate(27.000000, 43.000000) scale(-1, 1) translate(-27.000000, -43.000000) "></line>
+            <line x1="26" y1="42" x2="28" y2="40" id="Path" stroke="#FFFFFF" stroke-linecap="round"></line>
+            <line x1="41" y1="19" x2="43" y2="17" id="Path" stroke="#FFFFFF" stroke-linecap="round"></line>
+            <line x1="39" y1="19" x2="41" y2="17" id="Path" stroke="#FFFFFF" stroke-linecap="round" transform="translate(40.000000, 18.000000) scale(-1, 1) translate(-40.000000, -18.000000) "></line>
+        </g>
+    </g>
+</svg>

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.0.41",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.41.tgz",
-      "integrity": "sha1-GrDXiCUEqvJD5SL5fQjlt+W/0Ig="
+      "version": "0.0.45",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.45.tgz",
+      "integrity": "sha1-F1ertkYwErJ3J4Q9aEam//2UtTQ="
     },
     "@labkey/components": {
-      "version": "0.42.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.42.1.tgz",
-      "integrity": "sha1-zhQ/doBNSIum/RCPMmrf4g/XoOY=",
+      "version": "0.44.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.44.0.tgz",
+      "integrity": "sha1-Ohd00Hc9L74ZhAmKfswrL7RA4Oc=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.0.41",
+        "@labkey/api": "0.0.45",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",
@@ -285,7 +285,7 @@
         "react-sticky": "6.0.3",
         "react-treebeard": "3.2.4",
         "reactn": "2.2.6",
-        "vis": "4.21.0"
+        "vis-network": "6.5.2"
       }
     },
     "@types/events": {
@@ -751,9 +751,9 @@
       "dev": true
     },
     "babel-plugin-emotion": {
-      "version": "10.0.29",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.29.tgz",
-      "integrity": "sha512-7Jpi1OCxjyz0k163lKtqP+LHMg5z3S6A7vMBfHnF06l2unmtsOmFDzZBpGf0CWo1G4m8UACfVcDJiSiRuu/cSw==",
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@emotion/hash": "0.8.0",
@@ -1823,11 +1823,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
       }
-    },
-    "emitter-component": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
-      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -3140,11 +3135,6 @@
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
-    },
     "handle-thing": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
@@ -3747,11 +3737,6 @@
       "requires": {
         "minimist": "^1.2.0"
       }
-    },
-    "keycharm": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.2.0.tgz",
-      "integrity": "sha1-+m6i5DuQpoAohD0n8gddNajD5vk="
     },
     "keycode": {
       "version": "2.2.0",
@@ -4740,14 +4725,6 @@
             "loose-envify": "^1.0.0"
           }
         }
-      }
-    },
-    "propagating-hammerjs": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/propagating-hammerjs/-/propagating-hammerjs-1.4.7.tgz",
-      "integrity": "sha512-oW9Wd+W2Tp5uOz6Fh4mEU7p+FoyU85smLH/mPga83Loh0pHa6AH4ZHGywvwMk3TWP31l7iUsvJyW265p4Ipwrg==",
-      "requires": {
-        "hammerjs": "^2.0.8"
       }
     },
     "proxy-addr": {
@@ -6454,17 +6431,10 @@
         "velocity-animate": "^1.4.0"
       }
     },
-    "vis": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/vis/-/vis-4.21.0.tgz",
-      "integrity": "sha1-3XFji/9/ZJXQC8n0DCU1JhM97Ws=",
-      "requires": {
-        "emitter-component": "^1.1.1",
-        "hammerjs": "^2.0.8",
-        "keycharm": "^0.2.0",
-        "moment": "^2.18.1",
-        "propagating-hammerjs": "^1.4.6"
-      }
+    "vis-network": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-6.5.2.tgz",
+      "integrity": "sha512-Dj5oEtZMUWuhq7D7dwdmxmtJgrK3kwfV4Ov/ePSrhPZgNdJlXzpeDZU/Eq0pKGyOAPLClemgVImc0bZpZ4Yafw=="
     },
     "vm-browserify": {
       "version": "1.1.2",

--- a/list/package.json
+++ b/list/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.42.1"
+    "@labkey/components": "0.44.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.0.41",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.41.tgz",
-      "integrity": "sha1-GrDXiCUEqvJD5SL5fQjlt+W/0Ig="
+      "version": "0.0.45",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.0.45.tgz",
+      "integrity": "sha1-F1ertkYwErJ3J4Q9aEam//2UtTQ="
     },
     "@labkey/components": {
-      "version": "0.42.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.42.1.tgz",
-      "integrity": "sha1-zhQ/doBNSIum/RCPMmrf4g/XoOY=",
+      "version": "0.44.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.44.0.tgz",
+      "integrity": "sha1-Ohd00Hc9L74ZhAmKfswrL7RA4Oc=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.0.41",
+        "@labkey/api": "0.0.45",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",
@@ -285,7 +285,7 @@
         "react-sticky": "6.0.3",
         "react-treebeard": "3.2.4",
         "reactn": "2.2.6",
-        "vis": "4.21.0"
+        "vis-network": "6.5.2"
       }
     },
     "@types/events": {
@@ -751,9 +751,9 @@
       "dev": true
     },
     "babel-plugin-emotion": {
-      "version": "10.0.29",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.29.tgz",
-      "integrity": "sha512-7Jpi1OCxjyz0k163lKtqP+LHMg5z3S6A7vMBfHnF06l2unmtsOmFDzZBpGf0CWo1G4m8UACfVcDJiSiRuu/cSw==",
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@emotion/hash": "0.8.0",
@@ -1823,11 +1823,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
       }
-    },
-    "emitter-component": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
-      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -3140,11 +3135,6 @@
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
-    },
     "handle-thing": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
@@ -3747,11 +3737,6 @@
       "requires": {
         "minimist": "^1.2.0"
       }
-    },
-    "keycharm": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.2.0.tgz",
-      "integrity": "sha1-+m6i5DuQpoAohD0n8gddNajD5vk="
     },
     "keycode": {
       "version": "2.2.0",
@@ -4740,14 +4725,6 @@
             "loose-envify": "^1.0.0"
           }
         }
-      }
-    },
-    "propagating-hammerjs": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/propagating-hammerjs/-/propagating-hammerjs-1.4.7.tgz",
-      "integrity": "sha512-oW9Wd+W2Tp5uOz6Fh4mEU7p+FoyU85smLH/mPga83Loh0pHa6AH4ZHGywvwMk3TWP31l7iUsvJyW265p4Ipwrg==",
-      "requires": {
-        "hammerjs": "^2.0.8"
       }
     },
     "proxy-addr": {
@@ -6454,17 +6431,10 @@
         "velocity-animate": "^1.4.0"
       }
     },
-    "vis": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/vis/-/vis-4.21.0.tgz",
-      "integrity": "sha1-3XFji/9/ZJXQC8n0DCU1JhM97Ws=",
-      "requires": {
-        "emitter-component": "^1.1.1",
-        "hammerjs": "^2.0.8",
-        "keycharm": "^0.2.0",
-        "moment": "^2.18.1",
-        "propagating-hammerjs": "^1.4.6"
-      }
+    "vis-network": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-6.5.2.tgz",
+      "integrity": "sha512-Dj5oEtZMUWuhq7D7dwdmxmtJgrK3kwfV4Ov/ePSrhPZgNdJlXzpeDZU/Eq0pKGyOAPLClemgVImc0bZpZ4Yafw=="
     },
     "vm-browserify": {
       "version": "1.1.2",

--- a/query/package.json
+++ b/query/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.42.1"
+    "@labkey/components": "0.44.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/webpack/constants.js
+++ b/webpack/constants.js
@@ -64,7 +64,14 @@ module.exports = {
                         babelrc: false,
                         cacheDirectory: true,
                         presets: [
-                            "@babel/preset-env",
+                            [
+                                "@babel/preset-env",
+                                {
+                                    "targets": {
+                                        "node": "10"
+                                    }
+                                }
+                            ],
                             "@babel/preset-react"
                         ]
                     }
@@ -87,7 +94,14 @@ module.exports = {
                         babelrc: false,
                         cacheDirectory: true,
                         presets: [
-                            "@babel/preset-env",
+                            [
+                                "@babel/preset-env",
+                                {
+                                    "targets": {
+                                        "node": "10"
+                                    }
+                                }
+                            ],
                             "@babel/preset-react"
                         ],
                         plugins: [

--- a/webpack/constants.js
+++ b/webpack/constants.js
@@ -67,6 +67,7 @@ module.exports = {
                             [
                                 "@babel/preset-env",
                                 {
+                                    // support async/await
                                     "targets": {
                                         "node": "10"
                                     }
@@ -97,6 +98,7 @@ module.exports = {
                             [
                                 "@babel/preset-env",
                                 {
+                                    // support async/await
                                     "targets": {
                                         "node": "10"
                                     }

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -75,12 +75,6 @@ module.exports = {
     },
 
     plugins: [
-        // enable HMR globally
-        new webpack.HotModuleReplacementPlugin(),
-
-        // prints more readable modules names in the browser console on HMR updates
-        new webpack.NamedModulesPlugin(),
-
         // do not emit compiled assets that include errors
         new webpack.NoEmitOnErrorsPlugin()
     ]

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -19,6 +19,11 @@ for (let i = 0; i < entryPoints.apps.length; i++) {
 
     entries[entryPoint.name] = entryPoint.path + '/app.tsx';
 
+    // Skip generation of module views for apps that do not need it
+    if (entryPoint.generateViews === false) {
+        continue;
+    }
+
     plugins = plugins.concat([
         new HtmlWebpackPlugin({
             inject: false,


### PR DESCRIPTION
#### Rationale
This PR adds the lineage components from `@labkey/components` as a "beta" feature replacement for our Graphviz experiment run graph views. On the "Graph Summary View" it can be toggled in the upper right-hand corner.

**Old view**
![image](https://user-images.githubusercontent.com/3926239/77986069-08d00700-72cb-11ea-9cd9-ff8d3efc6504.png)

**New View**
![image](https://user-images.githubusercontent.com/3926239/77986187-53ea1a00-72cb-11ea-98d9-ac2630d02aa5.png)
(yup, icons for "Runs" still to come)

As we bring this feature fully online we can get a glimpse of what it looks like in a lot of different scenarios and gather feedback.

I believe this is our first React app that is exposed in LKS without it's own module view. To support this I've adjusted platform's webpack build configuration.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/205

#### Changes
* Use a new `registerApp` paradigm for loading "apps" in LKS. Hope to migrate this being a commonly available utility.
* Minor updates to `clientapi/core/Experiment.js` stemming from changes in https://github.com/LabKey/labkey-api-js/pull/44
* Switch run graph view to use a `.jsp` to more easily implement DOM.
* Remove explicit declaration of webpack plugins now included by default mode "development" and HMR.
* Expose a `generateViews` opt-out boolean flag for app entry points to elect if they need views/view.xmls generated for them.