### PR TITLE
Data Region: fix population of fields for getQueryDetails

### DIFF
--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -2008,10 +2008,11 @@ if (!LABKEY.DataRegions) {
             viewName = (this.view && this.view.name) || this.viewName || '';
 
         var userFilter = this.getUserFilterArray().map(function(filter) {
-            fields.push(filter.fieldKey);
+            var fieldKey = filter.getColumnName();
+            fields.push(fieldKey);
 
             return {
-                fieldKey: filter.getColumnName(),
+                fieldKey: fieldKey,
                 op: filter.getFilterType().getURLSuffix(),
                 value: filter.getValue()
             };


### PR DESCRIPTION
#### Rationale
This PR fixes a bug introduced with a small refactor in #1134 of how the fields are populated for the `getQueryDetails()` request made for a data region. The result ended up being `[undefined, undefined, ...]` fields being passed through rather than the expected `["columnA", "columnB", ...]`.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1134

#### Changes
* Switch to using `filter.getColumnName()` to populate the set of fields passed to `getQueryDetails`.
