### PR TITLE
Auto retry after database deadlock

### DIFF
--- a/devtools/src/org/labkey/devtools/TestController.java
+++ b/devtools/src/org/labkey/devtools/TestController.java
@@ -38,6 +38,7 @@ import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.DOM;
 import static org.labkey.api.util.DOM.Attribute.*;
 import org.labkey.api.util.ExceptionUtil;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
@@ -47,6 +48,7 @@ import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewContext;
+import org.springframework.dao.DeadlockLoserDataAccessException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
@@ -753,6 +755,25 @@ public class TestController extends SpringActionController
                 throw new UnauthorizedException();
             else
                 throw new UnauthorizedException(form.getMessage());
+        }
+
+        @Override
+        public NavTree appendNavTrail(NavTree root)
+        {
+            return null;
+        }
+    }
+
+
+    @RequiresSiteAdmin
+    public class DeadlockAction extends SimpleViewAction<ExceptionForm>
+    {
+        @Override
+        public ModelAndView getView(ExceptionForm form, BindException errors)
+        {
+            if (getViewContext().getRequest().getParameterMap().containsKey("_retry_"))
+                return new HtmlView(HtmlString.of("Second time's a charm"));
+            throw new DeadlockLoserDataAccessException("Try again", null);
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
Although best avoided deadlocks happen, and the correct thing to do is retry.  Here is a simple retry strategy to automatically retry GET requests that deadlock (probably not as common as POST, but it can happen).