### PR TITLE
Issue 40403: Timeline: audit log and user permission issues

### DIFF
--- a/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
@@ -300,6 +300,12 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
         return new DefaultAuditTypeTable(this, createStorageTableInfo(), userSchema, cf, getDefaultVisibleColumns());
     }
 
+    @Override
+    public TableInfo createTableInfo(UserSchema userSchema, ContainerFilter cf, boolean skipSeeAuditLogPerm)
+    {
+        return createTableInfo(userSchema, cf);
+    }
+
     public List<FieldKey> getDefaultVisibleColumns()
     {
         return null;

--- a/api/src/org/labkey/api/audit/AuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AuditTypeProvider.java
@@ -50,6 +50,8 @@ public interface AuditTypeProvider
 
     TableInfo createTableInfo(UserSchema schema, ContainerFilter cf);
 
+    TableInfo createTableInfo(UserSchema schema, ContainerFilter cf, boolean skipSeeAuditLogPerm);
+
     <K extends AuditTypeEvent> Class<K> getEventClass();
 
     /**

--- a/experiment/src/org/labkey/experiment/ExperimentAuditProvider.java
+++ b/experiment/src/org/labkey/experiment/ExperimentAuditProvider.java
@@ -31,6 +31,7 @@ import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
@@ -125,6 +126,12 @@ public class ExperimentAuditProvider extends AbstractAuditTypeProvider implement
     @Override
     public TableInfo createTableInfo(UserSchema userSchema, ContainerFilter cf)
     {
+        return createTableInfo(userSchema, cf, false);
+    }
+
+    @Override
+    public TableInfo createTableInfo(UserSchema userSchema, ContainerFilter cf, boolean skipSeeAuditLogPerm)
+    {
         DefaultAuditTypeTable table = new DefaultAuditTypeTable(this, createStorageTableInfo(), userSchema, cf, defaultVisibleColumns)
         {
             @Override
@@ -177,6 +184,16 @@ public class ExperimentAuditProvider extends AbstractAuditTypeProvider implement
                     col.setFk(new QueryForeignKey(CoreSchema.getInstance().getTableInfoQCState(), null, "RowId", "Label"));
                 }
             }
+
+            @Override
+            protected SimpleFilter.FilterClause getContainerFilterClause(ContainerFilter filter, FieldKey fieldKey)
+            {
+                if (!skipSeeAuditLogPerm)
+                    return super.getContainerFilterClause(filter, fieldKey);
+
+                return filter.createFilterClause(getSchema(), fieldKey, getContainer());
+            }
+
         };
 
         return table;

--- a/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
@@ -7,6 +7,7 @@ import org.labkey.api.audit.query.AbstractAuditDomainKind;
 import org.labkey.api.audit.query.DefaultAuditTypeTable;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
@@ -79,6 +80,12 @@ public class SampleTimelineAuditProvider extends AbstractAuditTypeProvider
     @Override
     public TableInfo createTableInfo(UserSchema userSchema, ContainerFilter cf)
     {
+        return createTableInfo(userSchema, cf, false);
+    }
+
+    @Override
+    public TableInfo createTableInfo(UserSchema userSchema, ContainerFilter cf, boolean skipSeeAuditLogPerm)
+    {
         DefaultAuditTypeTable table = new DefaultAuditTypeTable(this, createStorageTableInfo(), userSchema, cf, getDefaultVisibleColumns())
         {
             @Override
@@ -109,6 +116,16 @@ public class SampleTimelineAuditProvider extends AbstractAuditTypeProvider
                     col.setLabel("Lineage Update?");
                 }
             }
+
+            @Override
+            protected SimpleFilter.FilterClause getContainerFilterClause(ContainerFilter filter, FieldKey fieldKey)
+            {
+                if (!skipSeeAuditLogPerm)
+                    return super.getContainerFilterClause(filter, fieldKey);
+
+                return filter.createFilterClause(getSchema(), fieldKey, getContainer());
+            }
+
         };
         table.setTitleColumn(SAMPLE_NAME_COLUMN_NAME);
         appendValueMapColumns(table);


### PR DESCRIPTION
#### Rationale
It's observed that timeline page won't load at all if user lack CanSeeAuditLogPermission. While Timeline is backed by audit log, we shouldn't require user to have CanSeeAuditLogPermission to view it in LKSM. 

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/265

#### Changes
* Allow SampleTimelineAuditEvent and ExperimentAuditEvent to be able to bypass CanSeeAuditLogPermission check