### PR TITLE
add @Inherited to @MethodsAllowed annotation

### DIFF
--- a/api/src/org/labkey/api/security/MethodsAllowed.java
+++ b/api/src/org/labkey/api/security/MethodsAllowed.java
@@ -3,11 +3,14 @@ package org.labkey.api.security;
 import org.labkey.api.util.HttpUtil;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-public @Retention(java.lang.annotation.RetentionPolicy.RUNTIME) @Target(ElementType.TYPE)
-@interface MethodsAllowed
+@Inherited
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MethodsAllowed
 {
     HttpUtil.Method[] value();
 }


### PR DESCRIPTION
#### Rationale
Need @Inherited on MethodsAllowed so that MutatingActionApi default works