### PR TITLE
Issue 40375: Only get immediate parents not all generations when merging in lineage adjustments

### DIFF
--- a/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
+++ b/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
@@ -43,6 +43,8 @@ import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpDataClass;
 import org.labkey.api.exp.api.ExpDataRunInput;
+import org.labkey.api.exp.api.ExpLineage;
+import org.labkey.api.exp.api.ExpLineageOptions;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpProtocolApplication;
@@ -405,7 +407,12 @@ public abstract class UploadSamplesHelper
 
         if (isMerge)
         {
-            Pair<Set<ExpData>, Set<ExpMaterial>> currentParents = ExperimentService.get().getParents(c, user, runItem);
+            ExpLineageOptions options = new ExpLineageOptions();
+            options.setChildren(false);
+            options.setDepth(2); // use 2 to get the first generation of parents because the first "parent" is the run
+
+            ExpLineage lineage = ExperimentService.get().getLineage(c, user, runItem, options);
+            Pair<Set<ExpData>, Set<ExpMaterial>> currentParents = Pair.of(lineage.getDatas(), lineage.getMaterials());
             if (currentParents.first != null)
             {
                 Map<ExpData, String> existingParentData = new HashMap<>();


### PR DESCRIPTION
#### Rationale
The getParents method, despite its name, actually returns all generations of ancestors for a runItem.  When merging records and modifying the lineage, we want only the immediate parents to set up the modified run representing the sample's (or data object's) derivation.

#### Changes
* Issue 40375: Adding a source parent to a sample changes the sample's other parent lineage
