### PR TITLE
Fix flow tests by not trying to serialize protocol actions

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpProtocolImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpProtocolImpl.java
@@ -59,7 +59,7 @@ import java.util.stream.Collectors;
 
 public class ExpProtocolImpl extends ExpIdentifiableEntityImpl<Protocol> implements ExpProtocol
 {
-    private List<ExpProtocolActionImpl> _actions;
+    private transient List<ExpProtocolActionImpl> _actions;
 
     // For serialization
     protected ExpProtocolImpl() {}


### PR DESCRIPTION
#### Rationale
Don't need to serialize the list of protocol actions that are now cached, as it's causing test failures

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1443

#### Changes
* Make cached list transient so it's not part of the serialized job