### PR TITLE
Issue 40677: Error when "Downloading Data File" from "Import History"…

### DIFF
--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -2783,7 +2783,8 @@ public class StudyController extends BaseStudyController
                 @Override
                 public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
                 {
-                    out.write(PageFlowUtil.link("Download Data File").href("downloadTsv.view?id=" + ctx.get("RowId")).toString());
+                    ActionURL url = new ActionURL(DownloadTsvAction.class, ctx.getContainer()).addParameter("id", String.valueOf(ctx.get("RowId")));
+                    out.write(PageFlowUtil.link("Download Data File").href(url).toString());
                 }
             };
             dr.addDisplayColumn(dc);


### PR DESCRIPTION
… in a Study

#### Rationale
If path-first URLs are enabled on the server the "Download Data File" link on the "Import History" page is broken.

#### Changes
* Fix link
