### PR TITLE
fix getSelectName() assert

### DIFF
--- a/api/src/org/labkey/api/data/WrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/WrappedColumnInfo.java
@@ -114,6 +114,7 @@ public class WrappedColumnInfo
             @Override
             public String getSelectName()
             {
+                assert getParentTable() instanceof SchemaTableInfo : "Use getValueSql()";
                 return sourceColumnInfo.getSelectName();
             }
 


### PR DESCRIPTION
#### Rationale
The assert in getSelectName() caught a mis-use of getSelectName().  Fixed that usage in StatementUtils, and added the same assert to WrappedColumnInfo.getSelectName().
