### PR TITLE
Update api and internal packages to gradle 7-compatible configurations

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,8 +1,7 @@
 import org.labkey.gradle.util.BuildUtils
 
 apply plugin: 'java'
-if (project.hasProperty("gradle7Compat"))
-    apply plugin: 'java-library'
+apply plugin: 'java-library'
 apply plugin: 'org.labkey.javaModule'
 apply plugin: 'org.labkey.xmlBeans'
 
@@ -140,32 +139,18 @@ dependencies {
     // declare a transitive labkey dependency so the dependencies of the labkey-client-api are copied into api's lib directory
     // and so the dependencies are included in the dependencies.txt file.
     BuildUtils.addLabKeyDependency(project: project, config: "labkey", depProjectPath: BuildUtils.getRemoteApiProjectPath(gradle), transitive: true, depProjectConfig: "default", depVersion: project.labkeyClientApiVersion)
-    if (project.hasProperty("gradle7Compat"))
-    {
-        BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getBootstrapProjectPath(gradle))
-        api project.tasks.schemasCompile.outputs.files
-    }
-    else
-    {
-        BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: BuildUtils.getBootstrapProjectPath(gradle))
-        compile project.tasks.schemasCompile.outputs.files
-    }
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getBootstrapProjectPath(gradle))
+    api project.tasks.schemasCompile.outputs.files
+
     // always include labkey-client-api in the dependencies.txt file, whether that project is being built locally or not.
     creditable "org.labkey.api:labkey-client-api:${project.labkeyClientApiVersion}"
 
     BuildUtils.addTomcatBuildDependencies(project, "implementation")
     // the following two libraries are required for compilation but we don't want extra ones in the classpath, so we exclude
     // them from external dependencies in favor of the versions in the tomcat directory (FIXME seems somewhat sketchy...)
-    if (project.hasProperty("gradle7Compat"))
-    {
-        api "javax.servlet:servlet-api:${servletApiVersion}"
-        api "com.sun.mail:jakarta.mail:${javaMailVersion}"
-    }
-    else
-    {
-        compile "javax.servlet:servlet-api:${servletApiVersion}"
-        compile "com.sun.mail:jakarta.mail:${javaMailVersion}"
-    }
+    api "javax.servlet:servlet-api:${servletApiVersion}"
+    api "com.sun.mail:jakarta.mail:${javaMailVersion}"
+
 
     external("com.fasterxml.jackson.datatype:jackson-datatype-json-org:${jacksonVersion}") {
       // exclude this because it gets in the way of our own JSON object implementations from server/api

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -159,7 +159,7 @@ dependencies {
     if (project.hasProperty("gradle7Compat"))
     {
         api "javax.servlet:servlet-api:${servletApiVersion}"
-        implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
+        api "com.sun.mail:jakarta.mail:${javaMailVersion}"
     }
     else
     {

--- a/assay/build.gradle
+++ b/assay/build.gradle
@@ -2,6 +2,7 @@ import org.labkey.gradle.util.BuildUtils
 
 dependencies{
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"), depProjectConfig: "published", depExtension: "module")
+    apiImplementation "org.apache.tomcat:tomcat-jsp-api:${apacheTomcatVersion}"
 }
 
 project.evaluationDependsOn(BuildUtils.getPlatformProjectPath(project.gradle))

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,5 +11,7 @@ dependencies {
    jspImplementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
 }
 
+BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getBootstrapProjectPath(gradle))
+
 project.evaluationDependsOn(BuildUtils.getPlatformProjectPath(project.gradle))
 project.tasks.npmInstall.dependsOn(project.project(BuildUtils.getPlatformProjectPath(project.gradle)).tasks.npmInstall)

--- a/internal/build.gradle
+++ b/internal/build.gradle
@@ -1,29 +1,16 @@
 import org.labkey.gradle.util.BuildUtils
 
 apply plugin: 'java'
-if (project.hasProperty("gradle7Compat"))
-   apply plugin: 'java-library'
+apply plugin: 'java-library'
 apply plugin: 'org.labkey.javaModule'
 
 dependencies {
-   if (project.hasProperty("gradle7Compat"))
-   {
-      BuildUtils.addLabKeyDependency(project: project, config: "api", depProjectPath: BuildUtils.getApiProjectPath(project.gradle))
-      if (project.configurations.findByName("dedupe") != null)
-         BuildUtils.addLabKeyDependency(project: project, config: "dedupe", depProjectPath: BuildUtils.getApiProjectPath(project.gradle), depProjectConfig: "external")
-      implementation "org.apache.tomcat:tomcat-jsp-api:${apacheTomcatVersion}"
-      implementation "org.apache.tomcat:tomcat-jasper:${apacheTomcatVersion}"
-      api  "org.labkey.api:labkey-client-api:${labkeyClientApiVersion}"
-   }
-   else
-   {
-      BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: BuildUtils.getApiProjectPath(project.gradle))
-      if (project.configurations.findByName("dedupe") != null)
-         BuildUtils.addLabKeyDependency(project: project, config: "dedupe", depProjectPath: BuildUtils.getApiProjectPath(project.gradle), depProjectConfig: "external")
-      compile "org.apache.tomcat:tomcat-jsp-api:${apacheTomcatVersion}"
-      compile "org.apache.tomcat:tomcat-jasper:${apacheTomcatVersion}"
-      compile "org.labkey.api:labkey-client-api:${labkeyClientApiVersion}"
-   }
+   BuildUtils.addLabKeyDependency(project: project, config: "api", depProjectPath: BuildUtils.getApiProjectPath(project.gradle))
+   if (project.configurations.findByName("dedupe") != null)
+      BuildUtils.addLabKeyDependency(project: project, config: "dedupe", depProjectPath: BuildUtils.getApiProjectPath(project.gradle), depProjectConfig: "external")
+   implementation "org.apache.tomcat:tomcat-jsp-api:${apacheTomcatVersion}"
+   implementation "org.apache.tomcat:tomcat-jasper:${apacheTomcatVersion}"
+   api  "org.labkey.api:labkey-client-api:${labkeyClientApiVersion}"
    external  'com.sun.script.js:jsr223-js-engine:Aug2008'
    external  'org.mozilla:rhino:1.7R3'
 }

--- a/issues/build.gradle
+++ b/issues/build.gradle
@@ -1,6 +1,7 @@
 import org.labkey.gradle.util.BuildUtils
 
 dependencies {
+    implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"), depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "search"), depProjectConfig: "published", depExtension: "module")
 }

--- a/pipeline/build.gradle
+++ b/pipeline/build.gradle
@@ -1,6 +1,7 @@
 import org.labkey.gradle.util.BuildUtils
 
 dependencies {
+    implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
     external("org.apache.activemq:activemq-core:${activemqCoreVersion}") {
       exclude group: "javax.servlet", module: "servlet-api"
     }
@@ -30,7 +31,7 @@ dependencies {
             exclude group:"jaxen", module: "jaxen"
         }
 
-
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getBootstrapProjectPath(gradle))
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath:  BuildUtils.getPlatformModuleProjectPath(project.gradle, "core"), depProjectConfig: 'apiJarFile')
 }
 

--- a/study/build.gradle
+++ b/study/build.gradle
@@ -12,6 +12,7 @@ sourceSets {
 }
 
 dependencies {
+    implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
 


### PR DESCRIPTION
#### Rationale
The compile configuration is deprecated and its use will result in an error for Gradle 7 so we remove its use in api and internal and add explicit dependencies in modules that had been relying on dependencies that were leaking out of the compile dependency.

#### Related Pull Requests
* https://github.com/LabKey/moduleEditor/pull/4
* https://github.com/LabKey/LabDevKitModules/pull/33
* https://github.com/LabKey/ehrModules/pull/52
* https://github.com/LabKey/PanoramaPremiumModules/pull/34
* https://github.com/LabKey/premium/pull/194
* https://github.com/LabKey/wnprc-modules/pull/13
* https://github.com/LabKey/adjudication/pull/39

#### Changes
* Use java-library plugin for api and internal
* Convert compile dependencies to api or implementation
* Add missing dependencies no longer leaked out of api or internal.
