### PR TITLE
Issue 40918: Sample Import has become slower with change to prevent deadlocks

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -777,11 +777,9 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                     .setFileLinkDirectory("sampleset")
                     .setIndexFunction(lsids -> () ->
                     {
-                        for (String lsid : lsids)
+                        for (ExpMaterialImpl expMaterial : ExperimentServiceImpl.get().getExpMaterialsByLSID(lsids))
                         {
-                            ExpMaterialImpl expMaterial = ExperimentServiceImpl.get().getExpMaterial(lsid);
-                            if (null != expMaterial)
-                                expMaterial.index(null);
+                            expMaterial.index(null);
                         }
                     }));
 

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -68,6 +68,7 @@ import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.RowIdForeignKey;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.DeletePermission;
@@ -777,9 +778,13 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                     .setFileLinkDirectory("sampleset")
                     .setIndexFunction(lsids -> () ->
                     {
-                        for (ExpMaterialImpl expMaterial : ExperimentServiceImpl.get().getExpMaterialsByLSID(lsids))
+                        SearchService ss = SearchService.get();
+                        if (ss != null)
                         {
-                            expMaterial.index(null);
+                            for (ExpMaterialImpl expMaterial : ExperimentServiceImpl.get().getExpMaterialsByLSID(lsids))
+                            {
+                                ss.defaultTask().addRunnable(() -> expMaterial.index(null), SearchService.PRIORITY.bulk);
+                            }
                         }
                     }));
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -627,6 +627,18 @@ public class ExperimentServiceImpl implements ExperimentService
         return materials;
     }
 
+    @NotNull
+    public List<ExpMaterialImpl> getExpMaterialsByLSID(Collection<String> lsids)
+    {
+        SimpleFilter filter = new SimpleFilter().addInClause(FieldKey.fromParts(ExpMaterialTable.Column.LSID.name()), lsids);
+        TableSelector selector = new TableSelector(getTinfoMaterial(), filter, null);
+
+        final List<ExpMaterialImpl> materials = new ArrayList<>(lsids.size());
+        selector.forEach(material -> materials.add(new ExpMaterialImpl(material)), Material.class);
+
+        return materials;
+    }
+
     @Override
     @NotNull
     public List<ExpMaterialImpl> getExpMaterials(Container container, User user, Set<String> sampleNames, @Nullable ExpSampleType sampleType, boolean throwIfMissing, boolean createIfMissing)


### PR DESCRIPTION
#### Rationale
We like speed

#### Changes
* To speed up the queuing for the indexing, do a single big query instead of a bunch of little queries (one per row). This mirrors the approach already taken in ExpDataClassDataTableImpl.persistRows()
