### PR TITLE
Issue40062: Rename the Messages "Member List" to be "Notify List"

### DIFF
--- a/announcements/src/org/labkey/announcements/announcementThread.jsp
+++ b/announcements/src/org/labkey/announcements/announcementThread.jsp
@@ -103,7 +103,7 @@ if (bean.perm.allowUpdate(announcementModel) && !bean.print)
 if (settings.hasMemberList() && null != announcementModel.getMemberListIds())
 { %>
 <tr>
-    <td colspan="3">Members: <%=h(announcementModel.getMemberListDisplayString(c, user))%></td>
+    <td colspan="3">Notify: <%=h(announcementModel.getMemberListDisplayString(c, user))%></td>
 </tr><%
 }
 
@@ -189,7 +189,7 @@ if (!announcementModel.getResponses().isEmpty())
             if (settings.hasMemberList() && !Objects.equals(r.getMemberListIds(), prev.getMemberListIds()))
             { %>
             <tr>
-                <td colspan="2">Members: <%=h(r.getMemberListDisplayString(c, user))%></td>
+                <td colspan="2">Notify: <%=h(r.getMemberListDisplayString(c, user))%></td>
             </tr><%
             }
 

--- a/announcements/src/org/labkey/announcements/customize.jsp
+++ b/announcements/src/org/labkey/announcements/customize.jsp
@@ -80,7 +80,7 @@
                 </tr>
                 <tr>
                     <td valign="top"><input type="radio" name="secure" value="1"<%=checked(settings.isSecure())%>></td>
-                    <td><b>ON</b> - Only editors and those on the member list can view conversations, content can't be modified after posting, content is never sent via email</td>
+                    <td><b>ON</b> - Only editors and those on the notify list can view conversations, content can't be modified after posting, content is never sent via email</td>
                 </tr>
             </table>
         </td>
@@ -122,7 +122,7 @@
         <td><table><tr><td><input type="checkbox" name="titleEditable"<%=checked(settings.isTitleEditable())%>></td></tr></table></td>
     </tr>
     <tr>
-        <td class="labkey-form-label">Include Member List</td>
+        <td class="labkey-form-label">Include Notify List</td>
         <td><table><tr><td><input type="checkbox" name="memberList"<%=checked(settings.hasMemberList())%>></td></tr></table></td>
     </tr>
     <tr>

--- a/announcements/src/org/labkey/announcements/insert.jsp
+++ b/announcements/src/org/labkey/announcements/insert.jsp
@@ -85,7 +85,7 @@
     if (settings.hasMemberList())
     {
         %><tr>
-            <td class='labkey-form-label'>Members</td>
+            <td class='labkey-form-label'>Notify</td>
             <td><labkey:autoCompleteTextArea name="memberListInput" id="memberListInput" rows="5" cols="40" url="<%=completeUserUrl%>" value="<%=bean.memberList%>"/></td>
             <td><i><%
         if (settings.isSecure())
@@ -94,7 +94,7 @@
         }
         else
         {
-            %> The users on the member list<%
+            %> The users on the notify list<%
         }
         %> receive email notifications of new posts to this <%=h(settings.getConversationName().toLowerCase())%>.<br><br>Enter one or more email addresses, each on its own line.</i></td></tr><%
     }

--- a/announcements/src/org/labkey/announcements/respond.jsp
+++ b/announcements/src/org/labkey/announcements/respond.jsp
@@ -96,14 +96,14 @@ if (settings.hasAssignedTo())
 
 if (settings.hasMemberList())
 {
-    %><tr><td class="labkey-form-label">Members</td><td><labkey:autoCompleteTextArea name="memberListInput" id="memberListInput" rows="5" cols="40" url="<%=completeUserUrl%>" value="<%=bean.memberList%>"/></td><td><i><%
+    %><tr><td class="labkey-form-label">Notify</td><td><labkey:autoCompleteTextArea name="memberListInput" id="memberListInput" rows="5" cols="40" url="<%=completeUserUrl%>" value="<%=bean.memberList%>"/></td><td><i><%
     if (settings.isSecure())
     {
         %> This <%=h(settings.getConversationName().toLowerCase())%> is private; only editors and the users on this list can view it. These users will also<%
     }
     else
     {
-        %> The users on the member list<%
+        %> The users on the notify list<%
     }
     %> receive email notifications of new posts to this <%=h(settings.getConversationName().toLowerCase())%>.<br><br>Enter one or more email addresses, each on its own line.</i></td></tr><%
 }

--- a/announcements/src/org/labkey/announcements/update.jsp
+++ b/announcements/src/org/labkey/announcements/update.jsp
@@ -83,7 +83,7 @@ if (settings.hasAssignedTo())
 if (settings.hasMemberList())
 {
     %><tr>
-        <td class="labkey-form-label">Members</td>
+        <td class="labkey-form-label">Notify</td>
         <td><labkey:autoCompleteTextArea name="memberListInput" id="memberListInput" rows="5" cols="30" url="<%=completeUserUrl%>" value="<%=bean.memberList%>"/></td>
         <td><i><%
     if (settings.isSecure())
@@ -92,7 +92,7 @@ if (settings.hasMemberList())
     }
     else
     {
-        %> The users on the member list<%
+        %> The users on the notify list<%
     }
     %> receive email notifications of new posts to this <%=h(settings.getConversationName().toLowerCase())%>.<br><br>Enter one or more email addresses, each on its own line.</i></td></tr><%
 }


### PR DESCRIPTION
#### Rationale
See Issue 40062. A 'Notify List' is more consistent naming than a 'Member List'. Pictures are included of desired text changes. 

#### Changes
* ![image](https://user-images.githubusercontent.com/18537731/82603728-08841780-9b68-11ea-85de-fecd326db33b.png)

