### PR TITLE
Issue 40502: Dataset "Set default" view doesn't show custom views if dataset name and label differ

### DIFF
--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -3873,7 +3873,7 @@ public class StudyController extends BaseStudyController
         @Override
         public NavTree appendNavTrail(NavTree root)
         {
-            setHelpTopic(new HelpTopic("Set Default"));
+            setHelpTopic(new HelpTopic("customViews"));
 
             root.addChild(_study.getLabel(), new ActionURL(BeginAction.class, getContainer()));
 
@@ -3883,7 +3883,7 @@ public class StudyController extends BaseStudyController
             String label = _def.getLabel() != null ? _def.getLabel() : "" + _def.getDatasetId();
             root.addChild(new NavTree(label, datasetURL.getLocalURIString()));
 
-            root.addChild(new NavTree("Preferences"));
+            root.addChild(new NavTree("View Preferences"));
             return root;
         }
 

--- a/study/src/org/labkey/study/reports/ReportManager.java
+++ b/study/src/org/labkey/study/reports/ReportManager.java
@@ -97,9 +97,9 @@ public class ReportManager implements DatasetManager.DatasetListener
 
         // add any custom query views
         UserSchema schema = QueryService.get().getUserSchema(context.getUser(), context.getContainer(), "study");
-        QueryDefinition qd = QueryService.get().getQueryDef(context.getUser(), def.getContainer(), "study", def.getLabel());
+        QueryDefinition qd = QueryService.get().getQueryDef(context.getUser(), def.getContainer(), "study", def.getName());
         if (null == qd)
-            qd = schema.getQueryDefForTable(def.getLabel());
+            qd = schema.getQueryDefForTable(def.getName());
         Map<String, CustomView> views = qd.getCustomViews(context.getUser(), context.getRequest(), false, false);
         if (views != null)
         {


### PR DESCRIPTION
#### Rationale
Issue [40502](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40502): "Set default" is not working correctly for datasets with name and label both

The dataset "Set Default" page that shows the available saved custom views and reports was not showing any saved custom views if the dataset name and label didn't match. The reason for this was because the query to get the QueryDefinition object for the dataset was using the label instead of name.

#### Changes
* Change to use dataset def name when getting the QueryDefinition for the study schema
