### PR TITLE
Issue 40236: Resolved date loses time portion when resolved issue is updated or closed

### DIFF
--- a/issues/src/org/labkey/issue/model/Issue.java
+++ b/issues/src/org/labkey/issue/model/Issue.java
@@ -264,7 +264,7 @@ public class Issue extends Entity implements Serializable, Cloneable
 
     public Date getResolved()
     {
-        return (Date) JdbcType.DATE.convert(_properties.get("resolved"));
+        return (Date) JdbcType.TIMESTAMP.convert(_properties.get("resolved"));
     }
 
     public void setResolved(Date resolved)


### PR DESCRIPTION
#### Rationale
This change preserves the time portion of resolved date when resolved issue is updated or closed. Resolved date is specified to be JdbcType.Date and LenientSqlDateConverter.convert() returns the java.sql.Date that sets the time components to the time in the default time zone (the time zone of the Java virtual machine running the application) that corresponds to zero GMT. The change is to change resolved date to JdbcType.TIMESTAMP. 
