### PR TITLE
Dial back fixed buffer size for infer fields. Warn admins for < 2GB heap.

### DIFF
--- a/api/src/org/labkey/api/reader/DataLoader.java
+++ b/api/src/org/labkey/api/reader/DataLoader.java
@@ -98,7 +98,7 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
     protected Map<String, ColumnInfo> _columnInfoMap = Collections.emptyMap();
     protected ColumnDescriptor[] _columns;
     private boolean _initialized = false;
-    protected int _scanAheadLineCount = 10000; // number of lines to scan trying to infer data types
+    protected int _scanAheadLineCount = 7500; // number of lines to scan trying to infer data types
     // CONSIDER: explicit flags for hasHeaders, inferHeaders, skipLines etc.
     protected int _skipLines = -1;      // -1 means infer headers
     private boolean _inferTypes = true;

--- a/api/src/org/labkey/api/reader/TabLoader.java
+++ b/api/src/org/labkey/api/reader/TabLoader.java
@@ -285,8 +285,8 @@ public class TabLoader extends DataLoader
         if (null == _reader)
         {
             _reader = _readerFactory.getReader();
-            // Allocate a reasonably large buffer for "infer fields" scanning: 10K per row. #23437, #40544
-            _reader.mark(_scanAheadLineCount * 10 * 1024);
+            // Allocate a reasonably large buffer for "infer fields" scanning: 5K per row. #23437, #40544
+            _reader.mark(_scanAheadLineCount * 5 * 1024);
         }
 
         return _reader;

--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -108,14 +108,13 @@ public class CoreWarningProvider implements WarningProvider
 
     private void getHeapSizeWarnings(Warnings warnings)
     {
-        //FIX: 9683
-        //show admins warning about inadequate heap size (<= 1GB)
+        // Issue 9683 - show admins warning about inadequate heap size (< 2GB)
         MemoryMXBean membean = ManagementFactory.getMemoryMXBean();
         long maxMem = membean.getHeapMemoryUsage().getMax();
 
-        if (SHOW_ALL_WARNINGS || maxMem > 0 && maxMem < 1024*1024*1024)
+        if (SHOW_ALL_WARNINGS || maxMem > 0 && maxMem < 2*1024*1024*1024L)
         {
-            HtmlStringBuilder html = HtmlStringBuilder.of("The maximum amount of heap memory allocated to LabKey Server is too low (less than 1GB). LabKey recommends ");
+            HtmlStringBuilder html = HtmlStringBuilder.of("The maximum amount of heap memory allocated to LabKey Server is too low (less than 2GB). LabKey recommends ");
             html.append(new HelpTopic("configWebappMemory").getSimpleLinkHtml("setting the maximum heap to at least 2 gigabytes (-Xmx2G) on test/evaluation servers and at least 4 gigabytes (-Xmx4G) on production servers"));
             html.append(".");
             warnings.add(html.getHtmlString());


### PR DESCRIPTION
#### Rationale
New infer fields buffer size is a tad aggressive for deployments with small heap sizes.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1244

#### Changes
* Bump down row count and row size assumption to reduce infer fields buffer size from 195MB to 73MB
* Display admin warning for deployments configured with less than 2GB of heap
