### PR TITLE
Issue 40614: Mutating SQL exception executing DeleteReportAction

### DIFF
--- a/study/src/org/labkey/study/controllers/reports/ReportsController.java
+++ b/study/src/org/labkey/study/controllers/reports/ReportsController.java
@@ -111,6 +111,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.PrintWriter;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -160,10 +161,15 @@ public class ReportsController extends BaseStudyController
     }
 
     @RequiresPermission(UpdatePermission.class)
-    public class DeleteReportAction extends SimpleViewAction
+    public class DeleteReportAction extends FormHandlerAction<Object>
     {
         @Override
-        public ModelAndView getView(Object o, BindException errors)
+        public void validateCommand(Object target, Errors errors)
+        {
+        }
+
+        @Override
+        public boolean handlePost(Object o, BindException errors) throws Exception
         {
             String reportIdParam = getRequest().getParameter(ReportDescriptor.Prop.reportId.name());
             ReportIdentifier reportId = ReportService.get().getReportIdentifier(reportIdParam, getViewContext().getUser(), getViewContext().getContainer());
@@ -177,16 +183,27 @@ public class ReportsController extends BaseStudyController
             {
                 ReportManager.get().deleteReport(getViewContext(), report);
             }
-            String redirectUrl = getRequest().getParameter(ReportDescriptor.Prop.redirectUrl.name());
-            if (redirectUrl != null)
-                return HttpView.redirect(redirectUrl);
-            else
-                return HttpView.redirect(PageFlowUtil.urlProvider(ReportUrls.class).urlManageViews(getContainer()));
+
+            return true;
         }
 
         @Override
-        public void addNavTrail(NavTree root)
+        public URLHelper getSuccessURL(Object o)
         {
+            String redirectUrl = getRequest().getParameter(ReportDescriptor.Prop.redirectUrl.name());
+            if (redirectUrl != null)
+            {
+                try
+                {
+                    return new URLHelper(redirectUrl);
+                }
+                catch (URISyntaxException e)
+                {
+                    // ignore bad URI
+                }
+            }
+
+            return PageFlowUtil.urlProvider(ReportUrls.class).urlManageViews(getContainer());
         }
     }
 

--- a/study/src/org/labkey/study/view/participantAll.jsp
+++ b/study/src/org/labkey/study/view/participantAll.jsp
@@ -722,7 +722,7 @@
                             if (ptidLegacyReportIds.contains(reportId))
                             {
 %>
-                                <a class="labkey-text-link" href="<%=h(new ActionURL(ReportsController.DeleteReportAction.class, study.getContainer()).addParameter(ReportDescriptor.Prop.redirectUrl.name(), currentUrl).addParameter(ReportDescriptor.Prop.reportId.name(), ReportService.get().getReportIdentifier(reportId, user, getContainer()).toString()))%>">Remove Chart</a>
+                                <%=link("Remove Chart").href(new ActionURL(ReportsController.DeleteReportAction.class, study.getContainer()).addParameter(ReportDescriptor.Prop.redirectUrl.name(), currentUrl).addParameter(ReportDescriptor.Prop.reportId.name(), ReportService.get().getReportIdentifier(reportId, user, getContainer()).toString())).usePost()%>
                                 <%
                             }
                             else


### PR DESCRIPTION
#### Rationale
In the case of a "legacy" chart added to the default participant view, the "Remove Chart" link invokes DeleteReportAction via GET. We detect mutating SQL (a DELETE) and fail the operation appropriately with a big stack trace. This is not the ideal user experience...

#### Changes
* Convert DeleteReportAction to a FormHandlerAction
* Revise the "Remove Chart" link to use POST
