### PR TITLE
Don't insist modules' sourceDir be non-null

### DIFF
--- a/api/src/org/labkey/api/data/FileSqlScriptProvider.java
+++ b/api/src/org/labkey/api/data/FileSqlScriptProvider.java
@@ -245,7 +245,7 @@ public class FileSqlScriptProvider implements SqlScriptProvider
 
         File scriptsDir = getScriptDirectory(schema.getSqlDialect());
 
-        if (!scriptsDir.exists())
+        if (scriptsDir == null || !scriptsDir.exists())
             throw new IllegalStateException("SQL scripts directory not found");
 
         File file = new File(scriptsDir, description);

--- a/core/src/org/labkey/core/admin/sql/SqlScriptController.java
+++ b/core/src/org/labkey/core/admin/sql/SqlScriptController.java
@@ -1006,7 +1006,7 @@ public class SqlScriptController extends SpringActionController
         {
             File dir = provider.getScriptDirectory(dialect);
 
-            if (dir.exists())
+            if (dir != null && dir.exists())
             {
                 File[] files = dir.listFiles();
 


### PR DESCRIPTION
#### Rationale
When running on TeamCity with gradle plugin v1.12.0+, we `null` out the 'sourcePath' property of modules. Some places expect this to be non-null. BasicTest is failing when it attempts to visit `/labkey/admin-sql-orphanedScripts.view?`

#### Changes
* Add `null` checks
