### PR TITLE
migrateLegacyPortalPage() still does something that makes FolderTypes work

### DIFF
--- a/api/src/org/labkey/api/module/MultiPortalFolderType.java
+++ b/api/src/org/labkey/api/module/MultiPortalFolderType.java
@@ -40,6 +40,7 @@ import org.labkey.api.view.template.AppBar;
 import org.labkey.api.view.template.PageConfig;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -213,6 +214,17 @@ public abstract class MultiPortalFolderType extends DefaultFolderType
             }
         }
 
+        if (null != childContainer && childContainer.getFolderType() instanceof MultiPortalFolderType)
+        {
+            // We have childContainer, which means childContainer is a Container Tab
+            // Weird that this migration is here, but if childContainer is of MultiPortalFolderType, it needs to be done. But it only applys to MultiPortals so don't do it otherwise
+            migrateLegacyPortalPage(childContainer);
+        }
+        else
+        {
+            migrateLegacyPortalPage(ctx.getContainer());
+        }
+
         return new AppBar(getFolderTitle(ctx), ctx.getContainer().getStartURL(ctx.getUser()), buttons, subContainerTabs);
     }
 
@@ -251,6 +263,90 @@ public abstract class MultiPortalFolderType extends DefaultFolderType
         }
     }
 
+    private void migrateLegacyPortalPage(Container container)
+    {
+        try (var ignored = SpringActionController.ignoreSqlUpdates())
+        {
+            _migrateLegacyPortalPage(container);
+        }
+    }
+
+    private void _migrateLegacyPortalPage(Container container)
+    {
+        List<Portal.WebPart> legacyPortalParts = new ArrayList<>(Portal.getParts(container));
+        if (!legacyPortalParts.isEmpty())
+        {
+            FolderType folderType = container.getFolderType();
+            if (null == folderType.getDefaultTab() || null == StringUtils.trimToNull(folderType.getDefaultTab().getName()))
+                return;         // Nothing to do
+
+            // Check if there's a tab that has the legacy portal page ID
+            for (FolderTab folderTab : folderType.getDefaultTabs())
+            {
+                if (Portal.DEFAULT_PORTAL_PAGE_ID.equalsIgnoreCase(folderTab.getName()))
+                {
+                    // If so, we don't need to migrate anything
+                    return;
+                }
+            }
+
+            // get editable versions
+            legacyPortalParts = new ArrayList<>(Portal.getEditableParts(container));
+
+            String defaultTabName = folderType.getDefaultTab().getName();
+            List<Portal.WebPart> mergedParts = new ArrayList<>(Portal.getEditableParts(container, defaultTabName));
+            Iterator<Portal.WebPart> i = legacyPortalParts.iterator();
+            List<Portal.WebPart> required = getRequiredWebParts();
+            boolean changedLegacy = false;
+            boolean changedMerged = false;
+            while (i.hasNext())
+            {
+                Portal.WebPart defaultPortalPart = i.next();
+                String legacyPageAdded = defaultPortalPart.getPropertyMap().get(Portal.WEBPART_PROP_LegacyPageAdded);
+                if (!WebPartFactory.LOCATION_MENUBAR.equals(defaultPortalPart.getLocation()))
+                {
+                    if ((null == legacyPageAdded || !legacyPageAdded.equalsIgnoreCase("true")))
+                    {
+                        // Add it to the default tab if it's not already there
+                        if (null == findPart(mergedParts, defaultPortalPart))
+                        {
+                            Portal.WebPart webPart = new Portal.WebPart(defaultPortalPart);
+                            webPart.setPageId(defaultTabName);
+                            mergedParts.add(webPart);
+                            changedMerged = true;
+                        }
+                        // Remember that legacy portal page has been added to default tab
+                        defaultPortalPart.setProperty(Portal.WEBPART_PROP_LegacyPageAdded, "true");
+                        changedLegacy = true;
+                    }
+                    if (defaultPortalPart.isPermanent() && null != findPart(required, defaultPortalPart))
+                    {
+                        Portal.WebPart actualPart = findPart(mergedParts, defaultPortalPart);
+                        if (null == actualPart)
+                        {
+                            // It's required in this foldertype, but it's missing; add it
+                            Portal.WebPart webPart = new Portal.WebPart(defaultPortalPart);
+                            webPart.setPageId(defaultTabName);
+                            mergedParts.add(webPart);
+                            changedMerged = true;
+                        }
+                        else if (!actualPart.isPermanent())
+                        {
+                            // A required part is not marked required (perhaps because of switching folder types) so mark it so
+                            actualPart.setPermanent(true);
+                            changedMerged = true;
+                        }
+                    }
+                }
+            }
+
+            // Save the newly merged page and/or the legacy page
+            if (changedLegacy)
+                Portal.saveParts(container, legacyPortalParts);
+            if (changedMerged)
+                Portal.saveParts(container, defaultTabName, mergedParts);
+        }
+    }
 
     protected String getFolderTitle(ViewContext context)
     {   // Default; often overridden


### PR DESCRIPTION
#### Rationale
Removed migrateLegacyPortalPage() in recent "cleanup" because it "looks" like it does something with only old portal definitions.  Turns out it is needed to make create folder with FolderType work.

####  Changes
revert change that removed migrateLegacyPortalPage 
