### PR TITLE
Issue 40735: Stop caching ResultSets for standard grid renders

### DIFF
--- a/api/src/org/labkey/api/data/NestedRenderContext.java
+++ b/api/src/org/labkey/api/data/NestedRenderContext.java
@@ -140,6 +140,7 @@ public class NestedRenderContext extends RenderContext
         return result;
     }
 
+    @NotNull
     @Override
     public Map<String, List<Aggregate.Result>> getAggregates(List<DisplayColumn> displayColumns, TableInfo tinfo, QuerySettings settings, String dataRegionName, List<Aggregate> aggregatesIn,
             Map<String, Object> parameters, boolean async) throws IOException

--- a/api/src/org/labkey/api/data/RenderContext.java
+++ b/api/src/org/labkey/api/data/RenderContext.java
@@ -19,6 +19,7 @@ package org.labkey.api.data;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.LabKeyError;
 import org.labkey.api.collections.NullPreventingSet;
@@ -65,7 +66,7 @@ public class RenderContext implements Map<String, Object>, Serializable
     private final Map<String, Object> _extra = new HashMap<>();
     private Sort _baseSort;
     private int _mode = DataRegion.MODE_NONE;
-    private boolean _cache = true;
+    private boolean _cache = false;
     protected Set<FieldKey> _ignoredColumnFilters = new LinkedHashSet<>();
     private Set<String> _selected = null;
     private ShowRows _showRows = ShowRows.PAGINATED;
@@ -170,6 +171,7 @@ public class RenderContext implements Map<String, Object>, Serializable
         _baseSort = sort;
     }
 
+    @NotNull
     public List<AnalyticsProviderItem> getBaseSummaryStatsProviders()
     {
         List<AnalyticsProviderItem> summaryStatsProviders = new ArrayList<>();
@@ -183,7 +185,7 @@ public class RenderContext implements Map<String, Object>, Serializable
             }
         }
 
-        return !summaryStatsProviders.isEmpty() ? summaryStatsProviders : null;
+        return Collections.unmodifiableList(summaryStatsProviders);
     }
 
     public List<AnalyticsProviderItem> getBaseAnalyticsProviders()
@@ -324,6 +326,7 @@ public class RenderContext implements Map<String, Object>, Serializable
         return _results;
     }
 
+    @NotNull
     public Map<String, List<Aggregate.Result>> getAggregates(List<DisplayColumn> displayColumns, TableInfo tinfo, QuerySettings settings, String dataRegionName, List<Aggregate> aggregatesIn, Map<String, Object> parameters, boolean async) throws IOException
     {
         if (aggregatesIn == null || aggregatesIn.isEmpty())

--- a/api/src/org/labkey/api/data/RenderContextDecorator.java
+++ b/api/src/org/labkey/api/data/RenderContextDecorator.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.data;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.query.CustomView;
 import org.labkey.api.query.FieldKey;
@@ -120,6 +121,7 @@ public class RenderContextDecorator extends RenderContext
         _ctx.setBaseSort(sort);
     }
 
+    @NotNull
     @Override
     public List<AnalyticsProviderItem> getBaseSummaryStatsProviders()
     {
@@ -145,6 +147,7 @@ public class RenderContextDecorator extends RenderContext
         return _ctx.getResults(fieldMap, displayColumns, tinfo, settings, parameters, maxRows, offset, name, async);
     }
 
+    @NotNull
     @Override
     public Map<String, List<Aggregate.Result>> getAggregates(List<DisplayColumn> displayColumns, TableInfo tinfo, QuerySettings settings, String dataRegionName,
                                                              List<Aggregate> aggregatesIn, Map<String, Object> parameters, boolean async)

--- a/api/src/org/labkey/api/data/ResultSetImpl.java
+++ b/api/src/org/labkey/api/data/ResultSetImpl.java
@@ -46,6 +46,8 @@ public class ResultSetImpl extends LoggingResultSetWrapper implements TableResul
 
     private boolean _isComplete = true;
 
+    protected int _size;
+
     // for resource tracking
     private StackTraceElement[] _debugCreated = null;
     protected boolean _wasClosed = false;
@@ -95,7 +97,7 @@ public class ResultSetImpl extends LoggingResultSetWrapper implements TableResul
     @Override
     public int getSize()
     {
-        return -1;
+        return _size;
     }
 
     @Override
@@ -107,6 +109,11 @@ public class ResultSetImpl extends LoggingResultSetWrapper implements TableResul
         if (getRow() == _maxRows + 1)
         {
             _isComplete = false;
+        }
+        else
+        {
+            // Keep track of all of the rows that we've iterated
+            _size = Math.max(_size, getRow());
         }
         return getRow() <= _maxRows;
     }
@@ -139,15 +146,6 @@ public class ResultSetImpl extends LoggingResultSetWrapper implements TableResul
             _wasClosed = true;
         }
     }
-
-
-    public int size()
-    {
-        if (resultset instanceof CachedRowSet)
-            return ((CachedRowSet) resultset).size();
-        return -1;
-    }
-
 
     @Override
     public @NotNull Iterator<Map<String, Object>> iterator()

--- a/api/src/org/labkey/api/data/nestedGridScript.jsp
+++ b/api/src/org/labkey/api/data/nestedGridScript.jsp
@@ -30,7 +30,7 @@ function toggleNestedGrid(dataRegionName, url, elementName)
     {
         if (requestedURLs[url] == null)
         {
-            Ext.Ajax.request(
+            LABKEY.Ajax.request(
             {
                 url: url,
                 method: "GET",


### PR DESCRIPTION
#### Rationale
Let's not open ourselves to DOS attacks, intentional or not, by holding too many results in memory at the same time

#### Related Pull Requests
https://github.com/LabKey/commonAssays/pull/198

#### Changes
Don't cache results by default

Be smarter about when we need to know how many rows we'll be rendering, so we can calculate it as we traverse the ResultSet

Stop omitting button bar completely for small result sets with no buttons, since we don't know if it'll be a small result set or not

Clean up null/empty collection return values