### PR TITLE
use getResolvedField() instead of _resolved

### DIFF
--- a/query/src/org/labkey/query/sql/QuerySelect.java
+++ b/query/src/org/labkey/query/sql/QuerySelect.java
@@ -2107,7 +2107,8 @@ groupByLoop:
         @NotNull
         public JdbcType getJdbcType()
         {
-            return null != _resolved ? _resolved.getJdbcType() : JdbcType.NULL;
+            var resolved = getResolvedField();
+            return null != resolved ? resolved.getJdbcType() : JdbcType.NULL;
         }
 
 


### PR DESCRIPTION
#### Rationale
Fields are sometimes resolved lazily, call getResovledField()
https://www.labkey.org/home/Developer/issues/issues-update.view?issueId=40644
