### PR TITLE
use DateTime enum rather than DateAndTime for PropertiesEditor

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyDateAndContinuousTimepointTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDateAndContinuousTimepointTest.java
@@ -73,7 +73,7 @@ public class StudyDateAndContinuousTimepointTest extends BaseWebDriverTest
 
         PropertiesEditor fieldsEditor = editDatasetPage.getFieldsEditor();
         fieldsEditor.selectField(0).markForDeletion();
-        fieldsEditor.addField(new FieldDefinition("TestDate").setLabel("TestDate").setType(FieldDefinition.ColumnType.DateAndTime));
+        fieldsEditor.addField(new FieldDefinition("TestDate").setLabel("TestDate").setType(FieldDefinition.ColumnType.DateTime));
         editDatasetPage.save();
 
         log("Inserting rows in the dataset");


### PR DESCRIPTION
this fixes a [test failure](https://teamcity.labkey.org/viewLog.html?buildId=968754&tab=buildResultsDiv&buildTypeId=bt21#testNameId-7915287327132417818) on TeamCity