### PR TITLE
Issue 40182: Let folder admins set permissions on web part visibility

### DIFF
--- a/core/src/org/labkey/core/portal/ProjectController.java
+++ b/core/src/org/labkey/core/portal/ProjectController.java
@@ -1537,7 +1537,7 @@ public class ProjectController extends SpringActionController
     }
 
 
-    @RequiresSiteAdmin
+    @RequiresPermission(AdminPermission.class)
     public class SetWebPartPermissionsAction extends MutatingApiAction<WebPartPermissionsForm>
     {
         @Override
@@ -1554,8 +1554,9 @@ public class ProjectController extends SpringActionController
                 {
                     permissionContainer = ContainerManager.getForPath(form.getContainerPath());
 
-                    // Only throw NotFoundException if the user actively set the container to something else.
-                    if(permissionContainer == null)
+                    // Only throw NotFoundException if the user actively set the container to something else, or if the
+                    // user is trying to reference a real container that they don't have permission to see
+                    if(permissionContainer == null || !permissionContainer.hasPermission(getUser(), ReadPermission.class))
                     {
                         throw new NotFoundException("Could not resolve the folder for path: \"" + form.getContainerPath() +
                                 "\". The path may be incorrect or the folder may no longer exist.");

--- a/core/src/org/labkey/core/view/template/bootstrap/ViewServiceImpl.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/ViewServiceImpl.java
@@ -17,6 +17,7 @@ package org.labkey.core.view.template.bootstrap;
 
 import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.portal.ProjectUrls;
+import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.Link;
 import org.labkey.api.util.PageFlowUtil;
@@ -477,7 +478,7 @@ public class ViewServiceImpl implements ViewService
                 nMenu.addChild(config._customize);
             }
 
-            if (config._webpart != null && context.getUser().hasSiteAdminPermission())
+            if (config._webpart != null && context.getContainer().hasPermission(context.getUser(), AdminPermission.class))
             {
                 Portal.WebPart webPart = config._webpart;
                 String permissionString = null;


### PR DESCRIPTION
#### Rationale
Folder admins have full control over which web parts are shown on portal pages, but right now only site admins can configure which users see them based on permissions. That's overly stringent.
