### PR TITLE
Use $.each() instead of Array.forEach()

### DIFF
--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -1185,7 +1185,7 @@ if (!LABKEY.DataRegions) {
     LABKEY.DataRegion.prototype.getParameter = function(paramName) {
         var param = null;
 
-        _getParameters(this).forEach(function(pair) {
+        $.each(_getParameters(this), function(i, pair) {
             if (pair.length > 0 && pair[0] === paramName) {
                 param = pair.length > 1 ? pair[1] : '';
                 return false;
@@ -2383,7 +2383,7 @@ if (!LABKEY.DataRegions) {
             cols = this.columns;
 
         if (isString(columnIdentifier) && LABKEY.Utils.isArray(cols)) {
-            ['fieldKey', 'name', 'displayField', 'caption'].forEach(function(key) {
+            $.each(['fieldKey', 'name', 'displayField', 'caption'], function(i, key) {
                 $.each(cols, function(c, col) {
                     if (isString(col[key]) && col[key] == columnIdentifier) {
                         column = col;
@@ -2818,7 +2818,7 @@ if (!LABKEY.DataRegions) {
 
     var _removeAnalyticsProviderFromView = function(view, colFieldKey, providerName, isSummaryStatistic) {
         var indexToRemove = null;
-        view.analyticsProviders.forEach(function(existingProvider, index) {
+        $.each(view.analyticsProviders, function(index, existingProvider) {
             if (existingProvider.fieldKey === colFieldKey && existingProvider.name === providerName) {
                 indexToRemove = index;
                 return false;
@@ -3089,7 +3089,7 @@ if (!LABKEY.DataRegions) {
                     return region.name + prefix;
                 });
 
-                pairs.forEach(function(pair) {
+                $.each(pairs, function(i, pair) {
                     p = pair.split('=', 2);
                     key = p[0] = decodeURIComponent(p[0]);
                     lastIdx = key.indexOf(LAST);
@@ -3104,7 +3104,7 @@ if (!LABKEY.DataRegions) {
 
                     var stop = false;
                     if (skip) {
-                        skipPrefixSet.forEach(function(skipPrefix) {
+                        $.each(skipPrefixSet, function(j, skipPrefix) {
                             if (LABKEY.Utils.isString(skipPrefix)) {
 
                                 // Special prefix that should remove all filters, but no other parameters


### PR DESCRIPTION
#### Rationale
With #1134 I had switched several usages of `$.each()` to use `Array.forEach()` without realizing that `forEach()` does not support short-circuiting via `return false`. This PR reverts those usages that do make use of that mechanism so the logic works as expected.

This fixes the failing `LuminexEC50Test.testEC50` test case which I will confirm with a run of the Daily A test suite.

#### Related Pull Requests
* #1134

#### Changes
* Use `$.each()` instead of `Array.forEach()` in `DataRegion` for cases where short-circuit mechanism is utilized.
