### PR TITLE
Mechanism to register items on the Developer menu

### DIFF
--- a/api/src/org/labkey/api/rstudio/RStudioService.java
+++ b/api/src/org/labkey/api/rstudio/RStudioService.java
@@ -37,7 +37,7 @@ import java.util.Map;
 public interface RStudioService
 {
     String R_DOCKER_SANDBOX = "rDockerSandbox";
-    String R_DOCKER_ENGINE ="R Docker Scripting Engine";
+    String R_DOCKER_ENGINE = "R Docker Scripting Engine";
     String NO_RSTUDIO = "RStudio module is not present.";
 
     static RStudioService get()
@@ -95,5 +95,4 @@ public interface RStudioService
     {
         return null;
     }
-
 }

--- a/api/src/org/labkey/api/view/MenuProvider.java
+++ b/api/src/org/labkey/api/view/MenuProvider.java
@@ -1,0 +1,9 @@
+package org.labkey.api.view;
+
+import org.labkey.api.data.Container;
+import org.labkey.api.security.User;
+
+public interface MenuProvider
+{
+    void addMenuItems(Container c, User user, NavTrees trees);
+}

--- a/api/src/org/labkey/api/view/NavTrees.java
+++ b/api/src/org/labkey/api/view/NavTrees.java
@@ -1,0 +1,18 @@
+package org.labkey.api.view;
+
+import java.util.Collection;
+
+public class NavTrees
+{
+    private final Collection<NavTree> _navTrees;
+
+    public NavTrees(Collection<NavTree> navTrees)
+    {
+        _navTrees = navTrees;
+    }
+
+    public void add(NavTree navTree)
+    {
+        _navTrees.add(navTree);
+    }
+}

--- a/api/src/org/labkey/api/view/PopupDeveloperView.java
+++ b/api/src/org/labkey/api/view/PopupDeveloperView.java
@@ -17,15 +17,15 @@ package org.labkey.api.view;
 
 import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.admin.CoreUrls;
-import org.labkey.api.data.Container;
 import org.labkey.api.query.QueryUrls;
-import org.labkey.api.rstudio.RStudioService;
 import org.labkey.api.security.permissions.BrowserDeveloperPermission;
 import org.labkey.api.security.permissions.PlatformDeveloperPermission;
 import org.labkey.api.util.PageFlowUtil;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * The Developer menu that appears in the header when the user is in the Developers group, but is not an admin.
@@ -34,6 +34,8 @@ import java.util.List;
  */
 public class PopupDeveloperView extends PopupMenuView
 {
+    private static final List<MenuProvider> PROVIDERS = new CopyOnWriteArrayList<>();
+
     public PopupDeveloperView(ViewContext context)
     {
         NavTree navTree = new NavTree("Developer");
@@ -49,42 +51,42 @@ public class PopupDeveloperView extends PopupMenuView
 
     public static List<NavTree> getNavTree(ViewContext context)
     {
-        Container container = context.getContainer();
         ArrayList<NavTree> items = new ArrayList<>();
+        NavTrees trees = new NavTrees(items);
+        PROVIDERS.forEach(p -> p.addMenuItems(context.getContainer(), context.getUser(), trees));
+        items.sort(Comparator.comparing(NavTree::getText));
 
-        if (!container.isRoot())
-            items.add(new NavTree("Schema Browser", PageFlowUtil.urlProvider(QueryUrls.class).urlSchemaBrowser(container)));
-
-        items.add(new NavTree("UI Style Guide", PageFlowUtil.urlProvider(CoreUrls.class).getStyleGuideURL(container)));
-
-        if (context.getUser().hasRootPermission(PlatformDeveloperPermission.class))
-        {
-            String consoleURL = PageFlowUtil.urlProvider(AdminUrls.class).getSessionLoggingURL().getLocalURIString(false);
-            NavTree consoleNavTree = new NavTree("Server JavaScript Console");
-            consoleNavTree.setScript("window.open('" + consoleURL + "','javascriptconsole','width=400,height=400,location=0,menubar=0,resizable=1,status=0,alwaysRaised=yes')");
-            items.add(consoleNavTree);
-        }
-
-        String memTrackerURL = PageFlowUtil.urlProvider(AdminUrls.class).getTrackedAllocationsViewerURL().getLocalURIString(false);
-        NavTree memTrackerNavTree = new NavTree("Memory Allocations");
-        memTrackerNavTree.setScript("window.open('" + memTrackerURL + "','memoryallocations','width=500,height=400,location=0,menubar=0,resizable=1,status=0,alwaysRaised=yes')");
-        items.add(memTrackerNavTree);
-
-        items.add(new NavTree("JavaScript API Reference", "https://www.labkey.org/download/clientapi_docs/javascript-api/"));
-
-        items.add(new NavTree("XML Schema Reference", "https://www.labkey.org/download/schema-docs/xml-schemas"));
-
-        RStudioService rstudio = RStudioService.get();
-        if (null != rstudio)
-        {
-            ActionURL url = rstudio.getRStudioLink(context.getUser(), context.getContainer());
-            if (null != url)
-            {
-                NavTree rss = new NavTree("RStudio Server",url+"&method=LAUNCH");
-                rss.setTarget("labkey_rstudio");
-                items.add(rss);
-            }
-        }
         return items;
+    }
+
+    public static void registerMenuProvider(MenuProvider provider)
+    {
+        PROVIDERS.add(provider);
+    }
+
+    static
+    {
+        registerMenuProvider((c, user, items) -> {
+            items.add(new NavTree("JavaScript API Reference", "https://www.labkey.org/download/clientapi_docs/javascript-api/"));
+
+            String memTrackerURL = PageFlowUtil.urlProvider(AdminUrls.class).getTrackedAllocationsViewerURL().getLocalURIString(false);
+            NavTree memTrackerNavTree = new NavTree("Memory Allocations");
+            memTrackerNavTree.setScript("window.open('" + memTrackerURL + "','memoryallocations','width=500,height=400,location=0,menubar=0,resizable=1,status=0,alwaysRaised=yes')");
+            items.add(memTrackerNavTree);
+
+            if (!c.isRoot())
+                items.add(new NavTree("Schema Browser", PageFlowUtil.urlProvider(QueryUrls.class).urlSchemaBrowser(c)));
+
+            if (user.hasRootPermission(PlatformDeveloperPermission.class))
+            {
+                String consoleURL = PageFlowUtil.urlProvider(AdminUrls.class).getSessionLoggingURL().getLocalURIString(false);
+                NavTree consoleNavTree = new NavTree("Server JavaScript Console");
+                consoleNavTree.setScript("window.open('" + consoleURL + "','javascriptconsole','width=400,height=400,location=0,menubar=0,resizable=1,status=0,alwaysRaised=yes')");
+                items.add(consoleNavTree);
+            }
+
+            items.add(new NavTree("UI Style Guide", PageFlowUtil.urlProvider(CoreUrls.class).getStyleGuideURL(c)));
+            items.add(new NavTree("XML Schema Reference", "https://www.labkey.org/download/schema-docs/xml-schemas"));
+        });
     }
 }


### PR DESCRIPTION
#### Rationale
Modules need a way to register items on the Developer menu so that API doesn't need knowledge of a host of premium services.

#### Related Pull Requests
* https://github.com/LabKey/rstudio/pull/64

#### Changes
* Add PopupDeveloperView.registerMenuProvider()
* Register provider for standard menu items