### PR TITLE
Make TableInfo responsible for choosing appropriate spot to log audit entries

### DIFF
--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -114,6 +114,12 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
     @NotNull
     Map<String, Pair<IndexType, List<ColumnInfo>>> getAllIndices();
 
+    /** Log an audit event to capture a data change made to this table */
+    default void addAuditEvent(User user, Container container, AuditBehaviorType auditBehavior, QueryService.AuditAction auditAction, List<Map<String, Object>>[] parameters)
+    {
+        QueryService.get().addAuditEvent(user, container, this, auditBehavior, auditAction, parameters);
+    }
+
     enum IndexType
     {
         Primary(org.labkey.data.xml.IndexType.Type.PRIMARY, true),

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -446,10 +446,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         {
             AuditBehaviorType auditBehavior = configParameters != null ? (AuditBehaviorType) configParameters.get(AuditBehavior) : null;
 
-            if (getQueryTable().getPublicSchemaName().equalsIgnoreCase(SamplesSchema.SCHEMA_NAME))
-                SampleSetService.get().addAuditEvent(user, container, getQueryTable(), auditBehavior, auditAction, parameters);
-            else
-                QueryService.get().addAuditEvent(user, container, getQueryTable(), auditBehavior, auditAction, parameters);
+            getQueryTable().addAuditEvent(user, container, auditBehavior, auditAction, parameters);
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -49,6 +49,7 @@ import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpSampleSet;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.ExperimentUrls;
+import org.labkey.api.exp.api.SampleSetService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.query.ExpDataTable;
@@ -56,15 +57,18 @@ import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.exp.query.ExpSampleSetTable;
 import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.exp.query.SamplesSchema;
+import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.QueryForeignKey;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.RowIdForeignKey;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.Permission;
@@ -115,6 +119,20 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 return createPropertyColumn("Property");
         }
         return result;
+    }
+
+    @Override
+    public void addAuditEvent(User user, Container container, AuditBehaviorType auditBehavior, QueryService.AuditAction auditAction, List<Map<String, Object>>[] parameters)
+    {
+        if (getUserSchema().getName().equalsIgnoreCase(SamplesSchema.SCHEMA_NAME))
+        {
+            // Special case sample auditing to help build a useful timeline view
+            SampleSetService.get().addAuditEvent(user, container, this, auditBehavior, auditAction, parameters);
+        }
+        else
+        {
+            super.addAuditEvent(user, container, auditBehavior, auditAction, parameters);
+        }
     }
 
     public MutableColumnInfo createColumn(String alias, Column column)


### PR DESCRIPTION
#### Rationale
We want special handling for sample changes in our audit event logging. This pivots the responsibility for the special case so that the core query code doesn't need to know.