### PR TITLE
Remove appendNavTrail()

### DIFF
--- a/api/src/org/labkey/api/action/NavTrailAction.java
+++ b/api/src/org/labkey/api/action/NavTrailAction.java
@@ -16,7 +16,6 @@
 
 package org.labkey.api.action;
 
-import org.apache.log4j.Logger;
 import org.labkey.api.view.NavTree;
 
 /**
@@ -26,18 +25,5 @@ import org.labkey.api.view.NavTree;
  */
 public interface NavTrailAction
 {
-    Logger LOG = Logger.getLogger(NavTrailAction.class);
-
-    @Deprecated()  // Implement addNavTrail() instead
-    default NavTree appendNavTrail(NavTree root)
-    {
-        throw new IllegalStateException(getClass().getName() + " must implement addNavTrail()!");
-    }
-
-    default void addNavTrail(NavTree root)
-    {
-        appendNavTrail(root);
-        // The last method didn't throw IllegalStateException, so we know this action implements appendNavTrail()
-        LOG.warn(getClass().getName() + " should implement addNavTrail() instead of appendNavTrail()! The appendNavTrail() method is deprecated and will be removed shortly.");
-    }
+    void addNavTrail(NavTree root);
 }

--- a/api/src/org/labkey/api/assay/actions/BaseAssayAction.java
+++ b/api/src/org/labkey/api/assay/actions/BaseAssayAction.java
@@ -74,14 +74,6 @@ public abstract class BaseAssayAction<T extends ProtocolIdForm> extends SimpleVi
         return rgn;
     }
 
-    @Deprecated
-    @Override
-    public NavTree appendNavTrail(NavTree root)
-    {
-        addNavTrail(root);
-        return root;
-    }
-
     @Override
     public void addNavTrail(NavTree root)
     {


### PR DESCRIPTION
#### Rationale
`appendNavTrail()` was deprecated a while back in favor of `addNavTrail()`; it's time to remove the deprecated method.

#### Related Pull Requests
* https://github.com/LabKey/MacCossLabModules/pull/71
* https://github.com/LabKey/BimberLabKeyModules/pull/40
* https://github.com/LabKey/DiscvrLabKeyModules/pull/51

#### Changes
* Remove `appendNavTrail()` default implementation
