### PR TITLE
update usage of setValidators

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
@@ -140,8 +140,8 @@ public class StudySimpleExportTest extends StudyBaseTest
 
         DomainFormPanel fieldsEditor = editDatasetPage.getFieldsPanel();
         fieldsEditor.manuallyDefineFields(new FieldDefinition("TestInt").setLabel("TestInt").setType(FieldDefinition.ColumnType.Integer)
-                .setValidator(new FieldDefinition.RangeValidator("numberValidator", "numberValidator",
-                        "TestInt must equals '999'.", FieldDefinition.RangeType.Equals, "999")).setRequired(false));
+                .setValidators(List.of(new FieldDefinition.RangeValidator("numberValidator", "numberValidator",
+                        "TestInt must equals '999'.", FieldDefinition.RangeType.Equals, "999"))).setRequired(false));
         fieldsEditor.addField(new FieldDefinition("TestString").setLabel("TestRequiredString").setType(FieldDefinition.ColumnType.String)
                 .setRequired(true));
         // Format "TestDate" as "Date"


### PR DESCRIPTION
#### Rationale
This updates a test to align to a change in FieldDefinition, to cause setValidators to take a List<FieldValidator<?>>.

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/409

#### Changes
Updates the test to pass a list of FieldValidators
