### PR TITLE
TabBufferedReader, a special BufferedReader subclass that accommodates infer fields

### DIFF
--- a/api/src/org/labkey/api/reader/BufferedReader.java
+++ b/api/src/org/labkey/api/reader/BufferedReader.java
@@ -1,0 +1,507 @@
+package org.labkey.api.reader;
+
+/*
+This is a copy of an alternate implementation of java.io.BufferedReader.
+see https://github.com/google/google-authenticator/blob/master/mobile/blackberry/src/com/google/authenticator/blackberry/BufferedReader.java
+We use this implementation as it grows its buffer incrementally instead of allocating marklimit immediately (as java.io.BufferedReader)
+This implementation has only been changed as follows
+    1) setEnforceMarkLimit(bool) when set, read operations won't allow reading past the set mark limit
+    2) throw MarkLimitExceededException if a read would exceed the mark limit (no partial reads)
+*/
+
+/*-
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  Modifications:
+ *  -Changed package name
+ *  -Removed "@since Android 1.0" comments
+ *  -Removed logging
+ *  -Removed special error messages
+ *  -Removed annotations
+ *  -Replaced StringBuilder with StringBuffer
+ */
+
+import java.io.IOException;
+import java.io.Reader;
+
+/**
+ * Wraps an existing {@link Reader} and <em>buffers</em> the input. Expensive
+ * interaction with the underlying reader is minimized, since most (smaller)
+ * requests can be satisfied by accessing the buffer alone. The drawback is that
+ * some extra space is required to hold the buffer and that copying takes place
+ * when filling that buffer, but this is usually outweighed by the performance
+ * benefits.
+ *
+ * <p/>A typical application pattern for the class looks like this:<p/>
+ *
+ * <pre>
+ * BufferedReader buf = new BufferedReader(new FileReader(&quot;file.java&quot;));
+ * </pre>
+ *
+ */
+@SuppressWarnings("SynchronizeOnNonFinalField")
+public class BufferedReader extends Reader {
+
+    private final Reader in;
+
+    private char[] buf;
+
+    private int marklimit = -1;
+
+    private int count;
+
+    private int markpos = -1;
+
+    private int pos;
+
+    private boolean enforceMarkLimit = false;
+
+    /**
+     * Constructs a new BufferedReader on the Reader {@code in}. The
+     * buffer gets the default size (8 KB).
+     *
+     * @param in
+     *            the Reader that is buffered.
+     */
+    public BufferedReader(Reader in) {
+        super(in);
+        this.in = in;
+        buf = new char[8192];
+    }
+
+    /**
+     * Constructs a new BufferedReader on the Reader {@code in}. The buffer
+     * size is specified by the parameter {@code size}.
+     *
+     * @param in
+     *            the Reader that is buffered.
+     * @param size
+     *            the size of the buffer to allocate.
+     * @throws IllegalArgumentException
+     *             if {@code size <= 0}.
+     */
+    public BufferedReader(Reader in, int size) {
+        super(in);
+        if (size <= 0) {
+            throw new IllegalArgumentException();
+        }
+        this.in = in;
+        buf = new char[size];
+    }
+
+    /**
+     * Closes this reader. This implementation closes the buffered source reader
+     * and releases the buffer. Nothing is done if this reader has already been
+     * closed.
+     *
+     * @throws IOException
+     *             if an error occurs while closing this reader.
+     */
+    @Override
+    public void close() throws IOException {
+        synchronized (lock) {
+            if (!isClosed()) {
+                in.close();
+                buf = null;
+            }
+        }
+    }
+
+    private int fillbuf() throws IOException {
+        if (markpos == -1 || (pos - markpos >= marklimit)) {
+            if (markpos != -1 && enforceMarkLimit)
+                throw new MarkLimitExceededException();
+            /* Mark position not set or exceeded readlimit */
+            int result = in.read(buf, 0, buf.length);
+            if (result > 0) {
+                markpos = -1;
+                pos = 0;
+                count = result;
+            }
+            return result;
+        }
+        if (markpos == 0 && marklimit > buf.length) {
+            /* Increase buffer size to accommodate the readlimit */
+            int newLength = buf.length * 2;
+            if (newLength > marklimit) {
+                newLength = marklimit;
+            }
+            char[] newbuf = new char[newLength];
+            System.arraycopy(buf, 0, newbuf, 0, buf.length);
+            buf = newbuf;
+        } else if (markpos > 0) {
+            System.arraycopy(buf, markpos, buf, 0, buf.length - markpos);
+        }
+
+        /* Set the new position and mark position */
+        pos -= markpos;
+        count = markpos = 0;
+        int charsread = in.read(buf, pos, buf.length - pos);
+        count = charsread == -1 ? pos : pos + charsread;
+        return charsread;
+    }
+
+    /**
+     * Indicates whether or not this reader is closed.
+     *
+     * @return {@code true} if this reader is closed, {@code false}
+     *         otherwise.
+     */
+    private boolean isClosed() {
+        return buf == null;
+    }
+
+    /**
+     * Sets a mark position in this reader. The parameter {@code readlimit}
+     * indicates how many characters can be read before the mark is invalidated.
+     * Calling {@code reset()} will reposition the reader back to the marked
+     * position if {@code readlimit} has not been surpassed.
+     *
+     * @param readlimit
+     *            the number of characters that can be read before the mark is
+     *            invalidated.
+     * @throws IllegalArgumentException
+     *             if {@code readlimit < 0}.
+     * @throws IOException
+     *             if an error occurs while setting a mark in this reader.
+     * @see #markSupported()
+     * @see #reset()
+     */
+    @Override
+    public void mark(int readlimit) throws IOException {
+        if (readlimit < 0) {
+            throw new IllegalArgumentException();
+        }
+        synchronized (lock) {
+            if (isClosed()) {
+                throw new IOException();
+            }
+            marklimit = readlimit;
+            markpos = pos;
+        }
+    }
+
+    /**
+     * Indicates whether this reader supports the {@code mark()} and
+     * {@code reset()} methods. This implementation returns {@code true}.
+     *
+     * @return {@code true} for {@code BufferedReader}.
+     * @see #mark(int)
+     * @see #reset()
+     */
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+
+    /**
+     * Reads a single character from this reader and returns it with the two
+     * higher-order bytes set to 0. If possible, BufferedReader returns a
+     * character from the buffer. If there are no characters available in the
+     * buffer, it fills the buffer and then returns a character. It returns -1
+     * if there are no more characters in the source reader.
+     *
+     * @return the character read or -1 if the end of the source reader has been
+     *         reached.
+     * @throws IOException
+     *             if this reader is closed or some other I/O error occurs.
+     */
+    @Override
+    public int read() throws IOException {
+        synchronized (lock) {
+            if (isClosed()) {
+                throw new IOException();
+            }
+            /* Are there buffered characters available? */
+            if (pos < count || fillbuf() != -1) {
+                return buf[pos++];
+            }
+            return -1;
+        }
+    }
+
+    /**
+     * Reads at most {@code length} characters from this reader and stores them
+     * at {@code offset} in the character array {@code buffer}. Returns the
+     * number of characters actually read or -1 if the end of the source reader
+     * has been reached. If all the buffered characters have been used, a mark
+     * has not been set and the requested number of characters is larger than
+     * this readers buffer size, BufferedReader bypasses the buffer and simply
+     * places the results directly into {@code buffer}.
+     *
+     * @param buffer
+     *            the character array to store the characters read.
+     * @param offset
+     *            the initial position in {@code buffer} to store the bytes read
+     *            from this reader.
+     * @param length
+     *            the maximum number of characters to read, must be
+     *            non-negative.
+     * @return number of characters read or -1 if the end of the source reader
+     *         has been reached.
+     * @throws IndexOutOfBoundsException
+     *             if {@code offset < 0} or {@code length < 0}, or if
+     *             {@code offset + length} is greater than the size of
+     *             {@code buffer}.
+     * @throws IOException
+     *             if this reader is closed or some other I/O error occurs.
+     */
+    @Override
+    public int read(char[] buffer, int offset, int length) throws IOException {
+        synchronized (lock) {
+            if (isClosed()) {
+                throw new IOException();
+            }
+            if (length == 0) {
+                return 0;
+            }
+            int required;
+            if (pos < count) {
+                /* There are bytes available in the buffer. */
+                int copylength = Math.min(count - pos, length);
+                System.arraycopy(buf, pos, buffer, offset, copylength);
+                pos += copylength;
+                if (copylength == length || !in.ready()) {
+                    return copylength;
+                }
+                offset += copylength;
+                required = length - copylength;
+            } else {
+                required = length;
+            }
+
+            while (true) {
+                int read;
+                /*
+                 * If we're not marked and the required size is greater than the
+                 * buffer, simply read the bytes directly bypassing the buffer.
+                 */
+                if (markpos == -1 && required >= buf.length) {
+                    read = in.read(buffer, offset, required);
+                    if (read == -1) {
+                        return required == length ? -1 : length - required;
+                    }
+                } else {
+                    if (fillbuf() == -1) {
+                        return required == length ? -1 : length - required;
+                    }
+                    read = Math.min(count - pos, required);
+                    System.arraycopy(buf, pos, buffer, offset, read);
+                    pos += read;
+                }
+                required -= read;
+                if (required == 0) {
+                    return length;
+                }
+                if (!in.ready()) {
+                    return length - required;
+                }
+                offset += read;
+            }
+        }
+    }
+
+    /**
+     * Returns the next line of text available from this reader. A line is
+     * represented by zero or more characters followed by {@code '\n'},
+     * {@code '\r'}, {@code "\r\n"} or the end of the reader. The string does
+     * not include the newline sequence.
+     *
+     * @return the contents of the line or {@code null} if no characters were
+     *         read before the end of the reader has been reached.
+     * @throws IOException
+     *             if this reader is closed or some other I/O error occurs.
+     */
+    public String readLine() throws IOException {
+        synchronized (lock) {
+            if (isClosed()) {
+                throw new IOException();
+            }
+            /* Are there buffered characters available? */
+            if ((pos >= count) && (fillbuf() == -1)) {
+                return null;
+            }
+            for (int charPos = pos; charPos < count; charPos++) {
+                char ch = buf[charPos];
+                if (ch > '\r') {
+                    continue;
+                }
+                if (ch == '\n') {
+                    String res = new String(buf, pos, charPos - pos);
+                    pos = charPos + 1;
+                    return res;
+                } else if (ch == '\r') {
+                    String res = new String(buf, pos, charPos - pos);
+                    pos = charPos + 1;
+                    if (((pos < count) || (fillbuf() != -1))
+                            && (buf[pos] == '\n')) {
+                        pos++;
+                    }
+                    return res;
+                }
+            }
+
+            char eol = '\0';
+            StringBuilder result = new StringBuilder(80);
+            /* Typical Line Length */
+
+            result.append(buf, pos, count - pos);
+            pos = count;
+            while (true) {
+                if (eol == '\n') {
+                    return result.toString();
+                }
+                // attempt to fill buffer
+                if (fillbuf() == -1) {
+                    // characters or null.
+                    return result.length() > 0 || eol != '\0' ? result
+                            .toString() : null;
+                }
+                for (int charPos = pos; charPos < count; charPos++) {
+                    if (eol == '\0') {
+                        if ((buf[charPos] == '\n' || buf[charPos] == '\r')) {
+                            eol = buf[charPos];
+                        }
+                    } else if (eol == '\r' && (buf[charPos] == '\n')) {
+                        if (charPos > pos) {
+                            result.append(buf, pos, charPos - pos - 1);
+                        }
+                        pos = charPos + 1;
+                        return result.toString();
+                    } else {
+                        if (charPos > pos) {
+                            result.append(buf, pos, charPos - pos - 1);
+                        }
+                        pos = charPos;
+                        return result.toString();
+                    }
+                }
+                if (eol == '\0') {
+                    result.append(buf, pos, count - pos);
+                } else {
+                    result.append(buf, pos, count - pos - 1);
+                }
+                pos = count;
+            }
+        }
+
+    }
+
+    /**
+     * Indicates whether this reader is ready to be read without blocking.
+     *
+     * @return {@code true} if this reader will not block when {@code read} is
+     *         called, {@code false} if unknown or blocking will occur.
+     * @throws IOException
+     *             if this reader is closed or some other I/O error occurs.
+     * @see #read()
+     * @see #read(char[], int, int)
+     * @see #readLine()
+     */
+    @Override
+    public boolean ready() throws IOException {
+        synchronized (lock) {
+            if (isClosed()) {
+                throw new IOException();
+            }
+            return ((count - pos) > 0) || in.ready();
+        }
+    }
+
+    /**
+     * Resets this reader's position to the last {@code mark()} location.
+     * Invocations of {@code read()} and {@code skip()} will occur from this new
+     * location.
+     *
+     * @throws IOException
+     *             if this reader is closed or no mark has been set.
+     * @see #mark(int)
+     * @see #markSupported()
+     */
+    @Override
+    public void reset() throws IOException {
+        synchronized (lock) {
+            if (isClosed()) {
+                throw new IOException();
+            }
+            if (markpos == -1) {
+                throw new IOException();
+            }
+            pos = markpos;
+        }
+    }
+
+    /**
+     * Skips {@code amount} characters in this reader. Subsequent
+     * {@code read()}s will not return these characters unless {@code reset()}
+     * is used. Skipping characters may invalidate a mark if {@code readlimit}
+     * is surpassed.
+     *
+     * @param amount
+     *            the maximum number of characters to skip.
+     * @return the number of characters actually skipped.
+     * @throws IllegalArgumentException
+     *             if {@code amount < 0}.
+     * @throws IOException
+     *             if this reader is closed or some other I/O error occurs.
+     * @see #mark(int)
+     * @see #markSupported()
+     * @see #reset()
+     */
+    @Override
+    public long skip(long amount) throws IOException {
+        if (amount < 0) {
+            throw new IllegalArgumentException();
+        }
+        synchronized (lock) {
+            if (isClosed()) {
+                throw new IOException();
+            }
+            if (amount < 1) {
+                return 0;
+            }
+            if (count - pos >= amount) {
+                pos += amount;
+                return amount;
+            }
+
+            long read = count - pos;
+            pos = count;
+            while (read < amount) {
+                if (fillbuf() == -1) {
+                    return read;
+                }
+                if (count - pos >= amount - read) {
+                    pos += amount - read;
+                    return amount;
+                }
+                // Couldn't get all the characters, skip what we read
+                read += (count - pos);
+                pos = count;
+            }
+            return amount;
+        }
+    }
+
+    static class MarkLimitExceededException extends IOException
+    {
+    }
+
+    protected void setEnforceMarkLimit(boolean b)
+    {
+        enforceMarkLimit = b;
+    }
+}

--- a/api/src/org/labkey/api/reader/ReaderFactory.java
+++ b/api/src/org/labkey/api/reader/ReaderFactory.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.api.reader;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 
 /**
@@ -25,5 +24,5 @@ import java.io.IOException;
  */
 public interface ReaderFactory
 {
-    BufferedReader getReader() throws IOException;
+    TabBufferedReader getReader() throws IOException;
 }

--- a/api/src/org/labkey/api/reader/Readers.java
+++ b/api/src/org/labkey/api/reader/Readers.java
@@ -74,16 +74,24 @@ public class Readers
      */
     public static BufferedReader getBOMDetectingReader(InputStream in) throws IOException
     {
-        BOMInputStream bos = new BOMInputStream(in, ByteOrderMark.UTF_8, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_32BE, ByteOrderMark.UTF_32LE);
-        Charset charset = bos.hasBOM() ? Charset.forName(bos.getBOM().getCharsetName()) : StringUtilsLabKey.DEFAULT_CHARSET;
-        return new BufferedReader(new InputStreamReader(bos, charset));
+        return new BufferedReader(getBOMDetectingUnbufferedReader(in));
     }
 
     /**
      * Detects text file character encoding based on BOM... falling back on UTF-8 if no BOM present
      */
-    public static BufferedReader getBOMDetectingReader(File file) throws IOException
+    private static Reader getBOMDetectingUnbufferedReader(InputStream in) throws IOException
     {
-        return getBOMDetectingReader(new FileInputStream(file));
+        BOMInputStream bos = new BOMInputStream(in, ByteOrderMark.UTF_8, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_32BE, ByteOrderMark.UTF_32LE);
+        Charset charset = bos.hasBOM() ? Charset.forName(bos.getBOM().getCharsetName()) : StringUtilsLabKey.DEFAULT_CHARSET;
+        return new InputStreamReader(bos, charset);
+    }
+
+    /**
+     * Detects text file character encoding based on BOM... falling back on UTF-8 if no BOM present
+     */
+    public static Reader getBOMDetectingUnbufferedReader(File file) throws IOException
+    {
+        return getBOMDetectingUnbufferedReader(new FileInputStream(file));
     }
 }

--- a/api/src/org/labkey/api/reader/TabBufferedReader.java
+++ b/api/src/org/labkey/api/reader/TabBufferedReader.java
@@ -1,0 +1,157 @@
+package org.labkey.api.reader;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.lang.reflect.Field;
+
+/**
+ * A subclass of {@link BufferedReader} that's specifically designed to work with {@link TabLoader}'s infer fields
+ * capability. Our previous approach used {@link BufferedReader#mark(int)} to set a fixed size read-ahead buffer prior
+ * to import. BufferedReader allocates the entire buffer upfront and never resizes it, which restricted our ability to
+ * infer a large number of rows, since every import incurred the cost of a large buffer. TabBufferedReader starts with
+ * a relatively small read-ahead buffer and grows it as needed, the goal being to accommodate inferring and importing
+ * very large tables while incurring low memory footprint for smaller tables. This class also adjusts its behavior if
+ * the exact size of the input is known, for example, when reading from a file or a CharSequence; in this case, the
+ * buffer will never grow larger than the input size.
+ *
+ * Read-ahead mode is initiated by calling {@link #setReadAhead()} and ended by calling {@link #resetReadAhead()}. The
+ * key parameters that control read-ahead buffering are immediately below and can be adjusted to refine the behavior.
+ * The read-ahead buffer is initialized to input size or INITIAL_BUFFER_SIZE, whichever is smaller. Before each line is
+ * read, the remaining buffer space is checked; if it's smaller than two times the largest row seen so far then the
+ * buffer is expanded. The new buffer size is double the previous size, though growth is always limited to
+ * MAX_BUFFER_SIZE_INCREMENT and total size is never larger than the smaller of ABSOLUTE_MAX_BUFFER_SIZE or input size.
+ * Once created, all existing data are copied over to the new buffer and reading continues.
+ *
+ * Because {@link BufferedReader}'s buffering details are all private, this class must use reflection to manipulate a
+ * handful of buffer-controlling member variables: readAheadLimitField, markedChar, and nextChar.
+ */
+class TabBufferedReader extends BufferedReader
+{
+    // All buffer sizes are in characters (which are 2 bytes each)
+    private static final int ABSOLUTE_MAX_BUFFER_SIZE = 50*1024*1024;  // Maximum buffer size (unless input size is smaller)
+    private static final int MAX_BUFFER_SIZE_INCREMENT = 10*1024*1024; // Largest buffer size increment
+    private static final int INITIAL_BUFFER_SIZE = 1024*1024;          // Initial buffer size (unless input size is smaller)
+
+    // Maximum buffer size for this reader. Smaller than ABSOLUTE_MAX_BUFFER_SIZE if input size is known to be smaller.
+    private final int _maxBufferSize;
+    private final Field _readAheadLimitField;
+    private final Field _nextCharField;
+    private final Field _markedCharField;
+
+    private boolean _readAhead = false;
+    private int _currentBufferSize;
+    private int _maxLineLength = 10 * 1024; // Just an initial guess... this will increase as larger rows are read
+    private int _markedChar = -1;
+
+    private TabBufferedReader(@NotNull Reader in, int initialBufferSize, int maxBufferSize)
+    {
+        super(in, initialBufferSize);
+        _currentBufferSize = initialBufferSize;
+        _maxBufferSize = maxBufferSize;
+
+        try
+        {
+            _readAheadLimitField = BufferedReader.class.getDeclaredField("readAheadLimit");
+            _readAheadLimitField.setAccessible(true);
+            _nextCharField = BufferedReader.class.getDeclaredField("nextChar");
+            _nextCharField.setAccessible(true);
+            _markedCharField = BufferedReader.class.getDeclaredField("markedChar");
+            _markedCharField.setAccessible(true);
+        }
+        catch (NoSuchFieldException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public TabBufferedReader(@NotNull Reader in, long exactCharacterCount)
+    {
+        this(in, getInitialBufferSize(exactCharacterCount), getMaxBufferSize(exactCharacterCount));
+    }
+
+    public TabBufferedReader(@NotNull Reader in)
+    {
+        this(in, INITIAL_BUFFER_SIZE, ABSOLUTE_MAX_BUFFER_SIZE);
+    }
+
+    private static int getInitialBufferSize(long exactCharacterCount)
+    {
+        return (int)Math.min(exactCharacterCount, INITIAL_BUFFER_SIZE);
+    }
+
+    private static int getMaxBufferSize(long exactCharacterCount)
+    {
+        return (int)Math.min(exactCharacterCount, ABSOLUTE_MAX_BUFFER_SIZE);
+    }
+
+    public void setReadAhead() throws IOException
+    {
+        mark(_currentBufferSize);
+        _readAhead = true;
+        try
+        {
+            _markedChar = _markedCharField.getInt(this);
+        }
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void resetReadAhead() throws IOException
+    {
+        reset();
+        _readAhead = false;
+        _markedChar = -1;
+    }
+
+    @Override
+    public String readLine() throws IOException
+    {
+        if (!_readAhead || ensureBuffer())
+        {
+            String line = super.readLine();
+
+            if (null != line && line.length() > _maxLineLength)
+                _maxLineLength = line.length();
+
+            return line;
+        }
+
+        return null;
+    }
+
+    // Try to ensure enough room in the buffer for the line that's about to be read. We don't know how long that line
+    // is, so just verify that there's enough buffer space for double the longest line seen so far; if not, attempt to
+    // expand the buffer. Return false if we can't expand the buffer any more; in that case, caller must stop reading.
+    private boolean ensureBuffer()
+    {
+        try
+        {
+            int delta = _nextCharField.getInt(this) - _markedChar + (_maxLineLength * 2);
+            if (delta >= _currentBufferSize)
+            {
+                // Double the buffer size, but never increase by more than MAX_BUFFER_SIZE_INCREMENT
+                int targetBufferSize = Math.min(_currentBufferSize * 2, _currentBufferSize + MAX_BUFFER_SIZE_INCREMENT);
+                // And always stay at or below _maxBufferSize
+                int newBufferSize = Math.min(targetBufferSize, _maxBufferSize);
+
+                // If we haven't increased enough to accommodate a new line then bail out
+                if (newBufferSize < _currentBufferSize + (_maxLineLength * 2))
+                    return false;
+
+                _currentBufferSize = newBufferSize;
+                _readAheadLimitField.set(this, _currentBufferSize);
+            }
+        }
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+
+        return true;
+    }
+}

--- a/api/src/org/labkey/api/reader/TabBufferedReader.java
+++ b/api/src/org/labkey/api/reader/TabBufferedReader.java
@@ -2,21 +2,20 @@ package org.labkey.api.reader;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
-import java.lang.reflect.Field;
 
 /**
  * A subclass of {@link BufferedReader} that's specifically designed to work with {@link TabLoader}'s infer fields
  * capability. Our previous approach used {@link BufferedReader#mark(int)} to set a fixed size read-ahead buffer prior
- * to import. BufferedReader allocates the entire buffer upfront and never resizes it, which restricted our ability to
- * infer a large number of rows, since every import incurred the cost of a large buffer. TabBufferedReader starts with
+ * to import. java.io.BufferedReader allocates the entire buffer upfront and never resizes it, which restricted our ability to
+ * infer a large number of rows, since every import incurred the cost of a large buffer. TabBufferedReader uses an alternate
+ * implementation that starts with
  * a relatively small read-ahead buffer and grows it as needed, the goal being to accommodate inferring and importing
  * very large tables while incurring low memory footprint for smaller tables. This class also adjusts its behavior if
  * the exact size of the input is known, for example, when reading from a file or a CharSequence; in this case, the
  * buffer will never grow larger than the input size.
- *
+ * <p>
  * Read-ahead mode is initiated by calling {@link #setReadAhead()} and ended by calling {@link #resetReadAhead()}. The
  * key parameters that control read-ahead buffering are immediately below and can be adjusted to refine the behavior.
  * The read-ahead buffer is initialized to input size or INITIAL_BUFFER_SIZE, whichever is smaller. Before each line is
@@ -24,47 +23,20 @@ import java.lang.reflect.Field;
  * buffer is expanded. The new buffer size is double the previous size, though growth is always limited to
  * MAX_BUFFER_SIZE_INCREMENT and total size is never larger than the smaller of ABSOLUTE_MAX_BUFFER_SIZE or input size.
  * Once created, all existing data are copied over to the new buffer and reading continues.
- *
- * Because {@link BufferedReader}'s buffering details are all private, this class must use reflection to manipulate a
- * handful of buffer-controlling member variables: readAheadLimitField, markedChar, and nextChar.
  */
-class TabBufferedReader extends BufferedReader
+class TabBufferedReader extends org.labkey.api.reader.BufferedReader
 {
     // All buffer sizes are in characters (which are 2 bytes each)
     private static final int ABSOLUTE_MAX_BUFFER_SIZE = 50*1024*1024;  // Maximum buffer size (unless input size is smaller)
-    private static final int MAX_BUFFER_SIZE_INCREMENT = 10*1024*1024; // Largest buffer size increment
-    private static final int INITIAL_BUFFER_SIZE = 1024*1024;          // Initial buffer size (unless input size is smaller)
+    private static final int INITIAL_BUFFER_SIZE = 32*1024;            // Initial buffer size (unless input size is smaller)
 
     // Maximum buffer size for this reader. Smaller than ABSOLUTE_MAX_BUFFER_SIZE if input size is known to be smaller.
     private final int _maxBufferSize;
-    private final Field _readAheadLimitField;
-    private final Field _nextCharField;
-    private final Field _markedCharField;
-
-    private boolean _readAhead = false;
-    private int _currentBufferSize;
-    private int _maxLineLength = 10 * 1024; // Just an initial guess... this will increase as larger rows are read
-    private int _markedChar = -1;
 
     private TabBufferedReader(@NotNull Reader in, int initialBufferSize, int maxBufferSize)
     {
         super(in, initialBufferSize);
-        _currentBufferSize = initialBufferSize;
         _maxBufferSize = maxBufferSize;
-
-        try
-        {
-            _readAheadLimitField = BufferedReader.class.getDeclaredField("readAheadLimit");
-            _readAheadLimitField.setAccessible(true);
-            _nextCharField = BufferedReader.class.getDeclaredField("nextChar");
-            _nextCharField.setAccessible(true);
-            _markedCharField = BufferedReader.class.getDeclaredField("markedChar");
-            _markedCharField.setAccessible(true);
-        }
-        catch (NoSuchFieldException e)
-        {
-            throw new RuntimeException(e);
-        }
     }
 
     public TabBufferedReader(@NotNull Reader in, long exactCharacterCount)
@@ -87,71 +59,37 @@ class TabBufferedReader extends BufferedReader
         return (int)Math.min(exactCharacterCount, ABSOLUTE_MAX_BUFFER_SIZE);
     }
 
+    /*
+     * NOTE the behavior of setReadAhead() is different in from Reader.mark()
+     * in that it prevents over-running the readAheadLimit.  It is also
+     * different from commons.io.input.BoundedReader in that readLine()
+     * will not arbitrarily truncate a line in the middle.  You'll get the
+     * whole line or none of it.
+     */
     public void setReadAhead() throws IOException
     {
-        mark(_currentBufferSize);
-        _readAhead = true;
-        try
-        {
-            _markedChar = _markedCharField.getInt(this);
-        }
-        catch (IllegalAccessException e)
-        {
-            throw new RuntimeException(e);
-        }
+        mark(_maxBufferSize);
+        setEnforceMarkLimit(true);
     }
 
     public void resetReadAhead() throws IOException
     {
         reset();
-        _readAhead = false;
-        _markedChar = -1;
+        // NOTE reset doesn't actually remove the mark , so we have call setEnforceMarkLimit(false)
+        // could also implement super.removeMark()
+        setEnforceMarkLimit(false);
     }
 
     @Override
     public String readLine() throws IOException
     {
-        if (!_readAhead || ensureBuffer())
-        {
-            String line = super.readLine();
-
-            if (null != line && line.length() > _maxLineLength)
-                _maxLineLength = line.length();
-
-            return line;
-        }
-
-        return null;
-    }
-
-    // Try to ensure enough room in the buffer for the line that's about to be read. We don't know how long that line
-    // is, so just verify that there's enough buffer space for double the longest line seen so far; if not, attempt to
-    // expand the buffer. Return false if we can't expand the buffer any more; in that case, caller must stop reading.
-    private boolean ensureBuffer()
-    {
         try
         {
-            int delta = _nextCharField.getInt(this) - _markedChar + (_maxLineLength * 2);
-            if (delta >= _currentBufferSize)
-            {
-                // Double the buffer size, but never increase by more than MAX_BUFFER_SIZE_INCREMENT
-                int targetBufferSize = Math.min(_currentBufferSize * 2, _currentBufferSize + MAX_BUFFER_SIZE_INCREMENT);
-                // And always stay at or below _maxBufferSize
-                int newBufferSize = Math.min(targetBufferSize, _maxBufferSize);
-
-                // If we haven't increased enough to accommodate a new line then bail out
-                if (newBufferSize < _currentBufferSize + (_maxLineLength * 2))
-                    return false;
-
-                _currentBufferSize = newBufferSize;
-                _readAheadLimitField.set(this, _currentBufferSize);
-            }
+            return super.readLine();
         }
-        catch (IllegalAccessException e)
+        catch (MarkLimitExceededException x)
         {
-            throw new RuntimeException(e);
+            return null;
         }
-
-        return true;
     }
 }

--- a/api/src/org/labkey/api/reader/TabLoader.java
+++ b/api/src/org/labkey/api/reader/TabLoader.java
@@ -34,7 +34,6 @@ import org.labkey.api.util.Filter;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.writer.PrintWriters;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -332,7 +331,7 @@ public class TabLoader extends DataLoader
 
 
 
-    private CharSequence readLine(BufferedReader r, boolean skipComments, boolean skipBlankLines)
+    private CharSequence readLine(TabBufferedReader r, boolean skipComments, boolean skipBlankLines)
     {
         String line = readOneTextLine(r, skipComments, skipBlankLines);
         if (null == line || null == _lineDelimiter)
@@ -354,7 +353,7 @@ public class TabLoader extends DataLoader
     }
 
 
-    private String readOneTextLine(BufferedReader r, boolean skipComments, boolean skipBlankLines)
+    private String readOneTextLine(TabBufferedReader r, boolean skipComments, boolean skipBlankLines)
     {
         try
         {
@@ -377,7 +376,7 @@ public class TabLoader extends DataLoader
 
     Pattern _replaceDoubleQuotes = null;
 
-    private String[] readFields(BufferedReader r, @Nullable ColumnDescriptor[] columns)
+    private String[] readFields(TabBufferedReader r, @Nullable ColumnDescriptor[] columns)
     {
         CharSequence line = readLine(r, true, !isIncludeBlankLines());
 
@@ -648,7 +647,7 @@ public class TabLoader extends DataLoader
 
     public class TabLoaderIterator extends DataLoaderIterator
     {
-        private final BufferedReader reader;
+        private final TabBufferedReader reader;
 
         protected TabLoaderIterator() throws IOException
         {


### PR DESCRIPTION
#### Rationale
`TabLoader` uses `BufferedReader.mark(int)` to read data for inferring column data types, then `BufferedReader.reset()` to back up and actually import the data. `mark(int)` specifies the buffer size and `BufferedReader` allocates the entire buffer upfront and never resizes it, which restricts our ability to infer a large number of rows, since every import incurs the cost of a large buffer. `TabBufferedReader` addresses this limitation and provides more flexibility. It extends a new implementation of `BufferedReader` that starts with a small read-ahead buffer and grows it as needed. The goal here is to accommodate inferring and importing very large tables while using low memory footprint for smaller tables.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1244
* https://github.com/LabKey/platform/pull/1257