### PR TITLE
Fix AncillaryStudyTest to more relaxed when looking for the img.

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/AncillaryStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AncillaryStudyTest.java
@@ -293,7 +293,7 @@ public class AncillaryStudyTest extends StudyBaseTest
         waitForElement(Locator.name("Label"), WAIT_FOR_JAVASCRIPT);
         setFormElement(Locator.name("Label"), "Extra " + STUDY_NAME);
         setFormElement(Locator.name("Description"), "Extra " + STUDY_DESCRIPTION);
-        click(Locator.tag("img").withAttribute("src", "/labkey/_images/paperclip.gif")); //Attach a file
+        click(Locator.tag("img").withAttributeContaining("src", "/labkey/_images/paperclip.gif")); //Attach a file
         waitForElement(Locator.xpath("//div[contains(@class, 'protocolPanel')]//input[@type='file']"), WAIT_FOR_JAVASCRIPT);
         setFormElement(Locator.xpath("//div[contains(@class, 'protocolPanel')]//input[@type='file']"), PROTOCOL_DOC2.toString());
         clickButton("Submit");


### PR DESCRIPTION
#### Rationale
Test failed on TeamCity run because attribute of an img tag change slightly.

#### Related Pull Requests


#### Changes
* Changed Locator.tag("img").withAttribute to Locator.tag("img").withAttributeContaining
