### PR TITLE
20.7 fb core containers 41054

### DIFF
--- a/api/src/org/labkey/api/query/QueryForeignKey.java
+++ b/api/src/org/labkey/api/query/QueryForeignKey.java
@@ -210,7 +210,8 @@ public class QueryForeignKey extends AbstractForeignKey
                 targetSchema = (UserSchema)sourceSchema;
 
             /* see 41054 move the core.containers special case handling here from PdLookupForeignKey */
-            if (null != sourceSchema && sourceSchema.getDbSchema().getScope().isLabKeyScope())
+            boolean isLabKeyScope = null != sourceSchema && (null == sourceSchema.getDbSchema() || sourceSchema.getDbSchema().getScope().isLabKeyScope());
+            if (isLabKeyScope)
             {
                 if ("core".equalsIgnoreCase(lookupSchemaName) && "containers".equalsIgnoreCase(lookupTableName) && effectiveContainer.equals(sourceSchema.getContainer()))
                 {

--- a/api/src/org/labkey/api/query/QueryForeignKey.java
+++ b/api/src/org/labkey/api/query/QueryForeignKey.java
@@ -239,7 +239,6 @@ public class QueryForeignKey extends AbstractForeignKey
         _table = builder.table;
         _schema = builder.targetSchema;
         // TODO there is an EHR usage that fails this assert (AbstractTableCustomizer)
-        // TODO there is an EHR usage that fails this assert (AbstractTableCustomizer)
         // assert(null == _lookupContainer || getEffectiveContainer() == getLookupContainer());
     }
 

--- a/api/src/org/labkey/api/query/QueryForeignKey.java
+++ b/api/src/org/labkey/api/query/QueryForeignKey.java
@@ -208,6 +208,17 @@ public class QueryForeignKey extends AbstractForeignKey
         {
             if (null == lookupSchemaName && null == targetSchema)
                 targetSchema = (UserSchema)sourceSchema;
+
+            /* see 41054 move the core.containers special case handling here from PdLookupForeignKey */
+            if (null != sourceSchema && sourceSchema.getDbSchema().getScope().isLabKeyScope())
+            {
+                if ("core".equalsIgnoreCase(lookupSchemaName) && "containers".equalsIgnoreCase(lookupTableName) && effectiveContainer.equals(sourceSchema.getContainer()))
+                {
+                    if (null == containerFilter)
+                        containerFilter = new ContainerFilter.AllFolders(user);
+                }
+            }
+
             return new QueryForeignKey(this);
         }
     }
@@ -226,6 +237,7 @@ public class QueryForeignKey extends AbstractForeignKey
         _useRawFKValue = builder.useRawFKValue;
         _table = builder.table;
         _schema = builder.targetSchema;
+        // TODO there is an EHR usage that fails this assert (AbstractTableCustomizer)
         // TODO there is an EHR usage that fails this assert (AbstractTableCustomizer)
         // assert(null == _lookupContainer || getEffectiveContainer() == getLookupContainer());
     }

--- a/api/src/org/labkey/api/view/FolderTab.java
+++ b/api/src/org/labkey/api/view/FolderTab.java
@@ -73,7 +73,7 @@ public abstract class FolderTab
     }
 
     /** Controllers and their child actions (both are Spring Controller classes) claimed by this tab */
-    private Set<Class<? extends Controller>> _controllersAndActions = new HashSet<>();
+    private final Set<Class<? extends Controller>> _controllersAndActions = new HashSet<>();
 
     protected List<Class<? extends Permission>> _permissions;
 


### PR DESCRIPTION
#### Rationale
Make QueryForeignKey and PdLookupForeignKey act the same when they create lookups to core.containers
Both now use AllFolders container filter
Addresses issue 41054