### PR TITLE
Issue 40229: targetedms lookups target DB schema TableInfo

### DIFF
--- a/experiment/src/org/labkey/experiment/api/InputForeignKey.java
+++ b/experiment/src/org/labkey/experiment/api/InputForeignKey.java
@@ -81,13 +81,13 @@ public class InputForeignKey extends LookupForeignKey
             @Override
             public String getPublicName()
             {
-                return null;
+                return getName();
             }
 
             @Override
             public String getPublicSchemaName()
             {
-                return null;
+                return _schema.getName();
             }
 
             @Override


### PR DESCRIPTION
#### Rationale
We want lookups in the tables that we expose through the schema browser to be targeting other tables as exposed in the schema browser, not the lower level SchemaTableInfos

#### Changes
Improve metadata on special lookup types so that they don't report null for their schema name and give a better showing in the schema browser