### PR TITLE
Issue 39324: Add mothership metrics for Sample Manager, for those items based on database counts

### DIFF
--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -460,6 +460,9 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
                 results.put("sampleSetCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.materialsource").getObject(Long.class));
                 results.put("sampleCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.material").getObject(Long.class));
 
+                results.put("dataClassCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.dataclass").getObject(Long.class));
+                results.put("dataClassRowCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.data WHERE classid IN (SELECT rowid FROm exp.dataclass)").getObject(Long.class));
+
                 return results;
             });
         }

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -461,7 +461,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
                 results.put("sampleCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.material").getObject(Long.class));
 
                 results.put("dataClassCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.dataclass").getObject(Long.class));
-                results.put("dataClassRowCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.data WHERE classid IN (SELECT rowid FROm exp.dataclass)").getObject(Long.class));
+                results.put("dataClassRowCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.data WHERE classid IN (SELECT rowid FROM exp.dataclass)").getObject(Long.class));
 
                 return results;
             });


### PR DESCRIPTION
#### Rationale
Issue [39324](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=39324) suggests some Sample Manager specific metrics that we would like to add to the mothership metric logging. This PR as a couple of the simple "select count(*) from ..." type of metrics to the ExperimentModule.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/290

#### Changes
* Add metrics for data class count and total row count across data classes
