### PR TITLE
Issue 40823: Perf issue saving permission updates in parent with many workbook children

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -934,7 +934,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
         props.put("name", module.getName());
 
         props.save();
-        ContainerManager.notifyContainerChange(getId());
+        ContainerManager.notifyContainerChange(getId(), ContainerManager.Property.Modules);
         _defaultModule = null;
     }
 
@@ -967,7 +967,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
         }
 
         props.save();
-        ContainerManager.notifyContainerChange(getId());
+        ContainerManager.notifyContainerChange(getId(), ContainerManager.Property.Modules);
     }
 
     public void appendWorkbookModulesToParent(Set<Module> newModules, @Nullable User user)

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -155,6 +155,8 @@ public class ContainerManager
         Name,
         Parent,
         Policy,
+        /** The default or active set of modules in the container has changed */
+        Modules,
         WebRoot,
         AttachmentDirectory,
         PipelineRoot,
@@ -1813,12 +1815,6 @@ public class ContainerManager
             NavTreeManager.uncacheTree(project.getId());
             NavTreeManager.uncacheTree(PROJECT_LIST_ID + project.getId());
         }
-    }
-
-
-    public static void notifyContainerChange(String id)
-    {
-        notifyContainerChange(id, Property.Policy);
     }
 
     public static void notifyContainerChange(String id, Property prop)

--- a/api/src/org/labkey/api/security/SecurityPolicyManager.java
+++ b/api/src/org/labkey/api/security/SecurityPolicyManager.java
@@ -190,7 +190,7 @@ public class SecurityPolicyManager
     public static void notifyPolicyChange(String objectID)
     {
         // UNDONE: generalize cross manager/module notifications
-        ContainerManager.notifyContainerChange(objectID);
+        ContainerManager.notifyContainerChange(objectID, ContainerManager.Property.Policy);
     }
 
     public static void notifyPolicyChanges(List<String> objectIDs)


### PR DESCRIPTION
Don't fire a change event for Policy when the set of modules is what changed

#### Related Pull Requests
https://github.com/LabKey/LabDevKitModules/pull/37

