### PR TITLE
Remove reference to soon to be removed R test files

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyExportTest.java
@@ -32,6 +32,7 @@ import org.labkey.test.pages.study.ManageStudyPage;
 import org.labkey.test.pages.study.ManageVisitPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
+import org.labkey.test.util.RReportHelper;
 import org.labkey.test.util.StudyHelper;
 
 import java.io.File;
@@ -88,7 +89,7 @@ public class StudyExportTest extends StudyManualTest
         modifyDatasetColumn(MODIFIED_DATASET);
         setDemographicsBit();
 
-        _listHelper.importListArchive(getFolderName(), new File(TestFileUtils.getLabKeyRoot(), "remoteapi/r/test/listArchive.zip"));
+        _listHelper.importListArchive(getFolderName(), new File(RReportHelper.getRLibraryPath(), "/listArchive.zip"));
 
         // export new study to zip file using "xml" formats
         exportStudy(true);


### PR DESCRIPTION
#### Rationale
We will be deleting `remoteapi/r` from SVN. This test needs to find this list archive in the location where `:tools:Rpackages:installRLabkey` puts it.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/402

#### Changes
* Update reference to `remoteapi/r`
