### PR TITLE
Issue 40882: Migrate HTML encoding from server actions to client

### DIFF
--- a/api/webapp/ext-3.4.1/ext-patches.js
+++ b/api/webapp/ext-3.4.1/ext-patches.js
@@ -1,3 +1,6 @@
+// Declare a shorthand alias for htmlEncode
+Ext.htmlEncode = Ext.util.Format.htmlEncode;
+
 // Set USE_NATIVE_JSON so Ext.decode and Ext.encode use JSON.parse and JSON.stringify instead of eval
 Ext.USE_NATIVE_JSON = true;
 
@@ -327,3 +330,51 @@ if (Ext.isIE7 || Ext.isIE8) {
         }
     });
 }();
+
+/**
+ * @Override
+ * Ext.tree.TreeNodeUI does not HTML encode display values.
+ * This overrides the default renderElements() to encode using Ext.htmlEncode.
+ * https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40882
+ */
+Ext.override(Ext.tree.TreeNodeUI, {
+    renderElements : function(n, a, targetNode, bulkRender) {
+        this.indentMarkup = n.parentNode ? n.parentNode.ui.getChildIndent() : '';
+
+        var cb = Ext.isBoolean(a.checked),
+            nel,
+            href = this.getHref(a.href),
+            buf = [
+                '<li class="x-tree-node"><div ext:tree-node-id="',n.id,'" class="x-tree-node-el x-tree-node-leaf x-unselectable ', a.cls,'" unselectable="on">',
+                    '<span class="x-tree-node-indent">',this.indentMarkup,"</span>",
+                    '<img alt="" src="', this.emptyIcon, '" class="x-tree-ec-icon x-tree-elbow" />',
+                    '<img alt="" src="', a.icon || this.emptyIcon, '" class="x-tree-node-icon',(a.icon ? " x-tree-node-inline-icon" : ""),(a.iconCls ? " "+a.iconCls : ""),'" unselectable="on" />',
+                    cb ? ('<input class="x-tree-node-cb" type="checkbox" ' + (a.checked ? 'checked="checked" />' : '/>')) : '',
+                    '<a hidefocus="on" class="x-tree-node-anchor" href="',href,'" tabIndex="1" ',
+                    a.hrefTarget ? ' target="'+a.hrefTarget+'"' : "", '><span unselectable="on">',Ext.htmlEncode(n.text),"</span></a></div>",
+                    '<ul class="x-tree-node-ct" style="display:none;"></ul>',
+                '</li>'
+            ].join('');
+
+        if (bulkRender !== true && n.nextSibling && (nel = n.nextSibling.ui.getEl())) {
+            this.wrap = Ext.DomHelper.insertHtml("beforeBegin", nel, buf);
+        } else {
+            this.wrap = Ext.DomHelper.insertHtml("beforeEnd", targetNode, buf);
+        }
+
+        this.elNode = this.wrap.childNodes[0];
+        this.ctNode = this.wrap.childNodes[1];
+        var cs = this.elNode.childNodes;
+        this.indentNode = cs[0];
+        this.ecNode = cs[1];
+        this.iconNode = cs[2];
+        var index = 3;
+        if (cb) {
+            this.checkbox = cs[3];
+            this.checkbox.defaultChecked = this.checkbox.checked;
+            index++;
+        }
+        this.anchor = cs[index];
+        this.textNode = cs[index].firstChild;
+    }
+});

--- a/api/webapp/ext-4.2.1/ext-patches.js
+++ b/api/webapp/ext-4.2.1/ext-patches.js
@@ -1031,3 +1031,31 @@ Ext4.override(Ext4.window.MessageBox, {
     }
 });
 
+/**
+ * @Override
+ * Ext4.tree.Column does not HTML encode display values. This overrides the default cell template
+ * to encode the value using {value:htmlEncode}.
+ * https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40882
+ */
+Ext4.override(Ext4.tree.Column, {
+    cellTpl: [
+        '<tpl for="lines">',
+            '<img src="{parent.blankUrl}" class="{parent.childCls} {parent.elbowCls}-img ',
+            '{parent.elbowCls}-<tpl if=".">line<tpl else>empty</tpl>"/>',
+        '</tpl>',
+        '<img src="{blankUrl}" class="{childCls} {elbowCls}-img {elbowCls}',
+        '<tpl if="isLast">-end</tpl><tpl if="expandable">-plus {expanderCls}</tpl>"/>',
+        '<tpl if="checked !== null">',
+            '<input type="button" role="checkbox" <tpl if="checked">aria-checked="true" </tpl>',
+            'class="{childCls} {checkboxCls}<tpl if="checked"> {checkboxCls}-checked</tpl>"/>',
+        '</tpl>',
+        '<img src="{blankUrl}" class="{childCls} {baseIconCls} ',
+        '{baseIconCls}-<tpl if="leaf">leaf<tpl else>parent</tpl> {iconCls}"',
+        '<tpl if="icon">style="background-image:url({icon})"</tpl>/>',
+        '<tpl if="href">',
+            '<a href="{href}" target="{hrefTarget}" class="{textCls} {childCls}">{value:htmlEncode}</a>',
+        '<tpl else>',
+            '<span class="{textCls} {childCls}">{value:htmlEncode}</span>',
+        '</tpl>'
+    ]
+});

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -1214,7 +1214,7 @@ public class CoreController extends SpringActionController
         {
             JSONObject props = new JSONObject();
             props.put("id", c.getRowId());
-            props.put("text", PageFlowUtil.filter(form.isUseTitles() ? c.getTitle() : c.getName()));
+            props.put("text", form.isUseTitles() ? c.getTitle() : c.getName());
             props.put("containerPath", c.getPath());
             props.put("expanded", false);
             props.put("iconCls", "x4-tree-icon-parent");
@@ -1237,7 +1237,7 @@ public class CoreController extends SpringActionController
         protected JSONObject getContainerProps(Container c, ExtContainerTreeForm form)
         {
             JSONObject props = super.getContainerProps(c, form);
-            String text = PageFlowUtil.filter(c.getName());
+            String text = c.getName();
             if (!c.getPolicy().getResourceId().equals(c.getResourceId()))
                 text += "*";
             if (c.equals(getContainer()))

--- a/core/webapp/admin/FolderManagementPanel.js
+++ b/core/webapp/admin/FolderManagementPanel.js
@@ -442,7 +442,7 @@ Ext4.define('LABKEY.ext4.panel.FolderManagement', {
                                     else if (ps.data.id == pd.data.id) {
 
                                         var _t   = 'Move Folder';
-                                        var _msg = 'You are moving folder \'' + _s.data.text + '\'. Are you sure you would like to move this folder?';
+                                        var _msg = 'You are moving folder \'' + Ext4.htmlEncode(_s.data.text) + '\'. Are you sure you would like to move this folder?';
 
                                         Ext4.Msg.confirm(_t, _msg, function(btn){
                                             me.confirmation = true;
@@ -455,7 +455,7 @@ Ext4.define('LABKEY.ext4.panel.FolderManagement', {
                                         });
                                     }
                                     else {
-                                        Ext4.Msg.confirm('Change Project', 'You are moving folder \'' + _s.data.text + '\' from one project to another. ' +
+                                        Ext4.Msg.confirm('Change Project', 'You are moving folder \'' + Ext4.htmlEncode(_s.data.text) + '\' from one project to another. ' +
                                                 'After the move is complete, you will need to reconfigure permissions settings for this folder, any subfolders, and other secured resources. ' +
                                                 '<br/><b>This action cannot be undone.</b>',
                                                 function(btn){
@@ -596,6 +596,7 @@ Ext4.define('LABKEY.ext4.panel.FolderManagement', {
             }
         }
 
+        ret.msg = Ext4.htmlEncode(ret.msg);
         return ret;
     },
 

--- a/internal/webapp/WebPartPermissionsPanel.js
+++ b/internal/webapp/WebPartPermissionsPanel.js
@@ -223,7 +223,7 @@ Ext4.define('LABKEY.Portal.WebPartPermissionsPanel', {
             var expandNode = function(childNodes){
                 if(nodes.length > 0){
                     for(var i = 0; i < childNodes.length; i++){
-                        if(nodes[0] === Ext4.htmlDecode(childNodes[i].data.text)){
+                        if(nodes[0] === childNodes[i].data.text){
                             nodes.shift();
                             childNodes[i].expand(false, expandNode, this);
                             break;
@@ -233,7 +233,7 @@ Ext4.define('LABKEY.Portal.WebPartPermissionsPanel', {
             };
 
             var child = this.folderTree.getRootNode().findChildBy(function(node){
-                return nodes[0] === Ext4.htmlDecode(node.data.text);
+                return nodes[0] === node.data.text;
             }, this);
 
             if(child){

--- a/query/src/org/labkey/query/controllers/GetSchemaQueryTreeAction.java
+++ b/query/src/org/labkey/query/controllers/GetSchemaQueryTreeAction.java
@@ -34,7 +34,6 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.util.PageFlowUtil;
 import org.springframework.validation.BindException;
 
 import javax.servlet.http.HttpServletResponse;
@@ -55,13 +54,6 @@ import java.util.Map;
 @Action(ActionType.SelectMetaData.class)
 public class GetSchemaQueryTreeAction extends ReadOnlyApiAction<GetSchemaQueryTreeAction.Form>
 {
-    boolean _withHtmlEncoding = false;
-
-    public String filter(String s)
-    {
-        return _withHtmlEncoding ? PageFlowUtil.filter(s) : s;
-    }
-
     @Override
     protected long getLastModified(Form form)
     {
@@ -71,8 +63,6 @@ public class GetSchemaQueryTreeAction extends ReadOnlyApiAction<GetSchemaQueryTr
     @Override
     public ApiResponse execute(Form form, BindException errors) throws Exception
     {
-        _withHtmlEncoding = form.isWithHtmlEncoding();
-
         JSONArray respArray = new JSONArray();
         Container container = getContainer();
         User user = getUser();
@@ -116,7 +106,7 @@ public class GetSchemaQueryTreeAction extends ReadOnlyApiAction<GetSchemaQueryTr
                     String dsName = scope.getDataSourceName();
                     JSONObject ds = new JSONObject();
                     ds.put("text", "Schemas in " + scope.getDisplayName());
-                    ds.put("qtip", "Schemas in data source '" + dsName + "'");
+                    ds.put("description", "Schemas in data source '" + dsName + "'");
                     ds.put("expanded", true);
                     ds.put("children", schemas);
                     ds.put("name", dsName);
@@ -185,7 +175,7 @@ public class GetSchemaQueryTreeAction extends ReadOnlyApiAction<GetSchemaQueryTr
                     {
                         JSONObject fldr = new JSONObject();
                         fldr.put("text", "user-defined queries");
-                        fldr.put("qtip", "Custom queries created by you and those shared by others.");
+                        fldr.put("description", "Custom queries created by you and those shared by others.");
                         fldr.put("expanded", true);
                         fldr.put("children", userDefined);
                         fldr.put("schemaName", schemaPath);
@@ -195,8 +185,8 @@ public class GetSchemaQueryTreeAction extends ReadOnlyApiAction<GetSchemaQueryTr
                     if (builtIn.length() > 0)
                     {
                         JSONObject fldr = new JSONObject();
-                        fldr.put("text", filter("built-in queries & tables"));
-                        fldr.put("qtip", "Queries and tables that are part of the schema by default.");
+                        fldr.put("text", "built-in queries & tables");
+                        fldr.put("description", "Queries and tables that are part of the schema by default.");
                         fldr.put("expanded", true);
                         fldr.put("children", builtIn);
                         fldr.put("schemaName", schemaPath);
@@ -228,9 +218,8 @@ public class GetSchemaQueryTreeAction extends ReadOnlyApiAction<GetSchemaQueryTr
     protected JSONObject getSchemaProps(SchemaKey schemaName, QuerySchema schema)
     {
         JSONObject schemaProps = new JSONObject();
-        schemaProps.put("text", filter(schema.getName()));
-        schemaProps.put("description", filter(schema.getDescription()));
-        schemaProps.put("qtip", filter(schema.getDescription()));
+        schemaProps.put("text", schema.getName());
+        schemaProps.put("description", schema.getDescription());
         schemaProps.put("name", schema.getName());
         schemaProps.put("schemaName", schemaName);
         schemaProps.put("hidden", schema.isHidden());
@@ -246,12 +235,11 @@ public class GetSchemaQueryTreeAction extends ReadOnlyApiAction<GetSchemaQueryTr
         String text = qname;
         if (!qname.equalsIgnoreCase(label))
             text += " (" + label + ")";
-        qprops.put("text", filter(text));
+        qprops.put("text", text);
         qprops.put("leaf", true);
         if (null != description)
         {
             qprops.put("description", description);
-            qprops.put("qtip", filter(description));
         }
         qprops.put("hidden", hidden);
         list.put(qprops);
@@ -262,7 +250,6 @@ public class GetSchemaQueryTreeAction extends ReadOnlyApiAction<GetSchemaQueryTr
         private String _node;
         private SchemaKey _schemaName;
         private boolean _showHidden;
-        private boolean _withHtmlEncoding = false;
 
         public String getNode()
         {
@@ -292,17 +279,6 @@ public class GetSchemaQueryTreeAction extends ReadOnlyApiAction<GetSchemaQueryTr
         public void setShowHidden(boolean showHidden)
         {
             _showHidden = showHidden;
-        }
-
-        public boolean isWithHtmlEncoding()
-        {
-            return _withHtmlEncoding;
-        }
-
-        /* This is a crazy way to build an API, but apparently this was an Ext workaround */
-        public void setWithHtmlEncoding(boolean withHtmlEncoding)
-        {
-            _withHtmlEncoding = withHtmlEncoding;
         }
     }
 }

--- a/query/webapp/query/browser/Tree.js
+++ b/query/webapp/query/browser/Tree.js
@@ -21,7 +21,7 @@ Ext4.define('LABKEY.query.browser.Tree', {
                 extend: 'Ext.data.Model',
                 proxy: {
                     type: 'ajax',
-                    url: LABKEY.ActionURL.buildURL('query', 'getSchemaQueryTree.api', null, {showHidden : this.showHidden, withHtmlEncoding:true}),
+                    url: LABKEY.ActionURL.buildURL('query', 'getSchemaQueryTree.api', null, { showHidden : this.showHidden }),
                     // don't use the "_dc" defeat cache parameter
                     noCache: false,
                     listeners: {
@@ -36,7 +36,7 @@ Ext4.define('LABKEY.query.browser.Tree', {
                     {name: 'description'},
                     {name: 'hidden', type: 'boolean', defaultValue: false},
                     {name: 'name'},
-                    {name: 'qtip'},
+                    {name: 'qtip', convert: function(_, rec) { return Ext4.htmlEncode(rec.raw.description); } },
                     {name: 'schemaName'},
                     {name: 'queryName'},
                     {name: 'queryLabel'},
@@ -119,19 +119,5 @@ Ext4.define('LABKEY.query.browser.Tree', {
             window.location.href = url + window.location.hash;
         else
             window.location.href = url;
-
-        // TODO: Cannot show/hide nodes in ExtJS 4.2.1 -- Optimially, use TreeStore.filter() in ExtJS 4.2.3
-//        this.getRootNode().cascadeBy(function(node) {
-//            if (showHidden)
-//            {
-//                if (node.hidden)
-//                    node.ui.show();
-//            }
-//            else
-//            {
-//                if (node.hidden)
-//                    node.ui.hide();
-//            }
-//        }, this);
     }
 });

--- a/query/webapp/query/browser/view/SchemaDetails.js
+++ b/query/webapp/query/browser/view/SchemaDetails.js
@@ -104,7 +104,7 @@ Ext4.define('LABKEY.query.browser.view.SchemaDetails', {
                 {
                     if (schemaNodeChild.get('text') === "user-defined queries")
                         userDefined.push(Ext4.clone(queryNode.data));
-                    else if (schemaNodeChild.get('text') === "built-in queries &amp; tables")
+                    else if (schemaNodeChild.get('text') === "built-in queries & tables")
                         builtIn.push(Ext4.clone(queryNode.data));
                 });
             });
@@ -140,7 +140,7 @@ Ext4.define('LABKEY.query.browser.view.SchemaDetails', {
                     afterrender: {
                         fn: function(box) {
                             // bind links
-                            var nameLinks = Ext4.DomQuery.select('tbody tr td', box.getEl().id);
+                            var nameLinks = Ext4.DomQuery.select('tbody tr td .labkey-link', box.getEl().id);
                             if (!Ext4.isEmpty(nameLinks)) {
                                 for (var i = 0; i < nameLinks.length; i++) {
                                     Ext4.get(nameLinks[i]).on('click', function(evt, t) {


### PR DESCRIPTION
#### Rationale
This PR addressed issues [40882](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40882) which outlines the desire to migrate HTML encoding away from our server actions and into the client. Additionally, this addresses [40883](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=40883) by patching Ext3 and Ext4 to HTML encode their respective tree components.

Note: There are a number of client-side usages of these endpoints so there may be additional test failures that need to be addressed before merging this PR.

#### Changes
* Update actions outlined in [40082](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40882) to no longer HTML encode properties in their payload.
* Added a patch for Ext3 to encode the display text for the `Ext.tree.TreeNodeUI` component.
* Added a patch for Ext4 to encode the display text for the `Ext4.tree.Column` component.
* Additionally revise `query-getSchemaQueryTree.api` to no longer specify a `withHtmlEncoding` parameter nor pass a `qtip` property in the payload -- let the client be explicit about it.