### PR TITLE
Issue 40356: Handle null protocol when passed to AbstractAssayProvider.getPriority method

### DIFF
--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -71,7 +71,7 @@ public interface AssayService
     AssayProvider getProvider(String providerName);
 
     @Nullable
-    AssayProvider getProvider(ExpProtocol protocol);
+    AssayProvider getProvider(@Nullable ExpProtocol protocol);
 
     @Nullable
     AssayProvider getProvider(ExpRun run);

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -194,7 +194,7 @@ public class AssayManager implements AssayService
     @Nullable
     public AssayProvider getProvider(ExpProtocol protocol)
     {
-        return Handler.Priority.findBestHandler(getAssayProviders(), protocol);
+        return null == protocol ? null : Handler.Priority.findBestHandler(getAssayProviders(), protocol);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
This change avoids NPE in AbstractAssayProvider.getPriority when protocol is null.

