### PR TITLE
Rename 'External Tool Settings' to 'External Tool Access'.

### DIFF
--- a/api/src/org/labkey/api/view/PopupUserView.java
+++ b/api/src/org/labkey/api/view/PopupUserView.java
@@ -61,7 +61,7 @@ public class PopupUserView extends PopupMenuView
         ActionURL externalToolsViewURL = PageFlowUtil.urlProvider(SecurityUrls.class).getExternalToolsViewURL(user, currentURL);
         if (null != externalToolsViewURL)
         {
-            NavTree externalToolSettings = new NavTree("External Tool Settings", externalToolsViewURL);
+            NavTree externalToolSettings = new NavTree("External Tool Access", externalToolsViewURL);
             tree.addChild(externalToolSettings);
         }
 

--- a/core/api-src/org/labkey/api/external/tools/ExternalToolsViewProvider.java
+++ b/core/api-src/org/labkey/api/external/tools/ExternalToolsViewProvider.java
@@ -10,7 +10,7 @@ public interface ExternalToolsViewProvider
     /**
      *
      * @param user with access to the views
-     * @return a list of views to be accessed via 'External Tools Setting'
+     * @return a list of views to be accessed via 'External Tool Access'
      */
     List<ModelAndView> getViews(User user);
 }

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -1962,7 +1962,7 @@ public class SecurityController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            root.addChild("External Tool Settings");
+            root.addChild("External Tool Access");
         }
     }
 


### PR DESCRIPTION
#### Rationale
Rename 'External Tool Settings' to 'External Tool Access' to avoid confusion with the Settings part (since users are not Setting any configurations, but only retrieving it)

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/396
https://github.com/LabKey/connectors/pull/38
