### PR TITLE
40361: filtering doesn't work with "Mine" view

### DIFF
--- a/issues/src/org/labkey/issue/query/IssuesQuerySchema.java
+++ b/issues/src/org/labkey/issue/query/IssuesQuerySchema.java
@@ -278,7 +278,7 @@ public class IssuesQuerySchema extends UserSchema
 
                 if (!getUser().isGuest())
                 {
-                    filter = new SimpleFilter(FieldKey.fromString("AssignedTo/DisplayName"), "~me~");
+                    filter = new SimpleFilter(FieldKey.fromString("AssignedTo/DisplayName"), CompareType.ME_FILTER_PARAM_VALUE);
                     filter.addCondition(FieldKey.fromString("Status"), "closed", CompareType.NEQ_OR_NULL);
                     customViews.add(new IssuesBuiltInCustomView(qd, "mine", filter.getClauses(), sort));
                 }


### PR DESCRIPTION
## Rationale
The Issues custom 'mine' view uses a `~me~` filter on the assigned to display name column.  When the filter is applied, and the user opens the filter dialog for a different column, the query-selectDistcint.api fails to apply the `~me~` filter and no rows are returned.  When the query-selectDistinct.api is called, query will resolve all of the columns from the filters by FieldKey and create a `QAliasedColumn` for them if they haven't been selected.  The logic that expands the `~me~` filter value was attempting to account for aliased columns but had inverted the logic.

#### Related Pull Requests
#676 

#### Changes
- incorrect logic used when checking for `QAliasedColumn` user display columns created by query when resolving columns used in filters