### PR TITLE
Fix for NPE in DomainImpl when trying to access domain properties after they have been changed/deleted

### DIFF
--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -111,21 +111,25 @@ public class DomainImpl implements Domain
     public DomainImpl(DomainDescriptor dd)
     {
         _dd = dd;
-        List<PropertyDescriptor> pds = OntologyManager.getPropertiesForType(getTypeURI(), getContainer());
-        _properties = new ArrayList<>(pds.size());
         List<DomainPropertyManager.ConditionalFormatWithPropertyId> allFormats = DomainPropertyManager.get().getConditionalFormats(getContainer());
-        for (PropertyDescriptor pd : pds)
+
+        List<PropertyDescriptor> pds = OntologyManager.getPropertiesForType(getTypeURI(), getContainer());
+        _properties = new ArrayList<>();
+        if (pds != null)
         {
-            List<ConditionalFormat> formats = new ArrayList<>();
-            for (DomainPropertyManager.ConditionalFormatWithPropertyId format : allFormats)
+            for (PropertyDescriptor pd : pds)
             {
-                if (format.getPropertyId() == pd.getPropertyId())
+                List<ConditionalFormat> formats = new ArrayList<>();
+                for (DomainPropertyManager.ConditionalFormatWithPropertyId format : allFormats)
                 {
-                    formats.add(format);
+                    if (format.getPropertyId() == pd.getPropertyId())
+                    {
+                        formats.add(format);
+                    }
                 }
+                DomainPropertyImpl property = new DomainPropertyImpl(this, pd, formats);
+                _properties.add(property);
             }
-            DomainPropertyImpl property = new DomainPropertyImpl(this, pd, formats);
-            _properties.add(property);
         }
     }
 


### PR DESCRIPTION
- seen intermittently in SMSourceTypeUpdateTest.testUpdateSourceType via the search indexing

#### Rationale
The SMSourceTypeUpdateTest.testUpdateSourceType test case makes some changes to a Data Class definition and domain fields. It does this several times quickly back to back. Intermittently that test will fail on TeamCity with an NPE from the DomainImpl.java class as it is called from the search indexing code path: https://teamcity.labkey.org/viewLog.html?buildId=963206&tab=buildResultsDiv&buildTypeId=LabKey_Trunk_Premium_SampleManager_SampleManagerCPostgres#testNameId3014930189846036853

#### Changes
* Add null check in DomainImpl.java after call to OntologyManager.getPropertiesForType()