### PR TITLE
Revert subtle `CreateContainerAction` behavior change

### DIFF
--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -749,12 +749,8 @@ public class CoreController extends SpringActionController
                 {
                     folderType = FolderTypeManager.get().getFolderType(folderTypeName);
                 }
-                if (folderType == null)
-                {
-                    folderType = FolderType.NONE;
-                }
 
-                if (Container.hasRestrictedModule(folderType) && !getContainer().hasEnableRestrictedModules(getUser()))
+                if (null != folderType && Container.hasRestrictedModule(folderType) && !getContainer().hasEnableRestrictedModules(getUser()))
                 {
                     throw new UnauthorizedException("The folder type requires a restricted module for which you do not have permission.");
                 }
@@ -777,13 +773,12 @@ public class CoreController extends SpringActionController
                 }
 
                 Container newContainer = ContainerManager.createContainer(getContainer(), name, title, description, typeName, getUser());
-                if (folderType != FolderType.NONE)
+                if (folderType != null)
                 {
-                    newContainer.setFolderType(folderType, ensureModules, getUser());
+                    newContainer.setFolderType(folderType, getUser());
                 }
-                else if (!ensureModules.isEmpty())
+                if (!ensureModules.isEmpty())
                 {
-                    // Custom folder may inherit modules from parent. 'setFolderType' would remove them.
                     ensureModules.addAll(newContainer.getActiveModules());
                     newContainer.setActiveModules(ensureModules);
                 }


### PR DESCRIPTION
#### Rationale
The previous change caused new subfolders to not inherit active modules from their parent in some cases. This is causing some `trialshare` tests to fail.

#### Related Pull Requests
Initial breaking change: https://github.com/LabKey/platform/pull/1058
First fix attempt: https://github.com/LabKey/platform/pull/1073

#### Changes
* Match the [original `CreateContainerAction` behavior](https://github.com/LabKey/platform/blob/9346006e632d529c05fa1d0d1db55281df585dab/core/src/org/labkey/core/CoreController.java#L745) exactly unless the `ensureModules` property is provided
