### PR TITLE
Issue 40599: Support folder aliases for redirecting action-less URLs

### DIFF
--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -2248,6 +2248,12 @@ public class ContainerManager
     @Nullable
     private static Container resolveContainerPathAlias(String path, boolean top)
     {
+        // Strip any trailing slashes
+        while (path.endsWith("/"))
+        {
+            path = path.substring(0, path.length() - 1);
+        }
+
         // Simple case -- resolve directly (sans alias)
         Container aliased = getForPath(path);
         if (aliased != null)

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -837,7 +837,7 @@ public class DavController extends SpringActionController
                 // might be a little cleaner to register a javax.servlet.Filter
                 if (x.getStatus() != WebdavStatus.SC_NOT_FOUND || !"GET".equals(method))
                     throw x;
-                Container c = ContainerManager.getForPath(getResourcePath());
+                Container c = ContainerManager.resolveContainerPathAlias(getResourcePath().toString());
                 if (null == c)
                     throw x;
                 throw new RedirectException(c.getStartURL(getUser()));


### PR DESCRIPTION
#### Rationale
We only look at current container paths for resolving this lookup. We could easily support folder aliases as well, which would enable some new use cases in Panorama Public where a container gets copied as part of a workflow, and we want to have a stable URL that points to the original container before the copy, and the new copy afterwards.

#### Changes
Use existing method that first checks for a container with the exact path, and then checks for aliased containers