### PR TITLE
Add defensive check in Utils.modal()

### DIFF
--- a/api/webapp/clientapi/dom/Utils.js
+++ b/api/webapp/clientapi/dom/Utils.js
@@ -84,8 +84,15 @@ LABKEY.Utils = new function(impl, $) {
          );
 
         modal.find('.modal-content').html(html.join(''));
-        if (fn && typeof fn === 'function') {
+        if (LABKEY.Utils.isFunction(fn)) {
             fn.apply(this, args);
+        }
+
+        // Some views may not be able to access the modal.modal() method
+        if (!LABKEY.Utils.isFunction(modal.modal)) {
+            console.warn('LABKEY.Utils.displayModal() unable to display modal.');
+            console.warn(title, msg);
+            return;
         }
 
         // prevent the modal from being closed by clicking outside the dialog

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -249,9 +249,9 @@
       "integrity": "sha1-yDpHBYlLAIT3eNmuic8WG572ofY="
     },
     "@labkey/components": {
-      "version": "0.58.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.58.0.tgz",
-      "integrity": "sha1-3sfEq4GEl0HNZ/SW0CrAMcTT40I=",
+      "version": "0.59.2-fb-lineage-fixes-duex.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.59.2-fb-lineage-fixes-duex.0.tgz",
+      "integrity": "sha1-sfixd0VcWxpOKSg2YGjrqdgSX9Q=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -249,9 +249,9 @@
       "integrity": "sha1-yDpHBYlLAIT3eNmuic8WG572ofY="
     },
     "@labkey/components": {
-      "version": "0.59.2-fb-lineage-fixes-duex.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.59.2-fb-lineage-fixes-duex.0.tgz",
-      "integrity": "sha1-sfixd0VcWxpOKSg2YGjrqdgSX9Q=",
+      "version": "0.59.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.59.2.tgz",
+      "integrity": "sha1-K+G1FCzHQjTjMSErLpxcUNB9U2s=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
@@ -4086,9 +4086,9 @@
       }
     },
     "moment-timezone": {
-      "version": "0.5.28",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
-      "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.29.tgz",
+      "integrity": "sha512-qWtUhRIk29zviEFAhttY0fDbM/zsu/OlCRoeQG8vxuH6XcTTuji9ILJkOdxjr+vzIv0J39RsO/SPTuMvzm90wA==",
       "requires": {
         "moment": ">= 2.9.0"
       }
@@ -6922,12 +6922,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
-      "integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
-      "requires": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     },
     "yargs": {
       "version": "13.2.4",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.58.0"
+    "@labkey/components": "0.59.2-fb-lineage-fixes-duex.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.59.2-fb-lineage-fixes-duex.0"
+    "@labkey/components": "0.59.2"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",


### PR DESCRIPTION
#### Rationale
`LABKEY.Utils.displayModal()` is a method exposed by core/dom/Utils.js that displays a modal dialog to the user. There are instances where the `modal.modal()` method may not be available at the time of this call so this PR prevents an invalid dereference and instead logs a warning.

Fixes Biologics test `BiologicsAccountTest.logoutAwayFromApp`.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/249
* https://github.com/LabKey/biologics/pull/587

#### Changes
* Logs a console warning if `modal.modal()` not available.
