### PR TITLE
Issue 40544: Increase default infer fields row count to 10,000

### DIFF
--- a/api/src/org/labkey/api/reader/DataLoader.java
+++ b/api/src/org/labkey/api/reader/DataLoader.java
@@ -98,7 +98,7 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
     protected Map<String, ColumnInfo> _columnInfoMap = Collections.emptyMap();
     protected ColumnDescriptor[] _columns;
     private boolean _initialized = false;
-    protected int _scanAheadLineCount = 1000; // number of lines to scan trying to infer data types
+    protected int _scanAheadLineCount = 10000; // number of lines to scan trying to infer data types
     // CONSIDER: explicit flags for hasHeaders, inferHeaders, skipLines etc.
     protected int _skipLines = -1;      // -1 means infer headers
     private boolean _inferTypes = true;

--- a/api/src/org/labkey/api/reader/TabLoader.java
+++ b/api/src/org/labkey/api/reader/TabLoader.java
@@ -285,8 +285,8 @@ public class TabLoader extends DataLoader
         if (null == _reader)
         {
             _reader = _readerFactory.getReader();
-            // Issue 23437 - use a reasonably high limit for buffering
-            _reader.mark(10 * 1024 * 1024);
+            // Allocate a reasonalby large buffer for "infer fields" scanning: 10K per row. #23437, #40544
+            _reader.mark(_scanAheadLineCount * 10 * 1024);
         }
 
         return _reader;

--- a/api/src/org/labkey/api/reader/TabLoader.java
+++ b/api/src/org/labkey/api/reader/TabLoader.java
@@ -285,7 +285,7 @@ public class TabLoader extends DataLoader
         if (null == _reader)
         {
             _reader = _readerFactory.getReader();
-            // Allocate a reasonalby large buffer for "infer fields" scanning: 10K per row. #23437, #40544
+            // Allocate a reasonably large buffer for "infer fields" scanning: 10K per row. #23437, #40544
             _reader.mark(_scanAheadLineCount * 10 * 1024);
         }
 


### PR DESCRIPTION
#### Rationale
Creating a new dataset using infer fields can be very tedious, especially with extremely wide input. Increasing the number of rows used to infer field types reduces the iteration required to get data loaded.

And it's always better to merge to the right branch. Ugh.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1242
