### PR TITLE
Issue 40193: Unable to delete Sources parent

### DIFF
--- a/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
+++ b/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
@@ -305,8 +305,8 @@ public abstract class UploadSamplesHelper
     {
         Map<ExpMaterial, String> parentMaterials = new HashMap<>();
         Map<ExpData, String> parentData = new HashMap<>();
-        Set<String> parentDataTypesToRemove = new HashSet<>();
-        Set<String> parentSampleTypesToRemove = new HashSet<>();
+        Set<String> parentDataTypesToRemove = new CaseInsensitiveHashSet();
+        Set<String> parentSampleTypesToRemove = new CaseInsensitiveHashSet();
 
         Map<ExpMaterial, String> childMaterials = new HashMap<>();
         Map<ExpData, String> childData = new HashMap<>();


### PR DESCRIPTION
**Rationale**
Because applications sometimes send the field names for use in updating records in lower case,  we need to not be case sensitive when determining if parents have been cleared or not.

**Changes**
- Use CaseInsensitiveHashSet instead of plan HashSet