### PR TITLE
Issue 40540: Updating a sample by re-importing does not create a timeline entry

### DIFF
--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -45,6 +45,7 @@ import org.labkey.data.xml.TableType;
 import org.labkey.data.xml.queryCustomView.FilterType;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -118,6 +119,12 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
     default void addAuditEvent(User user, Container container, AuditBehaviorType auditBehavior, QueryService.AuditAction auditAction, List<Map<String, Object>>[] parameters)
     {
         QueryService.get().addAuditEvent(user, container, this, auditBehavior, auditAction, parameters);
+    }
+
+    @SuppressWarnings("unchecked")
+    default void addAuditEvent(User user, Container container, AuditBehaviorType auditBehavior, QueryService.AuditAction auditAction, Map<String, Object> parameters)
+    {
+        QueryService.get().addAuditEvent(user, container, this, auditBehavior, auditAction, Collections.singletonList(parameters));
     }
 
     enum IndexType

--- a/api/src/org/labkey/api/dataiterator/DetailedAuditLogDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/DetailedAuditLogDataIterator.java
@@ -20,15 +20,12 @@ import org.labkey.api.data.AuditConfigurable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.exp.api.SampleSetService;
-import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.security.User;
 
 import java.io.IOException;
-import java.util.Collections;
 
 import static org.labkey.api.gwt.client.AuditBehaviorType.DETAILED;
 
@@ -88,12 +85,7 @@ public class DetailedAuditLogDataIterator extends AbstractDataIterator
                 auditType = auditConfigurable.getAuditBehavior();
 
             if (auditType == DETAILED)
-            {
-                if (_table.getPublicSchemaName().equalsIgnoreCase(SamplesSchema.SCHEMA_NAME))
-                    SampleSetService.get().addAuditEvent(_user, _container, _table, auditType, _auditAction, Collections.singletonList(((MapDataIterator) _data).getMap()));
-                else
-                    QueryService.get().addAuditEvent(_user, _container, _table, auditType, _auditAction, Collections.singletonList(((MapDataIterator) _data).getMap()));
-            }
+                _table.addAuditEvent(_user, _container, auditType, _auditAction, ((MapDataIterator) _data).getMap());
         }
 
         return true;


### PR DESCRIPTION
#### Rationale
On import with merge, sample.rowId is auto incremented as sql param. We don't re-select DbSequenceColumn columns to update those values, so the data map will always have the incremented rowId, which will be problematic for its consumer (audit log creation). 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* reselect sample rowId on merge for detailed logging
