### PR TITLE
Incorporate fix for getSchemaPermissions

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -934,9 +934,9 @@
       }
     },
     "@labkey/api": {
-      "version": "0.2.1-fb-10-report.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.1-fb-10-report.0.tgz",
-      "integrity": "sha1-LZAwJFKPI+vbcOFovak48g3lr3I="
+      "version": "0.2.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.1.tgz",
+      "integrity": "sha1-nsc4CgHmvONGuau6ZCLid4HA2PU="
     },
     "@labkey/components": {
       "version": "0.49.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -934,9 +934,9 @@
       }
     },
     "@labkey/api": {
-      "version": "0.2.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.0.tgz",
-      "integrity": "sha1-GjEM55EHaeO/UCvK9OxitjpCQmc="
+      "version": "0.2.1-fb-10-report.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.1-fb-10-report.0.tgz",
+      "integrity": "sha1-LZAwJFKPI+vbcOFovak48g3lr3I="
     },
     "@labkey/components": {
       "version": "0.49.0",
@@ -977,6 +977,13 @@
         "react-treebeard": "3.2.4",
         "reactn": "2.2.6",
         "vis-network": "6.5.2"
+      },
+      "dependencies": {
+        "@labkey/api": {
+          "version": "0.2.0",
+          "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.0.tgz",
+          "integrity": "sha1-GjEM55EHaeO/UCvK9OxitjpCQmc="
+        }
       }
     },
     "@labkey/eslint-config-base": {

--- a/core/package.json
+++ b/core/package.json
@@ -90,7 +90,7 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "0.2.1-fb-10-report.0",
+    "@labkey/api": "0.2.1",
     "@labkey/components": "0.49.0",
     "@labkey/eslint-config-react": "0.0.5",
     "react-toggle-button": "2.2.0"

--- a/core/package.json
+++ b/core/package.json
@@ -90,7 +90,7 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "0.2.0",
+    "@labkey/api": "0.2.1-fb-10-report.0",
     "@labkey/components": "0.49.0",
     "@labkey/eslint-config-react": "0.0.5",
     "react-toggle-button": "2.2.0"


### PR DESCRIPTION
#### Rationale
Some EHR tests were failing due to a `Object` copying issue with `Security.getSchemaPermissions` in `@labkey/api`. This has been fixed with https://github.com/LabKey/labkey-api-js/pull/53 which is incorporated with this package version bump

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/53

#### Changes
* Bump `@labkey/api` dependency.
