### PR TITLE
Fix #36517, #40790, and #40799

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -94,6 +94,8 @@ import java.util.function.BooleanSupplier;
  */
 public class Container implements Serializable, Comparable<Container>, SecurableResource, ContainerContext, HasPermission, Parameter.JdbcParameterValue
 {
+    private static final Logger LOG = Logger.getLogger(Container.class);
+
     private GUID _id;
     private Path _path;
     private Date _created;
@@ -1324,7 +1326,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
     {
         ContainerType type = ContainerTypeRegistry.get().getType(typeString);
         if (type == null)
-            Logger.getLogger(Container.class).warn("Unknown container type: " + typeString);
+            LOG.warn("Unknown container type: " + typeString);
         else
             _containerType = type;
     }
@@ -1573,7 +1575,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
                 iconFile = dir.getFile();
             if (!NetworkDrive.exists(iconFile))
             {
-                Logger.getLogger(Container.class).warn("Could not find specified icon: "+iconPath);
+                LOG.warn("Could not find specified icon: " + iconPath);
                 iconPath = FolderType.NONE.getFolderIconPath();
             }
             if (!iconPath.startsWith("/"))

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1322,9 +1322,11 @@ public class Container implements Serializable, Comparable<Container>, Securable
 
     public void setType(String typeString)
     {
-        _containerType = ContainerTypeRegistry.get().getType(typeString);
-        if (_containerType == null)
-            throw new IllegalArgumentException("Unknown container type: " + typeString);
+        ContainerType type = ContainerTypeRegistry.get().getType(typeString);
+        if (type == null)
+            Logger.getLogger(Container.class).warn("Unknown container type: " + typeString);
+        else
+            _containerType = type;
     }
 
     public static class ContainerException extends Exception

--- a/api/src/org/labkey/api/query/import.jsp
+++ b/api/src/org/labkey/api/query/import.jsp
@@ -58,7 +58,7 @@
         if (bean.urlExcelTemplates.size() == 1)
         {
             Pair<String, String> p = bean.urlExcelTemplates.get(0);
-            %><%= button(p.first).href(p.second) %><br>&nbsp;<br><%
+            %><%= button(p.first).href(p.second).usePost() %><br>&nbsp;<br><%
         }
         else
         {

--- a/study/resources/schemas/study.xml
+++ b/study/resources/schemas/study.xml
@@ -530,7 +530,7 @@
         <description>A randomly generated date offset for this participant. This can be used to shift each participant's date values when publishing a study.</description>
       </column>
       <column columnName="AlternateId">
-        <description>A randomly generated alternate participant ID. This can be used in place of internal particiapnt IDs when publishing a study.</description>
+        <description>A randomly generated alternate participant ID. This can be used in place of internal participant IDs when publishing a study.</description>
       </column>
       <column columnName="LastIndexed"/>
       <column columnName="Modified"/>

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -3365,7 +3365,7 @@ public class StudyManager
     public int setImportedAlternateParticipantIds(Study study, DataLoader dl, BatchValidationException errors) throws IOException
     {
         // Use first line to determine order of columns we care about
-        // The first columcn in the data must contain the ones we are seeking
+        // The first column in the data must contain the ones we are seeking
         String[][] firstline = dl.getFirstNLines(1);
         if (null == firstline || 0 == firstline.length)
             return 0;       // Unexpected but just in case

--- a/study/src/org/labkey/study/view/manageAlternateIds.jsp
+++ b/study/src/org/labkey/study/view/manageAlternateIds.jsp
@@ -125,7 +125,9 @@
                     },{
                         xtype: 'button',
                         text: 'Export',
-                        handler: function() {window.location = <%= PageFlowUtil.jsString(new ActionURL(StudyController.ExportParticipantTransformsAction.class, getContainer()).toString())%>;}
+                        handler: function() {
+                            LABKEY.Utils.postToAction(<%=PageFlowUtil.jsString(new ActionURL(StudyController.ExportParticipantTransformsAction.class, getContainer()).toString())%>);
+                        }
                     },{
                         xtype: 'button',
                         text: 'Import',


### PR DESCRIPTION
#### Rationale
The Upload Participant Mapping page is not clear that an error during import (e.g., unrecognized participant ID) means nothing is imported. In the process of fixing that issue, I discovered that exporting the mapping can result in a MUTATING SQL exception and that Container is far too strict when it attempts to set a container type that it doesn't recognize.

#### Changes
* Fix [Issue 36517: Alternate participant ID import fails at job level](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=36517)
* Fix [Issue 40790: java.lang.IllegalStateException: MUTATING SQL executed as part of handling action: GET org.labkey.study.controllers.StudyController$ExportParticipantTransformsAction](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40790)
* Fix [Issue 40799: java.lang.IllegalArgumentException: Unknown container type: labbook](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40799)
