### PR TITLE
Ticket 40464: Consistency on Delete Permissions for Workbooks

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -82,7 +82,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
-import java.util.stream.Collectors;
 
 
 /**
@@ -201,9 +200,9 @@ public class Container implements Serializable, Comparable<Container>, Securable
         return targetContainer != null && targetContainer.getContainerType().allowRowMutationFromContainer(this, targetContainer);
     }
 
-    public boolean requiresAdminToDelete()
+    public Class<? extends Permission> getPermissionNeededToDelete()
     {
-        return _containerType.requiresAdminToDelete();
+        return _containerType.getPermissionNeededToDelete();
     }
 
     public boolean isDuplicatedInContainerFilter()

--- a/api/src/org/labkey/api/data/ContainerType.java
+++ b/api/src/org/labkey/api/data/ContainerType.java
@@ -18,6 +18,7 @@ package org.labkey.api.data;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.admin.ImportContext;
+import org.labkey.api.security.permissions.Permission;
 
 import java.io.Serializable;
 import java.util.Set;
@@ -102,14 +103,14 @@ public interface ContainerType extends Serializable
     boolean allowRowMutationFromContainer(Container primaryContainer, Container targetContainer);
 
     /**
-     * @return indication of whether a user needs to have admin permissions on this container to delete the container
+     * @return The permission class needed to delete this container type
      */
-    boolean requiresAdminToDelete();
+    Class<? extends Permission> getPermissionNeededToDelete();
 
     /**
-     * @return indication of whether a user needs admin permissions to be able create a container of this type
+     * @return The permission class needed to create this container type
      */
-    boolean requiresAdminToCreate();
+    public Class<? extends Permission> getPermissionNeededToCreate();
 
     /**
      *

--- a/api/src/org/labkey/api/data/NormalContainerType.java
+++ b/api/src/org/labkey/api/data/NormalContainerType.java
@@ -17,6 +17,8 @@ package org.labkey.api.data;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.admin.ImportContext;
+import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.permissions.Permission;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -76,15 +78,15 @@ public class NormalContainerType implements ContainerType
     }
 
     @Override
-    public boolean requiresAdminToDelete()
+    public Class<? extends Permission> getPermissionNeededToDelete()
     {
-        return true;
+        return AdminPermission.class;
     }
 
     @Override
-    public boolean requiresAdminToCreate()
+    public Class<? extends Permission> getPermissionNeededToCreate()
     {
-        return true;
+        return AdminPermission.class;
     }
 
     @Override

--- a/api/src/org/labkey/api/data/WorkbookContainerType.java
+++ b/api/src/org/labkey/api/data/WorkbookContainerType.java
@@ -30,6 +30,9 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.permissions.DeletePermission;
+import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.TestContext;
 
@@ -100,15 +103,15 @@ public class WorkbookContainerType implements ContainerType
     }
 
     @Override
-    public boolean requiresAdminToDelete()
+    public Class<? extends Permission> getPermissionNeededToDelete()
     {
-        return false;
+        return DeletePermission.class;
     }
 
     @Override
-    public boolean requiresAdminToCreate()
+    public Class<? extends Permission> getPermissionNeededToCreate()
     {
-        return false;
+        return InsertPermission.class;
     }
 
     @Override

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -723,12 +723,11 @@ public class CoreController extends SpringActionController
             if (type == null)
                 throw new ApiUsageException("Unknown container type: " + typeName);
 
-            if (type.requiresAdminToCreate())
+            Class<? extends Permission> permClass = type.getPermissionNeededToCreate();
+            if (!getContainer().hasPermission(getUser(), permClass))
             {
-                if (!getContainer().hasPermission(getUser(), AdminPermission.class))
-                {
-                    throw new UnauthorizedException("You must have admin permissions to create subfolders");
-                }
+                Permission perm = RoleManager.getPermission(permClass);
+                throw new UnauthorizedException("Insufficient permissions to create subfolders. " + perm.getName() + " permission required.");
             }
 
             if (name != null && getContainer().getChild(name) != null)
@@ -810,12 +809,11 @@ public class CoreController extends SpringActionController
         @Override
         public ApiResponse execute(SimpleApiJsonForm form, BindException errors)
         {
-            if (target.requiresAdminToDelete())
+            Class<? extends Permission> permClass = getContainer().getPermissionNeededToDelete();
+            if (!target.hasPermission(getUser(), permClass))
             {
-                if (!target.hasPermission(getUser(), AdminPermission.class))
-                {
-                    throw new UnauthorizedException("You must have admin permissions to delete subfolders");
-                }
+                Permission perm = RoleManager.getPermission(permClass);
+                throw new UnauthorizedException("Insufficient permissions to delete folder. " + perm.getName() + " permission required.");
             }
 
             ContainerManager.deleteAll(target, getUser());

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10272,6 +10272,11 @@ public class AdminController extends SpringActionController
                     controller.new ClearDeletedTabFoldersAction()
             );
 
+            // @RequiresPermission(DeletePermission.class)
+            assertForUpdateOrDeletePermission(user,
+                    controller.new DeleteFolderAction()
+            );
+
             // @RequiresPermission(AdminPermission.class)
             assertForAdminPermission(user,
                     new ResetResourceAction(),
@@ -10287,7 +10292,6 @@ public class AdminController extends SpringActionController
                     controller.new CreateFolderAction(),
                     controller.new SetFolderPermissionsAction(),
                     controller.new SetInitialFolderSettingsAction(),
-                    controller.new DeleteFolderAction(),
                     controller.new ReorderFoldersAction(),
                     controller.new ReorderFoldersApiAction(),
                     controller.new RevertFolderAction(),


### PR DESCRIPTION
@labkey-jeckels like we discussed, last year I made a change that made workbooks use the standard container delete pathway.  the problem is that workbooks should require DeletePermission, not AdminPermission.  These changes enforce the right permission based on what's being deleted.  Based on your suggestion, I also changed ContainerType based on your suggestion on the ticket.

Note: I dont know if team city will run tests off this.  i think it will require a branch on the labkey side of the work, but I dont think I can do this.