### PR TITLE
enable crawler

### DIFF
--- a/study/test/src/org/labkey/test/tests/search/SearchTest.java
+++ b/study/test/src/org/labkey/test/tests/search/SearchTest.java
@@ -28,6 +28,7 @@ import org.labkey.test.pages.core.admin.logger.ManagerPage;
 import org.labkey.test.tests.StudyBaseTest;
 import org.labkey.test.tests.issues.IssuesTest;
 import org.labkey.test.util.ApiPermissionsHelper;
+import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.IssuesHelper;
 import org.labkey.test.util.Log4jUtils;
 import org.labkey.test.util.LogMethod;
@@ -109,6 +110,7 @@ public abstract class SearchTest extends StudyBaseTest
     {
         Log4jUtils.setLogLevel("org.labkey.search", ManagerPage.LoggingLevel.DEBUG);
         Log4jUtils.setLogLevel("org.labkey.wiki", ManagerPage.LoggingLevel.DEBUG);
+        SearchAdminAPIHelper.startCrawler(getDriver());
         _searchHelper.initialize();
         enableEmailRecorder();
     }
@@ -417,5 +419,8 @@ public abstract class SearchTest extends StudyBaseTest
     public static void resetLogger()
     {
         Log4jUtils.resetAllLogLevels();
+
+        //Turn crawler off after test is finished
+        SearchAdminAPIHelper.pauseCrawler(getCurrentTest().getWrappedDriver());
     }
 }

--- a/study/test/src/org/labkey/test/tests/search/SearchTest.java
+++ b/study/test/src/org/labkey/test/tests/search/SearchTest.java
@@ -106,12 +106,13 @@ public abstract class SearchTest extends StudyBaseTest
         initTest.doSetup();
     }
 
+    @LogMethod
     private void doSetup()
     {
         Log4jUtils.setLogLevel("org.labkey.search", ManagerPage.LoggingLevel.DEBUG);
         Log4jUtils.setLogLevel("org.labkey.wiki", ManagerPage.LoggingLevel.DEBUG);
-        SearchAdminAPIHelper.startCrawler(getDriver());
         _searchHelper.initialize();
+        SearchAdminAPIHelper.startCrawler(getDriver());
         enableEmailRecorder();
     }
 


### PR DESCRIPTION
#### Rationale
Fix searchTests

#### Changes
Enable the search crawler for the duration of the Test(s) -- this is needed due to files being queued into the crawler for reindexing after a folder move
