### PR TITLE
Issue 39803: Use redirectURL.getURIString() for LogoutApiAction response

### DIFF
--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1481,7 +1481,7 @@ public class LoginController extends SpringActionController
             URLHelper redirectURL = SecurityManager.logoutUser(getViewContext().getRequest(), getUser(), form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL()));
             ApiSimpleResponse response = new ApiSimpleResponse("success", true);
             if (null != redirectURL)
-                response.put("redirectUrl", redirectURL);
+                response.put("redirectUrl", redirectURL.getURIString());
             return response;
         }
     }


### PR DESCRIPTION
#### Rationale
Related to issue: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39803
The previous CAS server logout changes (https://github.com/LabKey/platform/pull/1036) were tested with a mock setup using a second localhost sever as the CAS server. This masked an issue with the LogoutAPIAction response redirectURL which was using a relative path instead of an absolute path.

#### Changes
* Change in LogoutApiAction to use redirectURL.getURIString() so that the SM app logout case can redirect to the right CAS server via an absolute path