### PR TITLE
Issue 40379: When merging data, we need to skip over columns that are backed by DbSequences.

### DIFF
--- a/api/src/org/labkey/api/data/StatementUtils.java
+++ b/api/src/org/labkey/api/data/StatementUtils.java
@@ -726,6 +726,12 @@ public class StatementUtils
             if (done.contains(name))
                 continue;
             done.add(name);
+            if (Operation.merge == _operation)
+            {
+                ColumnInfo updatableColumn = updatable.getColumn(column.getName());
+                if (updatableColumn != null && updatableColumn.hasDbSequence())
+                    continue;
+            }
 
             SQLFragment valueSQL = new SQLFragment();
             if (column.getName().equalsIgnoreCase(objectIdColumnName))

--- a/api/src/org/labkey/api/data/StatementUtils.java
+++ b/api/src/org/labkey/api/data/StatementUtils.java
@@ -726,12 +726,10 @@ public class StatementUtils
             if (done.contains(name))
                 continue;
             done.add(name);
-            if (Operation.merge == _operation)
-            {
-                ColumnInfo updatableColumn = updatable.getColumn(column.getName());
-                if (updatableColumn != null && updatableColumn.hasDbSequence())
-                    continue;
-            }
+            ColumnInfo updatableColumn = updatable.getColumn(column.getName());
+            if (updatableColumn != null && updatableColumn.hasDbSequence())
+                _dontUpdateColumnNames.add(column.getName());
+
 
             SQLFragment valueSQL = new SQLFragment();
             if (column.getName().equalsIgnoreCase(objectIdColumnName))


### PR DESCRIPTION
#### Rationale
Since we converted the RowId column for the exp.materials column to be backed by a DbSequence instead of an auto-increment column from the database, we need to be sure that we don't try to update those columns when doing a merge.  

#### Related Pull Requests
None


