### PR TITLE
Migrate more sequence number handling from double to BigDecimal

### DIFF
--- a/api/src/org/labkey/api/study/Study.java
+++ b/api/src/org/labkey/api/study/Study.java
@@ -37,8 +37,6 @@ public interface Study extends StudyEntity
 {
     List<? extends Visit> getVisits(Visit.Order order);
 
-    Map<String, Double> getVisitAliases();
-
     Dataset getDataset(int id);
 
     Dataset getDatasetByName(String name);

--- a/api/src/org/labkey/api/study/Study.java
+++ b/api/src/org/labkey/api/study/Study.java
@@ -24,7 +24,6 @@ import org.labkey.api.security.User;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +35,9 @@ import java.util.Map;
 public interface Study extends StudyEntity
 {
     List<? extends Visit> getVisits(Visit.Order order);
+
+    @SuppressWarnings("unused")  // Used by cdisc_ODM StudyArchiveWriter.java
+    Map<String, Double> getVisitAliases();
 
     Dataset getDataset(int id);
 

--- a/api/src/org/labkey/api/study/Visit.java
+++ b/api/src/org/labkey/api/study/Visit.java
@@ -64,7 +64,7 @@ public interface Visit extends StudyEntity
 
     String getDescription();
 
-    public enum Type
+    enum Type
     {
         SCREENING('X', "Screening"),
         PREBASELINE('P', "Scheduled pre-baseline visit"),
@@ -82,7 +82,7 @@ public interface Visit extends StudyEntity
         private final char _code;
         private final String _meaning;
 
-        private Type(char code, String meaning)
+        Type(char code, String meaning)
         {
             _code = code;
             _meaning = meaning;
@@ -109,7 +109,7 @@ public interface Visit extends StudyEntity
         }
     }
 
-    public enum Order
+    enum Order
     {
         CHRONOLOGICAL("ChronologicalOrder,SequenceNumMin"),
         DISPLAY("DisplayOrder,SequenceNumMin"),
@@ -128,7 +128,7 @@ public interface Visit extends StudyEntity
         }
     }
 
-    public enum SequenceHandling
+    enum SequenceHandling
     {
         normal,             // as determined by TimepointType
         logUniqueByDate     // append days since start of study in fractional part of sequencenum

--- a/list/src/org/labkey/list/model/ListImporter.java
+++ b/list/src/org/labkey/list/model/ListImporter.java
@@ -78,7 +78,8 @@ import java.util.stream.Collectors;
 public class ListImporter
 {
     private static final String TYPE_NAME_COLUMN = "ListName";
-    private ListImportContext _importContext;
+
+    private final ListImportContext _importContext;
 
     public ListImporter(){
         _importContext = new ListImportContext(null, false);

--- a/study/src/org/labkey/study/controllers/VisitForm.java
+++ b/study/src/org/labkey/study/controllers/VisitForm.java
@@ -100,7 +100,7 @@ public class VisitForm extends ViewForm
             setProtocolDay(VisitImpl.calcDefaultDateBasedProtocolDay(getSequenceNumMin(), getSequenceNumMax()));
 
         VisitImpl visit = getBean();
-        if (visit.getSequenceNumMinDouble() > visit.getSequenceNumMaxDouble())
+        if (visit.getSequenceNumMin().compareTo(visit.getSequenceNumMax()) > 0)
         {
             errors.reject(null, "The minimum value cannot be greater than the maximum value for the visit range.");
 /*

--- a/study/src/org/labkey/study/importer/VisitImporter.java
+++ b/study/src/org/labkey/study/importer/VisitImporter.java
@@ -25,7 +25,6 @@ import org.labkey.study.xml.StudyDocument;
 import org.springframework.validation.BindException;
 
 import java.io.IOException;
-import java.sql.SQLException;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -47,17 +46,12 @@ public class VisitImporter implements InternalStudyImporter
     @Override
     public String getDataType() { return StudyArchiveDataTypes.VISIT_MAP; }
 
-
-    public boolean isEnsureDatasets()
-    {
-        return _ensureDatasets;
-    }
-
     public void setEnsureDatasets(boolean ensureDatasets)
     {
         _ensureDatasets = ensureDatasets;
     }
 
+    @Override
     public void process(StudyImportContext ctx, VirtualFile vf, BindException errors) throws IOException, ImportException, ValidationException
     {
         if (!ctx.isDataTypeSelected(getDataType()))

--- a/study/src/org/labkey/study/importer/VisitMapImporter.java
+++ b/study/src/org/labkey/study/importer/VisitMapImporter.java
@@ -214,11 +214,11 @@ public class VisitMapImporter
         {
             // This visit's min should be less than or equal to its max
             if (r.getSequenceNumMin().compareTo(r.getSequenceNumMax()) > 0)
-                throw new VisitMapImportException("Visit " + (r.toString()) + " has a sequence number minimum that's greater than its sequence number maximum.");
+                throw new VisitMapImportException("Visit " + r + " has a sequence number minimum that's greater than its sequence number maximum.");
 
             // This visit's min should be greater than the previous visit's max
             if (r.getSequenceNumMin().compareTo(max) <= 0)
-                throw new VisitMapImportException("Visit " + (r.toString()) + " range overlaps with another record in the visit map.");
+                throw new VisitMapImportException("Visit " + r + " range overlaps with another record in the visit map.");
 
             max = r.getSequenceNumMax();
         }
@@ -296,7 +296,7 @@ public class VisitMapImporter
                 {
                     if (visitManager.isVisitOverlapping(visit))
                     {
-                        throw new VisitMapImportException("Visit " + visit.toString() + ": range overlaps with an existing visit in this study.");
+                        throw new VisitMapImportException("Visit " + visit + ": range overlaps with an existing visit in this study.");
                     }
 
                     StudyManager.getInstance().updateVisit(user, visit);

--- a/study/src/org/labkey/study/importer/XmlVisitMapReader.java
+++ b/study/src/org/labkey/study/importer/XmlVisitMapReader.java
@@ -16,7 +16,6 @@
 
 package org.labkey.study.importer;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.xmlbeans.XmlError;
 import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlObject;

--- a/study/src/org/labkey/study/model/StudyImpl.java
+++ b/study/src/org/labkey/study/model/StudyImpl.java
@@ -230,6 +230,14 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     }
 
     @Override
+    public Map<String, Double> getVisitAliases()
+    {
+        return StudyManager.getInstance().getCustomVisitImportMapping(this)
+            .stream()
+            .collect(Collectors.toMap(StudyManager.VisitAlias::getName, StudyManager.VisitAlias::getSequenceNumDouble));
+    }
+
+    @Override
     public DatasetDefinition getDataset(int id)
     {
         return StudyManager.getInstance().getDatasetDefinition(this, id);

--- a/study/src/org/labkey/study/model/StudyImpl.java
+++ b/study/src/org/labkey/study/model/StudyImpl.java
@@ -230,14 +230,6 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     }
 
     @Override
-    public Map<String, Double> getVisitAliases()
-    {
-        return StudyManager.getInstance().getCustomVisitImportMapping(this)
-                .stream()
-                .collect(Collectors.toMap(StudyManager.VisitAlias::getName, StudyManager.VisitAlias::getSequenceNum));
-    }
-
-    @Override
     public DatasetDefinition getDataset(int id)
     {
         return StudyManager.getInstance().getDatasetDefinition(this, id);

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -1044,12 +1044,12 @@ public class StudyManager
             }
 
             if (existingVisit.getSequenceNumMin().compareTo(existingVisit.getSequenceNumMax()) > 0)
-                throw new VisitCreationException("Corrupt existing visit " + existingVisit.getLabel() +
+                throw new VisitCreationException("Corrupt existing visit " + existingVisit +
                         ": SequenceNumMin must be less than or equal to SequenceNumMax");
             boolean disjoint = (visit.getSequenceNumMax().compareTo(existingVisit.getSequenceNumMin()) < 0) || (visit.getSequenceNumMin().compareTo(existingVisit.getSequenceNumMax()) > 0);
             if (!disjoint)
             {
-                throw new VisitCreationException("New visit " + visit.toString() + " overlaps existing visit " + existingVisit.toString());
+                throw new VisitCreationException("New visit " + visit + " overlaps existing visit " + existingVisit);
             }
         }
 

--- a/study/src/org/labkey/study/model/VisitImpl.java
+++ b/study/src/org/labkey/study/model/VisitImpl.java
@@ -452,6 +452,7 @@ public class VisitImpl extends AbstractStudyEntity<VisitImpl> implements Cloneab
         ObjectFactory.Registry.register(VisitImpl.class, _f);
     }
 
+    @Override
     public String getDescription()
     {
         return _description;
@@ -495,6 +496,10 @@ public class VisitImpl extends AbstractStudyEntity<VisitImpl> implements Cloneab
         return _sequenceMin.compareTo(seqnum) <= 0 && _sequenceMax.compareTo(seqnum) >= 0;
     }
 
+    public String toString()
+    {
+        return (null != _label ? _label + " (" : "(") + getSequenceString() + ")";
+    }
 
     public static class TestCase extends Assert
     {

--- a/study/src/org/labkey/study/query/ParticipantVisitDatasetTable.java
+++ b/study/src/org/labkey/study/query/ParticipantVisitDatasetTable.java
@@ -112,7 +112,7 @@ public class ParticipantVisitDatasetTable extends VirtualTable<StudyQuerySchema>
                     visitList.add(visit);
             }
             //Resort the visit list
-            visitList.sort((v1, v2) -> v1.getDisplayOrder() != v2.getDisplayOrder() ? v1.getDisplayOrder() - v2.getDisplayOrder() : (int) (v1.getSequenceNumMinDouble() - v2.getSequenceNumMinDouble()));
+            visitList.sort((v1, v2) -> v1.getDisplayOrder() != v2.getDisplayOrder() ? v1.getDisplayOrder() - v2.getDisplayOrder() : v1.getSequenceNumMin().compareTo(v2.getSequenceNumMin()));
         }
 
         // duplicate label check a) two visits with same label b) two sequences with same visit
@@ -217,7 +217,7 @@ public class ParticipantVisitDatasetTable extends VirtualTable<StudyQuerySchema>
 
     private static boolean _inSequence(VisitImpl v, double seq)
     {
-        assert v.getSequenceNumMinDouble() <= v.getSequenceNumMaxDouble();
+        assert v.getSequenceNumMin().compareTo(v.getSequenceNumMax()) <= 0;
         return seq >= v.getSequenceNumMaxDouble() && seq <= v.getSequenceNumMaxDouble();
     }
 
@@ -234,6 +234,7 @@ public class ParticipantVisitDatasetTable extends VirtualTable<StudyQuerySchema>
             ret = new AliasedColumn(name, _colParticipantId);
         }
         ret.setFk(new AbstractForeignKey(getUserSchema(), cf) {
+            @Override
             public ColumnInfo createLookupColumn(ColumnInfo parent, String displayFieldName)
             {
                 TableInfo table = getLookupTableInfo();
@@ -254,6 +255,7 @@ public class ParticipantVisitDatasetTable extends VirtualTable<StudyQuerySchema>
                         parent, table.getColumn(_study.getSubjectColumnName()), displayField);
             }
 
+            @Override
             public TableInfo getLookupTableInfo()
             {
                 try

--- a/study/src/org/labkey/study/query/VisitUpdateService.java
+++ b/study/src/org/labkey/study/query/VisitUpdateService.java
@@ -18,16 +18,12 @@ package org.labkey.study.query;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.query.DefaultQueryUpdateService;
-import org.labkey.api.query.DuplicateKeyException;
-import org.labkey.api.query.InvalidKeyException;
-import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.study.Study;
 import org.labkey.study.model.StudyManager;
 import org.labkey.study.model.VisitImpl;
 
-import java.sql.SQLException;
 import java.util.Collections;
 import java.util.Map;
 
@@ -68,7 +64,7 @@ public class VisitUpdateService extends DefaultQueryUpdateService
             throw new ValidationException("A visit must include SequenceNumMin");
 
         VisitImpl visit = VisitImpl.fromMap(newRow, container);
-        VisitImpl currentVisit = studyManager.getVisitForSequence(study, visit.getSequenceNumMinDouble());
+        VisitImpl currentVisit = studyManager.getVisitForSequence(study, visit.getSequenceNumMin());
 
         if (null != currentVisit)
         {

--- a/study/src/org/labkey/study/reports/AssayProgressReport.java
+++ b/study/src/org/labkey/study/reports/AssayProgressReport.java
@@ -56,6 +56,7 @@ import org.labkey.study.model.StudyManager;
 import org.springframework.validation.BindException;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -86,7 +87,7 @@ public class AssayProgressReport extends AbstractReport
     public static final String SPECIMEN_UNUSABLE = "unusable";
     public static final String SPECIMEN_RESULTS_UNEXPECTED = "unexpected";
 
-    private SetValuedMap<String, ParticipantVisit> _copiedToStudyData = new HashSetValuedHashMap<>();
+    private final SetValuedMap<String, ParticipantVisit> _copiedToStudyData = new HashSetValuedHashMap<>();
 
     public enum SpecimenStatus
     {
@@ -99,10 +100,10 @@ public class AssayProgressReport extends AbstractReport
         UNUSABLE(SPECIMEN_UNUSABLE, "Unusable", "Unusable", "fa fa-trash-o"),
         UNEXPECTED(SPECIMEN_RESULTS_UNEXPECTED, "Unexpected results", "Needs QC Check", "fa fa-flag");
 
-        private String _name;
-        private String _lable;
-        private String _iconClass;
-        private String _description;
+        private final String _name;
+        private final String _lable;
+        private final String _iconClass;
+        private final String _description;
 
         SpecimenStatus(String name, String label, String description, String iconClass)
         {
@@ -234,7 +235,7 @@ public class AssayProgressReport extends AbstractReport
                     assayVisits.add(visitMap.get(visitId));
             }
 
-            assayVisits.sort((o1, o2) -> (int) (o1.getSequenceNumMinDouble() - o2.getSequenceNumMinDouble()));
+            assayVisits.sort(Comparator.comparing(Visit::getSequenceNumMin));
             assay.setExpectedVisits(assayVisits);
 
             if (assayConfigMap.containsKey(assay.getRowId()))

--- a/study/src/org/labkey/study/visitmanager/AbsoluteDateVisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/AbsoluteDateVisitManager.java
@@ -113,6 +113,7 @@ public class AbsoluteDateVisitManager extends RelativeDateVisitManager
         return null;
     }
 
+    @Override
     public boolean isVisitOverlapping(VisitImpl visit)
     {
         throw new UnsupportedOperationException("Study has no timepoints");

--- a/study/src/org/labkey/study/visitmanager/VisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/VisitManager.java
@@ -376,7 +376,7 @@ public abstract class VisitManager
      * Return a map mapping the minimum value of a visit to the visit.
      * In the case of a date-based study, this is actually a "Day" map, not a sequence map
      */
-    private TreeMap<Double, VisitImpl> getVisitSequenceMap()
+    private TreeMap<Double, VisitImpl> getVisitSequenceMapOld()
     {
         List<VisitImpl> visits = getStudy().getVisits(Visit.Order.DISPLAY);
         TreeMap<Double, VisitImpl> visitMap = new TreeMap<>();
@@ -389,7 +389,7 @@ public abstract class VisitManager
     public VisitImpl findVisitBySequence(double seq)
     {
         if (_sequenceMap == null)
-            _sequenceMap = getVisitSequenceMap();
+            _sequenceMap = getVisitSequenceMapOld();
 
         if (_sequenceMap.containsKey(seq))
             return _sequenceMap.get(seq);
@@ -411,7 +411,7 @@ public abstract class VisitManager
      * Return a map mapping the minimum value of a visit to the visit.
      * In the case of a date-based study, this is actually a "Day" map, not a sequence map
      */
-    private TreeMap<BigDecimal, VisitImpl> getVisitSequenceMapNew()
+    private TreeMap<BigDecimal, VisitImpl> getVisitSequenceMap()
     {
         List<VisitImpl> visits = getStudy().getVisits(Visit.Order.DISPLAY);
         TreeMap<BigDecimal, VisitImpl> visitMap = new TreeMap<>();
@@ -422,13 +422,13 @@ public abstract class VisitManager
 
     public Collection<VisitImpl> getVisits()
     {
-        return getVisitSequenceMapNew().values();
+        return getVisitSequenceMap().values();
     }
 
     public VisitImpl findVisitBySequence(BigDecimal seq)
     {
         if (_sequenceMapNew == null)
-            _sequenceMapNew = getVisitSequenceMapNew();
+            _sequenceMapNew = getVisitSequenceMap();
 
         if (_sequenceMapNew.containsKey(seq))
             return _sequenceMapNew.get(seq);
@@ -440,7 +440,8 @@ public abstract class VisitManager
         // v will be null only if we already searched for seq and didn't find it
         if (null == v)
             return null;
-        if (!(v.getSequenceNumMinDouble() <= seq.doubleValue() && seq.doubleValue() <= v.getSequenceNumMaxDouble()))
+
+        if (!(v.getSequenceNumMin().compareTo(seq) <= 0 && seq.compareTo(v.getSequenceNumMax()) <= 0))
             v = null;
         _sequenceMapNew.put(seq, v);
         return v;
@@ -461,8 +462,8 @@ public abstract class VisitManager
         SQLFragment sql = new SQLFragment("SELECT * FROM ");
         sql.append(visitTable, "vt");
         sql.append(" WHERE SequenceNumMax >= ? AND SequenceNumMin <= ? AND Container = ? AND RowId <> ?");
-        sql.add(visit.getSequenceNumMinDouble());
-        sql.add(visit.getSequenceNumMaxDouble());
+        sql.add(visit.getSequenceNumMin());
+        sql.add(visit.getSequenceNumMax());
         sql.add(visit.getContainer());
         sql.add(visit.getRowId()); // exclude the specified visit itself; new visits will have a rowId of 0, which shouldn't conflict
 

--- a/study/src/org/labkey/study/writer/XmlVisitMapWriter.java
+++ b/study/src/org/labkey/study/writer/XmlVisitMapWriter.java
@@ -34,7 +34,6 @@ import org.labkey.study.xml.VisitMapDocument.VisitMap.ImportAliases;
 import org.labkey.study.xml.VisitMapDocument.VisitMap.ImportAliases.Alias;
 
 import java.io.IOException;
-import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -49,11 +48,13 @@ public class XmlVisitMapWriter implements Writer<StudyImpl, StudyExportContext>
 {
     public static final String FILENAME = "visit_map.xml";
 
+    @Override
     public String getDataType()
     {
         return null;
     }
 
+    @Override
     public void write(StudyImpl study, StudyExportContext ctx, VirtualFile vf) throws IOException, ImportException
     {
         List<VisitImpl> visits = study.getVisits(Visit.Order.DISPLAY);
@@ -89,10 +90,10 @@ public class XmlVisitMapWriter implements Writer<StudyImpl, StudyExportContext>
 
                 visitXml.setSequenceNum(visit.getSequenceNumMinDouble());
 
-                if (visit.getSequenceNumMinDouble() != visit.getSequenceNumMaxDouble())
+                if (!visit.getSequenceNumMin().equals(visit.getSequenceNumMax()))
                     visitXml.setMaxSequenceNum(visit.getSequenceNumMaxDouble());
 
-                if (null != visit.getProtocolDayDouble())
+                if (null != visit.getProtocolDay())
                     visitXml.setProtocolDay(visit.getProtocolDayDouble());
 
                 if (null != visit.getCohort())
@@ -155,7 +156,7 @@ public class XmlVisitMapWriter implements Writer<StudyImpl, StudyExportContext>
             {
                 Alias aliasXml = ia.addNewAlias();
                 aliasXml.setName(alias.getName());
-                aliasXml.setSequenceNum(alias.getSequenceNum());
+                aliasXml.setSequenceNum(alias.getSequenceNumDouble());
             }
         }
 


### PR DESCRIPTION
#### Rationale
Sequence numbers are stored as DECIMAL(15, 4), but code that handles them is currently a messy mix of BigDecimal and double. This PR is a checkpoint that migrates more sequence number code paths from double to BigDecimal.

#### Changes
* Switch VisitAlias to use BigDecimal internally
* Migrate more sequence number handling from double to BigDecimal
* Implement toString() on VisitImpl and VisitAlias, and use it in error messages
