### PR TITLE
fix for automated test

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyReloadColumnInferenceTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyReloadColumnInferenceTest.java
@@ -113,8 +113,8 @@ public class StudyReloadColumnInferenceTest extends StudyBaseTest
     private static final DataToVerify INSTRUMENTS = new DataToVerify(LIST_INSTRUMENTS, Arrays.asList(COL_KEY, COL_INSTRUMENTID), 6, COL_INSTRUMENTID, Arrays.asList("ABI-4700"));
 
     private static final String DATASET_DEMOGRAPHICS = "Demographics";
-    private static final String COL_MOUSID = "mouseid";
-    private static final String COL_DATE = "date";
+    private static final String COL_MOUSID = "Mouse Id";
+    private static final String COL_DATE = "Date";
     private static final String COL_QCSTATELABEL = "qcstatelabel";
     private static final String COL_STARTDATE = "startdate";
     private static final String COL_HEIGHT = "height";


### PR DESCRIPTION
#### Rationale
This adds a fix for the StudyReloadColumnInferenceTest which started failing due to this [commit](https://github.com/LabKey/platform/commit/fa7e34b55dd40989f96902d08ee9ce67ea353cef). On further investigation the test was somewhat perpetuating the bug that the commit addressed in that the dataset schema reader that tries to infer incoming columns from an uploaded file was failing to filter out built in columns like subjectid, sequenceNum, date, visit... etc. This wouldn't affect data import but is used to mutate the domain to either add, remove columns or change column types.

#### Changes
- Make the expected (after reload) built in columns match casing (since they shouldn't have changed from the original import)