### PR TITLE
Issue 40123: Cannot view the lineage of a source on MS-SQL when medImmune module is included

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -934,9 +934,9 @@
       }
     },
     "@labkey/api": {
-      "version": "0.2.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.2.tgz",
-      "integrity": "sha1-3uthffvyvoPrduPETCeAfGkcap0="
+      "version": "0.2.2-fb-reportPopulateParams.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.2-fb-reportPopulateParams.0.tgz",
+      "integrity": "sha1-f0vOovrQBNBOKd/f1QUBMCu2DX0="
     },
     "@labkey/components": {
       "version": "0.52.1",
@@ -977,6 +977,13 @@
         "react-treebeard": "3.2.4",
         "reactn": "2.2.6",
         "vis-network": "6.5.2"
+      },
+      "dependencies": {
+        "@labkey/api": {
+          "version": "0.2.2",
+          "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.2.tgz",
+          "integrity": "sha1-3uthffvyvoPrduPETCeAfGkcap0="
+        }
       }
     },
     "@labkey/eslint-config-base": {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -934,9 +934,9 @@
       }
     },
     "@labkey/api": {
-      "version": "0.2.2-fb-reportPopulateParams.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.2-fb-reportPopulateParams.0.tgz",
-      "integrity": "sha1-f0vOovrQBNBOKd/f1QUBMCu2DX0="
+      "version": "0.2.2-fb-reportPopulateParams.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.2-fb-reportPopulateParams.1.tgz",
+      "integrity": "sha1-vlHvGZTflqFddhk1iCCMBFlsaI8="
     },
     "@labkey/components": {
       "version": "0.52.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -934,9 +934,9 @@
       }
     },
     "@labkey/api": {
-      "version": "0.2.2-fb-reportPopulateParams.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.2-fb-reportPopulateParams.1.tgz",
-      "integrity": "sha1-vlHvGZTflqFddhk1iCCMBFlsaI8="
+      "version": "0.2.3",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.3.tgz",
+      "integrity": "sha1-KJ7hmmDAn4ZOrTrG3TNAhotNhBQ="
     },
     "@labkey/components": {
       "version": "0.52.1",

--- a/core/package.json
+++ b/core/package.json
@@ -90,7 +90,7 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "0.2.2-fb-reportPopulateParams.1",
+    "@labkey/api": "0.2.3",
     "@labkey/components": "0.52.1",
     "@labkey/eslint-config-react": "0.0.5",
     "react-toggle-button": "2.2.0"

--- a/core/package.json
+++ b/core/package.json
@@ -90,7 +90,7 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "0.2.2-fb-reportPopulateParams.0",
+    "@labkey/api": "0.2.2-fb-reportPopulateParams.1",
     "@labkey/components": "0.52.1",
     "@labkey/eslint-config-react": "0.0.5",
     "react-toggle-button": "2.2.0"

--- a/core/package.json
+++ b/core/package.json
@@ -90,7 +90,7 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "0.2.2",
+    "@labkey/api": "0.2.2-fb-reportPopulateParams.0",
     "@labkey/components": "0.52.1",
     "@labkey/eslint-config-react": "0.0.5",
     "react-toggle-button": "2.2.0"

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -152,6 +152,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         if (dc != null)
             return new QueryRowReference(getContainer(), ExpSchema.SCHEMA_EXP_DATA, dc.getName(), FieldKey.fromParts(ExpDataTable.Column.RowId), getRowId());
 
+        // Issue 40123: see MedImmuneDataHandler MEDIMMUNE_DATA_TYPE, this claims the "Data" namespace
         DataType type = getDataType();
         if (type != null)
         {

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -148,15 +148,19 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
     @Override
     public @Nullable QueryRowReference getQueryRowReference()
     {
-        DataType type = getDataType();
-        if (type != null)
-            return type.getQueryRowReference(this);
-
         ExpDataClassImpl dc = getDataClass();
         if (dc != null)
             return new QueryRowReference(getContainer(), ExpSchema.SCHEMA_EXP_DATA, dc.getName(), FieldKey.fromParts(ExpDataTable.Column.RowId), getRowId());
-        else
-            return new QueryRowReference(getContainer(), ExpSchema.SCHEMA_EXP, ExpSchema.TableType.Data.name(), FieldKey.fromParts(ExpDataTable.Column.RowId), getRowId());
+
+        DataType type = getDataType();
+        if (type != null)
+        {
+            QueryRowReference queryRowReference = type.getQueryRowReference(this);
+            if (queryRowReference != null)
+                return queryRowReference;
+        }
+
+        return new QueryRowReference(getContainer(), ExpSchema.SCHEMA_EXP, ExpSchema.TableType.Data.name(), FieldKey.fromParts(ExpDataTable.Column.RowId), getRowId());
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Recent Sample Manager tests have exposed an issue on the lineage graph where the source (i.e. data class) details aren't being loaded because the lineage api response does not include the schema/query/etc. details. This only repros when the medImmune module is included in the build because that module claims the "Data" namespace which cause the ExpDataImpl.getQueryRowReference() to return the wrong response for this data class case.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/55

#### Changes
* ExpDataImpl.getQueryRowReference() fix to check for null QueryRowReference from the DataType case
* Update @labkey/api version with fix for medImmune module fix for InvokePipeAnalysisTest failure
