### PR TITLE
Issue 41014: fix flagging of flow FCSAnalysis wells

### DIFF
--- a/api/src/org/labkey/api/exp/Identifiable.java
+++ b/api/src/org/labkey/api/exp/Identifiable.java
@@ -17,6 +17,7 @@ package org.labkey.api.exp;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.query.QueryRowReference;
 import org.labkey.api.view.ActionURL;
 
@@ -44,6 +45,14 @@ public interface Identifiable
     }
 
     default @Nullable QueryRowReference getQueryRowReference()
+    {
+        return null;
+    }
+
+    /**
+     * Get the corresponding ExpObject for this Identifiable, if there is one.
+     */
+    default @Nullable ExpObject getExpObject()
     {
         return null;
     }

--- a/api/src/org/labkey/api/exp/api/ExpObject.java
+++ b/api/src/org/labkey/api/exp/api/ExpObject.java
@@ -75,4 +75,11 @@ public interface ExpObject extends Identifiable, Comparable<ExpObject>
      * @return Map from PropertyURI to ObjectProperty
      */
     Map<String, ObjectProperty> getObjectProperties();
+
+    @Override
+    @Nullable
+    default ExpObject getExpObject()
+    {
+        return this;
+    }
 }

--- a/experiment/src/org/labkey/experiment/api/Data.java
+++ b/experiment/src/org/labkey/experiment/api/Data.java
@@ -17,6 +17,7 @@ package org.labkey.experiment.api;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.exp.api.ExpData;
+import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
@@ -122,5 +123,11 @@ public class Data extends RunItem
         Data data = (Data) o;
 
         return !(getRowId() == 0 || getRowId() != data.getRowId());
+    }
+
+    @Override
+    public @Nullable ExpDataImpl getExpObject()
+    {
+        return new ExpDataImpl(this);
     }
 }

--- a/experiment/src/org/labkey/experiment/api/DataClass.java
+++ b/experiment/src/org/labkey/experiment/api/DataClass.java
@@ -17,6 +17,7 @@ package org.labkey.experiment.api;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.exp.api.ExpDataClass;
 import org.labkey.api.view.ActionURL;
 import org.labkey.experiment.controllers.exp.ExperimentController;
 
@@ -103,5 +104,11 @@ public class DataClass extends IdentifiableEntity implements Comparable<DataClas
     public int compareTo(@NotNull DataClass o)
     {
         return getName().compareToIgnoreCase(o.getName());
+    }
+
+    @Override
+    public @Nullable ExpDataClassImpl getExpObject()
+    {
+        return new ExpDataClassImpl(this);
     }
 }

--- a/experiment/src/org/labkey/experiment/api/DataInput.java
+++ b/experiment/src/org/labkey/experiment/api/DataInput.java
@@ -16,8 +16,10 @@
 
 package org.labkey.experiment.api;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.exp.LsidType;
 import org.labkey.api.exp.api.ExpDataRunInput;
+import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.settings.AppProps;
 
 import static org.labkey.api.util.PageFlowUtil.encode;
@@ -66,5 +68,11 @@ public class DataInput extends AbstractRunInput
     protected int getInputKey()
     {
         return _dataId;
+    }
+
+    @Override
+    public @Nullable ExpDataRunInputImpl getExpObject()
+    {
+        return new ExpDataRunInputImpl(this);
     }
 }

--- a/experiment/src/org/labkey/experiment/api/DataProtocolInput.java
+++ b/experiment/src/org/labkey/experiment/api/DataProtocolInput.java
@@ -15,6 +15,9 @@
  */
 package org.labkey.experiment.api;
 
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.exp.api.ExpObject;
+
 public class DataProtocolInput extends AbstractProtocolInput
 {
     protected Integer _dataClassId;
@@ -33,5 +36,11 @@ public class DataProtocolInput extends AbstractProtocolInput
     public String getObjectType()
     {
         return ExpDataImpl.DEFAULT_CPAS_TYPE;
+    }
+
+    @Override
+    public @Nullable ExpDataProtocolInputImpl getExpObject()
+    {
+        return new ExpDataProtocolInputImpl(this);
     }
 }

--- a/experiment/src/org/labkey/experiment/api/Experiment.java
+++ b/experiment/src/org/labkey/experiment/api/Experiment.java
@@ -15,6 +15,9 @@
  */
 package org.labkey.experiment.api;
 
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.exp.api.ExpExperiment;
+
 import java.io.Serializable;
 
 /**
@@ -100,5 +103,11 @@ public class Experiment extends IdentifiableEntity implements Serializable
     public void setBatchProtocolId(Integer batchProtocolId)
     {
         _batchProtocolId = batchProtocolId;
+    }
+
+    @Override
+    public @Nullable ExpExperimentImpl getExpObject()
+    {
+        return new ExpExperimentImpl(this);
     }
 }

--- a/experiment/src/org/labkey/experiment/api/ExperimentRun.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentRun.java
@@ -16,11 +16,9 @@
 package org.labkey.experiment.api;
 
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.data.Container;
-import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.experiment.controllers.exp.ExperimentController;
 
@@ -136,5 +134,11 @@ public class ExperimentRun extends IdentifiableEntity
         result = 31 * result + getRowId();
         result = 31 * result + (protocolLSID != null ? protocolLSID.hashCode() : 0);
         return result;
+    }
+
+    @Override
+    public @Nullable ExpRunImpl getExpObject()
+    {
+        return new ExpRunImpl(this);
     }
 }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1273,11 +1273,10 @@ public class ExperimentServiceImpl implements ExperimentService
     public ExpObject findObjectFromLSID(String lsid)
     {
         Identifiable id = LsidManager.get().getObject(lsid);
-        if (id instanceof ExpObject)
-        {
-            return (ExpObject) id;
-        }
-        return null;
+        if (id == null)
+            return null;
+
+        return id.getExpObject();
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/Material.java
+++ b/experiment/src/org/labkey/experiment/api/Material.java
@@ -15,7 +15,9 @@
  */
 package org.labkey.experiment.api;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.exp.api.ExpMaterial;
+import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.experiment.controllers.exp.ExperimentController;
@@ -54,5 +56,11 @@ public class Material extends RunItem
     public int hashCode()
     {
         return getRowId();
+    }
+
+    @Override
+    public @Nullable ExpMaterialImpl getExpObject()
+    {
+        return new ExpMaterialImpl(this);
     }
 }

--- a/experiment/src/org/labkey/experiment/api/MaterialInput.java
+++ b/experiment/src/org/labkey/experiment/api/MaterialInput.java
@@ -16,6 +16,7 @@
 
 package org.labkey.experiment.api;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.exp.LsidType;
 import org.labkey.api.exp.api.ExpMaterialRunInput;
 import org.labkey.api.settings.AppProps;
@@ -63,5 +64,11 @@ public class MaterialInput extends AbstractRunInput
     protected int getInputKey()
     {
         return _materialId;
+    }
+
+    @Override
+    public @Nullable ExpMaterialRunInputImpl getExpObject()
+    {
+        return new ExpMaterialRunInputImpl(this);
     }
 }

--- a/experiment/src/org/labkey/experiment/api/MaterialProtocolInput.java
+++ b/experiment/src/org/labkey/experiment/api/MaterialProtocolInput.java
@@ -15,6 +15,9 @@
  */
 package org.labkey.experiment.api;
 
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.exp.api.ExpObject;
+
 public class MaterialProtocolInput extends AbstractProtocolInput
 {
     protected Integer _materialSourceId;
@@ -33,5 +36,11 @@ public class MaterialProtocolInput extends AbstractProtocolInput
     public String getObjectType()
     {
         return ExpMaterialImpl.DEFAULT_CPAS_TYPE;
+    }
+
+    @Override
+    public @Nullable ExpMaterialProtocolInputImpl getExpObject()
+    {
+        return new ExpMaterialProtocolInputImpl(this);
     }
 }

--- a/experiment/src/org/labkey/experiment/api/MaterialSource.java
+++ b/experiment/src/org/labkey/experiment/api/MaterialSource.java
@@ -17,6 +17,8 @@ package org.labkey.experiment.api;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.exp.api.ExpObject;
+import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.query.ExpSampleTypeTable;
 import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.query.FieldKey;
@@ -169,4 +171,9 @@ public class MaterialSource extends IdentifiableEntity implements Comparable<Mat
         return getName().compareToIgnoreCase(o.getName());
     }
 
+    @Override
+    public @Nullable ExpSampleTypeImpl getExpObject()
+    {
+        return new ExpSampleTypeImpl(this);
+    }
 }

--- a/experiment/src/org/labkey/experiment/api/Protocol.java
+++ b/experiment/src/org/labkey/experiment/api/Protocol.java
@@ -16,14 +16,15 @@
 package org.labkey.experiment.api;
 
 import org.apache.commons.beanutils.BeanUtils;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.ProtocolParameter;
+import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpProtocolInput;
 
 import java.lang.reflect.InvocationTargetException;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -411,4 +412,9 @@ public class Protocol extends IdentifiableEntity
         return _protocolInputs;
     }
 
+    @Override
+    public @Nullable ExpProtocolImpl getExpObject()
+    {
+        return new ExpProtocolImpl(this);
+    }
 }

--- a/experiment/src/org/labkey/experiment/api/ProtocolApplication.java
+++ b/experiment/src/org/labkey/experiment/api/ProtocolApplication.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.experiment.api;
 
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.IdentifiableBase;
 
@@ -155,4 +157,9 @@ public class ProtocolApplication extends IdentifiableBase
 
     }
 
+    @Override
+    public @Nullable ExpProtocolApplicationImpl getExpObject()
+    {
+        return new ExpProtocolApplicationImpl(this);
+    }
 }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4627,10 +4627,6 @@ public class ExperimentController extends SpringActionController
                 throw new UnauthorizedException();
             }
 
-            if (!container.hasPermission(getUser(), UpdatePermission.class))
-            {
-                throw new UnauthorizedException();
-            }
             obj.setComment(getUser(), form.getComment());
 
             if (form.isRedirect())


### PR DESCRIPTION
#### Rationale
Flagging flow wells broke after flow objects were refactored to implement Identifiable.

The SetFlagAction uses ExperimentService.findObjectFromLSID() to resolve Identifiable objects using LsidManager.getObject(lsid) and expects the result to implement ExpObject.  After refactoring flow objects to implement Identifiable, FlowFCSAnalysis objects are now found before the underlying ExpData object.  The fix is to teach Identifiable how to get a corresponding ExpObject which the SetFlag action can use to set the comment.

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/220
* https://github.com/LabKey/commonAssays/pull/145
* https://github.com/LabKey/platform/pull/1000

#### Changes
- add Identifiable.getExpObject() for attaching flag comment
- also fix some unencoded strings
