### PR TITLE
Add more logging for DB connection pool status

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -984,6 +984,11 @@ public class DbScope
     {
         synchronized (_transaction)
         {
+            log.info("Data source " + toString() +
+                    ". Max connections: " + _dsProps.getMaxTotal() +
+                    ", active: " + _dsProps.getNumActive() +
+                    ", idle: " + _dsProps.getNumIdle());
+
             if (_transaction.isEmpty())
             {
                 log.info("There are no threads holding connections for the data source '" + toString() + "'");

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1138,6 +1138,32 @@ public abstract class SqlDialect
                 return null;
             }
         }
+
+        public Integer getNumActive()
+        {
+            try
+            {
+                return callGetter("getNumActive");
+            }
+            catch (ServletException e)
+            {
+                LOG.error("Could not extract connection num active from data source \"" + _dsName + "\"");
+                return null;
+            }
+        }
+        public Integer getNumIdle()
+        {
+            try
+            {
+                return callGetter("getNumIdle");
+            }
+            catch (ServletException e)
+            {
+                LOG.error("Could not extract connection num idle from data source \"" + _dsName + "\"");
+                return null;
+            }
+        }
+
     }
 
 

--- a/core/src/org/labkey/core/admin/admin.jsp
+++ b/core/src/org/labkey/core/admin/admin.jsp
@@ -88,7 +88,9 @@
                 { %>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>JDBC Driver Location</td><td id="databaseDriverLocation"><%=h(location)%></td></tr><%
                 } %>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Pool Size</td><td id="connectionPoolSize"><%=h(bean.scope.getDataSourceProperties().getMaxTotal())%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Pool Max Size</td><td id="connectionPoolSize"><%=h(bean.scope.getDataSourceProperties().getMaxTotal())%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Pool Active</td><td id="connectionPoolActive"><%=h(bean.scope.getDataSourceProperties().getNumActive())%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Pool Idle</td><td id="connectionPoolIdle"><%=h(bean.scope.getDataSourceProperties().getNumIdle())%></td></tr>
             </table>
             <br/>
 <%

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -533,7 +533,10 @@ public class QueryController extends SpringActionController
             sb.append("  <td class=\"labkey-column-header\">Current Status</td>");
             sb.append("  <td class=\"labkey-column-header\">URL</td>");
             sb.append("  <td class=\"labkey-column-header\">Product Name</td>");
-            sb.append("  <td class=\"labkey-column-header\">Product Version</td></tr>\n");
+            sb.append("  <td class=\"labkey-column-header\">Product Version</td>");
+            sb.append("  <td class=\"labkey-column-header\">Max Connections</td>");
+            sb.append("  <td class=\"labkey-column-header\">Active Connections</td>");
+            sb.append("  <td class=\"labkey-column-header\">Idle Connections</td></tr>\n");
 
             int rowCount = 0;
             for (DbScope scope : DbScope.getDbScopes())
@@ -567,11 +570,17 @@ public class QueryController extends SpringActionController
 
                 sb.append(status);
                 sb.append("</td><td>");
-                sb.append(scope.getURL());
+                sb.append(PageFlowUtil.filter(scope.getURL()));
                 sb.append("</td><td>");
-                sb.append(scope.getDatabaseProductName());
+                sb.append(PageFlowUtil.filter(scope.getDatabaseProductName()));
                 sb.append("</td><td>");
-                sb.append(scope.getDatabaseProductVersion());
+                sb.append(PageFlowUtil.filter(scope.getDatabaseProductVersion()));
+                sb.append("</td><td>");
+                sb.append(scope.getDataSourceProperties().getMaxTotal());
+                sb.append("</td><td>");
+                sb.append(scope.getDataSourceProperties().getNumActive());
+                sb.append("</td><td>");
+                sb.append(scope.getDataSourceProperties().getNumIdle());
                 sb.append("</td></tr>\n");
 
                 Collection<ExternalSchemaDef> dsDefs = byDataSourceName.get(scope.getDataSourceName());


### PR DESCRIPTION
#### Rationale
LabKey Server deadlocks are often related to the status of the DB connection pool. Thus, it's useful to better understand the status when doing a thread dump.

#### Changes
Add max, active, and idle counts to thread dumps
Add active and idle to Admin Console