### PR TITLE
Eliminate deprecated FormattedHtml constructor

### DIFF
--- a/api/src/org/labkey/api/exp/property/PropertyService.java
+++ b/api/src/org/labkey/api/exp/property/PropertyService.java
@@ -81,7 +81,7 @@ public interface PropertyService
     @NotNull
     Domain createDomain(Container container, String typeURI, String name, @Nullable TemplateInfo templateInfo);
 
-    /** return exiting Domain or create and save empty Domain if it does not exist */
+    /** return existing Domain or create and save empty Domain if it does not exist */
     @NotNull
     Domain ensureDomain(Container container, User user, String typeURI, String name);
 

--- a/api/src/org/labkey/api/wiki/FormattedHtml.java
+++ b/api/src/org/labkey/api/wiki/FormattedHtml.java
@@ -40,12 +40,6 @@ public class FormattedHtml
     private final Set<String> _anchors;
     private final Set<ClientDependency> _clientDependencies;
 
-    @Deprecated // use HtmlString
-    public FormattedHtml(String html)
-    {
-        this(null==html?null:HtmlString.unsafe(html), false, Collections.emptySet(), Collections.emptySet(), new LinkedHashSet<>());
-    }
-
     public FormattedHtml(HtmlString html)
     {
         this(html, false, Collections.emptySet(), Collections.emptySet(), new LinkedHashSet<>());

--- a/core/src/org/labkey/core/wiki/ClientDependencySubstitutionHandler.java
+++ b/core/src/org/labkey/core/wiki/ClientDependencySubstitutionHandler.java
@@ -18,6 +18,7 @@ package org.labkey.core.wiki;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.api.wiki.FormattedHtml;
 
@@ -33,13 +34,13 @@ public class ClientDependencySubstitutionHandler implements HtmlRenderer.Substit
         params = new CaseInsensitiveHashMap<>(params);
         if (!params.containsKey("path"))
         {
-            return new FormattedHtml("<br><font class='error' color='red'>Error: must provide the path of the client dependencies</font>");
+            return new FormattedHtml(HtmlString.unsafe("<br><font class='error' color='red'>Error: must provide the path of the client dependencies</font>"));
         }
 
         LinkedHashSet<ClientDependency> cds = new LinkedHashSet<>();
         ClientDependency cd = ClientDependency.fromPath(params.get("path"));
         if (cd == null)
-            return new FormattedHtml("<br><font class='error' color='red'>Error: unknown path: " + params.get("path") + "</font>");
+            return new FormattedHtml(HtmlString.unsafe("<br><font class='error' color='red'>Error: unknown path: " + PageFlowUtil.filter(params.get("path")) + "</font>"));
 
         cds.add(cd);
 

--- a/core/src/org/labkey/core/wiki/HtmlRenderer.java
+++ b/core/src/org/labkey/core/wiki/HtmlRenderer.java
@@ -212,14 +212,14 @@ public class HtmlRenderer implements WikiRenderer
     private FormattedHtml handleLabKeySubstitutions(String text)
     {
         if (text == null)
-            return new FormattedHtml("");
+            return new FormattedHtml(HtmlString.EMPTY_STRING);
         
         // Find all substitution templates embedded in wiki text that have the form ${labkey.<type>(<any_stream of characters>)}.
         Matcher webPartMatcher = _substitutionPattern.matcher(text);
 
         // If we find none, return immediately
         if (!webPartMatcher.find())
-            return new FormattedHtml(text);
+            return new FormattedHtml(HtmlString.unsafe(text));
 
         List<Definition> definitions = new ArrayList<>(10);
         Map<Definition, List<String>> wikiErrors = new HashMap<>();

--- a/internal/webapp/Impersonate.js
+++ b/internal/webapp/Impersonate.js
@@ -163,7 +163,7 @@ Ext4.define('LABKEY.Security.ImpersonateGroup', {
     getPanel: function(){
         var instructions = LABKEY.Security.currentUser.isRootAdmin ?
             "As a site or application administrator, you can impersonate any site or project group." :
-            "As a project administrator, you can impersonate any project group in within this project. While impersonating you will be restricted to this project.";
+            "As a project administrator, you can impersonate any project group in this project or any site group in which you're member. While impersonating you will be restricted to this project.";
 
         var divContainer = Ext4.create('Ext.container.Container', {
             html: "<div>" + instructions + "<br><br>Select a group from the list below and click the 'Impersonate' button</div>",


### PR DESCRIPTION
#### Rationale
Matt recently converted FormattedHtml to use HtmlString internally. This change eliminates the deprecated constructor that takes HTML as a String and forces callers to create an HtmlString.