### PR TITLE
Item 7353: Remove PropertiesEditor test class and move related enums to FieldDefinition class

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyPHIExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPHIExportTest.java
@@ -18,10 +18,10 @@ package org.labkey.test.tests.study;
 import org.junit.Assert;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
-import org.labkey.test.components.PropertiesEditor.PhiSelectType;
 import org.labkey.test.Locator;
 import org.labkey.test.SortDirection;
 import org.labkey.test.categories.DailyC;
+import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.StudyHelper;
@@ -52,7 +52,7 @@ public class StudyPHIExportTest extends StudyExportTest
         _originalFirstMouseStats = getFirstMouseStats();
         setParticipantIdPreface(idPreface, idLength);
 
-        exportStudy(true, false, PhiSelectType.NotPHI, true, true, false, null);
+        exportStudy(true, false, FieldDefinition.PhiSelectType.NotPHI, true, true, false, null);
     }
 
     protected void setParticipantIdPreface(String idPreface, int idLength)
@@ -169,7 +169,7 @@ public class StudyPHIExportTest extends StudyExportTest
 
         startSpecimenImport(4, StudyHelper.SPECIMEN_ARCHIVE_A);
         waitForPipelineJobsToComplete(4, "Specimen import", false);
-        exportStudy(true, false, PhiSelectType.NotPHI, true, true, true, null);
+        exportStudy(true, false, FieldDefinition.PhiSelectType.NotPHI, true, true, true, null);
 
         clickFolder(getFolderName());
         deleteStudy();

--- a/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
@@ -35,13 +35,13 @@ import org.labkey.test.components.ChartQueryDialog;
 import org.labkey.test.components.ChartTypeDialog;
 import org.labkey.test.components.DomainDesignerPage;
 import org.labkey.test.components.LookAndFeelTimeChart;
-import org.labkey.test.components.PropertiesEditor;
 import org.labkey.test.components.QueryMetadataEditorPage;
 import org.labkey.test.components.SaveChartDialog;
 import org.labkey.test.components.html.SiteNavBar;
 import org.labkey.test.pages.DatasetPropertiesPage;
 import org.labkey.test.pages.TimeChartWizard;
 import org.labkey.test.pages.search.SearchResultsPage;
+import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
@@ -1065,7 +1065,7 @@ public class StudyPublishTest extends StudyPHIExportTest
         List<String> fields = new ArrayList<>(Arrays.asList(phiFields));
         for (String field : fields)
         {
-            designerPage.fieldsPanel().getField(field).setPHILevel(PropertiesEditor.PhiSelectType.PHI);
+            designerPage.fieldsPanel().getField(field).setPHILevel(FieldDefinition.PhiSelectType.PHI);
         }
        designerPage.clickFinish();
     }


### PR DESCRIPTION
#### Rationale
With the GWT PropertiesEditor gone, it is time to also remove the PropertiesEditor test class. The only remaining items in use from the PropertiesEditor test class were three public enums. Those have been moved to the FieldDefinition test class as part of the testAutomation PR changes.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/341
* https://github.com/LabKey/compliance/pull/85
* https://github.com/LabKey/commonAssays/pull/174

#### Changes
* Class path changes for public enums moved from PropertiesEditor to FieldDefinition class
