### PR TITLE
Switch GetUser actions to use User.getUserProps

### DIFF
--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -484,20 +484,6 @@ public class User extends UserPrincipal implements Serializable, Cloneable
         return this == getSearchUser();
     }
 
-/*    public static synchronized User getSystemUser()
-    {
-        if (system == null)
-        {
-            Set<Role> roles = new HashSet<>();
-            roles.add(RoleManager.getRole(SiteAdminRole.class));
-            roles.add(RoleManager.getRole(PlatformDeveloperRole.class));
-            system = new LimitedUser(new User("@system", userSystem), new int[0], roles, true);
-            system.setPrincipalType(PrincipalType.SERVICE);
-        }
-        return system;
-    }
-*/
-
     public boolean isServiceUser()
     {
         return this.getPrincipalType() == PrincipalType.SERVICE;
@@ -595,28 +581,41 @@ public class User extends UserPrincipal implements Serializable, Cloneable
 
     public static JSONObject getUserProps(User user, @Nullable Container container)
     {
+        return getUserProps(user, user, container, true);
+    }
+
+    public static JSONObject getUserProps(User user, User currentUser, @Nullable Container container, boolean includePermissionProps)
+    {
+        boolean nonNullContainer = null != container;
+        boolean includeEmail = nonNullContainer && SecurityManager.canSeeUserDetails(container, currentUser);
+
         JSONObject props = new JSONObject();
 
         props.put("id", user.getUserId());
-        props.put("displayName", user.getDisplayName(user));
-        props.put("email", user.getEmail());
+        props.put("displayName", user.getDisplayName(currentUser));
+
+        if (includeEmail)
+            props.put("email", user.getEmail());
+
         props.put("phone", user.getPhone());
         props.put("avatar", user.getAvatarThumbnailPath());
 
-        boolean nonNullContainer = null != container;
-        props.put("canInsert", nonNullContainer && container.hasPermission(user, InsertPermission.class));
-        props.put("canUpdate", nonNullContainer && container.hasPermission(user, UpdatePermission.class));
-        props.put("canUpdateOwn", nonNullContainer && container.hasPermission(user, UpdatePermission.class));
-        props.put("canDelete", nonNullContainer && container.hasPermission(user, DeletePermission.class));
-        props.put("canDeleteOwn", nonNullContainer && container.hasPermission(user, DeletePermission.class));
-        props.put("isAdmin", nonNullContainer && container.hasPermission(user, AdminPermission.class));
-        props.put("isRootAdmin", user.hasRootAdminPermission());
-        props.put("isSystemAdmin", user.hasSiteAdminPermission());
-        props.put("isGuest", user.isGuest());
-        props.put("isDeveloper", user.isBrowserDev());
-        props.put("isAnalyst", user.hasRootPermission(AnalystPermission.class));
-        props.put("isTrusted", user.hasRootPermission(TrustedPermission.class));
-        props.put("isSignedIn", 0 != user.getUserId() || !user.isGuest());
+        if (includePermissionProps)
+        {
+            props.put("canInsert", nonNullContainer && container.hasPermission(user, InsertPermission.class));
+            props.put("canUpdate", nonNullContainer && container.hasPermission(user, UpdatePermission.class));
+            props.put("canUpdateOwn", nonNullContainer && container.hasPermission(user, UpdatePermission.class));
+            props.put("canDelete", nonNullContainer && container.hasPermission(user, DeletePermission.class));
+            props.put("canDeleteOwn", nonNullContainer && container.hasPermission(user, DeletePermission.class));
+            props.put("isAdmin", nonNullContainer && container.hasPermission(user, AdminPermission.class));
+            props.put("isRootAdmin", user.hasRootAdminPermission());
+            props.put("isSystemAdmin", user.hasSiteAdminPermission());
+            props.put("isGuest", user.isGuest());
+            props.put("isDeveloper", user.isBrowserDev());
+            props.put("isAnalyst", user.hasRootPermission(AnalystPermission.class));
+            props.put("isTrusted", user.hasRootPermission(TrustedPermission.class));
+            props.put("isSignedIn", 0 != user.getUserId() || !user.isGuest());
+        }
 
         return props;
     }

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -586,22 +586,17 @@ public class User extends UserPrincipal implements Serializable, Cloneable
 
     public static JSONObject getUserProps(User user, User currentUser, @Nullable Container container, boolean includePermissionProps)
     {
-        boolean nonNullContainer = null != container;
-        boolean includeEmail = nonNullContainer && SecurityManager.canSeeUserDetails(container, currentUser);
-
         JSONObject props = new JSONObject();
 
         props.put("id", user.getUserId());
         props.put("displayName", user.getDisplayName(currentUser));
-
-        if (includeEmail)
-            props.put("email", user.getEmail());
-
+        props.put("email", user.getEmail());
         props.put("phone", user.getPhone());
         props.put("avatar", user.getAvatarThumbnailPath());
 
         if (includePermissionProps)
         {
+            boolean nonNullContainer = null != container;
             props.put("canInsert", nonNullContainer && container.hasPermission(user, InsertPermission.class));
             props.put("canUpdate", nonNullContainer && container.hasPermission(user, UpdatePermission.class));
             props.put("canUpdateOwn", nonNullContainer && container.hasPermission(user, UpdatePermission.class));

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -249,9 +249,9 @@
       "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
     },
     "@labkey/components": {
-      "version": "0.67.3-fb-user-with-permissions.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.2.tgz",
-      "integrity": "sha1-SktKOagx4ps/A3dECMkuXdQeDLY=",
+      "version": "0.68.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.68.0.tgz",
+      "integrity": "sha1-gndFd1EWcxPNfx8DKQoqS7MLxvw=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.3.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.1.tgz",
-      "integrity": "sha1-qG+7cbdk5hSy+2ZdXyJOV0Cgy1A="
+      "version": "0.3.2-fb-user-with-permissions.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2-fb-user-with-permissions.1.tgz",
+      "integrity": "sha1-dQiN5yP/sAaruVTMDKWoc0gdWBc="
     },
     "@labkey/components": {
-      "version": "0.67.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.1.tgz",
-      "integrity": "sha1-H2u9ZRT25V3SvOnsHj/Nvmt/vhw=",
+      "version": "0.67.3-fb-user-with-permissions.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.1.tgz",
+      "integrity": "sha1-jWh/OsZetytg07hhQehC2F4M3D8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.3.1",
+        "@labkey/api": "0.3.2-fb-user-with-permissions.1",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.3.2-fb-user-with-permissions.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2-fb-user-with-permissions.1.tgz",
-      "integrity": "sha1-dQiN5yP/sAaruVTMDKWoc0gdWBc="
+      "version": "0.3.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2.tgz",
+      "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
     },
     "@labkey/components": {
-      "version": "0.67.3-fb-user-with-permissions.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.1.tgz",
-      "integrity": "sha1-jWh/OsZetytg07hhQehC2F4M3D8=",
+      "version": "0.67.3-fb-user-with-permissions.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.2.tgz",
+      "integrity": "sha1-SktKOagx4ps/A3dECMkuXdQeDLY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.3.2-fb-user-with-permissions.1",
+        "@labkey/api": "0.3.2",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.3-fb-user-with-permissions.2"
+    "@labkey/components": "0.68.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.3-fb-user-with-permissions.1"
+    "@labkey/components": "0.67.3-fb-user-with-permissions.2"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.1"
+    "@labkey/components": "0.67.3-fb-user-with-permissions.1"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/assay/src/client/AssayDataImport/AssayDataImport.tsx
+++ b/assay/src/client/AssayDataImport/AssayDataImport.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, ButtonToolbar, Panel } from "react-bootstrap";
 import {Map, List, fromJS} from 'immutable';
-import {ActionURL, Security, Utils, getServerContext} from '@labkey/api'
+import { ActionURL, getServerContext, PermissionTypes, Security, Utils } from '@labkey/api';
 import {
     Alert,
     Cards,
@@ -11,7 +11,6 @@ import {
     AssayDefinitionModel,
     InferDomainResponse,
     QueryColumn,
-    PermissionTypes,
     User,
     fetchAllAssays,
     importAssayRun,

--- a/assay/src/client/AssayDesigner/AssayDesigner.tsx
+++ b/assay/src/client/AssayDesigner/AssayDesigner.tsx
@@ -15,8 +15,8 @@
  */
 import React from 'react'
 import {Panel} from "react-bootstrap";
-import {ActionURL, Security, Utils, getServerContext} from "@labkey/api";
-import {Alert, LoadingSpinner, PermissionTypes, DomainFieldsDisplay, AssayProtocolModel, AssayDesignerPanels, fetchProtocol, BeforeUnload} from "@labkey/components";
+import { ActionURL, Security, Utils, getServerContext, PermissionTypes } from '@labkey/api';
+import { Alert, LoadingSpinner, DomainFieldsDisplay, AssayProtocolModel, AssayDesignerPanels, fetchProtocol, BeforeUnload } from '@labkey/components';
 
 import "@labkey/components/dist/components.css"
 

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -934,21 +934,21 @@
       }
     },
     "@labkey/api": {
-      "version": "0.3.2-fb-user-with-permissions.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2-fb-user-with-permissions.1.tgz",
-      "integrity": "sha1-dQiN5yP/sAaruVTMDKWoc0gdWBc="
+      "version": "0.3.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2.tgz",
+      "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
     },
     "@labkey/components": {
-      "version": "0.67.3-fb-user-with-permissions.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.1.tgz",
-      "integrity": "sha1-jWh/OsZetytg07hhQehC2F4M3D8=",
+      "version": "0.67.3-fb-user-with-permissions.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.2.tgz",
+      "integrity": "sha1-SktKOagx4ps/A3dECMkuXdQeDLY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.3.2-fb-user-with-permissions.1",
+        "@labkey/api": "0.3.2",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -934,21 +934,21 @@
       }
     },
     "@labkey/api": {
-      "version": "0.3.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.1.tgz",
-      "integrity": "sha1-qG+7cbdk5hSy+2ZdXyJOV0Cgy1A="
+      "version": "0.3.2-fb-user-with-permissions.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2-fb-user-with-permissions.1.tgz",
+      "integrity": "sha1-dQiN5yP/sAaruVTMDKWoc0gdWBc="
     },
     "@labkey/components": {
-      "version": "0.67.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.1.tgz",
-      "integrity": "sha1-H2u9ZRT25V3SvOnsHj/Nvmt/vhw=",
+      "version": "0.67.3-fb-user-with-permissions.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.1.tgz",
+      "integrity": "sha1-jWh/OsZetytg07hhQehC2F4M3D8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.3.1",
+        "@labkey/api": "0.3.2-fb-user-with-permissions.1",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -939,9 +939,9 @@
       "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
     },
     "@labkey/components": {
-      "version": "0.67.3-fb-user-with-permissions.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.2.tgz",
-      "integrity": "sha1-SktKOagx4ps/A3dECMkuXdQeDLY=",
+      "version": "0.68.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.68.0.tgz",
+      "integrity": "sha1-gndFd1EWcxPNfx8DKQoqS7MLxvw=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",

--- a/core/package.json
+++ b/core/package.json
@@ -94,8 +94,8 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "0.3.1",
-    "@labkey/components": "0.67.1",
+    "@labkey/api": "0.3.2-fb-user-with-permissions.1",
+    "@labkey/components": "0.67.3-fb-user-with-permissions.1",
     "@labkey/eslint-config-react": "0.0.5",
     "react-toggle-button": "2.2.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -94,8 +94,8 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "0.3.2-fb-user-with-permissions.1",
-    "@labkey/components": "0.67.3-fb-user-with-permissions.1",
+    "@labkey/api": "0.3.2",
+    "@labkey/components": "0.67.3-fb-user-with-permissions.2",
     "@labkey/eslint-config-react": "0.0.5",
     "react-toggle-button": "2.2.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -95,7 +95,7 @@
   },
   "dependencies": {
     "@labkey/api": "0.3.2",
-    "@labkey/components": "0.67.3-fb-user-with-permissions.2",
+    "@labkey/components": "0.68.0",
     "@labkey/eslint-config-react": "0.0.5",
     "react-toggle-button": "2.2.0"
   },

--- a/core/src/org/labkey/core/query/UserAvatarDisplayColumnFactory.java
+++ b/core/src/org/labkey/core/query/UserAvatarDisplayColumnFactory.java
@@ -24,7 +24,6 @@ import org.labkey.api.data.RenderContext;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
@@ -54,7 +53,7 @@ public class UserAvatarDisplayColumnFactory implements DisplayColumnFactory
             public String renderURL(RenderContext ctx)
             {
                 User user = getUserFromCtx(ctx);
-                return (user != null && user.getAvatarUrl() != null) ? user.getAvatarThumbnailPath() : null;
+                return user != null ? user.getAvatarThumbnailPath() : null;
             }
 
             @Override

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -2559,12 +2559,17 @@ public class UserController extends SpringActionController
             if (nameFilter.length() > 0)
                 response.put("name", nameFilter);
 
+            boolean includeEmail = SecurityManager.canSeeUserDetails(container, currentUser);
+
             for (User user : users)
             {
                 //according to the docs, startsWith will return true even if nameFilter is empty string
                 if (user.getEmail().toLowerCase().startsWith(nameFilter) || user.getDisplayName(null).toLowerCase().startsWith(nameFilter))
                 {
                     JSONObject userInfo = User.getUserProps(user, currentUser, container, false);
+
+                    if (!includeEmail)
+                        userInfo.remove("email");
 
                     // Backwards compatibility. This interface specifies "userId" while User.getUserProps() specifies "id"
                     userInfo.put("userId", user.getUserId());

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -249,9 +249,9 @@
       "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
     },
     "@labkey/components": {
-      "version": "0.67.3-fb-user-with-permissions.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.2.tgz",
-      "integrity": "sha1-SktKOagx4ps/A3dECMkuXdQeDLY=",
+      "version": "0.68.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.68.0.tgz",
+      "integrity": "sha1-gndFd1EWcxPNfx8DKQoqS7MLxvw=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.3.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.1.tgz",
-      "integrity": "sha1-qG+7cbdk5hSy+2ZdXyJOV0Cgy1A="
+      "version": "0.3.2-fb-user-with-permissions.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2-fb-user-with-permissions.1.tgz",
+      "integrity": "sha1-dQiN5yP/sAaruVTMDKWoc0gdWBc="
     },
     "@labkey/components": {
-      "version": "0.67.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.1.tgz",
-      "integrity": "sha1-H2u9ZRT25V3SvOnsHj/Nvmt/vhw=",
+      "version": "0.67.3-fb-user-with-permissions.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.1.tgz",
+      "integrity": "sha1-jWh/OsZetytg07hhQehC2F4M3D8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.3.1",
+        "@labkey/api": "0.3.2-fb-user-with-permissions.1",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.3.2-fb-user-with-permissions.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2-fb-user-with-permissions.1.tgz",
-      "integrity": "sha1-dQiN5yP/sAaruVTMDKWoc0gdWBc="
+      "version": "0.3.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2.tgz",
+      "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
     },
     "@labkey/components": {
-      "version": "0.67.3-fb-user-with-permissions.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.1.tgz",
-      "integrity": "sha1-jWh/OsZetytg07hhQehC2F4M3D8=",
+      "version": "0.67.3-fb-user-with-permissions.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.2.tgz",
+      "integrity": "sha1-SktKOagx4ps/A3dECMkuXdQeDLY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.3.2-fb-user-with-permissions.1",
+        "@labkey/api": "0.3.2",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.3-fb-user-with-permissions.2"
+    "@labkey/components": "0.68.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.3-fb-user-with-permissions.1"
+    "@labkey/components": "0.67.3-fb-user-with-permissions.2"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.1"
+    "@labkey/components": "0.67.3-fb-user-with-permissions.1"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -249,9 +249,9 @@
       "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
     },
     "@labkey/components": {
-      "version": "0.67.3-fb-user-with-permissions.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.2.tgz",
-      "integrity": "sha1-SktKOagx4ps/A3dECMkuXdQeDLY=",
+      "version": "0.68.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.68.0.tgz",
+      "integrity": "sha1-gndFd1EWcxPNfx8DKQoqS7MLxvw=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.3.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.1.tgz",
-      "integrity": "sha1-qG+7cbdk5hSy+2ZdXyJOV0Cgy1A="
+      "version": "0.3.2-fb-user-with-permissions.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2-fb-user-with-permissions.1.tgz",
+      "integrity": "sha1-dQiN5yP/sAaruVTMDKWoc0gdWBc="
     },
     "@labkey/components": {
-      "version": "0.67.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.1.tgz",
-      "integrity": "sha1-H2u9ZRT25V3SvOnsHj/Nvmt/vhw=",
+      "version": "0.67.3-fb-user-with-permissions.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.1.tgz",
+      "integrity": "sha1-jWh/OsZetytg07hhQehC2F4M3D8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.3.1",
+        "@labkey/api": "0.3.2-fb-user-with-permissions.1",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.3.2-fb-user-with-permissions.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2-fb-user-with-permissions.1.tgz",
-      "integrity": "sha1-dQiN5yP/sAaruVTMDKWoc0gdWBc="
+      "version": "0.3.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2.tgz",
+      "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
     },
     "@labkey/components": {
-      "version": "0.67.3-fb-user-with-permissions.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.1.tgz",
-      "integrity": "sha1-jWh/OsZetytg07hhQehC2F4M3D8=",
+      "version": "0.67.3-fb-user-with-permissions.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.2.tgz",
+      "integrity": "sha1-SktKOagx4ps/A3dECMkuXdQeDLY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.3.2-fb-user-with-permissions.1",
+        "@labkey/api": "0.3.2",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/issues/package.json
+++ b/issues/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.3-fb-user-with-permissions.2"
+    "@labkey/components": "0.68.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/issues/package.json
+++ b/issues/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.3-fb-user-with-permissions.1"
+    "@labkey/components": "0.67.3-fb-user-with-permissions.2"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/issues/package.json
+++ b/issues/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.1"
+    "@labkey/components": "0.67.3-fb-user-with-permissions.1"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -249,9 +249,9 @@
       "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
     },
     "@labkey/components": {
-      "version": "0.67.3-fb-user-with-permissions.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.2.tgz",
-      "integrity": "sha1-SktKOagx4ps/A3dECMkuXdQeDLY=",
+      "version": "0.68.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.68.0.tgz",
+      "integrity": "sha1-gndFd1EWcxPNfx8DKQoqS7MLxvw=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.3.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.1.tgz",
-      "integrity": "sha1-qG+7cbdk5hSy+2ZdXyJOV0Cgy1A="
+      "version": "0.3.2-fb-user-with-permissions.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2-fb-user-with-permissions.1.tgz",
+      "integrity": "sha1-dQiN5yP/sAaruVTMDKWoc0gdWBc="
     },
     "@labkey/components": {
-      "version": "0.67.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.1.tgz",
-      "integrity": "sha1-H2u9ZRT25V3SvOnsHj/Nvmt/vhw=",
+      "version": "0.67.3-fb-user-with-permissions.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.1.tgz",
+      "integrity": "sha1-jWh/OsZetytg07hhQehC2F4M3D8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.3.1",
+        "@labkey/api": "0.3.2-fb-user-with-permissions.1",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.3.2-fb-user-with-permissions.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2-fb-user-with-permissions.1.tgz",
-      "integrity": "sha1-dQiN5yP/sAaruVTMDKWoc0gdWBc="
+      "version": "0.3.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2.tgz",
+      "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
     },
     "@labkey/components": {
-      "version": "0.67.3-fb-user-with-permissions.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.1.tgz",
-      "integrity": "sha1-jWh/OsZetytg07hhQehC2F4M3D8=",
+      "version": "0.67.3-fb-user-with-permissions.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.2.tgz",
+      "integrity": "sha1-SktKOagx4ps/A3dECMkuXdQeDLY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.3.2-fb-user-with-permissions.1",
+        "@labkey/api": "0.3.2",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/list/package.json
+++ b/list/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.3-fb-user-with-permissions.2"
+    "@labkey/components": "0.68.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/list/package.json
+++ b/list/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.3-fb-user-with-permissions.1"
+    "@labkey/components": "0.67.3-fb-user-with-permissions.2"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/list/package.json
+++ b/list/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.1"
+    "@labkey/components": "0.67.3-fb-user-with-permissions.1"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/list/src/client/Designer/Designer.tsx
+++ b/list/src/client/Designer/Designer.tsx
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 import React from 'react'
-import { ActionURL, Security, Domain, getServerContext } from "@labkey/api";
+import { ActionURL, Domain, getServerContext, PermissionTypes, Security } from '@labkey/api';
 import {
     Alert,
     LoadingSpinner,
-    PermissionTypes,
     ListDesignerPanels,
     ListModel,
     fetchListDesign,

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -249,9 +249,9 @@
       "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
     },
     "@labkey/components": {
-      "version": "0.67.3-fb-user-with-permissions.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.2.tgz",
-      "integrity": "sha1-SktKOagx4ps/A3dECMkuXdQeDLY=",
+      "version": "0.68.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.68.0.tgz",
+      "integrity": "sha1-gndFd1EWcxPNfx8DKQoqS7MLxvw=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.3.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.1.tgz",
-      "integrity": "sha1-qG+7cbdk5hSy+2ZdXyJOV0Cgy1A="
+      "version": "0.3.2-fb-user-with-permissions.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2-fb-user-with-permissions.1.tgz",
+      "integrity": "sha1-dQiN5yP/sAaruVTMDKWoc0gdWBc="
     },
     "@labkey/components": {
-      "version": "0.67.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.1.tgz",
-      "integrity": "sha1-H2u9ZRT25V3SvOnsHj/Nvmt/vhw=",
+      "version": "0.67.3-fb-user-with-permissions.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.1.tgz",
+      "integrity": "sha1-jWh/OsZetytg07hhQehC2F4M3D8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.3.1",
+        "@labkey/api": "0.3.2-fb-user-with-permissions.1",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.3.2-fb-user-with-permissions.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2-fb-user-with-permissions.1.tgz",
-      "integrity": "sha1-dQiN5yP/sAaruVTMDKWoc0gdWBc="
+      "version": "0.3.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2.tgz",
+      "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
     },
     "@labkey/components": {
-      "version": "0.67.3-fb-user-with-permissions.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.1.tgz",
-      "integrity": "sha1-jWh/OsZetytg07hhQehC2F4M3D8=",
+      "version": "0.67.3-fb-user-with-permissions.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.2.tgz",
+      "integrity": "sha1-SktKOagx4ps/A3dECMkuXdQeDLY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.3.2-fb-user-with-permissions.1",
+        "@labkey/api": "0.3.2",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/query/package.json
+++ b/query/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.3-fb-user-with-permissions.2"
+    "@labkey/components": "0.68.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/query/package.json
+++ b/query/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.3-fb-user-with-permissions.1"
+    "@labkey/components": "0.67.3-fb-user-with-permissions.2"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/query/package.json
+++ b/query/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.1"
+    "@labkey/components": "0.67.3-fb-user-with-permissions.1"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -249,9 +249,9 @@
       "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
     },
     "@labkey/components": {
-      "version": "0.67.3-fb-user-with-permissions.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.2.tgz",
-      "integrity": "sha1-SktKOagx4ps/A3dECMkuXdQeDLY=",
+      "version": "0.68.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.68.0.tgz",
+      "integrity": "sha1-gndFd1EWcxPNfx8DKQoqS7MLxvw=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.3.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.1.tgz",
-      "integrity": "sha1-qG+7cbdk5hSy+2ZdXyJOV0Cgy1A="
+      "version": "0.3.2-fb-user-with-permissions.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2-fb-user-with-permissions.1.tgz",
+      "integrity": "sha1-dQiN5yP/sAaruVTMDKWoc0gdWBc="
     },
     "@labkey/components": {
-      "version": "0.67.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.1.tgz",
-      "integrity": "sha1-H2u9ZRT25V3SvOnsHj/Nvmt/vhw=",
+      "version": "0.67.3-fb-user-with-permissions.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.1.tgz",
+      "integrity": "sha1-jWh/OsZetytg07hhQehC2F4M3D8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.3.1",
+        "@labkey/api": "0.3.2-fb-user-with-permissions.1",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -244,21 +244,21 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "0.3.2-fb-user-with-permissions.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2-fb-user-with-permissions.1.tgz",
-      "integrity": "sha1-dQiN5yP/sAaruVTMDKWoc0gdWBc="
+      "version": "0.3.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2.tgz",
+      "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
     },
     "@labkey/components": {
-      "version": "0.67.3-fb-user-with-permissions.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.1.tgz",
-      "integrity": "sha1-jWh/OsZetytg07hhQehC2F4M3D8=",
+      "version": "0.67.3-fb-user-with-permissions.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.67.3-fb-user-with-permissions.2.tgz",
+      "integrity": "sha1-SktKOagx4ps/A3dECMkuXdQeDLY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.9.0",
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.11.2",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
         "@fortawesome/react-fontawesome": "0.1.4",
-        "@labkey/api": "0.3.2-fb-user-with-permissions.1",
+        "@labkey/api": "0.3.2",
         "bootstrap": "3.4.1",
         "classnames": "2.2.6",
         "font-awesome": "4.7.0",

--- a/study/package.json
+++ b/study/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.3-fb-user-with-permissions.2"
+    "@labkey/components": "0.68.0"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/study/package.json
+++ b/study/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.3-fb-user-with-permissions.1"
+    "@labkey/components": "0.67.3-fb-user-with-permissions.2"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",

--- a/study/package.json
+++ b/study/package.json
@@ -37,7 +37,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "0.67.1"
+    "@labkey/components": "0.67.3-fb-user-with-permissions.1"
   },
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",


### PR DESCRIPTION
#### Rationale
Make use of common `User` property processing in the `user-getUsers.api` and `user-getUsersWithPermissions.api` endpoints.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/65
* https://github.com/LabKey/labkey-ui-components/pull/269

#### Changes
* Use `User.getUserProps` for user property processing.
* Let caller decide if `includePermissionProps` based properties should be included.
* Miscellaneous cleanup.
