### PR TITLE
Issue 40920: Cannot export a sample type to a xar file

### DIFF
--- a/experiment/src/org/labkey/experiment/controllers/exp/SampleTypeContentsView.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/SampleTypeContentsView.java
@@ -117,7 +117,7 @@ public class SampleTypeContentsView extends QueryView
     {
         PanelButton result = super.createExportButton(recordSelectorColumns);
         ActionURL url = new ActionURL(ExperimentController.ExportSampleTypeAction.class, getContainer());
-        url.addParameter("sampleSetId", _source.getRowId());
+        url.addParameter("sampleTypeId", _source.getRowId());
         result.addSubPanel("XAR", new JspView<>("/org/labkey/experiment/controllers/exp/exportSampleTypeAsXar.jsp", url));
         return result;
     }


### PR DESCRIPTION
#### Rationale
Dan wants to export sample types to XARs, which was broken in the great renaming of 2020. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40920

#### Changes
* Correct the URL parameter name: sampleSetId → sampleTypeId
