### PR TITLE
Issue 40010: Related field is shown as updating when nothing has changed

### DIFF
--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -1168,10 +1168,10 @@ public class IssuesController extends SpringActionController
                 Set<Integer> newRelatedIds = issue.getRelatedIssues();
 
                 // this list represents all the ids which will need related handling for a creating a relatedIssue entry
-                List<Integer> newIssues = new ArrayList<>(newRelatedIds);
-                newIssues.removeAll(prevRelatedIds);
+                List<Integer> newAddedRelatedIssues = new ArrayList<>(newRelatedIds);
+                newAddedRelatedIssues.removeAll(prevRelatedIds);
 
-                for (int curIssueId : newIssues)
+                for (int curIssueId : newAddedRelatedIssues)
                 {
                     Issue relatedIssue = ChangeSummary.relatedIssueCommentHandler(issue.getIssueId(), curIssueId, user, false);
                     if (null != relatedIssue)

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -1168,8 +1168,7 @@ public class IssuesController extends SpringActionController
                 Set<Integer> newRelatedIds = issue.getRelatedIssues();
 
                 // this list represents all the ids which will need related handling for a creating a relatedIssue entry
-                Collection<Integer> newIssues = new ArrayList<>();
-                newIssues.addAll(newRelatedIds);
+                List<Integer> newIssues = new ArrayList<>(newRelatedIds);
                 newIssues.removeAll(prevRelatedIds);
 
                 for (int curIssueId : newIssues)
@@ -1182,8 +1181,7 @@ public class IssuesController extends SpringActionController
                 // this list represents all the ids which will need related handling for dropping a relatedIssue entry
                 if (!prevRelatedIds.equals(newRelatedIds))
                 {
-                    Collection<Integer> prevIssues = new ArrayList<>();
-                    prevIssues.addAll(prevRelatedIds);
+                    List<Integer> prevIssues = new ArrayList<>(prevRelatedIds);
                     prevIssues.removeAll(newRelatedIds);
                     for (int curIssueId : prevIssues)
                     {

--- a/issues/src/org/labkey/issue/actions/ChangeSummary.java
+++ b/issues/src/org/labkey/issue/actions/ChangeSummary.java
@@ -306,11 +306,15 @@ public class ChangeSummary
             else
                 newRelated.add(issueId);
 
-            sb.append("<div class=\"wiki\"><table class=issues-Changes>");
-            sb.append(String.format("<tr><td>Related</td><td>%s</td><td>&raquo;</td><td>%s</td></tr>", StringUtils.join(prevRelated, ", "), StringUtils.join(newRelated, ", ")));
-            sb.append("</table></div>");
+            if (!prevRelated.equals(newRelated))
+            {
+                sb.append("<div class=\"wiki\"><table class=issues-Changes>");
+                sb.append(String.format("<tr><td>Related</td><td>%s</td><td>&raquo;</td><td>%s</td></tr>", StringUtils.join(prevRelated, ", "), StringUtils.join(newRelated, ", ")));
+                sb.append("</table></div>");
 
-            relatedIssue.addComment(user, sb.toString());
+                relatedIssue.addComment(user, sb.toString());
+            }
+
             relatedIssue.setRelatedIssues(newRelated);
 
             return relatedIssue;


### PR DESCRIPTION
Changed the relatedIssueCommentHandler to only add comments in related issue when related issues are changed.