### PR TITLE
Fix Deleting AuthConfig Tests

### DIFF
--- a/core/src/client/AuthenticationConfiguration/authenticationConfiguration.scss
+++ b/core/src/client/AuthenticationConfiguration/authenticationConfiguration.scss
@@ -107,11 +107,13 @@ body {
 }
 
 .auth-row__delete-modal__cancel {
+  position: relative;
   margin-left: 10px;
   margin-top: 15px;
 }
 
-.auth-row__delete-modal__delete {
+.auth-row__confirm-delete {
+  position: relative;
   margin-left: 410px;
   margin-top: 15px;
 }

--- a/core/src/client/AuthenticationConfiguration/authenticationConfiguration.scss
+++ b/core/src/client/AuthenticationConfiguration/authenticationConfiguration.scss
@@ -106,16 +106,24 @@ body {
   border-bottom: 1px solid #eee;
 }
 
+.auth-row__delete-modal-bottom {
+  height: 65px;
+}
+
 .auth-row__delete-modal__cancel {
-  position: relative;
   margin-left: 10px;
-  margin-top: 15px;
+  vertical-align: middle;
+  position: relative;
+  top: 50%;
+  transform: translateY(-60%);
 }
 
 .auth-row__confirm-delete {
+  float: right;
+  margin-right: 10px;
   position: relative;
-  margin-left: 410px;
-  margin-top: 15px;
+  top: 50%;
+  transform: translateY(-60%);
 }
 
 .globalAuthConfig-textInput{

--- a/core/src/client/components/AuthRow.tsx
+++ b/core/src/client/components/AuthRow.tsx
@@ -133,7 +133,7 @@ export default class AuthRow extends PureComponent<Props, Partial<State>> {
                     <Modal.Title>Permanently delete {authConfig.provider} configuration?</Modal.Title>
                 </Modal.Header>
                 <div className="auth-row__delete-modal">
-                    <div className="auth-row__delete-modal__textBox">
+                    <div className="auth-row__delete-modal__textBox modal-body">
                         <p>
                             Deleting this authentication configuration will remove all settings associated with it. To
                             enable it again, the authentication configuration will need to be re-configured.

--- a/core/src/client/components/AuthRow.tsx
+++ b/core/src/client/components/AuthRow.tsx
@@ -150,7 +150,7 @@ export default class AuthRow extends PureComponent<Props, Partial<State>> {
                         Cancel
                     </Button>
 
-                    <Button className="labkey-button primary auth-row__delete-modal__delete" onClick={onDelete}>
+                    <Button className="labkey-button primary auth-row__confirm-delete" onClick={onDelete}>
                         Yes, delete
                     </Button>
                 </div>

--- a/core/src/client/components/AuthRow.tsx
+++ b/core/src/client/components/AuthRow.tsx
@@ -140,19 +140,20 @@ export default class AuthRow extends PureComponent<Props, Partial<State>> {
                         </p>
                         <p>Deletion cannot be undone.</p>
                     </div>
+                    <div className="auth-row__delete-modal-bottom">
+                        <Button
+                            className="labkey-button auth-row__delete-modal__cancel"
+                            onClick={() => {
+                                this.onToggleModal('deleteModalOpen', this.state.deleteModalOpen);
+                                toggleModalOpen(false);
+                            }}>
+                            Cancel
+                        </Button>
 
-                    <Button
-                        className="labkey-button auth-row__delete-modal__cancel"
-                        onClick={() => {
-                            this.onToggleModal('deleteModalOpen', this.state.deleteModalOpen);
-                            toggleModalOpen(false);
-                        }}>
-                        Cancel
-                    </Button>
-
-                    <Button className="labkey-button primary auth-row__confirm-delete" onClick={onDelete}>
-                        Yes, delete
-                    </Button>
+                        <Button className="labkey-button primary auth-row__confirm-delete" onClick={onDelete}>
+                            Yes, delete
+                        </Button>
+                    </div>
                 </div>
             </Modal>
         );


### PR DESCRIPTION
#### Rationale
Failures in SAMLTest and SecondaryAuthentication test are attributable to a wording change in the AuthConfig delete modal.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/373

#### Changes
* Add modal-body classname for test detection
* Replace classname of confirm delete button
* Fix small CSS bug