### PR TITLE
Issue 40830 getkeycolumns

### DIFF
--- a/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
+++ b/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
@@ -74,6 +74,7 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
     private int _sampleTypeId;
     private boolean _isLineageUpdate;
     private String _metadata;
+    private String _inventoryUpdateType;
 
     public SampleTimelineAuditEvent()
     {
@@ -155,6 +156,16 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
         _metadata = metadata;
     }
 
+    public String getInventoryUpdateType()
+    {
+        return _inventoryUpdateType;
+    }
+
+    public void setInventoryUpdateType(String inventoryUpdateType)
+    {
+        _inventoryUpdateType = inventoryUpdateType;
+    }
+
     @Override
     public Map<String, Object> getAuditLogMessageElements()
     {
@@ -165,6 +176,7 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
         elements.put("sampleType", getSampleType());
         elements.put("sampleTypeId", getSampleTypeId());
         elements.put("isLineageUpdate", getIsLineageUpdate());
+        elements.put("inventoryUpdateType", getInventoryUpdateType());
         elements.putAll(super.getAuditLogMessageElements());
         return elements;
     }

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -143,4 +143,6 @@ public interface SampleTypeService
     void addAuditEvent(User user, Container c, TableInfo table, AuditBehaviorType auditBehaviorType, QueryService.AuditAction action, List<Map<String, Object>>... params);
 
     void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata);
+
+    void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, String updateType);
 }

--- a/api/src/org/labkey/api/query/JavaExportScriptModel.java
+++ b/api/src/org/labkey/api/query/JavaExportScriptModel.java
@@ -56,7 +56,10 @@ public class JavaExportScriptModel extends ExportScriptModel
     @Override
     protected String makeFilterExpression(String name, CompareType operator, String value)
     {
-        return "cmd.addFilter(" + quote(name) + ", " + quote(value) + ", Filter.Operator." + operator.name() + ");\n";
+        // 40753: Lookup operator by programmatic name
+        String filterOperator = "Filter.Operator.getOperator(" + quote(operator.name()) + ")";
+
+        return "cmd.addFilter(" + quote(name) + ", " + quote(value) + ", " + filterOperator + ");\n";
     }
 
     private String getListOfColumns()

--- a/core/api-src/org/labkey/api/products/ProductRegistry.java
+++ b/core/api-src/org/labkey/api/products/ProductRegistry.java
@@ -85,31 +85,27 @@ public class ProductRegistry
     }
 
     @NotNull
-    public List<MenuSection> getProductMenuSections(@NotNull ViewContext context, @NotNull String currentProductId, @NotNull Container container, @Nullable Integer itemLimit)
+    public List<String> getProductIdsForContainer(@NotNull Container container)
     {
+        List<String> productIds = new ArrayList<>();
+
         Set<String> modules = container.getActiveModules().stream().map(Module::getName).collect(Collectors.toSet());
-        List<MenuSection> sections = new ArrayList<>();
-        ProductMenuProvider userMenuProvider = _productMap.get(currentProductId);
         for (String module : modules)
         {
            if (_moduleProviderMap.containsKey(module))
-           {
-               if (userMenuProvider == null)
-                   userMenuProvider = _moduleProviderMap.get(module);
-               sections.addAll(_moduleProviderMap.get(module).getSections(context, itemLimit));
-           }
+               productIds.add(_moduleProviderMap.get(module).getProductId());
         }
-        // always include the user menu as the last item
-        if (userMenuProvider != null)
-            sections.add(new UserInfoMenuSection(context, userMenuProvider));
-        return sections;
+
+        return productIds;
     }
 
     @NotNull
-    public List<MenuSection> getProductMenuSections(@NotNull ViewContext context, @NotNull String currentProductId, @NotNull List<String> productIds, @Nullable Integer itemLimit)
+    public List<MenuSection> getProductMenuSections(@NotNull ViewContext context, @NotNull String userMenuProductId, @Nullable List<String> origProductIds, @Nullable Integer itemLimit)
     {
+        List<String> productIds = origProductIds == null ? getProductIdsForContainer(context.getContainer()) : origProductIds;
+
         List<MenuSection> sections = new ArrayList<>();
-        ProductMenuProvider userMenuProvider = _productMap.get(currentProductId);
+        ProductMenuProvider userMenuProvider = _productMap.get(userMenuProductId);
         for (String productId : productIds)
         {
             if (_productMap.containsKey(productId))

--- a/core/src/org/labkey/core/products/ProductController.java
+++ b/core/src/org/labkey/core/products/ProductController.java
@@ -57,6 +57,9 @@ public class ProductController extends SpringActionController
             if (menuItemsForm.getCurrentProductId() == null)
                 errors.reject(ERROR_REQUIRED, "currentProductId is required");
 
+            if (menuItemsForm.getUserMenuProductId() == null)
+                errors.reject(ERROR_REQUIRED, "userMenuProductId is required");
+
             ProductRegistry registry = ProductRegistry.get();
             if (!StringUtils.isEmpty(menuItemsForm.getProductIds()))
             {
@@ -70,10 +73,7 @@ public class ProductController extends SpringActionController
         @Override
         public Object execute(MenuItemsForm menuItemsForm, BindException errors) throws Exception
         {
-            if (_productIds != null)
-                return ProductRegistry.get().getProductMenuSections(getViewContext(), menuItemsForm.getCurrentProductId(), _productIds, menuItemsForm.getItemLimit());
-            else
-                return ProductRegistry.get().getProductMenuSections(getViewContext(), menuItemsForm.getCurrentProductId(), getContainer(), menuItemsForm.getItemLimit());
+            return ProductRegistry.get().getProductMenuSections(getViewContext(), menuItemsForm.getUserMenuProductId(), _productIds, menuItemsForm.getItemLimit());
         }
     }
 
@@ -82,6 +82,7 @@ public class ProductController extends SpringActionController
         private String _productIds; // comma-separated list of productIds
         private Integer _itemLimit;
         private String _currentProductId;
+        private String _userMenuProductId;
 
         public String getProductIds()
         {
@@ -111,6 +112,16 @@ public class ProductController extends SpringActionController
         public void setCurrentProductId(String currentProductId)
         {
             _currentProductId = currentProductId;
+        }
+
+        public String getUserMenuProductId()
+        {
+            return _userMenuProductId;
+        }
+
+        public void setUserMenuProductId(String userMenuProductId)
+        {
+            _userMenuProductId = userMenuProductId;
         }
     }
 }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -972,8 +972,7 @@ public class SampleTypeServiceImpl extends AuditHandler implements SampleTypeSer
         return event;
     }
 
-    @Override
-    public void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata)
+    private SampleTimelineAuditEvent createAuditRecord(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata)
     {
         SampleTimelineAuditEvent event = new SampleTimelineAuditEvent(container.getId(), comment);
         if (container.getProject() != null)
@@ -988,6 +987,20 @@ public class SampleTypeServiceImpl extends AuditHandler implements SampleTypeSer
             event.setSampleTypeId(type.getRowId());
         }
         event.setMetadata(AbstractAuditTypeProvider.encodeForDataMap(container, metadata));
+        return event;
+    }
+
+    @Override
+    public void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata)
+    {
+        AuditLogService.get().addEvent(user, createAuditRecord(user, container, comment, sample, metadata));
+    }
+
+    @Override
+    public void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, String updateType)
+    {
+        SampleTimelineAuditEvent event = createAuditRecord(user, container, comment, sample, metadata);
+        event.setInventoryUpdateType(updateType);
         AuditLogService.get().addEvent(user, event);
     }
 }

--- a/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
@@ -29,6 +29,7 @@ public class SampleTimelineAuditProvider extends AbstractAuditTypeProvider
     public static final String SAMPLE_ID_COLUMN_NAME = "SampleID";
     public static final String METADATA_COLUMN_NAME = "Metadata";
     public static final String IS_LINEAGE_UPDATE_COLUMN_NAME = "IsLineageUpdate";
+    public static final String INVENTORY_UPDATE_TYPE_COLUMN_NAME = "InventoryUpdateType";
 
 
     static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
@@ -43,6 +44,7 @@ public class SampleTimelineAuditProvider extends AbstractAuditTypeProvider
         defaultVisibleColumns.add(FieldKey.fromParts(SAMPLE_NAME_COLUMN_NAME));
         defaultVisibleColumns.add(FieldKey.fromParts(SAMPLE_ID_COLUMN_NAME));
         defaultVisibleColumns.add(FieldKey.fromParts(IS_LINEAGE_UPDATE_COLUMN_NAME));
+        defaultVisibleColumns.add(FieldKey.fromParts(INVENTORY_UPDATE_TYPE_COLUMN_NAME));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_COMMENT));
     }
 
@@ -108,6 +110,10 @@ public class SampleTimelineAuditProvider extends AbstractAuditTypeProvider
                 {
                     col.setLabel("Lineage Update?");
                 }
+                else if (INVENTORY_UPDATE_TYPE_COLUMN_NAME.equalsIgnoreCase(col.getName()))
+                {
+                    col.setLabel("Inventory Update Type");
+                }
             }
         };
         table.setTitleColumn(SAMPLE_NAME_COLUMN_NAME);
@@ -144,6 +150,7 @@ public class SampleTimelineAuditProvider extends AbstractAuditTypeProvider
             fields.add(createPropertyDescriptor(SAMPLE_ID_COLUMN_NAME, PropertyType.INTEGER));
             fields.add(createPropertyDescriptor(SAMPLE_LSID_COLUMN_NAME, PropertyType.STRING));
             fields.add(createPropertyDescriptor(IS_LINEAGE_UPDATE_COLUMN_NAME, PropertyType.BOOLEAN));
+            fields.add(createPropertyDescriptor(INVENTORY_UPDATE_TYPE_COLUMN_NAME, PropertyType.STRING));
             fields.add(createPropertyDescriptor(METADATA_COLUMN_NAME, PropertyType.STRING, -1));        // varchar max
             fields.add(createPropertyDescriptor(OLD_RECORD_PROP_NAME, PropertyType.STRING, -1));        // varchar max
             fields.add(createPropertyDescriptor(NEW_RECORD_PROP_NAME, PropertyType.STRING, -1));        // varchar max

--- a/query/src/org/labkey/query/sql/Query.java
+++ b/query/src/org/labkey/query/sql/Query.java
@@ -1705,7 +1705,11 @@ public class Query
         new SqlTest("WITH UserCTE AS (SELECT 1001 as UserId) \n" +
                 "SELECT U1.UserId Expr1, U2.UserId Expr2\n" +
                 "FROM UserCTE AS U1, UserCTE AS U2 \n" +
-                "WHERE U1.UserId = U2.UserId", 2, 1)
+                "WHERE U1.UserId = U2.UserId", 2, 1),
+
+        // 40830, this query caused a problem because it has no simple field references (only an expression) and so
+        // getSuggestedColumns() is not called on the inner SELECT and therefore resolveFields() was not called before getKeyColumns()
+        new SqlTest("SELECT Name || '-' || Label FROM (SELECT Name, Label FROM core.Modules) M")
     };
 
 
@@ -1740,7 +1744,7 @@ public class Query
         new SqlTest("SELECT regr_slope(seven, d), day FROM R GROUP BY day", 2, 7),
         new SqlTest("SELECT regr_sxx(seven, d), day FROM R GROUP BY day", 2, 7),
         new SqlTest("SELECT regr_sxy(seven, d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT regr_syy(seven, d), day FROM R GROUP BY day", 2, 7),
+        new SqlTest("SELECT regr_syy(seven, d), day FROM R GROUP BY day", 2, 7)
     };
 
 

--- a/query/src/org/labkey/query/sql/QuerySelect.java
+++ b/query/src/org/labkey/query/sql/QuerySelect.java
@@ -1766,8 +1766,6 @@ groupByLoop:
     @Override
     Collection<String> getKeyColumns()
     {
-        if (!_resolved)
-            throw new IllegalStateException();
         // TODO handle multi column primary keys
         // TODO handle group by/distinct
         if (_tables.size() != 1 || null != _distinct || null != _groupBy || this.isAggregate())


### PR DESCRIPTION
#### Rationale
As a performance fix we no longer generate database SQL when we generate a TableInfo from a query.  This means that the "_resolved" flag is also not set.  This test case found an assert that I believe is unnecessary as we will resolve fields on demand (SelectColumn.getResolvedField()).