### PR TITLE
40283: Editing participant groups fails with duplicate participant

### DIFF
--- a/study/src/org/labkey/study/model/ParticipantGroupManager.java
+++ b/study/src/org/labkey/study/model/ParticipantGroupManager.java
@@ -612,7 +612,12 @@ public class ParticipantGroupManager
             {
                 // don't let the database catch the invalid ptid, so we can show a more reasonable error
                 if (!participantIdMap.containsKey(id))
+                {
+                    // issue 38130 - we may have already emptied out the participant IDs in this group and put it back in the
+                    // cache
+                    GROUP_CACHE.remove(getCacheKey(group.getCategoryId()));
                     throw new ValidationException(String.format("The %s ID specified : %s does not exist in this study. Please enter a valid identifier.", study.getSubjectNounSingular(), id));
+                }
 
                 executor.execute(sql.getSQL(), group.getRowId(), id, participantIdMap.get(id));
             }


### PR DESCRIPTION
#### Issues
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40283

#### Changes
* Fixed an edge case when updating a participant group, in preparation for saving we empty out participants for the group and then immediately recache that information. If we fail the internal validation check we need to remove that stale cache entry.
