### PR TITLE
40226: Respect "skipPrefixes" in async region

### DIFF
--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -677,17 +677,13 @@ if (!LABKEY.DataRegions) {
             ].join(' '));
         }
 
-        var userFilter = [];
-
-        $.each(this.getUserFilterArray(), function(i, filter) {
-            userFilter.push({
+        return this.getUserFilterArray().map(function(filter) {
+            return {
                 fieldKey: filter.getColumnName(),
                 op: filter.getFilterType().getURLSuffix(),
                 value: filter.getValue()
-            });
+            };
         });
-
-        return userFilter;
     };
 
     /**
@@ -697,8 +693,7 @@ if (!LABKEY.DataRegions) {
     LABKEY.DataRegion.prototype.getUserFilterArray = function() {
         var userFilter = [], me = this;
 
-        var pairs = _getParameters(this);
-        $.each(pairs, function(i, pair) {
+        _getParameters(this).forEach(function(pair) {
             if (pair[0].indexOf(me.name + '.') == 0 && pair[0].indexOf('~') > -1) {
                 var tilde = pair[0].indexOf('~');
                 var fieldKey = pair[0].substring(me.name.length + 1, tilde);
@@ -745,7 +740,7 @@ if (!LABKEY.DataRegions) {
             me = this;
 
         if (LABKEY.Utils.isArray(filters)) {
-            $.each(filters, function(i, filter) {
+            filters.forEach(function(filter) {
                 filterPrefixes.push(me.name + '.' + filter.getColumnName() + '~');
                 filterParams.push([filter.getURLParameterName(me.name), filter.getURLParameterValue()]);
             });
@@ -763,7 +758,7 @@ if (!LABKEY.DataRegions) {
         // support fieldKeys (e.g. ["ColumnA", "ColumnA/Sub1"])
         // A special case of fieldKey is "SUBJECT_PREFIX/", used by participant group facet
         if (fieldKeys.length > 0) {
-            $.each(_getParameters(this), function(i, param) {
+            _getParameters(this).forEach(function(param) {
                 var p = param[0];
                 if (p.indexOf(me.name + '.') === 0 && p.indexOf('~') > -1) {
                     $.each(fieldKeys, function(j, name) {
@@ -788,7 +783,7 @@ if (!LABKEY.DataRegions) {
         this.clearSelected({quiet: true});
         var skips = [], me = this;
 
-        $.each(_getParameters(this), function(i, param) {
+        _getParameters(this).forEach(function(param) {
             if (param[0].indexOf(me.name + '.') === 0 && param[0].indexOf(filterMatch) > -1) {
                 skips.push(param[0]);
             }
@@ -1190,7 +1185,7 @@ if (!LABKEY.DataRegions) {
     LABKEY.DataRegion.prototype.getParameter = function(paramName) {
         var param = null;
 
-        $.each(_getParameters(this), function(i, pair) {
+        _getParameters(this).forEach(function(pair) {
             if (pair.length > 0 && pair[0] === paramName) {
                 param = pair.length > 1 ? pair[1] : '';
                 return false;
@@ -1212,7 +1207,7 @@ if (!LABKEY.DataRegions) {
             re = new RegExp('^' + LABKEY.Utils.escapeRe(this.name) + PARAM_PREFIX.replace(/\./g, '\\.'), 'i'),
             name;
 
-        $.each(_getParameters(this), function(i, pair) {
+        _getParameters(this).forEach(function(pair) {
             if (pair.length > 0 && pair[0].match(re)) {
                 name = pair[0].replace(re, '');
                 if (toLowercase === true) {
@@ -1258,7 +1253,7 @@ if (!LABKEY.DataRegions) {
             $.each(params, applyParameters);
         }
         else if (LABKEY.Utils.isArray(params)) {
-            $.each(params, function(i, pair) {
+            params.forEach(function(pair) {
                 if (LABKEY.Utils.isArray(pair) && pair.length > 1) {
                     applyParameters(pair[0], pair[1]);
                 }
@@ -2007,25 +2002,22 @@ if (!LABKEY.DataRegions) {
 
     LABKEY.DataRegion.prototype.getQueryDetails = function(success, failure, scope) {
 
-        var userFilter = [],
-            userSort = this.getUserSort(),
+        var userSort = this.getUserSort(),
             userColumns = this.getParameter(this.name + COLUMNS_PREFIX),
             fields = [],
             viewName = (this.view && this.view.name) || this.viewName || '';
 
-        $.each(this.getUserFilterArray(), function(i, filter) {
-            userFilter.push({
+        var userFilter = this.getUserFilterArray().map(function(filter) {
+            fields.push(filter.fieldKey);
+
+            return {
                 fieldKey: filter.getColumnName(),
                 op: filter.getFilterType().getURLSuffix(),
                 value: filter.getValue()
-            });
+            };
         });
 
-        $.each(userFilter, function(i, filter) {
-            fields.push(filter.fieldKey);
-        });
-
-        $.each(userSort, function(i, sort) {
+        userSort.forEach(function(sort) {
             fields.push(sort.fieldKey);
         });
 
@@ -2300,7 +2292,7 @@ if (!LABKEY.DataRegions) {
         var callbacks = _paneCache[this.name];
         if (callbacks) {
             var me = this;
-            $.each(callbacks, function(i, config) {
+            callbacks.forEach(function(config) {
                 config.cb.call(config.scope || me, me);
             });
             delete _paneCache[this.name];
@@ -2390,7 +2382,7 @@ if (!LABKEY.DataRegions) {
             cols = this.columns;
 
         if (isString(columnIdentifier) && LABKEY.Utils.isArray(cols)) {
-            $.each(['fieldKey', 'name', 'displayField', 'caption'], function(i, key) {
+            ['fieldKey', 'name', 'displayField', 'caption'].forEach(function(key) {
                 $.each(cols, function(c, col) {
                     if (isString(col[key]) && col[key] == columnIdentifier) {
                         column = col;
@@ -2825,15 +2817,14 @@ if (!LABKEY.DataRegions) {
 
     var _removeAnalyticsProviderFromView = function(view, colFieldKey, providerName, isSummaryStatistic) {
         var indexToRemove = null;
-        $.each(view.analyticsProviders, function(index, existingProvider) {
+        view.analyticsProviders.forEach(function(existingProvider, index) {
             if (existingProvider.fieldKey === colFieldKey && existingProvider.name === providerName) {
                 indexToRemove = index;
                 return false;
             }
         });
 
-        if (indexToRemove != null)
-        {
+        if (indexToRemove != null) {
             view.analyticsProviders.splice(indexToRemove, 1);
             _updateSessionCustomView.call(this, view, isSummaryStatistic);
         }
@@ -2843,7 +2834,7 @@ if (!LABKEY.DataRegions) {
     // PRIVATE FUNCTIONS
     //
     var _applyOptionalParameters = function(region, params, optionalParams) {
-        $.each(optionalParams, function(i, p) {
+        optionalParams.forEach(function(p) {
             if (LABKEY.Utils.isObject(p)) {
                 if (region[p.name] !== undefined) {
                     if (p.check && !p.check.call(region, region[p.name])) {
@@ -2870,8 +2861,7 @@ if (!LABKEY.DataRegions) {
             newSorts = [];
 
         if (current != null) {
-            var sorts = current.split(',');
-            $.each(sorts, function(i, sort) {
+            current.split(',').forEach(function(sort) {
                 if (sort.length > 0 && (sort != columnName) && (sort != SORT_ASC + columnName) && (sort != SORT_DESC + columnName)) {
                     newSorts.push(sort);
                 }
@@ -2896,7 +2886,7 @@ if (!LABKEY.DataRegions) {
 
         var queryParts = [], key, value;
 
-        $.each(pairs, function(i, pair) {
+        pairs.forEach(function(pair) {
             key = pair[0];
             value = pair.length > 1 ? pair[1] : undefined;
 
@@ -3098,7 +3088,7 @@ if (!LABKEY.DataRegions) {
                     return region.name + prefix;
                 });
 
-                $.each(pairs, function(i, pair) {
+                pairs.forEach(function(pair) {
                     p = pair.split('=', 2);
                     key = p[0] = decodeURIComponent(p[0]);
                     lastIdx = key.indexOf(LAST);
@@ -3113,7 +3103,7 @@ if (!LABKEY.DataRegions) {
 
                     var stop = false;
                     if (skip) {
-                        $.each(skipPrefixSet, function(j, skipPrefix) {
+                        skipPrefixSet.forEach(function(skipPrefix) {
                             if (LABKEY.Utils.isString(skipPrefix)) {
 
                                 // Special prefix that should remove all filters, but no other parameters
@@ -3174,7 +3164,7 @@ if (!LABKEY.DataRegions) {
         else {
             if (sortParam) {
                 var fieldKey, dir;
-                $.each(sortParam.split(','), function(i, sort) {
+                sortParam.split(',').forEach(function(sort) {
                     fieldKey = sort;
                     dir = SORT_ASC;
                     if (sort.charAt(0) === SORT_DESC) {
@@ -3338,11 +3328,10 @@ if (!LABKEY.DataRegions) {
     };
 
     var _setParameters = function(region, newParamValPairs, skipPrefixes /* optional */) {
-
         // prepend region name
         // e.g. ['.hello', '.goodbye'] becomes ['aqwp19.hello', 'aqwp19.goodbye']
         if (LABKEY.Utils.isArray(skipPrefixes)) {
-            $.each(skipPrefixes, function(i, skip) {
+            skipPrefixes.forEach(function(skip, i) {
                 if (skip && skip.indexOf(region.name + '.') !== 0) {
                     skipPrefixes[i] = region.name + skip;
                 }
@@ -3353,7 +3342,7 @@ if (!LABKEY.DataRegions) {
             params = _getParameters(region, skipPrefixes);
 
         if (LABKEY.Utils.isArray(newParamValPairs)) {
-            $.each(newParamValPairs, function(i, newPair) {
+            newParamValPairs.forEach(function(newPair) {
                 if (!LABKEY.Utils.isArray(newPair)) {
                     throw new Error("DataRegion: _setParameters newParamValPairs improperly initialized. It is an array of arrays. You most likely passed in an array of strings.");
                 }
@@ -3372,7 +3361,7 @@ if (!LABKEY.DataRegions) {
         }
 
         if (region.async) {
-            _load(region, undefined, undefined, params);
+            _load(region, params, skipPrefixes);
         }
         else {
             region.setSearchString.call(region, region.name, _buildQueryString(region, params));
@@ -3422,9 +3411,18 @@ if (!LABKEY.DataRegions) {
         return ids;
     };
 
-    var _load = function(region, callback, scope, newParams) {
+    /**
+     * Asynchronous loader for a DataRegion
+     * @param region {DataRegion}
+     * @param [newParams] {string}
+     * @param [skipPrefixes] {string[]}
+     * @param [callback] {Function}
+     * @param [scope]
+     * @private
+     */
+    var _load = function(region, newParams, skipPrefixes, callback, scope) {
 
-        var params = _getAsyncParams(region, newParams ? newParams : _getParameters(region));
+        var params = _getAsyncParams(region, newParams ? newParams : _getParameters(region), skipPrefixes);
         var jsonData = _getAsyncBody(region, params);
 
         // TODO: This should be done in _getAsyncParams, but is not since _getAsyncBody relies on it. Refactor it.
@@ -3615,7 +3613,7 @@ if (!LABKEY.DataRegions) {
         return parameter && parameter.indexOf(region.name + '.') === 0 && parameter.indexOf('~') > 0;
     };
 
-    var _getAsyncParams = function(region, newParams) {
+    var _getAsyncParams = function(region, newParams, skipPrefixes) {
 
         var params = {};
         var name = region.name;
@@ -3718,8 +3716,10 @@ if (!LABKEY.DataRegions) {
         // apply all parameters
         //
 
+        var newParamPrefixes = {};
+
         if (newParams) {
-            $.each(newParams, function(i, pair) {
+            newParams.forEach(function(pair) {
                 //
                 // Filters may repeat themselves #25337
                 //
@@ -3734,6 +3734,20 @@ if (!LABKEY.DataRegions) {
                 }
                 else {
                     params[pair[0]] = pair[1];
+                }
+
+                newParamPrefixes[pair[0]] = true;
+            });
+        }
+
+        //
+        // 40226: Don't include parameters that are being logically excluded
+        //
+
+        if (skipPrefixes) {
+            skipPrefixes.forEach(function(skipKey) {
+                if (params.hasOwnProperty(skipKey) && !newParamPrefixes.hasOwnProperty(skipKey)) {
+                    delete params[skipKey];
                 }
             });
         }

--- a/query/resources/views/QWPDemo.html
+++ b/query/resources/views/QWPDemo.html
@@ -41,6 +41,7 @@
             <div class="tab"><a href="#testGetBaseFilters">Use getBaseFilters</a></div>
             <div class="tab"><a href="#testFilterOnSortColumn">Filter on "Sort" column</a></div>
             <div class="tab"><a href="#testButtonBarConfig">Use onRender via ButtonBarOptions</a></div>
+            <div class="tab"><a href="#testRespectExcludingPrefixes">Exclude "skipPrefixes"</a></div>
         </td>
         <td valign="top">
             <div id="qwpDiv"></div>

--- a/query/webapp/QWPDemo.js
+++ b/query/webapp/QWPDemo.js
@@ -28,7 +28,8 @@
             testShowAllTotalRows: testShowAllTotalRows,
             testGetBaseFilters: testGetBaseFilters,
             testFilterOnSortColumn: testFilterOnSortColumn,
-            testButtonBarConfig: testButtonBarConfig
+            testButtonBarConfig: testButtonBarConfig,
+            testRespectExcludingPrefixes: testRespectExcludingPrefixes
         };
 
         var PAGE_OFFSET = 4;
@@ -598,7 +599,6 @@
                 },
                 listeners: {
                     render: function(qwp) {
-                        debugger;
                         if (initialLoad) {
                             initialLoad = false;
                             var filterCount = getFilterMessageBoxCount();
@@ -667,7 +667,7 @@
                                     }
                                     else if (loadCount === 3) {
                                         loadCount++;
-                                        if (assertPagingCount(dr, 3, 4)) {
+                                        if (assertPagingCount(dr, 3, TOTAL_EXPECTED_ROWS)) {
                                             LABKEY.Utils.signalWebDriverTest('testHidePagingCount');
                                         }
                                     }
@@ -848,6 +848,41 @@
 
                             LABKEY.Utils.signalWebDriverTest('testButtonBarConfig');
                         }
+                    }
+                }
+            });
+        }
+
+        function testRespectExcludingPrefixes() {
+            var loadCount = 0;
+            new LABKEY.QueryWebPart({
+                title: 'Exclude specified parameter prefixes (Regression #40226)',
+                schemaName: 'Samples',
+                queryName: 'sampleDataTest1',
+                maxRows: 2, // split into 3 pages of results
+                offset: 4, // start on the 3rd page
+                sort: '-id',
+                renderTo: RENDERTO,
+                failure: function() {
+                    alert('Failed test: testRespectExcludingPrefixes failed to load');
+                },
+                listeners: {
+                    render: function(dr) {
+                        setTimeout(function() {
+                            if (loadCount === 0) {
+                                if (assertPagingCount(dr, 5, 6, 6)) {
+                                    loadCount++;
+
+                                    // filter to a result that includes rows on multiple page
+                                    dr.addFilter(LABKEY.Filter.create('Id', [6,5,4,3,2].join(';'), LABKEY.Filter.Types.IN));
+                                }
+                            }
+                            else if (loadCount === 1) {
+                                if (assertPagingCount(dr, 1, 2, 5)) {
+                                    LABKEY.Utils.signalWebDriverTest('testRespectExcludingPrefixes');
+                                }
+                            }
+                        }, 100);
                     }
                 }
             });

--- a/query/webapp/QWPDemo.js
+++ b/query/webapp/QWPDemo.js
@@ -868,16 +868,20 @@
                 },
                 listeners: {
                     render: function(dr) {
+                        loadCount++;
+                        // timeout is used here to defer displaying error until after region is rendered.
+                        // Less confusing when comparing error against current region state.
                         setTimeout(function() {
-                            if (loadCount === 0) {
+                            if (loadCount === 1) {
+                                // Expect to be on the last page of 3 (results 5-6 of 6)
                                 if (assertPagingCount(dr, 5, 6, 6)) {
-                                    loadCount++;
 
                                     // filter to a result that includes rows on multiple page
                                     dr.addFilter(LABKEY.Filter.create('Id', [6,5,4,3,2].join(';'), LABKEY.Filter.Types.IN));
                                 }
                             }
-                            else if (loadCount === 1) {
+                            else if (loadCount === 2) {
+                                // Expect to be on the first page of 3 (results 1-2 of 5)
                                 if (assertPagingCount(dr, 1, 2, 5)) {
                                     LABKEY.Utils.signalWebDriverTest('testRespectExcludingPrefixes');
                                 }


### PR DESCRIPTION
#### Rationale
This PR fixes [40226](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40226) which describes a scenario where an asynchronous data region fails to return to the first page after applying a filter on a subsequent page.

#### Fix
Synchronous data region behavior worked in this scenario by respecting the "skip prefixes" parameter. This parameter is used to indicate any set of parameters that should be "skipped" in processing and thus no longer applied. For example, when updating a filter, the update method asks for the `offset` prefix to be skipped:

```js
var _updateFilter = function(region, filter, skipPrefixes) {
    var params = [];
    if (filter) {
        params.push([filter.getURLParameterName(region.name), filter.getURLParameterValue()]);
    }

    // Skip [OFFSET_PREFIX] plus whatever the caller wants to skip
    _setParameters(region, params, [OFFSET_PREFIX].concat(skipPrefixes));
};
```

This wasn't being respected in the async processing and so the `offset` was still being carried forward (through the next load) resulting in the user being left on the page on which they applied the filter. With this PR these skip prefixes are now processed in the async handler as well.

#### Changes
* Pass explicit "skipPrefixes" parameter to `_load()` to handle processing parameters for the next load.
* Add regression test coverage to the `DataRegionTest`.
* Replace usages of `$.each` on arrays with `Array.forEach()` and/or `Array.map()`.
