### PR TITLE
Protect against sampleSet being null

### DIFF
--- a/experiment/src/org/labkey/experiment/DerivedSamplePropertyHelper.java
+++ b/experiment/src/org/labkey/experiment/DerivedSamplePropertyHelper.java
@@ -82,7 +82,7 @@ public class DerivedSamplePropertyHelper extends SamplePropertyHelper<Lsid>
         }
 
         PropertyDescriptor namePropertyDescriptor = new PropertyDescriptor(ExperimentServiceImpl.get().getTinfoMaterial().getColumn("Name"), c);
-        namePropertyDescriptor.setRequired(!_sampleSet.hasNameExpression());
+        namePropertyDescriptor.setRequired(_nameGenerator == null);
         _nameProperty = new DomainPropertyImpl(null, namePropertyDescriptor);
 
         List<DomainProperty> dps = new ArrayList<>();


### PR DESCRIPTION
#### Rationale
The name for a sample set is required if we have no name generator.


