### PR TITLE
Use readily available test data for study export test

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyExportTest.java
@@ -32,7 +32,6 @@ import org.labkey.test.pages.study.ManageStudyPage;
 import org.labkey.test.pages.study.ManageVisitPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
-import org.labkey.test.util.RReportHelper;
 import org.labkey.test.util.StudyHelper;
 
 import java.io.File;
@@ -89,7 +88,7 @@ public class StudyExportTest extends StudyManualTest
         modifyDatasetColumn(MODIFIED_DATASET);
         setDemographicsBit();
 
-        _listHelper.importListArchive(getFolderName(), new File(RReportHelper.getRLibraryPath(), "/listArchive.zip"));
+        _listHelper.importListArchive(getFolderName(), TestFileUtils.getSampleData("lists/ListOfPeople.lists.zip"));
 
         // export new study to zip file using "xml" formats
         exportStudy(true);


### PR DESCRIPTION
#### Rationale
`StudyExportTest` started failing because it depends on a list archive that was intended for Rlabkey testing and isn't necessarily present. The test doesn't actually seem to care what list archive you import.

#### Changes
* Use a list archive from `testAutomation/data`
