### PR TITLE
Issue 40793: Updated login JavaScript api doesn't work with custom login page

### DIFF
--- a/core/webapp/login.js
+++ b/core/webapp/login.js
@@ -80,8 +80,14 @@
             _toggleDelay();
         }
 
+        // update the button text for "Sign In"
         $('.signin-btn > span').html('Sign' + (submitting ? 'ing' : '') + ' In');
-        document.getElementsByClassName('signing-in-msg')[0].hidden = !submitting;
+
+        // hide/show the Signing In message (if element is present)
+        var msgEl = document.getElementsByClassName('signing-in-msg');
+        if (msgEl && msgEl.length > 0) {
+            msgEl[0].hidden = !submitting;
+        }
 
         _setErrors(errorMsg);
     }


### PR DESCRIPTION
#### Rationale
Issue [40793](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40793): Updated login JavaScript api doesn't work with custom login page

Recent changes to the login form and related JS code for issue [40548](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40548), resulted in a JS error for the custom login page case where it is calling the login.js helper for authenticating a user. This PR fixes that JS error.

#### Changes
* login.js update to conditionalize the update to the 'signing-in-msg' element based on if it exists or not
