### PR TITLE
handle errors thrown when reading pipeline status log file 

### DIFF
--- a/pipeline/src/org/labkey/pipeline/status/FileDisplayColumn.java
+++ b/pipeline/src/org/labkey/pipeline/status/FileDisplayColumn.java
@@ -107,7 +107,6 @@ public class FileDisplayColumn extends SimpleDisplayColumn
     }
 
     public static List<Path> listFiles(Path p, Container c, PipelineProvider provider)
-            throws IOException
     {
         Path parent = p.getParent();
 
@@ -132,6 +131,10 @@ public class FileDisplayColumn extends SimpleDisplayColumn
                         })
                         .sorted(Path::compareTo)
                         .collect(toList());
+            }
+            catch (IOException e)
+            {
+                // ignore, just return an empty file list
             }
         }
 

--- a/pipeline/src/org/labkey/pipeline/status/details.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/details.jsp
@@ -227,7 +227,7 @@
     </div>
     <br>
     <div id="log-container">
-        <% if (status.log == null) { %>
+        <% if (status.log == null || status.log.records == null) { %>
         <em>Log file doesn't exist.</em>
         <% } else { %>
         <div id="log-data">
@@ -542,14 +542,39 @@
         }
 
         function updateLog(log) {
-            if (log && log.records) {
-                let chunks = renderLog(log.records);
+            if (log) {
                 if (!logDataEl) {
                     // job is active, but the log file didn't exist during first page load
                     logContainerEl.innerHTML = '<div id="log-data"></div>';
                     logDataEl = document.getElementById('log-data');
                 }
-                chunks.forEach(function (chunk) { logDataEl.appendChild(chunk); });
+
+                if (log.success) {
+                    // successfully read the status log file
+                    if (log.records && log.records.length > 0) {
+                        let chunks = renderLog(log.records);
+                        chunks.forEach(function (chunk) { logDataEl.appendChild(chunk); });
+                    }
+                }
+                else {
+                    // error reading the status log file.
+                    let message = log.message || 'Error reading log file';
+
+                    // Add the error if the previous message was not the same error.
+                    let lastChild = logDataEl.lastElementChild;
+                    if (!lastChild || lastChild.innerText !== message) {
+                        let errEl = document.createElement('PRE');
+                        errEl.innerText = message;
+                        errEl.classList.add('labkey-log-text');
+                        errEl.classList.add('bg-warning');
+                        errEl.classList.add('text-danger');
+                        logDataEl.appendChild(errEl);
+                    }
+                    else {
+                        console.warn("Skipping duplicate error: " + message);
+                    }
+                }
+
                 scrollLog(true);
             }
         }


### PR DESCRIPTION
#### Rationale
Handle IOException thrown when reading pipeline status file as seen on TeamCity running the flow tests.

```java
java.nio.charset.MalformedInputException: Input length = 1
       at java.base/java.nio.charset.CoderResult.throwException(CoderResult.java:274)
       at java.base/sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:352)
       at java.base/sun.nio.cs.StreamDecoder.read(StreamDecoder.java:188)
       at java.base/java.io.InputStreamReader.read(InputStreamReader.java:181)
       at java.base/java.io.BufferedReader.read1(BufferedReader.java:210)
       at java.base/java.io.BufferedReader.read(BufferedReader.java:287)
       at java.base/java.io.Reader.transferTo(Reader.java:384)
       at org.labkey.pipeline.status.StatusDetailsBean.transferTo(StatusDetailsBean.java:162)
       at org.labkey.pipeline.status.StatusDetailsBean.create(StatusDetailsBean.java:113)
       at org.labkey.pipeline.status.StatusController$DetailsAction.getView(StatusController.java:482)
       at org.labkey.pipeline.status.StatusController$DetailsAction.getView(StatusController.java:441)
```

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/418

#### Changes
- report errors reading pipeline status log file to client
- increase default wait time for pipeline in tests

