### PR TITLE
fix PdLookupForeignKey targeting different container (regression)

### DIFF
--- a/api/src/org/labkey/api/query/PdLookupForeignKey.java
+++ b/api/src/org/labkey/api/query/PdLookupForeignKey.java
@@ -161,9 +161,8 @@ public class PdLookupForeignKey extends AbstractForeignKey
         if (null != _tableInfo)
             return _tableInfo;
 
-        // Can we assert that _sourceSchema != null?
         QuerySchema schema;
-        if (null != _sourceSchema)
+        if (null != _sourceSchema && _sourceSchema.getContainer().equals(container))
             schema = DefaultSchema.resolve(_sourceSchema, SchemaKey.fromString(_lookupSchemaName));
         else
             schema = QueryService.get().getUserSchema(_user, container, SchemaKey.fromString(_lookupSchemaName));


### PR DESCRIPTION
#### Rationale
fix regression with cross container property descriptor defined lookup