### PR TITLE
40893: enforce display column width using overflow-wrap

### DIFF
--- a/api/src/org/labkey/api/data/DisplayColumn.java
+++ b/api/src/org/labkey/api/data/DisplayColumn.java
@@ -1011,7 +1011,7 @@ public abstract class DisplayColumn extends RenderColumn
         if (_nowrap)
             style += "white-space:nowrap;";
 
-        // 34871: Support for column display width
+        // 40893: Support for column display width
         if (!StringUtils.isBlank(getWidth()))
             style += "overflow-wrap:anywhere;";
 

--- a/api/src/org/labkey/api/data/DisplayColumn.java
+++ b/api/src/org/labkey/api/data/DisplayColumn.java
@@ -1013,7 +1013,7 @@ public abstract class DisplayColumn extends RenderColumn
 
         // 34871: Support for column display width
         if (!StringUtils.isBlank(getWidth()))
-            style += "word-break:break-all;";
+            style += "overflow-wrap:anywhere;";
 
         return style;
     }


### PR DESCRIPTION
#### Rationale
This PR addresses [40893](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40893) by updating `DisplayColumn` to use `overflow-wrap: anywhere` in instead of `word-break: break-all`. Here is the description of `anywhere` from [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap):
> To prevent overflow, an otherwise unbreakable string of characters — like a long word or URL — may be broken at any point if there are no otherwise-acceptable break points in the line. No hyphenation character is inserted at the break point. Soft wrap opportunities introduced by the word break are considered when calculating min-content intrinsic sizes.

This allows for the cells to wrap on common break points (e.g. spaces, hyphens, etc) but will enforce the content breaks if a common break point cannot be found. Here is an example of two long running values in the "description" column:

![image](https://user-images.githubusercontent.com/3926239/87352394-cfd14080-c50f-11ea-8851-ce8fdeaeeaa0.png)


#### Changes
* Enforce explicit display column width by using `overflow-wrap: anywhere`.
* Updated issue comment to most recent.