### PR TITLE
fix projects.jsp when not used as a portal webpart

### DIFF
--- a/core/src/org/labkey/core/project/projects.jsp
+++ b/core/src/org/labkey/core/project/projects.jsp
@@ -186,6 +186,7 @@
         }%>
     </div>
 
+<% if (webPartId > 0) { %>
 <script type="text/javascript">
 
     function customizeProjectWebpart<%=webPartId%>(webpartId, pageId, index)
@@ -398,3 +399,4 @@
     }
 
 </script>
+<% } /* if webpart */ %>


### PR DESCRIPTION
#### Rationale
There is one place projects.jsp is used directly (not as a portal webpart), does not need webpart customize code in this case.

Note using getRequestScopedUID() would be typical way to uniquify the function name, but is awkward to communicate between factory and .jsp for uninteresting reasons.