### PR TITLE
JTidy rewrites <A> wrapping <DIV> so avoid that here

### DIFF
--- a/core/src/org/labkey/core/project/projects.jsp
+++ b/core/src/org/labkey/core/project/projects.jsp
@@ -161,10 +161,11 @@
             String displayName = displayName(c);
             // data-project can be use in style sheet to hide projects e.g.
             // <style>div[data-project="StudyVerifyProject"]{display:none !important;}</style>
+            // NOTE: JTidy does not like <A> tags wrapping <DIV> tags, so avoid that here
             if (details) {
-                %><div data-project="<%=projectName%>" class="thumb-wrap"><div style="width: 100%;" class="tool-icon thumb-wrap thumb-wrap-side"><a href="<%=h(c.getStartURL(getUser()))%>"><div class="thumb-img-side"><span class="fa fa-folder-open fa-lg"></span></div><span class="thumb-label-side"><%=h(displayName)%></span></a></div></div><%
+                %><div data-project="<%=projectName%>" class="thumb-wrap"><div style="width: 100%;" class="tool-icon thumb-wrap thumb-wrap-side"><div class="thumb-img-side"><a href="<%=h(c.getStartURL(getUser()))%>"><span class="fa fa-folder-open fa-lg"></span></a></div><a href="<%=h(c.getStartURL(getUser()))%>"><span class="thumb-label-side"><%=h(displayName)%></span></a></div></div><%
             } else {
-                %><div data-project="<%=projectName%>" style="display: inline-block;" class="thumb-wrap"><div style="width: <%=width%>;" class="tool-icon thumb-wrap thumb-wrap-bottom"><a href="<%=h(c.getStartURL(getUser()))%>"><div class="thumb-img-bottom"><span class="fa fa-folder-open <%=faX%>"></span></div><span class="thumb-label-bottom"><%=h(displayName)%></span></a></div></div><%
+                %><div data-project="<%=projectName%>" style="display: inline-block;" class="thumb-wrap"><div style="width: <%=width%>;" class="tool-icon thumb-wrap thumb-wrap-bottom"><div class="thumb-img-bottom"><a href="<%=h(c.getStartURL(getUser()))%>"><span class="fa fa-folder-open <%=faX%>"></span></a></div><a href="<%=h(c.getStartURL(getUser()))%>"><span class="thumb-label-bottom"><%=h(displayName)%></span></a></div></div><%
             }
         }
 %>


### PR DESCRIPTION
#### Rationale
Embedded web parts in wiki get run through JTidy for better or worse.  JTidy does not like <A> tags that wrap <DIV> so we need to avoid that.
Issue 40567