### PR TITLE
Preliminary support for PostgreSQL 13.x

### DIFF
--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -807,10 +807,10 @@ public abstract class SqlDialect
         Set<String> jdbcKeywords = getJdbcKeywords(executor);
 
         if (!KeywordCandidates.get().containsAll(jdbcKeywords, getProductName()))
-            throw new IllegalStateException("JDBC keywords from " + getProductName() + " are not all in the keyword candidate list (sqlKeywords.txt)");
+            throw new IllegalStateException("JDBC keywords from " + getProductName() + " are not all in the keyword candidate list (sqlKeywords.txt). See log for details.");
 
         if (!KeywordCandidates.get().containsAll(_reservedWordSet, getProductName()))
-            throw new IllegalStateException(getProductName() + " reserved words are not all in the keyword candidate list (sqlKeywords.txt)");
+            throw new IllegalStateException(getProductName() + " reserved words are not all in the keyword candidate list (sqlKeywords.txt). See log for details.");
     }
 
     public int getIdentifierMaxLength()

--- a/api/src/org/labkey/api/data/dialect/sqlKeywords.txt
+++ b/api/src/org/labkey/api/data/dialect/sqlKeywords.txt
@@ -332,6 +332,7 @@ expansion
 expire
 explain
 export
+expression
 extend
 extended
 extension

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -145,7 +145,8 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
             good("PostgreSQL", 10.0, 11.0, "", connectionUrl, null, PostgreSql_10_Dialect.class);
             good("PostgreSQL", 11.0, 12.0, "", connectionUrl, null, PostgreSql_11_Dialect.class);
             good("PostgreSQL", 12.0, 13.0, "", connectionUrl, null, PostgreSql_12_Dialect.class);
-            good("PostgreSQL", 13.0, 14.0, "", connectionUrl, null, PostgreSql_12_Dialect.class);
+            good("PostgreSQL", 13.0, 14.0, "", connectionUrl, null, PostgreSql_13_Dialect.class);
+            good("PostgreSQL", 14.0, 15.0, "", connectionUrl, null, PostgreSql_13_Dialect.class);
         }
     }
 
@@ -217,8 +218,8 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
                 protected Set<String> getBadUrls()
                 {
                     return new CsvSet("jddc:postgresql:database," +
-                            "jdbc:postgres://localhost/database," +
-                            "jdbc:postgresql://www.host.comdatabase");
+                        "jdbc:postgres://localhost/database," +
+                        "jdbc:postgresql://www.host.comdatabase");
                 }
             };
 

--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -21,8 +21,8 @@ public enum PostgreSqlVersion
     POSTGRESQL_10(100, false, true, PostgreSql_10_Dialect::new),
     POSTGRESQL_11(110, false, true, PostgreSql_11_Dialect::new),
     POSTGRESQL_12(120, false, true, PostgreSql_12_Dialect::new),
-    POSTGRESQL_13(130, false, false, PostgreSql_12_Dialect::new),
-    POSTGRESQL_FUTURE(Integer.MAX_VALUE, true, false, PostgreSql_12_Dialect::new);
+    POSTGRESQL_13(130, false, false, PostgreSql_13_Dialect::new),
+    POSTGRESQL_FUTURE(Integer.MAX_VALUE, true, false, PostgreSql_13_Dialect::new);
 
     private final int _version;
     private final boolean _deprecated;

--- a/core/src/org/labkey/core/dialect/PostgreSql_13_Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql_13_Dialect.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.core.dialect;
+
+public class PostgreSql_13_Dialect extends PostgreSql_12_Dialect
+{
+}


### PR DESCRIPTION
#### Rationale
PostgreSQL 13.0 is slated to release in the fall. That team has just released Beta 1. This PR adds internal support for 13.x. No external change; admins still receive a warning that 13.x is not tested.

#### Changes
* Add dialect, enum constant, and test case for PostgreSQL 13.x.