### PR TITLE
39778: Datasets not Editable After File Watcher Import

### DIFF
--- a/study/src/org/labkey/study/pipeline/DatasetInferSchemaReader.java
+++ b/study/src/org/labkey/study/pipeline/DatasetInferSchemaReader.java
@@ -143,6 +143,10 @@ public class DatasetInferSchemaReader extends DatasetFileReader implements Schem
 
                     for (ColumnDescriptor col : columns)
                     {
+                        // filter out the built-in types
+                        if (DatasetDefinition.isDefaultFieldName(col.getColumnName(), _study))
+                            continue;
+
                         PropertyType pt = PropertyType.getFromURI(null, col.getRangeURI(), null);
                         ImportTypesHelper.Builder pdb = new ImportTypesHelper.Builder(_study.getContainer(), pt);
 


### PR DESCRIPTION
#### Issues
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39778

#### Changes
* The dataset infer schema reader was not ignoring any of the base domain fields from a file watcher job. This resulted, if domain changes were allowed, in the possibility of reserved fields being created by the file watcher job. The change was to omit reserved field names from domain changes.