### PR TITLE
Make Junit Go action a standard MutatingApiAction

### DIFF
--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -1066,6 +1066,12 @@ public class ExceptionUtil
                 {
                     return user;
                 }
+
+                @Override
+                public String getMethod()
+                {
+                    return "GET";
+                }
             };
             ExceptionUtil.decorateException(ex, ExceptionInfo.SkipMothershipLogging, "true", true);
             ActionURL url = ExceptionUtil.handleException(req, res, ex, message, false, dummySearch, dummyLog);


### PR DESCRIPTION
#### Rationale
JunitTest fails periodically claiming that the Go action returned "null". I don't know what's causing that, but we might as well use our standard API action instead of constructing the response "manually."

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/423

#### Changes
* Convert Go action into a MutatingApiAction