### PR TITLE
Epic 6800: Update package-lock with latest 0.59.0 version.

### DIFF
--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -249,9 +249,9 @@
       "integrity": "sha1-yDpHBYlLAIT3eNmuic8WG572ofY="
     },
     "@labkey/components": {
-      "version": "0.58.0-fb-issuesdesigner-story3-6800.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.58.0-fb-issuesdesigner-story3-6800.1.tgz",
-      "integrity": "sha1-mI3QFSGz85Dn48FSGD1XN8nsIyA=",
+      "version": "0.59.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.59.0.tgz",
+      "integrity": "sha1-D8hM36h+3NEWMmMTaGlN3zBYXKE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",


### PR DESCRIPTION
#### Rationale
Missed to update package-lock.json file with Issues designer changes.

#### Changes
Updated package-lock with latest 0.59.0 version. 
