### PR TITLE
Fix core/package-lock.json

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -11005,7 +11005,7 @@
     },
     "rgba-regex": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
     },


### PR DESCRIPTION
#### Rationale
Flip `package-lock.json` for core module back to `https` for the `rgba-regex` package dependency. This is due to https://npm.community/t/npm-install-downgrading-resolved-packages-from-https-to-http-registry-in-package-lock-json/1818. This was accidentally inverted with #1064.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1064

#### Changes
* `+s`
