### PR TITLE
Issue 40508: provenance : copied to study rows not getting cleaned up after recall

### DIFF
--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -2595,6 +2595,8 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
     {
         // Get the ExpRuns referenced by the dataset row LSIDs
         List<? extends ExpRun> runs = pvs.getRuns(new HashSet<>(lsids));
+        // get all lsids for the dataset
+        Collection<String> allDatasetLsids = StudyManager.getInstance().getDatasetProvenanceLsids(this);
 
         // delete the provenance rows and the exp.object that the provenance module created for the dataset LSID row
         for (String lsid : lsids)
@@ -2618,10 +2620,11 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
             if (run.getProtocol().getLSID().equals(AssayPublishService.STUDY_PUBLISH_PROTOCOL_LSID))
             {
                 // get all the input and output LSIDs that remain for the selected runs
-                Set<String> allRunLsids = new HashSet<>(pvs.getProvenanceObjectUriSet(run.getInputProtocolApplication().getObjectId()));
-                allRunLsids.addAll(pvs.getProvenanceObjectUriSet(run.getOutputProtocolApplication().getObjectId()));
+                Set<String> allRunLsids = new HashSet<>(pvs.getProvenanceObjectUriSet(run.getInputProtocolApplication().getRowId()));
+                allRunLsids.addAll(pvs.getProvenanceObjectUriSet(run.getOutputProtocolApplication().getRowId()));
 
-                if (allRunLsids.isEmpty())
+                // if allRunLsids is empty or all the lsids of the dataset are recalled, delete the StudyPublishRun
+                if (allRunLsids.isEmpty() || allDatasetLsids.size() == lsids.size())
                 {
                     ExperimentService.get().deleteExperimentRunsByRowIds(getContainer(), u, run.getRowId());
                     syncNeeded = false;

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -2730,7 +2730,7 @@ public class StudyManager
         return dataset.deleteRows(cutoff);
     }
 
-    private Collection<String> getDatasetProvenanceLsids(DatasetDefinition ds)
+    public Collection<String> getDatasetProvenanceLsids(DatasetDefinition ds)
     {
         String datasetTableName = ds.getStorageTableInfo().getName();
 


### PR DESCRIPTION
#### Rationale
This PR fixes deleting the StudyPublishRun when all the rows for a dataset created by copy to study are recalled.

#### Related Pull Requests
https://github.com/LabKey/provenance/pull/27