### PR TITLE
Issue 40684: LDAP search config fails to save without MasterEncryptionKey, gives no error message

### DIFF
--- a/api/src/org/labkey/api/security/ConfigurationSettings.java
+++ b/api/src/org/labkey/api/security/ConfigurationSettings.java
@@ -1,13 +1,17 @@
 package org.labkey.api.security;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.log4j.Logger;
 import org.json.JSONObject;
 import org.labkey.api.data.AES;
+import org.labkey.api.settings.AppProps;
 
 import java.util.Map;
 
 public class ConfigurationSettings
 {
+    private static final Logger LOG = Logger.getLogger(ConfigurationSettings.class);
+
     private final Map<String, Object> _standardSettings;
     private final Map<String, Object> _properties;
     private final Map<String, Object> _encryptedProperties;
@@ -15,10 +19,26 @@ public class ConfigurationSettings
     public ConfigurationSettings(Map<String, Object> settings)
     {
         _standardSettings = settings;
-        String propertiesJson = (String)settings.get("Properties");
+        String propertiesJson = (String) settings.get("Properties");
         _properties = null != propertiesJson ? new JSONObject(propertiesJson) : new JSONObject();
-        String encryptedPropertiesJson = (String)settings.get("EncryptedProperties");
-        _encryptedProperties = null != encryptedPropertiesJson ? new JSONObject(AES.get().decrypt(Base64.decodeBase64(encryptedPropertiesJson))) : new JSONObject();
+        String encryptedPropertiesJson = (String) settings.get("EncryptedProperties");
+
+        if (null != encryptedPropertiesJson)
+        {
+            if (Encryption.isMasterEncryptionPassPhraseSpecified())
+            {
+                _encryptedProperties = new JSONObject(AES.get().decrypt(Base64.decodeBase64(encryptedPropertiesJson)));
+            }
+            else
+            {
+                LOG.warn("Encrypted properties can't be read: master encryption key has not been set in " + AppProps.getInstance().getWebappConfigurationFilename() + "!");
+                _encryptedProperties = new JSONObject();
+            }
+        }
+        else
+        {
+            _encryptedProperties = new JSONObject();
+        }
     }
 
     public Map<String, Object> getStandardSettings()

--- a/api/src/org/labkey/api/security/SaveConfigurationAction.java
+++ b/api/src/org/labkey/api/security/SaveConfigurationAction.java
@@ -73,6 +73,9 @@ public abstract class SaveConfigurationAction<F extends SaveConfigurationForm, A
 
     public static <F extends SaveConfigurationForm> void saveForm(F form, @Nullable User user)
     {
+        // This method might throw. Invoke proactively so BeanObjectFactory doesn't translate exception into an assert.
+        String ignore = form.getEncryptedProperties();
+
         if (null == form.getRowId())
         {
             Table.insert(user, CoreSchema.getInstance().getTableInfoAuthenticationConfigurations(), form);

--- a/api/src/org/labkey/api/security/SaveConfigurationForm.java
+++ b/api/src/org/labkey/api/security/SaveConfigurationForm.java
@@ -1,6 +1,11 @@
 package org.labkey.api.security;
 
+import org.apache.commons.codec.binary.Base64;
 import org.jetbrains.annotations.Nullable;
+import org.json.JSONObject;
+import org.labkey.api.data.AES;
+import org.labkey.api.settings.AppProps;
+import org.labkey.api.util.ConfigurationException;
 
 public abstract class SaveConfigurationForm
 {
@@ -48,5 +53,22 @@ public abstract class SaveConfigurationForm
     public void setEnabled(boolean enabled)
     {
         _enabled = enabled;
+    }
+
+    public @Nullable String getEncryptedProperties()
+    {
+        return null;
+    }
+
+    protected String encodeEncryptedProperties(JSONObject map)
+    {
+        if (Encryption.isMasterEncryptionPassPhraseSpecified())
+        {
+            return Base64.encodeBase64String(AES.get().encrypt(map.toString()));
+        }
+        else
+        {
+            throw new ConfigurationException("Can't save this configuration: MasterEncryptionKey has not been specified in " + AppProps.getInstance().getWebappConfigurationFilename());
+        }
     }
 }


### PR DESCRIPTION
#### Rationale
We want to display a reasonably clear error message when attempting to save an authentication configuration that requires encryption when the master encryption key is not set. Previously, getEncryptedProperties() would throw while BeanObjectFactory was attempting to map bean properties, which resulted in an assert or an invocation exception that didn't propagate to the client. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40684

#### Related Pull Requests
* https://github.com/LabKey/ldap/pull/15
* https://github.com/LabKey/duo/pull/22
* https://github.com/LabKey/saml/pull/28

#### Changes
* Proactively invoke getEncryptedProperties() before attempting to insert or update, to ensure expected exception is thrown
* Create a helper method that checks for master encryption key and throws a useful exception if not configured
* Recover somewhat gracefully if loading encrypted properties without a master encryption key
