### PR TITLE
Issue 40548: Login form shows no indication that it is waiting for a server response

### DIFF
--- a/core/resources/views/login.html
+++ b/core/resources/views/login.html
@@ -26,6 +26,9 @@
                 <a class="labkey-button" id="registerButton" href="login-register.view?">Register</a>
             </span>
         </div>
+        <div class="signing-in-msg" hidden>
+            <span class="fa fa-spinner fa-pulse"></span> Signing you in. This may take a moment.
+        </div>
 
         <input type="hidden" name="returnUrl">
         <input type="hidden" id="urlhash" name="urlhash">

--- a/core/webapp/login.css
+++ b/core/webapp/login.css
@@ -85,3 +85,7 @@ ul.sso-list > li {
     width: 284px;
     display: inline-block;
 }
+
+.signing-in-msg {
+    padding-top: 10px;
+}

--- a/core/webapp/login.js
+++ b/core/webapp/login.js
@@ -5,6 +5,9 @@
  */
 
 (function($) {
+    var submitting = false, delay = false;
+    var DELAY_MS = 500;
+
     // bind triggers, page init, etc
     function onReady() {
         // on document ready
@@ -28,6 +31,8 @@
         //the intent of this is to allow custom login pages to supply an element where id=returnUrl, which will always redirect the user after login
         var returnUrlElement = document.getElementById('returnUrl');
 
+        setSubmitting(true, '');
+
         LABKEY.Ajax.request({
             url: LABKEY.ActionURL.buildURL('login', 'loginApi.api', this.containerPath),
             method: 'POST',
@@ -42,19 +47,59 @@
                 urlhash: document.getElementById('urlhash').value
             },
             success: LABKEY.Utils.getCallbackWrapper(function(response) {
+                setSubmitting(false, '');
                 if (response && response.returnUrl) {
                     window.location = response.returnUrl;
                 }
             }, this),
             failure: LABKEY.Utils.getCallbackWrapper(function(response) {
-                if (document.getElementById('errors') && response && response.exception) {
-                    document.getElementById('errors').innerHTML = response.exception;
-                }
+                setSubmitting(false, response ? response.exception : '');
                 if (response && response.returnUrl) {
                     window.location = response.returnUrl;
                 }
             }, this)
         });
+    }
+
+    function setSubmitting(isSubmitting, errorMsg) {
+        // no-op if already submitting
+        if (submitting && isSubmitting) {
+            return;
+        }
+        // and if we are in the delay, re-queue this call to setSubmitting
+        else if (delay) {
+            setTimeout(function() {
+                setSubmitting(isSubmitting, errorMsg);
+            }, DELAY_MS);
+            return;
+        }
+
+        submitting = isSubmitting;
+
+        if (submitting) {
+            _toggleDelay();
+        }
+
+        $('.signin-btn > span').html('Sign' + (submitting ? 'ing' : '') + ' In');
+        document.getElementsByClassName('signing-in-msg')[0].hidden = !submitting;
+
+        _setErrors(errorMsg);
+    }
+
+    function _toggleDelay() {
+        delay = !delay;
+
+        // enable the delay for a min set time to prevent flashing of buttons/spinner
+        if (delay) {
+            setTimeout(_toggleDelay, DELAY_MS);
+        }
+    }
+
+    function _setErrors(text) {
+        var el = document.getElementById('errors');
+        if (el) {
+            el.innerHTML = text;
+        }
     }
 
     function acceptTermsOfUse() {
@@ -72,8 +117,8 @@
                 window.location = LABKEY.ActionURL.getParameter("returnUrl")
             },
             failure: LABKEY.Utils.getCallbackWrapper(function (response) {
-                if (document.getElementById('errors') && response && response.exception) {
-                    document.getElementById('errors').innerHTML = response.exception;
+                if (response && response.exception) {
+                    _setErrors(response.exception);
                 }
             }, this)
         });


### PR DESCRIPTION
#### Rationale
Issue [40548](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40548): Login form shows no indication that it's waiting for the server's response

The LabKey default login / sign in form does not give the user any indicator that it is waiting for a server response when the "Sign In" button is clicked. Most of the login attempts go very quickly and this isn't an issue, but as the issue 40548 mentioned, there can be cases like the LDAP auth that take a little more time. 

This PR addresses this issue in two ways, it changes the "Sign In" button text to "Signing In" during the submit state and it shows a loading spinner below the button. Also mentioned in this issue, is that if you hit the same error state case multiple times, it can look like nothing is happening when the Sign In button is clicked. To address this part, I added a half second delay to all response messages so that the user will always see the error clear, the loading message, and then the response.

#### Changes
* add loading spinner plus message and change Sign In button text on submit
* make sure to delay the response so that the submit indicator sticks around for at least 500ms
