### PR TITLE
Issue 40605: Include link to change notification settings in pipeline status emails

### DIFF
--- a/pipeline/src/org/labkey/pipeline/api/PipelineManager.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineManager.java
@@ -44,6 +44,7 @@ import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.pipeline.PipelineService;
+import org.labkey.api.pipeline.PipelineUrls;
 import org.labkey.api.pipeline.trigger.PipelineTriggerConfig;
 import org.labkey.api.pipeline.trigger.PipelineTriggerRegistry;
 import org.labkey.api.pipeline.trigger.PipelineTriggerType;
@@ -530,27 +531,53 @@ public class PipelineManager
         protected static final String DEFAULT_BODY = "Job description: ^jobDescription^\n" +
                 "Created: ^timeCreated^\n" +
                 "Status: ^status^\n" +
-                "Additional details for this job can be obtained by navigating to this link:\n\n^dataURL^";
+                "Additional details for this job can be obtained by navigating to this link:\n\n^dataURL^\n\n" +
+                "Manage your email notifications at\n" +
+                "^setupURL^\n";
 
         protected PipelineEmailTemplate(String name)
         {
             super(name);
 
-            _replacements.add(new ReplacementParam<String>("dataURL", String.class, "Link to the job details for this pipeline job"){
+            _replacements.add(new ReplacementParam<>("dataURL", String.class, "Link to the job details for this pipeline job")
+            {
                 @Override
-                public String getValue(Container c) {return _dataUrl;}
+                public String getValue(Container c)
+                {
+                    return _dataUrl;
+                }
             });
-            _replacements.add(new ReplacementParam<String>("jobDescription", String.class, "The job description"){
+            _replacements.add(new ReplacementParam<>("jobDescription", String.class, "The job description")
+            {
                 @Override
-                public String getValue(Container c) {return _jobDescription;}
+                public String getValue(Container c)
+                {
+                    return _jobDescription;
+                }
             });
-            _replacements.add(new ReplacementParam<Date>("timeCreated", Date.class, "The date and time this job was created"){
+            _replacements.add(new ReplacementParam<>("timeCreated", Date.class, "The date and time this job was created")
+            {
                 @Override
-                public Date getValue(Container c) {return _timeCreated;}
+                public Date getValue(Container c)
+                {
+                    return _timeCreated;
+                }
             });
-            _replacements.add(new ReplacementParam<String>("status", String.class, "The job status"){
+            _replacements.add(new ReplacementParam<>("status", String.class, "The job status")
+            {
                 @Override
-                public String getValue(Container c) {return _status;}
+                public String getValue(Container c)
+                {
+                    return _status;
+                }
+            });
+            _replacements.add(new ReplacementParam<>("setupURL", String.class, "URL to configure the pipeline, including email notifications")
+            {
+                @Override
+                public String getValue(Container c)
+                {
+                    return PageFlowUtil.urlProvider(PipelineUrls.class).urlSetup(c).getURIString();
+                }
             });
 
             _replacements.addAll(super.getValidReplacements());


### PR DESCRIPTION
#### Rationale
Users can subscribe to get email notifications when pipeline jobs succeed or fail. The email includes a link to the specific job, but doesn't give good guidance on how the update their setting.

#### Changes
Add link to pipeline setup page to default email template, and make it available as a substitution parameter.