### PR TITLE
Improve error logging

### DIFF
--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -157,7 +157,7 @@ public class FileUtil
         if (dir.exists())
         {
             log.warn("dumping thread because server could not delete directory: " + dir.getAbsolutePath());
-            DebugInfoDumper.dumpThreads(log);
+            DebugInfoDumper.dumpThreads(1);
         }
 
         return !dir.exists();

--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -143,7 +143,7 @@ public class FileUtil
             // wait a little then try again
             try
             {
-                log.error("Failed to delete file.  Sleep and try to delete again: " + FileUtil.getAbsoluteCaseSensitiveFile(dir));
+                log.warn("Failed to delete file.  Sleep and try to delete again: " + FileUtil.getAbsoluteCaseSensitiveFile(dir));
                 Thread.sleep(1000);
             }
             catch (InterruptedException e)
@@ -152,12 +152,6 @@ public class FileUtil
                 log.error("Failed to delete file after 5 attempts: " + FileUtil.getAbsoluteCaseSensitiveFile(dir));
                 return false;
             }
-        }
-
-        if (dir.exists())
-        {
-            log.warn("dumping thread because server could not delete directory: " + dir.getAbsolutePath());
-            DebugInfoDumper.dumpThreads(1);
         }
 
         return !dir.exists();

--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -143,13 +143,13 @@ public class FileUtil
             // wait a little then try again
             try
             {
-                log.warn("Failed to delete file.  Sleep and try to delete again: " + FileUtil.getAbsoluteCaseSensitiveFile(dir));
+                log.error("Failed to delete file.  Sleep and try to delete again: " + FileUtil.getAbsoluteCaseSensitiveFile(dir));
                 Thread.sleep(1000);
             }
             catch (InterruptedException e)
             {
                 // give up
-                log.warn("Failed to delete file after 5 attempts: " + FileUtil.getAbsoluteCaseSensitiveFile(dir));
+                log.error("Failed to delete file after 5 attempts: " + FileUtil.getAbsoluteCaseSensitiveFile(dir));
                 return false;
             }
         }

--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -141,20 +141,11 @@ public class FileUtil
 
             // Issue 39579: Folder import sometimes fails to delete temp directory
             // wait a little then try again
-            try
-            {
-                log.warn("Failed to delete file.  Sleep and try to delete again: " + FileUtil.getAbsoluteCaseSensitiveFile(dir));
-                Thread.sleep(1000);
-            }
-            catch (InterruptedException e)
-            {
-                // give up
-                log.error("Failed to delete file after 5 attempts: " + FileUtil.getAbsoluteCaseSensitiveFile(dir));
-                return false;
-            }
+            log.warn("Failed to delete file.  Sleep and try to delete again: " + FileUtil.getAbsoluteCaseSensitiveFile(dir));
+            try {Thread.sleep(1000);} catch (InterruptedException x) {/* pass */}
         }
-
-        return !dir.exists();
+        log.error("Failed to delete file after 5 attempts: " + FileUtil.getAbsoluteCaseSensitiveFile(dir));
+        return false;
     }
 
     public static void deleteDir(@NotNull Path dir) throws IOException

--- a/query/src/org/labkey/query/reports/ReportServiceImpl.java
+++ b/query/src/org/labkey/query/reports/ReportServiceImpl.java
@@ -883,14 +883,22 @@ public class ReportServiceImpl extends AbstractContainerListener implements Repo
                 if (descriptor instanceof RReportDescriptor && xmlFileName.toLowerCase().endsWith(".report.xml"))
                 {
                     String baseName = xmlFileName.substring(0, xmlFileName.length() - ".report.xml".length());
-                    InputStream is = root.getInputStream(baseName + ".R");
-                    if (null == is)
-                        is = root.getInputStream(baseName + ".r");
-                    if (null != is)
+                    InputStream is = null;
+                    try
                     {
-                        String script = IOUtils.toString(is, StringUtilsLabKey.DEFAULT_CHARSET);
-                        if (!StringUtils.isBlank(script))
-                            descriptor.setProperty(ScriptReportDescriptor.Prop.script, script);
+                        is = root.getInputStream(baseName + ".R");
+                        if (null == is)
+                            is = root.getInputStream(baseName + ".r");
+                        if (null != is)
+                        {
+                            String script = IOUtils.toString(is, StringUtilsLabKey.DEFAULT_CHARSET);
+                            if (!StringUtils.isBlank(script))
+                                descriptor.setProperty(ScriptReportDescriptor.Prop.script, script);
+                        }
+                    }
+                    finally
+                    {
+                        IOUtils.closeQuietly(is);
                     }
                 }
             }

--- a/query/src/org/labkey/query/reports/ReportServiceImpl.java
+++ b/query/src/org/labkey/query/reports/ReportServiceImpl.java
@@ -883,22 +883,14 @@ public class ReportServiceImpl extends AbstractContainerListener implements Repo
                 if (descriptor instanceof RReportDescriptor && xmlFileName.toLowerCase().endsWith(".report.xml"))
                 {
                     String baseName = xmlFileName.substring(0, xmlFileName.length() - ".report.xml".length());
-                    InputStream is = null;
-                    try
+                    InputStream is = root.getInputStream(baseName + ".R");
+                    if (null == is)
+                        is = root.getInputStream(baseName + ".r");
+                    if (null != is)
                     {
-                        is = root.getInputStream(baseName + ".R");
-                        if (null == is)
-                            is = root.getInputStream(baseName + ".r");
-                        if (null != is)
-                        {
-                            String script = IOUtils.toString(is, StringUtilsLabKey.DEFAULT_CHARSET);
-                            if (!StringUtils.isBlank(script))
-                                descriptor.setProperty(ScriptReportDescriptor.Prop.script, script);
-                        }
-                    }
-                    finally
-                    {
-                        IOUtils.closeQuietly(is);
+                        String script = IOUtils.toString(is, StringUtilsLabKey.DEFAULT_CHARSET);
+                        if (!StringUtils.isBlank(script))
+                            descriptor.setProperty(ScriptReportDescriptor.Prop.script, script);
                     }
                 }
             }


### PR DESCRIPTION
#### Rationale
When directory delete fails, the reason for the failure is a warning and will not be recorded in a pipeline job.

#### Changes
Change warn() to error()
also minor cleanup related to null check
