### PR TITLE
Issue 40753: Use operator lookup java export script 

### DIFF
--- a/api/src/org/labkey/api/query/JavaExportScriptModel.java
+++ b/api/src/org/labkey/api/query/JavaExportScriptModel.java
@@ -56,7 +56,10 @@ public class JavaExportScriptModel extends ExportScriptModel
     @Override
     protected String makeFilterExpression(String name, CompareType operator, String value)
     {
-        return "cmd.addFilter(" + quote(name) + ", " + quote(value) + ", Filter.Operator." + operator.name() + ");\n";
+        // 40753: Lookup operator by programmatic name
+        String filterOperator = "Filter.Operator.getOperator(" + quote(operator.name()) + ")";
+
+        return "cmd.addFilter(" + quote(name) + ", " + quote(value) + ", " + filterOperator + ");\n";
     }
 
     private String getListOfColumns()


### PR DESCRIPTION
#### Rationale
[Issue 40753](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40753) describes how the filter operator in a Java export script can be incorrect. This is due to the `scriptName` in the declared `CompareType`s do not strictly match the enumerated name for the corollary filter in `labkey-api-java`.

This PR changes the export script generator to emit `Filter.Operator.getOperator()` for looking up the operator by `operator.name()`.

```java
// Before
cmd.addFilter("Name", "", Filter.Operator.NOT_MISSING); // ERROR: NOT_MISSING is not defined (it's called NONBLANK)

// After
cmd.addFilter("Name", "", Filter.Operator.getOperator("NOT_MISSING")); // Returns Filter.Operator.NONBLANK
```

#### Changes
* Use `Filter.Operator.getOperator()` to determine operator type in Java export script generator.