### PR TITLE
Item 7326: Study query snapshot conversion to new dataset designer

### DIFF
--- a/study/src/org/labkey/study/view/createDatasetSnapshot.jsp
+++ b/study/src/org/labkey/study/view/createDatasetSnapshot.jsp
@@ -49,55 +49,69 @@
 
 <labkey:errors/>
 
-
-
 <labkey:form action="" method="post" onsubmit="validateForm();">
-    <table>
-        <tr><th colspan="10" class="labkey-header">Snapshot Name</th></tr>
-        <tr><td colspan="10" class="labkey-title-area-line"></td></tr>
-
+    <table class="lk-fields-table">
         <tr><td>&nbsp;</td></tr>
-        <tr><td>Snapshot&nbsp;Name:</td><td><input type="text" maxlength="200" size="50" name="<%= text(bean.isEdit() ? "" : "snapshotName") %>" <%= text(bean.isEdit() ? "readonly" : "") %> value="<%=h(StringUtils.trimToEmpty(bean.getSnapshotName()))%>"></td></tr>
+        <tr>
+            <td class="labkey-form-label">Snapshot&nbsp;Name:</td>
+            <% if (bean.isEdit()) { %>
+                <td><%=h(StringUtils.trimToEmpty(bean.getSnapshotName()))%></td>
+            <% } else { %>
+                <td><input type="text" maxlength="200" size="50" name="snapshotName" value="<%=h(StringUtils.trimToEmpty(bean.getSnapshotName()))%>"></td>
+            <% } %>
+        </tr>
         <% if (!filter.isEmpty()) { %>
-            <tr><td>Filters:</td><td><%= h(filter.getFilterText()) %></td></tr>
+            <tr><td class="labkey-form-label">Filters:</td><td><%= h(filter.getFilterText()) %></td></tr>
         <% } %>
         <% if (getActionURL().getParameterMap().containsKey("query.viewName")) { %>
-            <tr><td>Custom View:</td><td><%= h(getActionURL().getParameter("query.viewName") == null ? "<default>" : getActionURL().getParameter("query.viewName")) %></td></tr>
+            <tr><td class="labkey-form-label">Custom View:</td><td><%= h(StringUtils.isEmpty(getActionURL().getParameter("query.viewName")) ? "<default>" : getActionURL().getParameter("query.viewName")) %></td></tr>
         <% } %>
-        <tr><td>&nbsp;</td></tr>
-
-        <tr><th colspan="10" class="labkey-header">Snapshot Refresh</th></tr>
-        <tr><td colspan="10" class="labkey-title-area-line"></td></tr>
-        <tr><td colspan="2"><i>Snapshots can be configured to be manually updated or to automatically update<br/>within an amount of time after the
-            underlying data has changed.</i></td></tr>
-        <tr><td>&nbsp;</td></tr>
-
-        <tr><td>Manual&nbsp;Refresh</td><td><input<%=disabled(!isAutoUpdateable)%><%=checked(bean.getUpdateDelay() == 0)%> type="radio" name="updateType" value="manual" id="manualUpdate" onclick="onAutoUpdate();"></td></tr>
-        <tr><td>Automatic&nbsp;Refresh</td><td><input<%=disabled(!isAutoUpdateable)%><%=checked(bean.getUpdateDelay() != 0)%> type="radio" name="updateType" onclick="onAutoUpdate();"></td></tr>
-        <tr><td>&nbsp;</td></tr>
-        <tr><td></td><td><select name="updateDelay" id="updateDelay" style="display:<%= text(bean.getUpdateDelay() == 0 ? "none" : "block") %>"><labkey:options value="<%=text(String.valueOf(bean.getUpdateDelay()))%>" map="<%=updateDelay%>"></labkey:options></select></td></tr>
-        <tr><td colspan="10" class="labkey-title-area-line"></td></tr>
-        <tr><td colspan="10">
-                <%
+        <tr>
+            <td class="labkey-form-label">Snapshot Refresh</td>
+            <td>
+                <p>
+                    <i>Snapshots can be configured to be manually updated or to automatically update<br/>within an amount of time after the
+                        underlying data has changed.</i>
+                </p>
+                <table>
+                    <tr>
+                        <td style="padding-right: 10px">Manual&nbsp;Refresh</td>
+                        <td>
+                            <input<%=disabled(!isAutoUpdateable)%><%=checked(bean.getUpdateDelay() == 0)%> type="radio" name="updateType" value="manual" id="manualUpdate" onclick="onAutoUpdate();">
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding-right: 10px">Automatic&nbsp;Refresh</td><td>
+                            <input<%=disabled(!isAutoUpdateable)%><%=checked(bean.getUpdateDelay() != 0)%> type="radio" name="updateType" onclick="onAutoUpdate();">
+                            <select name="updateDelay" id="updateDelay" style="display:<%= text(bean.getUpdateDelay() == 0 ? "none" : "block") %>">
+                                <labkey:options value="<%=text(String.valueOf(bean.getUpdateDelay()))%>" map="<%=updateDelay%>"></labkey:options>
+                            </select>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+    <br/>
+        <%
             if (!bean.isEdit())
             {
                 out.println(button("Edit Dataset Definition").submit(true).onClick("this.form.action.value='" + StudyController.StudySnapshotForm.EDIT_DATASET + "'"));
-                out.print(text("&nbsp;"));
             }
 
             out.println(button(bean.isEdit() ? "Save" : "Create Snapshot").submit(true));
-            out.print(text("&nbsp;"));
 
             out.println(button(bean.isEdit() ? "Done" : "Cancel").submit(true).onClick("this.form.action.value='" + StudyController.StudySnapshotForm.CANCEL + "'"));
-
         %>
-    </table>
     <%  if (getActionURL().getParameter(DatasetDefinition.DATASETKEY) != null) { %>
     <input type="hidden" name="<%=h(DatasetDefinition.DATASETKEY)%>" value="<%=h(getActionURL().getParameter(DatasetDefinition.DATASETKEY))%>">
     <%  } %>
     <input type="hidden" name="action" value="<%=h(StudyController.StudySnapshotForm.CREATE_SNAPSHOT)%>" id="action">
     <input type="hidden" name="snapshotDatasetId" value="<%=bean.getSnapshotDatasetId()%>">
 </labkey:form>
+
+<%--These line brakes are for th edit snapshot case where there can be a DataRegion below this section--%>
+<br/>
 
 <script type="text/javascript">
 

--- a/study/src/org/labkey/study/view/createDatasetSnapshot.jsp
+++ b/study/src/org/labkey/study/view/createDatasetSnapshot.jsp
@@ -23,9 +23,9 @@
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.study.controllers.StudyController" %>
 <%@ page import="org.labkey.study.model.DatasetDefinition" %>
-<%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.LinkedHashMap" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -83,8 +83,8 @@
                     <tr>
                         <td style="padding-right: 10px">Automatic&nbsp;Refresh</td><td>
                             <input<%=disabled(!isAutoUpdateable)%><%=checked(bean.getUpdateDelay() != 0)%> type="radio" name="updateType" onclick="onAutoUpdate();">
-                            <select name="updateDelay" id="updateDelay" style="display:<%= text(bean.getUpdateDelay() == 0 ? "none" : "block") %>">
-                                <labkey:options value="<%=text(String.valueOf(bean.getUpdateDelay()))%>" map="<%=updateDelay%>"></labkey:options>
+                            <select name="updateDelay" id="updateDelay" style="display:<%= HtmlString.unsafe(bean.getUpdateDelay() == 0 ? "none" : "block") %>">
+                                <labkey:options value="<%=String.valueOf(bean.getUpdateDelay())%>" map="<%=updateDelay%>"></labkey:options>
                             </select>
                         </td>
                     </tr>

--- a/study/src/org/labkey/study/view/editSnapshot.jsp
+++ b/study/src/org/labkey/study/view/editSnapshot.jsp
@@ -50,7 +50,7 @@
 %>
 
 <%  if (def != null) { %>
-<table>
+<table class="lk-fields-table">
     <tr><td class="labkey-form-label">Name</td><td><%=h(def.getName())%></td>
     <tr><td class="labkey-form-label">Created By</td><td><%=h(def.getCreatedBy().getDisplayName(getUser()))%></td>
     <tr><td class="labkey-form-label">Modified By</td><td><%=h(def.getModifiedBy().getDisplayName(getUser()))%></td>
@@ -59,25 +59,19 @@
     <tr><td class="labkey-form-label">Query Source</td><td><textarea rows="20" cols="65" readonly="true"><%=h(queryDef != null ? queryDef.getSql() : null)%></textarea></td>
 </table>
 <%  } %>
-
+<br/>
 <labkey:form action="" method="POST">
     <input type="hidden" name="updateSnapshot" value="true">
-    <table>
-        <tr><td>&nbsp;</td></tr>
-        <tr>
-            <td><%= button("Update Snapshot").submit(true)
-                .onClick("this.form.action='';return confirm('Updating will replace all existing data with a new set of data. Continue?');")
-            %></td>
-<%      if (def != null && dsDef != null) {
-            ActionURL deleteSnapshotURL = new ActionURL(StudyController.DeleteDatasetAction.class, getContainer()).addParameter("id", dsDef.getDatasetId());
-%>
-            <td><%= button(historyLabel).href(context.cloneActionURL().replaceParameter("showHistory", String.valueOf(!showHistory))) %></td>
-            <td><%= button(datasetLabel).href(context.cloneActionURL().replaceParameter("showDataset", String.valueOf(!showDataset))) %></td>
-            <td><%= button("Delete Snapshot")
-                    .href(deleteSnapshotURL)
-                    .submit(true)
-                    .onClick("this.form.action='"+deleteSnapshotURL+"'; return confirm('Are you sure you want to delete this snapshot?  All related data will also be deleted.')") %></td>
-<%      } %>
-        </tr>
-    </table>
+    <%= button("Update Snapshot").submit(true).onClick("this.form.action='';return confirm('Updating will replace all existing data with a new set of data. Continue?');")%>
+    <% if (def != null && dsDef != null) {
+        ActionURL deleteSnapshotURL = new ActionURL(StudyController.DeleteDatasetAction.class, getContainer()).addParameter("id", dsDef.getDatasetId());
+    %>
+        <%= button("Delete Snapshot")
+                .href(deleteSnapshotURL)
+                .submit(true)
+                .onClick("this.form.action='"+deleteSnapshotURL+"'; return confirm('Are you sure you want to delete this snapshot?  All related data will also be deleted.')")
+        %>
+        <%= button(historyLabel).href(context.cloneActionURL().replaceParameter("showHistory", String.valueOf(!showHistory))) %>
+        <%= button(datasetLabel).href(context.cloneActionURL().replaceParameter("showDataset", String.valueOf(!showDataset))) %>
+    <% } %>
 </labkey:form>

--- a/study/src/org/labkey/study/view/editSnapshot.jsp
+++ b/study/src/org/labkey/study/view/editSnapshot.jsp
@@ -42,9 +42,6 @@
     boolean showHistory = BooleanUtils.toBoolean(getActionURL().getParameter("showHistory"));
     String historyLabel = showHistory ? "Hide History" : "Show History";
 
-    boolean showDataset = BooleanUtils.toBoolean(getActionURL().getParameter("showDataset"));
-    String datasetLabel = showDataset ? "Hide Dataset Definition" : "Edit Dataset Definition";
-
     final Study study = StudyManager.getInstance().getStudy(getContainer());
     final Dataset dsDef = StudyManager.getInstance().getDatasetDefinitionByName(study, bean.getSnapshotName());
 %>
@@ -65,6 +62,7 @@
     <%= button("Update Snapshot").submit(true).onClick("this.form.action='';return confirm('Updating will replace all existing data with a new set of data. Continue?');")%>
     <% if (def != null && dsDef != null) {
         ActionURL deleteSnapshotURL = new ActionURL(StudyController.DeleteDatasetAction.class, getContainer()).addParameter("id", dsDef.getDatasetId());
+        ActionURL editDatasetURL = new ActionURL(StudyController.EditTypeAction.class, getContainer()).addParameter("datasetId", dsDef.getDatasetId()).addReturnURL(getActionURL());
     %>
         <%= button("Delete Snapshot")
                 .href(deleteSnapshotURL)
@@ -72,6 +70,6 @@
                 .onClick("this.form.action='"+deleteSnapshotURL+"'; return confirm('Are you sure you want to delete this snapshot?  All related data will also be deleted.')")
         %>
         <%= button(historyLabel).href(context.cloneActionURL().replaceParameter("showHistory", String.valueOf(!showHistory))) %>
-        <%= button(datasetLabel).href(context.cloneActionURL().replaceParameter("showDataset", String.valueOf(!showDataset))) %>
+        <%= button("Edit Dataset Definition").href(editDatasetURL) %>
     <% } %>
 </labkey:form>

--- a/study/test/src/org/labkey/test/tests/study/QuerySnapshotTest.java
+++ b/study/test/src/org/labkey/test/tests/study/QuerySnapshotTest.java
@@ -24,11 +24,13 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.BVT;
+import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.html.BootstrapMenu;
+import org.labkey.test.pages.study.DatasetDesignerPage;
+import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.tests.StudyBaseTest;
 import org.labkey.test.util.APIAssayHelper;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 
@@ -447,15 +449,13 @@ public class QuerySnapshotTest extends StudyBaseTest
         if (keyField != null)
         {
             clickButton("Edit Dataset Definition");
-            waitForElement(Locator.input("dsName"), WAIT_FOR_JAVASCRIPT);
-
-            _listHelper.addField("Dataset Fields", keyField, null, ListHelper.ListColumnType.Integer);
-
-            click(Locator.name("ff_name0"));
-            click(Locator.radioButtonById("button_managedField"));
-            selectOptionByText(Locator.name("list_managedField"), keyField);
-            clickButton("Save", WAIT_FOR_JAVASCRIPT);
+            DatasetDesignerPage datasetDesignerPage = new DatasetDesignerPage(getDriver());
+            DomainFormPanel domainFormPanel = datasetDesignerPage.getFieldsPanel();
+            domainFormPanel.addField(keyField).setType(FieldDefinition.ColumnType.Integer);
+            datasetDesignerPage.setAdditionalKeyColManagedField(keyField);
+            datasetDesignerPage.clickSave();
         }
+
         clickButton("Create Snapshot");
     }
 


### PR DESCRIPTION
#### Rationale
The "Create Query Snapshot" and "Edit Snapshot" code paths have options that pull up the dataset designer. They were previously implemented so that the GWT dataset designer was pull into the page. This PR instead changes that so that both the create and edit snapshot case redirect to the dataset EditTypeAction for the given dataset id, and then include the proper returnUrl to get back to the snapshot action.

#### Changes
* Remove StudyGWTView usages of dataset designer from snapshot code paths
* Redirect to the StudyController.EditTypeAction for the newly created dataset in the create/edit snapshot UI
* Misc jsp cleanup of layout, styling, usages of lk-fields-table and labkey-form-label, etc.
* Convert QuerySnapshotTest to new dataset designer helpers
