### PR TITLE
41109 add support for EET, WEST, CEST, EEST timezones

### DIFF
--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -251,7 +251,8 @@ public class DateUtil
         // North America
         est(-5*60),edt(-4*60),cst(-6*60),cdt(-5*60),mst(-7*60),mdt(-6*60),pst(-8*60),pdt(-7*60),
         // Europe
-        cet("CET"), wet("WET")
+        wet("WET"), cet("CET"), eet("EET"),
+        west(+1*60), cest(+2*60), eest(+3*60)
         ;
 
         TimeZone tz=null;
@@ -2047,6 +2048,34 @@ Parse:
             assertEquals(onlyDate.getTime(), expectedDate.getTime());
             assertEquals(sqlDate.getTime(), combineDateTime(onlyDate, onlyTime).getTime());
             assertEquals(onlyTime.getTime(), new Date(70, 0, 1, 0, 0, 0).getTime());
+        }
+
+        int h(long m)
+        {
+            long hrs = m / (60*60*1000L);
+            return (int)(hrs % 24);
+        }
+
+        @Test
+        public void summerTime()
+        {
+            // see https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41109
+            // NOTE: WET, CET, EET automatically adjust according to the date (summer/winter).
+            //       WEST, CEST, EEST do not adjust. They are hard coded to summer offset.
+            assertEquals(12, h(parseDateTime("2020/1/1 12:00pm WET")));
+            assertEquals(11, h(parseDateTime("2020/6/1 12:00pm WET")));
+            assertEquals(11, h(parseDateTime("2020/1/1 12:00pm WEST")));
+            assertEquals(11, h(parseDateTime("2020/6/1 12:00pm WEST")));
+
+            assertEquals(11, h(parseDateTime("2020/1/1 12:00pm CET")));
+            assertEquals(10, h(parseDateTime("2020/6/1 12:00pm CET")));
+            assertEquals(10, h(parseDateTime("2020/1/1 12:00pm CEST")));
+            assertEquals(10, h(parseDateTime("2020/6/1 12:00pm CEST")));
+
+            assertEquals(10, h(parseDateTime("2020/1/1 12:00pm EET")));
+            assertEquals( 9, h(parseDateTime("2020/6/1 12:00pm EET")));
+            assertEquals( 9, h(parseDateTime("2020/1/1 12:00pm EEST")));
+            assertEquals( 9, h(parseDateTime("2020/6/1 12:00pm EEST")));
         }
     }
 }


### PR DESCRIPTION
in addition to the already supported CET and WET

#### Rationale
Better European timezone support

WET, CET, EET automatically adjust according to the date (summer/winter). This is how "Pacific" is handled for US dates
WEST, CEST, EEST do not adjust. They are hard coded to summer offset. This is how PST or PDT are handled for US dates.
