### PR TITLE
Issue 40838: Update platform to use @labkey/api v1.0.0

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -943,9 +943,9 @@
       }
     },
     "@labkey/api": {
-      "version": "0.3.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2.tgz",
-      "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
+      "version": "1.0.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.0.0.tgz",
+      "integrity": "sha1-vieF9kX0ykZaOCebfWS6dj9mVps="
     },
     "@labkey/components": {
       "version": "0.70.5",
@@ -986,6 +986,13 @@
         "react-treebeard": "3.2.4",
         "reactn": "2.2.6",
         "vis-network": "6.5.2"
+      },
+      "dependencies": {
+        "@labkey/api": {
+          "version": "0.3.2",
+          "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-0.3.2.tgz",
+          "integrity": "sha1-bgi8hnMcXW3QNWx+6OGuPNa8WLg="
+        }
       }
     },
     "@labkey/eslint-config-base": {

--- a/core/package.json
+++ b/core/package.json
@@ -94,7 +94,7 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "0.3.2",
+    "@labkey/api": "1.0.0",
     "@labkey/components": "0.70.5",
     "@labkey/eslint-config-react": "0.0.8",
     "react-toggle-button": "2.2.0"


### PR DESCRIPTION
#### Rationale
The release of @labkey/api v1.0.0 is intended to coincide with the v20.7 release of LKS.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/68

#### Changes
* Update version of `@labkey/api` to `v1.0.0`.
