### PR TITLE
throw NotFoundException in external/linked schema actions

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4268,6 +4268,9 @@ public class QueryController extends SpringActionController
                 setTitle("Delete Schema");
 
             AbstractExternalSchemaDef def = ExternalSchemaDefCache.getSchemaDef(getContainer(), form.getExternalSchemaId(), AbstractExternalSchemaDef.class);
+            if (def == null)
+                throw new NotFoundException();
+
             String schemaName = isBlank(def.getUserSchemaName()) ? "this schema" : "the schema '" + def.getUserSchemaName() + "'";
             return new HtmlView(HtmlString.of("Are you sure you want to delete " + schemaName + "? The tables and queries defined in this schema will no longer be accessible."));
         }
@@ -4276,6 +4279,9 @@ public class QueryController extends SpringActionController
         public boolean handlePost(SchemaForm form, BindException errors)
         {
             AbstractExternalSchemaDef def = ExternalSchemaDefCache.getSchemaDef(getContainer(), form.getExternalSchemaId(), AbstractExternalSchemaDef.class);
+            if (def == null)
+                throw new NotFoundException();
+
             QueryManager.get().delete(def);
             return true;
         }
@@ -4306,8 +4312,10 @@ public class QueryController extends SpringActionController
             form.validate(errors);
         }
 
+        @Nullable
         protected abstract T getCurrent(int externalSchemaId);
 
+        @NotNull
         protected T getDef(F form, boolean reshow)
         {
             T def;
@@ -4317,12 +4325,21 @@ public class QueryController extends SpringActionController
             {
                 def = form.getBean();
                 T current = getCurrent(def.getExternalSchemaId());
+                if (current == null)
+                    throw new NotFoundException();
+
                 defContainer = current.lookupContainer();
             }
             else
             {
                 form.refreshFromDb();
+                if (!form.isDataLoaded())
+                    throw new NotFoundException();
+
                 def = form.getBean();
+                if (def == null)
+                    throw new NotFoundException();
+
                 defContainer = def.lookupContainer();
             }
 
@@ -4383,6 +4400,7 @@ public class QueryController extends SpringActionController
             super(LinkedSchemaForm.class);
         }
 
+        @Nullable
         @Override
         protected LinkedSchemaDef getCurrent(int externalId)
         {
@@ -4407,6 +4425,7 @@ public class QueryController extends SpringActionController
             super(ExternalSchemaForm.class);
         }
 
+        @Nullable
         @Override
         protected ExternalSchemaDef getCurrent(int externalId)
         {
@@ -4772,6 +4791,9 @@ public class QueryController extends SpringActionController
         public boolean handlePost(SchemaForm form, BindException errors)
         {
             ExternalSchemaDef def = ExternalSchemaDefCache.getSchemaDef(getContainer(), form.getExternalSchemaId(), ExternalSchemaDef.class);
+            if (def == null)
+                throw new NotFoundException();
+
             QueryManager.get().reloadExternalSchema(def);
             _userSchemaName = def.getUserSchemaName();
 

--- a/query/src/org/labkey/query/persist/ExternalSchemaDefCache.java
+++ b/query/src/org/labkey/query/persist/ExternalSchemaDefCache.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.query.persist;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
@@ -40,6 +41,7 @@ public class ExternalSchemaDefCache
 {
     private static final Cache<Container, ExternalSchemaCollections> EXTERNAL_SCHEMA_DEF_CACHE = CacheManager.getBlockingCache(CacheManager.UNLIMITED, CacheManager.DAY, "External/Linked Schema Definition Cache", (c, argument) -> new ExternalSchemaCollections(c));
 
+    @Nullable
     public static <T extends AbstractExternalSchemaDef> T getSchemaDef(Container c, @Nullable String userSchemaName, Class<T> clazz)
     {
         if (userSchemaName == null)
@@ -48,11 +50,13 @@ public class ExternalSchemaDefCache
         return getCollections(c).getSchemaDef(userSchemaName, clazz);
     }
 
+    @Nullable
     public static <T extends AbstractExternalSchemaDef> T getSchemaDef(Container c, int rowId, Class<T> clazz)
     {
         return getCollections(c).getSchemaDef(rowId, clazz);
     }
 
+    @NotNull
     public static <T extends AbstractExternalSchemaDef> List<T> getSchemaDefs(@Nullable Container c, Class<T> clazz)
     {
         return getCollections(c).getSchemaDefs(clazz);
@@ -107,16 +111,19 @@ public class ExternalSchemaDefCache
             _byRowId = Collections.unmodifiableMap(byRowId);
         }
 
+        @Nullable
         private <T extends AbstractExternalSchemaDef> T getSchemaDef(String userSchemaName, Class<T> clazz)
         {
             return (T) _byName.get(clazz).get(userSchemaName);
         }
 
+        @Nullable
         private <T extends AbstractExternalSchemaDef> T getSchemaDef(int rowId, Class<T> clazz)
         {
             return (T) _byRowId.get(clazz).get(rowId);
         }
 
+        @NotNull
         private <T extends AbstractExternalSchemaDef> List<T> getSchemaDefs(Class<T> clazz)
         {
             Collection<T> collection = (Collection<T>) _byRowId.get(clazz).values();

--- a/query/src/org/labkey/query/persist/QueryManager.java
+++ b/query/src/org/labkey/query/persist/QueryManager.java
@@ -294,37 +294,43 @@ public class QueryManager
         CustomViewCache.uncache(ContainerManager.getForId(view.getContainerId()));
     }
 
+    @Nullable
     public ExternalSchemaDef getExternalSchemaDef(Container c, int rowId)
     {
         return ExternalSchemaDefCache.getSchemaDef(c, rowId, ExternalSchemaDef.class);
     }
 
+    @NotNull
     public List<ExternalSchemaDef> getExternalSchemaDefs(@Nullable Container container)
     {
         return ExternalSchemaDefCache.getSchemaDefs(container, ExternalSchemaDef.class);
     }
 
+    @Nullable
     public ExternalSchemaDef getExternalSchemaDef(Container container, @Nullable String userSchemaName)
     {
         return ExternalSchemaDefCache.getSchemaDef(container, userSchemaName, ExternalSchemaDef.class);
     }
 
+    @Nullable
     public LinkedSchemaDef getLinkedSchemaDef(Container c, int rowId)
     {
         return ExternalSchemaDefCache.getSchemaDef(c, rowId, LinkedSchemaDef.class);
     }
 
+    @NotNull
     public List<LinkedSchemaDef> getLinkedSchemaDefs(@Nullable Container c)
     {
         return ExternalSchemaDefCache.getSchemaDefs(c, LinkedSchemaDef.class);
     }
 
+    @Nullable
     public LinkedSchemaDef getLinkedSchemaDef(Container c, @Nullable String userSchemaName)
     {
         return ExternalSchemaDefCache.getSchemaDef(c, userSchemaName, LinkedSchemaDef.class);
     }
 
-    public void delete(AbstractExternalSchemaDef def)
+    public void delete(@NotNull AbstractExternalSchemaDef def)
     {
         Container c = def.lookupContainer();
         SimpleFilter filter = SimpleFilter.createContainerFilter(c);


### PR DESCRIPTION
#### Rationale
Attempting to edit an external or linked schema that doesn't belong to the current container will now return null from the `ExternalSchemaDefCache` and `QueryManager` methods.  To avoid NPEs, we now check the schema exists and throw a `NotFoundException` appropriately.

#### Related Pull Requests
#1083 

#### Changes
* Add `@Nullable` and `@NotNull` annotations for external/linked schema def methods
* Throw `NotFoundException` in view actions operating on existing external/linked schemas