### PR TITLE
Fix for study.StudyDatasetsTest test

### DIFF
--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -535,6 +535,8 @@ public class StudyController extends BaseStudyController
         public ModelAndView getView(DatasetForm form, BindException errors)
         {
             StudyImpl study = getStudyRedirectIfNull();
+            if (null == form.getDatasetId())
+                throw new NotFoundException("Invalid datasetId.");
             DatasetDefinition def = study.getDataset(form.getDatasetId());
             _def = def;
             if (null == def)


### PR DESCRIPTION
#### Rationale
The issue to fix was that the crawler encountered a NPE when hitting a url that attempts a script injection through a url param. 
Example url end, url-decoded for readability:
`study-editType.view?datasetId=-->">'>'"</script><img src="xss" onerror="alert("8(")>`

#### Changes
* Verify that datasetId is correctly formed and appears on the form obj before attempting to load dataset.