### PR TITLE
Issue 39848: List designer "export and print" checkbox not properly hiding print button on list grid 

### DIFF
--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -2222,8 +2222,9 @@ public class QueryView extends WebPartView<Object>
             // TODO: Until the "More" menu is dynamically populated the "Print" button has been moved back to the bar.
             // Print button is rendered separately to respect ordering -- we want it rendering after all custom buttons
             // added by overrides of populateButtonBar().
-            bb.add(createPrintButton());
-//        bar.add(populateMoreMenu());
+            // bar.add(populateMoreMenu());
+            if (showExportButtons())
+                bb.add(createPrintButton());
         }
         rgn.setButtonBar(bb);
 


### PR DESCRIPTION
#### Rationale
See issue https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39848
For a list in LKS, there is a list designer option to hide/show the "export and print" buttons from the list grid. The export button was properly respecting this setting, but the print button was not. This looks to be a regression from back when we did the updated UX rollout from a couple years ago and unrelated to the recent changes we've made to the List Designer.

#### Changes
* Update to QueryView.setupDataView to add check for showExportButtons() when adding createPrintButton()