### PR TITLE
Fix admin link to registration email and customize single list webpart

### DIFF
--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -80,6 +80,7 @@ import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.JunitUtil;
+import org.labkey.api.util.Link.LinkBuilder;
 import org.labkey.api.util.MailHelper;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
@@ -2814,8 +2815,8 @@ public class SecurityManager
         // hide showRegistrationEmail link if provider is specified for now
         if (messageContentsURL != null && provider == null)
         {
-            String href = "<a href=" + PageFlowUtil.filter(messageContentsURL) + " target=\"_blank\">here</a>";
-            message.append(" Click ").append(href).append(" to see the email.");
+            LinkBuilder link = new LinkBuilder("here").href(messageContentsURL).target("_blank").clearClasses();
+            message.append(" Click ").append(link).append(" to see the email.");
         }
 
         return message.getHtmlString();

--- a/list/src/org/labkey/list/view/customizeSingleListWebPart.jsp
+++ b/list/src/org/labkey/list/view/customizeSingleListWebPart.jsp
@@ -93,7 +93,7 @@ If you want to let users change the list that's displayed or customize the view 
                     if(myPanel.getForm().isValid()){
 
                         myPanel.getForm().submit({
-                            url : <%=(part.getCustomizePostURL(ctx)).getLocalURIString()%>,
+                            url : <%=q((part.getCustomizePostURL(ctx)).getLocalURIString())%>,
                             success : function(){},
                             failure : function(){}
                         });
@@ -113,6 +113,5 @@ If you want to let users change the list that's displayed or customize the view 
             standardSubmit: true,
             items : [title, queryCombo, viewCombo, submitButton, { xtype: 'hidden', name: 'X-LABKEY-CSRF', value: LABKEY.CSRF }]
         });
-
     });
 </script>


### PR DESCRIPTION
#### Rationale
Mistakes were made... and the tests caught them

#### Changes
* Fix admin link to registration email (link HTML getting encoded)
* Fix single list webpart customize page (missing q())
