### PR TITLE
Issue 41040: Announcements update action has a broken navtrail

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -945,15 +945,14 @@ public class AnnouncementsController extends SpringActionController
             return new VBox(threadView, respondView);
         }
 
-
         @Override
         public void addNavTrail(NavTree root)
         {
             new BeginAction(getViewContext()).addNavTrail(root);
             if (_parent != null)
             {
-                root.addChild(_parent.getTitle(), "thread.view?rowId=" + _parent.getRowId())
-                        .addChild("Respond to " + getSettings().getConversationName());
+                root.addChild(_parent.getTitle(), getThreadURL(getContainer(), _parent.getRowId()));
+                root.addChild("Respond to " + getSettings().getConversationName());
             }
          }
     }
@@ -1311,7 +1310,7 @@ public class AnnouncementsController extends SpringActionController
             if (null != urlHelper)
                 throw new RedirectException(urlHelper);
             else
-                throw new RedirectException(new ActionURL(ThreadAction.class, getContainer()).addParameter("rowId",ann.getRowId()));
+                throw new RedirectException(getThreadURL(getContainer(), ann.getParent(), ann.getRowId()));
         }
 
         @Override
@@ -1324,11 +1323,10 @@ public class AnnouncementsController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             new BeginAction(getViewContext()).addNavTrail(root);
-            root.addChild(_ann.getTitle(), "thread.view?rowId=" + _ann.getRowId());
-            root.addChild("Respond to " + getSettings().getConversationName());
+            root.addChild(_ann.getTitle(), getThreadURL(getContainer(), _ann.getParent(), _ann.getRowId()));
+            root.addChild("Edit Response to " + getSettings().getConversationName());
         }
     }
-
 
     public static ActionURL getThreadURL(Container c, String threadId, int rowId)
     {
@@ -1338,6 +1336,13 @@ public class AnnouncementsController extends SpringActionController
         return url;
     }
 
+    // Note: ThreadAction expects that rowId is a top-level message, not a response
+    public static ActionURL getThreadURL(Container c, int rowId)
+    {
+        ActionURL url = new ActionURL(ThreadAction.class, c);
+        url.addParameter("rowId", rowId);
+        return url;
+    }
 
     @RequiresPermission(ReadPermission.class)
     public class ThreadAction extends SimpleViewAction<AnnouncementForm>

--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -1198,8 +1198,8 @@ public class AnnouncementManager
                                      AnnouncementModel a, boolean isResponse, ActionURL removeURL, WikiRendererType currentRendererType, EmailNotificationBean.Reason reason)
         {
             this.recipient = recipient;
-            this.threadURL = new ActionURL(AnnouncementsController.ThreadAction.class, c).addParameter("rowId", a.getRowId());
-            this.threadParentURL = new ActionURL(AnnouncementsController.ThreadAction.class, c).addParameter("rowId", parent.getRowId());
+            this.threadURL = AnnouncementsController.getThreadURL(c, a.getRowId());
+            this.threadParentURL = AnnouncementsController.getThreadURL(c, parent.getRowId());
             this.boardPath = c.getPath();
             this.boardURL = AnnouncementsController.getBeginURL(c);
             this.siteURL = ActionURL.getBaseServerURL();


### PR DESCRIPTION
#### Rationale
A couple message board navtrails have problems:

- The update navtrail has a broken link if path-first URLs are on. If corrected to the intended thread action, the link is incorrect for responses.
- The respond navtrail is truncated due to a malformed NavTree. Correcting the NavTree to what was intended uncovers its own broken link.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41040

#### Changes
* Add a helper that produces ThreadAction URLs for top-level messages. Fix the above problems.
