### PR TITLE
Fb validate navtrail

### DIFF
--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -696,16 +696,16 @@ public abstract class SpringActionController implements Controller, HasViewConte
         if (action instanceof NavTrailAction)
         {
             ((NavTrailAction)action).addNavTrail(root);
-            assert isValidNavTree(root) : action.getClass().getName() + " is generating a malformed NavTree";
+            assert isValidNavTree(root, action) : action.getClass().getName() + " is generating a malformed NavTree";
         }
     }
 
     // NavTrail renders only the first level children, so flag the NavTree as invalid if any child has children. This
     // most likely means that addNavTrail() chained calls to addChild(), which adds nodes that will never render.
-    private boolean isValidNavTree(NavTree tree)
+    private boolean isValidNavTree(NavTree tree, Controller action)
     {
-        return tree.getChildren().stream()
-            .noneMatch(NavTree::hasChildren);
+        return tree.getChildren().stream()   // Very temporary exception for RespondAction. TODO: Remove once 20.7.2 changes are merged to develop.
+            .noneMatch(NavTree::hasChildren) || "org.labkey.announcements.AnnouncementsController$RespondAction".equals(action.getClass().getName());
     }
 
     protected void beforeAction(Controller action) throws ServletException

--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -696,7 +696,16 @@ public abstract class SpringActionController implements Controller, HasViewConte
         if (action instanceof NavTrailAction)
         {
             ((NavTrailAction)action).addNavTrail(root);
+            assert isValidNavTree(root) : action.getClass().getName() + " is generating a malformed NavTree";
         }
+    }
+
+    // NavTrail renders only the first level children, so flag the NavTree as invalid if any child has children. This
+    // most likely means that addNavTrail() chained calls to addChild(), which adds nodes that will never render.
+    private boolean isValidNavTree(NavTree tree)
+    {
+        return tree.getChildren().stream()
+            .noneMatch(NavTree::hasChildren);
     }
 
     protected void beforeAction(Controller action) throws ServletException


### PR DESCRIPTION
#### Rationale
Our navtrails render just the top-level children of a `NavTree`, ignoring all nodes at the second level or below. But `NavTree.addChild()` returns the just added child, not the parent, which means chaining `addChild()` calls orphans nodes and renders a truncated navtrail. One case of a truncated navtrail (messages `RespondAction`) was fixed in 20.7. This change flags all navtrail NavTrees with orphaned nodes, to detect existing and future problems.