### PR TITLE
Incorporate fix for LABKEY.Assay.getStudyNabGraphURL

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -934,9 +934,9 @@
       }
     },
     "@labkey/api": {
-      "version": "0.2.4-fb-10-assay.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.4-fb-10-assay.0.tgz",
-      "integrity": "sha1-4Zoe64jNJieoHBMuXuSaEE3Kkq0="
+      "version": "0.2.4",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.4.tgz",
+      "integrity": "sha1-NJIdAY//FYWYjCObiLH/TnC2adM="
     },
     "@labkey/components": {
       "version": "0.52.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -934,9 +934,9 @@
       }
     },
     "@labkey/api": {
-      "version": "0.2.3",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.3.tgz",
-      "integrity": "sha1-KJ7hmmDAn4ZOrTrG3TNAhotNhBQ="
+      "version": "0.2.4-fb-10-assay.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.4-fb-10-assay.0.tgz",
+      "integrity": "sha1-4Zoe64jNJieoHBMuXuSaEE3Kkq0="
     },
     "@labkey/components": {
       "version": "0.52.1",

--- a/core/package.json
+++ b/core/package.json
@@ -90,7 +90,7 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "0.2.4-fb-10-assay.0",
+    "@labkey/api": "0.2.4",
     "@labkey/components": "0.52.1",
     "@labkey/eslint-config-react": "0.0.5",
     "react-toggle-button": "2.2.0"

--- a/core/package.json
+++ b/core/package.json
@@ -90,7 +90,7 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "0.2.3",
+    "@labkey/api": "0.2.4-fb-10-assay.0",
     "@labkey/components": "0.52.1",
     "@labkey/eslint-config-react": "0.0.5",
     "react-toggle-button": "2.2.0"


### PR DESCRIPTION
#### Rationale
This PR fixes the `NAbAssayTest` failure. The test was utilizing the `LABKEY.Assay.getStudyNabGraphURL()` method which wasn't respecting the `containerPath` property in `@labkey/api`.

**[DailyA NabAssayTest results](https://teamcity.labkey.org/buildConfiguration/bt20/977974?buildTab=tests&pager.currentPage=1&filter=passed&filterText=NabAssayTest):**
![image](https://user-images.githubusercontent.com/3926239/80317905-6157ce80-87bb-11ea-9469-9b8523ab5cf5.png)

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/56

#### Changes
* Bump `@labkey/api`.
