### PR TITLE
Admin console defaults to "Settings"

### DIFF
--- a/api/src/org/labkey/api/view/menu/SiteAdminMenu.java
+++ b/api/src/org/labkey/api/view/menu/SiteAdminMenu.java
@@ -90,7 +90,6 @@ public class SiteAdminMenu extends NavTreeMenu
         AdminUrls adminUrls = PageFlowUtil.urlProvider(AdminUrls.class);
 
         ActionURL consoleUrl = adminUrls.getAdminConsoleURL();
-        consoleUrl.setFragment("info");
         if (null != context && null != context.getActionURL())
         {
             if (null == context.getActionURL().getReturnURL())

--- a/core/src/org/labkey/core/admin/admin.jsp
+++ b/core/src/org/labkey/core/admin/admin.jsp
@@ -62,8 +62,8 @@
 <div class="row">
     <div class="col-sm-12 col-md-3">
         <div id="lk-admin-nav" class="list-group">
-            <a href="#info" class="list-group-item">Server Information</a>
             <a href="#links" class="list-group-item">Settings</a>
+            <a href="#info" class="list-group-item">Server Information</a>
             <a href="#modules" class="list-group-item">Module Information</a>
             <a href="#users" class="list-group-item">Active Users</a>
         </div>
@@ -243,7 +243,7 @@
 <script type="text/javascript">
     +function($) {
 
-        var defaultRoute = "info";
+        var defaultRoute = "links";
 
         function loadRoute(hash) {
             if (!hash || hash === '#') {

--- a/mothership/test/src/org/labkey/test/util/mothership/MothershipHelper.java
+++ b/mothership/test/src/org/labkey/test/util/mothership/MothershipHelper.java
@@ -160,8 +160,7 @@ public class MothershipHelper
     public void setIgnoreExceptions(boolean ignore) throws IOException, CommandException
     {
         // Find the current server GUID
-        test.goToAdmin();
-        String serverGUID = test.getText(Locator.tagWithText("td", "Server GUID").followingSibling("td"));
+        String serverGUID = test.goToAdminConsole().getServerGUID();
 
         Connection connection = test.createDefaultConnection(true);
         // Find the corresponding serverInstallationId


### PR DESCRIPTION
#### Rationale
The admin console is more often than not used to access server-wide settings. This PR changes the default to the "Settings" tab instead of "Server Information".

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/332

#### Changes
* Reorder admin console tabs and default to settings tab (`#links`).
