### PR TITLE
Bump doc version in preparation for 20.7.0 release

### DIFF
--- a/api/src/org/labkey/api/Constants.java
+++ b/api/src/org/labkey/api/Constants.java
@@ -49,7 +49,7 @@ public class Constants
      */
     public static String getDocumentationVersion()
     {
-        return "20.3";
+        return "20.7";
     }
 
     /**


### PR DESCRIPTION
#### Rationale
We need to bump the documentation version to match each production release. Constants.TestCase started failing with the version bump to 20.7-SNAPSHOT (as it's designed to do); this fixes the test.