### PR TITLE
Serialize sequence nums as BigDecimal in folder/study archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1937,7 +1937,6 @@ core/resources/credits/executables.txt -text
 core/resources/credits/jars.txt -text
 core/resources/credits/scripts.txt -text
 core/resources/credits/tomcat_jars.txt -text
-core/resources/module.xml -text
 core/resources/schemas/dbscripts/postgresql/core-18.20-18.30.sql -text
 core/resources/schemas/dbscripts/postgresql/core-create.sql -text
 core/resources/schemas/dbscripts/postgresql/core-drop.sql -text
@@ -3542,10 +3541,8 @@ study/src/org/labkey/study/query/VisitUpdateService.java -text
 study/src/org/labkey/study/QueryHelper.java -text
 study/src/org/labkey/study/reports/AssayProgressReport.java -text
 study/src/org/labkey/study/reports/BaseStudyView.java -text
-study/src/org/labkey/study/reports/configureExportExcel.jsp -text
 study/src/org/labkey/study/reports/DatasetChartReport.java -text
 study/src/org/labkey/study/reports/DefaultAssayProgressSource.java -text
-study/src/org/labkey/study/reports/ExportExcelReport.java -text
 study/src/org/labkey/study/reports/ExternalReport.java -text
 study/src/org/labkey/study/reports/ParticipantReport.java -text
 study/src/org/labkey/study/reports/ParticipantReportDescriptor.java -text

--- a/api/schemas/visitMap.xsd
+++ b/api/schemas/visitMap.xsd
@@ -76,22 +76,22 @@
                                     </xs:documentation>
 							</xs:annotation>
 						</xs:attribute>
-						<xs:attribute name="sequenceNum" type="xs:double">
+						<xs:attribute name="sequenceNum" type="xs:decimal">
 							<xs:annotation>
 								<xs:documentation>
                                     The sequence number of the visit, or, if a maxSequenceNum is listed, the first
                                     sequence number in the range of visits
-                                    </xs:documentation>
+                                </xs:documentation>
 							</xs:annotation>
 						</xs:attribute>
-						<xs:attribute name="maxSequenceNum" type="xs:double">
+						<xs:attribute name="maxSequenceNum" type="xs:decimal">
 							<xs:annotation>
 								<xs:documentation>
                                     When included, visit sequence numbers can range from sequenceNum to maxSequenceNum, inclusive.
-                                    </xs:documentation>
+                                </xs:documentation>
 							</xs:annotation>
 						</xs:attribute>
-                        <xs:attribute name="protocolDay" type="xs:double">
+                        <xs:attribute name="protocolDay" type="xs:decimal">
                             <xs:annotation>
                                 <xs:documentation>
                                     The expected day for the visit.
@@ -102,7 +102,7 @@
 							<xs:annotation>
 								<xs:documentation>
                                     The order that this visit will be displayed in the list of visits.
-                                    </xs:documentation>
+                                </xs:documentation>
 							</xs:annotation>
 						</xs:attribute>
 						<xs:attribute name="chronologicalOrder" type="xs:int">
@@ -110,28 +110,28 @@
 								<xs:documentation>
                                     The chronological order of the visit, which is used to determine cohort assignments
                                     when your study uses the advanced cohort assignment type.
-                                    </xs:documentation>
+                                </xs:documentation>
 							</xs:annotation>
 						</xs:attribute>
 						<xs:attribute name="cohort" type="xs:string">
 							<xs:annotation>
 								<xs:documentation>
                                    The cohort associated with the visit.
-                                    </xs:documentation>
+                                </xs:documentation>
 							</xs:annotation>
 						</xs:attribute>
 						<xs:attribute name="typeCode" type="xs:string">
 							<xs:annotation>
 								<xs:documentation>
                                    The type of the visit.
-                                    </xs:documentation>
+                                </xs:documentation>
 							</xs:annotation>
 						</xs:attribute>
 						<xs:attribute name="showByDefault" type="xs:boolean" default="true">
 							<xs:annotation>
 								<xs:documentation>
                                    Indicates whether the visit is shown by default. 
-                                    </xs:documentation>
+                                </xs:documentation>
 							</xs:annotation>
 						</xs:attribute>
 						<xs:attribute name="visitDateDatasetId" type="xs:int" default="-1">
@@ -156,7 +156,7 @@
 							<xs:element name="alias" minOccurs="1" maxOccurs="unbounded">
 								<xs:complexType>
 									<xs:attribute name="name" type="xs:string"/>
-									<xs:attribute name="sequenceNum" type="xs:double"/>
+									<xs:attribute name="sequenceNum" type="xs:decimal"/>
 								</xs:complexType>
 							</xs:element>
 						</xs:sequence>

--- a/api/src/org/labkey/api/study/Study.java
+++ b/api/src/org/labkey/api/study/Study.java
@@ -23,6 +23,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
@@ -37,7 +38,7 @@ public interface Study extends StudyEntity
     List<? extends Visit> getVisits(Visit.Order order);
 
     @SuppressWarnings("unused")  // Used by cdisc_ODM StudyArchiveWriter.java
-    Map<String, Double> getVisitAliases();
+    Map<String, BigDecimal> getVisitAliases();
 
     Dataset getDataset(int id);
 

--- a/api/src/org/labkey/api/study/Visit.java
+++ b/api/src/org/labkey/api/study/Visit.java
@@ -47,9 +47,6 @@ public interface Visit extends StudyEntity
 
     BigDecimal getProtocolDay();
 
-    @Deprecated // Use getProtocolDay()
-    Double getProtocolDayDouble();
-
     Integer getCohortId();
 
     Integer getId();

--- a/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
+++ b/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
@@ -103,7 +103,7 @@ public class PublishResultsQueryView extends ResultsQueryView
     private final Map<Object, String> _reshowDates;
     private final Map<Object, String> _reshowPtids;
     private final Map<Object, String> _reshowTargetStudies;
-    private boolean _includeTimestamp;
+    private final boolean _includeTimestamp;
 
     private List<ActionButton> _buttons = null;
 

--- a/core/src/org/labkey/core/user/changeEmail.jsp
+++ b/core/src/org/labkey/core/user/changeEmail.jsp
@@ -46,9 +46,9 @@
         if (!isUserManager) { %>
             <p>NOTE: You will need to know your account password and have access to your new email address to change your email address!</p>
         <% } %>
-    <labkey:input type="text" name="currentEmail" id="currentEmail" label="Current Email" value="<%=currentEmail%>" isReadOnly="true"/>
-    <labkey:input type="text" name="requestedEmail" id="requestedEmail" label="New Email" value="<%=form.getRequestedEmail()%>" />
-    <labkey:input type="text" name="requestedEmailConfirmation" id="requestedEmailConfirmation" label="Retype New Email" value="<%=form.getRequestedEmailConfirmation()%>" />
+    <labkey:input type="text" size="50" name="currentEmail" id="currentEmail" label="Current Email" value="<%=currentEmail%>" isReadOnly="true"/>
+    <labkey:input type="text" size="50" name="requestedEmail" id="requestedEmail" label="New Email" value="<%=form.getRequestedEmail()%>" />
+    <labkey:input type="text" size="50" name="requestedEmailConfirmation" id="requestedEmailConfirmation" label="Retype New Email" value="<%=form.getRequestedEmailConfirmation()%>" />
     <labkey:input type="hidden" name="userId" value="<%=form.getUserId()%>"/>
     <labkey:input type="hidden" name="isChangeEmailRequest" value="true"/>
     <labkey:csrf/>
@@ -63,8 +63,8 @@
 %>
         <p>For security purposes, please enter your password.</p>
         <labkey:form action="<%=h(buildURL(ChangeEmailAction.class, Method.Post))%>" method="POST" layout="horizontal">
-            <labkey:input type="text" name="currentEmail" id="currentEmail" label="Email" value="<%=currentEmail%>" isReadOnly="true"/>
-            <labkey:input id="password" name="password" type="password" label="Password" contextContent="<%=resetPasswordLink%>"/>
+            <labkey:input size="50" type="text" name="currentEmail" id="currentEmail" label="Email" value="<%=currentEmail%>" isReadOnly="true"/>
+            <labkey:input size="50" id="password" name="password" type="password" label="Password" contextContent="<%=resetPasswordLink%>"/>
             <labkey:input type="hidden" name="userId" value="<%=form.getUserId()%>"/>
             <labkey:input type="hidden" name="requestedEmail" value="<%=form.getRequestedEmail()%>"/>
             <labkey:input type="hidden" name="verificationToken" value="<%=form.getVerificationToken()%>"/>

--- a/study/src/org/labkey/study/importer/VisitMapRecord.java
+++ b/study/src/org/labkey/study/importer/VisitMapRecord.java
@@ -56,14 +56,6 @@ class VisitMapRecord
     private final String _sequenceNumHandling;
     private final List<VisitTagRecord> _visitTagRecords;
 
-    public VisitMapRecord(double sequenceNumberMin, double sequenceNumberMax, @Nullable Double protocolDay, String visitType, String visitLabel, String visitDescription,
-                          String cohort, int visitDatePlate, Collection<Integer> requiredPlates, Collection<Integer> optionalPlates, boolean showByDefault,
-                          int displayOrder, int chronologicalOrder, String sequenceNumHandling, List<VisitTagRecord> visitTagRecords)
-    {
-        this(BigDecimal.valueOf(sequenceNumberMin), BigDecimal.valueOf(sequenceNumberMax), null != protocolDay ? BigDecimal.valueOf(protocolDay) : null, visitType, visitLabel,
-             visitDescription, cohort, visitDatePlate, requiredPlates, optionalPlates, showByDefault, displayOrder, chronologicalOrder, sequenceNumHandling, visitTagRecords);
-    }
-
     public VisitMapRecord(@NotNull BigDecimal sequenceNumberMin, @NotNull BigDecimal sequenceNumberMax, @Nullable BigDecimal protocolDay, String visitType, String visitLabel, String visitDescription,
                           String cohort, int visitDatePlate, Collection<Integer> requiredPlates, Collection<Integer> optionalPlates, boolean showByDefault,
                           int displayOrder, int chronologicalOrder, String sequenceNumHandling, List<VisitTagRecord> visitTagRecords)

--- a/study/src/org/labkey/study/importer/XmlVisitMapReader.java
+++ b/study/src/org/labkey/study/importer/XmlVisitMapReader.java
@@ -31,6 +31,7 @@ import org.labkey.study.xml.VisitMapDocument;
 import org.labkey.study.xml.VisitMapDocument.VisitMap.ImportAliases;
 import org.labkey.study.xml.VisitMapDocument.VisitMap.ImportAliases.Alias;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -92,8 +93,8 @@ public class XmlVisitMapReader implements VisitMapReader
 
         for (VisitMapDocument.VisitMap.Visit visitXml : visitsXml)
         {
-            double maxSequenceNum = visitXml.isSetMaxSequenceNum() ? visitXml.getMaxSequenceNum() : visitXml.getSequenceNum();
-            Double protocolDay = null;
+            BigDecimal maxSequenceNum = visitXml.isSetMaxSequenceNum() ? visitXml.getMaxSequenceNum() : visitXml.getSequenceNum();
+            BigDecimal protocolDay = null;
             if (visitXml.isSetProtocolDay())
                 protocolDay = visitXml.getProtocolDay();
             else if (TimepointType.DATE == timepointType)

--- a/study/src/org/labkey/study/model/SequenceNumImportHelper.java
+++ b/study/src/org/labkey/study/model/SequenceNumImportHelper.java
@@ -29,6 +29,7 @@ import org.labkey.api.study.Visit;
 import org.labkey.api.util.DateUtil;
 import org.labkey.study.visitmanager.SequenceVisitManager;
 
+import java.math.BigDecimal;
 import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -58,7 +59,7 @@ public class SequenceNumImportHelper
             _defaultSequenceNum = VisitImpl.DEMOGRAPHICS_VISIT;
         else
             _defaultSequenceNum = null;
-        for (Map.Entry<String, Double> entry : StudyManager.getInstance().getVisitImportMap(study, true).entrySet())
+        for (Map.Entry<String, BigDecimal> entry : StudyManager.getInstance().getVisitImportMap(study, true).entrySet())
             _translateMap.put(entry.getKey(), String.valueOf(entry.getValue()));
         if (_timetype.isVisitBased())
             _sequenceNumMap = new StudySequenceVisitMap(study);

--- a/study/src/org/labkey/study/model/StudyImpl.java
+++ b/study/src/org/labkey/study/model/StudyImpl.java
@@ -75,6 +75,7 @@ import org.labkey.study.query.StudyQuerySchema;
 import org.labkey.study.specimen.settings.RepositorySettings;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -230,11 +231,11 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     }
 
     @Override
-    public Map<String, Double> getVisitAliases()
+    public Map<String, BigDecimal> getVisitAliases()
     {
         return StudyManager.getInstance().getCustomVisitImportMapping(this)
             .stream()
-            .collect(Collectors.toMap(StudyManager.VisitAlias::getName, StudyManager.VisitAlias::getSequenceNumDouble));
+            .collect(Collectors.toMap(StudyManager.VisitAlias::getName, StudyManager.VisitAlias::getSequenceNum));
     }
 
     @Override

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -1237,12 +1237,12 @@ public class StudyManager
     }
 
 
-    public Map<String, Double> getVisitImportMap(Study study, boolean includeStandardMapping)
+    public Map<String, BigDecimal> getVisitImportMap(Study study, boolean includeStandardMapping)
     {
         Collection<VisitAlias> customMapping = getCustomVisitImportMapping(study);
         List<VisitImpl> visits = includeStandardMapping ? StudyManager.getInstance().getVisits(study, Visit.Order.SEQUENCE_NUM) : Collections.emptyList();
 
-        Map<String, Double> map = new CaseInsensitiveHashMap<>((customMapping.size() + visits.size()) * 3 / 4);
+        Map<String, BigDecimal> map = new CaseInsensitiveHashMap<>((customMapping.size() + visits.size()) * 3 / 4);
 
 //        // allow prepended "visit"
 //        for (Visit visit : visits)
@@ -1262,12 +1262,12 @@ public class StudyManager
 
             // Use the **first** instance of each label
             if (null != label && !map.containsKey(label))
-                map.put(label, visit.getSequenceNumMinDouble());
+                map.put(label, visit.getSequenceNumMin());
         }
 
         // Now load custom mapping, overwriting any existing standard labels
         for (VisitAlias alias : customMapping)
-            map.put(alias.getName(), alias.getSequenceNumDouble());
+            map.put(alias.getName(), alias.getSequenceNum());
 
         return map;
     }
@@ -1290,7 +1290,7 @@ public class StudyManager
     {
         List<VisitAlias> list = new LinkedList<>();
         Set<String> labels = new CaseInsensitiveHashSet();
-        Map<String, Double> customMap = getVisitImportMap(study, false);
+        Map<String, BigDecimal> customMap = getVisitImportMap(study, false);
 
         List<VisitImpl> visits = StudyManager.getInstance().getVisits(study, Visit.Order.SEQUENCE_NUM);
 
@@ -1332,10 +1332,9 @@ public class StudyManager
             _overridden = overridden;
         }
 
-        @Deprecated // Pass in sequenceNum as BigDecimal instead
-        public VisitAlias(String name, double sequenceNum)
+        public VisitAlias(String name, BigDecimal sequenceNum)
         {
-            this(name, new BigDecimal(sequenceNum).stripTrailingZeros(), null, false);
+            this(name, sequenceNum.stripTrailingZeros(), null, false);
         }
 
         public String getName()
@@ -1346,12 +1345,6 @@ public class StudyManager
         public void setName(String name)
         {
             _name = name;
-        }
-
-        @Deprecated
-        public double getSequenceNumDouble()
-        {
-            return _sequenceNum.doubleValue();
         }
 
         public BigDecimal getSequenceNum()

--- a/study/src/org/labkey/study/model/VisitImpl.java
+++ b/study/src/org/labkey/study/model/VisitImpl.java
@@ -265,13 +265,6 @@ public class VisitImpl extends AbstractStudyEntity<VisitImpl> implements Cloneab
     }
 
     @Override
-    @Deprecated // Use getProtocolDay()
-    public Double getProtocolDayDouble()
-    {
-        return null == _protocolDay ? null : _protocolDay.doubleValue();
-    }
-
-    @Override
     public BigDecimal getProtocolDay()
     {
         return _protocolDay;
@@ -299,11 +292,9 @@ public class VisitImpl extends AbstractStudyEntity<VisitImpl> implements Cloneab
     }
 
     // only 4 scale digits
-    @Deprecated // return BigDecimal instead
-    public static double parseSequenceNum(String s)
+    public static BigDecimal parseSequenceNum(String s)
     {
-        double d = Double.parseDouble(s);
-        return Math.round(d * SCALE_FACTOR) / SCALE_FACTOR;
+        return new BigDecimal(s);
     }
 
 
@@ -373,8 +364,8 @@ public class VisitImpl extends AbstractStudyEntity<VisitImpl> implements Cloneab
     {
         Map<String, Object> map = new HashMap<>();
         map.put("rowid", getRowId());
-        map.put("sequencenummin", getSequenceNumMinDouble());
-        map.put("sequencenummax", getSequenceNumMaxDouble());
+        map.put("sequencenummin", getSequenceNumMin());
+        map.put("sequencenummax", getSequenceNumMax());
         map.put("label", getLabel());
         map.put("typecode", getTypeCode());
         map.put("container", getContainer());
@@ -385,7 +376,7 @@ public class VisitImpl extends AbstractStudyEntity<VisitImpl> implements Cloneab
         map.put("chronologicalorder", getChronologicalOrder());
         map.put("sequencenumhandling", getSequenceNumHandling());
         map.put("description", getDescription());
-        map.put("protocolday", getProtocolDayDouble());
+        map.put("protocolday", getProtocolDay());
 
         return map;
     }
@@ -477,19 +468,11 @@ public class VisitImpl extends AbstractStudyEntity<VisitImpl> implements Cloneab
         }
     }
 
-    @Deprecated // Use BigDecimal version instead
-    public static double calcDefaultDateBasedProtocolDay(double sequenceMin, double sequenceMax)
-    {
-        return (double)Math.round((sequenceMin + sequenceMax)/2);
-    }
-
-
     public static BigDecimal calcDefaultDateBasedProtocolDay(BigDecimal sequenceMin, BigDecimal sequenceMax)
     {
         // Average and round, which is what the double version does
         return sequenceMin.add(sequenceMax).divide(BigDecimal.valueOf(2)).setScale(0, RoundingMode.HALF_UP);
     }
-
 
     public boolean isInRange(BigDecimal seqnum)
     {

--- a/study/src/org/labkey/study/writer/XmlVisitMapWriter.java
+++ b/study/src/org/labkey/study/writer/XmlVisitMapWriter.java
@@ -88,13 +88,13 @@ public class XmlVisitMapWriter implements Writer<StudyImpl, StudyExportContext>
                 if (!visit.isShowByDefault())
                     visitXml.setShowByDefault(visit.isShowByDefault());
 
-                visitXml.setSequenceNum(visit.getSequenceNumMinDouble());
+                visitXml.setSequenceNum(visit.getSequenceNumMin());
 
                 if (!visit.getSequenceNumMin().equals(visit.getSequenceNumMax()))
-                    visitXml.setMaxSequenceNum(visit.getSequenceNumMaxDouble());
+                    visitXml.setMaxSequenceNum(visit.getSequenceNumMax());
 
                 if (null != visit.getProtocolDay())
-                    visitXml.setProtocolDay(visit.getProtocolDayDouble());
+                    visitXml.setProtocolDay(visit.getProtocolDay());
 
                 if (null != visit.getCohort())
                     visitXml.setCohort(visit.getCohort().getLabel());
@@ -156,7 +156,7 @@ public class XmlVisitMapWriter implements Writer<StudyImpl, StudyExportContext>
             {
                 Alias aliasXml = ia.addNewAlias();
                 aliasXml.setName(alias.getName());
-                aliasXml.setSequenceNum(alias.getSequenceNumDouble());
+                aliasXml.setSequenceNum(alias.getSequenceNum());
             }
         }
 

--- a/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
@@ -188,7 +188,7 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
         // test the reload without first removing the overlapping visits
         importFolderArchiveWithFailureFlag(archive, true, 3, true);
         clickAndWait(Locator.linkWithText("ERROR"));
-        assertElementPresent(Locator.tagContainingText("pre", "New visit 2 week Post-V#1 (400.0 - 499.0) overlaps existing visit 2 week Post-V#1 (401.0)"));
+        assertElementPresent(Locator.tagContainingText("pre", "ERROR: New visit 2 week Post-V#1 (400.0 - 499.0) overlaps existing visit 2 week Post-V#1 (401.0)"));
 
         // delete some visits so that the reload will have the failure case
         deleteMultipleVisits(Arrays.asList("2 week Post-V#1", "411.0 - 491.0", "4 week Post-V#1", "1 week Post-V#2"));

--- a/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
@@ -188,7 +188,7 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
         // test the reload without first removing the overlapping visits
         importFolderArchiveWithFailureFlag(archive, true, 3, true);
         clickAndWait(Locator.linkWithText("ERROR"));
-        assertElementPresent(Locator.tagContainingText("pre", "ERROR: New visit 2 week Post-V#1 overlaps existing visit 2 week Post-V#1"));
+        assertElementPresent(Locator.tagContainingText("pre", "New visit 2 week Post-V#1 (400.0 - 499.0) overlaps existing visit 2 week Post-V#1 (401.0)"));
 
         // delete some visits so that the reload will have the failure case
         deleteMultipleVisits(Arrays.asList("2 week Post-V#1", "411.0 - 491.0", "4 week Post-V#1", "1 week Post-V#2"));


### PR DESCRIPTION
#### Rationale
Sequence numbers are stored as DECIMAL(15, 4), but code that handles them is currently a messy mix of BigDecimal and double. This PR is a checkpoint that migrates our XML serialization and corresponding XMLBeans to represent sequence nums as BigDecimal. That lets us migrate more code paths to BigDecimal and eliminate quite a few deprecated methods.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1157
* https://github.com/LabKey/cdisc_ODM/pull/29
* https://github.com/LabKey/redcap/pull/25

#### Changes
* Switch all sequence num elements in visitMap.xsd from xs:double to xs:decimal
* Migrate many code paths to use BigDecimal
* Fix StudyVisitManagementTest.java to expect new error message (changed in previous PR)
* Unrelated changes: update .gitattributes and more generous input widths on email change page
