### PR TITLE
Issue 40925: Exception caused by race condition between recreateViews() deferred upgrade and HTTP requests

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -1529,6 +1529,16 @@ public class ModuleLoader implements Filter, MemTrackerListener
         }
     }
 
+    // Runs the drop and create scripts in a single module
+    public void recreateViews(Module module)
+    {
+        synchronized (UPGRADE_LOCK)
+        {
+            runScripts(module, SchemaUpdateType.Before);
+            runScripts(module, SchemaUpdateType.After);
+        }
+    }
+
     /**
      * Module upgrade scripts have completed, and we are now completing module startup.
      * @return true if module startup in progress.

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -609,12 +609,11 @@ public class ExperimentUpgradeCode implements UpgradeCode
 
     // called from exp-20.005-20.006
     // Issue 40443: For SQL Server, if modifying a table that is used in a view, the views need to get recreated after that
-    // modification happens.  So we need to do that after the previous deferred upgrade scripts happen since
+    // modification happens. So we need to do that after the previous deferred upgrade scripts happen since
     // the createViews scripts run at the end of the regular upgrade scripts and thus before the deferred ones.
     @DeferredUpgrade
     public static void recreateViewsAfterMaterialRowIdDbSequence(ModuleContext context)
     {
-        ModuleLoader.getInstance().recreateViews();
+        ModuleLoader.getInstance().recreateViews(ModuleLoader.getInstance().getModule(context.getName()));
     }
-
 }


### PR DESCRIPTION
#### Rationale
TeamCity does a good job of inducing exceptions at bootstrap time by making requests while recreateViewsAfterMaterialRowIdDbSequence() deferred upgrade is in a bad state. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40925

#### Changes
* Eliminate bad state window by limiting the views that get recreated.