### PR TITLE
Issue 40503: Luminex Levey-Jennings fix for cross container display/query of single point control calc and QC flag data

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpQCFlagTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpQCFlagTableImpl.java
@@ -161,7 +161,7 @@ public class ExpQCFlagTableImpl extends ExpTableImpl<ExpQCFlagTable.Column> impl
             @Override
             public TableInfo getLookupTableInfo()
             {
-                return null == _provider ? null :  _provider.createProtocolSchema(_userSchema.getUser(), _userSchema.getContainer(), _assayProtocol, null).createRunsTable(null);
+                return null == _provider ? null :  _provider.createProtocolSchema(_userSchema.getUser(), _userSchema.getContainer(), _assayProtocol, null).createRunsTable(getContainerFilter());
             }
         });
 


### PR DESCRIPTION
#### Rationale
Issue [40503](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40503): the Luminex assay Levey-Jennings report was developed so that it would show any data uploaded to the given assay design for any container that has access to the assay design. It looks like there was a regression (possible during some of the containerFilter migration work) so that the single point control report would only show data for the given container (i.e. only those runs in the given container but not results for other runs uploaded to the same assay designer in different containers).

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/177

#### Changes
* ExpQCFlagTableImpl change to use getContainerFilter() in RowId fk to Runs table
