### PR TITLE
Issue 41058: GetQueryDetailsAction does not return public name of query

### DIFF
--- a/assay/api-src/org/labkey/api/assay/matrix/AbstractMatrixProtocolSchema.java
+++ b/assay/api-src/org/labkey/api/assay/matrix/AbstractMatrixProtocolSchema.java
@@ -70,13 +70,13 @@ public abstract class AbstractMatrixProtocolSchema extends AssayProtocolSchema
     {
         if (name.equals(getDataBySampleTableName()))
         {
-            return getDataBySampleTable(cf, rowAxisId, colAxisId, valueMeasureName, title); //TODO: change
+            return getDataBySampleTable(cf, rowAxisId, colAxisId, valueMeasureName, name, title); //TODO: change
         }
 
         return super.createTable(name, cf);
     }
 
-    public CrosstabTableInfo getDataBySampleTable(ContainerFilter cf, String rowAxisId, String colAxisId, String valueMeasureName, String title)
+    public CrosstabTableInfo getDataBySampleTable(ContainerFilter cf, String rowAxisId, String colAxisId, String valueMeasureName, String name, String title)
     {
         CrosstabSettings settings = new CrosstabSettings(getDataTableInfo(cf));
         CrosstabTable cti;
@@ -101,6 +101,7 @@ public abstract class AbstractMatrixProtocolSchema extends AssayProtocolSchema
         cti = new CrosstabTable(settings, members);
         cti.setDefaultVisibleColumns(defaultCols);
         cti.setTitle(title);
+        cti.setName(name);
 
         return cti;
     }

--- a/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
+++ b/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
@@ -51,6 +51,7 @@ public class NAbSpecimenTable extends FilteredTable<AssayProtocolSchema>
 
         wrapAllColumns(true);
         setTitle(DilutionManager.NAB_SPECIMEN_TABLE_NAME);
+        setName("Data");
 
         // TODO - add columns for all of the different cutoff values
         ExprColumn selectedAUC = new ExprColumn(this, "AUC", getSelectedCurveFitAUC(false), JdbcType.DECIMAL);

--- a/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
+++ b/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
@@ -50,6 +50,7 @@ public class NAbSpecimenTable extends FilteredTable<AssayProtocolSchema>
         super(DilutionManager.getTableInfoNAbSpecimen(), schema, cf);
 
         wrapAllColumns(true);
+        setTitle(DilutionManager.NAB_SPECIMEN_TABLE_NAME);
 
         // TODO - add columns for all of the different cutoff values
         ExprColumn selectedAUC = new ExprColumn(this, "AUC", getSelectedCurveFitAUC(false), JdbcType.DECIMAL);

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -171,6 +171,9 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
         if (auditHistoryUrl != null)
             resp.put("auditHistoryUrl", auditHistoryUrl);
 
+        // Return public name for query
+        resp.put("name", tinfo.getPublicName());
+
         resp.put("title", tinfo.getTitle());
         resp.put("titleColumn", tinfo.getTitleColumn());
 


### PR DESCRIPTION
#### Rationale
[41058](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41058): GetQueryDetailsAction returns the passed in query name as the actual query name in the response from this action, instead of the actual public name from the server.  This fixes this action to return the public name.  This affects the details in the schema browser, so needed to update the name on a handful of queries across a few repos.

#### Related Pull Requests
https://github.com/LabKey/targetedms/pull/241
https://github.com/LabKey/testAutomation/pull/424
https://github.com/LabKey/adjudication/pull/42

#### Changes, 
- Set name in GetQueryDetailsAction response to public name
- Pass through and set the correct name on AbstractMatrixSchema
- Update NAbSpecimenTable to use the same public name as the list of names in the schema
