### PR TITLE
Use DbSequence to back RowId for materials table

### DIFF
--- a/api/schemas/tableInfo.xsd
+++ b/api/schemas/tableInfo.xsd
@@ -451,6 +451,15 @@
                     </xs:documentation>
 				</xs:annotation>
 			</xs:element>
+            <xs:element name="isDbSequence" type="xs:boolean" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        True if the column is assigned an automatically incrementing value by the Java code for every
+                        new row inserted. Unlike autoInc columns, the value for this column can be available during
+                        insert without requiring additional selection to occur.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
 			<xs:element name="isDisplayColumn" type="xs:boolean" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>

--- a/api/schemas/tableInfo.xsd
+++ b/api/schemas/tableInfo.xsd
@@ -451,7 +451,7 @@
                     </xs:documentation>
 				</xs:annotation>
 			</xs:element>
-            <xs:element name="isDbSequence" type="xs:boolean" minOccurs="0">
+            <xs:element name="hasDbSequence" type="dat:DbSequenceType" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         True if the column is assigned an automatically incrementing value by the Java code for every
@@ -1268,6 +1268,26 @@
             </xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
+
+    <xs:complexType name="DbSequenceType">
+        <xs:annotation>
+            <xs:documentation>
+                Used to indicate that this column is backed by a Java-generated DbSequence.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:boolean">
+                <xs:attribute name="rootSequence" default="false" type="xs:boolean" >
+                    <xs:annotation>
+                        <xs:documentation>
+                            Indicates that the sequence is to be created using the root container rather than the
+                            container in which the objects are scoped.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
 
     <xs:simpleType name="DefaultValueEnumType">
         <xs:annotation>

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -597,12 +597,6 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     }
 
     @Override
-    public String getDbSequenceName(String columnName)
-    {
-        return (this.getSchema().getName() + ":" + this.getName() + ":" + columnName).toLowerCase();
-    }
-
-    @Override
     public String getName()
     {
         return _name;

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -597,6 +597,12 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     }
 
     @Override
+    public String getDbSequenceName(String columnName)
+    {
+        return this.getSchema().getName() + ":" + this.getName() + ":" + columnName;
+    }
+
+    @Override
     public String getName()
     {
         return _name;

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -599,7 +599,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     @Override
     public String getDbSequenceName(String columnName)
     {
-        return this.getSchema().getName() + ":" + this.getName() + ":" + columnName;
+        return (this.getSchema().getName() + ":" + this.getName() + ":" + columnName).toLowerCase();
     }
 
     @Override

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -87,6 +87,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Column
     private Object _defaultValue = null;
     private String _jdbcDefaultValue = null;  // TODO: Merge with defaultValue, see #17646
     private boolean _isAutoIncrement = false;
+    private boolean _isDbSequence = false;
     private boolean _isKeyField = false;
     private boolean _isReadOnly = false;
     private boolean _isUserEditable = true;
@@ -866,6 +867,17 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Column
     }
 
     @Override
+    public boolean isDbSequence()
+    {
+        return _isDbSequence;
+    }
+
+    public void setIsDbSequence(boolean isDbSequence)
+    {
+        _isDbSequence = isDbSequence;
+    }
+
+    @Override
     public boolean isReadOnly()
     {
         return _isReadOnly || _isAutoIncrement || isVersionColumn();
@@ -1041,6 +1053,8 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Column
             setURLTargetWindow(xmlCol.getUrlTarget());
         if (xmlCol.isSetIsAutoInc())
             _isAutoIncrement = xmlCol.getIsAutoInc();
+        if (xmlCol.isSetIsDbSequence())
+            _isDbSequence = xmlCol.getIsDbSequence();
         if (xmlCol.isSetIsReadOnly())
             _isReadOnly = xmlCol.getIsReadOnly();
         if (xmlCol.isSetIsUserEditable())

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -46,6 +46,7 @@ import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.util.StringExpressionFactory.FieldKeyStringExpression;
 import org.labkey.data.xml.ColumnType;
+import org.labkey.data.xml.DbSequenceType;
 import org.labkey.data.xml.PropertiesType;
 
 import java.beans.Introspector;
@@ -87,7 +88,8 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Column
     private Object _defaultValue = null;
     private String _jdbcDefaultValue = null;  // TODO: Merge with defaultValue, see #17646
     private boolean _isAutoIncrement = false;
-    private boolean _isDbSequence = false;
+    private boolean _hasDbSequence = false;
+    private boolean _isRootDbSequence = false;
     private boolean _isKeyField = false;
     private boolean _isReadOnly = false;
     private boolean _isUserEditable = true;
@@ -867,14 +869,25 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Column
     }
 
     @Override
-    public boolean isDbSequence()
+    public boolean hasDbSequence()
     {
-        return _isDbSequence;
+        return _hasDbSequence;
     }
 
-    public void setIsDbSequence(boolean isDbSequence)
+    public void setHasDbSequence(boolean hasDbSequence)
     {
-        _isDbSequence = isDbSequence;
+        _hasDbSequence = hasDbSequence;
+    }
+
+    @Override
+    public boolean isRootDbSequence()
+    {
+        return _isRootDbSequence;
+    }
+
+    public void setIsRootDbSequence(boolean isRootDbSequence)
+    {
+        _isRootDbSequence = isRootDbSequence;
     }
 
     @Override
@@ -1053,8 +1066,12 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Column
             setURLTargetWindow(xmlCol.getUrlTarget());
         if (xmlCol.isSetIsAutoInc())
             _isAutoIncrement = xmlCol.getIsAutoInc();
-        if (xmlCol.isSetIsDbSequence())
-            _isDbSequence = xmlCol.getIsDbSequence();
+        if (xmlCol.isSetHasDbSequence())
+        {
+            DbSequenceType dbSequenceType = xmlCol.getHasDbSequence();
+            _hasDbSequence = dbSequenceType.getBooleanValue();
+            _isRootDbSequence = dbSequenceType.getRootSequence();
+        }
         if (xmlCol.isSetIsReadOnly())
             _isReadOnly = xmlCol.getIsReadOnly();
         if (xmlCol.isSetIsUserEditable())

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -893,7 +893,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     @Override
     public boolean isReadOnly()
     {
-        return _isReadOnly || _isAutoIncrement || isVersionColumn();
+        return _isReadOnly || _isAutoIncrement || _hasDbSequence || isVersionColumn();
     }
 
     public void setReadOnly(boolean readOnly)

--- a/api/src/org/labkey/api/data/ColumnInfo.java
+++ b/api/src/org/labkey/api/data/ColumnInfo.java
@@ -255,6 +255,8 @@ public interface ColumnInfo extends ColumnRenderProperties
 
     boolean isLookup();
 
+    boolean isDbSequence();
+
     @NotNull List<ConditionalFormat> getConditionalFormats();
 
     @NotNull List<? extends IPropertyValidator> getValidators();

--- a/api/src/org/labkey/api/data/ColumnInfo.java
+++ b/api/src/org/labkey/api/data/ColumnInfo.java
@@ -255,7 +255,14 @@ public interface ColumnInfo extends ColumnRenderProperties
 
     boolean isLookup();
 
-    boolean isDbSequence();
+    boolean hasDbSequence();
+
+    boolean isRootDbSequence();
+
+    default Container getDbSequenceContainer(Container container)
+    {
+        return isRootDbSequence() ? ContainerManager.getRoot() : container;
+    }
 
     @NotNull List<ConditionalFormat> getConditionalFormats();
 

--- a/api/src/org/labkey/api/data/SchemaTableInfo.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfo.java
@@ -443,7 +443,7 @@ public class SchemaTableInfo implements TableInfo, UpdateableTableInfo, AuditCon
     @Override
     public String getDbSequenceName(String columnName)
     {
-        return this.getSchema().getName() + ":" + this.getName() + ":" + columnName;
+        return (this.getSchema().getName() + ":" + this.getName() + ":" + columnName).toLowerCase();
     }
 
     protected SchemaColumnMetaData createSchemaColumnMetaData() throws SQLException

--- a/api/src/org/labkey/api/data/SchemaTableInfo.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfo.java
@@ -440,6 +440,12 @@ public class SchemaTableInfo implements TableInfo, UpdateableTableInfo, AuditCon
         }
     }
 
+    @Override
+    public String getDbSequenceName(String columnName)
+    {
+        return this.getSchema().getName() + ":" + this.getName() + ":" + columnName;
+    }
+
     protected SchemaColumnMetaData createSchemaColumnMetaData() throws SQLException
     {
         return new SchemaColumnMetaData(this, _autoLoadMetaData);

--- a/api/src/org/labkey/api/data/SchemaTableInfo.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfo.java
@@ -440,11 +440,6 @@ public class SchemaTableInfo implements TableInfo, UpdateableTableInfo, AuditCon
         }
     }
 
-    @Override
-    public String getDbSequenceName(String columnName)
-    {
-        return (this.getSchema().getName() + ":" + this.getName() + ":" + columnName).toLowerCase();
-    }
 
     protected SchemaColumnMetaData createSchemaColumnMetaData() throws SQLException
     {

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -195,6 +195,8 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
 
     Set<String> getColumnNameSet();
 
+    String getDbSequenceName(String colName);
+
     /**
      * Return a list of ColumnInfos that make up the extended set of
      * columns that could be considered a part of this table by default.
@@ -209,6 +211,7 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
      * @return All columns.
      */
     Map<FieldKey, ColumnInfo> getExtendedColumns(boolean includeHidden);
+
 
     /**
      * @return the {@link org.labkey.api.query.FieldKey}s that should be part of the default view of the table,

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -195,7 +195,10 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
 
     Set<String> getColumnNameSet();
 
-    String getDbSequenceName(String colName);
+    default String getDbSequenceName(String columnName)
+    {
+        return (this.getSchema().getName() + ":" + this.getName() + ":" + columnName).toLowerCase();
+    }
 
     /**
      * Return a list of ColumnInfos that make up the extended set of

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -1115,6 +1115,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             t.selectAll();
         }
         t.addBuiltInColumns(context, c, user, target, false);
+        t.addDbSequenceColumns(c, target);
         return t;
     }
 
@@ -1146,6 +1147,15 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         }
     }
 
+    public void addDbSequenceColumns(@Nullable Container c, @NotNull TableInfo target)
+    {
+        target.getColumns().forEach(columnInfo -> {
+            if (columnInfo.isDbSequence())
+            {
+                addSequenceColumn(columnInfo, c, target.getDbSequenceName(columnInfo.getName()));
+            }
+        });
+    }
 
     /**
      * Provide values for common built-in columns.  Usually we do not allow the user to specify values for these columns,

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -1150,9 +1150,9 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
     public void addDbSequenceColumns(@Nullable Container c, @NotNull TableInfo target)
     {
         target.getColumns().forEach(columnInfo -> {
-            if (columnInfo.isDbSequence())
+            if (columnInfo.hasDbSequence())
             {
-                addSequenceColumn(columnInfo, c, target.getDbSequenceName(columnInfo.getName()));
+                addSequenceColumn(columnInfo, columnInfo.getDbSequenceContainer(c), target.getDbSequenceName(columnInfo.getName()));
             }
         });
     }

--- a/api/src/org/labkey/api/query/FilteredTable.java
+++ b/api/src/org/labkey/api/query/FilteredTable.java
@@ -128,6 +128,12 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
     }
 
     @Override
+    public String getDbSequenceName(String columnName)
+    {
+        return (_rootTable.getSchema().getName() + ":" + _rootTable.getName() + ":" + columnName).toLowerCase();
+    }
+
+    @Override
     public void loadFromXML(QuerySchema schema, @Nullable Collection<TableType> xmlTable, Collection<QueryException> errors)
     {
         if (_rootTable instanceof SchemaTableInfo)

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-20.003-20.004.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-20.003-20.004.sql
@@ -1,0 +1,6 @@
+SELECT core.executeJavaUpgradeCode('addDbSequenceForMaterialsRowId');
+
+-- TODO need to remove foreign key constraints and add them back
+ALTER SEQUENCE material_rowid_seq owned by NONE;
+ALTER TABLE material ALTER COLUMN rowId DROP DEFAULT;
+DROP SEQUENCE material_row_id;

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-20.003-20.004.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-20.003-20.004.sql
@@ -1,5 +1,1 @@
 SELECT core.executeJavaUpgradeCode('addDbSequenceForMaterialsRowId');
-
-ALTER SEQUENCE exp.material_rowid_seq owned by NONE;
-ALTER TABLE exp.material ALTER COLUMN rowId DROP DEFAULT;
-DROP SEQUENCE exp.material_rowid_seq;

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-20.003-20.004.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-20.003-20.004.sql
@@ -1,6 +1,5 @@
 SELECT core.executeJavaUpgradeCode('addDbSequenceForMaterialsRowId');
 
--- TODO need to remove foreign key constraints and add them back
-ALTER SEQUENCE material_rowid_seq owned by NONE;
-ALTER TABLE material ALTER COLUMN rowId DROP DEFAULT;
-DROP SEQUENCE material_row_id;
+ALTER SEQUENCE exp.material_rowid_seq owned by NONE;
+ALTER TABLE exp.material ALTER COLUMN rowId DROP DEFAULT;
+DROP SEQUENCE exp.material_rowid_seq;

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-20.003-20.004.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-20.003-20.004.sql
@@ -1,9 +1,1 @@
 EXEC core.executeJavaUpgradeCode 'addDbSequenceForMaterialsRowId';
-
-ALTER TABLE exp.material ADD RowId_copy INT NULL;
-
-UPDATE exp.material SET RowId_copy = RowId;
-
-ALTER TABLE exp.material DROP COLUMN RowId;
-
-EXEC sp_rename 'exp.material.RowId_copy', 'RowId', 'COLUMN';

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-20.003-20.004.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-20.003-20.004.sql
@@ -1,0 +1,9 @@
+EXEC core.executeJavaUpgradeCode 'addDbSequenceForMaterialsRowId';
+
+ALTER TABLE exp.material ADD RowId_copy INT NULL;
+
+UPDATE exp.material SET RowId_copy = RowId;
+
+ALTER TABLE exp.material DROP COLUMN RowId;
+
+EXEC sp_rename 'exp.material.RowId_copy', 'RowId', 'COLUMN';

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -134,7 +134,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     public Double getSchemaVersion()
     {
-        return 20.003;
+        return 20.004;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -18,6 +18,7 @@ package org.labkey.experiment;
 import com.google.common.collect.Sets;
 import org.apache.log4j.Logger;
 import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.DbSequence;
@@ -501,6 +502,19 @@ public class ExperimentUpgradeCode implements UpgradeCode
 
         int count = new SqlExecutor(scope).execute(update);
         LOG.info("DataClass '" + ds.getName() + "' (" + ds.getRowId() + ") updated 'name' and 'classId' column, count=" + count);
+    }
+
+    // called from exp-20.003-20.004
+    public static void addDbSequenceForMaterialsRowId(ModuleContext context)
+    {
+        if (context.isNewInstall())
+            return;
+
+        SQLFragment frag = new SQLFragment("SELECT MAX(rowId) FROM exp.material");
+        int maxId = new SqlSelector(ExperimentService.get().getSchema(), frag).getObject(Integer.class);
+
+        DbSequence sequence = DbSequenceManager.get(ContainerManager.getRoot(), ExperimentService.get().getTinfoMaterial().getDbSequenceName("RowId"));
+        sequence.ensureMinimum(maxId);
     }
 
 }

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -550,6 +550,9 @@ public class ExperimentUpgradeCode implements UpgradeCode
             // and microarray
             sql.append("IF EXISTS (SELECT 1 FROM sys.schemas WHERE NAME = 'microarray')\n" +
                     "   ALTER TABLE microarray.FeatureData DROP CONSTRAINT FK_FeatureData_SampleId;\n");
+            // and idri
+            sql.append("IF EXISTS (SELECT 1 FROM sys.schemas WHERE NAME = 'idri')\n" +
+                    "   ALTER TABLE idri.concentrations DROP CONSTRAINT FK_Lot;\n");
             // Remove primary key constraint
             sql.append("ALTER TABLE exp.Material DROP CONSTRAINT PK_Material;\n");
 
@@ -579,9 +582,10 @@ public class ExperimentUpgradeCode implements UpgradeCode
             );
             sql.append("IF EXISTS (SELECT 1 FROM sys.schemas WHERE NAME = 'microarray')\n" +
                     "   ALTER TABLE microarray.FeatureData ADD CONSTRAINT FK_FeatureData_SampleId FOREIGN KEY (SampleId) REFERENCES exp.material (RowId);\n");
+            sql.append("IF EXISTS (SELECT 1 FROM sys.schemas WHERE NAME = 'idri')\n" +
+                    "   ALTER TABLE idri.concentrations ADD CONSTRAINT FK_Lot FOREIGN KEY (Lot) REFERENCES exp.Material(RowId);\n");
             new SqlExecutor(scope).execute(sql);
         }
-
     }
 
 }

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -547,6 +547,9 @@ public class ExperimentUpgradeCode implements UpgradeCode
              // and labbook
             sql.append("IF EXISTS (SELECT 1 FROM sys.schemas WHERE NAME = 'labbook')\n" +
                             "   ALTER TABLE labbook.LabBookExperimentMaterial DROP CONSTRAINT FK_LabBookExperimentMaterial_MaterialId;\n");
+            // and microarray
+            sql.append("IF EXISTS (SELECT 1 FROM sys.schemas WHERE NAME = 'microarray')\n" +
+                    "   ALTER TABLE microarray.FeatureData DROP CONSTRAINT FK_FeatureData_SampleId;\n");
             // Remove primary key constraint
             sql.append("ALTER TABLE exp.Material DROP CONSTRAINT PK_Material;\n");
 
@@ -574,6 +577,8 @@ public class ExperimentUpgradeCode implements UpgradeCode
             sql.append("IF EXISTS (SELECT 1 FROM sys.schemas WHERE Name = 'labbook')\n" +
                     "       ALTER TABLE labbook.LabBookExperimentMaterial ADD CONSTRAINT FK_LabBookExperimentMaterial_MaterialId FOREIGN KEY (MaterialId) REFERENCES exp.Material (RowId);\n"
             );
+            sql.append("IF EXISTS (SELECT 1 FROM sys.schemas WHERE NAME = 'microarray')\n" +
+                    "   ALTER TABLE microarray.FeatureData ADD CONSTRAINT FK_FeatureData_SampleId FOREIGN KEY (SampleId) REFERENCES exp.material (RowId);\n");
             new SqlExecutor(scope).execute(sql);
         }
 

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -534,8 +534,8 @@ public class ExperimentUpgradeCode implements UpgradeCode
         }
         else
         {
-            // For SQLServer We can't do this modification in place for the RowId column, so we make a copy of the column, drop the original\n" +
-            // column then rename the copy and add back the constraints.\n" +
+            // For SQLServer We can't do this modification in place for the RowId column, so we make a copy of the column, drop the original
+            // column then rename the copy and add back the constraints.
             sql = new SQLFragment();
 
             sql.append("ALTER TABLE exp.material ADD RowId_copy INT NULL;\n");
@@ -548,8 +548,6 @@ public class ExperimentUpgradeCode implements UpgradeCode
             sql.append("IF EXISTS (SELECT 1 FROM sys.schemas WHERE NAME = 'labbook')\n" +
                             "   ALTER TABLE labbook.LabBookExperimentMaterial DROP CONSTRAINT FK_LabBookExperimentMaterial_MaterialId;\n");
             // Remove primary key constraint
-            // TODO? -- DROP INDEX IX_CL_Material_RunId ON exp.Material;
-            // Seems to work OK without dropping and recreating this index, but does this cause internal bleeding of some sort?
             sql.append("ALTER TABLE exp.Material DROP CONSTRAINT PK_Material;\n");
 
             new SqlExecutor(scope).execute(sql);
@@ -564,11 +562,10 @@ public class ExperimentUpgradeCode implements UpgradeCode
             new SqlExecutor(scope).execute(sql);
 
             sql = new SQLFragment();
-            // Rename the copy to the original name and restore it as as a Non-Null PK
+            // Rename the copy to the original name and restore it as a Non-Null PK
             sql.append("EXEC sp_rename 'exp.material.RowId_copy', 'RowId', 'COLUMN';\n");
             sql.append("ALTER TABLE exp.Material ALTER COLUMN RowId INT NOT NULL;\n");
             sql.append("ALTER TABLE exp.Material ADD CONSTRAINT PK_Material PRIMARY KEY (RowId);\n");
-            // TODO? -- CREATE CLUSTERED INDEX IX_CL_Material_RunId ON exp.Material(RunId);
             // Add the foreign key constraints back again
             sql.append("ALTER TABLE exp.materialInput ADD CONSTRAINT FK_MaterialInput_Material FOREIGN KEY (MaterialId) REFERENCES exp.Material (RowId);\n");
             sql.append("IF EXISTS (SELECT 1 FROM sys.schemas WHERE Name = 'ms2') \n" +

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -219,6 +219,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 // When no sorts are added by views, QueryServiceImpl.createDefaultSort() adds the primary key's default sort direction
                 ret.setSortDirection(Sort.SortDirection.DESC);
                 ret.setFk(new RowIdForeignKey(ret));
+                ret.setUserEditable(false);
                 ret.setHidden(true);
                 ret.setShownInInsertView(false);
                 ret.setHasDbSequence(true);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -221,6 +221,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 ret.setFk(new RowIdForeignKey(ret));
                 ret.setHidden(true);
                 ret.setShownInInsertView(false);
+                ret.setIsDbSequence(true);
                 return ret;
             }
             case Property:

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -221,7 +221,8 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 ret.setFk(new RowIdForeignKey(ret));
                 ret.setHidden(true);
                 ret.setShownInInsertView(false);
-                ret.setIsDbSequence(true);
+                ret.setHasDbSequence(true);
+                ret.setIsRootDbSequence(true);
                 return ret;
             }
             case Property:

--- a/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
@@ -41,7 +41,6 @@ public class SampleTimelineAuditProvider extends AbstractAuditTypeProvider
         defaultVisibleColumns.add(FieldKey.fromParts(SAMPLE_TYPE_COLUMN_NAME));
         defaultVisibleColumns.add(FieldKey.fromParts(SAMPLE_TYPE_ID_COLUMN_NAME));
         defaultVisibleColumns.add(FieldKey.fromParts(SAMPLE_NAME_COLUMN_NAME));
-        defaultVisibleColumns.add(FieldKey.fromParts(SAMPLE_LSID_COLUMN_NAME));
         defaultVisibleColumns.add(FieldKey.fromParts(SAMPLE_ID_COLUMN_NAME));
         defaultVisibleColumns.add(FieldKey.fromParts(IS_LINEAGE_UPDATE_COLUMN_NAME));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_COMMENT));


### PR DESCRIPTION
#### Rationale
When doing file imports of samples, we want to be able to create detailed audit logs that use the RowId instead of the LSID as the identifier for the sample since the LSID is cumbersome, unknown in the Sample Manager application and, because it references the name of the sample, can be confusing if we get to a point where a sample can be renamed.  During file imports, the RowId is not available at the time the audit logs are created and would require a reselect.  Import of samples is already expensive enough as is, so we opt for using a Java-managed DbSequence for the RowId, the value of which is readily available during import.

#### Changes
* Upgrade script that removes the auto-increment property from RowId
* Modification to `tableInfo.xsd` to allow columns to be designated as having DbSequences and whether the sequence is "global" (i.e., associated with the root container) or not 
* Modifications to SimpleTranslator DataIterator to automatically add DbSequence columns for columns designated as having such sequences
