### PR TITLE
Assert getWritableProperties() without causing NPE

### DIFF
--- a/api/src/org/labkey/api/data/PropertyManager.java
+++ b/api/src/org/labkey/api/data/PropertyManager.java
@@ -105,12 +105,20 @@ public class PropertyManager
         return STORE.getProperties(user, container, category);
     }
 
+    private static void assertWritableProperties(@Nullable PropertyMap writableProps, boolean create)
+    {
+        // getWritableProperties() will return null if an existing map is not found and create is false.
+        if (writableProps == null)
+            assert !create;
+        else
+            assert !writableProps.isModified();
+    }
 
     /** For global system properties that get attached to the root container. */
     public static PropertyMap getWritableProperties(String category, boolean create)
     {
         PropertyMap ret = STORE.getWritableProperties(category, create);
-        assert !ret.isModified();
+        assertWritableProperties(ret, create);
         return ret;
     }
 
@@ -118,7 +126,7 @@ public class PropertyManager
     public static PropertyMap getWritableProperties(Container container, String category, boolean create)
     {
         PropertyMap ret = STORE.getWritableProperties(container, category, create);
-        assert !ret.isModified();
+        assertWritableProperties(ret, create);
         return ret;
     }
 
@@ -126,7 +134,7 @@ public class PropertyManager
     public static PropertyMap getWritableProperties(User user, Container container, String category, boolean create)
     {
         PropertyMap ret = STORE.getWritableProperties(user, container, category, create);
-        assert !ret.isModified();
+        assertWritableProperties(ret, create);
         return ret;
     }
 

--- a/api/src/org/labkey/api/data/PropertyManager.java
+++ b/api/src/org/labkey/api/data/PropertyManager.java
@@ -105,20 +105,22 @@ public class PropertyManager
         return STORE.getProperties(user, container, category);
     }
 
-    private static void assertWritableProperties(@Nullable PropertyMap writableProps, boolean create)
+    private static boolean assertWritableProperties(@Nullable PropertyMap writableProps, boolean create)
     {
         // getWritableProperties() will return null if an existing map is not found and create is false.
         if (writableProps == null)
             assert !create;
         else
             assert !writableProps.isModified();
+
+        return true;
     }
 
     /** For global system properties that get attached to the root container. */
     public static PropertyMap getWritableProperties(String category, boolean create)
     {
         PropertyMap ret = STORE.getWritableProperties(category, create);
-        assertWritableProperties(ret, create);
+        assert assertWritableProperties(ret, create);
         return ret;
     }
 
@@ -126,7 +128,7 @@ public class PropertyManager
     public static PropertyMap getWritableProperties(Container container, String category, boolean create)
     {
         PropertyMap ret = STORE.getWritableProperties(container, category, create);
-        assertWritableProperties(ret, create);
+        assert assertWritableProperties(ret, create);
         return ret;
     }
 
@@ -134,7 +136,7 @@ public class PropertyManager
     public static PropertyMap getWritableProperties(User user, Container container, String category, boolean create)
     {
         PropertyMap ret = STORE.getWritableProperties(user, container, category, create);
-        assertWritableProperties(ret, create);
+        assert assertWritableProperties(ret, create);
         return ret;
     }
 


### PR DESCRIPTION
#### Rationale
A couple of recent test runs I'd performed resulted in NPE's from `PropertyManager` as it was asserting the state of the return value from `getWritableProperties()`. This PR updates the assertion to align with expected behavior based on the `create` argument. 

#### Example Stacktrace

```
ERROR FlowController           2020-05-09 20:01:36,218     http-nio-8111-exec-6 : Error
java.lang.NullPointerException
	at org.labkey.api.data.PropertyManager.getWritableProperties(PropertyManager.java:121)
	at org.labkey.flow.FlowSettings.setWorkingDirectoryPath(FlowSettings.java:76)
	at org.labkey.flow.controllers.FlowController$FlowAdminAction.handlePost(FlowController.java:536)
	at org.labkey.flow.controllers.FlowController$FlowAdminAction.handlePost(FlowController.java:501)
	at org.labkey.api.action.FormViewAction.handleRequest(FormViewAction.java:95)
	at org.labkey.api.action.FormViewAction.handleRequest(FormViewAction.java:74)
	at org.labkey.api.action.BaseViewAction.handleRequest(BaseViewAction.java:176)
	at org.labkey.api.action.SpringActionController.handleRequest(SpringActionController.java:492)
	at org.labkey.api.module.DefaultModule.dispatch(DefaultModule.java:1167)
	at org.labkey.api.view.ViewServlet._service(ViewServlet.java:206)
	at org.labkey.api.view.ViewServlet.service(ViewServlet.java:133)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:741)
```

#### Changes
* Conditionalize `assert` of `getWritableProperties()` return value to align with expected behavior. Assert check itself will no longer cause an NPE.
