### PR TITLE
Improve external schema delete action and database version handling

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -1689,6 +1689,7 @@ public class AnnouncementsController extends SpringActionController
             return _stringValues.get("parentid");
         }
 
+        @SuppressWarnings("unused")
         public void setMemberListInput(String memberListInput)
         {
             _memberListInput = memberListInput;
@@ -1825,14 +1826,14 @@ public class AnnouncementsController extends SpringActionController
 
         public boolean isFromDiscussion()
         {
-            String fromDiscussion = (String)get("fromDiscussion");
+            String fromDiscussion = get("fromDiscussion");
 
             return Boolean.parseBoolean(fromDiscussion);
         }
 
         public boolean allowMultipleDiscussions()
         {
-            String fromDiscussion = (String)get("allowMultipleDiscussions");
+            String fromDiscussion = get("allowMultipleDiscussions");
 
             return Boolean.parseBoolean(fromDiscussion);
         }

--- a/api/src/org/labkey/api/action/ConfirmAction.java
+++ b/api/src/org/labkey/api/action/ConfirmAction.java
@@ -17,17 +17,15 @@
 package org.labkey.api.action;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
-import org.labkey.api.view.HttpView;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.RedirectException;
-import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.template.PageConfig;
 import org.springframework.beans.PropertyValues;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
-import org.labkey.api.util.URLHelper;
 
 /**
  * Base class for actions that want to show a full-page confirmation step prior to performing the actual operation.
@@ -56,10 +54,9 @@ public abstract class ConfirmAction<FORM> extends BaseViewAction<FORM>
         return false;
     }
 
+    @Override
     public final ModelAndView handleRequest() throws Exception
     {
-        ViewContext context = HttpView.currentContext();
-
         BindException errors = bindParameters(getPropertyValues());
         FORM form = (FORM)errors.getTarget();
 
@@ -86,7 +83,7 @@ public abstract class ConfirmAction<FORM> extends BaseViewAction<FORM>
             else
             {
                 ModelAndView confirmView = getConfirmView(form, errors);
-                JspView<ConfirmAction> confirmWrapper = new JspView<>("/org/labkey/api/action/confirmWrapper.jsp", this);
+                JspView<ConfirmAction<FORM>> confirmWrapper = new JspView<>("/org/labkey/api/action/confirmWrapper.jsp", this);
                 confirmWrapper.setBody(confirmView);
                 getPageConfig().setTemplate(PageConfig.Template.Dialog);
 
@@ -108,6 +105,7 @@ public abstract class ConfirmAction<FORM> extends BaseViewAction<FORM>
     }
 
 
+    @Override
     protected String getCommandClassMethodName()
     {
         return "handlePost";
@@ -133,6 +131,7 @@ public abstract class ConfirmAction<FORM> extends BaseViewAction<FORM>
      */
     public abstract boolean handlePost(FORM form, BindException errors) throws Exception;
 
+    @Override
     public void validate(Object form, Errors errors)
     {
         validateCommand((FORM)form, errors);

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -330,12 +330,14 @@ public class DbScope
             }
             finally
             {
+                String dialectProductVersion = null != _dialect ? _dialect.getProductVersion() : null;
+
                 // Always log the attempt, even if DatabaseNotSupportedException, etc. occurs, to help with diagnosis
                 LOG.info("Initializing DbScope with the following configuration:" +
                         "\n    DataSource Name:          " + dsName +
                         "\n    Server URL:               " + dbmd.getURL() +
                         "\n    Database Product Name:    " + dbmd.getDatabaseProductName() +
-                        "\n    Database Product Version: " + dbmd.getDatabaseProductVersion() +
+                        "\n    Database Product Version: " + (null != dialectProductVersion ? dialectProductVersion : dbmd.getDatabaseProductVersion()) +
                         "\n    JDBC Driver Name:         " + dbmd.getDriverName() +
                         "\n    JDBC Driver Version:      " + dbmd.getDriverVersion() +
     (null != _dialect ? "\n    SQL Dialect:              " + _dialect.getClass().getSimpleName() : "") +
@@ -406,7 +408,9 @@ public class DbScope
 
     public String getDatabaseProductVersion()
     {
-        return _databaseProductVersion;
+        // Prefer the dialect's product version over DatabaseMetaData.getDatabaseProductVersion()
+        String dialectProductVersion = _dialect.getProductVersion();
+        return null != dialectProductVersion ? dialectProductVersion : _databaseProductVersion;
     }
 
     public String getDriverName()

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -322,6 +322,7 @@ public class DbScope
             DatabaseMetaData dbmd = conn.getMetaData();
             _dsProps = new DataSourceProperties(dsName, dataSource);
             Integer maxTotal = _dsProps.getMaxTotal();
+            _databaseProductVersion = dbmd.getDatabaseProductVersion();
 
             try
             {
@@ -330,14 +331,12 @@ public class DbScope
             }
             finally
             {
-                String dialectProductVersion = null != _dialect ? _dialect.getProductVersion() : null;
-
                 // Always log the attempt, even if DatabaseNotSupportedException, etc. occurs, to help with diagnosis
                 LOG.info("Initializing DbScope with the following configuration:" +
                         "\n    DataSource Name:          " + dsName +
                         "\n    Server URL:               " + dbmd.getURL() +
                         "\n    Database Product Name:    " + dbmd.getDatabaseProductName() +
-                        "\n    Database Product Version: " + (null != dialectProductVersion ? dialectProductVersion : dbmd.getDatabaseProductVersion()) +
+                        "\n    Database Product Version: " + (null != _dialect ? _dialect.getProductVersion(_databaseProductVersion) : _databaseProductVersion) +
                         "\n    JDBC Driver Name:         " + dbmd.getDriverName() +
                         "\n    JDBC Driver Version:      " + dbmd.getDriverVersion() +
     (null != _dialect ? "\n    SQL Dialect:              " + _dialect.getClass().getSimpleName() : "") +
@@ -350,7 +349,6 @@ public class DbScope
             _databaseName = _dialect.getDatabaseName(_dsProps);
             _URL = dbmd.getURL();
             _databaseProductName = dbmd.getDatabaseProductName();
-            _databaseProductVersion = dbmd.getDatabaseProductVersion();
             _driverName = dbmd.getDriverName();
             _driverVersion = dbmd.getDriverVersion();
             _labkeyProps = props;
@@ -408,9 +406,8 @@ public class DbScope
 
     public String getDatabaseProductVersion()
     {
-        // Prefer the dialect's product version over DatabaseMetaData.getDatabaseProductVersion()
-        String dialectProductVersion = _dialect.getProductVersion();
-        return null != dialectProductVersion ? dialectProductVersion : _databaseProductVersion;
+        // Dialect may be able to provide more useful version information
+        return _dialect.getProductVersion(_databaseProductVersion);
     }
 
     public String getDriverName()

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -119,11 +119,6 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
         _tinfo = tinfo;
     }
 
-    protected void setDynaClass(StringWrapperDynaClass dynaClass)
-    {
-        _dynaClass = dynaClass;
-    }
-
     /**
      * Sets the table. NOTE This will also overwrite any previously
      * set dynaClass with one derived from the table.
@@ -193,7 +188,7 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
             set("container", _c.getId());
 
         Object[] pkVal = getPkVals();
-        Map newMap = Table.update(_user, _tinfo, getTypedValues(), pkVal);
+        Map<String, Object> newMap = Table.update(_user, _tinfo, getTypedValues(), pkVal);
         setTypedValues(newMap, true);
     }
 
@@ -656,6 +651,7 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
         return _stringValues.containsKey(col.getFormFieldName(ctx));
     }
 
+    @Override
     public String get(String arg0)
     {
         return _stringValues.get(arg0);
@@ -666,6 +662,7 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
         return _stringValues.get(getFormFieldName(col));
     }
 
+    @Override
     public void set(String arg0, Object arg1)
     {
         String v;
@@ -687,36 +684,43 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
         _values = null;
     }
 
+    @Override
     public boolean contains(String arg0, String arg1)
     {
         throw new UnsupportedOperationException("No mapped properties in a table");
     }
 
+    @Override
     public Object get(String arg0, String arg1)
     {
         throw new UnsupportedOperationException("No mapped properties in a table");
     }
 
+    @Override
     public Object get(String arg0, int arg1)
     {
         throw new UnsupportedOperationException("No indexed properties in a table");
     }
 
+    @Override
     public DynaClass getDynaClass()
     {
         return _dynaClass;
     }
 
+    @Override
     public void remove(String arg0, String arg1)
     {
         throw new UnsupportedOperationException("No indexed properties in a table");
     }
 
+    @Override
     public void set(String arg0, String arg1, Object arg2)
     {
         throw new UnsupportedOperationException("No mapped properties in a table");
     }
 
+    @Override
     public void set(String arg0, int arg1, Object arg2)
     {
         throw new UnsupportedOperationException("No indexed properties in a table");
@@ -798,7 +802,7 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
         catch (Exception ignored) {}
     }
 
-
+    @Override
     public @NotNull BindException bindParameters(PropertyValues params)
     {
         /*

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -79,8 +79,6 @@ public abstract class SqlDialect
     protected static final String INPUT_TOO_LONG_ERROR_MESSAGE = "The input you provided was too long.";
     protected static final int MAX_VARCHAR_SIZE = 4000;  //Any length over this will be set to nvarchar(max)/text
 
-    private int _databaseVersion = 0;
-    private String _productVersion = "0";
     private DialectStringHandler _stringHandler = null;
 
     private final Set<String> _reservedWordSet;
@@ -435,34 +433,14 @@ public abstract class SqlDialect
         return keywordSet;
     }
 
-    // Internal version number
-    public int getDatabaseVersion()
-    {
-        return _databaseVersion;
-    }
-
-    public void setDatabaseVersion(int databaseVersion)
-    {
-        _databaseVersion = databaseVersion;
-    }
-
-    // Human readable product version number
-    public String getProductVersion()
-    {
-        return _productVersion;
-    }
-
-    public void setProductVersion(String productVersion)
-    {
-        _productVersion = productVersion;
-    }
-
-    public abstract String getProductName();
-
-    public @Nullable String getProductEdition()
+    // Human readable product version number. Dialects should override this if they can provide a more useful product
+    // version than DatabaseMetaData.getDatabaseProductVersion().
+    public @Nullable String getProductVersion()
     {
         return null;
     }
+
+    public abstract String getProductName();
 
     public abstract String getSQLScriptPath();
 

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -433,11 +433,11 @@ public abstract class SqlDialect
         return keywordSet;
     }
 
-    // Human readable product version number. Dialects should override this if they can provide a more useful product
-    // version than DatabaseMetaData.getDatabaseProductVersion().
-    public @Nullable String getProductVersion()
+    // Human readable product version number. Pass through by default; dialects should override this if they can provide
+    // more useful product version information than what's returned from DatabaseMetaData.getDatabaseProductVersion().
+    public @Nullable String getProductVersion(String dbmdProductVersion)
     {
-        return null;
+        return dbmdProductVersion;
     }
 
     public abstract String getProductName();

--- a/api/src/org/labkey/api/query/QueryChangeListener.java
+++ b/api/src/org/labkey/api/query/QueryChangeListener.java
@@ -86,7 +86,7 @@ public interface QueryChangeListener
     Collection<String> queryDependents(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull Collection<String> queries);
 
     // CONSIDER: Create a generic class instead of using an enum.
-    public enum QueryProperty
+    enum QueryProperty
     {
         Name(String.class),
         Container(Container.class),
@@ -138,10 +138,16 @@ public interface QueryChangeListener
         }
 
         public QueryDefinition getSource() { return _queryDef; }
+
+        @Override
         @NotNull
         public QueryProperty getProperty() { return _property; }
+
+        @Override
         @Nullable
         public V getOldValue() { return _oldValue; }
+
+        @Override
         @Nullable
         public V getNewValue() { return _newValue; }
     }

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -151,7 +151,6 @@ public interface QueryService
      * NOTE: user is not the owner of the custom views, but is used for container and schema permission checks.
      */
     List<CustomView> getSharedCustomViews(@NotNull User user, Container container, @Nullable String schemaName, @Nullable String queryName, boolean includeInherited);
-    CustomView getSharedCustomView(@NotNull User user, Container container, String schema, String query, String name);
 
     /**
      * Returns custom views stored in the database (not module custom views) that meet the criteria. This is not appropriate

--- a/api/src/org/labkey/api/query/QueryUpdateForm.java
+++ b/api/src/org/labkey/api/query/QueryUpdateForm.java
@@ -68,6 +68,7 @@ public class QueryUpdateForm extends TableViewForm
         }
     }
 
+    @Override
     @Nullable
     public ColumnInfo getColumnByFormFieldName(@NotNull String name)
     {
@@ -77,9 +78,9 @@ public class QueryUpdateForm extends TableViewForm
         return getTable().getColumn(_ignorePrefix ? name : name.substring(PREFIX.length()));
     }
 
+    @Override
     public String getFormFieldName(@NotNull ColumnInfo column)
     {
         return (_ignorePrefix ? "" : PREFIX) + column.getName();
     }
-
 }

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -79,7 +79,6 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
 
     private volatile boolean _groupConcatInstalled = false;
     private volatile String _versionYear = null;
-    private volatile String _versionNumber = null;
     private volatile Edition _edition = null;
 
     @SuppressWarnings("unused")
@@ -245,20 +244,15 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
         return MicrosoftSqlServerDialectFactory.PRODUCT_NAME;
     }
 
-    void setVersionNumber(String versionNumber)
-    {
-        _versionNumber = versionNumber;
-    }
-
     void setVersionYear(String versionYear)
     {
         _versionYear = versionYear;
     }
 
     @Override
-    public String getProductVersion()
+    public String getProductVersion(String dbmdProductVersion)
     {
-        return _versionYear + " (" + _versionNumber + ")" + (null != _edition ? " " + _edition.name() + " Edition" : "");
+        return _versionYear + " (" + dbmdProductVersion + ")" + (null != _edition ? " " + _edition.name() + " Edition" : "");
     }
 
     @Override
@@ -1665,8 +1659,8 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     {
         ClrAssemblyManager.addAdminWarningMessages(warnings);
 
-        if ("2008R2".equals(getProductVersion()))
-            warnings.add(HtmlString.of("LabKey Server no longer supports " + getProductName() + " " + getProductVersion() + "; please upgrade. " + MicrosoftSqlServerDialectFactory.RECOMMENDED));
+        if ("2008R2".equals(_versionYear))
+            warnings.add(HtmlString.of("LabKey Server no longer supports " + getProductName() + " " + _versionYear + "; please upgrade. " + MicrosoftSqlServerDialectFactory.RECOMMENDED));
     }
 
     @Override

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -78,7 +78,9 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     private static final int MAX_INDEX_SIZE = 900;
 
     private volatile boolean _groupConcatInstalled = false;
-    private volatile Edition _edition = Edition.Unknown;
+    private volatile String _versionYear = null;
+    private volatile String _versionNumber = null;
+    private volatile Edition _edition = null;
 
     @SuppressWarnings("unused")
     enum Edition
@@ -243,11 +245,20 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
         return MicrosoftSqlServerDialectFactory.PRODUCT_NAME;
     }
 
-    @Nullable
-    @Override
-    public String getProductEdition()
+    void setVersionNumber(String versionNumber)
     {
-        return _edition.name() + " Edition";
+        _versionNumber = versionNumber;
+    }
+
+    void setVersionYear(String versionYear)
+    {
+        _versionYear = versionYear;
+    }
+
+    @Override
+    public String getProductVersion()
+    {
+        return _versionYear + " (" + _versionNumber + ")" + (null != _edition ? " " + _edition.name() + " Edition" : "");
     }
 
     @Override

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
@@ -78,14 +78,15 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
         if (!md.getDatabaseProductName().equals(getProductName()))
             return null;
 
-        VersionNumber versionNumber = new VersionNumber(md.getDatabaseProductVersion());
+        String jdbcProductVersion = md.getDatabaseProductVersion();
+        VersionNumber versionNumber = new VersionNumber(jdbcProductVersion);
         int version = versionNumber.getVersionInt();
 
         // Get the appropriate dialect and stash version information
-        SqlDialect dialect = getDialect(version, md.getDatabaseProductVersion(), logWarnings, primaryDataSource);
-        dialect.setDatabaseVersion(version);
+        BaseMicrosoftSqlServerDialect dialect = getDialect(version, jdbcProductVersion, logWarnings, primaryDataSource);
+        dialect.setVersionNumber(jdbcProductVersion);
         String className = dialect.getClass().getSimpleName();
-        dialect.setProductVersion(className.substring(18, className.indexOf("Dialect")));
+        dialect.setVersionYear(className.substring(18, className.indexOf("Dialect")));
 
         String driverName = md.getDriverName();
 
@@ -95,7 +96,7 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
         return dialect;
     }
 
-    private SqlDialect getDialect(int version, String databaseProductVersion, boolean logWarnings, boolean primaryDataSource)
+    private BaseMicrosoftSqlServerDialect getDialect(int version, String databaseProductVersion, boolean logWarnings, boolean primaryDataSource)
     {
         // Good resources for past & current SQL Server version numbers:
         // - http://www.sqlteam.com/article/sql-server-versions
@@ -140,7 +141,7 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
     }
 
     @Override
-    public Collection<? extends Class> getJUnitTests()
+    public Collection<? extends Class<?>> getJUnitTests()
     {
         return Arrays.asList(DialectRetrievalTestCase.class, InlineProcedureTestCase.class, JdbcHelperTestCase.class);
     }
@@ -166,6 +167,7 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
 
     public static class DialectRetrievalTestCase extends AbstractDialectRetrievalTestCase
     {
+        @Override
         public void testDialectRetrieval()
         {
             // These should result in bad database exception

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
@@ -82,9 +82,8 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
         VersionNumber versionNumber = new VersionNumber(jdbcProductVersion);
         int version = versionNumber.getVersionInt();
 
-        // Get the appropriate dialect and stash version information
+        // Get the appropriate dialect and stash the version year
         BaseMicrosoftSqlServerDialect dialect = getDialect(version, jdbcProductVersion, logWarnings, primaryDataSource);
-        dialect.setVersionNumber(jdbcProductVersion);
         String className = dialect.getClass().getSimpleName();
         dialect.setVersionYear(className.substring(18, className.indexOf("Dialect")));
 

--- a/core/src/org/labkey/core/admin/admin.jsp
+++ b/core/src/org/labkey/core/admin/admin.jsp
@@ -51,9 +51,6 @@
     catch (Exception ignored)
     {}
 
-    String edition = bean.scope.getSqlDialect().getProductEdition();
-    String databaseProductVersion = bean.scope.getDatabaseProductVersion() + (null != edition ? " (" + edition + ")" : "");
-
     int row = 0;
 %>
 <style type="text/css">
@@ -84,7 +81,7 @@
                 <tr><td class="labkey-column-header">Property</td><td class="labkey-column-header">Value</td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Database Server URL</td><td id="databaseServerURL"><%=h(bean.scope.getURL())%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Database Product Name</td><td id="databaseProductName"><%=h(bean.scope.getDatabaseProductName())%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Database Product Version</td><td id="databaseProductVersion"><%=h(databaseProductVersion)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Database Product Version</td><td id="databaseProductVersion"><%=h(bean.scope.getDatabaseProductVersion())%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>JDBC Driver Name</td><td id="databaseDriverName"><%=h(bean.scope.getDriverName())%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>JDBC Driver Version</td><td id="databaseDriverVersion"><%=h(bean.scope.getDriverVersion())%></td></tr><%
                 if (null != location)

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -82,11 +82,8 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
 
         // Get the appropriate dialect and stash version information
         int version = versionNumber.getVersionInt();
-        SqlDialect dialect = getDialect(version, databaseProductVersion, logWarnings);
-        dialect.setDatabaseVersion(version);
-        dialect.setProductVersion(String.valueOf(version/(double)10));
 
-        return dialect;
+        return getDialect(version, databaseProductVersion, logWarnings);
     }
 
     private @NotNull SqlDialect getDialect(int version, String databaseProductVersion, boolean logWarnings)

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -80,10 +80,8 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
 
         VersionNumber versionNumber = new VersionNumber(databaseProductVersion);
 
-        // Get the appropriate dialect and stash version information
-        int version = versionNumber.getVersionInt();
-
-        return getDialect(version, databaseProductVersion, logWarnings);
+        // Return the appropriate dialect based on the version
+        return getDialect(versionNumber.getVersionInt(), databaseProductVersion, logWarnings);
     }
 
     private @NotNull SqlDialect getDialect(int version, String databaseProductVersion, boolean logWarnings)

--- a/internal/src/org/labkey/api/data/BeanViewForm.java
+++ b/internal/src/org/labkey/api/data/BeanViewForm.java
@@ -82,6 +82,7 @@ public class BeanViewForm<K> extends TableViewForm implements DynaBean
         this.setTypedValues(factory.toMap(bean, null), false);
     }
 
+    @Override
     public Map<String, String> getStrings()
     {
         //If we don't have strings and do have typed values then
@@ -100,6 +101,7 @@ public class BeanViewForm<K> extends TableViewForm implements DynaBean
         return strings;
     }
 
+    @Override
     public void setOldValues(Object o)
     {
         if (o == null)

--- a/issues/src/org/labkey/issue/CustomColumnConfiguration.java
+++ b/issues/src/org/labkey/issue/CustomColumnConfiguration.java
@@ -29,18 +29,9 @@ import java.util.Map;
 public interface CustomColumnConfiguration
 {
     CustomColumn getCustomColumn(String name);
-
     Map<String, DomainProperty> getPropertyMap();
     Collection<DomainProperty> getCustomProperties();
-
-    @Deprecated
-    Collection<CustomColumn> getCustomColumns();
     Collection<CustomColumn> getCustomColumns(User user);
-
-    @Deprecated
-    boolean shouldDisplay(String name);
     boolean shouldDisplay(User user, String name);
-
-    @Nullable
-    String getCaption(String name);
+    @Nullable String getCaption(String name);
 }

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -140,7 +140,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -358,6 +357,7 @@ public class IssuesController extends SpringActionController
             return issueDefName;
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             String issueDefName = getViewContext().getActionURL().getParameter(IssuesListView.ISSUE_LIST_DEF_NAME);
@@ -400,6 +400,7 @@ public class IssuesController extends SpringActionController
             }
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             return null;
@@ -453,6 +454,7 @@ public class IssuesController extends SpringActionController
             return new JspView<>("/org/labkey/issue/view/detailView.jsp", page);
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             NavTree nav = new ListAction(getViewContext()).appendNavTrail(root);
@@ -617,6 +619,7 @@ public class IssuesController extends SpringActionController
             return new JspView<>("/org/labkey/issue/view/updateView.jsp", page);
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             IssueManager.EntryTypeNames names = getEntryTypeNames();
@@ -973,9 +976,7 @@ public class IssuesController extends SpringActionController
                         // update the duplicate issue
                         if (duplicateOf != null)
                         {
-                            StringBuilder sb = new StringBuilder();
-                            sb.append("<em>Issue ").append(issue.getIssueId()).append(" marked as duplicate of this issue.</em>");
-                            duplicateOf.addComment(getUser(), sb.toString());
+                            duplicateOf.addComment(getUser(), "<em>Issue " + issue.getIssueId() + " marked as duplicate of this issue.</em>");
                             IssueManager.saveIssue(getUser(), getContainer(), duplicateOf);
                         }
 
@@ -1259,6 +1260,7 @@ public class IssuesController extends SpringActionController
             }
         }
 
+        @Override
         public ActionURL getSuccessURL(IssuesController.IssuesForm form)
         {
             if (getIssue(form.getIssueId(), false).getStatus().equals("closed"))
@@ -1335,7 +1337,7 @@ public class IssuesController extends SpringActionController
             visible.add("attachments");
 
             // Add all the enabled custom fields
-            for (CustomColumn cc : ccc.getCustomColumns())
+            for (CustomColumn cc : ccc.getCustomColumns(getUser()))
             {
                 visible.add(cc.getName());
             }
@@ -1426,11 +1428,10 @@ public class IssuesController extends SpringActionController
 
     public static class CustomColumnConfigurationImpl implements CustomColumnConfiguration
     {
-        private Map<String, CustomColumn> _columnMap = new LinkedCaseInsensitiveMap<>();
-        private Map<String, String> _captionMap = new LinkedCaseInsensitiveMap<>();
-        private Set<String> _baseNames = new CaseInsensitiveHashSet();
-        private Map<String, DomainProperty> _propertyMap = new CaseInsensitiveHashMap<>();
-        private List<DomainProperty> _customProperties = new ArrayList<>();
+        private final Map<String, CustomColumn> _columnMap = new LinkedCaseInsensitiveMap<>();
+        private final Set<String> _baseNames = new CaseInsensitiveHashSet();
+        private final Map<String, DomainProperty> _propertyMap = new CaseInsensitiveHashMap<>();
+        private final List<DomainProperty> _customProperties = new ArrayList<>();
 
         public CustomColumnConfigurationImpl(Container c, User user, IssueListDef issueDef)
         {
@@ -1443,24 +1444,20 @@ public class IssuesController extends SpringActionController
                             "assignedto", "resolution"));
                 }
 
-                if (domain != null)
+                for (DomainProperty prop : domain.getProperties())
                 {
-                    for (DomainProperty prop : domain.getProperties())
+                    _propertyMap.put(prop.getName(), prop);
+                    if (!_baseNames.contains(prop.getName()))
                     {
-                        _propertyMap.put(prop.getName(), prop);
-                        if (!_baseNames.contains(prop.getName()))
-                        {
-                            _customProperties.add(prop);
-                            // treat anything higher than NotPHI as needing special permission
-                            CustomColumn col = new CustomColumn(c,
-                                    prop.getName().toLowerCase(),
-                                    prop.getLabel() != null ? prop.getLabel() : ColumnInfo.labelFromName(prop.getName()),
-                                    prop.getLookup() != null,
-                                    prop.getPHI().isExportLevelAllowed(PHI.NotPHI) ? ReadPermission.class : InsertPermission.class);
+                        _customProperties.add(prop);
+                        // treat anything higher than NotPHI as needing special permission
+                        CustomColumn col = new CustomColumn(c,
+                                prop.getName().toLowerCase(),
+                                prop.getLabel() != null ? prop.getLabel() : ColumnInfo.labelFromName(prop.getName()),
+                                prop.getLookup() != null,
+                                prop.getPHI().isExportLevelAllowed(PHI.NotPHI) ? ReadPermission.class : InsertPermission.class);
 
-                            _columnMap.put(col.getName(), col);
-                            _captionMap.put(col.getName(), col.getCaption());
-                        }
+                        _columnMap.put(col.getName(), col);
                     }
                 }
             }
@@ -1485,37 +1482,21 @@ public class IssuesController extends SpringActionController
         }
 
         @Override
-        public Collection<CustomColumn> getCustomColumns()
-        {
-            return _columnMap.values();
-        }
-
-        @Override
         public Collection<CustomColumn> getCustomColumns(User user)
         {
             return _columnMap.values();
         }
 
         @Override
-        public boolean shouldDisplay(String name)
-        {
-            return true;
-        }
-
-        @Override
         public boolean shouldDisplay(User user, String name)
         {
             CustomColumn col = _columnMap.get(name);
+            // short term hack
             if (col != null)
             {
                 return col.getContainer().hasPermission(user, col.getPermission());
             }
-            else if (_baseNames.contains(name))
-            {
-                // short term hack
-                return true;
-            }
-            return false;
+            else return _baseNames.contains(name);
         }
 
         @Nullable
@@ -1533,25 +1514,23 @@ public class IssuesController extends SpringActionController
         private GUID _entityId = null;
         private String _name = null;
 
-
         public GUID getEntityId()
         {
             return _entityId;
         }
 
-
+        @SuppressWarnings("unused")
         public void setEntityId(GUID entityId)
         {
             _entityId = entityId;
         }
-
 
         public String getName()
         {
             return _name;
         }
 
-
+        @SuppressWarnings("unused")
         public void setName(String name)
         {
             _name = name;
@@ -1582,7 +1561,7 @@ public class IssuesController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class DownloadAction extends BaseDownloadAction<IssueAttachmentForm>
+    public static class DownloadAction extends BaseDownloadAction<IssueAttachmentForm>
     {
         @Nullable
         @Override
@@ -1618,6 +1597,7 @@ public class IssuesController extends SpringActionController
     @RequiresPermission(ReadPermission.class)
     public class UpdateAction extends AbstractIssueAction
     {
+        @Override
         public ModelAndView getView(IssuesController.IssuesForm form, boolean reshow, BindException errors) throws Exception
         {
             int issueId = form.getIssueId();
@@ -1652,6 +1632,7 @@ public class IssuesController extends SpringActionController
             return new JspView<>("/org/labkey/issue/view/updateView.jsp", page);
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             new DetailsAction(_issue, getViewContext()).appendNavTrail(root);
@@ -1684,7 +1665,7 @@ public class IssuesController extends SpringActionController
             {
                 if (form.get("resolution") != null)
                 {
-                    _issue.setResolution((String) form.get("resolution"));
+                    _issue.setResolution(form.get("resolution"));
                 }
             }
             beforeReshow(reshow, form, _issue, getIssueListDef());
@@ -1706,6 +1687,7 @@ public class IssuesController extends SpringActionController
             return new JspView<>("/org/labkey/issue/view/updateView.jsp", page);
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             IssueManager.EntryTypeNames names = getEntryTypeNames();
@@ -1753,6 +1735,7 @@ public class IssuesController extends SpringActionController
             return new JspView<>("/org/labkey/issue/view/updateView.jsp", page);
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             IssueManager.EntryTypeNames names = getEntryTypeNames();
@@ -1803,6 +1786,7 @@ public class IssuesController extends SpringActionController
             return new JspView<>("/org/labkey/issue/view/updateView.jsp", page);
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             IssueManager.EntryTypeNames names = getEntryTypeNames();
@@ -1816,8 +1800,9 @@ public class IssuesController extends SpringActionController
     @RequiresPermission(ReadPermission.class)
     public class EmailPrefsAction extends FormViewAction<EmailPrefsForm>
     {
-        String _message = null;
+        private String _message = null;
 
+        @Override
         public ModelAndView getView(EmailPrefsForm form, boolean reshow, BindException errors)
         {
             if (getUser().isGuest())
@@ -1831,6 +1816,7 @@ public class IssuesController extends SpringActionController
             return new JspView<>("/org/labkey/issue/view/emailPreferences.jsp", form, errors);
         }
 
+        @Override
         public boolean handlePost(EmailPrefsForm form, BindException errors)
         {
             int emailPref = 0;
@@ -1844,6 +1830,7 @@ public class IssuesController extends SpringActionController
             return true;
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             new ListAction(getViewContext()).appendNavTrail(root);
@@ -1852,11 +1839,12 @@ public class IssuesController extends SpringActionController
             return root;
         }
 
-
+        @Override
         public void validateCommand(EmailPrefsForm emailPrefsForm, Errors errors)
         {
         }
 
+        @Override
         public ActionURL getSuccessURL(EmailPrefsForm emailPrefsForm)
         {
             return null;
@@ -2047,6 +2035,7 @@ public class IssuesController extends SpringActionController
             }
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             return null;
@@ -2201,6 +2190,7 @@ public class IssuesController extends SpringActionController
             return null;
         }
 
+        @Override
         public String reviseQuery(ViewContext ctx, String q)
         {
             String status = ctx.getActionURL().getParameter("status");
@@ -2488,7 +2478,9 @@ public class IssuesController extends SpringActionController
             return issueListDef;
         }
 
-        public void setTable(TableInfo table)
+        // Make this method public
+        @Override
+        public void setTable(@NotNull TableInfo table)
         {
             super.setTable(table);
         }
@@ -2529,7 +2521,6 @@ public class IssuesController extends SpringActionController
         }
     }
 
-
     public static class SummaryBean
     {
         public boolean hasPermission;
@@ -2538,7 +2529,7 @@ public class IssuesController extends SpringActionController
         public String issueDefName;
     }
 
-
+    @Override
     protected synchronized void afterAction(Throwable t)
     {
         super.afterAction(t);

--- a/issues/src/org/labkey/issue/actions/IssueValidation.java
+++ b/issues/src/org/labkey/issue/actions/IssueValidation.java
@@ -29,16 +29,12 @@ import org.labkey.api.data.validator.ColumnValidator;
 import org.labkey.api.data.validator.ColumnValidators;
 import org.labkey.api.issues.IssuesSchema;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.security.SecurityPolicy;
-import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
-import org.labkey.api.security.roles.OwnerRole;
 import org.labkey.api.security.roles.Role;
-import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewServlet;
 import org.labkey.issue.CustomColumnConfiguration;
@@ -100,20 +96,20 @@ public class IssueValidation
             }
         }
         if (newFields.containsKey("comment"))
-            validateRequired("comment", newFields.get("comment"), requiredFields, customColumnConfiguration, requiredErrors);
+            validateRequired(user, "comment", newFields.get("comment"), requiredFields, customColumnConfiguration, requiredErrors);
 
         // When resolving Duplicate, the 'duplicate' field should be set.
         if ("Duplicate".equals(newFields.get("resolution")))
-            validateRequired("duplicate", newFields.get("duplicate"), "duplicate", customColumnConfiguration, requiredErrors);
+            validateRequired(user, "duplicate", newFields.get("duplicate"), "duplicate", customColumnConfiguration, requiredErrors);
 
         // when resolving, a resolution is always required
         if (newFields.containsKey("resolution"))
-            validateRequired("resolution", newFields.get("resolution"), "resolution", customColumnConfiguration, requiredErrors);
+            validateRequired(user, "resolution", newFields.get("resolution"), "resolution", customColumnConfiguration, requiredErrors);
 
         errors.addAllErrors(requiredErrors);
     }
 
-    private static void validateRequired(String columnName, String value, String requiredFields, @Nullable CustomColumnConfiguration ccc, Errors errors)
+    private static void validateRequired(User user, String columnName, String value, String requiredFields, @Nullable CustomColumnConfiguration ccc, Errors errors)
     {
         if (requiredFields != null)
         {
@@ -124,7 +120,7 @@ public class IssueValidation
                     String name = null;
 
                     // TODO: Not sure what to do here
-                    if (ccc != null && ccc.shouldDisplay(columnName))
+                    if (ccc != null && ccc.shouldDisplay(user, columnName))
                     {
                         name = ccc.getCaption(columnName);
                     }
@@ -176,7 +172,7 @@ public class IssueValidation
         }
     }
 
-    public static boolean relatedIssueHandler(Issue issue, User user, BindException errors)
+    public static void relatedIssueHandler(Issue issue, User user, BindException errors)
     {
         String textInput = issue.getRelated();
         Set<Integer> newRelatedIssues = new TreeSet<>();
@@ -191,12 +187,12 @@ public class IssueValidation
                 if (relatedId == 0)
                 {
                     errors.reject(SpringActionController.ERROR_MSG, "Invalid issue id in related string.");
-                    return false;
+                    return;
                 }
                 if (issue.getIssueId() == relatedId)
                 {
                     errors.reject(SpringActionController.ERROR_MSG, "As issue may not be related to itself");
-                    return false;
+                    return;
                 }
 
                 // only need to verify that the related issue exists without regard to folder permissions (issue:27483), so just query
@@ -205,7 +201,7 @@ public class IssueValidation
                 if (related == null)
                 {
                     errors.reject(SpringActionController.ERROR_MSG, "Related issue '" + relatedId + "' not found");
-                    return false;
+                    return;
                 }
                 newRelatedIssues.add(relatedId);
             }
@@ -224,14 +220,13 @@ public class IssueValidation
                 if (related == null || !related.lookupContainer().hasPermission(user, ReadPermission.class))
                 {
                     errors.reject(SpringActionController.ERROR_MSG, "User does not have Read Permission for related issue '" + relatedId + "'");
-                    return false;
+                    return;
                 }
             }
         }
 
         // this sets the collection of integer ids for all related issues
         issue.setRelatedIssues(newRelatedIssues);
-        return true;
     }
 
     public static void validateComments(IssuesController.IssuesForm form, Errors errors)
@@ -276,8 +271,6 @@ public class IssueValidation
 
     private static Set<Role> getContextualRoles(User user, Issue issue, Container c)
     {
-        Set<Role> roles = new HashSet<>();
-
         // we can't support AuthorRoles until we address issue: 36942
 /*
         SecurityPolicy policy = SecurityPolicyManager.getPolicy(c);
@@ -291,6 +284,6 @@ public class IssueValidation
         }
 */
 
-        return roles;
+        return new HashSet<>();
     }
 }

--- a/query/src/org/labkey/query/CustomQueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/CustomQueryDefinitionImpl.java
@@ -42,17 +42,20 @@ public class CustomQueryDefinitionImpl extends QueryDefinitionImpl
         super(user, container, schema, name);
     }
 
+    @Override
     public void setSql(String sql)
     {
         edit().setSql(sql);
         // CONSIDER: Add sql QueryPropertyChange to _changes
     }
 
+    @Override
     public boolean isMetadataEditable()
     {
         return true;
     }
 
+    @Override
     public String getSql()
     {
         return getQueryDef().getSql();

--- a/query/src/org/labkey/query/ExternalSchemaDefImporterFactory.java
+++ b/query/src/org/labkey/query/ExternalSchemaDefImporterFactory.java
@@ -17,10 +17,9 @@ package org.labkey.query;
 
 import org.apache.xmlbeans.XmlObject;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.admin.AbstractFolderImportFactory;
-import org.labkey.api.admin.FolderImporter;
 import org.labkey.api.admin.FolderArchiveDataTypes;
+import org.labkey.api.admin.FolderImporter;
 import org.labkey.api.admin.ImportContext;
 import org.labkey.api.admin.ImportException;
 import org.labkey.api.data.Container;

--- a/query/src/org/labkey/query/QueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/QueryDefinitionImpl.java
@@ -101,7 +101,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
     // todo: spec 25628 making _cache static prevents the entire map of all tableInfos from being reloaded each time GetQueryViewsAction instantiates a new copy of QueryDefintionImpl
     // but may make _cache susceptible to concurrency conflicts or security problems -- more investigation is needed
     // private static Map<Pair<String, Boolean>, TableInfo> _cache = new HashMap<>();
-    private  Map<Pair<String, Boolean>, TableInfo> _cache = new HashMap<>();
+    private final Map<Pair<String, Boolean>, TableInfo> _cache = new HashMap<>();
 
     private Map<String, TableType> _metadataTableMap = null;
 

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -49,6 +49,7 @@ import org.labkey.api.module.ModuleResourceCacheListener;
 import org.labkey.api.module.ModuleResourceCaches;
 import org.labkey.api.module.ResourceRootProvider;
 import org.labkey.api.query.*;
+import org.labkey.api.query.QueryChangeListener.QueryPropertyChange;
 import org.labkey.api.query.snapshot.QuerySnapshotDefinition;
 import org.labkey.api.resource.Resource;
 import org.labkey.api.security.User;
@@ -149,7 +150,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
     private static final Logger LOG = Logger.getLogger(QueryServiceImpl.class);
     private static final ResourceRootProvider QUERY_AND_ASSAY_PROVIDER = new ResourceRootProvider()
     {
-        private ResourceRootProvider ASSAY_QUERY = ResourceRootProvider.chain(ResourceRootProvider.getAssayProviders(Path.rootPath), ResourceRootProvider.QUERY);
+        private final ResourceRootProvider ASSAY_QUERY = ResourceRootProvider.chain(ResourceRootProvider.getAssayProviders(Path.rootPath), ResourceRootProvider.QUERY);
 
         @Override
         public void fillResourceRoots(@NotNull Resource topRoot, @NotNull Collection<Resource> roots)
@@ -393,9 +394,6 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         }
     }
 
-
-
-
     static public QueryServiceImpl get()
     {
         return (QueryServiceImpl)QueryService.get();
@@ -426,6 +424,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
     }
 
 
+    @Override
     public UserSchema getUserSchema(User user, Container container, String schemaPath)
     {
         QuerySchema schema = DefaultSchema.get(user, container, schemaPath);
@@ -435,6 +434,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return null;
     }
 
+    @Override
     public UserSchema getUserSchema(User user, Container container, SchemaKey schemaPath)
     {
         QuerySchema schema = DefaultSchema.get(user, container, schemaPath);
@@ -444,27 +444,32 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return null;
     }
 
+    @Override
     @Deprecated /* Use SchemaKey form instead. */
     public QueryDefinition createQueryDef(User user, Container container, String schema, String name)
     {
         return new CustomQueryDefinitionImpl(user, container, SchemaKey.fromString(schema), name);
     }
 
+    @Override
     public QueryDefinition createQueryDef(User user, Container container, SchemaKey schema, String name)
     {
         return new CustomQueryDefinitionImpl(user, container, schema, name);
     }
 
+    @Override
     public QueryDefinition createQueryDef(User user, Container container, UserSchema schema, String name)
     {
         return new CustomQueryDefinitionImpl(user, container, schema, name);
     }
 
+    @Override
     public ActionURL urlQueryDesigner(User user, Container container, String schema)
     {
         return urlFor(user, container, QueryAction.begin, schema, null);
     }
 
+    @Override
     public ActionURL urlFor(User user, Container container, QueryAction action, @Nullable String schema, @Nullable String query)
     {
         ActionURL ret = null;
@@ -489,6 +494,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return ret;
     }
 
+    @Override
     public ActionURL urlDefault(Container container, QueryAction action, @Nullable String schema, @Nullable String query)
     {
         if (action == QueryAction.schemaBrowser)
@@ -502,12 +508,14 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return ret;
     }
 
+    @Override
     public DetailsURL urlDefault(Container container, QueryAction action, String schema, String query, Map<String, ?> params)
     {
         ActionURL url = urlDefault(container, action, schema, query);
         return new DetailsURL(url, params);
     }
 
+    @Override
     public DetailsURL urlDefault(Container container, QueryAction action, TableInfo table)
     {
         Map<String, FieldKey> params = new LinkedHashMap<>();
@@ -517,11 +525,13 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return urlDefault(container, action, table.getPublicSchemaName(), table.getPublicName(), params);
     }
 
+    @Override
     public QueryDefinition createQueryDefForTable(UserSchema schema, String tableName)
     {
         return new TableQueryDefinition(schema, tableName);
     }
 
+    @Override
     public Map<String, QueryDefinition> getQueryDefs(User user, @NotNull Container container, String schemaName)
     {
         Map<String, QueryDefinition> ret = new LinkedHashMap<>();
@@ -535,6 +545,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
     /**
      * Get all custom queries in the database (no file-based module queries) in the container hierarchy.
      */
+    @Override
     public List<QueryDefinition> getQueryDefs(User user, @NotNull Container container)
     {
         return new ArrayList<>(getAllQueryDefs(user, container, null, true, false, true, false).values());
@@ -669,6 +680,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         map.computeIfAbsent(key, (key2) -> new CustomQueryDefinitionImpl(user, c, queryDef));
     }
 
+    @Override
     public List<QueryDefinition> getFileBasedQueryDefs(User user, Container container, String schemaName, Path path, Module... extraModules)
     {
         Collection<Module> modules = new HashSet<>(container.getActiveModules(user));
@@ -700,6 +712,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         }
     }
 
+    @Override
     public QueryDefinition getQueryDef(User user, @NotNull Container container, String schema, String name)
     {
         Map<String, QueryDefinition> ret = new CaseInsensitiveHashMap<>();
@@ -900,8 +913,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
             if (schema == null)
                 return null;
 
-            Set<String> tableNames = new HashSet<>();
-            tableNames.addAll(schema.getTableAndQueryNames(true));
+            Set<String> tableNames = new HashSet<>(schema.getTableAndQueryNames(true));
 
             if (tableNames.contains(queryName))
             {
@@ -927,24 +939,20 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return qd;
     }
 
+    @Override
     public CustomView getCustomView(@NotNull User user, Container container, @Nullable User owner, String schema, String query, String name)
     {
         Map<String, CustomView> views = getCustomViewMap(user, container, owner, schema, query, false, false);
         return views.get(name);
     }
 
+    @Override
     public List<CustomView> getCustomViews(@NotNull User user, Container container, @Nullable User owner, @Nullable String schemaName, @Nullable String queryName, boolean includeInherited)
     {
         return _getCustomViews(user, container, owner, schemaName, queryName, includeInherited, false);
     }
 
-    // TODO: Unused... delete?
-    public CustomView getSharedCustomView(@NotNull User user, Container container, String schema, String query, String name)
-    {
-        Map<String, CustomView> views = getCustomViewMap(user, container, null, schema, query, false, true);
-        return views.get(name);
-    }
-
+    @Override
     public List<CustomView> getSharedCustomViews(@NotNull User user, Container container, @Nullable String schemaName, @Nullable String queryName, boolean includeInherited)
     {
         return _getCustomViews(user, container, null, schemaName, queryName, includeInherited, true);
@@ -971,6 +979,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return new ArrayList<>(views);
     }
 
+    @Override
     public List<CustomView> getDatabaseCustomViews(@NotNull User user, Container container, @Nullable User owner, @Nullable String schemaName, @Nullable String queryName, boolean includeInherited, boolean sharedOnly)
     {
         if (schemaName == null || queryName == null)
@@ -1009,6 +1018,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return new ArrayList<>(getCustomViewMap(user, container, owner, schemaName, queryName, includeInherited, sharedOnly).values());
     }
 
+    @Override
     public List<CustomView> getFileBasedCustomViews(Container container, QueryDefinition qd, Path path, String query, Module... extraModules)
     {
         Collection<Module> currentModules = new HashSet<>(container.getActiveModules());
@@ -1052,12 +1062,14 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         }
     }
 
+    @Override
     public void writeTables(Container c, User user, VirtualFile dir, Map<String, List<Map<String, Object>>> schemas, ColumnHeaderType header) throws IOException
     {
         TableWriter writer = new TableWriter();
         writer.write(c, user, dir, schemas, header);
     }
 
+    @Override
     public int importCustomViews(User user, Container container, VirtualFile viewDir) throws IOException
     {
         QueryManager mgr = QueryManager.get();
@@ -1101,6 +1113,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
     }
 
 
+    @Override
     public Map<String, Object> getCustomViewProperties(@Nullable CustomView view, @NotNull User currentUser)
     {
         return getCustomViewProperties(view, currentUser, true);
@@ -1146,6 +1159,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return ret;
     }
 
+    @Override
     public @Nullable QuerySnapshotDefinition getSnapshotDef(Container container, String schema, String snapshotName)
     {
         QuerySnapshotDef def = QueryManager.get().getQuerySnapshotDef(container, schema, snapshotName);
@@ -1153,11 +1167,13 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return null != def ? new QuerySnapshotDefImpl(def) : null;
     }
 
+    @Override
     public boolean isQuerySnapshot(Container container, String schema, String name)
     {
         return getSnapshotDef(container, schema, name) != null;
     }
 
+    @Override
     public List<QuerySnapshotDefinition> getQuerySnapshotDefs(Container container, String schemaName)
     {
         return QueryManager.get().getQuerySnapshots(container, schemaName)
@@ -1201,6 +1217,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
     }
 
 
+    @Override
     public QueryDefinition saveSessionQuery(ViewContext context, Container container, String schemaName, String sql, String metadataXml)
     {
         return saveSessionQuery(context.getRequest().getSession(true), container, context.getUser(), schemaName, sql, metadataXml);
@@ -1315,6 +1332,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return ret;
     }
 
+    @Override
     public QueryDefinition getSessionQuery(ViewContext context, Container container, String schemaName, String queryName)
     {
         return getSessionQuery(context.getSession(), container, context.getUser(), schemaName,queryName);
@@ -1341,11 +1359,13 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return qdef;
     }
 
+    @Override
     public QuerySnapshotDefinition createQuerySnapshotDef(Container container, QueryDefinition queryDef, String name)
     {
         return new QuerySnapshotDefImpl(queryDef, container, name);
     }
 
+    @Override
     public QuerySnapshotDefinition createQuerySnapshotDef(QueryDefinition queryDef, String name)
     {
         return createQuerySnapshotDef(queryDef.getContainer(), queryDef, name);
@@ -1419,13 +1439,14 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return ret;
     }
 
+    @Override
     @NotNull
     public Map<FieldKey, ColumnInfo> getColumns(@NotNull TableInfo table, @NotNull Collection<FieldKey> fields)
     {
         return getColumns(table, fields, Collections.emptySet());
     }
 
-
+    @Override
     @NotNull
     public LinkedHashMap<FieldKey, ColumnInfo> getColumns(@NotNull TableInfo table, @NotNull Collection<FieldKey> fields, @NotNull Collection<ColumnInfo> existingColumns)
     {
@@ -1468,6 +1489,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
     }
 
 
+    @Override
     public List<DisplayColumn> getDisplayColumns(@NotNull TableInfo table, Collection<Entry<FieldKey, Map<CustomView.ColumnProperty, String>>> fields)
     {
         List<DisplayColumn> ret = new ArrayList<>();
@@ -1498,6 +1520,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
     }
 
 
+    @Override
     public Collection<ColumnInfo> ensureRequiredColumns(@NotNull TableInfo table, @NotNull Collection<ColumnInfo> columns,
                                                         @Nullable Filter filter, @Nullable Sort sort, @Nullable Set<FieldKey> unresolvedColumns)
     {
@@ -1758,6 +1781,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return ret;
     }
 
+    @Override
     public UserSchema getLinkedSchema(User user, Container c, String name)
     {
         LinkedSchemaDef def = QueryManager.get().getLinkedSchemaDef(c, name);
@@ -1777,6 +1801,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return null;
     }
 
+    @Override
     public UserSchema createLinkedSchema(User user, Container c, String name, String sourceContainerId, String sourceSchemaName,
                                          String metadata, String tables, String template)
     {
@@ -1792,6 +1817,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return LinkedSchema.get(user, c, newDef);
     }
 
+    @Override
     public void deleteLinkedSchema(User user, Container c, String name)
     {
         try
@@ -1972,6 +1998,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return tableTypes;
     }
 
+    @Override
     public TableType parseMetadata(String metadataXML, Collection<QueryException> errors)
     {
         QueryDef def = new QueryDef();
@@ -1990,7 +2017,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
     // Use a WeakHashMap to cache QueryDefs. This means that the cache entries will only be associated directly
     // with the exact same UserSchema instance, regardless of whatever UserSchema.equals() returns. This means
     // that the scope of the cache is very limited, and this is a very conservative cache.
-    private Map<ObjectIdentityCacheKey, WeakReference<Map<String, List<QueryDef>>>> _metadataCache = Collections.synchronizedMap(new WeakHashMap<>());
+    private final Map<ObjectIdentityCacheKey, WeakReference<Map<String, List<QueryDef>>>> _metadataCache = Collections.synchronizedMap(new WeakHashMap<>());
 
     /** Hides whatever the underlying key might do for .equals() and .hashCode() and instead relies on pointer equality */
     private static class ObjectIdentityCacheKey
@@ -2727,7 +2754,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
     {
         synchronized(_schemaLinkActions)
         {
-            if (_schemaLinkActions.keySet().contains(actionClass))
+            if (_schemaLinkActions.containsKey(actionClass))
                 throw new IllegalStateException("Schema link action : " + actionClass.getName() + " has previously been registered.");
 
             _schemaLinkActions.put(actionClass, new Pair<>(module, linkLabel));
@@ -2779,7 +2806,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
     }
 
 
-    private static ThreadLocal<HashMap<Environment, Object>> environments = ThreadLocal.withInitial(HashMap::new);
+    private static final ThreadLocal<HashMap<Environment, Object>> environments = ThreadLocal.withInitial(HashMap::new);
 
 
     @Override
@@ -2962,7 +2989,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
     }
 
     @Override
-    public void fireQueryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, QueryChangeListener.QueryProperty property, Collection<QueryChangeListener.QueryPropertyChange> changes)
+    public void fireQueryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, QueryChangeListener.QueryProperty property, Collection<QueryPropertyChange> changes)
     {
         QueryManager.get().fireQueryChanged(user, container, scope, schema, property, changes);
     }

--- a/query/src/org/labkey/query/QuerySnapshotQueryChangeListener.java
+++ b/query/src/org/labkey/query/QuerySnapshotQueryChangeListener.java
@@ -39,7 +39,7 @@ import java.util.Map;
 public class QuerySnapshotQueryChangeListener implements QueryChangeListener
 {
     @Override
-    public void queryCreated(User user, Container container, ContainerFilter scope, SchemaKey schema, Collection<String> queries)
+    public void queryCreated(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull Collection<String> queries)
     {
     }
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -37,8 +37,6 @@ import org.json.JSONObject;
 import org.labkey.api.action.*;
 import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.audit.AbstractAuditTypeProvider;
-import org.labkey.api.audit.AuditLogService;
-import org.labkey.api.audit.view.AuditChangesView;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.RowMapFactory;
 import org.labkey.api.data.*;
@@ -130,6 +128,7 @@ import org.labkey.query.audit.QueryUpdateAuditProvider;
 import org.labkey.query.persist.AbstractExternalSchemaDef;
 import org.labkey.query.persist.CstmView;
 import org.labkey.query.persist.ExternalSchemaDef;
+import org.labkey.query.persist.ExternalSchemaDefCache;
 import org.labkey.query.persist.LinkedSchemaDef;
 import org.labkey.query.persist.QueryDef;
 import org.labkey.query.persist.QueryManager;
@@ -166,7 +165,6 @@ import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -224,7 +222,7 @@ public class QueryController extends SpringActionController
 
         public static ActionURL urlEditRemoteConnection(Container c, String connectionName)
         {
-            ActionURL url = new ActionURL(QueryController.EditRemoteConnectionAction.class, c);
+            ActionURL url = new ActionURL(EditRemoteConnectionAction.class, c);
             url.addParameter("connectionName", connectionName);
             return url;
         }
@@ -236,7 +234,7 @@ public class QueryController extends SpringActionController
 
         public static ActionURL urlDeleteRemoteConnection(Container c, @Nullable String connectionName)
         {
-            ActionURL url = new ActionURL(QueryController.DeleteRemoteConnectionAction.class, c);
+            ActionURL url = new ActionURL(DeleteRemoteConnectionAction.class, c);
             if (connectionName != null)
                 url.addParameter("connectionName", connectionName);
             return url;
@@ -244,7 +242,7 @@ public class QueryController extends SpringActionController
 
         public static ActionURL urlTestRemoteConnection(Container c, String connectionName)
         {
-            ActionURL url = new ActionURL(QueryController.TestRemoteConnectionAction.class, c);
+            ActionURL url = new ActionURL(TestRemoteConnectionAction.class, c);
             url.addParameter("connectionName", connectionName);
             return url;
         }
@@ -451,21 +449,21 @@ public class QueryController extends SpringActionController
 
         public ActionURL urlUpdateExternalSchema(Container c, AbstractExternalSchemaDef def)
         {
-            ActionURL url = new ActionURL(QueryController.EditExternalSchemaAction.class, c);
+            ActionURL url = new ActionURL(EditExternalSchemaAction.class, c);
             url.addParameter("externalSchemaId", Integer.toString(def.getExternalSchemaId()));
             return url;
         }
 
         public ActionURL urlReloadExternalSchema(Container c, AbstractExternalSchemaDef def)
         {
-            ActionURL url = new ActionURL(QueryController.ReloadExternalSchemaAction.class, c);
+            ActionURL url = new ActionURL(ReloadExternalSchemaAction.class, c);
             url.addParameter("externalSchemaId", Integer.toString(def.getExternalSchemaId()));
             return url;
         }
 
-        public ActionURL urlDeleteExternalSchema(Container c, AbstractExternalSchemaDef def)
+        public ActionURL urlDeleteSchema(Container c, AbstractExternalSchemaDef def)
         {
-            ActionURL url = new ActionURL(QueryController.DeleteExternalSchemaAction.class, c);
+            ActionURL url = new ActionURL(DeleteSchemaAction.class, c);
             url.addParameter("externalSchemaId", Integer.toString(def.getExternalSchemaId()));
             return url;
         }
@@ -499,8 +497,8 @@ public class QueryController extends SpringActionController
         public ActionURL urlCreateExcelTemplate(Container c, String schemaName, String queryName)
         {
             return new ActionURL(ExportExcelTemplateAction.class, c)
-                    .addParameter(QueryParam.schemaName, schemaName)
-                    .addParameter("query.queryName", queryName);
+                .addParameter(QueryParam.schemaName, schemaName)
+                .addParameter("query.queryName", queryName);
         }
     }
 
@@ -514,7 +512,7 @@ public class QueryController extends SpringActionController
     }
 
     @AdminConsoleAction(AdminOperationsPermission.class)
-    public static class DataSourceAdminAction extends SimpleViewAction
+    public static class DataSourceAdminAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
@@ -651,6 +649,7 @@ public class QueryController extends SpringActionController
             return new HtmlView(HtmlString.unsafe(sb.toString()));
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             requireNonNull(PageFlowUtil.urlProvider(AdminUrls.class)).appendAdminNavTrail(root, "Data Source Administration ", null);
@@ -660,13 +659,15 @@ public class QueryController extends SpringActionController
 
 
     @RequiresPermission(ReadPermission.class)
-    public static class BrowseAction extends SimpleViewAction
+    public static class BrowseAction extends SimpleViewAction<Object>
     {
+        @Override
         public ModelAndView getView(Object o, BindException errors)
         {
             return new JspView<>("/org/labkey/query/view/browse.jsp", null);
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             return root.addChild("Schema Browser");
@@ -686,13 +687,15 @@ public class QueryController extends SpringActionController
             setViewContext(ctx);
         }
 
+        @Override
         public ModelAndView getView(QueryForm form, BindException errors)
         {
-            JspView view = new JspView<>("/org/labkey/query/view/browse.jsp", form);
+            JspView<QueryForm> view = new JspView<>("/org/labkey/query/view/browse.jsp", form);
             view.setFrame(WebPartView.FrameType.NONE);
             return view;
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             root.addChild("Query Schema Browser", new QueryUrlsImpl().urlSchemaBrowser(getContainer()));
@@ -710,12 +713,14 @@ public class QueryController extends SpringActionController
             _form = form;
         }
 
+        @Override
         public ModelAndView getView(QueryForm form, BindException errors)
         {
             _form = form;
             return new JspView<>("/org/labkey/query/view/browse.jsp", form);
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             if (_form.getSchema() != null)
@@ -759,6 +764,7 @@ public class QueryController extends SpringActionController
         private NewQueryForm _form;
         private ActionURL _successUrl;
 
+        @Override
         public void validateCommand(NewQueryForm target, org.springframework.validation.Errors errors)
         {
             target.ff_newQueryName = StringUtils.trimToNull(target.ff_newQueryName);
@@ -766,6 +772,7 @@ public class QueryController extends SpringActionController
                 errors.reject(ERROR_MSG, "QueryName is required");
         }
 
+        @Override
         public ModelAndView getView(NewQueryForm form, boolean reshow, BindException errors)
         {
             if (form.getSchema() == null)
@@ -789,6 +796,7 @@ public class QueryController extends SpringActionController
             return new JspView<>("/org/labkey/query/view/newQuery.jsp", form, errors);
         }
 
+        @Override
         public boolean handlePost(NewQueryForm form, BindException errors)
         {
             if (form.getSchema() == null)
@@ -863,11 +871,13 @@ public class QueryController extends SpringActionController
             }
         }
 
+        @Override
         public ActionURL getSuccessURL(NewQueryForm newQueryForm)
         {
             return _successUrl;
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             new SchemaAction(_form).appendNavTrail(root);
@@ -875,7 +885,6 @@ public class QueryController extends SpringActionController
             return root;
         }
     }
-
 
     // CONSIDER : deleting this action after the SQL editor UI changes are finalized, keep in mind that built-in views
     // use this view as well via the edit metadata page.
@@ -944,7 +953,7 @@ public class QueryController extends SpringActionController
             return new JspView<>("/org/labkey/query/view/sourceQuery.jsp", this, errors);
         }
 
-
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             setHelpTopic(new HelpTopic("useSqlEditor"));
@@ -1220,6 +1229,7 @@ public class QueryController extends SpringActionController
             return true;
         }
 
+        @Override
         @NotNull
         public ActionURL getSuccessURL(SourceForm queryForm)
         {
@@ -1331,7 +1341,7 @@ public class QueryController extends SpringActionController
                 url.addParameter("schemaName", userSchemaName);
 
                 SqlDialect dialect = scope.getSqlDialect();
-                HttpView scopeInfo = new ScopeView("Scope and Schema Information", scope, _dbSchemaName, url, _dbTableName);
+                ScopeView scopeInfo = new ScopeView("Scope and Schema Information", scope, _dbSchemaName, url, _dbTableName);
 
                 result.addView(scopeInfo);
 
@@ -1381,10 +1391,11 @@ public class QueryController extends SpringActionController
 
 
     @RequiresPermission(AdminOperationsPermission.class)
-    public class RawSchemaMetaDataAction extends SimpleViewAction
+    public class RawSchemaMetaDataAction extends SimpleViewAction<Object>
     {
         private String _schemaName;
 
+        @Override
         public ModelAndView getView(Object form, BindException errors) throws Exception
         {
             _schemaName = getViewContext().getActionURL().getParameter("schemaName");
@@ -1425,6 +1436,7 @@ public class QueryController extends SpringActionController
             return new VBox(scopeInfo, tablesView);
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             root.addChild("JDBC Meta Data For Schema \"" + _schemaName + "\"");
@@ -1479,6 +1491,7 @@ public class QueryController extends SpringActionController
     @Action(ActionType.Export.class)
     public class PrintRowsAction extends ExecuteQueryAction
     {
+        @Override
         public ModelAndView getView(QueryForm form, BindException errors) throws Exception
         {
             _print = true;
@@ -1494,6 +1507,7 @@ public class QueryController extends SpringActionController
 
     abstract static class _ExportQuery<K extends ExportQueryForm> extends SimpleViewAction<K>
     {
+        @Override
         public ModelAndView getView(K form, BindException errors) throws Exception
         {
             QueryView view = form.getQueryView();
@@ -1514,6 +1528,7 @@ public class QueryController extends SpringActionController
 
         abstract void _export(K form, QueryView view) throws Exception;
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             return null;
@@ -1542,6 +1557,7 @@ public class QueryController extends SpringActionController
     @Action(ActionType.SelectMetaData.class)    // This is called "export" but it doesn't export any data
     public static class ExportScriptAction extends SimpleViewAction<ExportScriptForm>
     {
+        @Override
         public ModelAndView getView(ExportScriptForm form, BindException errors)
         {
             // comment? Is this call ehre for validation purposes?
@@ -1550,6 +1566,7 @@ public class QueryController extends SpringActionController
             return ExportScriptModel.getExportScriptView(QueryView.create(form, errors), form.getScriptType(), getPageConfig(), getViewContext().getResponse());
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             return null;
@@ -1559,8 +1576,9 @@ public class QueryController extends SpringActionController
 
     @RequiresPermission(ReadPermission.class)
     @Action(ActionType.Export.class)
-    public static class ExportRowsExcelAction extends _ExportQuery
+    public static class ExportRowsExcelAction extends _ExportQuery<ExportQueryForm>
     {
+        @Override
         void _export(ExportQueryForm form, QueryView view) throws Exception
         {
             view.exportToExcel(getViewContext().getResponse(), form.getHeaderType(), ExcelWriter.ExcelDocumentType.xls, form.getRenameColumns());
@@ -1569,8 +1587,9 @@ public class QueryController extends SpringActionController
 
     @RequiresPermission(ReadPermission.class)
     @Action(ActionType.Export.class)
-    public static class ExportRowsXLSXAction extends _ExportQuery
+    public static class ExportRowsXLSXAction extends _ExportQuery<ExportQueryForm>
     {
+        @Override
         void _export(ExportQueryForm form, QueryView view) throws Exception
         {
             view.exportToExcel(getViewContext().getResponse(), form.getHeaderType(), ExcelWriter.ExcelDocumentType.xlsx, form.getRenameColumns());
@@ -1679,6 +1698,7 @@ public class QueryController extends SpringActionController
             setCommandClass(TemplateForm.class);
         }
 
+        @Override
         void _export(TemplateForm form, QueryView view) throws Exception
         {
             boolean respectView = form.getViewName() != null;
@@ -1784,6 +1804,7 @@ public class QueryController extends SpringActionController
             setCommandClass(ExportRowsTsvForm.class);
         }
 
+        @Override
         void _export(ExportRowsTsvForm form, QueryView view) throws Exception
         {
             view.exportToTsv(getViewContext().getResponse(), form.getDelim(), form.getQuote(), form.getHeaderType(), form.getRenameColumns());
@@ -1796,6 +1817,7 @@ public class QueryController extends SpringActionController
     @Action(ActionType.Export.class)
     public static class ExcelWebQueryAction extends ExportRowsTsvAction
     {
+        @Override
         public ModelAndView getView(ExportRowsTsvForm form, BindException errors) throws Exception
         {
             if (!getContainer().hasPermission(getUser(), ReadPermission.class))
@@ -1827,6 +1849,7 @@ public class QueryController extends SpringActionController
     @Action(ActionType.Export.class)
     public class ExcelWebQueryDefinitionAction extends SimpleViewAction<QueryForm>
     {
+        @Override
         public ModelAndView getView(QueryForm form, BindException errors) throws Exception
         {
             getPageConfig().setTemplate(PageConfig.Template.None);
@@ -1854,6 +1877,7 @@ public class QueryController extends SpringActionController
             return null;
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             return null;
@@ -2311,11 +2335,13 @@ public class QueryController extends SpringActionController
     @RequiresPermission(DeletePermission.class)
     public static class DeleteQueryRowsAction extends FormHandlerAction<QueryForm>
     {
+        @Override
         public void validateCommand(QueryForm target, Errors errors)
         {
         }
 
-        public boolean handlePost(QueryForm form, BindException errors) throws Exception
+        @Override
+        public boolean handlePost(QueryForm form, BindException errors)
         {
             TableInfo table = form.getQueryView().getTable();
 
@@ -2398,11 +2424,11 @@ public class QueryController extends SpringActionController
             return !errors.hasErrors();
         }
 
+        @Override
         public ActionURL getSuccessURL(QueryForm form)
         {
             return form.getReturnActionURL();
         }
-
     }
 
     @RequiresPermission(ReadPermission.class)
@@ -2635,6 +2661,7 @@ public class QueryController extends SpringActionController
             return false;
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             root.addChild("Edit Multiple " + _table.getName());
@@ -2789,6 +2816,7 @@ public class QueryController extends SpringActionController
     @Action(ActionType.SelectData.class)
     public class SelectRowsAction extends ReadOnlyApiAction<APIQueryForm>
     {
+        @Override
         public ApiResponse execute(APIQueryForm form, BindException errors)
         {
             // Issue 12233: add implicit maxRows=100k when using client API
@@ -2853,6 +2881,7 @@ public class QueryController extends SpringActionController
     @Action(ActionType.SelectData.class)
     public static class GetDataAction extends ReadOnlyApiAction<SimpleApiJsonForm>
     {
+        @Override
         public ApiResponse execute(SimpleApiJsonForm form, BindException errors) throws Exception
         {
             ObjectMapper mapper = new ObjectMapper();
@@ -2920,11 +2949,13 @@ public class QueryController extends SpringActionController
             _offset = offset;
         }
 
+        @Override
         public void setLimit(Integer limit)
         {
             _maxRows = limit;
         }
 
+        @Override
         public void setStart(Integer start)
         {
             _offset = start;
@@ -2960,6 +2991,7 @@ public class QueryController extends SpringActionController
     @Action(ActionType.SelectData.class)
     public class ExecuteSqlAction extends ReadOnlyApiAction<ExecuteSqlForm>
     {
+        @Override
         public ApiResponse execute(ExecuteSqlForm form, BindException errors)
         {
             if (form.getSchema() == null)
@@ -3186,18 +3218,15 @@ public class QueryController extends SpringActionController
             // 18875: Support Parameterized queries in Select Distinct
             Map<String, Object> _namedParameters = settings.getQueryParameters();
 
-            if (null != _namedParameters)
+            try
             {
-                try
-                {
-                    service.bindNamedParameters(sql, _namedParameters);
-                    service.validateNamedParameters(sql);
-                }
-                catch (ConversionException | QueryService.NamedParameterNotProvided e)
-                {
-                    errors.reject(ERROR_MSG, e.getMessage());
-                    return null;
-                }
+                service.bindNamedParameters(sql, _namedParameters);
+                service.validateNamedParameters(sql);
+            }
+            catch (ConversionException | QueryService.NamedParameterNotProvided e)
+            {
+                errors.reject(ERROR_MSG, e.getMessage());
+                return null;
             }
 
             return new SqlSelector(table.getSchema().getScope(), sql, QueryLogging.noValidationNeededQueryLogging());
@@ -3250,6 +3279,7 @@ public class QueryController extends SpringActionController
                 _colFieldKey = fieldKeys.get(0);
         }
 
+        @Override
         public ApiResponse execute(QueryForm form, BindException errors)
         {
             ApiSimpleResponse response = new ApiSimpleResponse();
@@ -3305,7 +3335,7 @@ public class QueryController extends SpringActionController
                 // query the table/view for the aggregate results
                 Collection<ColumnInfo> columns = Collections.singleton(displayColumn.getColumnInfo());
                 TableSelector selector = new TableSelector(view.getTable(), columns, filter, null).setNamedParameters(form.getQuerySettings().getQueryParameters());
-                Map<String, List<Aggregate.Result>> aggResults = selector.getAggregates(new ArrayList(colAggregates));
+                Map<String, List<Aggregate.Result>> aggResults = selector.getAggregates(new ArrayList<>(colAggregates));
 
                 // create a response object mapping the analytics providers to their relevant aggregate results
                 Map<String, Map<String, Object>> aggregateResults = new HashMap<>();
@@ -3438,6 +3468,7 @@ public class QueryController extends SpringActionController
     @Action(ActionType.Export.class)
     public static class ExportSqlAction extends ExportAction<ExportSqlForm>
     {
+        @Override
         public void export(ExportSqlForm form, HttpServletResponse response, BindException errors) throws IOException, ExportException
         {
             String schemaName = StringUtils.trimToNull(form.getSchemaName());
@@ -3505,6 +3536,7 @@ public class QueryController extends SpringActionController
     {
         insert(InsertPermission.class)
         {
+            @Override
             public List<Map<String, Object>> saveRows(QueryUpdateService qus, List<Map<String, Object>> rows, User user, Container container, Map<Enum, Object> configParameters, Map<String, Object> extraContext)
                     throws SQLException, InvalidKeyException, QueryUpdateServiceException, BatchValidationException, DuplicateKeyException
             {
@@ -3517,6 +3549,7 @@ public class QueryController extends SpringActionController
         },
         insertWithKeys(InsertPermission.class)
         {
+            @Override
             public List<Map<String, Object>> saveRows(QueryUpdateService qus, List<Map<String, Object>> rows, User user, Container container, Map<Enum, Object> configParameters, Map<String, Object> extraContext)
                     throws SQLException, InvalidKeyException, QueryUpdateServiceException, BatchValidationException, DuplicateKeyException
             {
@@ -3549,6 +3582,7 @@ public class QueryController extends SpringActionController
         },
         importRows(InsertPermission.class)
         {
+            @Override
             public List<Map<String, Object>> saveRows(QueryUpdateService qus, List<Map<String, Object>> rows, User user, Container container, Map<Enum, Object> configParameters, Map<String, Object> extraContext)
                     throws SQLException, BatchValidationException
             {
@@ -3562,6 +3596,7 @@ public class QueryController extends SpringActionController
         },
         update(UpdatePermission.class)
         {
+            @Override
             public List<Map<String, Object>> saveRows(QueryUpdateService qus, List<Map<String, Object>> rows, User user, Container container, Map<Enum, Object> configParameters, Map<String, Object> extraContext)
                     throws SQLException, InvalidKeyException, QueryUpdateServiceException, BatchValidationException
             {
@@ -3571,6 +3606,7 @@ public class QueryController extends SpringActionController
         },
         updateChangingKeys(UpdatePermission.class)
         {
+            @Override
             public List<Map<String, Object>> saveRows(QueryUpdateService qus, List<Map<String, Object>> rows, User user, Container container, Map<Enum, Object> configParameters, Map<String, Object> extraContext)
                     throws SQLException, InvalidKeyException, QueryUpdateServiceException, BatchValidationException
             {
@@ -3635,7 +3671,7 @@ public class QueryController extends SpringActionController
         public static final String PROP_COMMAND = "command";
         private static final String PROP_ROWS = "rows";
 
-        protected JSONObject executeJson(JSONObject json, CommandType commandType, boolean allowTransaction, Errors errors) throws IOException, BatchValidationException, SQLException, InvalidKeyException, QueryUpdateServiceException
+        protected JSONObject executeJson(JSONObject json, CommandType commandType, boolean allowTransaction, Errors errors) throws IOException, BatchValidationException, SQLException, InvalidKeyException
         {
             JSONObject response = new JSONObject();
             Container container = getContainer();
@@ -3992,13 +4028,15 @@ public class QueryController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public static class ApiTestAction extends SimpleViewAction
+    public static class ApiTestAction extends SimpleViewAction<Object>
     {
+        @Override
         public ModelAndView getView(Object o, BindException errors)
         {
-            return new JspView("/org/labkey/query/view/apitest.jsp");
+            return new JspView<>("/org/labkey/query/view/apitest.jsp");
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             return root.addChild("API Test");
@@ -4149,7 +4187,6 @@ public class QueryController extends SpringActionController
             root.addChild("Define Schema", new ActionURL(getClass(), getContainer()));
             return root;
         }
-
     }
 
     @RequiresPermission(AdminOperationsPermission.class)
@@ -4160,6 +4197,7 @@ public class QueryController extends SpringActionController
             super(LinkedSchemaForm.class);
         }
 
+        @Override
         public ModelAndView getView(LinkedSchemaForm form, boolean reshow, BindException errors)
         {
             setHelpTopic(new HelpTopic("filterSchema"));
@@ -4175,6 +4213,7 @@ public class QueryController extends SpringActionController
             super(ExternalSchemaForm.class);
         }
 
+        @Override
         public ModelAndView getView(ExternalSchemaForm form, boolean reshow, BindException errors)
         {
             setHelpTopic(new HelpTopic("externalSchemas"));
@@ -4182,65 +4221,44 @@ public class QueryController extends SpringActionController
         }
     }
 
-    private abstract static class BaseDeleteSchemaAction<F extends AbstractExternalSchemaForm<T>, T extends AbstractExternalSchemaDef> extends ConfirmAction<F>
+    @RequiresPermission(AdminOperationsPermission.class)
+    public static class DeleteSchemaAction extends ConfirmAction<SchemaForm>
     {
+        @Override
         public String getConfirmText()
         {
             return "Delete";
         }
 
-        public ModelAndView getConfirmView(F form, BindException errors)
+        @Override
+        public ModelAndView getConfirmView(SchemaForm form, BindException errors)
         {
             if (getPageConfig().getTitle() == null)
                 setTitle("Delete Schema");
 
-            form.refreshFromDb();
-            String schemaName = isBlank(form.getBean().getUserSchemaName()) ? "this schema" : "the schema '" + form.getBean().getUserSchemaName() + "'";
-            return new HtmlView("Are you sure you want to delete " + schemaName + "? The tables and queries defined in this schema will no longer be accessible.");
+            AbstractExternalSchemaDef def = ExternalSchemaDefCache.getSchemaDef(getContainer(), form.getExternalSchemaId(), AbstractExternalSchemaDef.class);
+            String schemaName = isBlank(def.getUserSchemaName()) ? "this schema" : "the schema '" + def.getUserSchemaName() + "'";
+            return new HtmlView(HtmlString.of("Are you sure you want to delete " + schemaName + "? The tables and queries defined in this schema will no longer be accessible."));
         }
 
-        public boolean handlePost(F form, BindException errors)
+        @Override
+        public boolean handlePost(SchemaForm form, BindException errors)
         {
-            delete(form);
+            AbstractExternalSchemaDef def = ExternalSchemaDefCache.getSchemaDef(getContainer(), form.getExternalSchemaId(), AbstractExternalSchemaDef.class);
+            QueryManager.get().delete(def);
             return true;
         }
 
         @Override
-        protected String getCommandClassMethodName()
-        {
-            return "delete";
-        }
-
-        public abstract void delete(F form);
-
-        public void validateCommand(F form, Errors errors)
+        public void validateCommand(SchemaForm form, Errors errors)
         {
         }
 
+        @Override
         @NotNull
-        public ActionURL getSuccessURL(F form)
+        public ActionURL getSuccessURL(SchemaForm form)
         {
             return new QueryUrlsImpl().urlExternalSchemaAdmin(getContainer());
-        }
-    }
-
-    @RequiresPermission(AdminOperationsPermission.class)
-    public static class DeleteLinkedSchemaAction extends BaseDeleteSchemaAction<LinkedSchemaForm, LinkedSchemaDef>
-    {
-        public void delete(LinkedSchemaForm form)
-        {
-            form.refreshFromDb();
-            QueryManager.get().delete(form.getBean());
-        }
-    }
-
-    @RequiresPermission(AdminOperationsPermission.class)
-    public static class DeleteExternalSchemaAction extends BaseDeleteSchemaAction<ExternalSchemaForm, ExternalSchemaDef>
-    {
-        public void delete(ExternalSchemaForm form)
-        {
-            form.refreshFromDb();
-            QueryManager.get().delete(form.getBean());
         }
     }
 
@@ -4259,7 +4277,7 @@ public class QueryController extends SpringActionController
 
         protected abstract T getCurrent(int externalSchemaId);
 
-        protected T getDef(F form, boolean reshow, BindException errors)
+        protected T getDef(F form, boolean reshow)
         {
             T def;
             Container defContainer;
@@ -4343,7 +4361,7 @@ public class QueryController extends SpringActionController
         @Override
         public ModelAndView getView(LinkedSchemaForm form, boolean reshow, BindException errors)
         {
-            LinkedSchemaDef def = getDef(form, reshow, errors);
+            LinkedSchemaDef def = getDef(form, reshow);
 
             setHelpTopic(new HelpTopic("linkedSchemas"));
             return new JspView<>("/org/labkey/query/view/linkedSchema.jsp", new LinkedSchemaBean(getContainer(), def, false), errors);
@@ -4367,7 +4385,7 @@ public class QueryController extends SpringActionController
         @Override
         public ModelAndView getView(ExternalSchemaForm form, boolean reshow, BindException errors)
         {
-            ExternalSchemaDef def = getDef(form, reshow, errors);
+            ExternalSchemaDef def = getDef(form, reshow);
 
             setHelpTopic(new HelpTopic("externalSchemas"));
             return new JspView<>("/org/labkey/query/view/externalSchema.jsp", new ExternalSchemaBean(getContainer(), def, false), errors);
@@ -4405,8 +4423,7 @@ public class QueryController extends SpringActionController
             if (o == null || getClass() != o.getClass()) return false;
 
             DataSourceInfo that = (DataSourceInfo) o;
-            if (sourceName != null ? !sourceName.equals(that.sourceName) : that.sourceName != null) return false;
-            return true;
+            return sourceName != null ? sourceName.equals(that.sourceName) : that.sourceName == null;
         }
 
         @Override
@@ -4456,14 +4473,13 @@ public class QueryController extends SpringActionController
 
         public ActionURL getDeleteURL()
         {
-            return new QueryUrlsImpl().urlDeleteExternalSchema(_c, _def);
+            return new QueryUrlsImpl().urlDeleteSchema(_c, _def);
         }
 
         public String getHelpHTML(String fieldName)
         {
             return _help.get(fieldName);
         }
-
     }
 
     public static class LinkedSchemaBean extends BaseExternalSchemaBean<LinkedSchemaDef>
@@ -4473,6 +4489,7 @@ public class QueryController extends SpringActionController
             super(c, def, insert);
         }
 
+        @Override
         public DataSourceInfo getInitialSource()
         {
             Container sourceContainer = getInitialContainer();
@@ -4686,7 +4703,7 @@ public class QueryController extends SpringActionController
     }
 
     @RequiresPermission(AdminOperationsPermission.class)
-    public static class SchemaTemplatesAction extends ReadOnlyApiAction
+    public static class SchemaTemplatesAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public ApiResponse execute(Object form, BindException errors)
@@ -4710,36 +4727,36 @@ public class QueryController extends SpringActionController
         }
     }
 
-
-
     @RequiresPermission(AdminPermission.class)
-    public static class ReloadExternalSchemaAction extends FormHandlerAction<ExternalSchemaForm>
+    public static class ReloadExternalSchemaAction extends FormHandlerAction<SchemaForm>
     {
+        private String _userSchemaName;
+
         @Override
-        public void validateCommand(ExternalSchemaForm form, Errors errors)
+        public void validateCommand(SchemaForm form, Errors errors)
         {
         }
 
         @Override
-        public boolean handlePost(ExternalSchemaForm form, BindException errors)
+        public boolean handlePost(SchemaForm form, BindException errors)
         {
-            form.refreshFromDb();
-            ExternalSchemaDef def = form.getBean();
+            ExternalSchemaDef def = ExternalSchemaDefCache.getSchemaDef(getContainer(), form.getExternalSchemaId(), ExternalSchemaDef.class);
             QueryManager.get().reloadExternalSchema(def);
+            _userSchemaName = def.getUserSchemaName();
 
             return true;
         }
 
         @Override
-        public ActionURL getSuccessURL(ExternalSchemaForm form)
+        public ActionURL getSuccessURL(SchemaForm form)
         {
-            return new QueryUrlsImpl().urlExternalSchemaAdmin(getContainer(), form.getBean().getUserSchemaName());
+            return new QueryUrlsImpl().urlExternalSchemaAdmin(getContainer(), _userSchemaName);
         }
     }
 
 
     @RequiresPermission(AdminPermission.class)
-    public static class ReloadAllUserSchemas extends FormHandlerAction
+    public static class ReloadAllUserSchemas extends FormHandlerAction<Object>
     {
         @Override
         public void validateCommand(Object target, Errors errors)
@@ -4764,6 +4781,7 @@ public class QueryController extends SpringActionController
     @RequiresPermission(ReadPermission.class)
     public static class TableInfoAction extends SimpleViewAction<TableInfoForm>
     {
+        @Override
         public ModelAndView getView(TableInfoForm form, BindException errors) throws Exception
         {
             TablesDocument ret = TablesDocument.Factory.newInstance();
@@ -4788,6 +4806,7 @@ public class QueryController extends SpringActionController
             return null;
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             return root;
@@ -5045,11 +5064,13 @@ public class QueryController extends SpringActionController
     @RequiresPermission(AdminPermission.class)
     public class InternalDeleteView extends ConfirmAction<InternalViewForm>
     {
+        @Override
         public ModelAndView getConfirmView(InternalViewForm form, BindException errors)
         {
             return new JspView<>("/org/labkey/query/view/internalDeleteView.jsp", form, errors);
         }
 
+        @Override
         public boolean handlePost(InternalViewForm form, BindException errors)
         {
             CstmView view = form.getViewAndCheckPermission();
@@ -5057,10 +5078,12 @@ public class QueryController extends SpringActionController
             return true;
         }
 
+        @Override
         public void validateCommand(InternalViewForm internalViewForm, Errors errors)
         {
         }
 
+        @Override
         @NotNull
         public ActionURL getSuccessURL(InternalViewForm internalViewForm)
         {
@@ -5123,6 +5146,7 @@ public class QueryController extends SpringActionController
     {
         int _customViewId = 0;
 
+        @Override
         public void validateCommand(InternalNewViewForm form, Errors errors)
         {
             if (StringUtils.trimToNull(form.ff_schemaName) == null)
@@ -5135,11 +5159,13 @@ public class QueryController extends SpringActionController
             }
         }
 
+        @Override
         public ModelAndView getView(InternalNewViewForm form, boolean reshow, BindException errors)
         {
             return new JspView<>("/org/labkey/query/view/internalNewView.jsp", form, errors);
         }
 
+        @Override
         public boolean handlePost(InternalNewViewForm form, BindException errors)
         {
             if (form.ff_share)
@@ -5188,6 +5214,7 @@ public class QueryController extends SpringActionController
             return true;
         }
 
+        @Override
         public ActionURL getSuccessURL(InternalNewViewForm form)
         {
             ActionURL forward = new ActionURL(InternalSourceViewAction.class, getContainer());
@@ -5195,6 +5222,7 @@ public class QueryController extends SpringActionController
             return forward;
         }
 
+        @Override
         public NavTree appendNavTrail(NavTree root)
         {
             root.addChild("Create New Grid View");
@@ -5258,8 +5286,7 @@ public class QueryController extends SpringActionController
         @Override
         public void validateForm(QueryForm form, Errors errors)
         {
-            if (form.getSchemaName().isEmpty() ||
-                form.getQueryName() == null)
+            if (form.getSchemaName().isEmpty() || form.getQueryName() == null)
             {
                 errors.reject(ERROR_MSG, "schemaName and queryName required");
             }
@@ -5364,7 +5391,6 @@ public class QueryController extends SpringActionController
     }
 
 
-    @SuppressWarnings({"unused", "WeakerAccess"})
     public static class GetSchemasForm
     {
         private boolean _includeHidden = true;
@@ -5375,6 +5401,7 @@ public class QueryController extends SpringActionController
             return _schemaName;
         }
 
+        @SuppressWarnings("unused")
         public void setSchemaName(SchemaKey schemaName)
         {
             _schemaName = schemaName;
@@ -5385,6 +5412,7 @@ public class QueryController extends SpringActionController
             return _includeHidden;
         }
 
+        @SuppressWarnings("unused")
         public void setIncludeHidden(boolean includeHidden)
         {
             _includeHidden = includeHidden;
@@ -5402,6 +5430,7 @@ public class QueryController extends SpringActionController
             return QueryService.get().metadataLastModified();
         }
 
+        @Override
         public ApiResponse execute(GetSchemasForm form, BindException errors)
         {
             final Container container = getContainer();
@@ -5410,7 +5439,7 @@ public class QueryController extends SpringActionController
             final boolean includeHidden = form.isIncludeHidden();
             if (getRequestedApiVersion() >= 9.3)
             {
-                SimpleSchemaTreeVisitor visitor = new SimpleSchemaTreeVisitor<Void, JSONObject>(includeHidden)
+                SimpleSchemaTreeVisitor<Void, JSONObject> visitor = new SimpleSchemaTreeVisitor<>(includeHidden)
                 {
                     @Override
                     public Void visitUserSchema(UserSchema schema, Path path, JSONObject json)
@@ -5535,6 +5564,7 @@ public class QueryController extends SpringActionController
             return QueryService.get().metadataLastModified();
         }
 
+        @Override
         public ApiResponse execute(GetQueriesForm form, BindException errors)
         {
             if (null == StringUtils.trimToNull(form.getSchemaName()))
@@ -5721,6 +5751,7 @@ public class QueryController extends SpringActionController
             return QueryService.get().metadataLastModified();
         }
 
+        @Override
         public ApiResponse execute(GetQueryViewsForm form, BindException errors)
         {
             if (null == StringUtils.trimToNull(form.getSchemaName()))
@@ -5789,8 +5820,9 @@ public class QueryController extends SpringActionController
     }
 
     @RequiresNoPermission
-    public static class GetServerDateAction extends ReadOnlyApiAction
+    public static class GetServerDateAction extends ReadOnlyApiAction<Object>
     {
+        @Override
         public ApiResponse execute(Object o, BindException errors)
         {
             return new ApiSimpleResponse("date", new Date());
@@ -5851,6 +5883,7 @@ public class QueryController extends SpringActionController
     @RequiresPermission(ReadPermission.class)
     public static class SaveApiTestAction extends MutatingApiAction<SaveApiTestForm>
     {
+        @Override
         public ApiResponse execute(SaveApiTestForm form, BindException errors)
         {
             ApiSimpleResponse response = new ApiSimpleResponse();
@@ -5896,7 +5929,7 @@ public class QueryController extends SpringActionController
     }
 
 
-    private abstract static class ParseAction extends SimpleViewAction
+    private abstract static class ParseAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
@@ -5978,6 +6011,7 @@ public class QueryController extends SpringActionController
     @RequiresPermission(AdminOperationsPermission.class)
     public static class ParseExpressionAction extends ParseAction
     {
+        @Override
         QNode _parse(String s, List<QueryParseException> errors)
         {
             return new SqlParser().parseExpr(s, errors);
@@ -5993,6 +6027,7 @@ public class QueryController extends SpringActionController
     @RequiresPermission(AdminOperationsPermission.class)
     public static class ParseQueryAction extends ParseAction
     {
+        @Override
         QNode _parse(String s, List<QueryParseException> errors)
         {
             return new SqlParser().parseQuery(s, errors, null);
@@ -6010,6 +6045,7 @@ public class QueryController extends SpringActionController
     @Action(ActionType.SelectMetaData.class)
     public static class ValidateQueryMetadataAction extends ReadOnlyApiAction<QueryForm>
     {
+        @Override
         public ApiResponse execute(QueryForm form, BindException errors)
         {
             UserSchema schema = form.getSchema();
@@ -6081,6 +6117,7 @@ public class QueryController extends SpringActionController
     @RequiresPermission(AdminPermission.class)
     public static class QueryExportAuditRedirectAction extends SimpleRedirectAction<QueryExportAuditForm>
     {
+        @Override
         public URLHelper getRedirectURL(QueryExportAuditForm form)
         {
             if (form.getRowId() == 0)
@@ -6109,7 +6146,7 @@ public class QueryController extends SpringActionController
             if (schemaName == null || queryName == null)
                 throw new NotFoundException("Query export audit event has not schemaName or queryName");
 
-            ActionURL url = new ActionURL(QueryController.ExecuteQueryAction.class, getContainer());
+            ActionURL url = new ActionURL(ExecuteQueryAction.class, getContainer());
 
             // Apply the sorts and filters
             if (detailsURL != null)
@@ -6546,7 +6583,7 @@ public class QueryController extends SpringActionController
 
     // could make this requires(ReadPermission), but it could be pretty easy to abuse, or maybe RequiresLogin && ReadPermission
     @RequiresLogin
-    public static class TestSQLAction extends SimpleViewAction
+    public static class TestSQLAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
@@ -6565,7 +6602,7 @@ public class QueryController extends SpringActionController
 
 
     @RequiresPermission(ReadPermission.class)
-    public static class AnalyzeQueriesAction extends ReadOnlyApiAction
+    public static class AnalyzeQueriesAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public Object execute(Object o, BindException errors) throws Exception
@@ -6695,15 +6732,16 @@ public class QueryController extends SpringActionController
 
     private static class QueryMetadataApiForm
     {
-        MetadataTableJSON _domain;
-        String _schemaName;
-        boolean _userDefinedQuery;
+        private MetadataTableJSON _domain;
+        private String _schemaName;
+        private boolean _userDefinedQuery;
 
         public MetadataTableJSON getDomain()
         {
             return _domain;
         }
 
+        @SuppressWarnings("unused")
         public void setDomain(MetadataTableJSON domain)
         {
             _domain = domain;
@@ -6714,6 +6752,7 @@ public class QueryController extends SpringActionController
             return _schemaName;
         }
 
+        @SuppressWarnings("unused")
         public void setSchemaName(String schemaName)
         {
             _schemaName = schemaName;
@@ -6724,6 +6763,7 @@ public class QueryController extends SpringActionController
             return _userDefinedQuery;
         }
 
+        @SuppressWarnings("unused")
         public void setUserDefinedQuery(boolean userDefinedQuery)
         {
             _userDefinedQuery = userDefinedQuery;
@@ -6816,8 +6856,7 @@ public class QueryController extends SpringActionController
                 controller.new RawSchemaMetaDataAction(),
                 new InsertLinkedSchemaAction(),
                 new InsertExternalSchemaAction(),
-                new DeleteLinkedSchemaAction(),
-                new DeleteExternalSchemaAction(),
+                new DeleteSchemaAction(),
                 new EditLinkedSchemaAction(),
                 new EditExternalSchemaAction(),
                 new GetTablesAction(),

--- a/query/src/org/labkey/query/controllers/SchemaForm.java
+++ b/query/src/org/labkey/query/controllers/SchemaForm.java
@@ -1,0 +1,17 @@
+package org.labkey.query.controllers;
+
+public class SchemaForm
+{
+    private int _externalSchemaId;
+
+    public int getExternalSchemaId()
+    {
+        return _externalSchemaId;
+    }
+
+    @SuppressWarnings("unused")
+    public void setExternalSchemaId(int externalSchemaId)
+    {
+        _externalSchemaId = externalSchemaId;
+    }
+}

--- a/query/src/org/labkey/query/persist/QueryManager.java
+++ b/query/src/org/labkey/query/persist/QueryManager.java
@@ -45,6 +45,7 @@ import org.labkey.api.query.CustomViewChangeListener;
 import org.labkey.api.query.CustomViewInfo;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryChangeListener;
+import org.labkey.api.query.QueryChangeListener.QueryPropertyChange;
 import org.labkey.api.query.QueryDefinition;
 import org.labkey.api.query.QueryParseException;
 import org.labkey.api.query.QueryParseWarning;
@@ -325,7 +326,10 @@ public class QueryManager
 
     public void delete(AbstractExternalSchemaDef def)
     {
-        Table.delete(getTableInfoExternalSchema(), def.getExternalSchemaId());
+        Container c = def.lookupContainer();
+        SimpleFilter filter = SimpleFilter.createContainerFilter(c);
+        filter.addCondition(getTableInfoExternalSchema().getColumn("ExternalSchemaId"), def.getExternalSchemaId());
+        Table.delete(getTableInfoExternalSchema(), filter);
         updateExternalSchemas(def.lookupContainer());
     }
 
@@ -484,7 +488,7 @@ public class QueryManager
             l.queryCreated(user, container, scope, schema, queries);
     }
 
-    public void fireQueryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryChangeListener.QueryProperty property, @NotNull Collection<QueryChangeListener.QueryPropertyChange> changes)
+    public void fireQueryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryChangeListener.QueryProperty property, @NotNull Collection<QueryPropertyChange> changes)
     {
         QueryService.get().updateLastModified();
         assert checkChanges(property, changes);
@@ -493,7 +497,7 @@ public class QueryManager
     }
 
     // Checks all changes have the correct property and type.
-    private boolean checkChanges(QueryChangeListener.QueryProperty property, Collection<QueryChangeListener.QueryPropertyChange> changes)
+    private boolean checkChanges(QueryChangeListener.QueryProperty property, Collection<QueryPropertyChange> changes)
     {
         if (property == null)
         {
@@ -502,7 +506,7 @@ public class QueryManager
         }
 
         boolean valid = true;
-        for (QueryChangeListener.QueryPropertyChange change : changes)
+        for (QueryPropertyChange change : changes)
         {
             if (change.getProperty() != property)
             {

--- a/query/src/org/labkey/query/view/admin.jsp
+++ b/query/src/org/labkey/query/view/admin.jsp
@@ -93,7 +93,7 @@ else
         ActionURL urlEdit = urls.urlUpdateExternalSchema(c, def);
         ActionURL urlView = urls.urlSchemaBrowser(c, def.getUserSchemaName());
         ActionURL urlReload = urls.urlReloadExternalSchema(c, def);
-        ActionURL urlDelete = urls.urlDeleteExternalSchema(c, def);
+        ActionURL urlDelete = urls.urlDeleteSchema(c, def);
 
     %>
         <tr class='<%=getShadeRowClass(i)%>'>
@@ -169,7 +169,7 @@ else
     {
         ActionURL urlView = urls.urlSchemaBrowser(c, linkedSchema.getUserSchemaName());
         ActionURL urlEdit = new ActionURL(QueryController.EditLinkedSchemaAction.class, c).addParameter("externalSchemaId", Integer.toString(linkedSchema.getExternalSchemaId()));
-        ActionURL urlDelete = new ActionURL(QueryController.DeleteLinkedSchemaAction.class, c).addParameter("externalSchemaId", Integer.toString(linkedSchema.getExternalSchemaId()));
+        ActionURL urlDelete = urls.urlDeleteSchema(c, linkedSchema);
 
         Container sourceContainer = linkedSchema.lookupSourceContainer();
 

--- a/query/src/org/labkey/query/view/externalSchema.jsp
+++ b/query/src/org/labkey/query/view/externalSchema.jsp
@@ -22,7 +22,7 @@
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.data.xml.externalSchema.TemplateSchemaType" %>
-<%@ page import="org.labkey.query.controllers.QueryController.BaseExternalSchemaBean" %>
+<%@ page import="org.labkey.query.controllers.QueryController" %>
 <%@ page import="org.labkey.query.controllers.QueryController.DataSourceInfo" %>
 <%@ page import="org.labkey.query.persist.AbstractExternalSchemaDef" %>
 <%@ page import="org.labkey.query.persist.AbstractExternalSchemaDef.SchemaType" %>
@@ -30,7 +30,6 @@
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.Arrays" %>
 <%@ page import="java.util.Collection" %>
-<%@ page import="org.labkey.query.controllers.QueryController" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
     @Override
@@ -84,7 +83,7 @@
     String initialTemplateName = bean.getSchemaDef().getSchemaTemplate();
     TemplateSchemaType initialTemplate = bean.getSchemaDef().lookupTemplate(c);
 %>
-var dataSources = <%=text(dataSourcesJson.toString())%>;
+var dataSources = <%=dataSourcesJson%>;
 var initialDataSourceIndex = <%=coreIndex%>;
 
 var dataSourceStore = new Ext.data.SimpleStore({
@@ -232,7 +231,7 @@ else if (initialTemplate != null && initialTemplate.isSetTables())
     tables.addAll(Arrays.asList(initialTemplate.getTables().getTableNameArray()));
 }
 %>
-var initialTables = <%=text(new JSONArray(tables).toString())%>;
+var initialTables = <%=new JSONArray(tables)%>;
 
 // create the table grid
 var grid = new Ext.grid.GridPanel({

--- a/query/src/org/labkey/query/view/linkedSchema.jsp
+++ b/query/src/org/labkey/query/view/linkedSchema.jsp
@@ -375,8 +375,7 @@
             name: 'tables',
             fieldLabel: false,
             width: 395,
-            //value: <%=text(new JSONArray(tables).toString())%>,
-            initialValue: <%=text(new JSONArray(tables).toString())%>,
+            initialValue: <%=new JSONArray(tables)%>,
             // Prevent the 'dataloaded' event from being fired when the template changes when creating a new linked schema.
             initiallyLoaded: <%=bean.isInsert()%>,
             disabled: <%=def.getTables() == null && initialTemplate != null%>,

--- a/study/src/org/labkey/study/importer/SpecimenImporter.java
+++ b/study/src/org/labkey/study/importer/SpecimenImporter.java
@@ -129,7 +129,7 @@ public class SpecimenImporter
         UpdateAllStatistics, CommitTransaction, ClearCaches, PopulateMaterials, PopulateSpecimens, PopulateVials, PopulateSpecimenEvents,
         PopulateTempTable, PopulateLabs, SpecimenTypes, DeleteOldData, PrepareQcComments, NotifyChanged}
 
-    private static MultiPhaseCPUTimer<ImportPhases> TIMER = new MultiPhaseCPUTimer<>(ImportPhases.class, ImportPhases.values());
+    private static final MultiPhaseCPUTimer<ImportPhases> TIMER = new MultiPhaseCPUTimer<>(ImportPhases.class, ImportPhases.values());
 
     public static class ImportableColumn
     {


### PR DESCRIPTION
#### Rationale
Initial goal was to fix [issue 39831](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39831), simplify external & linked schema deleting from three actions to one, and eliminate a few uses of BeanViewForm. In the process, I also added a bunch of `@Override` annotations and addressed other IntelliJ warnings. And a simple change to start logging and displaying the SQL Server version year led to removing most version handling in the dialect. DbScope already holds onto the product and version information from DatabaseMetaData, so this was largely redundant. DbScope defers to SqlDialect only when the dialect has more useful information to share, e.g., the product year and edition in the case of SQL Server.

#### Changes
* Single DeleteSchemaAction replaces base action and separate delete actions for external & linked schemas.
* Fix [issue 39831](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39831).
* Display more useful product information for SQL Server databases in startup logging, admin console, diagnostics, and data sources page. Was "15.00.2000 (Developer Edition)" now "2019 (15.00.2000) Developer Edition"
