### PR TITLE
Sort "impersonate user" drop-down list by email address

### DIFF
--- a/api/src/org/labkey/api/security/ProjectAndSiteGroupsCache.java
+++ b/api/src/org/labkey/api/security/ProjectAndSiteGroupsCache.java
@@ -42,23 +42,18 @@ public class ProjectAndSiteGroupsCache
     private static final CoreSchema CORE = CoreSchema.getInstance();
     private static final BlockingCache<Container, Collection<Integer>> CACHE = CacheManager.getBlockingCache(1000, CacheManager.DAY, "Project Groups", null);
 
-    private static final CacheLoader<Container, Collection<Integer>> GROUP_LIST_LOADER = new CacheLoader<Container, Collection<Integer>>()
-    {
-        @Override
-        public Collection<Integer> load(Container c, Object argument)
-        {
-            String containerClause = c.isRoot() ? "IS NULL" : "= ?";
+    private static final CacheLoader<Container, Collection<Integer>> GROUP_LIST_LOADER = (c, argument) -> {
+        String containerClause = c.isRoot() ? "IS NULL" : "= ?";
 
-            SQLFragment sql = new SQLFragment(
-                "SELECT UserId FROM " + CORE.getTableInfoPrincipals() + "\n" +
-                    "WHERE Type = '" + PrincipalType.GROUP.getTypeChar() + "' AND Container " + containerClause + "\n" +
-                    "ORDER BY LOWER(Name)");  // Force case-insensitve order for consistency
+        SQLFragment sql = new SQLFragment(
+            "SELECT UserId FROM " + CORE.getTableInfoPrincipals() + "\n" +
+                "WHERE Type = '" + PrincipalType.GROUP.getTypeChar() + "' AND Container " + containerClause + "\n" +
+                "ORDER BY LOWER(Name)");  // Force case-insensitve order for consistency
 
-            if (!c.isRoot())
-                sql.add(c);
+        if (!c.isRoot())
+            sql.add(c);
 
-            return Collections.unmodifiableCollection(new SqlSelector(CORE.getSchema(), sql).getCollection(Integer.class));
-        }
+        return Collections.unmodifiableCollection(new SqlSelector(CORE.getSchema(), sql).getCollection(Integer.class));
     };
 
 

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -2652,7 +2652,8 @@ public class UserController extends SpringActionController
             {
                 Map<String, Object> map = new HashMap<>();
                 map.put("userId", user.getUserId());
-                map.put("displayName", user.getEmail() + " (" + user.getDisplayName(currentUser) + ")");
+                map.put("email", user.getEmail());
+                map.put("displayName", user.getDisplayName(currentUser));
                 map.put("active", user.isActive());
                 responseUsers.add(map);
             }

--- a/internal/webapp/Impersonate.js
+++ b/internal/webapp/Impersonate.js
@@ -60,9 +60,9 @@ Ext4.define('LABKEY.Security.ImpersonateUser', {
             tpl: Ext4.create('Ext.XTemplate',
                 '<tpl for=".">',
                     '<tpl if="active">',
-                        '<div class="x4-boundlist-item">{displayName:htmlEncode}</div>',
+                        '<div class="x4-boundlist-item">{email:htmlEncode} ({displayName:htmlEncode})</div>',
                     '<tpl else>',
-                        '<div class="x4-boundlist-item" style="color: #999999;">{displayName:htmlEncode} (inactive)</div>',
+                        '<div class="x4-boundlist-item" style="color: #999999;">{email:htmlEncode} ({displayName:htmlEncode}) (inactive)</div>',
                     '</tpl>',
                 '</tpl>')
         });
@@ -83,6 +83,7 @@ Ext4.define('LABKEY.Security.ImpersonateUser', {
                 extend: 'Ext.data.Model',
                 fields: [
                     {name: 'userId', type: 'integer'},
+                    {name: 'email', type: 'string'},
                     {name: 'displayName', type: 'string'},
                     {name: 'active', type: 'boolean'}
                 ]
@@ -91,6 +92,13 @@ Ext4.define('LABKEY.Security.ImpersonateUser', {
 
         return Ext4.create('Ext.data.Store', {
             model: 'LABKEY.Security.ImpersonationUsers',
+            // Hard-code the sort for now. TODO: provide an option in the UI to switch sort between email & display name
+            sorters: [
+                {
+                    property : 'email',
+                    direction: 'ASC'
+                },
+            ],
             autoLoad: true,
             proxy: {
                 type: 'ajax',


### PR DESCRIPTION
#### Rationale
Impersonate user drop-down is currently sorted by user ID, which is not particularly useful. Sorting by email address will improve the administrator's experience.

#### Changes
* Sort the corresponding store by email address
* Pass email address and display name as separate columns and switch concatenation to the client; this opens up the option of offering an administrator sort option (email vs. display name) in the future (NYI)
