### PR TITLE
Issue 40594: Extend AnnouncementService to allow posting to a message thread

### DIFF
--- a/announcements/src/org/labkey/announcements/api/AnnouncementImpl.java
+++ b/announcements/src/org/labkey/announcements/api/AnnouncementImpl.java
@@ -63,6 +63,12 @@ public class AnnouncementImpl implements Announcement
         _model.setRowId(rowId);
     }
 
+    @Override
+    public String getEntityId()
+    {
+        return _model.getEntityId();
+    }
+
     public String getTitle()
     {
         return _model.getTitle();

--- a/announcements/src/org/labkey/announcements/api/AnnouncementServiceImpl.java
+++ b/announcements/src/org/labkey/announcements/api/AnnouncementServiceImpl.java
@@ -67,7 +67,8 @@ public class AnnouncementServiceImpl implements AnnouncementService
         if (parentRowId != null)
         {
             Announcement parentAnnouncement = getAnnouncement(c, u, parentRowId);
-            if(parentAnnouncement == null)
+            if (parentAnnouncement == null)
+
             {
                 throw new NotFoundException("Can't find a parent announcement with the given id: " + parentRowId);
             }

--- a/api/src/org/labkey/api/announcements/api/Announcement.java
+++ b/api/src/org/labkey/api/announcements/api/Announcement.java
@@ -33,6 +33,7 @@ public interface Announcement
     String getBody();
     Date getExpires();
     int getRowId();
+    String getEntityId();
     Container getContainer();
     Collection<Attachment> getAttachments();
     String getStatus();

--- a/api/src/org/labkey/api/announcements/api/AnnouncementService.java
+++ b/api/src/org/labkey/api/announcements/api/AnnouncementService.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.announcements.api;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
@@ -40,6 +41,9 @@ public interface AnnouncementService
 
     // IRUD (Insert, Read, Update, Delete)
     Announcement insertAnnouncement(Container container, User u, String title, String body, boolean sendEmailNotification);
+
+    /** @param parentRowId optionally, the existing thread to add the post to. If null, start a new thread */
+    Announcement insertAnnouncement(Container container, User u, String title, String body, boolean sendEmailNotification, @Nullable Integer parentRowId);
 
     // Get One
     Announcement getAnnouncement(Container container, User user, int RowId);


### PR DESCRIPTION
#### Rationale
We have an API to create a new thread, but not add to an existing one. We have a new use case for the latter.

#### Changes
Simple pass-through argument to specify the parent thread, and to expose the EntityId for an announcement