### PR TITLE
Fetch pipeline status log after job is complete to ensure entire log is read

### DIFF
--- a/pipeline/src/org/labkey/pipeline/status/LogFileParser.java
+++ b/pipeline/src/org/labkey/pipeline/status/LogFileParser.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 /**
  * Parse a pipeline job log file.
- * The log format is intialized in {@link org.labkey.api.pipeline.PipelineJob#getLogger()} and is:
+ * The log format is initialized in {@link org.labkey.api.pipeline.PipelineJob.OutputLogger#write(String, Throwable, String)} and is:
  * <code>%d{DATE} %-5p: %m%n</code>
  */
 public class LogFileParser

--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -520,7 +520,7 @@ public class StatusController extends SpringActionController
             if (_statusFile.getJobStore() != null && (getUser().hasRootAdminPermission() || c.hasPermission(getUser(), UpdatePermission.class)))
                 bean.retryUrl = urlRetry(_statusFile);
 
-            bean.status = StatusDetailsBean.create(getContainer(), _statusFile, 0);
+            bean.status = StatusDetailsBean.create(getContainer(), _statusFile, 0, 0);
 
             return new JspView<DetailsBean>("/org/labkey/pipeline/status/details.jsp", bean, errors);
         }
@@ -585,7 +585,7 @@ public class StatusController extends SpringActionController
             if (psf == null)
                 throw new NotFoundException("Could not find status file for rowId " + form.getRowId());
 
-            var status = StatusDetailsBean.create(c, psf, form.getOffset());
+            var status = StatusDetailsBean.create(c, psf, form.getOffset(), form.getCount());
             return success(status);
         }
     }

--- a/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
@@ -58,14 +58,15 @@ public class StatusDetailsBean
     public final List<StatusDetailFile> files;
     public final List<StatusDetailRun> runs;
     public final StatusDetailLog log;
+    public final Integer fetchCount;
 
     // private constructor for parent/split job status
     private StatusDetailsBean(Container c, PipelineStatusFile psf)
     {
-        this(c, psf, null, null, null, null, null);
+        this(c, psf, null, null, null, null, null, null);
     }
 
-    public StatusDetailsBean(Container c, PipelineStatusFile psf, List<StatusDetailFile> files, List<StatusDetailRun> runs, StatusDetailsBean parentStatus, List<StatusDetailsBean> splitStatus, StatusDetailLog log)
+    public StatusDetailsBean(Container c, PipelineStatusFile psf, List<StatusDetailFile> files, List<StatusDetailRun> runs, StatusDetailsBean parentStatus, List<StatusDetailsBean> splitStatus, StatusDetailLog log, Integer fetchCount)
     {
         this.rowId = psf.getRowId();
         this.jobId = psf.getJobId();
@@ -87,9 +88,10 @@ public class StatusDetailsBean
         this.files = files;
         this.runs = runs;
         this.log = log;
+        this.fetchCount = fetchCount;
     }
 
-    public static StatusDetailsBean create(Container c, PipelineStatusFile psf, long logOffset)
+    public static StatusDetailsBean create(Container c, PipelineStatusFile psf, long logOffset, int fetchCount)
     {
         var statusRuns = ExperimentService.get().getExpRunsForJobId(psf.getRowId()).stream().map(StatusDetailRun::create).collect(toList());
         var statusFiles = Collections.emptyList();
@@ -157,7 +159,7 @@ public class StatusDetailsBean
                     .collect(toList());
         }
 
-        return new StatusDetailsBean(c, psf, statusFiles, statusRuns, parentStatus, splitStatus, statusLog);
+        return new StatusDetailsBean(c, psf, statusFiles, statusRuns, parentStatus, splitStatus, statusLog, fetchCount);
     }
 
     // Copy the file content from Path to the PrintWriter,


### PR DESCRIPTION
Attempt fix for FlowTest's expected positivity report error job

#### Rationale
The [FlowTest](https://teamcity.labkey.org/viewLog.html?buildId=1082668&tab=buildResultsDiv&buildTypeId=LabkeyTrunk_DailySqlserverb#testNameId-138282980268216274) fails occasionally when running an R positivity report script to cause an expected error.  The job finishes quickly and it's possible the entire log file hasn't been written by the time the jsp renders.  In this case, the job log will appear truncated or sometimes have a read error.  To avoid this, the job status will be fetched a few times after the job is complete by checking for a change in the nextOffset marker.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1438
* https://github.com/LabKey/platform/pull/1420

#### Changes
- job errors quickly before log file is completely written
- fetch the log file a few times after job is complete to ensure entire log contents have been retrieved
