### PR TITLE
Issue 40221: Update verbiage in standard database authentication audit log entry

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -913,7 +913,7 @@ public class AuthenticationManager
             return new PrimaryAuthenticationResult(AuthenticationStatus.InactiveUser);
         }
 
-        addAuditEvent(user, request, email + " " + UserManager.UserAuditEvent.LOGGED_IN + " successfully via " + response.getConfiguration().getDescription() + " authentication.");
+        addAuditEvent(user, request, email + " " + UserManager.UserAuditEvent.LOGGED_IN + " successfully via the \"" + response.getConfiguration().getDescription() + "\" configuration.");
 
         return new PrimaryAuthenticationResult(user, response);
     }


### PR DESCRIPTION
#### Rationale
I recently changed the "successfully logged in" audit message to include the description of the configuration followed by " authentication". (Previously, we only logged the provider name, which could now be ambiguous given that we support multiple configurations per provider.) That was a good change, but it caused the AuditLogTest to fail, since it expected the old message. It also produced an odd message in the case of database authentication: **...logged in successfully via Standard database authentication authentication.**

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/315

#### Changes
* Tweak message to **...logged in successfully via the "\<description\>" configuration.** For example, **...logged in successfully via the "Standard database authentication" configuration.** or **...logged in successfully via the "CAS against labkey.org" configuration.**