### PR TITLE
Prohibit USE statement

### DIFF
--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -898,7 +898,7 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     protected void checkSqlScript(String lowerNoComments, String lowerNoCommentsNoWhiteSpace, Collection<String> errors)
     {
         if (lowerNoCommentsNoWhiteSpace.contains("setsearch_pathto"))
-            errors.add("Do not use \"SET search_path TO <schema>\".  Instead, schema-qualify references to all objects.");
+            errors.add("Do not use \"SET search_path TO <schema>\". Instead, schema-qualify references to all objects.");
 
         if (!lowerNoCommentsNoWhiteSpace.endsWith(";"))
             errors.add("Script must end with a semicolon");

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -320,6 +320,8 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     @Override
     protected void checkSqlScript(String lowerNoComments, String lowerNoCommentsNoWhiteSpace, Collection<String> errors)
     {
+        if (lowerNoComments.startsWith("use ") || lowerNoComments.contains("\nuse "))
+            errors.add("USE statements are prohibited");
     }
 
 


### PR DESCRIPTION
#### Rationale
SQL Server upgrade scripts that invoke the `USE` statement (e.g., `USE MyDatabase`) are guaranteed to fail on TeamCity and other developers' machines.

#### Changes
* Detect and refuse to run scripts that include `USE` statements.
