### PR TITLE
40910: mute mothership client-side errors when page unloads

### DIFF
--- a/internal/webapp/mothership.js
+++ b/internal/webapp/mothership.js
@@ -773,7 +773,7 @@ LABKEY.Mothership = (function () {
         window.addEventListener('error', report);
 
         // 40910: mute reporting errors when page unloads
-        window.addEventListener('beforeunload', function() { enable(true); });
+        window.addEventListener('beforeunload', function() { enable(false); });
 
         // catch unhandled errors in promises
         // https://developer.mozilla.org/en-US/docs/Web/Events/unhandledrejection

--- a/internal/webapp/mothership.js
+++ b/internal/webapp/mothership.js
@@ -45,6 +45,9 @@ LABKEY.Mothership = (function () {
     // Maximum number of milliseconds to attempt hook installation before giving up.
     var _maxDelayMillis = 4*1000;
 
+    function enable(enabled) {
+        _enabled = enabled;
+    }
 
     function log() {
         if (_debug && console && console.debug)
@@ -769,6 +772,9 @@ LABKEY.Mothership = (function () {
     function initEventListeners() {
         window.addEventListener('error', report);
 
+        // 40910: mute reporting errors when page unloads
+        window.addEventListener('beforeunload', function() { enable(true); });
+
         // catch unhandled errors in promises
         // https://developer.mozilla.org/en-US/docs/Web/Events/unhandledrejection
         if (window.hasOwnProperty('onunhandledrejection')) {
@@ -804,7 +810,7 @@ LABKEY.Mothership = (function () {
         hookLabKey : function () { if (_hookLabKey) { replaceLabKeyListeners(0); } },
 
         /** Turn error reporting on or off (default is on). */
-        enable  : function (b) { _enabled = b; },
+        enable: enable,
 
         /** Process and updates a stack trace by integrating available source map information */
         processStackTrace : processStackTrace,


### PR DESCRIPTION
#### Rationale
This PR disables client-side mothership reporting of errors once the page fires the `beforeunload` event. This is being done to avoid reporting flaky errors that occur when outbound async requests are aborted/cancelled by the browser upon navigation.

I could have hooked the `unload` page event instead, however, in my local testing that event fires well after request processing has failed so I elected to bind `beforeunload` instead. A drawback of this approach is that a user could invoke the `beforeunload` event but subsequently elect to stay on the page and mothership would stay disabled. I've elected to forego attempting to handle that scenario as there isn't really a clear solution to recognize this case.

#### Changes
* Disable client-side mothership reporting upon `beforeunload` event.
