### PR TITLE
Issue 40921: ResultSetImpl.getSize updates to ensure resultset iterated before calling getSize

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -702,19 +702,24 @@ public abstract class AssayProtocolSchema extends AssaySchema
                             DataView dataView = allResultsQueryView.createDataView();
                             try (Results r = dataView.getDataRegion().getResults(dataView.getRenderContext()))
                             {
-                                final int rowCount = r.getSize();
+                                if (null != r)
+                                {
+                                    // In order to get size must first iterate through result set
+                                    while (r.next()) ;
 
-                                baseQueryView.setMessageSupplier(dataRegion -> {
-                                    if (dataRegion.getTotalRows() != null && dataRegion.getTotalRows() < rowCount)
-                                    {
-                                        long count = rowCount - dataRegion.getTotalRows();
-                                        String msg = count > 1 ? "There are " + count + " rows not shown due to unapproved QC state."
-                                                : "There is one row not shown due to unapproved QC state.";
-                                        DataRegion.Message drm = new DataRegion.Message(msg, DataRegion.MessageType.WARNING, DataRegion.MessagePart.view);
-                                        return Collections.singletonList(drm);
-                                    }
-                                    return Collections.emptyList();
-                                });
+                                    final int rowCount = r.getSize();
+                                    baseQueryView.setMessageSupplier(dataRegion -> {
+                                        if (dataRegion.getTotalRows() != null && dataRegion.getTotalRows() < rowCount)
+                                        {
+                                            long count = rowCount - dataRegion.getTotalRows();
+                                            String msg = count > 1 ? "There are " + count + " rows not shown due to unapproved QC state."
+                                                    : "There is one row not shown due to unapproved QC state.";
+                                            DataRegion.Message drm = new DataRegion.Message(msg, DataRegion.MessageType.WARNING, DataRegion.MessagePart.view);
+                                            return Collections.singletonList(drm);
+                                        }
+                                        return Collections.emptyList();
+                                    });
+                                }
                             }
                         }
                         catch (SQLException | IOException e)

--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -705,7 +705,7 @@ public abstract class AssayProtocolSchema extends AssaySchema
                                 if (null != r)
                                 {
                                     // In order to get size must first iterate through result set
-                                    while (r.next()) ;
+                                    r.iterateAll() ;
 
                                     final int rowCount = r.getSize();
                                     baseQueryView.setMessageSupplier(dataRegion -> {

--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -705,7 +705,7 @@ public abstract class AssayProtocolSchema extends AssaySchema
                                 if (null != r)
                                 {
                                     // In order to get size must first iterate through result set
-                                    r.iterateAll() ;
+                                    while(r.next());
 
                                     final int rowCount = r.getSize();
                                     baseQueryView.setMessageSupplier(dataRegion -> {

--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -704,10 +704,7 @@ public abstract class AssayProtocolSchema extends AssaySchema
                             {
                                 if (null != r)
                                 {
-                                    // In order to get size must first iterate through result set
-                                    while(r.next());
-
-                                    final int rowCount = r.getSize();
+                                    final int rowCount = r.countAll();
                                     baseQueryView.setMessageSupplier(dataRegion -> {
                                         if (dataRegion.getTotalRows() != null && dataRegion.getTotalRows() < rowCount)
                                         {

--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -1099,7 +1099,7 @@ public class DataRegion extends DisplayElement
         if (useTableWrap)
             out.write("</tbody></table>");
 
-        if (usesResultSet() && rs instanceof TableResultSet && ((TableResultSet) rs).iterateAll() && ((TableResultSet) rs).getSize() != -1)
+        if (usesResultSet() && rs instanceof TableResultSet && ((TableResultSet) rs).countAll() != -1)
         {
             _rowCount = ((TableResultSet) rs).getSize();
             if (_complete && _totalRows == null)

--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -1099,7 +1099,7 @@ public class DataRegion extends DisplayElement
         if (useTableWrap)
             out.write("</tbody></table>");
 
-        if (usesResultSet() && rs instanceof TableResultSet && ((TableResultSet) rs).getSize() != -1)
+        if (usesResultSet() && rs instanceof TableResultSet && ((TableResultSet) rs).iterateAll() && ((TableResultSet) rs).getSize() != -1)
         {
             _rowCount = ((TableResultSet) rs).getSize();
             if (_complete && _totalRows == null)

--- a/api/src/org/labkey/api/data/GroupedResultSet.java
+++ b/api/src/org/labkey/api/data/GroupedResultSet.java
@@ -181,7 +181,7 @@ public class GroupedResultSet extends ResultSetImpl
         if (_ignoreNext)
         {
             _ignoreNext = false;
-            return true;
+            return hasNext(true);
         }
         Object previousValue;
         if (getRow() > 0)
@@ -197,7 +197,7 @@ public class GroupedResultSet extends ResultSetImpl
         {
             if (!super.next())
             {
-                return false;
+                return hasNext(false);
             }
             currentValue = getObject(_columnIndex);
         }
@@ -205,9 +205,9 @@ public class GroupedResultSet extends ResultSetImpl
 
         if (_lastRow != 0)
         {
-            return getRow() <= _lastRow;
+            return hasNext(getRow() <= _lastRow);
         }
-        return true;
+        return hasNext(true);
     }
 
     public ResultSet getNextResultSet() throws SQLException
@@ -241,12 +241,12 @@ public class GroupedResultSet extends ResultSetImpl
             if (_ignoreNext)
             {
                 _ignoreNext = false;
-                return true;
+                return hasNext(true);
             }
             boolean success = innerNext();
 
             if (!success)
-                return success;
+                return hasNext(success);
 
             if (null == _currentValue)
                 _currentValue = getObject(_columnIndex);
@@ -258,7 +258,7 @@ public class GroupedResultSet extends ResultSetImpl
                 previous();  // Back it up
             }
 
-            return success;
+            return hasNext(success);
         }
 
         @Override

--- a/api/src/org/labkey/api/data/ResultSetImpl.java
+++ b/api/src/org/labkey/api/data/ResultSetImpl.java
@@ -96,6 +96,14 @@ public class ResultSetImpl extends LoggingResultSetWrapper implements TableResul
     }
 
     @Override
+    public boolean iterateAll() throws SQLException
+    {
+        while(next());
+
+        return true;
+    }
+
+    @Override
     public int getSize()
     {
         if (!_iterationComplete)

--- a/api/src/org/labkey/api/data/ResultSetImpl.java
+++ b/api/src/org/labkey/api/data/ResultSetImpl.java
@@ -114,16 +114,17 @@ public class ResultSetImpl extends LoggingResultSetWrapper implements TableResul
         {
             if (Table.ALL_ROWS != _maxRows)
             {
-                if (getRow() == _maxRows)
+                if (getRow() == _maxRows + 1)
                 {
                     _isComplete = false;
                 }
 
-                hasNext = getRow() < _maxRows;
+                hasNext = getRow() <= _maxRows;
             }
 
             // Keep track of all of the rows that we've iterated
-            _size = Math.max(_size, getRow());
+            if (_isComplete)
+                _size = Math.max(_size, getRow());
         }
 
         if (!hasNext) {

--- a/api/src/org/labkey/api/data/ResultSetImpl.java
+++ b/api/src/org/labkey/api/data/ResultSetImpl.java
@@ -96,11 +96,7 @@ public class ResultSetImpl extends LoggingResultSetWrapper implements TableResul
 
     protected boolean hasNext(boolean hasNext)
     {
-        if (hasNext)
-        {
-            _countComplete = false;
-        }
-        _countComplete = true;
+        _countComplete = !hasNext;
 
         return hasNext;
     }

--- a/api/src/org/labkey/api/data/ResultSetImpl.java
+++ b/api/src/org/labkey/api/data/ResultSetImpl.java
@@ -114,12 +114,12 @@ public class ResultSetImpl extends LoggingResultSetWrapper implements TableResul
         {
             if (Table.ALL_ROWS != _maxRows)
             {
-                if (getRow() == _maxRows + 1)
+                if (getRow() == _maxRows)
                 {
                     _isComplete = false;
                 }
 
-                hasNext = getRow() <= _maxRows;
+                hasNext = getRow() < _maxRows;
             }
 
             // Keep track of all of the rows that we've iterated

--- a/api/src/org/labkey/api/data/ResultSetImpl.java
+++ b/api/src/org/labkey/api/data/ResultSetImpl.java
@@ -43,6 +43,7 @@ public class ResultSetImpl extends LoggingResultSetWrapper implements TableResul
     private final @Nullable DbScope _scope;
     private final @Nullable Connection _connection;
     private int _maxRows;
+    private boolean _iterationComplete;
 
     private boolean _isComplete = true;
 
@@ -97,25 +98,39 @@ public class ResultSetImpl extends LoggingResultSetWrapper implements TableResul
     @Override
     public int getSize()
     {
+        if (!_iterationComplete)
+        {
+            throw new IllegalStateException("ResultSet must first be iterated through before getting size");
+        }
         return _size;
     }
 
     @Override
     public boolean next() throws SQLException
     {
-        boolean success = super.next();
-        if (!success || Table.ALL_ROWS == _maxRows)
-            return success;
-        if (getRow() == _maxRows + 1)
+        boolean hasNext = super.next();
+
+        if (hasNext)
         {
-            _isComplete = false;
-        }
-        else
-        {
+            if (Table.ALL_ROWS != _maxRows)
+            {
+                if (getRow() == _maxRows + 1)
+                {
+                    _isComplete = false;
+                }
+
+                hasNext = getRow() <= _maxRows;
+            }
+
             // Keep track of all of the rows that we've iterated
             _size = Math.max(_size, getRow());
         }
-        return getRow() <= _maxRows;
+
+        if (!hasNext) {
+            _iterationComplete = true;
+        }
+
+        return hasNext;
     }
 
 

--- a/api/src/org/labkey/api/data/ResultsImpl.java
+++ b/api/src/org/labkey/api/data/ResultsImpl.java
@@ -255,6 +255,12 @@ public class ResultsImpl implements Results, DataIterator
         return ((TableResultSet) _rs).getSize();
     }
 
+    @Override
+    public int countAll() throws SQLException
+    {
+        return ((TableResultSet) _rs).countAll();
+    }
+
 
     //
     // FieldKey getters

--- a/api/src/org/labkey/api/data/TableResultSet.java
+++ b/api/src/org/labkey/api/data/TableResultSet.java
@@ -41,8 +41,8 @@ public interface TableResultSet extends ResultSet, Iterable<Map<String, Object>>
     /** @return the number of rows in the result set. -1 if unknown */
     int getSize();
 
-    default boolean iterateAll() throws SQLException
+    default int countAll() throws SQLException
     {
-        return true;
+        return -1;
     }
 }

--- a/api/src/org/labkey/api/data/TableResultSet.java
+++ b/api/src/org/labkey/api/data/TableResultSet.java
@@ -40,4 +40,9 @@ public interface TableResultSet extends ResultSet, Iterable<Map<String, Object>>
 
     /** @return the number of rows in the result set. -1 if unknown */
     int getSize();
+
+    default boolean iterateAll() throws SQLException
+    {
+        return true;
+    }
 }

--- a/internal/src/org/labkey/api/data/ResultSetCollapser.java
+++ b/internal/src/org/labkey/api/data/ResultSetCollapser.java
@@ -88,9 +88,9 @@ public class ResultSetCollapser extends ResultSetImpl
         {
             if (!lastValue.equals(getObject(_columnName)))
             {
-                return true;
+                return hasNext(true);
             }
         }
-        return false;
+        return hasNext(false);
     }
 }


### PR DESCRIPTION
#### Rationale
ResultSetImpl.getSize behavior changed to require the result set to be fully iterated first before getSize can be called.  Added tracking to enforce that and an unsupported exception if trying to call before fully iterated.  Added method to iterate and calculate size if usage does not iterate already.

#### Changes
- ResultSetImpl and descendants call hasNext when returning from Next() which will set flag if resultset is fully iterated
- getSize will throw error if the fully iterated flag is not true
- countAll will iterated (if not already done) and return the size
