### PR TITLE
Bump up of some important caches that have been "limited" on production servers

### DIFF
--- a/api/src/org/labkey/api/cache/DbCache.java
+++ b/api/src/org/labkey/api/cache/DbCache.java
@@ -37,7 +37,7 @@ public class DbCache
 {
     private static final Map<Path, DatabaseCache<String, Object>> CACHES = new HashMap<>(100);
 
-    public static int DEFAULT_CACHE_SIZE = 1000;   // Each TableInfo can override this (see tableInfo.xsd <cacheSize> element)
+    public static int DEFAULT_CACHE_SIZE = 5000;   // Each TableInfo can override this (see tableInfo.xsd <cacheSize> element)
 
 
     public static <K> DatabaseCache<String, K> getCacheGeneric(TableInfo tinfo)

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -97,9 +97,9 @@ import static org.labkey.api.search.SearchService.PROPERTY;
 public class OntologyManager
 {
     private static final Logger _log = Logger.getLogger(OntologyManager.class);
-    private static final Cache<String, Map<String, ObjectProperty>> mapCache = new DatabaseCache<>(getExpSchema().getScope(), 5000, "Property maps");
-    private static final Cache<String, Integer> objectIdCache = new DatabaseCache<>(getExpSchema().getScope(), 1000, "ObjectIds");
-    private static final Cache<Pair<String, GUID>, PropertyDescriptor> propDescCache = new BlockingCache<>(new DatabaseCache<>(getExpSchema().getScope(), 10000, CacheManager.UNLIMITED, "Property descriptors"), new CacheLoader<>()
+    private static final Cache<String, Map<String, ObjectProperty>> mapCache = new DatabaseCache<>(getExpSchema().getScope(), 10000, "Property maps");
+    private static final Cache<String, Integer> objectIdCache = new DatabaseCache<>(getExpSchema().getScope(), 2000, "ObjectIds");
+    private static final Cache<Pair<String, GUID>, PropertyDescriptor> propDescCache = new BlockingCache<>(new DatabaseCache<>(getExpSchema().getScope(), 40000, CacheManager.UNLIMITED, "Property descriptors"), new CacheLoader<>()
     {
         @Override
         public PropertyDescriptor load(@NotNull Pair<String, GUID> key, @Nullable Object argument)
@@ -174,7 +174,7 @@ public class OntologyManager
     }
 
     private static final BlockingCache<Integer, DomainDescriptor> domainDescByIDCache = new BlockingCache<>(new DatabaseCache<>(getExpSchema().getScope(),2000, CacheManager.UNLIMITED,"Domain descriptors by ID"), new DomainDescriptorLoader());
-    private static final BlockingCache<Pair<String, GUID>, List<Pair<String, Boolean>>> domainPropertiesCache = new BlockingCache<>(new DatabaseCache<>(getExpSchema().getScope(), 2000, CacheManager.UNLIMITED, "Domain properties"), new CacheLoader<>()
+    private static final BlockingCache<Pair<String, GUID>, List<Pair<String, Boolean>>> domainPropertiesCache = new BlockingCache<>(new DatabaseCache<>(getExpSchema().getScope(), 5000, CacheManager.UNLIMITED, "Domain properties"), new CacheLoader<>()
     {
         @Override
         public List<Pair<String, Boolean>> load(@NotNull Pair<String, GUID> key, @Nullable Object argument)

--- a/api/src/org/labkey/api/security/GroupCache.java
+++ b/api/src/org/labkey/api/security/GroupCache.java
@@ -17,7 +17,6 @@ package org.labkey.api.security;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.BlockingCache;
-import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.SQLFragment;
@@ -31,16 +30,11 @@ import org.labkey.api.data.SqlSelector;
 public class GroupCache
 {
     private static final CoreSchema CORE = CoreSchema.getInstance();
-    private static final BlockingCache<Integer, Group> CACHE = CacheManager.getBlockingCache(10000, CacheManager.DAY, "Groups", new CacheLoader<Integer, Group>()
-    {
-        @Override
-        public Group load(Integer groupId, Object argument)
-        {
-            SQLFragment sql = new SQLFragment("SELECT * FROM " + CORE.getTableInfoPrincipals() + " WHERE Type <> 'u' AND UserId = ?", groupId);
-            SqlSelector selector = new SqlSelector(CORE.getSchema(), sql);
+    private static final BlockingCache<Integer, Group> CACHE = CacheManager.getBlockingCache(20000, CacheManager.DAY, "Groups", (groupId, argument) -> {
+        SQLFragment sql = new SQLFragment("SELECT * FROM " + CORE.getTableInfoPrincipals() + " WHERE Type <> 'u' AND UserId = ?", groupId);
+        SqlSelector selector = new SqlSelector(CORE.getSchema(), sql);
 
-            return selector.getObject(Group.class);
-        }
+        return selector.getObject(Group.class);
     });
 
 

--- a/api/src/org/labkey/api/util/StringExpressionFactory.java
+++ b/api/src/org/labkey/api/util/StringExpressionFactory.java
@@ -70,8 +70,8 @@ public class StringExpressionFactory
 {
     private static final Logger LOG = Logger.getLogger(StringExpressionFactory.class);
 
-    private static Cache<String, StringExpression> templates = CacheManager.getCache(5000, CacheManager.DAY, "StringExpression templates");
-    private static Cache<String, StringExpression> templatesUrl = CacheManager.getCache(5000, CacheManager.DAY, "StringExpression template URLs");
+    private static final Cache<String, StringExpression> templates = CacheManager.getCache(5000, CacheManager.DAY, "StringExpression templates");
+    private static final Cache<String, StringExpression> templatesUrl = CacheManager.getCache(10000, CacheManager.DAY, "StringExpression template URLs");
 
     public static final StringExpression EMPTY_STRING = new ConstantStringExpression("");
 


### PR DESCRIPTION
#### Rationale
The limits we set on caches should be reviewed periodically as data volumes and standard RAM configurations change. We're not particularly scientific about this, but our "caches" admin page flags all caches that have been limited, providing a simple way to identify candidates whose limits might be increased. We don't blindly increase every one that's flagged; some caches are supposed to be restricted in size. This PR increases the default limit for DbCaches and doubles the limit for some widely used core caches that have been flagged on labkey.org or Atlas.

#### Changes
* Increase the DbCache default limit from 1,000 to 5,000
* Double the limit on key caches that have hit the limit production servers: Property maps, ObjectIds, Property descriptors, Domain properties, Groups, StringExpression template URLs