### PR TITLE
Update default sampledata location for server-side tests

### DIFF
--- a/api/src/org/labkey/api/util/JunitUtil.java
+++ b/api/src/org/labkey/api/util/JunitUtil.java
@@ -253,7 +253,7 @@ public class JunitUtil
                 message = "Sample data directory not found for [" + module.getName() + "] module.";
             }
         }
-        if (!file.exists())
+        if (message == null && !file.exists())
         {
             message = "No sample data found at [" + file.getAbsolutePath() + "].";
         }

--- a/api/src/org/labkey/api/util/JunitUtil.java
+++ b/api/src/org/labkey/api/util/JunitUtil.java
@@ -261,9 +261,9 @@ public class JunitUtil
         }
 
         if (AppProps.getInstance().isDevMode())
-            Assert.assertTrue(message, message != null);
+            Assert.assertTrue(message, message == null);
         else
-            Assume.assumeTrue(message + " Skipping test in production mode.", message != null);
+            Assume.assumeTrue(message + " Skipping test in production mode.", message == null);
 
         return file;
     }

--- a/api/src/org/labkey/api/util/JunitUtil.java
+++ b/api/src/org/labkey/api/util/JunitUtil.java
@@ -207,7 +207,7 @@ public class JunitUtil
 
         if (null == module)
         {
-            sampleDataDir = new File(projectRoot, "sampledata");
+            sampleDataDir = new File(projectRoot, "server/testAutomation/data");
         }
         else
         {

--- a/api/src/org/labkey/api/util/JunitUtil.java
+++ b/api/src/org/labkey/api/util/JunitUtil.java
@@ -16,6 +16,7 @@
 package org.labkey.api.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -36,10 +37,8 @@ import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.BrokenBarrierException;
@@ -75,8 +74,7 @@ public class JunitUtil
         fact.setIgnoringComments(true);
         fact.setNamespaceAware(false);
         DocumentBuilder builder = fact.newDocumentBuilder();
-        Document doc = builder.parse(new InputSource(new StringReader(tidy)));
-        return doc;
+        return builder.parse(new InputSource(new StringReader(tidy)));
     }
 
     /**
@@ -150,7 +148,7 @@ public class JunitUtil
         };
 
         ExecutorService pool = Executors.newFixedThreadPool(threads);
-        Collection<Future> futures = new LinkedList<>();
+        Collection<Future<?>> futures = new LinkedList<>();
 
         for (int i = 0; i < threads; i++)
             futures.add(pool.submit(runnableWrapper));
@@ -158,7 +156,7 @@ public class JunitUtil
         pool.shutdown();
         pool.awaitTermination(timeoutSeconds, TimeUnit.SECONDS);
 
-        for (Future future : futures)
+        for (Future<?> future : futures)
         {
             try
             {
@@ -195,7 +193,7 @@ public class JunitUtil
      * @throws AssertionError in dev mode if file is not found.
      * @throws org.junit.AssumptionViolatedException in production mode if file is not found.
      */
-    public static File getSampleData(@Nullable Module module, String relativePath) throws IOException
+    public static @NotNull File getSampleData(@Nullable Module module, String relativePath) throws IOException
     {
         String projectRoot = AppProps.getInstance().getProjectRoot();
 
@@ -261,9 +259,14 @@ public class JunitUtil
         }
 
         if (AppProps.getInstance().isDevMode())
+        {
+            //noinspection SimplifiableJUnitAssertion
             Assert.assertTrue(message, message == null);
+        }
         else
+        {
             Assume.assumeTrue(message + " Skipping test in production mode.", message == null);
+        }
 
         return file;
     }

--- a/core/src/org/labkey/core/notification/EmailServiceImpl.java
+++ b/core/src/org/labkey/core/notification/EmailServiceImpl.java
@@ -336,9 +336,6 @@ public class EmailServiceImpl implements EmailService
             EmailMessage msg = getBaseMessage();
             File attachment = JunitUtil.getSampleData(null, PROTOCOL_ATTACHMENT_PATH);
 
-            if (attachment == null)
-                return;
-
             assertTrue("Couldn't find " + attachment, attachment.isFile());
 
             List<String> lines = Files.readAllLines(Paths.get(attachment.toURI()), Charset.defaultCharset());
@@ -372,9 +369,6 @@ public class EmailServiceImpl implements EmailService
         {
             EmailMessage msg = getBaseMessage();
             File studySampleData = JunitUtil.getSampleData(null, "study");
-
-            if (studySampleData == null)
-                return;
 
             List<File> attachmentList = Collections.singletonList(new File(studySampleData, name));
 

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -1811,7 +1811,6 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
             assertTrue(sampledata.isDirectory());
             SearchService ss = SearchService.get();
             LuceneSearchServiceImpl lssi = (LuceneSearchServiceImpl) ss;
-            Map<String, Pair<Integer, String[]>> expectations = getExpectations();
 
             for (File file : sampledata.listFiles(File::isFile))
             {
@@ -1862,7 +1861,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
             add(map, "pptx_sample.pptx", 109, "Slide With Image", "Slide With Text", "Hello world", "How are you?");
             add(map, "rtf_sample.rtf", 11, "One on One");
             add(map, "sample.txt", 48, "Sample text file", "1", "2", "9");
-            add(map, "sql_sample.sql", 2322, "for JDBC Login support", "Container of parent, if parent has no ACLs");
+            add(map, "sql_sample.sql", 2233, "for JDBC Login support", "Container of parent, if parent has no ACLs");
             add(map, "svg_sample.svg", 18, " "); // Not empty, but just a bunch of whitespace
             add(map, "tgz_sample.tgz", 7767, "assertthat is an extension", "Custom failure messages");
             add(map, "tif_sample.tif", 0);

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -1784,7 +1784,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
                     if (null != message)
                     {
                         if (strict)
-                            fail(message);
+                            fail(file.getName() + ": " + message);
                         else
                             _log.info(file.getName() + ": " + message);
                     }
@@ -1860,7 +1860,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
             add(map, "ppt_sample.ppt", 116, "Slide With Image", "Slide With Text", "Hello world", "How are you?");
             add(map, "pptx_sample.pptx", 109, "Slide With Image", "Slide With Text", "Hello world", "How are you?");
             add(map, "rtf_sample.rtf", 11, "One on One");
-            add(map, "sample.txt", 48, "Sample text file", "1", "2", "9");
+            add(map, "sample.txt", 38, "Sample text file", "1", "2", "9");
             add(map, "sql_sample.sql", 2233, "for JDBC Login support", "Container of parent, if parent has no ACLs");
             add(map, "svg_sample.svg", 18, " "); // Not empty, but just a bunch of whitespace
             add(map, "tgz_sample.tgz", 7767, "assertthat is an extension", "Custom failure messages");


### PR DESCRIPTION
#### Rationale
`/sampledata` has been deleted from SVN. Most of it has moved to individual modules or the `testAutomation` repository. I anticipate that there are some sample data that this won't fix but it's a start.

#### Changes
* Get sample data from 'testAutomation' if no module is specified.
