### PR TITLE
Issue 40443: If changing tables in a deferred upgrade script, you als…

### DIFF
--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-20.005-20.006.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-20.005-20.006.sql
@@ -1,0 +1,1 @@
+EXEC core.executeJavaInitializationCode 'recreateViewsAfterMaterialRowIdDbSequence';

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -135,7 +135,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     public Double getSchemaVersion()
     {
-        return 20.005;
+        return 20.006;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -46,6 +46,7 @@ import org.labkey.api.exp.property.DomainKind;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.module.ModuleContext;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.experiment.api.DataClass;
 import org.labkey.experiment.api.DataClassDomainKind;
 import org.labkey.experiment.api.ExpDataClassImpl;
@@ -613,6 +614,16 @@ public class ExperimentUpgradeCode implements UpgradeCode
             }
             tx.commit();
         }
+    }
+
+    // called from exp-20.005-20.006
+    // For SQL Server, if modifying a table that is used in a view, the views need to get recreated after that
+    // modification happens.  So we need to do that after the previous deferred upgrade scripts happen since
+    // the createViews scripts run at the end of the regular upgrade scripts and thus before the deferred ones.
+    @DeferredUpgrade
+    public static void recreateViewsAfterMaterialRowIdDbSequence(ModuleContext context)
+    {
+        ModuleLoader.getInstance().recreateViews();
     }
 
 }

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -617,7 +617,7 @@ public class ExperimentUpgradeCode implements UpgradeCode
     }
 
     // called from exp-20.005-20.006
-    // For SQL Server, if modifying a table that is used in a view, the views need to get recreated after that
+    // Issue 40443: For SQL Server, if modifying a table that is used in a view, the views need to get recreated after that
     // modification happens.  So we need to do that after the previous deferred upgrade scripts happen since
     // the createViews scripts run at the end of the regular upgrade scripts and thus before the deferred ones.
     @DeferredUpgrade


### PR DESCRIPTION
#### Rationale
Previous changes updated the exp.Materials table in deferred upgrade scripts.  On SQL Server, changing tables can cause the views that reference these tables to be messed up, so we need to recreated the view after the deferred upgrade scripts have happened.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1090

#### Changes
* Issue 40443: If changing tables in a deferred upgrade script, you also need to recreate the views in SQLServer