### PR TITLE
Use stringUtils from commons-lang3 instead of springframework and remove some unused imports

### DIFF
--- a/assay/api-src/org/labkey/api/assay/AssayDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayDomainKind.java
@@ -34,7 +34,6 @@ import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.security.User;
-import org.labkey.api.assay.security.DesignAssayPermission;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;

--- a/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
@@ -26,7 +26,6 @@ import org.labkey.api.exp.property.Domain;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 
-import java.util.HashSet;
 import java.util.Set;
 
 /**

--- a/assay/api-src/org/labkey/api/assay/plate/PlateReader.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateReader.java
@@ -18,7 +18,6 @@ package org.labkey.api.assay.plate;
 
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.query.ValidationException;
-import org.labkey.api.assay.plate.PlateTemplate;
 
 import java.io.File;
 import java.util.Map;

--- a/assay/api-src/org/labkey/api/assay/plate/PlateService.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateService.java
@@ -22,7 +22,6 @@ import org.labkey.api.assay.dilution.DilutionCurve;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.statistics.FitFailedException;
 import org.labkey.api.data.statistics.StatsService;
-import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;

--- a/assay/api-src/org/labkey/api/assay/plate/WellGroup.java
+++ b/assay/api-src/org/labkey/api/assay/plate/WellGroup.java
@@ -16,10 +16,6 @@
 
 package org.labkey.api.assay.plate;
 
-import org.jetbrains.annotations.Nullable;
-import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.view.ActionURL;
-
 import java.util.List;
 import java.util.Set;
 

--- a/pipeline/api-src/org/labkey/api/pipeline/trigger/PipelineTriggerConfigImpl.java
+++ b/pipeline/api-src/org/labkey/api/pipeline/trigger/PipelineTriggerConfigImpl.java
@@ -15,9 +15,9 @@
  */
 package org.labkey.api.pipeline.trigger;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.labkey.api.data.Entity;
-import org.springframework.util.StringUtils;
 
 import java.util.Date;
 import java.util.HashMap;


### PR DESCRIPTION
#### Rationale
springframwork.StringUtils is meant to be used by springframework and unused imports are not needed.  

These were found while testing the publishing of artifacts with the non-deprecated maven-publish plugin.  They cause no real problems, but I figure I'll change them anyway.

#### Changes
* adjust some imports
