### PR TITLE
handle docid that uses containerid (guid) instead of container path

### DIFF
--- a/search/src/org/labkey/search/view/search.jsp
+++ b/search/src/org/labkey/search/view/search.jsp
@@ -117,9 +117,13 @@
                 Path path = Path.parse(hit.docid.substring(4));
                 if (path.startsWith(dav))
                     path = dav.relativize(path);
-                if (path.startsWith(containerPath))
+                if (path.startsWith(containerPath) || path.startsWith(new Path(c.getId())))
                 {
-                    Path rel = containerPath.relativize(path);
+                    Path rel;
+                    if (path.startsWith(containerPath))
+                        rel = containerPath.relativize(path);
+                    else
+                        rel = path.subpath(1, path.size());
                     if (rel.startsWith(files) || rel.startsWith(pipeline))
                     {
                         if (path.size() > 0) path = path.getParent();


### PR DESCRIPTION
#### Rationale
Fix search.jsp to handle new docid format (using containerid instead of container path)