### PR TITLE
For improved browser caching, update webpack to use ".cache." in generated filenames 

### DIFF
--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -1885,7 +1885,10 @@ public class PageFlowUtil
         {
             return staticResourcePrefix + slash + resourcePath;
         }
-        return AppProps.getInstance().getContextPath() + slash + resourcePath + "?" + getServerSessionHash();
+        if (resourcePath.contains(".cache."))        // CONSIDER: move DavController.alwaysCache() somewhere we can call it
+            return AppProps.getInstance().getContextPath() + slash + resourcePath;
+        else
+            return AppProps.getInstance().getContextPath() + slash + resourcePath + "?" + getServerSessionHash();
     }
 
 

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -4933,14 +4933,18 @@ public class DavController extends SpringActionController
     }
 
 
-    Path extPath = new Path(PageFlowUtil.extJsRoot());
-    Path mcePath = new Path("timymce");
+    static final Path jquery = new Path("internal","jQuery");
 
-    boolean alwaysCacheFile(Path p)
+    public static boolean alwaysCacheFile(Path p)
     {
-        return p.startsWith(extPath) || p.startsWith(mcePath);
+        String firstpart = p.get(0);
+        if (firstpart.startsWith("ext-"))
+            return true;
+        if (p.startsWith(jquery))
+            return true;
+        String name = p.getName();
+        return name.contains(".cache.");
     }
-
 
     private WebdavStatus serveResource(WebdavResource resource, boolean content)
             throws DavException, IOException
@@ -4973,12 +4977,11 @@ public class DavController extends SpringActionController
 
             if (!resource.getName().contains(".nocache."))
             {
-                boolean isPerfectCache = resource.getName().contains(".cache.");
                 boolean allowCaching = AppProps.getInstance().isCachingAllowed();
-
-                if (allowCaching || isPerfectCache || alwaysCacheFile(resource.getPath()))
+                boolean alwaysCache = alwaysCacheFile(resource.getPath());
+                if (allowCaching || alwaysCache)
                 {
-                    getResponse().setPublicStatic(isPerfectCache ? 365 : 35);
+                    getResponse().setPublicStatic(alwaysCache ? 365 : 35);
                 }
             }
         }

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -22,7 +22,7 @@ module.exports = {
     output: {
         path: constants.outputPath(__dirname),
         publicPath: './', // allows context path to resolve in both js/css
-        filename: '[name].[contenthash].js'
+        filename: '[name].[contenthash].cache.js'
     },
 
     module: {


### PR DESCRIPTION
#### Rationale
Some webpack artifacts can be _really_ large.  Since they have hashes in the filenames, we can enable very aggressive browser caching.  We already do this for files with ".cache." in their names, so we can reuse that mechanism.
