### PR TITLE
Issue 40571: Guests and Readers see "customize email template" on issue list

### DIFF
--- a/issues/src/org/labkey/issue/query/IssuesQueryView.java
+++ b/issues/src/org/labkey/issue/query/IssuesQueryView.java
@@ -100,6 +100,7 @@ public class IssuesQueryView extends QueryView
 
                 ActionURL customEmailTemplateUrl = PageFlowUtil.urlProvider(AdminUrls.class).getCustomizeEmailURL(getContainer(), IssueUpdateEmailTemplate.class, getViewContext().getActionURL());
                 ActionButton customEmailTemplateButton = new ActionButton(customEmailTemplateUrl, "Customize Email Template", ActionButton.Action.LINK);
+                customEmailTemplateButton.setDisplayPermission(AdminPermission.class);
                 bar.add(customEmailTemplateButton);
             }
 


### PR DESCRIPTION
#### Rationale
Only admins should see the 'Customize email template' button in Issues list
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40571