### PR TITLE
Issue 40168: Lookups from Assay to Sample Sets in a different container fail to resolve sample on assay run upload

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -985,7 +985,8 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                 if (o instanceof String && (byNameSS != null || lookupToAllSamplesByName.contains(pd)))
                 {
                     String ssName = byNameSS != null ? byNameSS.getName() : null;
-                    ExpMaterial material = exp.findExpMaterial(container, user, ssName, (String)o, cache, materialCache);
+                    Container lookupContainer = byNameSS != null ? byNameSS.getContainer() : container;
+                    ExpMaterial material = exp.findExpMaterial(lookupContainer, user, ssName, (String)o, cache, materialCache);
                     if (material != null)
                     {
                         materialInputs.putIfAbsent(material, pd.getName());


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40168

Assay designs can have results fields that are lookups to sample sets (which might be in the same container or a different container). It looks like a regression related to resolving samples when that lookup points to a different container was added during the 20.3 release with the code changes from this PR https://github.com/LabKey/platform/pull/546. The issue is that when we are trying to resolve a sample rowId from the sample name during an assay data results import, we are looking for the sample set only in the current container. 

#### Changes
* Fix in AbstractAssayTsvDataHandler.checkData so that when resolving a sample rowId from the sample name be sure to use the container where the sample set is defined