### PR TITLE
Add experimental feature that causes LabKeyJspWriter to throw on JSP rendering warnings

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -46,6 +46,7 @@ import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.files.FileSystemWatcherImpl;
 import org.labkey.api.iterator.MarkableIterator;
 import org.labkey.api.jsp.LabKeyJspFactory;
+import org.labkey.api.jsp.LabKeyJspWriter;
 import org.labkey.api.markdown.MarkdownService;
 import org.labkey.api.module.CodeOnlyModule;
 import org.labkey.api.module.FolderTypeManager;
@@ -132,6 +133,7 @@ public class ApiModule extends CodeOnlyModule
     {
         SystemMaintenance.addTask(new ApiKeyMaintenanceTask());
         AuthenticationManager.registerMetricsProvider();
+        LabKeyJspWriter.registerExperimentalFeature();
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Once we clear a test suite of JSP warnings, we want tests in that suite to fail if warnings are introduced in the future.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1419

#### Changes
* Add experimental feature that throws on JSP warnings such as print(String)
