### PR TITLE
Issue 40333: generate rowId from DbSequence when doing single-sample inserts

### DIFF
--- a/experiment/src/org/labkey/experiment/api/AbstractRunItemImpl.java
+++ b/experiment/src/org/labkey/experiment/api/AbstractRunItemImpl.java
@@ -149,6 +149,11 @@ public abstract class AbstractRunItemImpl<Type extends RunItem> extends ExpIdent
         return _object.getRowId();
     }
 
+    protected void setRowId(int rowId)
+    {
+        _object.setRowId(rowId);
+    }
+
     public User getCreatedBy()
     {
         return _object.getCreatedBy() == null ? null : UserManager.getUser(_object.getCreatedBy().intValue());

--- a/experiment/src/org/labkey/experiment/api/ExpIdentifiableBaseImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpIdentifiableBaseImpl.java
@@ -104,7 +104,12 @@ public abstract class ExpIdentifiableBaseImpl<Type extends IdentifiableBase> ext
 
     protected void save(User user, TableInfo table, boolean ensureObject)
     {
-        if (getRowId() == 0)
+        save(user, table, ensureObject, getRowId() == 0);
+    }
+
+    protected void save(User user, TableInfo table, boolean ensureObject, boolean isInsert)
+    {
+        if (isInsert)
         {
             if (ensureObject)
             {

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -18,10 +18,13 @@ package org.labkey.experiment.api;
 
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.math3.exception.OutOfRangeException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.DbSequenceManager;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SqlExecutor;
@@ -206,7 +209,16 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
     protected void save(User user, TableInfo table, boolean ensureObject)
     {
         assert ensureObject;
-        super.save(user, table, true);
+        boolean isInsert = false;
+        if (getRowId() == 0)
+        {
+            isInsert = true;
+            long longId = DbSequenceManager.get(ContainerManager.getRoot(), ExperimentService.get().getTinfoMaterial().getDbSequenceName("RowId")).next();
+            if (longId > Integer.MAX_VALUE)
+                throw new OutOfRangeException(longId, 0, Integer.MAX_VALUE);
+            setRowId((int) longId);
+        }
+        super.save(user, table, true, isInsert);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We switched to using a DbSequence to back the RowId for the exp.Materials table to better support detailed logging.  This code path for inserting single samples that does not use DataIterators was missed in that conversion

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1090

#### Changes
*[ Issue 40333](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40333): Generate a rowId before using Table.insert
