### PR TITLE
On folder delete, disable the submit button after click

### DIFF
--- a/core/src/org/labkey/core/admin/deleteFolder.jsp
+++ b/core/src/org/labkey/core/admin/deleteFolder.jsp
@@ -192,7 +192,7 @@
                 <%
             }
             %>
-            <%= button("Delete").submit(true) %>
+            <%= button("Delete").disableOnClick(true).submit(true) %>
             <%= button("Cancel").href(urlProvider(AdminUrls.class).getManageFoldersURL(getContainer())) %>
         </labkey:form>
         <%
@@ -203,7 +203,7 @@
         String targetStr = "&targets=" + StringUtils.join(ids, "&targets=");
         %>
 
-        <%= button("Delete All Folders").primary(true).href(buildURL(AdminController.DeleteFolderAction.class) + "recurse=1" + targetStr) %>
+        <%= button("Delete All Folders").disableOnClick(true).primary(true).href(buildURL(AdminController.DeleteFolderAction.class) + "recurse=1" + targetStr) %>
         <%= button("Cancel").href(urlProvider(AdminUrls.class).getManageFoldersURL(getContainer())) %>
 
         <%


### PR DESCRIPTION
Several times recently we've had situations where a user deletes a folder or workbook.  After hitting 'delete' there is a delay while the delete is happening.  The user gets impatient and re-hits the delete button.  The server gives a 'there is a delete is progress' message, which is good; however, it seems like we should just disable the delete button after click.  This patch does that