### PR TITLE
Issue 37936: Roundtrip of demo study fails import on Specimen Sample Set

### DIFF
--- a/api/src/org/labkey/api/study/SpecimenService.java
+++ b/api/src/org/labkey/api/study/SpecimenService.java
@@ -45,6 +45,8 @@ import java.util.Set;
  */
 public interface SpecimenService
 {
+    String SAMPLE_TYPE_NAME = "Study Specimens";
+
     static void setInstance(SpecimenService serviceImpl)
     {
         ServiceRegistry.get().registerService(SpecimenService.class, serviceImpl);

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -69,6 +69,7 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.study.SpecimenService;
 import org.labkey.api.study.assay.AssayPublishService;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.util.DateUtil;
@@ -490,8 +491,13 @@ public class XarReader extends AbstractXarImporter
             {
                 List<IdentifiableEntity.Difference> diffs = new ArrayList<>();
                 IdentifiableEntity.diff(materialSource.getName(), existingMaterialSource.getName(), "Name", diffs);
-                IdentifiableEntity.diff(materialSource.getDescription(), existingMaterialSource.getDescription(), "Description", diffs);
-                IdentifiableEntity.diff(materialSource.getMaterialLSIDPrefix(), existingMaterialSource.getMaterialLSIDPrefix(), "Material LSID prefix", diffs);
+
+                // Issue 37936 - Skip validation of description for the magic specimen/sample link, which is auto-generated based on the container name
+                if (!existingMaterialSource.getName().equalsIgnoreCase(SpecimenService.SAMPLE_TYPE_NAME))
+                {
+                    IdentifiableEntity.diff(materialSource.getMaterialLSIDPrefix(), existingMaterialSource.getMaterialLSIDPrefix(), "Material LSID prefix", diffs);
+                    IdentifiableEntity.diff(materialSource.getDescription(), existingMaterialSource.getDescription(), "Description", diffs);
+                }
                 if (!diffs.isEmpty())
                 {
                     getLog().error("The SampleSet specified with LSID '" + lsid + "' has " + diffs.size() + " differences from the one that has already been loaded");

--- a/experiment/src/org/labkey/experiment/samplesAndAnalytes.jsp
+++ b/experiment/src/org/labkey/experiment/samplesAndAnalytes.jsp
@@ -23,6 +23,7 @@
 <%@ page import="org.labkey.experiment.api.SampleSetServiceImpl" %>
 <%@ page import="org.labkey.experiment.controllers.exp.ExperimentController" %>
 <%@ page import="java.util.List" %>
+<%@ page import="org.labkey.api.study.SpecimenService" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     Container proj = getContainer().getProject();
@@ -39,7 +40,7 @@
         for (ExpSampleSet sampleSet : sampleSets)
         {
             ActionURL url;
-            boolean isStudySample = "Study Specimens".equals(sampleSet.getName());
+            boolean isStudySample = SpecimenService.SAMPLE_TYPE_NAME.equals(sampleSet.getName());
             if (isStudySample)
                 url = urlProvider(SamplesUrls.class).getSamplesURL(sampleSet.getContainer());
             else

--- a/study/src/org/labkey/study/SpecimenManager.java
+++ b/study/src/org/labkey/study/SpecimenManager.java
@@ -53,6 +53,7 @@ import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExpSampleSet;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.SampleSetService;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleHtmlView;
 import org.labkey.api.query.CustomView;
@@ -62,6 +63,7 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.settings.AppProps;
+import org.labkey.api.study.SpecimenService;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyCachable;
 import org.labkey.api.study.StudyService;
@@ -136,8 +138,6 @@ import java.util.concurrent.locks.ReentrantLock;
 public class SpecimenManager implements ContainerManager.ContainerListener
 {
     private final static SpecimenManager _instance = new SpecimenManager();
-
-    public static final String STUDY_SPECIMENS_SAMPLE_SET_NAME = "Study Specimens";
 
     private final QueryHelper<SpecimenRequestEvent> _requestEventHelper;
 //    private final QueryHelper<AdditiveType> _additiveHelper;
@@ -2042,7 +2042,7 @@ public class SpecimenManager implements ContainerManager.ContainerListener
         DbSchema expSchema = ExperimentService.get().getSchema();
         TableInfo tinfoMaterial = expSchema.getTable("Material");
 
-        ExpSampleSet sampleSet = ExperimentService.get().getSampleSet(c, SpecimenManager.STUDY_SPECIMENS_SAMPLE_SET_NAME);
+        ExpSampleSet sampleSet = SampleSetService.get().getSampleSet(c, SpecimenService.SAMPLE_TYPE_NAME);
 
         if (sampleSet != null)
         {

--- a/study/src/org/labkey/study/importer/SpecimenImporter.java
+++ b/study/src/org/labkey/study/importer/SpecimenImporter.java
@@ -45,6 +45,7 @@ import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.api.ExpSampleSet;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.SampleSetService;
 import org.labkey.api.exp.list.ListImportProgress;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
@@ -2354,15 +2355,15 @@ public class SpecimenImporter
 
         String prefix = new Lsid(StudyService.SPECIMEN_NAMESPACE_PREFIX, "Folder-" + info.getContainer().getRowId(), "").toString();
         String cpasType;
-        ExpSampleSet sampleSet = ExperimentService.get().getSampleSet(info.getContainer(), SpecimenManager.STUDY_SPECIMENS_SAMPLE_SET_NAME);
+        ExpSampleSet sampleSet = SampleSetService.get().getSampleSet(info.getContainer(), SpecimenService.SAMPLE_TYPE_NAME);
 
         if (sampleSet == null)
         {
-            ExpSampleSet source = ExperimentService.get().createSampleSet();
+            ExpSampleSet source = SampleSetService.get().createSampleSet();
             source.setContainer(info.getContainer());
             source.setMaterialLSIDPrefix(prefix);
-            source.setName(SpecimenManager.STUDY_SPECIMENS_SAMPLE_SET_NAME);
-            source.setLSID(ExperimentService.get().getSampleSetLsid(SpecimenManager.STUDY_SPECIMENS_SAMPLE_SET_NAME, info.getContainer()).toString());
+            source.setName(SpecimenService.SAMPLE_TYPE_NAME);
+            source.setLSID(SampleSetService.get().getSampleSetLsid(SpecimenService.SAMPLE_TYPE_NAME, info.getContainer()).toString());
             source.setDescription("Study specimens for " + info.getContainer().getPath());
             source.save(null);
             cpasType = source.getLSID();

--- a/study/src/org/labkey/study/specimen/SpecimenSampleSetDomainKind.java
+++ b/study/src/org/labkey/study/specimen/SpecimenSampleSetDomainKind.java
@@ -19,11 +19,10 @@ import org.labkey.api.data.Container;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.security.User;
+import org.labkey.api.study.SpecimenService;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.experiment.api.SampleSetDomainKind;
-
-import static org.labkey.study.SpecimenManager.STUDY_SPECIMENS_SAMPLE_SET_NAME;
 
 public class SpecimenSampleSetDomainKind extends SampleSetDomainKind
 {
@@ -37,7 +36,7 @@ public class SpecimenSampleSetDomainKind extends SampleSetDomainKind
         Lsid lsid = new Lsid(domainURI);
         String prefix = lsid.getNamespacePrefix();
         String name = lsid.getObjectId();
-        if ("SampleSet".equals(prefix) && STUDY_SPECIMENS_SAMPLE_SET_NAME.equals(name))
+        if ("SampleSet".equals(prefix) && SpecimenService.SAMPLE_TYPE_NAME.equals(name))
             return Priority.HIGH;
         return null;
     }


### PR DESCRIPTION
#### Rationale
We want to support round-tripping a container with study specimens and runs that use them. The problem was an export that included both the study and its specimens, and the XAR file. We're not perfect on the round-trip (the derived sample type doesn't get recreated) but that's out of scope of this fix.

#### Changes
Be less picky about an exact match on the magic specimen sample set/type

Use a shared constant for the sample set name

Stop using deprecated methods