### PR TITLE
EnumHasHtmlString -> SimpleHasHtmlString

### DIFF
--- a/api/src/org/labkey/api/miniprofiler/MiniProfiler.java
+++ b/api/src/org/labkey/api/miniprofiler/MiniProfiler.java
@@ -25,10 +25,10 @@ import org.labkey.api.data.PropertyManager;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
-import org.labkey.api.util.EnumHasHtmlString;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.MemTracker;
+import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.ViewServlet;
 
@@ -274,7 +274,7 @@ public class MiniProfiler
         _collectTroubleshootingStackTraces = enabled;
     }
 
-    public enum RenderPosition implements EnumHasHtmlString
+    public enum RenderPosition implements SimpleHasHtmlString
     {
         TopLeft("left"),
         TopRight("right"),

--- a/api/src/org/labkey/api/query/QueryParam.java
+++ b/api/src/org/labkey/api/query/QueryParam.java
@@ -16,11 +16,11 @@
 
 package org.labkey.api.query;
 
-import org.labkey.api.util.EnumHasHtmlString;
-import org.labkey.api.view.ActionURL;
+import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.api.util.URLHelper;
+import org.labkey.api.view.ActionURL;
 
-public enum QueryParam implements EnumHasHtmlString
+public enum QueryParam implements SimpleHasHtmlString
 {
     schemaName,
     queryName,

--- a/api/src/org/labkey/api/reports/report/ReportDescriptor.java
+++ b/api/src/org/labkey/api/reports/report/ReportDescriptor.java
@@ -40,10 +40,10 @@ import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
-import org.labkey.api.util.EnumHasHtmlString;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.api.util.XmlBeansUtil;
 import org.labkey.api.util.XmlValidationException;
 import org.labkey.api.view.ViewContext;
@@ -97,7 +97,7 @@ public class ReportDescriptor extends Entity implements SecurableResource, Clone
     // serialize these twice
     protected Map<String, Object> _mapReportProps = new HashMap<>();
 
-    public enum Prop implements ReportProperty, EnumHasHtmlString
+    public enum Prop implements ReportProperty, SimpleHasHtmlString
     {
         descriptorType,
         reportId,

--- a/api/src/org/labkey/api/search/SearchScope.java
+++ b/api/src/org/labkey/api/search/SearchScope.java
@@ -17,14 +17,14 @@ package org.labkey.api.search;
 
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.util.EnumHasHtmlString;
+import org.labkey.api.util.SimpleHasHtmlString;
 
 /**
  * Options for how widely or narrowly to search on the server, based on the number of containers to include.
  * User: adam
  * Date: 2/18/12
  */
-public enum SearchScope implements EnumHasHtmlString
+public enum SearchScope implements SimpleHasHtmlString
 {
     All() {
         @Override

--- a/api/src/org/labkey/api/security/WikiTermsOfUseProvider.java
+++ b/api/src/org/labkey/api/security/WikiTermsOfUseProvider.java
@@ -22,10 +22,10 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.Project;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.SecurityManager.TermsOfUseProvider;
-import org.labkey.api.util.EnumHasHtmlString;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.SessionHelper;
+import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.RedirectException;
 import org.labkey.api.view.ViewContext;
@@ -169,7 +169,8 @@ public class WikiTermsOfUseProvider implements TermsOfUseProvider
         }
     }
 
-    public enum TermsOfUseType implements EnumHasHtmlString { NONE, PROJECT_LEVEL, SITE_WIDE }
+    public enum TermsOfUseType implements SimpleHasHtmlString
+    { NONE, PROJECT_LEVEL, SITE_WIDE }
 
     public static class TermsOfUse
     {

--- a/api/src/org/labkey/api/study/TimepointType.java
+++ b/api/src/org/labkey/api/study/TimepointType.java
@@ -18,14 +18,14 @@ package org.labkey.api.study;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.query.ValidationException;
-import org.labkey.api.util.EnumHasHtmlString;
+import org.labkey.api.util.SimpleHasHtmlString;
 
 /**
  * List of ways that a study can group events based on their time.
  * User: markigra
  * Date: Oct 31, 2007
  */
-public enum TimepointType implements EnumHasHtmlString
+public enum TimepointType implements SimpleHasHtmlString
 {
     /** Events should be explicitly assigned a visit number */
     VISIT(true),

--- a/api/src/org/labkey/api/util/EnumHasHtmlString.java
+++ b/api/src/org/labkey/api/util/EnumHasHtmlString.java
@@ -21,11 +21,7 @@ package org.labkey.api.util;
  */
 
 // TODO: Remove type parameter. This requires a multi-repo commit, so we'll change all the implementors first, then circle back to remove it here.
-public interface EnumHasHtmlString<E extends Enum<?>> extends HasHtmlString
+@Deprecated // Enums should simply implement SimpleHasHtmlString instead
+public interface EnumHasHtmlString<E extends Enum<?>> extends SimpleHasHtmlString
 {
-    @Override
-    default HtmlString getHtmlString()
-    {
-        return HtmlString.of(toString());
-    }
 }

--- a/api/src/org/labkey/api/util/GUID.java
+++ b/api/src/org/labkey/api/util/GUID.java
@@ -64,7 +64,7 @@ import java.util.regex.Pattern;
 
 
 @SuppressWarnings({"UnnecessarySemicolon"})
-public class GUID implements Serializable, Parameter.JdbcParameterValue
+public class GUID implements Serializable, Parameter.JdbcParameterValue, SimpleHasHtmlString
 {
     private static final int version  =       0x00001000;
     private static final int reserved =       0x00008000;

--- a/api/src/org/labkey/api/util/SimpleHasHtmlString.java
+++ b/api/src/org/labkey/api/util/SimpleHasHtmlString.java
@@ -1,0 +1,15 @@
+package org.labkey.api.util;
+
+/**
+ * Any class can implement this interface to implement {@code HasHtmlString} in a standard way. The {@code getHtmlString()}
+ * method returns an encoded version of the class's {@code toString()} method. Classes that implement this interface can be
+ * safely rendered by JSPs.
+ */
+public interface SimpleHasHtmlString extends HasHtmlString
+{
+    @Override
+    default HtmlString getHtmlString()
+    {
+        return HtmlString.of(toString());
+    }
+}

--- a/api/src/org/labkey/api/view/ActionURL.java
+++ b/api/src/org/labkey/api/view/ActionURL.java
@@ -26,9 +26,9 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.module.SimpleAction;
 import org.labkey.api.settings.AppProps;
-import org.labkey.api.util.EnumHasHtmlString;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.api.util.URLHelper;
 import org.springframework.web.servlet.mvc.Controller;
 
@@ -52,7 +52,7 @@ public class ActionURL extends URLHelper implements Cloneable
         return AppProps.getInstance().getUseContainerRelativeURL();
     }
 
-    public enum Param implements EnumHasHtmlString
+    public enum Param implements SimpleHasHtmlString
     {
         returnUrl,
         redirectUrl,    // mostly deprecated for returnUrl

--- a/api/src/org/labkey/api/wiki/WikiRendererType.java
+++ b/api/src/org/labkey/api/wiki/WikiRendererType.java
@@ -16,8 +16,8 @@
 
 package org.labkey.api.wiki;
 
-import org.labkey.api.util.EnumHasHtmlString;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.JspView;
@@ -27,7 +27,7 @@ import org.labkey.api.view.JspView;
  * User: Tamra Myers
  * Date: Aug 17, 2006
  */
-public enum WikiRendererType implements EnumHasHtmlString
+public enum WikiRendererType implements SimpleHasHtmlString
 {
     RADEOX
         {
@@ -38,7 +38,7 @@ public enum WikiRendererType implements EnumHasHtmlString
             @Override
             public HttpView getSyntaxHelpView()
             {
-                return new JspView("/org/labkey/api/wiki/wikiRadeoxHelp.jsp");
+                return new JspView<>("/org/labkey/api/wiki/wikiRadeoxHelp.jsp");
             }
         },
     HTML
@@ -74,7 +74,7 @@ public enum WikiRendererType implements EnumHasHtmlString
             public String getFileExtension() {return ".md";}
             @Override
             public HttpView getSyntaxHelpView(){
-                return new JspView("/org/labkey/api/wiki/wikiMarkdownHelp.jsp");
+                return new JspView<>("/org/labkey/api/wiki/wikiMarkdownHelp.jsp");
             }
         };
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1538,7 +1538,7 @@ public class AdminController extends SpringActionController
         void setRestrictedColumnsEnabled(boolean restrictedColumnsEnabled);
     }
 
-    public enum MigrateFilesOption implements EnumHasHtmlString
+    public enum MigrateFilesOption implements SimpleHasHtmlString
     {
         leave {
             @Override
@@ -1816,7 +1816,7 @@ public class AdminController extends SpringActionController
         }
     }
 
-    public enum FileRootProp implements EnumHasHtmlString
+    public enum FileRootProp implements SimpleHasHtmlString
     {
         disable,
         siteDefault,

--- a/core/src/org/labkey/core/admin/admin.jsp
+++ b/core/src/org/labkey/core/admin/admin.jsp
@@ -27,10 +27,9 @@
 <%@ page import="org.labkey.api.settings.AppProps" %>
 <%@ page import="org.labkey.api.util.GUID" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
-<%@ page import="org.labkey.api.util.Pair" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
-<%@ page import="org.labkey.api.view.NavTree"%>
-<%@ page import="org.labkey.core.admin.AdminController" %>
+<%@ page import="org.labkey.api.view.NavTree" %>
+<%@ page import="org.labkey.core.admin.AdminController"%>
 <%@ page import="java.util.Collection" %>
 <%@ page import="java.util.Date" %>
 <%@ page import="java.util.Map" %>

--- a/experiment/src/org/labkey/experiment/LSIDRelativizer.java
+++ b/experiment/src/org/labkey/experiment/LSIDRelativizer.java
@@ -23,7 +23,7 @@ import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpObject;
-import org.labkey.api.util.EnumHasHtmlString;
+import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.experiment.xar.AutoFileLSIDReplacer;
 
 import java.util.HashMap;
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
  * User: jeckels
  * Date: Nov 21, 2005
  */
-public enum LSIDRelativizer implements EnumHasHtmlString
+public enum LSIDRelativizer implements SimpleHasHtmlString
 {
     /** Keeps the original LSID from the source server */
     ABSOLUTE("Absolute")

--- a/experiment/src/org/labkey/experiment/XarExportType.java
+++ b/experiment/src/org/labkey/experiment/XarExportType.java
@@ -16,13 +16,13 @@
 
 package org.labkey.experiment;
 
-import org.labkey.api.util.EnumHasHtmlString;
+import org.labkey.api.util.SimpleHasHtmlString;
 
 /**
  * User: jeckels
  * Date: Sep 12, 2006
  */
-public enum XarExportType implements EnumHasHtmlString
+public enum XarExportType implements SimpleHasHtmlString
 {
     BROWSER_DOWNLOAD("Download to web browser"),
     PIPELINE_FILE("Write to exportedXars directory in pipeline");

--- a/study/src/org/labkey/study/CohortFilter.java
+++ b/study/src/org/labkey/study/CohortFilter.java
@@ -24,7 +24,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
-import org.labkey.api.util.EnumHasHtmlString;
+import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.api.view.ActionURL;
 import org.labkey.study.model.CohortImpl;
 
@@ -47,7 +47,7 @@ public interface CohortFilter
     @Deprecated /** Callers need to handle multiple cohorts case */
     int getCohortId();
 
-    enum Type implements EnumHasHtmlString
+    enum Type implements SimpleHasHtmlString
     {
         PTID_INITIAL("Initial cohort")
         {

--- a/study/src/org/labkey/study/CohortFilterFactory.java
+++ b/study/src/org/labkey/study/CohortFilterFactory.java
@@ -23,8 +23,8 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
-import org.labkey.api.util.EnumHasHtmlString;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.api.view.ActionURL;
 import org.labkey.study.CohortFilter.Type;
 import org.labkey.study.model.CohortImpl;
@@ -46,7 +46,7 @@ import java.util.Set;
  */
 public class CohortFilterFactory
 {
-    public static enum Params implements EnumHasHtmlString
+    public static enum Params implements SimpleHasHtmlString
     {
         cohortFilterType
         {

--- a/study/src/org/labkey/study/SpecimenManager.java
+++ b/study/src/org/labkey/study/SpecimenManager.java
@@ -69,11 +69,11 @@ import org.labkey.api.study.StudyCachable;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.TimepointType;
 import org.labkey.api.util.DateUtil;
-import org.labkey.api.util.EnumHasHtmlString;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.ViewContext;
@@ -2244,7 +2244,7 @@ public class SpecimenManager implements ContainerManager.ContainerListener
         }
     }
 
-    public enum SpecimenTypeLevel implements EnumHasHtmlString
+    public enum SpecimenTypeLevel implements SimpleHasHtmlString
     {
         PrimaryType()
         {

--- a/study/src/org/labkey/study/controllers/security/SecurityController.java
+++ b/study/src/org/labkey/study/controllers/security/SecurityController.java
@@ -41,12 +41,12 @@ import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.Study;
-import org.labkey.api.util.EnumHasHtmlString;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.HttpView;
@@ -626,7 +626,7 @@ public class SecurityController extends SpringActionController
 
     }
 
-    public enum PermissionType implements EnumHasHtmlString
+    public enum PermissionType implements SimpleHasHtmlString
     {
         defaultPermission,
         customPermission,

--- a/study/src/org/labkey/study/pipeline/AbstractDatasetImportTask.java
+++ b/study/src/org/labkey/study/pipeline/AbstractDatasetImportTask.java
@@ -25,8 +25,8 @@ import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.RecordedActionSet;
 import org.labkey.api.pipeline.TaskFactory;
 import org.labkey.api.query.snapshot.QuerySnapshotService;
-import org.labkey.api.util.EnumHasHtmlString;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.api.writer.VirtualFile;
 import org.labkey.study.StudySchema;
 import org.labkey.study.importer.StudyImportContext;
@@ -205,7 +205,7 @@ public abstract class AbstractDatasetImportTask<FactoryType extends AbstractData
     }
 
 
-    public enum Action implements EnumHasHtmlString
+    public enum Action implements SimpleHasHtmlString
     {
         REPLACE,
         APPEND,

--- a/study/src/org/labkey/study/specimen/report/SpecimenVisitReportParameters.java
+++ b/study/src/org/labkey/study/specimen/report/SpecimenVisitReportParameters.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.study.specimen.report;
 
-import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.jsp.taglib.AutoCompleteTextTag;
 import org.labkey.api.query.CustomView;
@@ -24,10 +23,10 @@ import org.labkey.api.study.Cohort;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.util.DemoMode;
-import org.labkey.api.util.EnumHasHtmlString;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.SimpleHasHtmlString;
 import org.labkey.api.util.element.Option.OptionBuilder;
 import org.labkey.api.util.element.Select;
 import org.labkey.api.view.ActionURL;
@@ -74,7 +73,7 @@ public abstract class SpecimenVisitReportParameters extends ViewForm
         hideEmptyColumns
     }
 
-    public enum Status implements EnumHasHtmlString
+    public enum Status implements SimpleHasHtmlString
     {
         ALL("All vials"),
         AVAILABLE("Available vials"),
@@ -84,15 +83,16 @@ public abstract class SpecimenVisitReportParameters extends ViewForm
         REQUESTED_COMPLETE("Vials in completed requests"),
         NOT_REQUESTED_COMPLETE("Vials not in completed requests");
 
-        private String _caption;
-        public String getCaption()
-        {
-            return _caption;
-        }
+        private final String _caption;
 
         Status(String caption)
         {
             _caption = caption;
+        }
+
+        public String getCaption()
+        {
+            return _caption;
         }
     }
 
@@ -249,10 +249,10 @@ public abstract class SpecimenVisitReportParameters extends ViewForm
 
     public static final String COMPLETED_REQUESTS_FILTER_SQL =
             "SELECT SpecimenGlobalUniqueId FROM study.SampleRequestSpecimen\n" +
-                    "\tJOIN study.SampleRequest ON study.SampleRequestSpecimen.SampleRequestId = study.SampleRequest.RowId\n" +
-                    "\tJOIN study.SampleRequestStatus ON study.SampleRequest.StatusId = study.SampleRequestStatus.RowId\n" +
-                    "\tWHERE study.SampleRequestStatus.SpecimensLocked = ? AND study.SampleRequestStatus.FinalState = ?\n" +
-                    "\tAND study.SampleRequest.Container = ?";
+                "\tJOIN study.SampleRequest ON study.SampleRequestSpecimen.SampleRequestId = study.SampleRequest.RowId\n" +
+                "\tJOIN study.SampleRequestStatus ON study.SampleRequest.StatusId = study.SampleRequestStatus.RowId\n" +
+                "\tWHERE study.SampleRequestStatus.SpecimensLocked = ? AND study.SampleRequestStatus.FinalState = ?\n" +
+                "\tAND study.SampleRequest.Container = ?";
 
     protected void addAvailabilityFilter(SimpleFilter filter, Status status)
     {

--- a/study/src/org/labkey/study/specimen/settings/RequestNotificationSettings.java
+++ b/study/src/org/labkey/study/specimen/settings/RequestNotificationSettings.java
@@ -15,17 +15,17 @@
  */
 package org.labkey.study.specimen.settings;
 
+import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 import org.labkey.api.security.ValidEmail;
-import org.labkey.api.data.Container;
 import org.labkey.api.settings.LookAndFeelProperties;
-import org.labkey.api.util.EnumHasHtmlString;
+import org.labkey.api.util.SimpleHasHtmlString;
 
 import javax.mail.Address;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
-import java.util.List;
-import java.util.ArrayList;
 
 /*
  * User: brittp
@@ -51,9 +51,9 @@ public class RequestNotificationSettings
     private DefaultEmailNotifyEnum _defaultEmailNotify = DefaultEmailNotifyEnum.ActorsInvolved;
     private SpecimensAttachmentEnum _specimensAttachment = SpecimensAttachmentEnum.InEmailBody;
 
-    public enum DefaultEmailNotifyEnum implements EnumHasHtmlString
+    public enum DefaultEmailNotifyEnum implements SimpleHasHtmlString
     {All, None, ActorsInvolved}
-    public enum SpecimensAttachmentEnum implements EnumHasHtmlString
+    public enum SpecimensAttachmentEnum implements SimpleHasHtmlString
     {InEmailBody, ExcelAttachment, TextAttachment, Never}
 
     public RequestNotificationSettings()


### PR DESCRIPTION
#### Rationale
`EnumHasHtmlString` approach can be generalized to provide an easy way for any class to implement `HasHtmlString`. Test failures caused by immport JSPs outputting `GUID` objects can be silenced using this new approach. 

#### Changes
* Generalize `EnumHasHtmlString` to `SimpleHasHtmlString`, which any class can implement
* Switch platform enums to implement `SimpleHasHtmlString`
* Silence immport test failures by making `GUID` implement `SimpleHasHtmlString`
