### PR TITLE
Issue 40921: QC message about hidden rows not being displayed

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -700,20 +700,38 @@ public abstract class AssayProtocolSchema extends AssaySchema
                             QueryView allResultsQueryView = createAllResultsQueryView(viewContext, qs);
 
                             DataView dataView = allResultsQueryView.createDataView();
-                            try (Results r = dataView.getDataRegion().getResults(dataView.getRenderContext()))
+
+                            RenderContext renderContext = dataView.getRenderContext();
+                            renderContext.setCache(true);
+                            try (Results r = dataView.getDataRegion().getResults(renderContext))
                             {
                                 final int rowCount = r.getSize();
 
                                 baseQueryView.setMessageSupplier(dataRegion -> {
-                                    if (dataRegion.getTotalRows() != null && dataRegion.getTotalRows() < rowCount)
+                                    try
                                     {
-                                        long count = rowCount - dataRegion.getTotalRows();
-                                        String msg = count > 1 ? "There are " + count + " rows not shown due to unapproved QC state."
-                                                : "There is one row not shown due to unapproved QC state.";
-                                        DataRegion.Message drm = new DataRegion.Message(msg, DataRegion.MessageType.WARNING, DataRegion.MessagePart.view);
-                                        return Collections.singletonList(drm);
+                                        // Getting all results for the data region requires an operation that iterates
+                                        // through and counts the total rows in the data region. getAggregateResults
+                                        // with ALL_ROWS will perform this calculation
+                                        int maxRows = dataRegion.getSettings().getMaxRows();
+                                        dataRegion.getSettings().setMaxRows(Table.ALL_ROWS);
+                                        dataRegion.getAggregateResults(renderContext);
+                                        dataRegion.getSettings().setMaxRows(maxRows);
+
+                                        if (dataRegion.getTotalRows() != null && dataRegion.getTotalRows() < rowCount)
+                                        {
+                                            long count = rowCount - dataRegion.getTotalRows();
+                                            String msg = count > 1 ? "There are " + count + " rows not shown due to unapproved QC state."
+                                                    : "There is one row not shown due to unapproved QC state.";
+                                            DataRegion.Message drm = new DataRegion.Message(msg, DataRegion.MessageType.WARNING, DataRegion.MessagePart.view);
+                                            return Collections.singletonList(drm);
+                                        }
+                                        return Collections.emptyList();
                                     }
-                                    return Collections.emptyList();
+                                    catch(IOException e)
+                                    {
+                                        throw new RuntimeException(e);
+                                    }
                                 });
                             }
                         }

--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -702,6 +702,7 @@ public abstract class AssayProtocolSchema extends AssaySchema
                             DataView dataView = allResultsQueryView.createDataView();
 
                             RenderContext renderContext = dataView.getRenderContext();
+                            // Issue 40921: use cached result set as it will have size available without iterating the results
                             renderContext.setCache(true);
                             try (Results r = dataView.getDataRegion().getResults(renderContext))
                             {
@@ -710,7 +711,7 @@ public abstract class AssayProtocolSchema extends AssaySchema
                                 baseQueryView.setMessageSupplier(dataRegion -> {
                                     try
                                     {
-                                        // Getting all results for the data region requires an operation that iterates
+                                        // Issue 40921: Getting all results for the data region requires an operation that iterates
                                         // through and counts the total rows in the data region. getAggregateResults
                                         // with ALL_ROWS will perform this calculation
                                         int maxRows = dataRegion.getSettings().getMaxRows();


### PR DESCRIPTION
#### Rationale
Due to updates in size calculations of resultsets and data regions, the QC row count comparison used to generate QC hidden rows message is not working.  This updates AssayProtocolSchema's calculations to generate that message

#### Changes
- Update calculation of all rows, not filtered for QC to use cached result sets. This will have calculated size.
- Update data region to iterate through its rows on an aggregate operation to get total row count.
