### PR TITLE
Issue40028: SAML settings dialog Login Page Logo picker suggests wrong extensions

### DIFF
--- a/core/src/client/components/DynamicFields.tsx
+++ b/core/src/client/components/DynamicFields.tsx
@@ -283,7 +283,7 @@ export class DynamicFields extends PureComponent<DynamicFieldsProps> {
                             onFileChange={onFileChange}
                             onFileRemoval={onFileRemoval}
                             value={name}
-                            index={index + 2} // There are two other FileAttachmentForms (from SSOFields) on modal
+                            index={index + 3} // There are two other FileAttachmentForms (from SSOFields) on modal
                             canEdit={canEdit}
                             requiredFieldEmpty={requiredFieldEmpty}
                             defaultValue={field.defaultValue}


### PR DESCRIPTION
#### Rationale
FileAttachmentForms must be handed unique indexes when multiple instances of the component appear on a page. SSO image file attachments take indexes 1 and 2, so dynamically created components must count up from 3. Currently (due to an off by one error) they count up from 2. 

#### Changes
* Change buffer int val from 2 to 3
