### PR TITLE
Update references to sample study

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/SCHARPStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SCHARPStudyTest.java
@@ -21,6 +21,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.DailyA;
+import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PostgresOnlyTest;
 
 import java.io.File;
@@ -36,9 +37,7 @@ public class SCHARPStudyTest extends BaseWebDriverTest implements PostgresOnlyTe
 {
     public static final String PROJECT_NAME="SCHARP Study Test";
 
-    private String _labkeyRoot = TestFileUtils.getLabKeyRoot();
-    private String _pipelinePathMain = new File(_labkeyRoot, "/sampledata/study").getPath();
-    private File _studyZipFile = TestFileUtils.getSampleData("studies/studyshell.zip");
+    private final File _studyZipFile = TestFileUtils.getSampleData("studies/studyshell.zip");
 
     protected static class StatusChecker implements Supplier<Boolean>
     {
@@ -69,21 +68,12 @@ public class SCHARPStudyTest extends BaseWebDriverTest implements PostgresOnlyTe
         _containerHelper.createProject(PROJECT_NAME, "Study");
 
         clickProject(PROJECT_NAME);
-        log("importing study...");
-        setupPipeline();
         importStudy();
 
         log("Study imported and queries validated successfully.");
     }
 
-    protected void setupPipeline()
-    {
-        log("Setting pipeline root to " + _pipelinePathMain + "...");
-        setPipelineRoot(_pipelinePathMain);
-        assertTextPresent("The pipeline root was set");
-        clickProject(PROJECT_NAME);
-    }
-
+    @LogMethod
     protected void importStudy()
     {
         log("Importing study from " + _studyZipFile + "...");

--- a/study/test/src/org/labkey/test/tests/study/SampleMindedImportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SampleMindedImportTest.java
@@ -90,18 +90,13 @@ public class SampleMindedImportTest extends BaseWebDriverTest
         selectOptionByValue(Locator.name("sequenceNumHandling"), "logUniqueByDate");
         clickAndWait(Locator.lkButton("Save"));
 
-        // "overview" is a dumb place for this link
-        clickAndWait(Locator.linkWithText("Overview"));
-        clickAndWait(Locator.linkWithText("manage files"));
-        setPipelineRoot(TestFileUtils.getLabKeyRoot() + "/sampledata/study");
-        clickProject(PROJECT_NAME);
         clickTab("Overview");
         clickAndWait(Locator.linkWithText("Manage Files"));
-
-        clickButton("Process and Import Data");
-        _fileBrowserHelper.importFile("specimens/" + FILE, "Import Specimen Data");
+        _fileBrowserHelper.uploadFile(TestFileUtils.getSampleData("study/specimens/" + FILE));
+        _fileBrowserHelper.importFile(FILE, "Import Specimen Data");
         clickButton("Start Import");
         waitForPipelineJobsToComplete(1, "Import specimens: SampleMindedExport.xlsx", false);
+
         clickTab("Specimen Data");
         waitForElement(Locator.linkWithText("BAL"));
         assertElementPresent(Locator.linkWithText("BAL"));

--- a/study/test/src/org/labkey/test/tests/study/SpecimenMergeTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SpecimenMergeTest.java
@@ -46,7 +46,7 @@ public class SpecimenMergeTest extends BaseWebDriverTest
     protected static final File SPECIMEN_TEMP_DIR = StudyHelper.getStudyTempDir();
     protected int pipelineJobCount = 3;
 
-    protected String _studyDataRoot = null;
+    protected final String _studyDataRoot = StudyHelper.getPipelinePath();
 
     @Override
     public List<String> getAssociatedModules()
@@ -69,7 +69,6 @@ public class SpecimenMergeTest extends BaseWebDriverTest
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
-        _studyDataRoot = TestFileUtils.getLabKeyRoot() + "/sampledata/study";
         File tempDir = SPECIMEN_TEMP_DIR;
         if (tempDir.exists())
         {
@@ -107,8 +106,6 @@ public class SpecimenMergeTest extends BaseWebDriverTest
 
     protected void setUpSteps()
     {
-        _studyDataRoot = TestFileUtils.getLabKeyRoot() + "/sampledata/study";
-
         _containerHelper.createProject(PROJECT_NAME, null);
 
         _containerHelper.createSubfolder(PROJECT_NAME, PROJECT_NAME, FOLDER_NAME, "Study", null);


### PR DESCRIPTION
#### Rationale
There was a study in the root `sampledata/study` used by numerous tests. They often had the study's location hard-coded instead of using `TestFileUtils.getSampleData`

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/376

#### Changes
* Update reference to sample study
* Upload study instead of setting pipeline root
