### PR TITLE
Heisenbug, make ColumnInfo collections more thread-safe

### DIFF
--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -60,6 +60,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1160,7 +1161,11 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
         if (xmlCol.isSetExcludeFromShifting())
             _isExcludeFromShifting = xmlCol.getExcludeFromShifting();
         if (xmlCol.isSetImportAliases())
-            _importAliases.addAll(Arrays.asList(xmlCol.getImportAliases().getImportAliasArray()));
+        {
+            LinkedHashSet<String> set = new LinkedHashSet<>(getImportAliasSet());
+            set.addAll(Arrays.asList(xmlCol.getImportAliases().getImportAliasArray()));
+            setImportAliasesSet(set);
+        }
         if (xmlCol.isSetConditionalFormats())
         {
             setConditionalFormats(ConditionalFormat.convertFromXML(xmlCol.getConditionalFormats()));

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -40,7 +40,6 @@ import org.labkey.api.gwt.client.FacetingBehaviorType;
 import org.labkey.api.query.AliasManager;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryParseException;
-import org.labkey.api.query.QueryService;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.StringExpressionFactory;
@@ -99,9 +98,8 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     protected String _selectName = null;
     protected ColumnInfo _displayField;
     private List<FieldKey> _sortFieldKeys = null;
-    private Map<FieldKey, ColumnInfo> _cachedSortColumns = new HashMap<>();
-    private List<ConditionalFormat> _conditionalFormats = new ArrayList<>();
-    private List<? extends IPropertyValidator> _validators = Collections.emptyList();
+    private List<ConditionalFormat> _conditionalFormats = List.of();
+    private List<? extends IPropertyValidator> _validators = List.of();
     private DisplayColumnFactory _displayColumnFactory = DEFAULT_FACTORY;
     private boolean _shouldLog = true;
     private boolean _lockName = false;
@@ -1815,7 +1813,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     public void setSortFieldKeys(List<FieldKey> sortFieldKeys)
     {
         checkLocked();
-        _sortFieldKeys = sortFieldKeys;
+        _sortFieldKeys = copyFixedList(sortFieldKeys);
     }
 
     @Override
@@ -2054,8 +2052,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     public void setConditionalFormats(@NotNull List<ConditionalFormat> formats)
     {
         checkLocked();
-        _conditionalFormats.clear();
-        _conditionalFormats.addAll(formats);
+        _conditionalFormats = copyFixedList(formats);
     }
 
     @Override
@@ -2069,7 +2066,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     public void setValidators(List<? extends IPropertyValidator> validators)
     {
         checkLocked();
-        _validators = validators;
+        _validators = copyFixedList(validators);
     }
 
     // TODO: fix up OORIndicator

--- a/api/src/org/labkey/api/data/ColumnRenderPropertiesImpl.java
+++ b/api/src/org/labkey/api/data/ColumnRenderPropertiesImpl.java
@@ -25,7 +25,10 @@ import org.labkey.api.gwt.client.FacetingBehaviorType;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.StringExpression;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -75,7 +78,8 @@ public abstract class ColumnRenderPropertiesImpl implements MutableColumnRenderP
     protected String _urlTargetWindow;
     protected String _urlCls;
     protected String _onClick;
-    protected Set<String> _importAliases = new LinkedHashSet<>();
+    // methods use Set<>, but I'm using a List<> here because it is simpler and more thread safe and explicitly preserves order
+    protected List<String> _importAliases = List.of();
     protected DefaultValueType _defaultValueType = null;
     protected FacetingBehaviorType _facetingBehaviorType = FacetingBehaviorType.AUTOMATIC;
     protected PHI _phi = PHI.NotPHI;
@@ -89,6 +93,19 @@ public abstract class ColumnRenderPropertiesImpl implements MutableColumnRenderP
     {
         checkLocked();
         return true;
+    }
+
+    /*
+     * ColumnRenderProperties live in caches so its Collection type members need to be immutable.
+     */
+    protected static <T> List<T> copyFixedList(Collection<T> src)
+    {
+        if (null == src)
+            return null;
+        if (src.isEmpty())
+            return List.of();
+        // unmodifiable arraylist does not need to be synchronized
+        return List.copyOf(src);
     }
 
     @Override
@@ -119,7 +136,7 @@ public abstract class ColumnRenderPropertiesImpl implements MutableColumnRenderP
         to._recommendedVariable = _recommendedVariable;
         to._defaultScale = _defaultScale;
         to._url = _url;
-        to._importAliases = new LinkedHashSet<>(_importAliases);
+        to._importAliases = copyFixedList(_importAliases);
         to._facetingBehaviorType = _facetingBehaviorType;
         to._crosstabColumnMember = _crosstabColumnMember;
         to._phi = _phi;
@@ -547,7 +564,9 @@ public abstract class ColumnRenderPropertiesImpl implements MutableColumnRenderP
     @NotNull
     public Set<String> getImportAliasSet()
     {
-        return _importAliases;
+        if (_importAliases.isEmpty())
+            return Set.of();
+        return Collections.unmodifiableSet(new LinkedHashSet<>(_importAliases));
     }
 
     @Override
@@ -555,7 +574,7 @@ public abstract class ColumnRenderPropertiesImpl implements MutableColumnRenderP
     {
         assert _checkLocked();
         assert importAliases != null;
-        _importAliases = importAliases;
+        _importAliases = copyFixedList(importAliases);
     }
 
     public static String convertToString(Set<String> set)

--- a/api/src/org/labkey/api/exp/PropertyDescriptor.java
+++ b/api/src/org/labkey/api/exp/PropertyDescriptor.java
@@ -401,7 +401,7 @@ public class PropertyDescriptor extends ColumnRenderPropertiesImpl implements Pa
     /** Need the string version of this method because it's called by reflection and must match by name */
     public void setImportAliases(String importAliases)
     {
-        _importAliases = ColumnRenderPropertiesImpl.convertToSet(importAliases);
+        super.setImportAliasesSet(ColumnRenderPropertiesImpl.convertToSet(importAliases));
     }
 
     @Override

--- a/api/src/org/labkey/api/reader/TabLoader.java
+++ b/api/src/org/labkey/api/reader/TabLoader.java
@@ -215,7 +215,7 @@ public class TabLoader extends DataLoader
     // This constructor doesn't support MV Indicators:
     public TabLoader(final CharSequence src, Boolean hasColumnHeaders)
     {
-        this(() -> new TabBufferedReader(new CharSequenceReader(src), src.length()), hasColumnHeaders, null);
+        this(() -> new TabBufferedReader(new CharSequenceReader(src)), hasColumnHeaders, null);
 
         if (src == null)
             throw new IllegalArgumentException("src cannot be null");

--- a/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
@@ -52,6 +52,7 @@ import org.labkey.api.view.ActionURL;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -153,7 +154,9 @@ abstract public class ExpTableImpl<C extends Enum>
     protected ColumnInfo addContainerColumn(C containerCol, ActionURL url)
     {
         var result = addColumn(containerCol);
-        result.getImportAliasSet().add("container");
+        Set<String> set = new LinkedHashSet(result.getImportAliasSet());
+        set.add("container");
+        result.setImportAliasesSet(set);
         ContainerForeignKey.initColumn(result, _userSchema, url);
         return result;
     }


### PR DESCRIPTION
#### Rationale
* fix occasional error related to LinkedHashMap
* shouldn't set BufferedReader buffer size in TabLoader()

#### Related
https://github.com/LabKey/sampleManagement/pull/296
https://github.com/LabKey/platform/pull/1294