### PR TITLE
Issue 40848: Adding Percent Neutralization Max and Percent Neutralization Initial Dilution to the NAb Assay results and copied-to-study dataset

### DIFF
--- a/assay/api-src/org/labkey/api/assay/dilution/DilutionDataHandler.java
+++ b/assay/api-src/org/labkey/api/assay/dilution/DilutionDataHandler.java
@@ -504,8 +504,13 @@ public abstract class DilutionDataHandler extends AbstractExperimentDataHandler
 
     public PropertyDescriptor getStringPropertyDescriptor(Container container, ExpProtocol protocol, String propertyName)
     {
+        return getTypedPropertyDescriptor(container, protocol, propertyName, PropertyType.STRING);
+    }
+
+    public PropertyDescriptor getTypedPropertyDescriptor(Container container, ExpProtocol protocol, String propertyName, PropertyType type)
+    {
         Lsid propertyURI = new Lsid(NAB_PROPERTY_LSID_PREFIX, protocol.getName(), propertyName);
-        PropertyDescriptor pd = new PropertyDescriptor(propertyURI.toString(), PropertyType.STRING, propertyName, propertyName, container);
+        PropertyDescriptor pd = new PropertyDescriptor(propertyURI.toString(), type, propertyName, propertyName, container);
         pd.setFormat(null);
         return pd;
     }

--- a/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
+++ b/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
@@ -113,8 +113,7 @@ public class NAbSpecimenTable extends FilteredTable<AssayProtocolSchema>
     {
         return new SQLFragment("(SELECT MAX(PercentNeutralization) FROM ")
             .append(DilutionManager.getTableInfoDilutionData(), "dd")
-            .append(" WHERE dd.RunDataId = ").append(ExprColumn.STR_TABLE_ALIAS + ".RowId")
-            .append(" GROUP BY dd.RunDataId)");
+            .append(" WHERE dd.RunDataId = ").append(ExprColumn.STR_TABLE_ALIAS + ".RowId)");
     }
 
     private SQLFragment getPercentNeutralizationInitialDilution()

--- a/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
+++ b/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
@@ -16,23 +16,34 @@
 
 package org.labkey.api.assay.nab.query;
 
+import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.dilution.DilutionAssayProvider;
+import org.labkey.api.assay.dilution.DilutionDataHandler;
 import org.labkey.api.assay.dilution.DilutionManager;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.exp.OntologyManager;
+import org.labkey.api.exp.PropertyDescriptor;
+import org.labkey.api.exp.PropertyType;
+import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.assay.AssayProtocolSchema;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 public class NAbSpecimenTable extends FilteredTable<AssayProtocolSchema>
 {
     private static final FieldKey CONTAINER_FIELD_KEY = FieldKey.fromParts("Container");
+
+    public static final String PERCENT_NEUT_MAX_PROP = "PercentNeutralizationMax";
+    public static final String PERCENT_NEUT_INIT_DILUTION_PROP = "PercentNeutralizationInitialDilution";
 
     public NAbSpecimenTable(AssayProtocolSchema schema, ContainerFilter cf)
     {
@@ -45,6 +56,13 @@ public class NAbSpecimenTable extends FilteredTable<AssayProtocolSchema>
         ExprColumn selectedPositiveAUC = new ExprColumn(this, "PositiveAUC", getSelectedCurveFitAUC(true), JdbcType.DECIMAL);
         addColumn(selectedAUC);
         addColumn(selectedPositiveAUC);
+
+        ExprColumn percNeutMax = new ExprColumn(this, PERCENT_NEUT_MAX_PROP, getPercentNeutralizationMax(), JdbcType.DECIMAL);
+        percNeutMax.setHidden(true);
+        addColumn(percNeutMax);
+        ExprColumn percNeutInitDilution = new ExprColumn(this, PERCENT_NEUT_INIT_DILUTION_PROP, getPercentNeutralizationInitialDilution(), JdbcType.DECIMAL);
+        percNeutInitDilution.setHidden(true);
+        addColumn(percNeutInitDilution);
 
         addCondition(getRealTable().getColumn("ProtocolID"), _userSchema.getProtocol().getRowId());
     }
@@ -91,11 +109,37 @@ public class NAbSpecimenTable extends FilteredTable<AssayProtocolSchema>
         return sql;
     }
 
+    private SQLFragment getPercentNeutralizationMax()
+    {
+        return new SQLFragment("(SELECT MAX(PercentNeutralization) FROM ")
+            .append(DilutionManager.getTableInfoDilutionData(), "dd")
+            .append(" WHERE dd.RunDataId = ").append(ExprColumn.STR_TABLE_ALIAS + ".RowId")
+            .append(" GROUP BY dd.RunDataId)");
+    }
+
+    private SQLFragment getPercentNeutralizationInitialDilution()
+    {
+        return new SQLFragment("(SELECT PercentNeutralization FROM ")
+            .append(DilutionManager.getTableInfoDilutionData(), "dd")
+            .append(" WHERE dd.RunDataId = ").append(ExprColumn.STR_TABLE_ALIAS + ".RowId")
+            .append(" AND dd.DilutionOrder = 1)");
+    }
+
     @Override
     protected ColumnInfo resolveColumn(String name)
     {
         ColumnInfo columnInfo;
         columnInfo = super.resolveColumn(name);
         return columnInfo;
+    }
+
+    public List<PropertyDescriptor> getAdditionalDataProperties(ExpProtocol protocol)
+    {
+        DilutionAssayProvider provider = (DilutionAssayProvider) AssayService.get().getProvider(protocol);
+        DilutionDataHandler dataHandler = provider.getDataHandler();
+        List<PropertyDescriptor> propertyDescriptors = new ArrayList<>();
+        propertyDescriptors.add(dataHandler.getTypedPropertyDescriptor(getContainer(), protocol, PERCENT_NEUT_MAX_PROP, PropertyType.DECIMAL));
+        propertyDescriptors.add(dataHandler.getTypedPropertyDescriptor(getContainer(), protocol, PERCENT_NEUT_INIT_DILUTION_PROP, PropertyType.DECIMAL));
+        return propertyDescriptors;
     }
 }


### PR DESCRIPTION
#### Rationale
See info from issue [40848](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40848) and related support ticket [40640](https://www.labkey.org/Atlas/support%20tickets/issues-details.view?issueId=40640). A lab using the LabKey NAb assay tool requested that two new values be calculated and added to the NAb assay results grid. These values were simple calculations off of the DilutionData values we already stored for the NAb assay runs.

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/206

#### Changes
* add ExprColumn for two calculated values to the NAbSpecimenTable
* expose the new calculated columns in the NabRunDataTable, but don't add them to the default view
* override isValidDataProperty() in NAbDataHandler so that it considers the two new column names valid
