### PR TITLE
Use @labkey/api by default

### DIFF
--- a/api/src/org/labkey/api/view/template/ClientDependency.java
+++ b/api/src/org/labkey/api/view/template/ClientDependency.java
@@ -322,7 +322,7 @@ public abstract class ClientDependency
         if (StringUtils.isEmpty(FileUtil.getExtension(requestedPath)))
             requestedPath = requestedPath + TYPE.lib.getExtension();
 
-        // When experimental @labkey/api flag is enabled replace requests for clientapi_core with labkey_api_js.
+        // When experimental @labkey/api flag is disabled replace requests for clientapi_core with labkey_api_js.
         // The results are cached so this can only take effect upon a cleared cache.
         if ("clientapi_core.lib.xml".equalsIgnoreCase(requestedPath) &&
             !ExperimentalFeatureService.get().isFeatureEnabled(AppProps.EXPERIMENTAL_JAVASCRIPT_API))

--- a/api/src/org/labkey/api/view/template/ClientDependency.java
+++ b/api/src/org/labkey/api/view/template/ClientDependency.java
@@ -325,7 +325,7 @@ public abstract class ClientDependency
         // When experimental @labkey/api flag is enabled replace requests for clientapi_core with labkey_api_js.
         // The results are cached so this can only take effect upon a cleared cache.
         if ("clientapi_core.lib.xml".equalsIgnoreCase(requestedPath) &&
-            ExperimentalFeatureService.get().isFeatureEnabled(AppProps.EXPERIMENTAL_JAVASCRIPT_API))
+            !ExperimentalFeatureService.get().isFeatureEnabled(AppProps.EXPERIMENTAL_JAVASCRIPT_API))
         {
             requestedPath = "labkey_api_js.lib.xml";
         }

--- a/api/webapp/clientapi/core/Utils.js
+++ b/api/webapp/clientapi/core/Utils.js
@@ -90,91 +90,6 @@ LABKEY.Utils = new function()
         }
     }
 
-    var getNextRow = function(rowElem, targetTagName)
-    {
-        if (null == rowElem)
-            return null;
-
-
-        var nextRow = rowElem.nextSibling;
-        while (nextRow != null && !nextRow.tagName)
-            nextRow = nextRow.nextSibling;
-
-        if (nextRow == null)
-            return null;
-
-        if (targetTagName)
-        {
-            if (nextRow.tagName != targetTagName)
-                return null;
-        }
-        else
-        {
-            if (nextRow.tagName != "TR")
-                return null;
-        }
-
-        return nextRow;
-    };
-
-    var collapseExpand = function(elem, notify, targetTagName)
-    {
-        var collapse = false;
-        var url = elem.href;
-        if (targetTagName)
-        {
-            while (elem.tagName != targetTagName)
-                elem = elem.parentNode;
-        }
-        else
-        {
-            while (elem.tagName != 'TR')
-                elem = elem.parentNode;
-        }
-
-        var nextRow = getNextRow(elem, targetTagName);
-        if (null != nextRow && nextRow.style.display != "none")
-            collapse = true;
-
-        while (nextRow != null)
-        {
-            if (nextRow.className.indexOf("labkey-header") != -1)
-                break;
-            if (nextRow.style.display != "none")
-                nextRow.style.display = "none";
-            else
-                nextRow.style.display = "";
-            nextRow = getNextRow(nextRow, targetTagName);
-        }
-
-        if (null != url && notify)
-            notifyExpandCollapse(url, collapse);
-        return false;
-    };
-
-    var notifyExpandCollapse = function(url, collapse)
-    {
-        if (url) {
-            if (collapse)
-                url += "&collapse=true";
-            LABKEY.Ajax.request({url: url});
-        }
-    };
-
-    var toggleLink = function(link, notify, targetTagName)
-    {
-        collapseExpand(link, notify, targetTagName);
-        var i = 0;
-        while (typeof(link.childNodes[i].src) == "undefined" )
-            i++;
-
-        if (link.childNodes[i].src.search("plus.gif") >= 0)
-            link.childNodes[i].src = link.childNodes[i].src.replace("plus.gif", "minus.gif");
-        else
-            link.childNodes[i].src = link.childNodes[i].src.replace("minus.gif", "plus.gif");
-        return false;
-    };
-
     var isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
 
     /**
@@ -995,11 +910,6 @@ LABKEY.Utils = new function()
                 throw "Date string not in expected format. Expecting yyyy-MM-dd HH:mm:ss.SSS";
             }
         },
-
-        // private
-        collapseExpand: collapseExpand,
-        notifyExpandCollapse: notifyExpandCollapse,
-        toggleLink: toggleLink
     };
 };
 

--- a/api/webapp/clientapi/dom/Utils.js
+++ b/api/webapp/clientapi/dom/Utils.js
@@ -96,6 +96,33 @@ LABKEY.Utils = new function(impl, $) {
         modal.modal('show');
     };
 
+    var getNextRow = function(rowElem, targetTagName)
+    {
+        if (null == rowElem)
+            return null;
+
+
+        var nextRow = rowElem.nextSibling;
+        while (nextRow != null && !nextRow.tagName)
+            nextRow = nextRow.nextSibling;
+
+        if (nextRow == null)
+            return null;
+
+        if (targetTagName)
+        {
+            if (nextRow.tagName != targetTagName)
+                return null;
+        }
+        else
+        {
+            if (nextRow.tagName != "TR")
+                return null;
+        }
+
+        return nextRow;
+    };
+
     /**
      * Documentation available in core/Utils.js -- search for "@name displayAjaxErrorResponse"
      */
@@ -554,6 +581,64 @@ LABKEY.Utils = new function(impl, $) {
     impl.getSimpleLinkHtml = function(topic, displayText)
     {
         return '<a href="' + LABKEY.Utils.encodeHtml(LABKEY.Utils.getHelpTopicHref(topic)) + '" target="labkeyHelp">' + LABKEY.Utils.encodeHtml(displayText) + "</a>";
+    };
+
+    impl.notifyExpandCollapse = function(url, collapse)
+    {
+        if (url) {
+            if (collapse)
+                url += "&collapse=true";
+            LABKEY.Ajax.request({url: url});
+        }
+    };
+
+    impl.collapseExpand = function(elem, notify, targetTagName)
+    {
+        var collapse = false;
+        var url = elem.href;
+        if (targetTagName)
+        {
+            while (elem.tagName != targetTagName)
+                elem = elem.parentNode;
+        }
+        else
+        {
+            while (elem.tagName != 'TR')
+                elem = elem.parentNode;
+        }
+
+        var nextRow = getNextRow(elem, targetTagName);
+        if (null != nextRow && nextRow.style.display != "none")
+            collapse = true;
+
+        while (nextRow != null)
+        {
+            if (nextRow.className.indexOf("labkey-header") != -1)
+                break;
+            if (nextRow.style.display != "none")
+                nextRow.style.display = "none";
+            else
+                nextRow.style.display = "";
+            nextRow = getNextRow(nextRow, targetTagName);
+        }
+
+        if (null != url && notify)
+            impl.notifyExpandCollapse(url, collapse);
+        return false;
+    };
+
+    impl.toggleLink = function(link, notify, targetTagName)
+    {
+        impl.collapseExpand(link, notify, targetTagName);
+        var i = 0;
+        while (typeof(link.childNodes[i].src) == "undefined")
+            i++;
+
+        if (link.childNodes[i].src.search("plus.gif") >= 0)
+            link.childNodes[i].src = link.childNodes[i].src.replace("plus.gif", "minus.gif");
+        else
+            link.childNodes[i].src = link.childNodes[i].src.replace("minus.gif", "plus.gif");
+        return false;
     };
 
     return impl;

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.1.tgz",
-      "integrity": "sha1-OKBFHbzPMekCqNW7raEq+FtBzOA="
+      "version": "0.1.2-fb-10-query.7",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.7.tgz",
+      "integrity": "sha1-/vicEwSLoUVBsq9otDN8s0A8Xqk="
     },
     "@labkey/components": {
-      "version": "0.48.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.1.tgz",
-      "integrity": "sha1-SnLIR0Fcv8/c9Y7rc9UV1VJkudw=",
+      "version": "0.48.3-fb-10-query.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.3-fb-10-query.0.tgz",
+      "integrity": "sha1-M8g1tqOg0LX6nZjOLEJWao6zkCE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.1.1",
+        "@labkey/api": "0.1.2-fb-10-query.7",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.1.2-fb-10-query.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.8.tgz",
-      "integrity": "sha1-Xz1ahCJGoW2wJKILn88NM0YVSPA="
+      "version": "0.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.0.tgz",
+      "integrity": "sha1-GjEM55EHaeO/UCvK9OxitjpCQmc="
     },
     "@labkey/components": {
-      "version": "0.48.4-fb-10-query.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.4-fb-10-query.0.tgz",
-      "integrity": "sha1-hiRDV37t4OKnM8GgoZTN2deJHnk=",
+      "version": "0.49.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.49.0.tgz",
+      "integrity": "sha1-dotKmjBFHlFvo+Tj5xUjApy3cu4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.1.2-fb-10-query.8",
+        "@labkey/api": "0.2.0",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.1.2-fb-10-query.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.7.tgz",
-      "integrity": "sha1-/vicEwSLoUVBsq9otDN8s0A8Xqk="
+      "version": "0.1.2-fb-10-query.8",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.8.tgz",
+      "integrity": "sha1-Xz1ahCJGoW2wJKILn88NM0YVSPA="
     },
     "@labkey/components": {
-      "version": "0.48.3-fb-10-query.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.3-fb-10-query.0.tgz",
-      "integrity": "sha1-M8g1tqOg0LX6nZjOLEJWao6zkCE=",
+      "version": "0.48.4-fb-10-query.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.4-fb-10-query.0.tgz",
+      "integrity": "sha1-hiRDV37t4OKnM8GgoZTN2deJHnk=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.1.2-fb-10-query.7",
+        "@labkey/api": "0.1.2-fb-10-query.8",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.48.3-fb-10-query.0"
+    "@labkey/components": "0.48.4-fb-10-query.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.48.1"
+    "@labkey/components": "0.48.3-fb-10-query.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.48.4-fb-10-query.0"
+    "@labkey/components": "0.49.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -934,21 +934,21 @@
       }
     },
     "@labkey/api": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.1.tgz",
-      "integrity": "sha1-OKBFHbzPMekCqNW7raEq+FtBzOA="
+      "version": "0.1.2-fb-10-query.7",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.7.tgz",
+      "integrity": "sha1-/vicEwSLoUVBsq9otDN8s0A8Xqk="
     },
     "@labkey/components": {
-      "version": "0.48.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.1.tgz",
-      "integrity": "sha1-SnLIR0Fcv8/c9Y7rc9UV1VJkudw=",
+      "version": "0.48.3-fb-10-query.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.3-fb-10-query.0.tgz",
+      "integrity": "sha1-M8g1tqOg0LX6nZjOLEJWao6zkCE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.1.1",
+        "@labkey/api": "0.1.2-fb-10-query.7",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",
@@ -10998,7 +10998,7 @@
     },
     "rgba-regex": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
     },

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -934,21 +934,21 @@
       }
     },
     "@labkey/api": {
-      "version": "0.1.2-fb-10-query.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.8.tgz",
-      "integrity": "sha1-Xz1ahCJGoW2wJKILn88NM0YVSPA="
+      "version": "0.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.0.tgz",
+      "integrity": "sha1-GjEM55EHaeO/UCvK9OxitjpCQmc="
     },
     "@labkey/components": {
-      "version": "0.48.4-fb-10-query.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.4-fb-10-query.0.tgz",
-      "integrity": "sha1-hiRDV37t4OKnM8GgoZTN2deJHnk=",
+      "version": "0.49.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.49.0.tgz",
+      "integrity": "sha1-dotKmjBFHlFvo+Tj5xUjApy3cu4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.1.2-fb-10-query.8",
+        "@labkey/api": "0.2.0",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -934,21 +934,21 @@
       }
     },
     "@labkey/api": {
-      "version": "0.1.2-fb-10-query.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.7.tgz",
-      "integrity": "sha1-/vicEwSLoUVBsq9otDN8s0A8Xqk="
+      "version": "0.1.2-fb-10-query.8",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.8.tgz",
+      "integrity": "sha1-Xz1ahCJGoW2wJKILn88NM0YVSPA="
     },
     "@labkey/components": {
-      "version": "0.48.3-fb-10-query.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.3-fb-10-query.0.tgz",
-      "integrity": "sha1-M8g1tqOg0LX6nZjOLEJWao6zkCE=",
+      "version": "0.48.4-fb-10-query.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.4-fb-10-query.0.tgz",
+      "integrity": "sha1-hiRDV37t4OKnM8GgoZTN2deJHnk=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.1.2-fb-10-query.7",
+        "@labkey/api": "0.1.2-fb-10-query.8",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/core/package.json
+++ b/core/package.json
@@ -90,8 +90,8 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "0.1.2-fb-10-query.7",
-    "@labkey/components": "0.48.3-fb-10-query.0",
+    "@labkey/api": "0.1.2-fb-10-query.8",
+    "@labkey/components": "0.48.4-fb-10-query.0",
     "@labkey/eslint-config-react": "0.0.5",
     "react-toggle-button": "2.2.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -90,8 +90,8 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "0.1.1",
-    "@labkey/components": "0.48.1",
+    "@labkey/api": "0.1.2-fb-10-query.7",
+    "@labkey/components": "0.48.3-fb-10-query.0",
     "@labkey/eslint-config-react": "0.0.5",
     "react-toggle-button": "2.2.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -90,8 +90,8 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "0.1.2-fb-10-query.8",
-    "@labkey/components": "0.48.4-fb-10-query.0",
+    "@labkey/api": "0.2.0",
+    "@labkey/components": "0.49.0",
     "@labkey/eslint-config-react": "0.0.5",
     "react-toggle-button": "2.2.0"
   },

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -912,8 +912,8 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         }
 
         AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_JAVASCRIPT_API,
-                "Use @labkey/api on the client-side",
-                "Serve @labkey/api as the default client-side implementation of JavaScript API.",
+                "Use clientapi_core.lib.xml instead of @labkey/api on the client-side",
+                "As of LabKey Server v20.5 @labkey/api as the default client-side implementation of JavaScript API.",
                 false);
         AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_JAVASCRIPT_MOTHERSHIP,
                 "Client-side Exception Logging To Mothership",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.1.tgz",
-      "integrity": "sha1-OKBFHbzPMekCqNW7raEq+FtBzOA="
+      "version": "0.1.2-fb-10-query.7",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.7.tgz",
+      "integrity": "sha1-/vicEwSLoUVBsq9otDN8s0A8Xqk="
     },
     "@labkey/components": {
-      "version": "0.48.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.1.tgz",
-      "integrity": "sha1-SnLIR0Fcv8/c9Y7rc9UV1VJkudw=",
+      "version": "0.48.3-fb-10-query.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.3-fb-10-query.0.tgz",
+      "integrity": "sha1-M8g1tqOg0LX6nZjOLEJWao6zkCE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.1.1",
+        "@labkey/api": "0.1.2-fb-10-query.7",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.1.2-fb-10-query.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.8.tgz",
-      "integrity": "sha1-Xz1ahCJGoW2wJKILn88NM0YVSPA="
+      "version": "0.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.0.tgz",
+      "integrity": "sha1-GjEM55EHaeO/UCvK9OxitjpCQmc="
     },
     "@labkey/components": {
-      "version": "0.48.4-fb-10-query.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.4-fb-10-query.0.tgz",
-      "integrity": "sha1-hiRDV37t4OKnM8GgoZTN2deJHnk=",
+      "version": "0.49.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.49.0.tgz",
+      "integrity": "sha1-dotKmjBFHlFvo+Tj5xUjApy3cu4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.1.2-fb-10-query.8",
+        "@labkey/api": "0.2.0",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.1.2-fb-10-query.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.7.tgz",
-      "integrity": "sha1-/vicEwSLoUVBsq9otDN8s0A8Xqk="
+      "version": "0.1.2-fb-10-query.8",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.8.tgz",
+      "integrity": "sha1-Xz1ahCJGoW2wJKILn88NM0YVSPA="
     },
     "@labkey/components": {
-      "version": "0.48.3-fb-10-query.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.3-fb-10-query.0.tgz",
-      "integrity": "sha1-M8g1tqOg0LX6nZjOLEJWao6zkCE=",
+      "version": "0.48.4-fb-10-query.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.4-fb-10-query.0.tgz",
+      "integrity": "sha1-hiRDV37t4OKnM8GgoZTN2deJHnk=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.1.2-fb-10-query.7",
+        "@labkey/api": "0.1.2-fb-10-query.8",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.48.3-fb-10-query.0"
+    "@labkey/components": "0.48.4-fb-10-query.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.48.1"
+    "@labkey/components": "0.48.3-fb-10-query.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.48.4-fb-10-query.0"
+    "@labkey/components": "0.49.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.1.tgz",
-      "integrity": "sha1-OKBFHbzPMekCqNW7raEq+FtBzOA="
+      "version": "0.1.2-fb-10-query.7",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.7.tgz",
+      "integrity": "sha1-/vicEwSLoUVBsq9otDN8s0A8Xqk="
     },
     "@labkey/components": {
-      "version": "0.48.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.1.tgz",
-      "integrity": "sha1-SnLIR0Fcv8/c9Y7rc9UV1VJkudw=",
+      "version": "0.48.3-fb-10-query.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.3-fb-10-query.0.tgz",
+      "integrity": "sha1-M8g1tqOg0LX6nZjOLEJWao6zkCE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.1.1",
+        "@labkey/api": "0.1.2-fb-10-query.7",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.1.2-fb-10-query.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.8.tgz",
-      "integrity": "sha1-Xz1ahCJGoW2wJKILn88NM0YVSPA="
+      "version": "0.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.0.tgz",
+      "integrity": "sha1-GjEM55EHaeO/UCvK9OxitjpCQmc="
     },
     "@labkey/components": {
-      "version": "0.48.4-fb-10-query.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.4-fb-10-query.0.tgz",
-      "integrity": "sha1-hiRDV37t4OKnM8GgoZTN2deJHnk=",
+      "version": "0.49.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.49.0.tgz",
+      "integrity": "sha1-dotKmjBFHlFvo+Tj5xUjApy3cu4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.1.2-fb-10-query.8",
+        "@labkey/api": "0.2.0",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.1.2-fb-10-query.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.7.tgz",
-      "integrity": "sha1-/vicEwSLoUVBsq9otDN8s0A8Xqk="
+      "version": "0.1.2-fb-10-query.8",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.8.tgz",
+      "integrity": "sha1-Xz1ahCJGoW2wJKILn88NM0YVSPA="
     },
     "@labkey/components": {
-      "version": "0.48.3-fb-10-query.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.3-fb-10-query.0.tgz",
-      "integrity": "sha1-M8g1tqOg0LX6nZjOLEJWao6zkCE=",
+      "version": "0.48.4-fb-10-query.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.4-fb-10-query.0.tgz",
+      "integrity": "sha1-hiRDV37t4OKnM8GgoZTN2deJHnk=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.1.2-fb-10-query.7",
+        "@labkey/api": "0.1.2-fb-10-query.8",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/list/package.json
+++ b/list/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.48.3-fb-10-query.0"
+    "@labkey/components": "0.48.4-fb-10-query.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/list/package.json
+++ b/list/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.48.1"
+    "@labkey/components": "0.48.3-fb-10-query.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/list/package.json
+++ b/list/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.48.4-fb-10-query.0"
+    "@labkey/components": "0.49.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.1.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.1.tgz",
-      "integrity": "sha1-OKBFHbzPMekCqNW7raEq+FtBzOA="
+      "version": "0.1.2-fb-10-query.7",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.7.tgz",
+      "integrity": "sha1-/vicEwSLoUVBsq9otDN8s0A8Xqk="
     },
     "@labkey/components": {
-      "version": "0.48.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.1.tgz",
-      "integrity": "sha1-SnLIR0Fcv8/c9Y7rc9UV1VJkudw=",
+      "version": "0.48.3-fb-10-query.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.3-fb-10-query.0.tgz",
+      "integrity": "sha1-M8g1tqOg0LX6nZjOLEJWao6zkCE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.1.1",
+        "@labkey/api": "0.1.2-fb-10-query.7",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.1.2-fb-10-query.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.8.tgz",
-      "integrity": "sha1-Xz1ahCJGoW2wJKILn88NM0YVSPA="
+      "version": "0.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.0.tgz",
+      "integrity": "sha1-GjEM55EHaeO/UCvK9OxitjpCQmc="
     },
     "@labkey/components": {
-      "version": "0.48.4-fb-10-query.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.4-fb-10-query.0.tgz",
-      "integrity": "sha1-hiRDV37t4OKnM8GgoZTN2deJHnk=",
+      "version": "0.49.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.49.0.tgz",
+      "integrity": "sha1-dotKmjBFHlFvo+Tj5xUjApy3cu4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.1.2-fb-10-query.8",
+        "@labkey/api": "0.2.0",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.1.2-fb-10-query.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.7.tgz",
-      "integrity": "sha1-/vicEwSLoUVBsq9otDN8s0A8Xqk="
+      "version": "0.1.2-fb-10-query.8",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.1.2-fb-10-query.8.tgz",
+      "integrity": "sha1-Xz1ahCJGoW2wJKILn88NM0YVSPA="
     },
     "@labkey/components": {
-      "version": "0.48.3-fb-10-query.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.3-fb-10-query.0.tgz",
-      "integrity": "sha1-M8g1tqOg0LX6nZjOLEJWao6zkCE=",
+      "version": "0.48.4-fb-10-query.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.48.4-fb-10-query.0.tgz",
+      "integrity": "sha1-hiRDV37t4OKnM8GgoZTN2deJHnk=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.1.2-fb-10-query.7",
+        "@labkey/api": "0.1.2-fb-10-query.8",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/query/package.json
+++ b/query/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.48.3-fb-10-query.0"
+    "@labkey/components": "0.48.4-fb-10-query.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/query/package.json
+++ b/query/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.48.1"
+    "@labkey/components": "0.48.3-fb-10-query.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/query/package.json
+++ b/query/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.48.4-fb-10-query.0"
+    "@labkey/components": "0.49.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",


### PR DESCRIPTION
#### Rationale
This PR flips the JS API experimental flag introduced in #1021 thus switching to `@labkey/api` by default. This is a big step towards v1.0 for the package and it ensures that the package receives additional coverage, beyond our tests, for the remainder of this release cycle. Woot!

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/51
- https://github.com/LabKey/labkey-ui-components/pull/219

#### Changes
* Invert JS API experimental flag making `@labkey/api` the default version served in LKS.
* Move `collapseExpand`, `notifyExpandCollapse`, and `toggleLink` to the DOM variant of `LABKEY.Utils`.