### PR TITLE
fix unclosed InputStream

### DIFF
--- a/query/src/org/labkey/query/QueryImporter.java
+++ b/query/src/org/labkey/query/QueryImporter.java
@@ -47,6 +47,7 @@ import org.labkey.data.xml.query.QueryType;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -101,8 +102,11 @@ public class QueryImporter implements FolderImporter
                 if (fileName.endsWith(QueryWriter.FILE_EXTENSION))
                 {
                     // make sure a SQL file/input stream exists before adding it to the array
-                    if (null != queriesDir.getInputStream(fileName))
-                        sqlFileNames.add(fileName);
+                    try (InputStream is = queriesDir.getInputStream(fileName))
+                    {
+                        if (null != is)
+                            sqlFileNames.add(fileName);
+                    }
                 }
                 else if (fileName.endsWith(QueryWriter.META_FILE_EXTENSION))
                 {
@@ -142,6 +146,7 @@ public class QueryImporter implements FolderImporter
                 if (null == queryDoc)
                     throw new ServletException("QueryImport: SQL file \"" + sqlFileName + "\" has no corresponding meta data file.");
 
+                // getStreamContentsAsStream() closes the InputStream
                 String sql = PageFlowUtil.getStreamContentsAsString(queriesDir.getInputStream(sqlFileName));
 
                 createQueryDef(ctx, createdQueries, changedQueries, metaFileName, queryDoc, sqlFileName, sql);


### PR DESCRIPTION
#### Rationale
Unclosed InputStream in QueryImporter can later cause deleteImportDirectory() to fail.   That's the theory anyway.

see https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39579