### PR TITLE
HTML improperly escaped

### DIFF
--- a/study/src/org/labkey/study/assay/view/publishChooseStudy.jsp
+++ b/study/src/org/labkey/study/assay/view/publishChooseStudy.jsp
@@ -22,6 +22,7 @@
 <%@ page import="org.labkey.api.study.Study" %>
 <%@ page import="org.labkey.api.study.StudyUrls" %>
 <%@ page import="org.labkey.api.study.assay.AssayPublishService" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.util.Pair" %>
 <%@ page import="org.labkey.api.util.element.Input" %>
 <%@ page import="org.labkey.api.util.element.Option" %>
@@ -157,7 +158,7 @@
     <%
         if (unambiguous)
         {
-            String label = "All data is marked for copying to study <b>" + h(firstStudy.getLabel()) + "</b> in folder <b>" + h(firstStudy.getContainer().getPath()) + "</b>.";
+            HtmlString label = HtmlString.unsafe("All data is marked for copying to study <b>" + h(firstStudy.getLabel()) + "</b> in folder <b>" + h(firstStudy.getContainer().getPath()) + "</b>.");
     %>
     <labkey:input type="displayfield" value="<%=label%>"/>
     <labkey:input type="checkbox" label="Copy to a different study" id="chooseStudy" onChange="toggleStudies();"/>


### PR DESCRIPTION
#### Rationale
Cosmetic fix to the copy to study page, which in certain case will show escaped HTML tags.

#### Related Issue
[40723: Display error on Copy-to-Study (from run table) screen](https://www.labkey.org/NIHS/Support%20Tickets/issues-details.view?issueId=40723)

#### Changes
Pass HtmlString into our input tags instead of String object.