### PR TITLE
Make `CreateContainerAction` mirror UI behavior

### DIFF
--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -713,8 +713,6 @@ public class CoreController extends SpringActionController
             String title = StringUtils.trimToNull(json.getString("title"));
             String description = StringUtils.trimToNull(json.getString("description"));
             String typeName = StringUtils.trimToNull(json.getString("type"));
-            // Inherit parent container's modules for Custom(NONE) folder type unless otherwise indicated
-            boolean inheritModules = !json.has("inheritModules") || json.isNull("inheritModules") || json.getBoolean("inheritModules");
             boolean isWorkbook = false;
             if (typeName == null)
             {
@@ -779,11 +777,10 @@ public class CoreController extends SpringActionController
                 }
 
                 Container newContainer = ContainerManager.createContainer(getContainer(), name, title, description, typeName, getUser());
-                if (folderType == FolderType.NONE && inheritModules)
+                if (folderType != FolderType.NONE || !ensureModules.isEmpty())
                 {
-                    ensureModules.addAll(newContainer.getActiveModules(getUser()));
+                    newContainer.setFolderType(folderType, ensureModules, getUser());
                 }
-                newContainer.setFolderType(folderType, ensureModules, getUser());
 
                 return new ApiSimpleResponse(newContainer.toJSON(getUser()));
             }

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -713,6 +713,8 @@ public class CoreController extends SpringActionController
             String title = StringUtils.trimToNull(json.getString("title"));
             String description = StringUtils.trimToNull(json.getString("description"));
             String typeName = StringUtils.trimToNull(json.getString("type"));
+            // Inherit parent container's modules for Custom(NONE) folder type unless otherwise indicated
+            boolean inheritModules = !json.has("inheritModules") || json.isNull("inheritModules") || json.getBoolean("inheritModules");
             boolean isWorkbook = false;
             if (typeName == null)
             {
@@ -777,6 +779,10 @@ public class CoreController extends SpringActionController
                 }
 
                 Container newContainer = ContainerManager.createContainer(getContainer(), name, title, description, typeName, getUser());
+                if (folderType == FolderType.NONE && inheritModules)
+                {
+                    ensureModules.addAll(newContainer.getActiveModules(getUser()));
+                }
                 newContainer.setFolderType(folderType, ensureModules, getUser());
 
                 return new ApiSimpleResponse(newContainer.toJSON(getUser()));

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -760,7 +760,7 @@ public class CoreController extends SpringActionController
                 }
 
                 Set<Module> ensureModules = new HashSet<>();
-                if (json.has("ensureModules"))
+                if (json.has("ensureModules") && !json.isNull("ensureModules"))
                 {
                     List<String> requestedModules = Arrays.stream(json.getJSONArray("ensureModules")
                             .toArray()).map(Object::toString).collect(Collectors.toList());
@@ -777,9 +777,15 @@ public class CoreController extends SpringActionController
                 }
 
                 Container newContainer = ContainerManager.createContainer(getContainer(), name, title, description, typeName, getUser());
-                if (folderType != FolderType.NONE || !ensureModules.isEmpty())
+                if (folderType != FolderType.NONE)
                 {
                     newContainer.setFolderType(folderType, ensureModules, getUser());
+                }
+                else if (!ensureModules.isEmpty())
+                {
+                    // Custom folder may inherit modules from parent. 'setFolderType' would remove them.
+                    ensureModules.addAll(newContainer.getActiveModules());
+                    newContainer.setActiveModules(ensureModules);
                 }
 
                 return new ApiSimpleResponse(newContainer.toJSON(getUser()));


### PR DESCRIPTION
Several tests started failing after previous update to `CreateContainerAction` (https://github.com/LabKey/platform/pull/1058). They are expecting new subfolders created over the API inherit the project's enabled modules but `setFolderType` clears out the active modules set by `createContainer`.
This change should retain the original API behavior for custom folders while allowing the option to enable additional modules.