### PR TITLE
39793: Look & feel configure responsive logo

### DIFF
--- a/api/src/org/labkey/api/settings/LookAndFeelPropertiesManager.java
+++ b/api/src/org/labkey/api/settings/LookAndFeelPropertiesManager.java
@@ -1,5 +1,8 @@
 package org.labkey.api.settings;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.admin.CoreUrls;
 import org.labkey.api.attachments.Attachment;
 import org.labkey.api.attachments.AttachmentCache;
 import org.labkey.api.attachments.AttachmentFile;
@@ -10,10 +13,14 @@ import org.labkey.api.attachments.SpringAttachmentFile;
 import org.labkey.api.data.Container;
 import org.labkey.api.resource.Resource;
 import org.labkey.api.security.User;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.Link.LinkBuilder;
+import org.labkey.api.util.PageFlowUtil;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 
 public class LookAndFeelPropertiesManager
@@ -28,155 +35,370 @@ public class LookAndFeelPropertiesManager
         return INSTANCE;
     }
 
-    private String getLogoFileName(String name, String attachmentPrefix) throws ServletException
+    // TODO: Merge with TemplateResourceHandler?
+    public enum ResourceType
     {
-        int index = name.lastIndexOf(".");
-        if (index == -1)
-            throw new ServletException("No file extension on the uploaded image");
-
-        // Set the name to something we'll recognize as a logo file
-        return attachmentPrefix + name.substring(name.lastIndexOf("."));
-    }
-
-    private void handleLogoFile(MultipartFile file, Container c, User user, String attachmentPrefix) throws ServletException, IOException
-    {
-        String logoFileName = getLogoFileName(file.getOriginalFilename(), attachmentPrefix);
-        handleLogoFile(new SpringAttachmentFile(file, logoFileName), c, user, attachmentPrefix);
-    }
-
-    public void handleLogoFile(Resource resource, Container c, User user, String attachmentPrefix) throws ServletException, IOException
-    {
-        String logoFileName = getLogoFileName(resource.getName(), attachmentPrefix);
-        handleLogoFile(new InputStreamAttachmentFile(resource.getInputStream(), logoFileName), c, user, attachmentPrefix);
-    }
-
-    private void handleLogoFile(AttachmentFile file, Container c, User user, String attachmentPrefix) throws IOException
-    {
-        deleteExistingLogo(c, user, attachmentPrefix);
-        AttachmentService.get().addAttachments(new LookAndFeelResourceAttachmentParent(c), Collections.singletonList(file), user);
-        clearLogoCache(attachmentPrefix);
-    }
-
-    private void clearLogoCache(String attachmentPrefix)
-    {
-        switch (attachmentPrefix)
+        HEADER_LOGO
         {
-            case AttachmentCache.LOGO_FILE_NAME_PREFIX: AttachmentCache.clearLogoCache(); return;
-            case AttachmentCache.MOBILE_LOGO_FILE_NAME_PREFIX: AttachmentCache.clearLogoMobileCache(); return;
-            default: throw new IllegalArgumentException(attachmentPrefix + " is not a supported logo prefix.");
-        }
-    }
-
-    private void deleteExistingLogo(Container c, User user, String attachmentPrefix)
-    {
-        LookAndFeelResourceAttachmentParent parent = new LookAndFeelResourceAttachmentParent(c);
-
-        for (Attachment attachment : AttachmentService.get().getAttachments(parent))
-        {
-            if (attachment.getName().startsWith(attachmentPrefix))
+            @Override
+            public String getShortLabel()
             {
-                AttachmentService.get().deleteAttachment(parent, attachment.getName(), user);
-                clearLogoCache(attachmentPrefix);
+                return "Header logo";
+            }
+
+            @Override
+            public HtmlString getHelpPopup()
+            {
+                return HtmlString.unsafe(PageFlowUtil.helpPopup("Header Logo", "Appears in the header on every page when the page width is greater than 767px.<br><br>Recommend size: 100px x 30px", true, 300));
+            }
+
+            @Override
+            public LinkBuilder getViewLink(Container c)
+            {
+                return PageFlowUtil.link("view logo").href(TemplateResourceHandler.LOGO.getURL(c));
+            }
+
+            @Override
+            public String getFieldName()
+            {
+                return "logoImage";
+            }
+
+            @Override
+            public void delete(Container c, User user)
+            {
+                deleteExistingLogo(c, user);
+            }
+
+            @Override
+            public String getFileName(Resource resource) throws ServletException
+            {
+                return getLogoFileName(resource.getName(), getAttachmentName());
+            }
+
+            @Override
+            public void save(MultipartFile file, Container c, User user) throws ServletException, IOException
+            {
+                String logoFileName = getLogoFileName(file.getOriginalFilename(), getAttachmentName());
+                save(new SpringAttachmentFile(file, logoFileName), c, user);
+            }
+
+            @Override
+            public boolean isSet(Container c)
+            {
+                return null != AttachmentCache.lookupLogoAttachment(c);
+            }
+
+            @Override
+            protected String getAttachmentName()
+            {
+                return AttachmentCache.LOGO_FILE_NAME_PREFIX;
+            }
+
+            @Override
+            protected void clearCache()
+            {
+                AttachmentCache.clearLogoCache();
+            }
+        },
+        MOBILE_LOGO
+        {
+            @Override
+            public String getShortLabel()
+            {
+                return "Responsive logo";
+            }
+
+            @Override
+            public HtmlString getHelpPopup()
+            {
+                return HtmlString.unsafe(PageFlowUtil.helpPopup("Responsive Logo", "Appears in the header on every page when the page width is less than 768px.<br><br>Recommend size: 30px x 30px", true, 300));
+            }
+
+            @Override
+            public LinkBuilder getViewLink(Container c)
+            {
+                return PageFlowUtil.link("view logo").href(TemplateResourceHandler.LOGO_MOBILE.getURL(c));
+            }
+
+            @Override
+            public String getFieldName()
+            {
+                return "logoMobileImage";
+            }
+
+            @Override
+            public void delete(Container c, User user)
+            {
+                deleteExistingLogo(c, user);
+            }
+
+            @Override
+            public String getFileName(Resource resource) throws ServletException
+            {
+                return getLogoFileName(resource.getName(), getAttachmentName());
+            }
+
+            @Override
+            public void save(MultipartFile file, Container c, User user) throws ServletException, IOException
+            {
+                String logoFileName = getLogoFileName(file.getOriginalFilename(), getAttachmentName());
+                save(new SpringAttachmentFile(file, logoFileName), c, user);
+            }
+
+            @Override
+            public boolean isSet(Container c)
+            {
+                return null != AttachmentCache.lookupMobileLogoAttachment(c);
+            }
+
+            @Override
+            protected String getAttachmentName()
+            {
+                return AttachmentCache.MOBILE_LOGO_FILE_NAME_PREFIX;
+            }
+
+            @Override
+            protected void clearCache()
+            {
+                AttachmentCache.clearLogoMobileCache();
+            }
+        },
+        FAVICON
+        {
+            @Override
+            public String getShortLabel()
+            {
+                return "Favorite icon";
+            }
+
+            @Override
+            public String getLongLabel()
+            {
+                return "Favorite icon (displayed in user's favorites or bookmarks, .ico file only)";
+            }
+
+            @Override
+            public LinkBuilder getViewLink(Container c)
+            {
+                return PageFlowUtil.link("view icon").href(TemplateResourceHandler.FAVICON.getURL(c));
+            }
+
+            @Override
+            protected String getAttachmentName()
+            {
+                return AttachmentCache.FAVICON_FILE_NAME;
+            }
+
+            @Override
+            public String getFieldName()
+            {
+                return "iconImage";
+            }
+
+            @Override
+            public void delete(Container c, User user)
+            {
+                deleteResource(c, user, this);
+                clearCache();
+            }
+
+            @Override
+            public String getFileName(Resource resource) throws ServletException
+            {
+                verifyIconFileName(resource.getName());
+                return getAttachmentName();
+            }
+
+            @Override
+            public void save(MultipartFile file, Container c, User user) throws ServletException, IOException
+            {
+                verifyIconFileName(file.getOriginalFilename());
+
+                AttachmentFile attachmentFile = new SpringAttachmentFile(file, getAttachmentName());
+                save(attachmentFile, c, user);
+            }
+
+            @Override
+            public boolean isSet(Container c)
+            {
+                return null != AttachmentCache.lookupFavIconAttachment(new LookAndFeelResourceAttachmentParent(c));
+            }
+
+            @Override
+            protected void clearCache()
+            {
+                AttachmentCache.clearFavIconCache();
+            }
+        },
+        STYLESHEET
+        {
+            @Override
+            public String getShortLabel()
+            {
+                return "Stylesheet";
+            }
+
+            @Override
+            public LinkBuilder getViewLink(Container c)
+            {
+                return PageFlowUtil.link("view CSS").href(PageFlowUtil.urlProvider(CoreUrls.class).getCustomStylesheetURL(c));
+            }
+
+            @Override
+            public String getDeleteText()
+            {
+                return "Delete custom stylesheet";
+            }
+
+            @Override
+            public String getDefaultText()
+            {
+                return "No custom stylesheet";
+            }
+
+            @Override
+            protected String getAttachmentName()
+            {
+                return AttachmentCache.STYLESHEET_FILE_NAME;
+            }
+
+            @Override
+            public String getFieldName()
+            {
+                return "customStylesheet";
+            }
+
+            @Override
+            public void delete(Container c, User user)
+            {
+                deleteResource(c, user, this);
+                // This custom stylesheet is still cached in CoreController, but look & feel revision checking should ensure
+                // that it gets cleared out on the next request.
+            }
+
+            @Override
+            public String getFileName(Resource resource)
+            {
+                return getAttachmentName();
+            }
+
+            @Override
+            public void save(MultipartFile file, Container c, User user) throws IOException
+            {
+                AttachmentFile attachmentFile = new SpringAttachmentFile(file, getAttachmentName());
+                save(attachmentFile, c, user);
+            }
+
+            @Override
+            public boolean isSet(Container c)
+            {
+                return null != AttachmentCache.lookupCustomStylesheetAttachment(new LookAndFeelResourceAttachmentParent(c));
+            }
+
+            @Override
+            protected void clearCache()
+            {
+                // Don't need to clear cache -- lookAndFeelRevision gets checked on retrieval
+            }
+        };
+
+        public abstract String getShortLabel();
+
+        public String getLongLabel()
+        {
+            return getShortLabel();
+        }
+        public HtmlString getHelpPopup()
+        {
+            return HtmlString.EMPTY_STRING;
+        }
+
+        public abstract LinkBuilder getViewLink(Container c);
+
+        public String getDeleteText()
+        {
+            return "Reset " + getShortLabel().toLowerCase() + " to default";
+        }
+
+        public String getDefaultText()
+        {
+            return "Currently using the default " + getShortLabel().toLowerCase();
+        }
+
+        // Name associated with this type in a form
+        public abstract String getFieldName();
+
+        public abstract void delete(Container c, User user);
+        public abstract String getFileName(Resource resource) throws ServletException;
+        public abstract void save(MultipartFile file, Container c, User user) throws ServletException, IOException;
+        public abstract boolean isSet(Container c);
+
+        // Returns either a prefix or a full filename, depending on type
+        protected abstract String getAttachmentName();
+        protected abstract void clearCache();
+
+        protected final void save(AttachmentFile attachmentFile, Container c, User user) throws IOException
+        {
+            delete(c, user);
+            LookAndFeelResourceAttachmentParent parent = new LookAndFeelResourceAttachmentParent(c);
+            AttachmentService.get().addAttachments(parent, Collections.singletonList(attachmentFile), user);
+            clearCache();
+        }
+
+        protected void deleteExistingLogo(Container c, User user)
+        {
+            LookAndFeelResourceAttachmentParent parent = new LookAndFeelResourceAttachmentParent(c);
+
+            for (Attachment attachment : AttachmentService.get().getAttachments(parent))
+            {
+                if (attachment.getName().startsWith(getAttachmentName()))
+                {
+                    AttachmentService.get().deleteAttachment(parent, attachment.getName(), user);
+                    clearCache();
+                }
             }
         }
+
+        protected void deleteResource(Container c, User user, @NotNull ResourceType type)
+        {
+            LookAndFeelResourceAttachmentParent parent = new LookAndFeelResourceAttachmentParent(c);
+            AttachmentService.get().deleteAttachment(parent, type.getAttachmentName(), user);
+        }
+
+        protected String getLogoFileName(String name, String attachmentPrefix) throws ServletException
+        {
+            int index = name.lastIndexOf(".");
+            if (index == -1)
+                throw new ServletException("No file extension on the uploaded image");
+
+            // Set the name to something we'll recognize as a logo file
+            return attachmentPrefix + name.substring(name.lastIndexOf("."));
+        }
+
+        protected void verifyIconFileName(String name) throws ServletException
+        {
+            if (!name.toLowerCase().endsWith(".ico"))
+                throw new ServletException("FavIcon must be a .ico file");
+        }
     }
 
-    public void handleLogoFile(MultipartFile file, Container c, User user) throws ServletException, IOException
+    public @Nullable SiteResourceHandler getResourceHandler(@NotNull String name)
     {
-        handleLogoFile(file, c, user, AttachmentCache.LOGO_FILE_NAME_PREFIX);
+        ResourceType type = Arrays.stream(ResourceType.values()).filter(t->t.getFieldName().equals(name)).findFirst().orElse(null);
+
+        if (null == type)
+            return null;
+
+        return (resource, c, user) -> {
+            AttachmentFile attachmentFile = new InputStreamAttachmentFile(resource.getInputStream(), type.getFileName(resource));
+            type.save(attachmentFile, c, user);
+        };
     }
 
-    public void handleLogoFile(Resource resource, Container c, User user) throws ServletException, IOException
+    @FunctionalInterface
+    public interface SiteResourceHandler
     {
-        handleLogoFile(resource, c, user, AttachmentCache.LOGO_FILE_NAME_PREFIX);
-    }
-
-    public void deleteExistingLogo(Container c, User user)
-    {
-        deleteExistingLogo(c, user, AttachmentCache.LOGO_FILE_NAME_PREFIX);
-    }
-
-    public void handleMobileLogoFile(MultipartFile file, Container c, User user) throws ServletException, IOException
-    {
-        handleLogoFile(file, c, user, AttachmentCache.MOBILE_LOGO_FILE_NAME_PREFIX);
-    }
-
-    public void handleMobileLogoFile(Resource resource, Container c, User user) throws ServletException, IOException
-    {
-        handleLogoFile(resource, c, user, AttachmentCache.MOBILE_LOGO_FILE_NAME_PREFIX);
-    }
-
-    public void deleteExistingMobileLogo(Container c, User user)
-    {
-        deleteExistingLogo(c, user, AttachmentCache.MOBILE_LOGO_FILE_NAME_PREFIX);
-    }
-
-    public void handleIconFile(MultipartFile file, Container c, User user) throws IOException, ServletException
-    {
-        verifyIconFileName(file.getOriginalFilename());
-
-        AttachmentFile attachmentFile = new SpringAttachmentFile(file, AttachmentCache.FAVICON_FILE_NAME);
-        handleIconFile(attachmentFile, c, user);
-    }
-
-    public void handleIconFile(Resource resource, Container c, User user) throws IOException, ServletException
-    {
-        verifyIconFileName(resource.getName());
-
-        AttachmentFile attachmentFile = new InputStreamAttachmentFile(resource.getInputStream(), AttachmentCache.FAVICON_FILE_NAME);
-        handleIconFile(attachmentFile, c, user);
-    }
-
-    private void verifyIconFileName(String name) throws ServletException
-    {
-        if (!name.toLowerCase().endsWith(".ico"))
-            throw new ServletException("FavIcon must be a .ico file");
-    }
-
-    private void handleIconFile(AttachmentFile file, Container c, User user) throws IOException
-    {
-        deleteExistingFavicon(c, user);
-
-        LookAndFeelResourceAttachmentParent parent = new LookAndFeelResourceAttachmentParent(c);
-        AttachmentService.get().addAttachments(parent, Collections.singletonList(file), user);
-        AttachmentCache.clearFavIconCache();
-    }
-
-    public void deleteExistingFavicon(Container c, User user)
-    {
-        LookAndFeelResourceAttachmentParent parent = new LookAndFeelResourceAttachmentParent(c);
-        AttachmentService.get().deleteAttachment(parent, AttachmentCache.FAVICON_FILE_NAME, user);
-        AttachmentCache.clearFavIconCache();
-    }
-
-    public void handleCustomStylesheetFile(MultipartFile file, Container c, User user) throws IOException
-    {
-        AttachmentFile attachmentFile = new SpringAttachmentFile(file, AttachmentCache.STYLESHEET_FILE_NAME);
-        handleCustomStylesheetFile(attachmentFile, c, user);
-    }
-
-    public void handleCustomStylesheetFile(Resource resource, Container c, User user) throws IOException
-    {
-        AttachmentFile attachmentFile = new InputStreamAttachmentFile(resource.getInputStream(), AttachmentCache.STYLESHEET_FILE_NAME);
-        handleCustomStylesheetFile(attachmentFile, c, user);
-    }
-
-    private void handleCustomStylesheetFile(AttachmentFile file, Container c, User user) throws IOException
-    {
-        deleteExistingCustomStylesheet(c, user);
-
-        LookAndFeelResourceAttachmentParent parent = new LookAndFeelResourceAttachmentParent(c);
-        AttachmentService.get().addAttachments(parent, Collections.singletonList(file), user);
-
-        // Don't need to clear cache -- lookAndFeelRevision gets checked on retrieval
-    }
-
-    public void deleteExistingCustomStylesheet(Container c, User user)
-    {
-        LookAndFeelResourceAttachmentParent parent = new LookAndFeelResourceAttachmentParent(c);
-        AttachmentService.get().deleteAttachment(parent, AttachmentCache.STYLESHEET_FILE_NAME, user);
-
-        // This custom stylesheet is still cached in CoreController, but look & feel revision checking should ensure
-        // that it gets cleared out on the next request.
+        void accept(Resource resource, Container container, User user) throws ServletException, IOException;
     }
 }

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -107,6 +107,7 @@ import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.settings.ExperimentalFeatureService.ExperimentalFeatureServiceImpl;
 import org.labkey.api.settings.FolderSettingsCache;
 import org.labkey.api.settings.LookAndFeelPropertiesManager;
+import org.labkey.api.settings.LookAndFeelPropertiesManager.SiteResourceHandler;
 import org.labkey.api.settings.WriteableAppProps;
 import org.labkey.api.settings.WriteableLookAndFeelProperties;
 import org.labkey.api.stats.AnalyticsProviderRegistry;
@@ -229,7 +230,6 @@ import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.impl.StdSchedulerFactory;
 
-import javax.servlet.ServletException;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -1265,24 +1265,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
 
     private @Nullable SiteResourceHandler getResourceHandler(@NotNull String name)
     {
-        switch (name)
-        {
-            case "logoImage":
-                return LookAndFeelPropertiesManager.get()::handleLogoFile;
-            case "logoMobileImage":
-                return LookAndFeelPropertiesManager.get()::handleMobileLogoFile;
-            case "iconImage":
-                return LookAndFeelPropertiesManager.get()::handleIconFile;
-            case "customStylesheet":
-                return LookAndFeelPropertiesManager.get()::handleCustomStylesheetFile;
-            default:
-                return null;
-        }
-    }
-
-    @FunctionalInterface
-    public interface SiteResourceHandler {
-        void accept(Resource resource, Container container, User user) throws ServletException, IOException;
+        return LookAndFeelPropertiesManager.get().getResourceHandler(name);
     }
 
     private boolean setSiteResource(SiteResourceHandler resourceHandler, ConfigProperty prop, User user)

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1269,6 +1269,8 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         {
             case "logoImage":
                 return LookAndFeelPropertiesManager.get()::handleLogoFile;
+            case "logoMobileImage":
+                return LookAndFeelPropertiesManager.get()::handleMobileLogoFile;
             case "iconImage":
                 return LookAndFeelPropertiesManager.get()::handleIconFile;
             case "customStylesheet":

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1167,6 +1167,16 @@ public class AdminController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
+    public static class ResetMobileLogoAction extends ResetResourceAction
+    {
+        @Override
+        protected @NotNull BiConsumer<Container, User> getDeleteResourceDelegate()
+        {
+            return LookAndFeelPropertiesManager.get()::deleteExistingMobileLogo;
+        }
+    }
+
+    @RequiresPermission(AdminPermission.class)
     public static class ResetFaviconAction extends ResetResourceAction
     {
         @Override
@@ -9997,6 +10007,20 @@ public class AdminController extends SpringActionController
                 }
             }
 
+            MultipartFile logoMobileFile = fileMap.get("logoMobileImage");
+            if (logoMobileFile != null && !logoMobileFile.isEmpty())
+            {
+                try
+                {
+                    LookAndFeelPropertiesManager.get().handleMobileLogoFile(logoMobileFile, c, getUser());
+                }
+                catch (Exception e)
+                {
+                    errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
+                    return false;
+                }
+            }
+
             MultipartFile iconFile = fileMap.get("iconImage");
             if (logoFile != null && !iconFile.isEmpty())
             {
@@ -10279,12 +10303,14 @@ public class AdminController extends SpringActionController
     public static class LookAndFeelResourcesBean extends LookAndFeelBean
     {
         public final Attachment customLogo;
+        public final Attachment customLogoMobile;
         public final Attachment customFavIcon;
         public final Attachment customStylesheet;
 
         LookAndFeelResourcesBean(Container c)
         {
             customLogo = AttachmentCache.lookupLogoAttachment(c);
+            customLogoMobile = AttachmentCache.lookupMobileLogoAttachment(c);
             customFavIcon = AttachmentCache.lookupFavIconAttachment(new LookAndFeelResourceAttachmentParent(c));
             customStylesheet = AttachmentCache.lookupCustomStylesheetAttachment(new LookAndFeelResourceAttachmentParent(c));
         }
@@ -10311,6 +10337,7 @@ public class AdminController extends SpringActionController
             // @RequiresPermission(AdminPermission.class)
             assertForAdminPermission(user,
                     new ResetLogoAction(),
+                    new ResetMobileLogoAction(),
                     new ResetPropertiesAction(),
                     new ResetFaviconAction(),
                     new DeleteCustomStylesheetAction(),

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -154,7 +154,7 @@ import org.labkey.api.settings.ConceptURIProperties;
 import org.labkey.api.settings.DateParsingMode;
 import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.settings.LookAndFeelProperties;
-import org.labkey.api.settings.LookAndFeelPropertiesManager;
+import org.labkey.api.settings.LookAndFeelPropertiesManager.ResourceType;
 import org.labkey.api.settings.NetworkDriveProps;
 import org.labkey.api.settings.WriteableAppProps;
 import org.labkey.api.settings.WriteableFolderLookAndFeelProperties;
@@ -238,7 +238,6 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1132,67 +1131,46 @@ public class AdminController extends SpringActionController
         }
     }
 
-    abstract static class ResetResourceAction extends FormHandlerAction
+    public static class ResourceForm
+    {
+        private String _resource;
+
+        public String getResource()
+        {
+            return _resource;
+        }
+
+        public void setResource(String resource)
+        {
+            _resource = resource;
+        }
+
+        public ResourceType getResourceType()
+        {
+            return ResourceType.valueOf(_resource);
+        }
+    }
+
+    @RequiresPermission(AdminPermission.class)
+    public static class ResetResourceAction extends FormHandlerAction<ResourceForm>
     {
         @Override
-        public void validateCommand(Object target, Errors errors)
+        public void validateCommand(ResourceForm target, Errors errors)
         {
         }
 
         @Override
-        public boolean handlePost(Object o, BindException errors) throws Exception
+        public boolean handlePost(ResourceForm form, BindException errors) throws Exception
         {
-            getDeleteResourceDelegate().accept(getContainer(), getUser());
+            form.getResourceType().delete(getContainer(), getUser());
             WriteableAppProps.incrementLookAndFeelRevisionAndSave();
             return true;
         }
 
         @Override
-        public URLHelper getSuccessURL(Object o)
+        public URLHelper getSuccessURL(ResourceForm form)
         {
             return new AdminUrlsImpl().getLookAndFeelResourcesURL(getContainer());
-        }
-
-        protected abstract @NotNull BiConsumer<Container, User> getDeleteResourceDelegate();
-    }
-
-    @RequiresPermission(AdminPermission.class)
-    public static class ResetLogoAction extends ResetResourceAction
-    {
-        @Override
-        protected @NotNull BiConsumer<Container, User> getDeleteResourceDelegate()
-        {
-            return LookAndFeelPropertiesManager.get()::deleteExistingLogo;
-        }
-    }
-
-    @RequiresPermission(AdminPermission.class)
-    public static class ResetMobileLogoAction extends ResetResourceAction
-    {
-        @Override
-        protected @NotNull BiConsumer<Container, User> getDeleteResourceDelegate()
-        {
-            return LookAndFeelPropertiesManager.get()::deleteExistingMobileLogo;
-        }
-    }
-
-    @RequiresPermission(AdminPermission.class)
-    public static class ResetFaviconAction extends ResetResourceAction
-    {
-        @Override
-        protected @NotNull BiConsumer<Container, User> getDeleteResourceDelegate()
-        {
-            return LookAndFeelPropertiesManager.get()::deleteExistingFavicon;
-        }
-    }
-
-    @RequiresPermission(AdminPermission.class)
-    public static class DeleteCustomStylesheetAction extends ResetResourceAction
-    {
-        @Override
-        protected @NotNull BiConsumer<Container, User> getDeleteResourceDelegate()
-        {
-            return LookAndFeelPropertiesManager.get()::deleteExistingCustomStylesheet;
         }
     }
 
@@ -9978,7 +9956,7 @@ public class AdminController extends SpringActionController
         @Override
         protected HttpView getTabView(Object o, boolean reshow, BindException errors)
         {
-            LookAndFeelResourcesBean bean = new LookAndFeelResourcesBean(getContainer());
+            LookAndFeelBean bean = new LookAndFeelBean();
             return new JspView<>("/org/labkey/core/admin/lookAndFeelResources.jsp", bean, errors);
         }
 
@@ -9993,59 +9971,21 @@ public class AdminController extends SpringActionController
             Container c = getContainer();
             Map<String, MultipartFile> fileMap = getFileMap();
 
-            MultipartFile logoFile = fileMap.get("logoImage");
-            if (logoFile != null && !logoFile.isEmpty())
+            for (ResourceType type : ResourceType.values())
             {
-                try
-                {
-                    LookAndFeelPropertiesManager.get().handleLogoFile(logoFile, c, getUser());
-                }
-                catch (Exception e)
-                {
-                    errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
-                    return false;
-                }
-            }
+                MultipartFile file = fileMap.get(type.getFieldName());
 
-            MultipartFile logoMobileFile = fileMap.get("logoMobileImage");
-            if (logoMobileFile != null && !logoMobileFile.isEmpty())
-            {
-                try
+                if (file != null && !file.isEmpty())
                 {
-                    LookAndFeelPropertiesManager.get().handleMobileLogoFile(logoMobileFile, c, getUser());
-                }
-                catch (Exception e)
-                {
-                    errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
-                    return false;
-                }
-            }
-
-            MultipartFile iconFile = fileMap.get("iconImage");
-            if (logoFile != null && !iconFile.isEmpty())
-            {
-                try
-                {
-                    LookAndFeelPropertiesManager.get().handleIconFile(iconFile, c, getUser());
-                }
-                catch (Exception e)
-                {
-                    errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
-                    return false;
-                }
-            }
-
-            MultipartFile customStylesheetFile = fileMap.get("customStylesheet");
-            if (customStylesheetFile != null && !customStylesheetFile.isEmpty())
-            {
-                try
-                {
-                    LookAndFeelPropertiesManager.get().handleCustomStylesheetFile(customStylesheetFile, c, getUser());
-                }
-                catch (Exception e)
-                {
-                    errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
-                    return false;
+                    try
+                    {
+                        type.save(file, c, getUser());
+                    }
+                    catch (Exception e)
+                    {
+                        errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
+                        return false;
+                    }
                 }
             }
 
@@ -10300,23 +10240,6 @@ public class AdminController extends SpringActionController
     }
 
 
-    public static class LookAndFeelResourcesBean extends LookAndFeelBean
-    {
-        public final Attachment customLogo;
-        public final Attachment customLogoMobile;
-        public final Attachment customFavIcon;
-        public final Attachment customStylesheet;
-
-        LookAndFeelResourcesBean(Container c)
-        {
-            customLogo = AttachmentCache.lookupLogoAttachment(c);
-            customLogoMobile = AttachmentCache.lookupMobileLogoAttachment(c);
-            customFavIcon = AttachmentCache.lookupFavIconAttachment(new LookAndFeelResourceAttachmentParent(c));
-            customStylesheet = AttachmentCache.lookupCustomStylesheetAttachment(new LookAndFeelResourceAttachmentParent(c));
-        }
-    }
-
-
     public static class TestCase extends AbstractActionPermissionTest
     {
         @Override
@@ -10336,11 +10259,8 @@ public class AdminController extends SpringActionController
 
             // @RequiresPermission(AdminPermission.class)
             assertForAdminPermission(user,
-                    new ResetLogoAction(),
-                    new ResetMobileLogoAction(),
+                    new ResetResourceAction(),
                     new ResetPropertiesAction(),
-                    new ResetFaviconAction(),
-                    new DeleteCustomStylesheetAction(),
                     controller.new SiteValidationAction(),
                     controller.new ResetQueryStatisticsAction(),
                     controller.new FolderAliasesAction(),

--- a/core/src/org/labkey/core/admin/lookAndFeelResources.jsp
+++ b/core/src/org/labkey/core/admin/lookAndFeelResources.jsp
@@ -16,23 +16,18 @@
  */
 %>
 <%@ page import="org.labkey.api.admin.AdminUrls"%>
-<%@ page import="org.labkey.api.admin.CoreUrls" %>
 <%@ page import="org.labkey.api.data.Container" %>
-<%@ page import="org.labkey.api.settings.TemplateResourceHandler" %>
+<%@ page import="org.labkey.api.security.permissions.ApplicationAdminPermission" %>
+<%@ page import="org.labkey.api.settings.LookAndFeelPropertiesManager.ResourceType" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
-<%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
-<%@ page import="org.labkey.core.admin.AdminController" %>
-<%@ page import="org.labkey.core.admin.AdminController.DeleteCustomStylesheetAction" %>
-<%@ page import="org.labkey.core.admin.AdminController.ResetFaviconAction" %>
-<%@ page import="org.labkey.core.admin.AdminController.ResetLogoAction" %>
-<%@ page import="org.labkey.core.admin.AdminController.ResetMobileLogoAction" %>
-<%@ page import="org.labkey.api.security.permissions.ApplicationAdminPermission" %>
+<%@ page import="org.labkey.core.admin.AdminController.LookAndFeelBean" %>
+<%@ page import="org.labkey.core.admin.AdminController.ResetResourceAction" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
-    AdminController.LookAndFeelResourcesBean bean = ((JspView<AdminController.LookAndFeelResourcesBean>)HttpView.currentView()).getModelBean();
+    LookAndFeelBean bean = ((JspView<LookAndFeelBean>)HttpView.currentView()).getModelBean();
     Container c = getContainer();
     boolean canUpdate = !c.isRoot() || c.hasPermission(getUser(), ApplicationAdminPermission.class);
     HtmlString rowSpan = HtmlString.of(!canUpdate ? "1" : "2");
@@ -47,93 +42,42 @@
 </tr>
 
 <tr>
-    <td colspan=2>Customize the logo, icon, and stylesheets used <%=text(c.isRoot() ? "throughout the site" : "in this project")%> (<%=bean.helpLink%>)</td>
+    <td colspan=2>Customize the header logo, responsive logo, favorite icon, and stylesheet used <%=h(c.isRoot() ? "throughout the site" : "in this project")%> (<%=bean.helpLink%>)</td>
 </tr>
 <tr>
     <td colspan=2>&nbsp;</td>
 </tr>
-<tr>
-    <td class="labkey-form-label" rowspan="<%=rowSpan%>">Header logo<%=helpPopup("Header Logo", "Appears in the header on every page when the page width is greater than 767px.<br><br>Recommend size: 100px x 30px", true, 300)%></td>
-    <td>
-        <% if (null != bean.customLogo)
-        { %>
-            Currently using a custom header logo. <%=link("view logo", TemplateResourceHandler.LOGO.getURL(c))%> <%=canUpdate ? link("reset header logo to default", ResetLogoAction.class).usePost() : HtmlString.EMPTY_STRING%>
-        <% } else { %>
-            Currently using the default header logo.
-        <% } %>
-    </td>
-</tr>
 <%
-    if (canUpdate)
+    for (ResourceType type : ResourceType.values())
     {
 %>
-<tr>
-    <td>Replace with: <input type="file" name="logoImage" size="25" style="border: none;"></td>
-</tr>
+    <tr>
+        <td class="labkey-form-label" rowspan="<%=rowSpan%>"><%=h(type.getLongLabel())%><%=type.getHelpPopup()%></td>
+        <td>
+            <% if (type.isSet(getContainer()))
+            { %>
+            Currently using a custom <%=h(type.getShortLabel().toLowerCase())%>. <%=type.getViewLink(getContainer()).target("_view")%> <%=canUpdate ? link(type.getDeleteText(), urlFor(ResetResourceAction.class).addParameter("resource", type.name())).usePost() : HtmlString.EMPTY_STRING%>
+            <% } else { %>
+            <%=h(type.getDefaultText())%>.
+            <% } %>
+        </td>
+    </tr>
 <%
-    }
+        if (canUpdate)
+        {
 %>
-<tr>
-    <td class="labkey-form-label" rowspan="<%=rowSpan%>">Responsive logo<%=helpPopup("Responsive Logo", "Appears in the header on every page when the page width is less than 768px.<br><br>Recommend size: 30px x 30px", true, 300)%></td>
-    <td>
-        <% if (null != bean.customLogoMobile)
-        { %>
-        Currently using a custom responsive logo. <%=link("view logo", TemplateResourceHandler.LOGO_MOBILE.getURL(c))%> <%=canUpdate ? link("reset responsive logo to default", ResetMobileLogoAction.class).usePost() : HtmlString.EMPTY_STRING%>
-        <% } else { %>
-        Currently using the default responsive logo.
-        <% } %>
-    </td>
-</tr>
+    <tr>
+        <td>Replace with: <input type="file" name="<%=type.getFieldName()%>" size="25" style="border: none;"></td>
+    </tr>
 <%
-    if (canUpdate)
-    {
-%>
-<tr>
-    <td>Replace with: <input type="file" name="logoMobileImage" size="25" style="border: none;"></td>
-</tr>
-<%
-    }
-%>
-<tr>
-    <td class="labkey-form-label" rowspan="<%=rowSpan%>">Favorite icon (displayed in user's favorites or bookmarks, .ico file only)</td>
-    <td>
-        <% if (null != bean.customFavIcon)
-        { %>
-            Currently using a custom favorite icon. <%=link("view icon", TemplateResourceHandler.FAVICON.getURL(c))%> <%=canUpdate ? link("reset favorite icon to default", ResetFaviconAction.class).usePost() : HtmlString.EMPTY_STRING%>
-        <% } else { %>
-            Currently using the default favorite icon.
-        <% } %>
-    </td>
-</tr>
-<%
-    if (canUpdate)
-    {
-%>
-<tr>
-    <td>Replace with: <input type="file" name="iconImage" size="25" style="border: none;"></td>
-</tr>
-<%
+        }
     }
 %>
 
-<tr>
-    <td class="labkey-form-label" rowspan="<%=rowSpan%>">Custom stylesheet</td>
-    <td>
-        <% if (null != bean.customStylesheet)
-        { %>
-            Currently using a custom stylesheet. <%=link("view CSS", PageFlowUtil.urlProvider(CoreUrls.class).getCustomStylesheetURL(getContainer()))%> <%=canUpdate ? link("delete custom stylesheet", DeleteCustomStylesheetAction.class).usePost() : HtmlString.EMPTY_STRING%>
-        <% } else { %>
-            No custom stylesheet.
-        <% } %>
-    </td>
-</tr>
 <%
     if (canUpdate)
     {
 %>
-<tr>
-    <td>Replace with: <input type="file" name="customStylesheet" size="25" style="border: none;"></td>
-</tr>
 <tr>
     <td><br/><%=button("Save").submit(true).onClick("_form.setClean();")%></td>
 </tr>

--- a/core/src/org/labkey/core/admin/lookAndFeelResources.jsp
+++ b/core/src/org/labkey/core/admin/lookAndFeelResources.jsp
@@ -18,7 +18,6 @@
 <%@ page import="org.labkey.api.admin.AdminUrls"%>
 <%@ page import="org.labkey.api.admin.CoreUrls" %>
 <%@ page import="org.labkey.api.data.Container" %>
-<%@ page import="org.labkey.api.security.permissions.AdminOperationsPermission" %>
 <%@ page import="org.labkey.api.settings.TemplateResourceHandler" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.util.PageFlowUtil" %>
@@ -28,6 +27,7 @@
 <%@ page import="org.labkey.core.admin.AdminController.DeleteCustomStylesheetAction" %>
 <%@ page import="org.labkey.core.admin.AdminController.ResetFaviconAction" %>
 <%@ page import="org.labkey.core.admin.AdminController.ResetLogoAction" %>
+<%@ page import="org.labkey.core.admin.AdminController.ResetMobileLogoAction" %>
 <%@ page import="org.labkey.api.security.permissions.ApplicationAdminPermission" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
@@ -53,13 +53,13 @@
     <td colspan=2>&nbsp;</td>
 </tr>
 <tr>
-    <td class="labkey-form-label" rowspan="<%=rowSpan%>">Header logo (appears in every page header in the upper left)</td>
+    <td class="labkey-form-label" rowspan="<%=rowSpan%>">Header logo<%=helpPopup("Header Logo", "Appears in the header on every page when the page width is greater than 767px.<br><br>Recommend size: 100px x 30px", true, 300)%></td>
     <td>
         <% if (null != bean.customLogo)
         { %>
-            Currently using a custom logo. <%=link("view logo", TemplateResourceHandler.LOGO.getURL(c))%> <%=canUpdate ? link("reset logo to default", ResetLogoAction.class).usePost() : HtmlString.EMPTY_STRING%>
+            Currently using a custom header logo. <%=link("view logo", TemplateResourceHandler.LOGO.getURL(c))%> <%=canUpdate ? link("reset header logo to default", ResetLogoAction.class).usePost() : HtmlString.EMPTY_STRING%>
         <% } else { %>
-            Currently using the default logo.
+            Currently using the default header logo.
         <% } %>
     </td>
 </tr>
@@ -73,7 +73,27 @@
 <%
     }
 %>
-
+<tr>
+    <td class="labkey-form-label" rowspan="<%=rowSpan%>">Responsive logo<%=helpPopup("Responsive Logo", "Appears in the header on every page when the page width is less than 768px.<br><br>Recommend size: 30px x 30px", true, 300)%></td>
+    <td>
+        <% if (null != bean.customLogoMobile)
+        { %>
+        Currently using a custom responsive logo. <%=link("view logo", TemplateResourceHandler.LOGO_MOBILE.getURL(c))%> <%=canUpdate ? link("reset responsive logo to default", ResetMobileLogoAction.class).usePost() : HtmlString.EMPTY_STRING%>
+        <% } else { %>
+        Currently using the default responsive logo.
+        <% } %>
+    </td>
+</tr>
+<%
+    if (canUpdate)
+    {
+%>
+<tr>
+    <td>Replace with: <input type="file" name="logoMobileImage" size="25" style="border: none;"></td>
+</tr>
+<%
+    }
+%>
 <tr>
     <td class="labkey-form-label" rowspan="<%=rowSpan%>">Favorite icon (displayed in user's favorites or bookmarks, .ico file only)</td>
     <td>


### PR DESCRIPTION
#### Rationale
During the UI improvements a few years ago we introduced the concept of a "mobile" logo which we use as the header logo in medium or smaller responsive layouts. [Issue 39793](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39793) points out how this was never made configurable by the user and thus all sites experience our default LabKey logo when the page width is less than 768px.

With this PR users can now configure a "Responsive Logo" that will be used in these layouts.

![LogoResize](https://user-images.githubusercontent.com/3926239/79536589-45bf2c00-8035-11ea-9bf9-38cff24f9727.gif)

This is configured via Look & Feel Settings under the resources tab.

#### Changes
* Add option to Look & Feel Settings to set a responsive logo.
* Factor out persistence logic common to both logo variants.
* Refactor Look & Feel resource handling, introducing ResourceType enum to eliminate duplicated code blocks.