### PR TITLE
Issue 40921: ResultSetImpl.getSize() must iterate through result set first

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -670,7 +670,7 @@ public abstract class AssayProtocolSchema extends AssaySchema
                             DataView dataView = allResultsQueryView.createDataView();
                             try (Results r = dataView.getDataRegion().getResults(dataView.getRenderContext()))
                             {
-                                final int rowCount = r.getSize();
+                                final int rowCount = r.countAll();
 
                                 baseQueryView.setMessageSupplier(dataRegion -> {
                                     if (dataRegion.getTotalRows() != null && dataRegion.getTotalRows() < rowCount)

--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -670,8 +670,6 @@ public abstract class AssayProtocolSchema extends AssaySchema
                             DataView dataView = allResultsQueryView.createDataView();
 
                             RenderContext renderContext = dataView.getRenderContext();
-                            // Issue 40921: use cached result set as it will have size available without iterating the results
-                            renderContext.setCache(true);
                             try (Results r = dataView.getDataRegion().getResults(renderContext))
                             {
                                 final int rowCount = r.countAll();

--- a/api/src/org/labkey/api/data/GroupedResultSet.java
+++ b/api/src/org/labkey/api/data/GroupedResultSet.java
@@ -181,7 +181,7 @@ public class GroupedResultSet extends ResultSetImpl
         if (_ignoreNext)
         {
             _ignoreNext = false;
-            return true;
+            return hasNext(true);
         }
         Object previousValue;
         if (getRow() > 0)
@@ -197,7 +197,7 @@ public class GroupedResultSet extends ResultSetImpl
         {
             if (!super.next())
             {
-                return false;
+                return hasNext(false);
             }
             currentValue = getObject(_columnIndex);
         }
@@ -205,9 +205,9 @@ public class GroupedResultSet extends ResultSetImpl
 
         if (_lastRow != 0)
         {
-            return getRow() <= _lastRow;
+            return hasNext(getRow() <= _lastRow);
         }
-        return true;
+        return hasNext(true);
     }
 
     public ResultSet getNextResultSet() throws SQLException
@@ -241,12 +241,12 @@ public class GroupedResultSet extends ResultSetImpl
             if (_ignoreNext)
             {
                 _ignoreNext = false;
-                return true;
+                return hasNext(true);
             }
             boolean success = innerNext();
 
             if (!success)
-                return success;
+                return hasNext(success);
 
             if (null == _currentValue)
                 _currentValue = getObject(_columnIndex);
@@ -258,7 +258,7 @@ public class GroupedResultSet extends ResultSetImpl
                 previous();  // Back it up
             }
 
-            return success;
+            return hasNext(success);
         }
 
         @Override

--- a/api/src/org/labkey/api/data/ResultsImpl.java
+++ b/api/src/org/labkey/api/data/ResultsImpl.java
@@ -255,6 +255,11 @@ public class ResultsImpl implements Results, DataIterator
         return ((TableResultSet) _rs).getSize();
     }
 
+    @Override
+    public int countAll() throws SQLException
+    {
+        return ((TableResultSet) _rs).countAll();
+    }
 
     //
     // FieldKey getters

--- a/api/src/org/labkey/api/data/TableResultSet.java
+++ b/api/src/org/labkey/api/data/TableResultSet.java
@@ -40,4 +40,9 @@ public interface TableResultSet extends ResultSet, Iterable<Map<String, Object>>
 
     /** @return the number of rows in the result set. -1 if unknown */
     int getSize();
+
+    default int countAll() throws SQLException
+    {
+        return getSize();
+    }
 }

--- a/internal/src/org/labkey/api/data/ResultSetCollapser.java
+++ b/internal/src/org/labkey/api/data/ResultSetCollapser.java
@@ -88,9 +88,9 @@ public class ResultSetCollapser extends ResultSetImpl
         {
             if (!lastValue.equals(getObject(_columnName)))
             {
-                return true;
+                return hasNext(true);
             }
         }
-        return false;
+        return hasNext(false);
     }
 }


### PR DESCRIPTION
#### Rationale
ResultSetImpl was updated to calculate size on iteration, therefore calls to getSize should throw an exception if the result set is not completely iterated.  This PR includes tracking for when the result set is iterated and throws an exception if getSize is called before completely iterated.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/1409

#### Changes
- ResultSetImple.getSize() throws exception if result set not iterated
- ResultSetImpl.hasNext() added to track when iterated. Called from ResultSetImpl.next() and classes overriding this function.
- Update to ResultSetImpl.next() to ensure counting is done for all rows case
- Add countAll() function to iterate and count a result set
