### PR TITLE
Improve SelectBuilder and stop using SelectTag

### DIFF
--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -40,6 +40,7 @@ import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.UniqueID;
 import org.labkey.api.util.element.Input;
 import org.labkey.api.util.element.Option;
+import org.labkey.api.util.element.Option.OptionBuilder;
 import org.labkey.api.util.element.Select;
 import org.labkey.api.util.element.TextArea;
 import org.labkey.api.view.HttpView;
@@ -720,14 +721,14 @@ public class DataColumn extends DisplayColumn
             List<Option> options = new ArrayList<>();
 
             // add empty option
-            options.add(new Option.OptionBuilder().build());
+            options.add(new OptionBuilder().build());
 
             for (NamedObject entry : entryList)
             {
                 String entryName = entry.getName();
-                Option.OptionBuilder option = new Option.OptionBuilder()
-                        .selected(isSelectInputSelected(entryName, value, strVal))
-                        .value(entryName);
+                OptionBuilder option = new OptionBuilder()
+                    .selected(isSelectInputSelected(entryName, value, strVal))
+                    .value(entryName);
 
                 if (null != entry.getObject())
                     option.label(getSelectInputDisplayValue(entry));

--- a/api/src/org/labkey/api/jsp/taglib/PanelTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/PanelTag.java
@@ -20,7 +20,6 @@ import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.UnexpectedException;
 
-import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.tagext.BodyTagSupport;
 import java.io.IOException;
 
@@ -32,7 +31,6 @@ import static org.labkey.api.util.DOM.cl;
 public class PanelTag extends BodyTagSupport
 {
     private String className = null;
-    private String id = null;
     private String type = "default";
     private String title = null;
     private Integer width = null;
@@ -45,18 +43,6 @@ public class PanelTag extends BodyTagSupport
     public void setClassName(String className)
     {
         this.className = className;
-    }
-
-    @Override
-    public String getId()
-    {
-        return id;
-    }
-
-    @Override
-    public void setId(String id)
-    {
-        this.id = id;
     }
 
     public String getType()
@@ -92,7 +78,7 @@ public class PanelTag extends BodyTagSupport
     Pair<HtmlString,HtmlString> tag;
 
     @Override
-    public int doStartTag() throws JspException
+    public int doStartTag()
     {
         String style = getWidth() != null ? "width: " + getWidth() + "px;" : "";
 
@@ -120,7 +106,7 @@ public class PanelTag extends BodyTagSupport
     }
 
     @Override
-    public int doEndTag() throws JspException
+    public int doEndTag()
     {
         try
         {

--- a/api/src/org/labkey/api/jsp/taglib/SelectTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/SelectTag.java
@@ -21,26 +21,11 @@ import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.tagext.BodyTagSupport;
 import java.io.IOException;
 
+@Deprecated // Migrate all remaining usages to SelectBuilder and delete this class
 public class SelectTag extends BodyTagSupport
 {
-    private String message = null;
-    private String id = null;
     private String label = null;
     private String name = null;
-    private String onChange = null;
-    private String onKeyUp = null;
-
-    @Override
-    public String getId()
-    {
-        return id;
-    }
-
-    @Override
-    public void setId(String id)
-    {
-        this.id = id;
-    }
 
     public String getLabel()
     {
@@ -50,16 +35,6 @@ public class SelectTag extends BodyTagSupport
     public void setLabel(String label)
     {
         this.label = label;
-    }
-
-    public String getMessage()
-    {
-        return message;
-    }
-
-    public void setMessage(String message)
-    {
-        this.message = message;
     }
 
     public String getName()
@@ -72,31 +47,9 @@ public class SelectTag extends BodyTagSupport
         this.name = name;
     }
 
-    public String getOnChange()
-    {
-        return onChange;
-    }
-
-    public void setOnChange(String onChange)
-    {
-        this.onChange = onChange;
-    }
-
-    public String getOnKeyUp()
-    {
-        return onKeyUp;
-    }
-
-    public void setOnKeyUp(String onKeyUp)
-    {
-        this.onKeyUp = onKeyUp;
-    }
-
     @Override
     public int doStartTag() throws JspException
     {
-        // TODO: Delegate to SelectBuilder
-
         StringBuilder sb = new StringBuilder();
 
         sb.append("<label class=\"control-label\">");
@@ -110,12 +63,6 @@ public class SelectTag extends BodyTagSupport
         if (getId() != null)
             sb.append(" id=\"").append(getId()).append("\"");
 
-        // events
-        if (getOnChange() != null)
-            sb.append(" onchange=\"").append(getOnChange()).append("\"");
-        if (getOnKeyUp() != null)
-            sb.append(" onkeyup=\"").append(getOnKeyUp()).append("\"");
-
         sb.append(">");
 
         print(sb);
@@ -128,10 +75,6 @@ public class SelectTag extends BodyTagSupport
         StringBuilder sb = new StringBuilder();
 
         sb.append("</select>");
-
-        // render unescaped message (may contain HTML)
-        if (getMessage() != null)
-            sb.append("<span class=\"help-block\">").append(getMessage()).append("</span>");
 
         print(sb);
         return BodyTagSupport.EVAL_PAGE;

--- a/api/src/org/labkey/api/miniprofiler/MiniProfiler.java
+++ b/api/src/org/labkey/api/miniprofiler/MiniProfiler.java
@@ -274,7 +274,7 @@ public class MiniProfiler
         _collectTroubleshootingStackTraces = enabled;
     }
 
-    public enum RenderPosition implements EnumHasHtmlString<RenderPosition>
+    public enum RenderPosition implements EnumHasHtmlString
     {
         TopLeft("left"),
         TopRight("right"),

--- a/api/src/org/labkey/api/query/QueryParam.java
+++ b/api/src/org/labkey/api/query/QueryParam.java
@@ -20,7 +20,7 @@ import org.labkey.api.util.EnumHasHtmlString;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.util.URLHelper;
 
-public enum QueryParam implements EnumHasHtmlString<QueryParam>
+public enum QueryParam implements EnumHasHtmlString
 {
     schemaName,
     queryName,

--- a/api/src/org/labkey/api/reports/report/ReportDescriptor.java
+++ b/api/src/org/labkey/api/reports/report/ReportDescriptor.java
@@ -97,7 +97,7 @@ public class ReportDescriptor extends Entity implements SecurableResource, Clone
     // serialize these twice
     protected Map<String, Object> _mapReportProps = new HashMap<>();
 
-    public enum Prop implements ReportProperty, EnumHasHtmlString<Prop>
+    public enum Prop implements ReportProperty, EnumHasHtmlString
     {
         descriptorType,
         reportId,

--- a/api/src/org/labkey/api/search/SearchScope.java
+++ b/api/src/org/labkey/api/search/SearchScope.java
@@ -24,7 +24,7 @@ import org.labkey.api.util.EnumHasHtmlString;
  * User: adam
  * Date: 2/18/12
  */
-public enum SearchScope implements EnumHasHtmlString<SearchScope>
+public enum SearchScope implements EnumHasHtmlString
 {
     All() {
         @Override

--- a/api/src/org/labkey/api/security/WikiTermsOfUseProvider.java
+++ b/api/src/org/labkey/api/security/WikiTermsOfUseProvider.java
@@ -169,7 +169,7 @@ public class WikiTermsOfUseProvider implements TermsOfUseProvider
         }
     }
 
-    public enum TermsOfUseType implements EnumHasHtmlString<TermsOfUseType> { NONE, PROJECT_LEVEL, SITE_WIDE }
+    public enum TermsOfUseType implements EnumHasHtmlString { NONE, PROJECT_LEVEL, SITE_WIDE }
 
     public static class TermsOfUse
     {

--- a/api/src/org/labkey/api/study/TimepointType.java
+++ b/api/src/org/labkey/api/study/TimepointType.java
@@ -25,7 +25,7 @@ import org.labkey.api.util.EnumHasHtmlString;
  * User: markigra
  * Date: Oct 31, 2007
  */
-public enum TimepointType implements EnumHasHtmlString<TimepointType>
+public enum TimepointType implements EnumHasHtmlString
 {
     /** Events should be explicitly assigned a visit number */
     VISIT(true),

--- a/api/src/org/labkey/api/study/actions/StudyPickerColumn.java
+++ b/api/src/org/labkey/api/study/actions/StudyPickerColumn.java
@@ -28,7 +28,9 @@ import org.labkey.api.assay.AbstractAssayProvider;
 import org.labkey.api.study.assay.AssayPublishService;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.element.Option;
+import org.labkey.api.util.element.Option.OptionBuilder;
 import org.labkey.api.util.element.Select;
+import org.labkey.api.util.element.Select.SelectBuilder;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -107,22 +109,20 @@ public class StudyPickerColumn extends UploadWizardAction.InputDisplayColumn
 
         boolean disabled = isDisabledInput();
 
-        Select.SelectBuilder select = new Select.SelectBuilder()
-                .name(_inputName)
-                .disabled(disabled);
-        List<Option> options = new ArrayList<>();
-        options.add(new Option.OptionBuilder().label("[None]").build());
+        SelectBuilder select = new SelectBuilder()
+            .name(_inputName)
+            .disabled(disabled);
+        select.addOption(new OptionBuilder().label("[None]"));
         for (Study study : studies)
         {
             Container container = study.getContainer();
-            options.add(new Option.OptionBuilder()
-                    .label(PageFlowUtil.filter(container.getPath() + " (" + study.getLabel()) + ")")
-                    .value(PageFlowUtil.filter(container.getId()))
-                    .selected(container.getId().equals(value))
-                    .build()
+            select.addOption(new OptionBuilder()
+                .label(container.getPath() + " (" + study.getLabel() + ")")
+                .value(container.getId())
+                .selected(container.getId().equals(value))
             );
         }
-        out.write(select.addOptions(options).toString());
+        out.write(select.toString());
         
         if (disabled)
             out.write("<input type=\"hidden\" name=\"" +_inputName + "\" value=\"" + PageFlowUtil.filter(value) + "\">");

--- a/api/src/org/labkey/api/util/EnumHasHtmlString.java
+++ b/api/src/org/labkey/api/util/EnumHasHtmlString.java
@@ -16,14 +16,16 @@
 package org.labkey.api.util;
 
 /**
- * Turns any Enum into a HasHtmlString, where each constant returns an HtmlString containing its name.
- * @param <E> The Enum
+ * Turns any Enum into a HasHtmlString, where each constant returns an HtmlString containing an encoded version of its
+ * toString(). Enums that implement this interface can be safely rendered from a JSP.
  */
-public interface EnumHasHtmlString<E extends Enum> extends HasHtmlString
+
+// TODO: Remove type parameter. This requires a multi-repo commit, so we'll change all the implementors first, then circle back to remove it here.
+public interface EnumHasHtmlString<E extends Enum<?>> extends HasHtmlString
 {
     @Override
     default HtmlString getHtmlString()
     {
-        return HtmlString.of(((E)this).name());
+        return HtmlString.of(toString());
     }
 }

--- a/api/src/org/labkey/api/util/HasHtmlString.java
+++ b/api/src/org/labkey/api/util/HasHtmlString.java
@@ -26,6 +26,13 @@ public interface HasHtmlString extends DOM.Renderable
      */
     HtmlString getHtmlString();
 
+    /**
+     * Must be consistent with {@code HtmlString}; see above. This method definition is a no-op (Object implements toString()),
+     * but included here as reminder of the consistency requirement. Also makes for easy inspection to verify consistency.
+     * @return A String that's consistent with {@code HtmlString}
+     */
+    String toString();
+
     @Override
     default Appendable appendTo(Appendable builder)
     {

--- a/api/src/org/labkey/api/util/element/Input.java
+++ b/api/src/org/labkey/api/util/element/Input.java
@@ -644,6 +644,8 @@ public class Input extends DisplayElement implements HasHtmlString
         private String _min;
         private Boolean _multiple;
         private String _name;
+        private String _onChange;
+        private String _onKeyUp;
         private String _placeholder;
         private Boolean _readOnly;
         private Boolean _required;
@@ -656,9 +658,6 @@ public class Input extends DisplayElement implements HasHtmlString
         private String _type = "text";
         private HtmlString _value;
         private Boolean _needsWrapping;
-
-        protected String _onChange;
-        protected String _onKeyUp;
 
         public InputBuilder()
         {

--- a/api/src/org/labkey/api/util/element/Input.java
+++ b/api/src/org/labkey/api/util/element/Input.java
@@ -644,8 +644,6 @@ public class Input extends DisplayElement implements HasHtmlString
         private String _min;
         private Boolean _multiple;
         private String _name;
-        private String _onChange;
-        private String _onKeyUp;
         private String _placeholder;
         private Boolean _readOnly;
         private Boolean _required;
@@ -658,6 +656,9 @@ public class Input extends DisplayElement implements HasHtmlString
         private String _type = "text";
         private HtmlString _value;
         private Boolean _needsWrapping;
+
+        protected String _onChange;
+        protected String _onKeyUp;
 
         public InputBuilder()
         {

--- a/api/src/org/labkey/api/util/element/Option.java
+++ b/api/src/org/labkey/api/util/element/Option.java
@@ -57,14 +57,7 @@ public class Option implements HasHtmlString
         return _value;
     }
 
-    @Override
-    public String toString()
-    {
-        return getHtmlString().toString();
-    }
-
-    @Override
-    public HtmlString getHtmlString()
+    public HtmlString render(boolean forceSelected)
     {
         // TODO: This method should do the rendering via DOM or HtmlStringBuilder
         StringBuilder sb = new StringBuilder();
@@ -75,7 +68,7 @@ public class Option implements HasHtmlString
         if (isDisabled())
             sb.append(" disabled");
 
-        if (isSelected())
+        if (forceSelected || isSelected())
             sb.append(" selected");
 
         sb.append(">");
@@ -86,6 +79,18 @@ public class Option implements HasHtmlString
         sb.append("</option>");
 
         return HtmlString.unsafe(sb.toString());
+    }
+
+    @Override
+    public HtmlString getHtmlString()
+    {
+        return render(false);
+    }
+
+    @Override
+    public String toString()
+    {
+        return getHtmlString().toString();
     }
 
     public static class OptionBuilder implements HasHtmlString

--- a/api/src/org/labkey/api/util/element/Select.java
+++ b/api/src/org/labkey/api/util/element/Select.java
@@ -16,17 +16,23 @@
 package org.labkey.api.util.element;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.element.Option.OptionBuilder;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 public class Select extends Input
 {
     private final boolean _multiple;
     private final List<Option> _options;
     private final List<String> _styles;
+    private final String _selected;
 
     private Select(SelectBuilder builder)
     {
@@ -34,6 +40,7 @@ public class Select extends Input
         _multiple = builder._multiple;
         _options = builder._options;
         _styles = builder._styles;
+        _selected = builder._selected;
     }
 
     @Override
@@ -42,7 +49,7 @@ public class Select extends Input
         return _multiple;
     }
 
-    public List<Option> getOptions()
+    public @NotNull List<Option> getOptions()
     {
         return _options;
     }
@@ -86,47 +93,112 @@ public class Select extends Input
 
     private void doOptions(StringBuilder sb)
     {
-        if (getOptions() != null)
+        for (Option o : getOptions())
         {
-            for (Option o : getOptions())
+            if (o != null)
             {
-                if (o != null)
-                    sb.append(o.toString());
+                boolean forceSelected = null != _selected && _selected.equals(o.getValue());
+                sb.append(o.render(forceSelected));
             }
         }
     }
 
     public static class SelectBuilder extends InputBuilder<SelectBuilder>
     {
+        private final List<Option> _options = new ArrayList<>();
         private final List<String> _styles = new ArrayList<>();
 
         private boolean _multiple;
-        private List<Option> _options;
+        // Alternative way to specify the selected option - useful when adding options as Strings or Objects
+        private String _selected = null;
 
         public SelectBuilder()
         {
         }
 
-        public SelectBuilder addOption(Option option)
+        /**
+         * Adds a single option, either a previously created Option object or a new Option where the key is set to the value.
+         * @param option An Option, String, or Object
+         * @return The SelectBuilder
+         */
+        public SelectBuilder addOption(Object option)
         {
-            return addOptions(Collections.singletonList(option));
+            return addOptions(Stream.of(option));
         }
 
-        public SelectBuilder addOptions(List<Option> options)
+        /**
+         * Adds a single Option built from an OptionBuilder, as a convenience.
+         * @param  builder An OptionBuilder
+         * @return The SelectBuilder
+         */
+        public SelectBuilder addOption(OptionBuilder builder)
         {
-            if (options != null)
-            {
-                if (_options == null)
-                    _options = new ArrayList<>();
+            return addOptions(Stream.of(builder.build()));
+        }
 
-                for (Option o : options)
-                {
-                    if (o != null)
-                        _options.add(o);
-                }
-            }
+        /**
+         * Adds a single option with the specified label and value.
+         * @param label The new option's label
+         * @param value The new option's value
+         * @return The SelectBuilder
+         */
+        public SelectBuilder addOption(String label, String value)
+        {
+            return addOption(new OptionBuilder(label, value));
+        }
+
+        /**
+         * Adds multiple options to the &lt;select> elements by supplying a collection of objects. See {@link #addOptions(Stream)}
+         * for more details.
+         * @param options A collection of Options, OptionBuilders, Strings, or Objects
+         * @return The SelectBuilder
+         */
+        public SelectBuilder addOptions(@NotNull Collection<?> options)
+        {
+            return addOptions(options.stream());
+        }
+
+        /**
+         * Adds multiple options to the &lt;select> element by supplying a {@code Stream<Object>}. If the {@code Stream}
+         * elements are {@code Option} objects then they are simply added. If the elements are {@code OptionBuilder}
+         * objects then new {@code Option} objects are built and added. If the elements are {@code String} or
+         * {@code Object} then new {@code Option} objects are created and added; in this case, the key and value are both
+         * set to the String value of each object.
+         *
+         * @param options A {@code Stream} of Options, OptionBuilders, Strings, or Objects
+         * @return This SelectBuilder
+         */
+        public SelectBuilder addOptions(@NotNull Stream<?> options)
+        {
+            options
+                .filter(Objects::nonNull)
+                .map(o -> {
+                    if (o instanceof Option)
+                    {
+                        return (Option) o;
+                    }
+                    else if (o instanceof OptionBuilder)
+                    {
+                        return ((OptionBuilder) o).build();
+                    }
+                    else
+                    {
+                        String value = o.toString();
+                        return new OptionBuilder(value, value).build();
+                    }
+
+                })
+                .forEach(_options::add);
 
             return this;
+        }
+
+        public SelectBuilder addOptions(Map<?, String> options)
+        {
+            return addOptions(
+                options.entrySet().stream()
+                    .map(e->new OptionBuilder(e.getValue(), e.getKey()).build())
+            );
         }
 
         public SelectBuilder style(String style)
@@ -144,6 +216,12 @@ public class Select extends Input
         public SelectBuilder multiple(boolean multiple)
         {
             _multiple = multiple;
+            return this;
+        }
+
+        public SelectBuilder selected(Object key)
+        {
+            _selected = key.toString();
             return this;
         }
 

--- a/api/src/org/labkey/api/view/ActionURL.java
+++ b/api/src/org/labkey/api/view/ActionURL.java
@@ -52,7 +52,7 @@ public class ActionURL extends URLHelper implements Cloneable
         return AppProps.getInstance().getUseContainerRelativeURL();
     }
 
-    public enum Param implements EnumHasHtmlString<Param>
+    public enum Param implements EnumHasHtmlString
     {
         returnUrl,
         redirectUrl,    // mostly deprecated for returnUrl

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1538,7 +1538,7 @@ public class AdminController extends SpringActionController
         void setRestrictedColumnsEnabled(boolean restrictedColumnsEnabled);
     }
 
-    public enum MigrateFilesOption implements EnumHasHtmlString<MigrateFilesOption>
+    public enum MigrateFilesOption implements EnumHasHtmlString
     {
         leave {
             @Override
@@ -1816,7 +1816,7 @@ public class AdminController extends SpringActionController
         }
     }
 
-    public enum FileRootProp implements EnumHasHtmlString<FileRootProp>
+    public enum FileRootProp implements EnumHasHtmlString
     {
         disable,
         siteDefault,

--- a/core/src/org/labkey/core/admin/rConfiguration.jsp
+++ b/core/src/org/labkey/core/admin/rConfiguration.jsp
@@ -1,19 +1,19 @@
 <%
-    /*
-     * Copyright (c) 2018-2019 LabKey Corporation
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     http://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
+/*
+ * Copyright (c) 2018-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 %>
 <%@ page import="org.jetbrains.annotations.Nullable" %>
 <%@ page import="org.labkey.api.data.Container" %>
@@ -21,6 +21,7 @@
 <%@ page import="org.labkey.api.reports.LabkeyScriptEngineManager" %>
 <%@ page import="org.labkey.api.reports.RemoteRNotEnabledException" %>
 <%@ page import="org.labkey.api.services.ServiceRegistry" %>
+<%@ page import="org.labkey.api.util.element.Option.OptionBuilder" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
@@ -115,22 +116,14 @@
             </label>
         </div>
         <div class="col-md-5 form-inline">
-            <labkey:select name="reportEngine">
-                <option disabled <%= selected(!isFolderScoped || (currentReportEngine == null))%> value="">
-                    Select a configuration...
-                </option>
-            <%
-                for (ExternalScriptEngineDefinition def : engineDefinitions)
-                {
+            <%=select()
+                .name("reportEngine")
+                .addOption(new OptionBuilder("Select a configuration...", "").disabled(true).selected(!isFolderScoped || (currentReportEngine == null)))
+                .addOptions(
+                    engineDefinitions.stream()
+                        .map(def->new OptionBuilder(def.getName(), def.getRowId()).selected(def.getName().equals(currentReportEngine)))
+                )
             %>
-                    <option <%= selected(def.getName().equals(currentReportEngine)) %> value="<%=h(def.getRowId())%>">
-                        <%=h(def.getName())%>
-                    </option>
-            <%
-                }
-            %>
-            </labkey:select>
-
         </div>
     </div>
     <div class="row engine-row">
@@ -144,21 +137,14 @@
             </label>
         </div>
         <div class="col-md-5 form-inline">
-            <labkey:select name="pipelineEngine">
-                <option disabled <%= selected(!isFolderScoped || (currentPipelineEngine == null)) %> value="">
-                    Select a configuration...
-                </option>
-                <%
-                    for (ExternalScriptEngineDefinition def : engineDefinitions)
-                    {
-                %>
-                <option <%= selected(def.getName().equals(currentPipelineEngine)) %> value="<%=h(def.getRowId())%>">
-                    <%=h(def.getName())%>
-                </option>
-                <%
-                    }
-                %>
-            </labkey:select>
+            <%=select()
+                .name("pipelineEngine")
+                .addOption(new OptionBuilder("Select a configuration...", "").disabled(true).selected(!isFolderScoped || (currentPipelineEngine == null)))
+                .addOptions(
+                    engineDefinitions.stream()
+                        .map(def->new OptionBuilder(def.getName(), def.getRowId()).selected(def.getName().equals(currentPipelineEngine)))
+                )
+            %>
         </div>
     </div>
     <div class="row" id="rButtonGroup" style="margin-left: 0">

--- a/experiment/src/org/labkey/experiment/LSIDRelativizer.java
+++ b/experiment/src/org/labkey/experiment/LSIDRelativizer.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
  * User: jeckels
  * Date: Nov 21, 2005
  */
-public enum LSIDRelativizer implements EnumHasHtmlString<LSIDRelativizer>
+public enum LSIDRelativizer implements EnumHasHtmlString
 {
     /** Keeps the original LSID from the source server */
     ABSOLUTE("Absolute")

--- a/experiment/src/org/labkey/experiment/XarExportType.java
+++ b/experiment/src/org/labkey/experiment/XarExportType.java
@@ -22,7 +22,7 @@ import org.labkey.api.util.EnumHasHtmlString;
  * User: jeckels
  * Date: Sep 12, 2006
  */
-public enum XarExportType implements EnumHasHtmlString<XarExportType>
+public enum XarExportType implements EnumHasHtmlString
 {
     BROWSER_DOWNLOAD("Download to web browser"),
     PIPELINE_FILE("Write to exportedXars directory in pipeline");

--- a/experiment/src/org/labkey/experiment/deriveSamplesChooseTarget.jsp
+++ b/experiment/src/org/labkey/experiment/deriveSamplesChooseTarget.jsp
@@ -87,9 +87,7 @@
         <tr>
             <td class="labkey-form-label">Target sample type:</td>
             <td colspan="2">
-                <labkey:select name="targetSampleTypeId">
-                    <labkey:options value="<%=bean.getTargetSampleTypeId()%>" map="<%=sampleTypeOptions%>"/>
-                </labkey:select>
+                <%=select().name("targetSampleTypeId").addOptions(sampleTypeOptions).selected(bean.getTargetSampleTypeId())%>
             </td>
         </tr>
         <tr>

--- a/experiment/src/org/labkey/experiment/types/types.jsp
+++ b/experiment/src/org/labkey/experiment/types/types.jsp
@@ -28,9 +28,7 @@
 
 <b>Domain Kinds:</b>
 <form method="GET" action="experiment-types-types.view">
-    <labkey:select label="Domain Kinds" name="domainKind" onChange="this.form.submit();">
-        <labkey:options value="<%=h(bean.domainKind)%>" set="<%=bean.domainKinds.keySet()%>"/>
-    </labkey:select>
+    <%=select().name("domainKind").label("Domain Kinds").onChange("this.form.submit();").addOptions(bean.domainKinds.keySet()).selected(bean.domainKind)%>
 </form>
 
 <h3>local types</h3>

--- a/query/src/org/labkey/query/view/newQuery.jsp
+++ b/query/src/org/labkey/query/view/newQuery.jsp
@@ -17,15 +17,12 @@
 %>
 <%@ page import="org.labkey.api.query.QueryParam"%>
 <%@ page import="org.labkey.api.query.QueryUrls"%>
-<%@ page import="org.labkey.api.util.element.Option" %>
 <%@ page import="org.labkey.api.util.element.Option.OptionBuilder" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.query.controllers.NewQueryForm" %>
 <%@ page import="org.labkey.query.controllers.QueryController" %>
 <%@ page import="java.util.HashMap" %>
-<%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
-<%@ page import="java.util.stream.Collectors" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -46,19 +43,16 @@
                   id="ff_newQueryName"
                   name="ff_newQueryName"
                   value="<%=form.ff_newQueryName%>" />
-    <%
-        List<Option> options = namesAndLabels.entrySet().stream()
+    <%=select().name("ff_baseTableName").label("Which query/table do you want this new query to be based on?").addOptions(
+        namesAndLabels.entrySet().stream()
             .map(entry->{
                 String queryLabel = entry.getValue();
                 String queryName = entry.getKey();
                 String displayText = queryName;
                 if (!queryName.equalsIgnoreCase(queryLabel))
                     displayText += " (" + queryLabel + ")";
-                return new OptionBuilder(displayText, queryName).selected(queryName.equals(form.ff_baseTableName)).build();
-            })
-            .collect(Collectors.toList());
-    %>
-    <%=select().name("ff_baseTableName").label("Which query/table do you want this new query to be based on?").addOptions(options)%>
+                return new OptionBuilder(displayText, queryName).selected(queryName.equals(form.ff_baseTableName));
+            }))%>
     <%= button("Create and Edit Source").disableOnClick(true).submit(true) %>
     <%= button("Cancel").href(urlProvider(QueryUrls.class).urlSchemaBrowser(getContainer(), form.getSchemaName())) %>
 </labkey:form>

--- a/study/src/org/labkey/study/CohortFilter.java
+++ b/study/src/org/labkey/study/CohortFilter.java
@@ -47,7 +47,7 @@ public interface CohortFilter
     @Deprecated /** Callers need to handle multiple cohorts case */
     int getCohortId();
 
-    public enum Type implements EnumHasHtmlString<Type>
+    enum Type implements EnumHasHtmlString
     {
         PTID_INITIAL("Initial cohort")
         {

--- a/study/src/org/labkey/study/CohortFilterFactory.java
+++ b/study/src/org/labkey/study/CohortFilterFactory.java
@@ -46,7 +46,7 @@ import java.util.Set;
  */
 public class CohortFilterFactory
 {
-    public static enum Params implements EnumHasHtmlString<Params>
+    public static enum Params implements EnumHasHtmlString
     {
         cohortFilterType
         {

--- a/study/src/org/labkey/study/SpecimenManager.java
+++ b/study/src/org/labkey/study/SpecimenManager.java
@@ -2244,7 +2244,7 @@ public class SpecimenManager implements ContainerManager.ContainerListener
         }
     }
 
-    public enum SpecimenTypeLevel implements EnumHasHtmlString<SpecimenTypeLevel>
+    public enum SpecimenTypeLevel implements EnumHasHtmlString
     {
         PrimaryType()
         {

--- a/study/src/org/labkey/study/controllers/security/SecurityController.java
+++ b/study/src/org/labkey/study/controllers/security/SecurityController.java
@@ -626,7 +626,7 @@ public class SecurityController extends SpringActionController
 
     }
 
-    public enum PermissionType implements EnumHasHtmlString<PermissionType>
+    public enum PermissionType implements EnumHasHtmlString
     {
         defaultPermission,
         customPermission,

--- a/study/src/org/labkey/study/pipeline/AbstractDatasetImportTask.java
+++ b/study/src/org/labkey/study/pipeline/AbstractDatasetImportTask.java
@@ -205,7 +205,7 @@ public abstract class AbstractDatasetImportTask<FactoryType extends AbstractData
     }
 
 
-    public enum Action implements EnumHasHtmlString<Action>
+    public enum Action implements EnumHasHtmlString
     {
         REPLACE,
         APPEND,

--- a/study/src/org/labkey/study/specimen/report/SpecimenVisitReportParameters.java
+++ b/study/src/org/labkey/study/specimen/report/SpecimenVisitReportParameters.java
@@ -74,7 +74,7 @@ public abstract class SpecimenVisitReportParameters extends ViewForm
         hideEmptyColumns
     }
 
-    public enum Status implements EnumHasHtmlString<Status>
+    public enum Status implements EnumHasHtmlString
     {
         ALL("All vials"),
         AVAILABLE("Available vials"),

--- a/study/src/org/labkey/study/specimen/settings/RequestNotificationSettings.java
+++ b/study/src/org/labkey/study/specimen/settings/RequestNotificationSettings.java
@@ -51,9 +51,9 @@ public class RequestNotificationSettings
     private DefaultEmailNotifyEnum _defaultEmailNotify = DefaultEmailNotifyEnum.ActorsInvolved;
     private SpecimensAttachmentEnum _specimensAttachment = SpecimensAttachmentEnum.InEmailBody;
 
-    public enum DefaultEmailNotifyEnum implements EnumHasHtmlString<DefaultEmailNotifyEnum>
+    public enum DefaultEmailNotifyEnum implements EnumHasHtmlString
     {All, None, ActorsInvolved}
-    public enum SpecimensAttachmentEnum implements EnumHasHtmlString<SpecimensAttachmentEnum>
+    public enum SpecimensAttachmentEnum implements EnumHasHtmlString
     {InEmailBody, ExcelAttachment, TextAttachment, Never}
 
     public RequestNotificationSettings()


### PR DESCRIPTION
#### Rationale
Wouldn't it be nice to have shiny new ways to specify the options for a `SelectBuilder`? Like giving it a collection, map, or stream of strings, objects, `OptionBuilder`s, or `Option`s? Wouldn't that make for some compact and readable code? And doesn't `SelectTag` seem redundant and powerless now?

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/218

#### Changes
* Give `SelectBuilder` many new ways to accept option definitions. Also, add `selected()` as an alternative way to specify the currently selected option.
* Use the capabilities in existing `SelectBuilder` usages
* Migrate all `SelectTag` usages to `SelectBuilder`