### PR TITLE
Fix intermittent browser client error

### DIFF
--- a/filecontent/webapp/File/panel/Browser.js
+++ b/filecontent/webapp/File/panel/Browser.js
@@ -1321,7 +1321,8 @@ Ext4.define('File.panel.Browser', {
                 customProperties: extraColumnNames
             }),
             success: LABKEY.Utils.getCallbackWrapper(function(data) {
-                this.processCustomFileProperties(data.rows, extraColumnNames);
+                if (data)
+                    this.processCustomFileProperties(data.rows, extraColumnNames);
             }),
             scope: this
         });


### PR DESCRIPTION
#### Rationale
The following client side error started to happen intermittently on TeamCity starting around Jun 4th. I have not be able to reproduce the error locally. The suspicion is that a Firefox upgrade changed how (pending or active) XHR is handled when page is navigated away. The stacktrace appears to indicate some sort of binding error. responseTransformer param for browser should be null so responseTransformer should never be called, but it did. For some weird reason,  fn is passed in as responseTransformer. 

Without a local repro, I was not able to figure out why the arguments to LABKEY.Utils.getCallbackWrapper are messed up. So instead, a simple null check is added to avoid the client side error. 
```
TypeError: data is undefined
  attachCustomFileProperties/<.success< (http://localhost:8111/labkey/File/panel/Browser.js:1324:17)
  responseTransformer.call (webpack:///src/labkey/Utils.ts:472:15)
  callback (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:7250:26)
  onComplete (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:32937:17)
  onStateChange (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:32896:16)
  bind/< (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:2094:27)
```

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* add null check for data before access data.row
