### PR TITLE
Mock Mascot servlet for testing

### DIFF
--- a/devtools/src/org/labkey/devtools/mascot/MockMascotServlet.java
+++ b/devtools/src/org/labkey/devtools/mascot/MockMascotServlet.java
@@ -40,8 +40,8 @@ public class MockMascotServlet extends HttpServlet
     {
         if (req.getPathInfo().equals("/cgi/submit.pl"))
         {
-            assert req.getQueryString().equals("1+--taskID+5678+--sessionID+1234");
-            assert req.getParts().size() == 40;
+            throwIfNotEqual("1+--taskID+5678+--sessionID+1234", req.getQueryString());
+            throwIfNotEqual(40, req.getParts().size());
             testPart(req, "CHARGE", "1+, 2+ and 3+");
             testPart(req, "CLE", "Trypsin");
             testPart(req, "COM", "Comments on this Mascot search");
@@ -81,7 +81,7 @@ public class MockMascotServlet extends HttpServlet
             testPart(req, "MASS", "Average");
             testPart(req, "ITOL", "0.8");
             testPart(req, "ITOLU", "Da");
-            assert req.getPart("FILE").getSize() == 8403;
+            throwIfNotEqual(req.getPart("FILE").getSize(), 8403L);
             resp.setStatus(HttpServletResponse.SC_OK);
             ServletOutputStream os = resp.getOutputStream();
             os.println("Peptide #1: GWKEPA");
@@ -94,6 +94,12 @@ public class MockMascotServlet extends HttpServlet
     private void testPart(HttpServletRequest req, String name, String expectedValue) throws IOException, ServletException
     {
         String value = IOUtils.toString(req.getPart(name).getInputStream(), StandardCharsets.US_ASCII);
-        assert expectedValue.equals(value);
+        throwIfNotEqual(expectedValue, value);
+    }
+
+    private void throwIfNotEqual(Object expected, Object value)
+    {
+        if (!expected.equals(value))
+            throw new IllegalStateException("Expected " + expected.toString() + ", but value was " + value.toString());
     }
 }

--- a/devtools/src/org/labkey/devtools/mascot/MockMascotServlet.java
+++ b/devtools/src/org/labkey/devtools/mascot/MockMascotServlet.java
@@ -1,0 +1,99 @@
+package org.labkey.devtools.mascot;
+
+import org.apache.commons.io.IOUtils;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.annotation.MultipartConfig;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Mocks a minimal (incomplete) set of Mascot APIs to allow for rudimentary testing without a Mascot server. See MascotClientImpl.TestCase.
+ */
+@MultipartConfig
+public class MockMascotServlet extends HttpServlet
+{
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+    {
+        // Respond to GET mockservlet/cgi/client.pl?version
+        if (req.getPathInfo().equals("/cgi/client.pl") && req.getQueryString().equals("version"))
+        {
+            resp.setStatus(HttpServletResponse.SC_OK);
+            resp.setHeader("Server", "LabKey MockMascotServer 1.0");
+            resp.getOutputStream().print("Hello");
+            resp.flushBuffer();
+        }
+        else if (req.getPathInfo().equals("/cgi/login.pl"))
+        {
+            resp.getOutputStream().print("sessionID=1234");
+            resp.flushBuffer();
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException
+    {
+        if (req.getPathInfo().equals("/cgi/submit.pl"))
+        {
+            assert req.getQueryString().equals("1+--taskID+5678+--sessionID+1234");
+            assert req.getParts().size() == 40;
+            testPart(req, "CHARGE", "1+, 2+ and 3+");
+            testPart(req, "CLE", "Trypsin");
+            testPart(req, "COM", "Comments on this Mascot search");
+            testPart(req, "DB", "IPI_human_plus");
+            testPart(req, "ERRORTOLERANT", "0");
+            testPart(req, "FORMAT", "Mascot generic");
+            testPart(req, "FORMVER", "1.01");
+            testPart(req, "ICAT", "");
+            testPart(req, "INSTRUMENT", "Default");
+            testPart(req, "INTERMEDIATE", "");
+            testPart(req, "IT_MODS", "");
+            testPart(req, "MODS", "");
+            testPart(req, "OVERVIEW", "");
+            testPart(req, "PFA", "1");
+            testPart(req, "PRECURSOR", "");
+            testPart(req, "REPORT", "20");
+            testPart(req, "REPTYPE", "peptide");
+            testPart(req, "SEARCH", "MIS");
+            testPart(req, "SEG", "");
+            testPart(req, "TAXONOMY", "All entries");
+            testPart(req, "TOLU", "Da");
+            testPart(req, "USEREMAIL", "useremail@domain");
+            testPart(req, "USERNAME", "");
+            testPart(req, "IATOL", "0");
+            testPart(req, "IASTOL", "0");
+            testPart(req, "IA2TOL", "0");
+            testPart(req, "IBTOL", "1");
+            testPart(req, "IBSTOL", "0");
+            testPart(req, "IB2TOL", "1");
+            testPart(req, "IYTOL", "1");
+            testPart(req, "IYSTOL", "0");
+            testPart(req, "IY2TOL", "1");
+            testPart(req, "PEAK", "auto");
+            testPart(req, "LTOL", "");
+            testPart(req, "SHOWALLMODS", "");
+            testPart(req, "TOL", "2.0");
+            testPart(req, "MASS", "Average");
+            testPart(req, "ITOL", "0.8");
+            testPart(req, "ITOLU", "Da");
+            assert req.getPart("FILE").getSize() == 8403;
+            resp.setStatus(HttpServletResponse.SC_OK);
+            ServletOutputStream os = resp.getOutputStream();
+            os.println("Peptide #1: GWKEPA");
+            os.println("Peptide #2: AQPPVTA");
+            os.println("Finished uploading search details");
+            resp.flushBuffer();
+        }
+    }
+
+    private void testPart(HttpServletRequest req, String name, String expectedValue) throws IOException, ServletException
+    {
+        String value = IOUtils.toString(req.getPart(name).getInputStream(), StandardCharsets.US_ASCII);
+        assert expectedValue.equals(value);
+    }
+}

--- a/devtools/src/org/labkey/devtools/mascot/MockMascotServletContextListener.java
+++ b/devtools/src/org/labkey/devtools/mascot/MockMascotServletContextListener.java
@@ -1,0 +1,22 @@
+package org.labkey.devtools.mascot;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.ServletRegistration;
+import javax.servlet.annotation.WebListener;
+
+@WebListener
+public class MockMascotServletContextListener implements ServletContextListener
+{
+    @Override
+    public void contextInitialized(ServletContextEvent servletContextEvent)
+    {
+        ServletRegistration.Dynamic servlet = servletContextEvent.getServletContext().addServlet("MockMascotServlet", MockMascotServlet.class);
+        servlet.addMapping("/mockmascot/*");
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent servletContextEvent)
+    {
+    }
+}


### PR DESCRIPTION
#### Rationale
The MS2 module includes integration with the Mascot search engine, but LabKey doesn't have a license to a Mascot server, so we have no way to test that integration. MockMascotServlet mimics a Mascot server by implementing a couple APIs that MascotClientImpl invokes. The primary motivation was to provide a way to test the only code in the product still using the 13-year-old commons HttpClient. With these tests in place, we can migrate this code to a modern HTTP library with confidence. See MascotClientImpl.TestCase.

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/159

#### Changes
* Add MockMascotServlet and MockMascotServletContextListener
