### PR TITLE
Issue 40329: Sample Manager source samples: limit to 1st generation o…

### DIFF
--- a/api/schemas/queryCustomView.xsd
+++ b/api/schemas/queryCustomView.xsd
@@ -124,6 +124,7 @@
             <xsd:enumeration value="containsnoneof"/>
             <xsd:enumeration value="memberof"/>
             <xsd:enumeration value="exp:childof"/>
+            <xsd:enumeration value="exp:lineageof"/>
             <xsd:enumeration value="exp:parentof"/>
             <xsd:enumeration value="q"/>
             <xsd:enumeration value="where"/>

--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -937,7 +937,7 @@ public abstract class CompareType
         return QueryService.get().getCompareTypes();
     }
 
-    private static Set<String> parseParams(Object value_, String separator)
+    protected static Set<String> parseParams(Object value_, String separator)
     {
         if (value_ == null)
             return Collections.emptySet();

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -82,6 +82,7 @@ import org.labkey.api.webdav.WebdavService;
 import org.labkey.experiment.api.*;
 import org.labkey.experiment.api.data.ChildOfCompareType;
 import org.labkey.experiment.api.data.ChildOfMethod;
+import org.labkey.experiment.api.data.LineageCompareType;
 import org.labkey.experiment.api.data.ParentOfCompareType;
 import org.labkey.experiment.api.data.ParentOfMethod;
 import org.labkey.experiment.api.property.DomainPropertyImpl;
@@ -164,8 +165,9 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
 
         QueryService.get().addCompareType(new ChildOfCompareType());
         QueryService.get().addCompareType(new ParentOfCompareType());
-        QueryService.get().registerMethod(ChildOfMethod.NAME, new ChildOfMethod(), null, 2, 2);
-        QueryService.get().registerMethod(ParentOfMethod.NAME, new ParentOfMethod(), null, 2, 2);
+        QueryService.get().addCompareType(new LineageCompareType());
+        QueryService.get().registerMethod(ChildOfMethod.NAME, new ChildOfMethod(), null, 2, 3);
+        QueryService.get().registerMethod(ParentOfMethod.NAME, new ParentOfMethod(), null, 2, 3);
 
         PropertyService.get().registerValidatorKind(new RegExValidator());
         PropertyService.get().registerValidatorKind(new RangeValidator());

--- a/experiment/src/org/labkey/experiment/api/data/ChildOfClause.java
+++ b/experiment/src/org/labkey/experiment/api/data/ChildOfClause.java
@@ -30,16 +30,13 @@ public class ChildOfClause extends LineageClause
         super(fieldKey, value);
     }
 
+    @Override
     protected ExpLineageOptions createOptions()
     {
-        return LineageHelper.createChildOfOptions();
+        return LineageHelper.createChildOfOptions(0);
     }
 
-    protected String getLsidColumn()
-    {
-        return "lsid";
-    }
-
+    @Override
     protected String filterTextType()
     {
         return "child of";

--- a/experiment/src/org/labkey/experiment/api/data/ChildOfMethod.java
+++ b/experiment/src/org/labkey/experiment/api/data/ChildOfMethod.java
@@ -6,12 +6,13 @@ import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.query.AbstractMethodInfo;
 
 /**
+ * method takes 3 params: fieldKey, lsid, depth (optional)
  * <code>
  * SELECT
  *   d.*
  * FROM assay.General.MyAssay.Data d
  * WHERE
-    ExpChildOf(d.resultsample.LSID, 'urn:lsid:labkey.com:Data.Folder-123:1aec9396-3fa2-1038-86f4-495e1672e522') OR ExpChildOf(d.Run.runsample.LSID, 'urn:lsid:labkey.com:Data.Folder-123:1aec9396-3fa2-1038-86f4-495e1672e522')
+    ExpChildOf(d.resultsample.LSID, 'urn:lsid:labkey.com:Data.Folder-123:1aec9396-3fa2-1038-86f4-495e1672e522', 1) OR ExpChildOf(d.Run.runsample.LSID, 'urn:lsid:labkey.com:Data.Folder-123:1aec9396-3fa2-1038-86f4-495e1672e522', 0)
  * </code>
  */
 
@@ -29,7 +30,11 @@ public class ChildOfMethod extends AbstractMethodInfo
     {
         SQLFragment fieldKeyFrag = arguments[0];
         SQLFragment lsidFrag = arguments[1];
-        return LineageHelper.createInSQL(fieldKeyFrag, lsidFrag, LineageHelper.createChildOfOptions());
+        int depth = 0;
+        if (arguments.length > 2)
+            depth = Integer.parseInt(arguments[2].getRawSQL());
+
+        return LineageHelper.createInSQL(fieldKeyFrag, lsidFrag, LineageHelper.createChildOfOptions(depth));
     }
 
 }

--- a/experiment/src/org/labkey/experiment/api/data/LineageCompareType.java
+++ b/experiment/src/org/labkey/experiment/api/data/LineageCompareType.java
@@ -12,7 +12,8 @@ import java.util.Set;
 
 /**
  * <code>
- * Filter.create('lsid', '{json:}', Filter.Types.EXP_LINEAGE_OF)
+ * Filter.create('lsid', '{json:["urn:lsid:labkey.com:Data.Folder-123:1aec9396-3fa2-1038-86f4-495e1672e522",1]}', Filter.Types.EXP_LINEAGE_OF)
+ * Filter.create('lsid', ["urn:lsid:labkey.com:Data.Folder-123:1aec9396-3fa2-1038-86f4-495e1672e522",1], Filter.Types.EXP_LINEAGE_OF)
  * </code>
  */
 public class LineageCompareType extends CompareType

--- a/experiment/src/org/labkey/experiment/api/data/LineageCompareType.java
+++ b/experiment/src/org/labkey/experiment/api/data/LineageCompareType.java
@@ -1,0 +1,68 @@
+package org.labkey.experiment.api.data;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.ColumnRenderProperties;
+import org.labkey.api.data.CompareType;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.query.FieldKey;
+import org.labkey.data.xml.queryCustomView.OperatorType;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * <code>
+ * Filter.create('lsid', '{json:}', Filter.Types.EXP_LINEAGE_OF)
+ * </code>
+ */
+public class LineageCompareType extends CompareType
+{
+    public static final String SEPARATOR = ",";
+
+    public LineageCompareType()
+    {
+        super("In The Lineage Of", "exp:lineageof", "EXP_LINEAGE_OF", true, " in the lineage of", OperatorType.EXP_LINEAGEOF);
+    }
+
+    @Override
+    protected SimpleFilter.FilterClause createFilterClause(@NotNull FieldKey fieldKey, Object value)
+    {
+        Object[] values;
+        Object collection;
+        if (value instanceof Collection)
+        {
+            collection = value;
+            values = ((Collection) value).toArray();
+        }
+        else
+        {
+            Set<String> params = parseParams(value, getValueSeparator());
+            collection = params;
+            values = params.toArray();
+        }
+
+        String lsid = (String) values[0];
+        int depth = 0;
+        if (values.length > 1)
+        {
+            Object depthObj = values[1];
+            if (depthObj instanceof String)
+                depth = Integer.parseInt((String) depthObj);
+            else if (depthObj instanceof Integer)
+                depth = (Integer) depthObj;
+        }
+        return new LineageClause(fieldKey, collection, lsid, depth);
+    }
+
+    @Override
+    public String getValueSeparator()
+    {
+        return SEPARATOR;
+    }
+
+    @Override
+    public boolean meetsCriteria(ColumnRenderProperties col, Object value, Object[] paramVals)
+    {
+        throw new UnsupportedOperationException("Conditional formatting not yet supported for EXP_LINEAGE_OF");
+    }
+}

--- a/experiment/src/org/labkey/experiment/api/data/LineageHelper.java
+++ b/experiment/src/org/labkey/experiment/api/data/LineageHelper.java
@@ -38,21 +38,23 @@ public class LineageHelper
         return svc.generateExperimentTreeSQLLsidSeeds(runsToInvestigate, options);
     }
 
-    static ExpLineageOptions createChildOfOptions()
+    static ExpLineageOptions createChildOfOptions(int depth)
     {
         ExpLineageOptions options = new ExpLineageOptions();
         options.setForLookup(true);
         options.setParents(false);
         options.setChildren(true);
+        options.setDepth(depth);
         return options;
     }
 
-    static ExpLineageOptions createParentOfOptions()
+    static ExpLineageOptions createParentOfOptions(int depth)
     {
         ExpLineageOptions options = new ExpLineageOptions();
         options.setForLookup(true);
         options.setParents(true);
         options.setChildren(false);
+        options.setDepth(depth);
         return options;
     }
 

--- a/experiment/src/org/labkey/experiment/api/data/ParentOfClause.java
+++ b/experiment/src/org/labkey/experiment/api/data/ParentOfClause.java
@@ -30,16 +30,13 @@ public class ParentOfClause extends LineageClause
         super(fieldKey, value);
     }
 
+    @Override
     protected ExpLineageOptions createOptions()
     {
-        return LineageHelper.createParentOfOptions();
+        return LineageHelper.createParentOfOptions(0);
     }
 
-    protected String getLsidColumn()
-    {
-        return "lsid";
-    }
-
+    @Override
     protected String filterTextType()
     {
         return "parent of";

--- a/experiment/src/org/labkey/experiment/api/data/ParentOfMethod.java
+++ b/experiment/src/org/labkey/experiment/api/data/ParentOfMethod.java
@@ -19,7 +19,10 @@ public class ParentOfMethod extends AbstractMethodInfo
     {
         SQLFragment fieldKeyFrag = arguments[0];
         SQLFragment lsidFrag = arguments[1];
-        return LineageHelper.createInSQL(fieldKeyFrag, lsidFrag, LineageHelper.createParentOfOptions());
+        int depth = 0;
+        if (arguments.length > 2)
+            depth = Integer.parseInt(arguments[2].getRawSQL());
+        return LineageHelper.createInSQL(fieldKeyFrag, lsidFrag, LineageHelper.createParentOfOptions(depth));
     }
 
 }


### PR DESCRIPTION
#### Rationale
Lineage operators returns all generations of parents and children. This PR add support to allow any N levels of child (N > 0) or parent (N < 0).

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1118
* https://github.com/LabKey/labkey-ui-components/pull/239
* https://github.com/LabKey/sampleManagement/pull/258
* https://github.com/LabKey/labkey-api-js/pull/57

#### Changes
* added LineageCompareType that can query for child or parent for up to any specified depth
* modifieed ChildOfMethod and ParentOfMethod to take depth as optional 3rd parameter
