### PR TITLE
Issue 38105: Override box plot x-axis sorting for study visit labels

### DIFF
--- a/visualization/resources/web/vis/chartWizard/genericChartPanel.js
+++ b/visualization/resources/web/vis/chartWizard/genericChartPanel.js
@@ -723,7 +723,7 @@ Ext4.define('LABKEY.ext4.GenericChartPanel', {
 
         // Issue 38105: For box plot of study visit labels, sort by sequenceNum
         if (this.renderType === 'box_plot' && this.measures.x && this.measures.x.fieldKey === 'ParticipantVisit/Visit') {
-            sortKey = 'ParticipantVisit/SequenceNum';
+            sortKey = 'ParticipantVisit/Visit/DisplayOrder, ParticipantVisit/SequenceNum';
         }
 
         var config = {

--- a/visualization/resources/web/vis/chartWizard/genericChartPanel.js
+++ b/visualization/resources/web/vis/chartWizard/genericChartPanel.js
@@ -719,6 +719,12 @@ Ext4.define('LABKEY.ext4.GenericChartPanel', {
     getQueryConfig : function(serialize)
     {
         var dataRegion = LABKEY.DataRegions[this.panelDataRegionName];
+        var sortKey = 'lsid'; // needed to keep expected ordering for legend data
+
+        // Issue 38105: For box plot of study visit labels, sort by sequenceNum
+        if (this.renderType === 'box_plot' && this.measures.x && this.measures.x.fieldKey === 'ParticipantVisit/Visit') {
+            sortKey = 'ParticipantVisit/SequenceNum';
+        }
 
         var config = {
             schemaName  : this.schemaName,
@@ -729,7 +735,7 @@ Ext4.define('LABKEY.ext4.GenericChartPanel', {
             parameters  : this.parameters,
             requiredVersion : 13.2,
             maxRows: -1,
-            sort: 'lsid', // needed to keep expected ordering for legend data
+            sort: sortKey,
             method: 'POST'
         };
 

--- a/visualization/resources/web/vis/chartWizard/genericChartPanel.js
+++ b/visualization/resources/web/vis/chartWizard/genericChartPanel.js
@@ -721,7 +721,7 @@ Ext4.define('LABKEY.ext4.GenericChartPanel', {
         var dataRegion = LABKEY.DataRegions[this.panelDataRegionName];
         var sortKey = 'lsid'; // needed to keep expected ordering for legend data
 
-        // Issue 38105: For box plot of study visit labels, sort by sequenceNum
+        // Issue 38105: For box plot of study visit labels, sort by visit display order and then sequenceNum
         if (this.renderType === 'box_plot' && this.measures.x && this.measures.x.fieldKey === 'ParticipantVisit/Visit') {
             sortKey = 'ParticipantVisit/Visit/DisplayOrder, ParticipantVisit/SequenceNum';
         }

--- a/visualization/resources/web/vis/genericChart/genericChartHelper.js
+++ b/visualization/resources/web/vis/genericChart/genericChartHelper.js
@@ -380,7 +380,7 @@ LABKEY.vis.GenericChartHelper = new function(){
         if (chartType === "box_plot")
         {
             // Issue 38105: For box plot of study visit labels, don't sort alphabetically
-            var sortFn = measures.x.fieldKey === 'ParticipantVisit/Visit' ? undefined : LABKEY.vis.discreteSortFn;
+            var sortFn = measures.x && measures.x.fieldKey === 'ParticipantVisit/Visit' ? undefined : LABKEY.vis.discreteSortFn;
 
             scales.x = {
                 scaleType: 'discrete', // Force discrete x-axis scale for box plots.

--- a/visualization/resources/web/vis/genericChart/genericChartHelper.js
+++ b/visualization/resources/web/vis/genericChart/genericChartHelper.js
@@ -379,9 +379,12 @@ LABKEY.vis.GenericChartHelper = new function(){
 
         if (chartType === "box_plot")
         {
+            // Issue 38105: For box plot of study visit labels, don't sort alphabetically
+            var sortFn = measures.x.fieldKey === 'ParticipantVisit/Visit' ? undefined : LABKEY.vis.discreteSortFn;
+
             scales.x = {
                 scaleType: 'discrete', // Force discrete x-axis scale for box plots.
-                sortFn: LABKEY.vis.discreteSortFn,
+                sortFn: sortFn,
                 tickLabelMax: DEFAULT_TICK_LABEL_MAX
             };
 


### PR DESCRIPTION
#### Rationale
Fox box plots, the default sorting function for the x-axis box labels is to sort them alphabetically. This makes sense as the default, but when the x-axis selected measure is the study visit column, this isn't ideal. In that case, the user would like for the sorting to be based on the visit's sequenceNum.

#### Changes
* when x-axis measures is ParticipantVisit/Visit explicitly sort the data by sequenceNum instead
