### PR TITLE
@labkey/api package update

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -934,9 +934,9 @@
       }
     },
     "@labkey/api": {
-      "version": "0.2.4",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.4.tgz",
-      "integrity": "sha1-NJIdAY//FYWYjCObiLH/TnC2adM="
+      "version": "0.2.8",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.2.8.tgz",
+      "integrity": "sha1-yDpHBYlLAIT3eNmuic8WG572ofY="
     },
     "@labkey/components": {
       "version": "0.56.3",

--- a/core/package.json
+++ b/core/package.json
@@ -90,7 +90,7 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "0.2.4",
+    "@labkey/api": "0.2.8",
     "@labkey/components": "0.56.3",
     "@labkey/eslint-config-react": "0.0.5",
     "react-toggle-button": "2.2.0"


### PR DESCRIPTION
#### Rationale
This updates our core package's dependency on `@labkey/api` to the latest revision. This incorporates updates from `v0.2.5` - `v0.2.8`. See the [package change log](https://github.com/LabKey/labkey-api-js/blob/master/CHANGELOG.md) for the specific changes.

I've run the Specimen tests (included in "Daily C") to ensure coverage of the `Specimen` module updates. The [results are consistent](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyCSqlserver2014/988848) with the latest from develop.

#### Changes
* Bump `@labkey/api` package dependency version.
