### PR TITLE
Issue 40365: Clearing XML metadata for a built-in table deletes custom views

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1142,8 +1142,9 @@ public class QueryController extends SpringActionController
                 {
                     if (QueryManager.get().getQueryDef(getContainer(), form.getSchemaName(), form.getQueryName(), false) != null)
                     {
-                        // delete the query in order to reset the metadata over a built-in query
-                        queryDef.delete(getUser());
+                        // delete the query in order to reset the metadata over a built-in query, but don't
+                        // fire the listener because we haven't actually deleted the table. See issue 40365
+                        queryDef.delete(getUser(), false);
                     }
                 }
                 else


### PR DESCRIPTION
#### Rationale
When we reset XML metadata set through the schema browser on a "real" table, we may be deleting the row from query.queryDef, but we're not actually deleting the table.