### PR TITLE
Issue 40415: Server JavaScript Console not displaying trigger messages fired by ETL

### DIFF
--- a/api/src/org/labkey/api/util/SessionAppender.java
+++ b/api/src/org/labkey/api/util/SessionAppender.java
@@ -17,7 +17,7 @@ package org.labkey.api.util;
 
 import org.apache.log4j.spi.LoggingEvent;
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.collections.ConcurrentCaseInsensitiveSortedMap;
+import org.springframework.util.ConcurrentReferenceHashMap;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -48,7 +48,7 @@ public class SessionAppender extends org.apache.log4j.AppenderSkeleton
     }
 
     private static final ThreadLocal<AppenderInfo> localInfo = new ThreadLocal<>();
-    private static final Map<String, AppenderInfo> appenderInfos = new ConcurrentCaseInsensitiveSortedMap<>();
+    private static final Map<String, AppenderInfo> appenderInfos = new ConcurrentReferenceHashMap<>();
 
     // Makes appenderInfo available outside this thread
     private static void registerAppenderInfo(AppenderInfo info)
@@ -56,8 +56,8 @@ public class SessionAppender extends org.apache.log4j.AppenderSkeleton
         appenderInfos.put(info.key, info);
     }
 
-    // If accessing appenderInfo using this function ensure operations on it are thread safe as multiple threads
-    // could be accessing it.
+    // If accessing appenderInfo using this function ensure operations on the appenderInfo are thread safe as multiple
+    // threads could be accessing it.
     public static AppenderInfo getAppenderInfoByKey(String key)
     {
         return appenderInfos.get(key);
@@ -137,6 +137,11 @@ public class SessionAppender extends org.apache.log4j.AppenderSkeleton
             registerAppenderInfo(info);
             return info;
         }
+    }
+
+    public static void removeAppenderInfo()
+    {
+        localInfo.remove();
     }
 
     // set up logging for this thread, based on an already existing AppenderInfo

--- a/api/src/org/labkey/api/util/SessionAppender.java
+++ b/api/src/org/labkey/api/util/SessionAppender.java
@@ -58,7 +58,7 @@ public class SessionAppender extends org.apache.log4j.AppenderSkeleton
 
     // If accessing appenderInfo using this function ensure operations on it are thread safe as multiple threads
     // could be accessing it.
-    public static AppenderInfo getAppenderInfo(String key)
+    public static AppenderInfo getAppenderInfoByKey(String key)
     {
         return appenderInfos.get(key);
     }

--- a/api/src/org/labkey/api/util/SessionAppender.java
+++ b/api/src/org/labkey/api/util/SessionAppender.java
@@ -139,7 +139,7 @@ public class SessionAppender extends org.apache.log4j.AppenderSkeleton
         }
     }
 
-    // set up logging for this thread, based on session settings
+    // set up logging for this thread, based on an already existing AppenderInfo
     public static void initThread(AppenderInfo info)
     {
         localInfo.set(info);

--- a/api/src/org/labkey/api/util/SessionAppender.java
+++ b/api/src/org/labkey/api/util/SessionAppender.java
@@ -48,7 +48,12 @@ public class SessionAppender extends org.apache.log4j.AppenderSkeleton
     }
 
     private static final ThreadLocal<AppenderInfo> localInfo = new ThreadLocal<>();
-    private static final Map<String, AppenderInfo> appenderInfos = new ConcurrentReferenceHashMap<>();
+
+    // AppenderInfos are thread-local variables initialized with the user session. This Map allows background threads to share an
+    // active session's appenderInfo to output logs to that session's SessionAppender. When the session is ended, the
+    // thread-local appenderInfo will be released and this map, which uses weak references, will allow gc to remove and
+    // reclaim the appenderInfo entry.
+    private static final Map<String, AppenderInfo> appenderInfos = new ConcurrentReferenceHashMap<>(16, ConcurrentReferenceHashMap.ReferenceType.WEAK);
 
     // Makes appenderInfo available outside this thread
     private static void registerAppenderInfo(AppenderInfo info)

--- a/api/src/org/labkey/api/util/SessionAppender.java
+++ b/api/src/org/labkey/api/util/SessionAppender.java
@@ -56,7 +56,8 @@ public class SessionAppender extends org.apache.log4j.AppenderSkeleton
         appenderInfos.put(info.key, info);
     }
 
-    // If accessing appenderInfo using this function ensure operations on it are thread safe
+    // If accessing appenderInfo using this function ensure operations on it are thread safe as multiple threads
+    // could be accessing it.
     public static AppenderInfo getAppenderInfo(String key)
     {
         return appenderInfos.get(key);


### PR DESCRIPTION
#### Rationale
Update SessionAppender to store appender infos for cross thread access.  This is to allow trigger script console messages triggered from an ETL pipeline job to use the same appender info as the current view context.

#### Related Pull Requests
https://github.com/LabKey/dataintegration/pull/46

#### Changes
Add register mechanism to save appender infos to concurrent map.  Add functions to get appender info by key and to set the current thread's appender info to an already existing appender info.
