### PR TITLE
Issue 41030: Field key change in copy to study columns breaks saved v…

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -796,6 +796,30 @@ public abstract class AssayProtocolSchema extends AssaySchema
         col.setURL(fkse.remapFieldKeys(null, map));
     }
 
+    /**
+     * Transform an illegal name into a safe version. All non-letter characters
+     * become underscores, and the first character must be a letter. Retain this implementation for backwards
+     * compatibility with copied to study column names. See issue 41030.
+     */
+    private String sanitizeName(String originalName)
+    {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true; // first character is special
+        for (int i = 0; i < originalName.length(); i++)
+        {
+            char c = originalName.charAt(i);
+            if (AliasManager.isLegalNameChar(c, first))
+            {
+                sb.append(c);
+                first = false;
+            }
+            else if (!first)
+            {
+                sb.append('_');
+            }
+        }
+        return sb.toString();
+    }
 
     /**
      * Adds columns to an assay data table, providing a link to any datasets that have
@@ -833,7 +857,7 @@ public abstract class AssayProtocolSchema extends AssaySchema
                 String studyName = assayDataset.getStudy().getLabel();
                 if (studyName == null)
                     continue; // No study in that folder
-                String studyColumnName = "copied_to_" + AliasManager.legalNameFromName(studyName);
+                String studyColumnName = "copied_to_" + sanitizeName(studyName);
 
                 // column names must be unique. Prevent collisions
                 while (usedColumnNames.contains(studyColumnName))

--- a/api/src/org/labkey/api/query/AliasManager.java
+++ b/api/src/org/labkey/api/query/AliasManager.java
@@ -55,8 +55,8 @@ public class AliasManager
             claimAliases(columns);
     }
 
-
-    private static boolean isLegalNameChar(char ch, boolean first)
+    /** Allows alpha and underscores, and numbers for all but the first character */
+    public static boolean isLegalNameChar(char ch, boolean first)
     {
         if (ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z' || ch == '_')
             return true;

--- a/api/src/org/labkey/api/util/ResultSetUtil.java
+++ b/api/src/org/labkey/api/util/ResultSetUtil.java
@@ -25,6 +25,7 @@ import org.labkey.api.collections.ResultSetRowMapFactory;
 import org.labkey.api.data.CachedResultSet;
 import org.labkey.api.data.CachedResultSets;
 import org.labkey.api.data.ResultSetMetaDataImpl;
+import org.labkey.api.query.AliasManager;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -187,26 +188,13 @@ public class ResultSetUtil
     }
 
 
-    /* copied from AliasManager, should have shared JS XML specific versions */
-    private static boolean isLegalNameChar(char ch, boolean first)
-    {
-        if (ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z' || ch == '_')
-            return true;
-        if (first)
-            return false;
-        if (ch >= '0' && ch <= '9')
-            return true;
-        return false;
-    }
-
-
     public static String legalNameFromName(String str)
     {
         StringBuilder buf = null;
 
         for (int i = 0; i < str.length(); i++)
         {
-            if (isLegalNameChar(str.charAt(i), i == 0))
+            if (AliasManager.isLegalNameChar(str.charAt(i), i == 0))
                 continue;
             if (buf == null)
             {


### PR DESCRIPTION
#### Rationale
In 20.7, I removed an alternative version of column name sanitization to consolidate implementations, which was being used solely when adding columns to assays for each study it's been copied to. This breaks backwards compatibility with saved views and custom queries

#### Changes
* Restore the variant that copied to columns were using earlier
* Eliminate duplicate copies of the isLegalNameChar() method