### PR TITLE
Property to disable loading resources from module source

### DIFF
--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -920,7 +920,10 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
 
     public final void setSourcePath(String sourcePath)
     {
-        _sourcePath = sourcePath;
+        if (!AppProps.getInstance().isIgnoreModuleSource())
+        {
+            _sourcePath = sourcePath;
+        }
     }
 
     @Override
@@ -932,7 +935,10 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
     @SuppressWarnings({"UnusedDeclaration"})
     public final void setBuildPath(String buildPath)
     {
-        _buildPath = buildPath;
+        if (!AppProps.getInstance().isIgnoreModuleSource())
+        {
+            _buildPath = buildPath;
+        }
     }
 
     @Override
@@ -1266,7 +1272,7 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         // - The module's enlistment ID matches EITHER the enlistment ID in the web server's source root OR the enlistment ID in
         //   the module's sourcePath
         //
-        if (AppProps.getInstance().isLoadingResourcesFromSourceEnabled())
+        if (AppProps.getInstance().isDevMode())
         {
             String sourcePath = getSourcePath();
 

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -1266,7 +1266,7 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         // - The module's enlistment ID matches EITHER the enlistment ID in the web server's source root OR the enlistment ID in
         //   the module's sourcePath
         //
-        if (AppProps.getInstance().isDevMode())
+        if (AppProps.getInstance().isLoadingResourcesFromSourceEnabled())
         {
             String sourcePath = getSourcePath();
 

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -131,6 +131,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
  * Drives the process of initializing all of the modules at startup time and otherwise managing their life cycle.
@@ -2158,7 +2159,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
 
     public void registerResourcePrefix(String prefix, String name, String sourcePath, String buildPath)
     {
-        if (null == prefix)
+        if (null == prefix || isEmpty(sourcePath) || isEmpty(buildPath))
             return;
 
         if (!new File(sourcePath).isDirectory() || !new File(buildPath).isDirectory())

--- a/api/src/org/labkey/api/settings/AppProps.java
+++ b/api/src/org/labkey/api/settings/AppProps.java
@@ -76,6 +76,8 @@ public interface AppProps
 
     boolean isRecompileJspEnabled();
 
+    boolean isLoadingResourcesFromSourceEnabled();
+
     void setProjectRoot(String projectRoot);
 
     /**

--- a/api/src/org/labkey/api/settings/AppProps.java
+++ b/api/src/org/labkey/api/settings/AppProps.java
@@ -76,7 +76,7 @@ public interface AppProps
 
     boolean isRecompileJspEnabled();
 
-    boolean isLoadingResourcesFromSourceEnabled();
+    boolean isIgnoreModuleSource();
 
     void setProjectRoot(String projectRoot);
 

--- a/api/src/org/labkey/api/settings/AppProps.java
+++ b/api/src/org/labkey/api/settings/AppProps.java
@@ -18,6 +18,7 @@ package org.labkey.api.settings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.module.DefaultModule;
 import org.labkey.api.util.ExceptionReportingLevel;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.UsageReportingLevel;
@@ -76,6 +77,19 @@ public interface AppProps
 
     boolean isRecompileJspEnabled();
 
+    /**
+     * Indicates whether modules' "sourcePath" and "buildPath" values be ignored. This allows a server to run in devMode
+     * without the risk of loading unwanted resources from a source tree that may not match the deployed server.
+     *
+     * <strong>WARNING</strong>: Setting this flag will interfere with the population of module beans, resulting in a
+     * mismatch between deployed modules and their properties on the server.
+     *
+     * @return value of the 'labkey.ignoreModuleSource' system property. Defaults to <code>false</code>
+     *
+     * @see org.labkey.api.module.DefaultModule#setSourcePath(String)
+     * @see org.labkey.api.module.DefaultModule#setBuildPath(String)
+     * @see DefaultModule#computeResourceDirectory()
+     */
     boolean isIgnoreModuleSource();
 
     void setProjectRoot(String projectRoot);

--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -435,6 +435,11 @@ class AppPropsImpl extends AbstractWriteableSettingsGroup implements AppProps
         return isDevMode() && !Boolean.getBoolean("labkey.disableRecompileJsp");
     }
 
+    /**
+     * @inheritDoc
+     *
+     * Default Implementation.
+     */
     @Override
     public boolean isIgnoreModuleSource()
     {

--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -436,6 +436,12 @@ class AppPropsImpl extends AbstractWriteableSettingsGroup implements AppProps
     }
 
     @Override
+    public boolean isLoadingResourcesFromSourceEnabled()
+    {
+        return isDevMode() && !Boolean.getBoolean("labkey.disableResourcesFromSource");
+    }
+
+    @Override
     public void setProjectRoot(String projectRoot)
     {
         _projectRoot = projectRoot;

--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -436,9 +436,9 @@ class AppPropsImpl extends AbstractWriteableSettingsGroup implements AppProps
     }
 
     @Override
-    public boolean isLoadingResourcesFromSourceEnabled()
+    public boolean isIgnoreModuleSource()
     {
-        return isDevMode() && !Boolean.getBoolean("labkey.disableResourcesFromSource");
+        return Boolean.getBoolean("labkey.ignoreModuleSource");
     }
 
     @Override

--- a/api/src/org/labkey/api/util/JunitUtil.java
+++ b/api/src/org/labkey/api/util/JunitUtil.java
@@ -232,7 +232,6 @@ public class JunitUtil
                         for (java.nio.file.Path path : Arrays.asList(
                                 Paths.get("externalModules"),
                                 Paths.get("server", "modules"),
-                                Paths.get("server", "customModules"),
                                 Paths.get("server", "optionalModules")))
                         {
                             Files.walk(Paths.get(projectRoot).resolve(path), 2)

--- a/api/src/org/labkey/api/util/JunitUtil.java
+++ b/api/src/org/labkey/api/util/JunitUtil.java
@@ -18,6 +18,7 @@ package org.labkey.api.util;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assume;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.module.Module;
@@ -218,46 +219,33 @@ public class JunitUtil
             }
             else
             {
-                // Modules have null sourcePath on TeamCity, so crawl for test/sampledata directories and populate
+                // Modules might have null sourcePath on TeamCity, so crawl for test/sampledata directories and populate
                 // a map the first time, then stash the map for future lookups.
-                String buildPath = module.getBuildPath();
+                String name = module.getExplodedPath().getName();
 
-                // We don't know if the build machine used Windows or Linux separators, so search for both
-                int idx = StringUtils.lastIndexOfAny(buildPath, "/", "\\");
-
-                if (-1 != idx)
+                synchronized (MAP_LOCK)
                 {
-                    String name = buildPath.substring(idx + 1);
-
-                    synchronized (MAP_LOCK)
+                    if (null == _sampleDataDirectories)
                     {
-                        if (null == _sampleDataDirectories)
+                        Map<String, File> map = new CaseInsensitiveHashMap<>();
+
+                        for (java.nio.file.Path path : Arrays.asList(
+                                Paths.get("externalModules"),
+                                Paths.get("server", "modules"),
+                                Paths.get("server", "customModules"),
+                                Paths.get("server", "optionalModules")))
                         {
-                            Map<String, File> map = new HashMap<>();
-
-                            for (java.nio.file.Path path : Arrays.asList(
-                                    Paths.get("externalModules"),
-                                    Paths.get("server", "modules"),
-                                    Paths.get("server", "customModules"),
-                                    Paths.get("server", "optionalModules")))
-                            {
-                                Files.walk(Paths.get(projectRoot).resolve(path), 2)
-                                    .filter(Files::isDirectory)
-                                    .map(p -> p.resolve(SAMPLE_DATA_PATH))
-                                    .filter(p -> Files.isDirectory(p))
-                                    .forEach(p -> map.put(p.getName(p.getNameCount() - 3).toString(), p.toFile()));
-                            }
-
-                            _sampleDataDirectories = Collections.unmodifiableMap(map);
+                            Files.walk(Paths.get(projectRoot).resolve(path), 2)
+                                .filter(Files::isDirectory)
+                                .map(p -> p.resolve(SAMPLE_DATA_PATH))
+                                .filter(p -> Files.isDirectory(p))
+                                .forEach(p -> map.put(p.getName(p.getNameCount() - 3).toString(), p.toFile()));
                         }
 
-                        sampleDataDir = _sampleDataDirectories.get(name);
+                        _sampleDataDirectories = Collections.unmodifiableMap(map);
                     }
-                }
-                else
-                {
-                    // buildPath is null or not parseable
-                    sampleDataDir = null;
+
+                    sampleDataDir = _sampleDataDirectories.get(name);
                 }
             }
         }


### PR DESCRIPTION
This serves a similar purpose to the `disableRecompileJsp` property.
Prevents generated resources from leaking between branches on TeamCity.

#### Rationale
Occasionally, on TeamCity, a feature branch build will leave generated files that get picked up by subsequent test suites that run on the same build agent. This can cause numerous spurious failures depending on the tests being run and the changes in the feature branch.

#### Related Pull Requests
* Gradle plugin 1.12.0 will set this flag when running on TeamCity (No PR)
