### PR TITLE
Issue 40353: Remove autoincrement for rowId column of exp.materials for databases bootstrapped since the last upgrade script was implemented

### DIFF
--- a/experiment/resources/schemas/dbscripts/postgresql/exp-20.003-20.004.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-20.003-20.004.sql
@@ -1,1 +1,1 @@
-SELECT core.executeJavaUpgradeCode('addDbSequenceForMaterialsRowId');
+SELECT core.executeJavaInitializationCode('addDbSequenceForMaterialsRowId');

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-20.004-20.005.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-20.004-20.005.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('addDbSequenceForMaterialsRowIdIfMissed');

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-20.003-20.004.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-20.003-20.004.sql
@@ -1,1 +1,1 @@
-EXEC core.executeJavaUpgradeCode 'addDbSequenceForMaterialsRowId';
+EXEC core.executeJavaInitializationCode  'addDbSequenceForMaterialsRowId';

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-20.004-20.005.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-20.004-20.005.sql
@@ -1,0 +1,1 @@
+EXEC core.executeJavaUpgradeCode 'addDbSequenceForMaterialsRowIdIfMissed';

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -134,7 +134,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     public Double getSchemaVersion()
     {
-        return 20.004;
+        return 20.005;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -513,9 +513,22 @@ public class ExperimentUpgradeCode implements UpgradeCode
      @DeferredUpgrade
     public static void addDbSequenceForMaterialsRowId(ModuleContext context)
     {
-        if (context.isNewInstall())
-            return;
+        _addDbSequenceForMaterialRowId();
+    }
 
+    // called from exp-20.004-20.005
+    // The previous method originally mistakenly did not update RowId column for new installs,
+    // leaving databases bootstrapped after the previous upgrade script was implemented in a strange state.
+    // This method will fix up the databases where that removal of autoIncrement was missed.
+    @DeferredUpgrade
+    public static void addDbSequenceForMaterialsRowIdIfMissed(ModuleContext context)
+    {
+        if (ExperimentService.get().getTinfoMaterial().getColumn("RowId").isAutoIncrement())
+            _addDbSequenceForMaterialRowId();
+    }
+
+    private static void _addDbSequenceForMaterialRowId()
+    {
         SQLFragment frag = new SQLFragment("SELECT MAX(rowId) FROM exp.material");
         Integer maxId = new SqlSelector(ExperimentService.get().getSchema(), frag).getObject(Integer.class);
 


### PR DESCRIPTION
#### Rationale
Previous upgrade script mistakenly prevented the conversion of the RowId column from happening during an initial install.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1090
* https://github.com/LabKey/platform/pull/1126

#### Changes
* new upgrade script that runs only if the autoIncrement property is still set and remove early exit from previous upgrade script for new installs.
