### PR TITLE
Move productId to Service in API so it is accessible

### DIFF
--- a/api/src/org/labkey/api/inventory/InventoryService.java
+++ b/api/src/org/labkey/api/inventory/InventoryService.java
@@ -34,6 +34,8 @@ import java.util.Map;
  */
 public interface InventoryService
 {
+    String PRODUCT_ID = "freezerManager";
+
     static void setInstance(InventoryService impl)
     {
         ServiceRegistry.get().registerService(InventoryService.class, impl);


### PR DESCRIPTION
#### Rationale
We want to create links to the Freezer Manager application from the Sample Manager application in the product mega-menu, and that is best done using a common constant for the productId.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/338
* https://github.com/LabKey/inventory/pull/63

#### Changes
* Move Inventory Product id into InventoryService from inventory module.
