### PR TITLE
Fix JSP print(String) warnings in Daily test suites

### DIFF
--- a/announcements/src/org/labkey/announcements/announcementThread.jsp
+++ b/announcements/src/org/labkey/announcements/announcementThread.jsp
@@ -60,7 +60,7 @@ ActionURL discussionSrc = null;
 if (!bean.embedded && null != announcementModel.getDiscussionSrcURL())
 {
     discussionSrc = DiscussionServiceImpl.fromSaved(announcementModel.getDiscussionSrcURL());
-    discussionSrc.replaceParameter("discussion.id", "" + announcementModel.getRowId());
+    discussionSrc.replaceParameter("discussion.id", announcementModel.getRowId());
 }
 
 if (!bean.print && null != discussionSrc)
@@ -262,8 +262,8 @@ if (!bean.isResponse && !bean.print)
         {
             // UNDONE: respond in place
             URLHelper url = bean.currentURL.clone();
-            url.replaceParameter("discussion.id",""+ announcementModel.getRowId());
-            url.replaceParameter("discussion.reply","1");
+            url.replaceParameter("discussion.id", announcementModel.getRowId());
+            url.replaceParameter("discussion.reply", "1");
             %>
         <%= button("Respond").href(url) %>&nbsp;<%
         }

--- a/api/src/org/json/JSONArray.java
+++ b/api/src/org/json/JSONArray.java
@@ -820,6 +820,16 @@ public class JSONArray implements HasHtmlString
     }
 
     /**
+     * Make a pretty-printed JSON text of this JSONArray
+     * @param indentFactor Number of spaces to add to each level of indentation
+     * @return HtmlString holding the JSON representation
+     */
+    public HtmlString getHtmlString(int indentFactor)
+    {
+        return HtmlString.unsafe(toString(indentFactor));
+    }
+
+    /**
      * Make a prettyprinted JSON text of this JSONArray.
      * Warning: This method assumes that the data structure is acyclical.
      * @param indentFactor The number of spaces to add to each level of

--- a/api/src/org/json/JSONObject.java
+++ b/api/src/org/json/JSONObject.java
@@ -1186,6 +1186,16 @@ public class JSONObject extends HashMap<String, Object> implements HasHtmlString
     }
 
     /**
+     * Make a pretty-printed JSON text of this JSONObject
+     * @param indentFactor Number of spaces to add to each level of indentation
+     * @return HtmlString holding the JSON representation
+     */
+    public HtmlString getHtmlString(int indentFactor)
+    {
+        return HtmlString.unsafe(toString(indentFactor));
+    }
+
+    /**
      * Make a prettyprinted JSON text of this JSONObject.
      * <p>
      * Warning: This method assumes that the data structure is acyclical.

--- a/api/src/org/labkey/api/assay/bulkPropertiesInput.jsp
+++ b/api/src/org/labkey/api/assay/bulkPropertiesInput.jsp
@@ -36,13 +36,13 @@
 <script type="text/javascript">
     function toggleBulkProperties()
     {
-        if (document.getElementById('<%= BulkPropertiesDisplayColumn.ENABLED_FIELD_NAME %>On').checked)
+        if (document.getElementById(<%=q(BulkPropertiesDisplayColumn.ENABLED_FIELD_NAME + "On")%>).checked)
         {
-            document.getElementById('<%= BulkPropertiesDisplayColumn.PROPERTIES_FIELD_NAME%>').style.display='block';
+            document.getElementById(<%=q(BulkPropertiesDisplayColumn.PROPERTIES_FIELD_NAME)%>).style.display='block';
         }
         else
         {
-            document.getElementById('<%= BulkPropertiesDisplayColumn.PROPERTIES_FIELD_NAME%>').style.display='none';
+            document.getElementById(<%=q(BulkPropertiesDisplayColumn.PROPERTIES_FIELD_NAME)%>).style.display='none';
         }
     }
 </script>
@@ -50,8 +50,8 @@
 <table>
     <tr>
         <td>
-            <input type="radio" id="<%= BulkPropertiesDisplayColumn.ENABLED_FIELD_NAME %>Off"<%=checked(!useBulk)%> value="off"
-            onclick="toggleBulkProperties()" name="<%= BulkPropertiesDisplayColumn.ENABLED_FIELD_NAME %>">
+            <input type="radio" id="<%=h(BulkPropertiesDisplayColumn.ENABLED_FIELD_NAME)%>Off"<%=checked(!useBulk)%> value="off"
+            onclick="toggleBulkProperties()" name="<%=h(BulkPropertiesDisplayColumn.ENABLED_FIELD_NAME)%>">
         </td>
         <td>
             Enter run properties for each run separately by entering values into a form
@@ -59,8 +59,8 @@
     </tr>
     <tr>
         <td>
-            <input type="radio" id="<%= BulkPropertiesDisplayColumn.ENABLED_FIELD_NAME %>On"<%=checked(useBulk)%> value="on"
-            onclick="toggleBulkProperties()" name="<%= BulkPropertiesDisplayColumn.ENABLED_FIELD_NAME %>">
+            <input type="radio" id="<%=h(BulkPropertiesDisplayColumn.ENABLED_FIELD_NAME)%>On"<%=checked(useBulk)%> value="on"
+            onclick="toggleBulkProperties()" name="<%=h(BulkPropertiesDisplayColumn.ENABLED_FIELD_NAME)%>">
         </td>
         <td>
             Specify run properties for all runs at once with tab-separated values (TSV)<%=helpPopup("Bulk Properties", form.getHelpPopupHTML(), true)%>
@@ -68,15 +68,15 @@
     </tr>
     <tr>
         <td/>
-        <td id="<%= BulkPropertiesDisplayColumn.PROPERTIES_FIELD_NAME %>" <%= !useBulk ? "style=\"display: none;\"" : "" %>>
+        <td id="<%=h(BulkPropertiesDisplayColumn.PROPERTIES_FIELD_NAME)%>" <%=h(!useBulk ? "style=\"display: none;\"" : "")%>>
             <% if (form.getTemplateURL() != null) { %><%=link("download Excel template", form.getTemplateURL())%><br/><% } %>
             <textarea style="width: 100%"
                     rows="5" cols="80"
-                    name="<%= BulkPropertiesDisplayColumn.PROPERTIES_FIELD_NAME %>"><%=h(existingValue) %></textarea>
+                    name="<%=h(BulkPropertiesDisplayColumn.PROPERTIES_FIELD_NAME)%>"><%=h(existingValue) %></textarea>
         </td>
     </tr>
 </table>
 <script type="text/javascript">
     // Allow tabs in the TSV text area
-    Ext.EventManager.on('<%= BulkPropertiesDisplayColumn.PROPERTIES_FIELD_NAME%>', 'keydown', LABKEY.ext.Utils.handleTabsInTextArea);
+    Ext.EventManager.on(<%=q(BulkPropertiesDisplayColumn.PROPERTIES_FIELD_NAME)%>, 'keydown', LABKEY.ext.Utils.handleTabsInTextArea);
 </script>

--- a/api/src/org/labkey/api/jsp/LabKeyJspWriter.java
+++ b/api/src/org/labkey/api/jsp/LabKeyJspWriter.java
@@ -60,7 +60,7 @@ public class LabKeyJspWriter extends JspWriterWrapper
     }
 
     @Override
-    public void print(char[] s) throws IOException
+    public void print(char[] s)
     {
         throw new IllegalStateException("A JSP is attempting to render a character array!");
     }

--- a/api/src/org/labkey/api/query/excelExportOptions.jsp
+++ b/api/src/org/labkey/api/query/excelExportOptions.jsp
@@ -124,21 +124,21 @@
                 if (xlsxExportEl.is(':checked')) {
                     if (isSign) {
                         exportUrl = <%=q(model.getSignXlsxURL().getPath())%>;
-                        exportParams = <%=text( new JSONObject(model.getSignXlsxURL().getParameterMap()).toString(2) )%>;
+                        exportParams = <%=new JSONObject(model.getSignXlsxURL().getParameterMap()).getHtmlString(2)%>;
                     }
                     else {
                         exportUrl = <%=q(model.getXlsxURL().getPath())%>;
-                        exportParams = <%=text( new JSONObject(model.getXlsxURL().getParameterMap()).toString(2) )%>;
+                        exportParams = <%=new JSONObject(model.getXlsxURL().getParameterMap()).getHtmlString(2)%>;
                     }
                 }
                 else if (xlsExportEl.is(':checked')) {
                     if (isSign) {
                         exportUrl = <%=q(model.getSignXlsURL().getPath())%>;
-                        exportParams = <%=text( new JSONObject(model.getSignXlsURL().getParameterMap()).toString(2) )%>;
+                        exportParams = <%=new JSONObject(model.getSignXlsURL().getParameterMap()).getHtmlString(2)%>;
                     }
                     else {
                         exportUrl = <%=q(model.getXlsURL().getPath())%>;
-                        exportParams = <%=text( new JSONObject(model.getXlsURL().getParameterMap()).toString(2) )%>;
+                        exportParams = <%=new JSONObject(model.getXlsURL().getParameterMap()).getHtmlString(2)%>;
                     }
                 <% if (model.getIqyURL() != null) { %>
                 }

--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -216,7 +216,8 @@ public interface Dataset<T extends Dataset> extends StudyEntity, StudyCachable<T
         SUBJECT_VISIT(2),
         SUBJECT_VISIT_OTHER(3);
         
-        private int _cardinality;
+        private final int _cardinality;
+
         KeyType(int cardinality)
         {
             _cardinality = cardinality;

--- a/api/src/org/labkey/api/util/URLHelper.java
+++ b/api/src/org/labkey/api/util/URLHelper.java
@@ -651,6 +651,10 @@ public class URLHelper implements Cloneable, Serializable, HasHtmlString
         return addParameter(key, value);
     }
 
+    public URLHelper replaceParameter(String key, long value)
+    {
+        return replaceParameter(key, Long.toString(value));
+    }
 
     // CONSIDER: convert URLHelper implementation to use PropertyValues internally
     public PropertyValues getPropertyValues()

--- a/api/src/org/labkey/api/view/ActionURL.java
+++ b/api/src/org/labkey/api/view/ActionURL.java
@@ -344,11 +344,17 @@ public class ActionURL extends URLHelper implements Cloneable
 
     public ActionURL replaceParameter(Enum key, long value)
     {
-        return replaceParameter(key.toString(), Long.toString(value));
+        return replaceParameter(key.toString(), value);
     }
 
     @Override
     public ActionURL replaceParameter(String key, String value)
+    {
+        return (ActionURL) super.replaceParameter(key, value);
+    }
+
+    @Override
+    public ActionURL replaceParameter(String key, long value)
     {
         return (ActionURL) super.replaceParameter(key, value);
     }

--- a/assay/api-src/org/labkey/api/assay/nab/RenderAssayBean.java
+++ b/assay/api-src/org/labkey/api/assay/nab/RenderAssayBean.java
@@ -305,7 +305,7 @@ public class RenderAssayBean extends RenderAssayForm
     {
         ExpRun run = _assay.getRun();
         ActionURL pageUrl = context.getActionURL().clone();
-        pageUrl.replaceParameter("rowId", "" + run.getRowId());
+        pageUrl.replaceParameter("rowId", run.getRowId());
         String discussionTitle = "Discuss Run " + run.getRowId() + ": " + run.getName();
         String entityId = run.getLSID();
         DiscussionService service = DiscussionService.get();

--- a/assay/src/org/labkey/api/assay/nab/view/runGraph.jsp
+++ b/assay/src/org/labkey/api/assay/nab/view/runGraph.jsp
@@ -43,11 +43,11 @@
     int graphCount = 0;
     for (int firstSample = 0; firstSample < sampleCount; firstSample += maxSamplesPerGraph)
     {
-        graphAction.replaceParameter("firstSample", "" + firstSample);
-        graphAction.replaceParameter("maxSamples", "" + maxSamplesPerGraph);
+        graphAction.replaceParameter("firstSample", firstSample);
+        graphAction.replaceParameter("maxSamples", maxSamplesPerGraph);
         ActionURL zoomGraphURL = graphAction.clone();
-        zoomGraphURL.replaceParameter("width", "" + 800);
-        zoomGraphURL.replaceParameter("height", "" + 600);
+        zoomGraphURL.replaceParameter("width", 800);
+        zoomGraphURL.replaceParameter("height", 600);
 %>
         <td><a href="<%=zoomGraphURL%>" target="_blank">
             <img src="<%=graphAction%>" alt="Neutralization Graph">

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -115,6 +115,8 @@ import org.labkey.api.study.assay.AssayPublishService;
 import org.labkey.api.util.ContainerTree;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.HelpTopic;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
@@ -509,8 +511,10 @@ public class AssayController extends SpringActionController
                 }
             };
             ActionURL copyHereURL = PageFlowUtil.urlProvider(AssayUrls.class).getDesignerURL(form.getContainer(), _protocol, true, null);
-            HtmlView fileTree = new HtmlView("<table><tr><td><b>Select destination folder:</b></td></tr>" +
-                    tree.render().toString() + "</table>");
+            HtmlView fileTree = new HtmlView(HtmlStringBuilder.of()
+                    .append(HtmlString.unsafe("<table><tr><td><b>Select destination folder:</b></td></tr>"))
+                    .append(tree.getHtmlString())
+                    .append(HtmlString.unsafe("</table>")).getHtmlString());
             HtmlView bbar = new HtmlView(
                     PageFlowUtil.button("Cancel").href(new ActionURL(AssayRunsAction.class, getContainer()).addParameter("rowId", _protocol.getRowId())) + " " +
                     (form.getContainer().hasPermission(getUser(), InsertPermission.class) ? PageFlowUtil.button("Copy to Current Folder").href(copyHereURL) : ""));

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -38,6 +38,7 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.ContainerTree;
 import org.labkey.api.util.HelpTopic;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
@@ -260,9 +261,9 @@ public class PlateController extends SpringActionController
 
     public static class CopyTemplateBean
     {
-        private String _treeHtml;
-        private String _templateName;
-        private String _selectedDestination;
+        private final HtmlString _treeHtml;
+        private final String _templateName;
+        private final String _selectedDestination;
         private List<? extends PlateTemplate> _destinationTemplates;
 
         public CopyTemplateBean(final Container container, final User user, final String templateName, final String selectedDestination)
@@ -301,7 +302,7 @@ public class PlateController extends SpringActionController
                 }
             }
 
-            _treeHtml = tree.render().toString();
+            _treeHtml = tree.getHtmlString();
         }
 
         public String getSelectedDestination()
@@ -309,7 +310,7 @@ public class PlateController extends SpringActionController
             return _selectedDestination;
         }
 
-        public String getTreeHtml()
+        public HtmlString getTreeHtml()
         {
             return _treeHtml;
         }

--- a/assay/src/org/labkey/assay/plate/view/copyTemplate.jsp
+++ b/assay/src/org/labkey/assay/plate/view/copyTemplate.jsp
@@ -32,7 +32,7 @@
     <tr>
         <td>Copy <b><%= h(bean.getTemplateName()) %></b> to:</td>
     </tr>
-    <%= text(bean.getTreeHtml()) %>
+    <%=bean.getTreeHtml()%>
     <tr>
         <td>
             <br>

--- a/assay/src/org/labkey/assay/view/assayList2.jsp
+++ b/assay/src/org/labkey/assay/view/assayList2.jsp
@@ -42,7 +42,7 @@
         else
             url = urls.getSummaryRedirectURL(c);
 
-        url.replaceParameter("rowId", ""+ protocol.getRowId());
+        url.replaceParameter("rowId", protocol.getRowId());
         %>
 <b><a href="<%=url%>"><%=h(protocol.getName())%></a></b>
 <%      if (null != protocol.getDescription())

--- a/assay/src/org/labkey/assay/view/batchDetails.jsp
+++ b/assay/src/org/labkey/assay/view/batchDetails.jsp
@@ -38,8 +38,8 @@
 %>
 <script type="text/javascript">
 LABKEY.page = LABKEY.page || {};
-LABKEY.page.assay = <%= new JSONObject(assay).toString(2) %>;
-LABKEY.page.batch = new LABKEY.Exp.RunGroup(<%=batchJson.toString(2)%>);
+LABKEY.page.assay = <%= new JSONObject(assay).getHtmlString(2) %>;
+LABKEY.page.batch = new LABKEY.Exp.RunGroup(<%=batchJson.getHtmlString(2)%>);
 LABKEY.page.batch.batchProtocolId = <%= protocol.getRowId() %>;
 LABKEY.page.batch.loaded = true;
 </script>

--- a/assay/src/org/labkey/assay/view/begin.jsp
+++ b/assay/src/org/labkey/assay/view/begin.jsp
@@ -29,7 +29,7 @@
 %>
 <script type="text/javascript">
 LABKEY.page = LABKEY.page || {};
-LABKEY.page.assay = <%= new JSONObject(assay).toString(2) %>;
+LABKEY.page.assay = <%= new JSONObject(assay).getHtmlString(2) %>;
 </script>
 <p>
 <%

--- a/assay/src/org/labkey/assay/view/customizeAssayDetailsWebPart.jsp
+++ b/assay/src/org/labkey/assay/view/customizeAssayDetailsWebPart.jsp
@@ -51,14 +51,14 @@
         nameToId.put(provider.getName() + ": " + protocol.getName(), protocol.getRowId());
     }
 %>
-<p><%=bean.description%></p>
+<p><%=h(bean.description)%></p>
 
 <labkey:form action="<%=postUrl%>" method="post">
     <table class="lk-fields-table">
         <tr>
             <td class="labkey-form-label">Assay</td>
             <td>
-                <select name="<%=AssayBaseWebPartFactory.PROTOCOL_ID_KEY %>">
+                <select name="<%=h(AssayBaseWebPartFactory.PROTOCOL_ID_KEY)%>">
                     <%
                         for (Map.Entry<String, Integer> entry : nameToId.entrySet())
                         {
@@ -73,7 +73,7 @@
         </tr>
         <tr>
             <td class="labkey-form-label">Show buttons in web part</td>
-            <td><input type="checkbox" name="<%=AssayBaseWebPartFactory.SHOW_BUTTONS_KEY%>" value="true"<%=checked(showButtons)%>></td>
+            <td><input type="checkbox" name="<%=h(AssayBaseWebPartFactory.SHOW_BUTTONS_KEY)%>" value="true"<%=checked(showButtons)%>></td>
         </tr>
         <tr>
             <td/>

--- a/assay/src/org/labkey/assay/view/moduleAssayListView.jsp
+++ b/assay/src/org/labkey/assay/view/moduleAssayListView.jsp
@@ -29,7 +29,7 @@
 %>
 <script type="text/javascript">
 LABKEY.page = LABKEY.page || {};
-LABKEY.page.assay = <%= new JSONObject(assay).toString(2) %>;
+LABKEY.page.assay = <%= new JSONObject(assay).getHtmlString(2) %>;
 </script>
 <p>
 <%

--- a/assay/src/org/labkey/assay/view/moduleAssayUpload.jsp
+++ b/assay/src/org/labkey/assay/view/moduleAssayUpload.jsp
@@ -65,13 +65,13 @@
 %>
 <script type="text/javascript">
 LABKEY.page = LABKEY.page || {};
-LABKEY.page.assay = <%= new JSONObject(assay).toString(2) %>;
+LABKEY.page.assay = <%= new JSONObject(assay).getHtmlString(2)%>;
 <%
  if (batchId > 0)
  {
     ExpExperiment batch = lookupBatch(batchId);
     JSONObject batchJson = AssayJSONConverter.serializeBatch(batch, provider, protocol, getUser(), ExperimentJSONConverter.DEFAULT_SETTINGS);
-    %>LABKEY.page.batch = new LABKEY.Exp.RunGroup(<%=batchJson.toString(2)%>);<%
+    %>LABKEY.page.batch = new LABKEY.Exp.RunGroup(<%=batchJson.getHtmlString(2)%>);<%
  }
  else
  {

--- a/assay/src/org/labkey/assay/view/resultDetails.jsp
+++ b/assay/src/org/labkey/assay/view/resultDetails.jsp
@@ -48,8 +48,8 @@
 %>
 <script type="text/javascript">
 LABKEY.page = LABKEY.page || {};
-LABKEY.page.assay = <%= new JSONObject(assay).toString(2) %>;
-LABKEY.page.result = <%= result.toString(2) %>;
+LABKEY.page.assay = <%= new JSONObject(assay).getHtmlString(2) %>;
+LABKEY.page.result = <%= result.getHtmlString(2) %>;
 </script>
 <p>
 <%

--- a/assay/src/org/labkey/assay/view/runDetails.jsp
+++ b/assay/src/org/labkey/assay/view/runDetails.jsp
@@ -38,8 +38,8 @@
 %>
 <script type="text/javascript">
 LABKEY.page = LABKEY.page || {};
-LABKEY.page.assay = <%= new JSONObject(assay).toString(2) %>;
-LABKEY.page.run = new LABKEY.Exp.Run(<%= runJson.toString(2) %>);
+LABKEY.page.assay = <%= new JSONObject(assay).getHtmlString(2) %>;
+LABKEY.page.run = new LABKEY.Exp.Run(<%= runJson.getHtmlString(2) %>);
 </script>
 <p>
 <%

--- a/core/src/org/labkey/core/admin/folderAliases.jsp
+++ b/core/src/org/labkey/core/admin/folderAliases.jsp
@@ -31,7 +31,7 @@
         <td>
             For example, if you enter <b>/otherproject/otherfolder</b> below,
             URLs directed to a folder with name <b>/otherproject/otherfolder</b>
-            will be redirected to this folder, <b><%= getContainer().getPath() %></b>.
+            will be redirected to this folder, <b><%=h(getContainer().getPath())%></b>.
         </td>
     </tr>
     <tr>
@@ -49,7 +49,7 @@
                     sb.append(separator);
                     separator = "\r\n";
                     sb.append(path);
-                }%><%= sb.toString() %></textarea><br><br>
+                }%><%=h(sb.toString())%></textarea><br><br>
             <%= button("Save Aliases").submit(true) %>
             <%= button("Cancel").href(urlProvider(AdminUrls.class).getManageFoldersURL(getContainer())) %>
         </labkey:form>

--- a/core/src/org/labkey/core/admin/moduleErrors.jsp
+++ b/core/src/org/labkey/core/admin/moduleErrors.jsp
@@ -54,7 +54,7 @@
         }
 %>
         <tr class="<%=getShadeRowClass(rowIndex++)%>">
-            <td valign="top"><strong><pre><%=entry.getKey()%></pre></strong></td>
+            <td valign="top"><strong><pre><%=h(entry.getKey())%></pre></strong></td>
             <td valign="top"><% if (message != null) { %>
                 <strong class="labkey-error"><pre><%= h(message) %></pre></strong>
                 <pre>Full details:</pre>

--- a/core/src/org/labkey/core/admin/testNetworkDrive.jsp
+++ b/core/src/org/labkey/core/admin/testNetworkDrive.jsp
@@ -18,6 +18,7 @@
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.core.admin.TestNetworkDriveBean" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 
 <%
@@ -31,7 +32,7 @@
     Drive contents:<br/>
     <ul>
         <% for (String file : bean.getFiles()) { %>
-            <li><%= file %></li>
+            <li><%=h(file)%></li>
         <% } %>
     </ul>
 <% } %>

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -61,6 +61,8 @@ import org.labkey.api.util.ContainerUtil;
 import org.labkey.api.util.FileStream;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.MimeMap;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
@@ -284,7 +286,7 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
     public HttpView getErrorView(List<AttachmentFile> files, BindException errors, URLHelper returnURL)
     {
         boolean hasErrors = null != errors && errors.hasErrors();
-        String errorHtml = getErrorHtml(files);      // TODO: Get rid of getErrorHtml() -- use errors collection
+        HtmlString errorHtml = getErrorHtml(files);      // TODO: Get rid of getErrorHtml() -- use errors collection
 
         if (null == errorHtml && !hasErrors)
             return null;
@@ -300,31 +302,30 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
     }
 
 
-    private String getErrorHtml(List<AttachmentFile> files)
+    private @Nullable HtmlString getErrorHtml(List<AttachmentFile> files)
     {
-        StringBuilder errorHtml = new StringBuilder();
+        HtmlStringBuilder builder = HtmlStringBuilder.of();
 
         for (AttachmentFile file : files)
         {
             String error = file.getError();
 
             if (null != error)
-                errorHtml.append(error).append("<br><br>");
+                builder.append(error).append(HtmlString.unsafe("<br><br>"));
         }
 
-        if (errorHtml.length() > 0)
-            return errorHtml.toString();
-        else
-            return null;
+        HtmlString html = builder.getHtmlString();
+
+        return HtmlString.isEmpty(html) ? null : html;
     }
 
 
     public static class ErrorView extends JspView<Object>
     {
-        public String errorHtml;
+        public HtmlString errorHtml;
         public URLHelper returnURL;
 
-        private ErrorView(String errorHtml, BindException errors, URLHelper returnURL)
+        private ErrorView(HtmlString errorHtml, BindException errors, URLHelper returnURL)
         {
             super("/org/labkey/core/attachment/showErrors.jsp", new Object(), errors);
             this.errorHtml = errorHtml;

--- a/core/src/org/labkey/core/security/addUsers.jsp
+++ b/core/src/org/labkey/core/security/addUsers.jsp
@@ -124,7 +124,7 @@
             String LDAPDomain = AuthenticationManager.getLdapDomain();
             if (LDAPDomain != null && LDAPDomain.length() > 0 && !AuthenticationManager.ALL_DOMAINS.equals(LDAPDomain))
             {
-                %>, non-<%=LDAPDomain%><%
+                %>, non-<%=h(LDAPDomain)%><%
             }
             %> users</label><br><br>
         </td></tr>

--- a/core/src/org/labkey/core/security/apiKey.jsp
+++ b/core/src/org/labkey/core/security/apiKey.jsp
@@ -49,7 +49,7 @@
     }
     catch (IllegalArgumentException ex)
     {
-        %><%=ex.getMessage()%><%
+        %><%=h(ex.getMessage())%><%
     }
 
     boolean apiKeys = AppProps.getInstance().isAllowApiKeys();

--- a/core/src/org/labkey/core/webdav/list.jsp
+++ b/core/src/org/labkey/core/webdav/list.jsp
@@ -26,6 +26,7 @@
 <%@ page import="java.util.Date" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.TreeMap" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
     FastDateFormat dateFormat = FastDateFormat.getInstance("EEE, dd MMM yyyy HH:mm:ss zzz");
@@ -118,7 +119,7 @@
         long modified = info.getLastModified();
         %><tr class="<%=getShadeRowClass(shade)%>"><td align="left"><a href="<%=h(info.getLocalHref(context))%>?listing=html"><%=h(name)%></a></td><%
         %><td align="right">&nbsp;</td><%
-        %><td align="right" nowrap><%=modified==0?"&nbsp;":dateFormat.format(new Date(modified))%></td></tr><%
+        %><td align="right" nowrap><%=modified==0 ? HtmlString.NBSP : h(dateFormat.format(new Date(modified)))%></td></tr><%
         out.println();
     }
     for (Map.Entry<String, WebdavResource> entry : dirs.entrySet())
@@ -129,7 +130,7 @@
         long modified = info.getLastModified();
         %><tr class="<%=getShadeRowClass(shade)%>"><td align="left"><a href="<%=h(info.getLocalHref(context))%>?listing=html"><%=h(name)%></a></td><%
         %><td align="right">&nbsp;</td><%
-        %><td align="right" nowrap><%=modified==0?"&nbsp;":dateFormat.format(new Date(modified))%></td></tr><%
+        %><td align="right" nowrap><%=modified==0 ? HtmlString.NBSP : h(dateFormat.format(new Date(modified)))%></td></tr><%
         out.println();
     }
     for (Map.Entry<String, WebdavResource> entry : files.entrySet())
@@ -147,7 +148,7 @@
             %><tr class="<%=getShadeRowClass(shade)%>"><td align="left"><%=h(name)%></td><%
         }
         %><td align="right"><%=info.getContentLength()%></td><%
-        %><td align="right" nowrap><%=modified==0?"&nbsp;":dateFormat.format(new Date(modified))%></td></tr><%
+        %><td align="right" nowrap><%=modified==0 ? HtmlString.NBSP : h(dateFormat.format(new Date(modified)))%></td></tr><%
         out.println();
     }
 %></table>

--- a/core/src/org/labkey/core/webdav/list.jsp
+++ b/core/src/org/labkey/core/webdav/list.jsp
@@ -18,6 +18,7 @@
 <%@ page import="org.apache.commons.lang3.StringUtils" %>
 <%@ page import="org.apache.commons.lang3.time.FastDateFormat" %>
 <%@ page import="org.labkey.api.security.User" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.ViewContext" %>
 <%@ page import="org.labkey.api.webdav.WebdavResource" %>
@@ -26,7 +27,6 @@
 <%@ page import="java.util.Date" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.TreeMap" %>
-<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
     FastDateFormat dateFormat = FastDateFormat.getInstance("EEE, dd MMM yyyy HH:mm:ss zzz");
@@ -169,7 +169,7 @@ This is a WebDav enabled directory.<br>
         String comma = "";
         for (int i=0 ; i<can.size() ; i++)
         {
-            %><%=comma%><%=(i==can.size()-1 && i > 1) ? "and ":""%><%=can.get(i)%><%
+            %><%=h(comma)%><%=h((i==can.size()-1 && i > 1) ? "and ":"")%><%=h(can.get(i))%><%
             comma = ", ";
         }
         %> files in this directory.<br><%

--- a/core/src/org/labkey/core/workbook/MoveWorkbooksBean.java
+++ b/core/src/org/labkey/core/workbook/MoveWorkbooksBean.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.core.workbook;
 
+import org.json.JSONArray;
 import org.labkey.api.data.Container;
 
 import java.util.ArrayList;
@@ -27,7 +28,7 @@ import java.util.List;
 */
 public class MoveWorkbooksBean
 {
-    private List<Container> _workbooks = new ArrayList<>();
+    private final List<Container> _workbooks = new ArrayList<>();
 
     public void addWorkbook(Container workbook)
     {
@@ -39,16 +40,10 @@ public class MoveWorkbooksBean
         return _workbooks;
     }
 
-    public String getIDInitializer()
+    public JSONArray getIDInitializer()
     {
-        StringBuilder ids = new StringBuilder();
-        String sep = "";
-        for (Container wb : _workbooks)
-        {
-            ids.append(sep);
-            ids.append(wb.getRowId());
-            sep = ",";
-        }
-        return ids.toString();
+        return _workbooks.stream()
+            .map(Container::getRowId)
+            .collect(JSONArray.collector());
     }
 }

--- a/core/src/org/labkey/core/workbook/moveWorkbooks.jsp
+++ b/core/src/org/labkey/core/workbook/moveWorkbooks.jsp
@@ -17,6 +17,7 @@
 %>
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.data.ContainerManager" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.core.workbook.MoveWorkbooksBean" %>
@@ -27,7 +28,7 @@
     MoveWorkbooksBean bean = (MoveWorkbooksBean)me.getModelBean();
     List<Container> workbooks = bean.getWorkbooks();
 
-    String noun = workbooks.size() > 1 ? "workbooks" : "workbook";
+    HtmlString noun = h(workbooks.size() > 1 ? "workbooks" : "workbook");
     String buttonCaption = workbooks.size() > 1 ? "Move Workbooks" : "Move Workbook";
 %>
 
@@ -42,7 +43,7 @@ to the selected folder:</div>
 <script type="text/javascript">
 
     var _containerTree;
-    var _workbookIds = [<%=bean.getIDInitializer()%>];
+    var _workbookIds = <%=bean.getIDInitializer()%>;
     var _curIndex = 0;
     var _newParentId;
     var _newParentPath;

--- a/experiment/src/org/labkey/experiment/ProtocolApplications.jsp
+++ b/experiment/src/org/labkey/experiment/ProtocolApplications.jsp
@@ -117,7 +117,7 @@
             <td valign="top">
                 <%
                     if (!props.isEmpty())
-                        out.print(h(new JSONObject(props).toString(2)));
+                        out.print(new JSONObject(props).getHtmlString(2));
                 %>
             </td>
         </tr>
@@ -139,7 +139,7 @@
                         <td width="200px"><%= h(protocolInput != null ? protocolInput.getName() : null)%></td>
                         <td>
                             <% Map<String, Object> map = ((ExpMaterialRunInputImpl)materialRunInput).getProperties(); %>
-                            <% if (!map.isEmpty()) out.print(h(new JSONObject(map).toString(2))); %>
+                            <% if (!map.isEmpty()) out.print(new JSONObject(map).getHtmlString(2)); %>
                         </td>
                     </tr>
                     <% } %>
@@ -159,7 +159,7 @@
                         <td width="200px"><%= h(protocolInput != null ? protocolInput.getName() : null)%></td>
                         <td>
                             <% Map<String, Object> map = ((ExpDataRunInputImpl)dataRunInput).getProperties(); %>
-                            <% if (!map.isEmpty()) out.print(h(new JSONObject(map).toString(2))); %>
+                            <% if (!map.isEmpty()) out.print(new JSONObject(map).getHtmlString(2)); %>
                         </td>
                     </tr>
                     <% } %>
@@ -179,7 +179,7 @@
                         <td width="200px"><%= h(protocolInput != null ? protocolInput.getName() : null)%></td>
                         <td>
                             <% Map<String, Object> map = ((ExpMaterialRunInputImpl)materialRunInput).getProperties(); %>
-                            <% if (!map.isEmpty()) out.print(h(new JSONObject(map).toString(2))); %>
+                            <% if (!map.isEmpty()) out.print(new JSONObject(map).getHtmlString(2)); %>
                         </td>
                     </tr>
                     <% } %>
@@ -199,7 +199,7 @@
                         <td width="200px"><%= h(protocolInput != null ? protocolInput.getName() : null)%></td>
                         <td>
                             <% Map<String, Object> map = ((ExpDataRunInputImpl)dataRunInput).getProperties(); %>
-                            <% if (!map.isEmpty()) out.print(h(new JSONObject(map).toString(2))); %>
+                            <% if (!map.isEmpty()) out.print(new JSONObject(map).getHtmlString(2)); %>
                         </td>
                     </tr>
                     <% } %>

--- a/experiment/src/org/labkey/experiment/ProtocolSteps.jsp
+++ b/experiment/src/org/labkey/experiment/ProtocolSteps.jsp
@@ -125,7 +125,7 @@
             <%=h(predecessorNames)%>
         </td>
         <td valign="top">
-            <% if (!props.isEmpty()) out.print(h(new JSONObject(props).toString(2))); %>
+            <% if (!props.isEmpty()) out.print(new JSONObject(props).getHtmlString(2)); %>
         </td>
         <% } %>
     </tr>
@@ -175,7 +175,7 @@
                     <td width="20px"><%=h(mpi.getMaxOccurs())%></td>
                     <td>
                         <% Map<String, Object> map = ((ExpMaterialProtocolInputImpl)mpi).getProperties(); %>
-                        <% if (!map.isEmpty()) out.print(h(new JSONObject(map).toString(2))); %>
+                        <% if (!map.isEmpty()) out.print(new JSONObject(map).getHtmlString(2)); %>
                     </td>
                 </tr>
                 <% } %>
@@ -196,7 +196,7 @@
                     <td width="20px"><%=h(dpi.getMaxOccurs())%></td>
                     <td>
                         <% Map<String, Object> map = ((ExpDataProtocolInputImpl)dpi).getProperties(); %>
-                        <% if (!map.isEmpty()) out.print(h(new JSONObject(map).toString(2))); %>
+                        <% if (!map.isEmpty()) out.print(new JSONObject(map).getHtmlString(2)); %>
                     </td>
                 </tr>
                 <% } %>
@@ -222,7 +222,7 @@
                     <td width="20px"><%=h(mpo.getMaxOccurs())%></td>
                     <td>
                         <% Map<String, Object> map = ((ExpMaterialProtocolInputImpl)mpo).getProperties(); %>
-                        <% if (!map.isEmpty()) out.print(h(new JSONObject(map).toString(2))); %>
+                        <% if (!map.isEmpty()) out.print(new JSONObject(map).getHtmlString(2)); %>
                     </td>
                 </tr>
                 <% } %>
@@ -243,7 +243,7 @@
                     <td width="20px"><%=h(dpo.getMaxOccurs())%></td>
                     <td>
                         <% Map<String, Object> map = ((ExpDataProtocolInputImpl)dpo).getProperties(); %>
-                        <% if (!map.isEmpty()) out.print(h(new JSONObject(map).toString(2))); %>
+                        <% if (!map.isEmpty()) out.print(new JSONObject(map).getHtmlString(2)); %>
                     </td>
                 </tr>
                 <% } %>

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -876,7 +876,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
             {
                 String dataclass = ctx.getActionURL().getParameter(PROPERTY);
                 ActionURL url = ctx.cloneActionURL().deleteParameter(PROPERTY);
-                url.replaceParameter("_dc", String.valueOf((int)Math.round(1000 * Math.random())));
+                url.replaceParameter("_dc", (int)Math.round(1000 * Math.random()));
 
                 StringBuilder html = new StringBuilder();
                 html.append("<div class=\"labkey-search-filter\">");

--- a/experiment/src/org/labkey/experiment/deriveSamplesChooseTarget.jsp
+++ b/experiment/src/org/labkey/experiment/deriveSamplesChooseTarget.jsp
@@ -57,13 +57,13 @@
                 { %>
                     <tr class="<%=h(roleIndex % 2 == 0 ? "labkey-alternate-row" : "labkey-row")%>">
                         <td><input type="hidden" name="rowIds" value="<%= material.getRowId()%>" /><%= h(material.getName())%></td>
-                        <td><select name="inputRole<%= roleIndex %>" onchange="document.getElementById('customRole<%= roleIndex %>').disabled = this.value != '<%= ExperimentController.DeriveSamplesChooseTargetBean.CUSTOM_ROLE %>';">
+                        <td><select name="inputRole<%= roleIndex %>" onchange="document.getElementById('customRole<%= roleIndex %>').disabled = this.value != '<%=h(ExperimentController.DeriveSamplesChooseTargetBean.CUSTOM_ROLE)%>';">
                             <option value=""></option>
                             <% for (String inputRole : bean.getInputRoles())
                             { %>
                                 <option value="<%= h(inputRole)%>"><%= h(inputRole) %></option>
                             <% } %>
-                            <option value="<%= ExperimentController.DeriveSamplesChooseTargetBean.CUSTOM_ROLE %>">Add a new role...</option>
+                            <option value="<%=h(ExperimentController.DeriveSamplesChooseTargetBean.CUSTOM_ROLE)%>">Add a new role...</option>
                         </select> <input name="customRole<%= roleIndex %>" disabled="true" id="customRole<%= roleIndex %>"/></td>
                     </tr>
                 <%

--- a/experiment/src/org/labkey/experiment/moveRunsLocation.jsp
+++ b/experiment/src/org/labkey/experiment/moveRunsLocation.jsp
@@ -39,10 +39,10 @@
     <%
         for (String id : DataRegionSelection.getSelected(getViewContext(), false))
         { %>
-            <input type="hidden" name="<%= DataRegion.SELECT_CHECKBOX_NAME%>" value="<%= h(id) %>" /><%
+            <input type="hidden" name="<%=h(DataRegion.SELECT_CHECKBOX_NAME)%>" value="<%= h(id) %>" /><%
         }
     %>
-    <input type="hidden" name="<%= DataRegionSelection.DATA_REGION_SELECTION_KEY %>" value="<%= bean.getDataRegionSelectionKey() %>" />
+    <input type="hidden" name="<%=h(DataRegionSelection.DATA_REGION_SELECTION_KEY)%>" value="<%=h(bean.getDataRegionSelectionKey())%>" />
     <input type="hidden" name="targetContainerId" />
 <table class="labkey-data-region">
 <tr>
@@ -52,7 +52,7 @@
     </td>
 </tr>
 <tr><td>&nbsp;</td></tr>
-<%=bean.getContainerTree().render()%>
+<%=bean.getContainerTree().getHtmlString()%>
 </table>
 
 </labkey:form>

--- a/experiment/src/org/labkey/experiment/samplesAndAnalytes.jsp
+++ b/experiment/src/org/labkey/experiment/samplesAndAnalytes.jsp
@@ -44,7 +44,7 @@
             if (isStudySample)
                 url = urlProvider(SamplesUrls.class).getSamplesURL(sampleType.getContainer());
             else
-                url = new ActionURL(ExperimentController.ShowSampleTypeAction.class, sampleType.getContainer()).replaceParameter("rowId", "" + sampleType.getRowId());
+                url = new ActionURL(ExperimentController.ShowSampleTypeAction.class, sampleType.getContainer()).replaceParameter("rowId", sampleType.getRowId());
             %>
     <a style="font-weight:bold" href="<%=url%>"><%=h(isStudySample ? sampleType.getContainer().getName() : sampleType.getName())%></a>
                 <br><%=h(sampleType.getDescription() != null ? sampleType.getDescription() : sampleType.getContainer().getPath())%>

--- a/experiment/src/org/labkey/experiment/summarizeMaterialInputs.jsp
+++ b/experiment/src/org/labkey/experiment/summarizeMaterialInputs.jsp
@@ -68,17 +68,18 @@
                     Map<DomainProperty, DisplayColumnGroup> groups = helper.getGroups();
                     for (int i = 0; i < helper.getSampleNames().size(); i++)
                     {
-                        %><%= separator %>
+                        %><%=h(separator)%>
                         <a href="#" onclick="{<%
                         for (Map.Entry<PropertyDescriptor, Object> propEntry : entry.getKey().getPropertyValues().entrySet())
                         {
                             DisplayColumnGroup group = groups.get(propEntry.getKey());
                             if (group != null && group.isCopyable())
                             {
-                                %>document.getElementsByName('<%= group.getColumns().get(i).getColumnInfo().getPropertyName() %>')[0].value = '<%= h(propEntry.getValue()) %>';
-                                if (document.getElementsByName('<%= group.getColumns().get(i).getColumnInfo().getPropertyName() %>')[0].onchange != null)
+                                String propName = group.getColumns().get(i).getColumnInfo().getPropertyName();
+                                %>document.getElementsByName(<%=q(propName)%>)[0].value = '<%=h(propEntry.getValue())%>';
+                                if (document.getElementsByName(<%=q(propName)%>)[0].onchange != null)
                                 {
-                                    document.getElementsByName('<%= group.getColumns().get(i).getColumnInfo().getPropertyName() %>')[0].onchange();
+                                    document.getElementsByName(<%=q(propName)%>)[0].onchange();
                                 } <%
                             }
                         }

--- a/experiment/src/org/labkey/experiment/types/findConcepts.jsp
+++ b/experiment/src/org/labkey/experiment/types/findConcepts.jsp
@@ -134,7 +134,7 @@ else
 		}
 		if (false)
 		{
-		%><%=and%><a href="javascript:concept(<%=q(uri)%>)"><%=h(name)%></a><%
+		%><%=h(and)%><a href="javascript:concept(<%=q(uri)%>)"><%=h(name)%></a><%
 		}
 		out.println(unsafe("<br>"));
 		if (row == match)

--- a/experiment/src/org/labkey/experiment/types/repair.jsp
+++ b/experiment/src/org/labkey/experiment/types/repair.jsp
@@ -82,9 +82,9 @@ else
         {
             %><tr style=""><%
         }
-        %><td align=right><span style="font-size:7pt;"><%=null!=st.prop?""+st.prop.getPropertyId():"&nbsp;"%></span></td>
+        %><td align=right><span style="font-size:7pt;"><%=null != st.prop ? h(st.prop.getPropertyId()) : HtmlString.NBSP%></span></td>
         <td><%=toCell(st.getName())%></td>
-        <td><%=st.hasMv()?"X":"&nbsp;"%></td>
+        <td><%=st.hasMv() ? h("X") : HtmlString.NBSP%></td>
         <td><%=toCell(st.colName)%></td>
         <td><%=toCell(st.mvColName)%></td>
         <td><%=toCell(st.fix)%></td>

--- a/internal/src/org/labkey/api/exp/property/AbstractDomainKind.java
+++ b/internal/src/org/labkey/api/exp/property/AbstractDomainKind.java
@@ -53,7 +53,6 @@ import java.util.Set;
  */
 public abstract class AbstractDomainKind<T> extends DomainKind<T>
 {
-
     public static final String OBJECT_URI_COLUMN_NAME = "lsid";
 
     @Override
@@ -61,7 +60,6 @@ public abstract class AbstractDomainKind<T> extends DomainKind<T>
     {
         return null;
     }
-
 
     @Override
     public boolean canCreateDefinition(User user, Container container)

--- a/internal/src/org/labkey/api/util/ContainerTree.java
+++ b/internal/src/org/labkey/api/util/ContainerTree.java
@@ -86,17 +86,11 @@ public class ContainerTree
         _initialLevel = initialLevel;
     }
 
-    public void render(StringBuilder html)
-    {
-        renderChildren(html, ContainerManager.getContainerTree(_root), _root, _initialLevel);
-    }
-
-
-    public StringBuilder render()
+    public HtmlString getHtmlString()
     {
         StringBuilder html = new StringBuilder();
-        render(html);
-        return html;
+        renderChildren(html, ContainerManager.getContainerTree(_root), _root, _initialLevel);
+        return HtmlString.unsafe(html.toString());
     }
 
     public String getPurpose()
@@ -105,7 +99,7 @@ public class ContainerTree
     }
 
 
-    protected boolean renderChildren(StringBuilder html, MultiValuedMap<Container, Container> mm, Container parent, int level)
+    private boolean renderChildren(StringBuilder html, MultiValuedMap<Container, Container> mm, Container parent, int level)
     {
         // Hide hidden folders, unless you're an administrator
         if (!parent.shouldDisplay(_user) || !parent.isInFolderNav())

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -2268,7 +2268,7 @@ public class IssuesController extends SpringActionController
             {
                 String status = ctx.getActionURL().getParameter("status");
                 ActionURL statusResearchURL = ctx.cloneActionURL().deleteParameter("status");
-                statusResearchURL.replaceParameter("_dc", String.valueOf((int)Math.round(1000 * Math.random())));
+                statusResearchURL.replaceParameter("_dc", (int)Math.round(1000 * Math.random()));
 
                 StringBuilder html = new StringBuilder("<table width=100% cellpadding=\"0\" cellspacing=\"0\"><tr>\n");
                 html.append("<td class=\"labkey-search-filter\">&nbsp;");

--- a/query/src/org/labkey/query/reports/view/reportsWebPartConfig.jsp
+++ b/query/src/org/labkey/query/reports/view/reportsWebPartConfig.jsp
@@ -128,11 +128,10 @@
         // ajax call to get report section names
         if (element)
         {
-            var url = "<%=h(urlProvider(ReportUrls.class).urlReportSections(c))%>";
+            var url = "<%=h(urlProvider(ReportUrls.class).urlReportSections(c).addParameter(sectionName, pm.get(sectionName)))%>";
 
-            url = url.concat("&<%=PageFlowUtil.encode(ReportDescriptor.Prop.reportId.name())%>=");
+            url = url.concat("&<%=unsafe(PageFlowUtil.encode(ReportDescriptor.Prop.reportId.name()))%>=");
             url = url.concat(element.value);
-            url = url.concat("&<%=PageFlowUtil.encode(sectionName)%>=<%=PageFlowUtil.encode(pm.get(sectionName))%>");
 
             LABKEY.Ajax.request({
                 url: url,

--- a/query/src/org/labkey/query/view/editApp.jsp
+++ b/query/src/org/labkey/query/view/editApp.jsp
@@ -20,6 +20,7 @@
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.query.controllers.OlapController" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -124,14 +125,14 @@
     <tr>
         <td valign="top" class="labkey-form-label">Defaults:</td>
         <td>
-            <textarea name="defaults" id="defaults"><%=text(defaults == null ? "" : defaults.toString(OlapController.APP_CONTEXT_JSON_INDENT))%></textarea>
+            <textarea name="defaults" id="defaults"><%=defaults == null ? HtmlString.EMPTY_STRING : defaults.getHtmlString(OlapController.APP_CONTEXT_JSON_INDENT)%></textarea>
         </td>
     </tr>
 
     <tr>
         <td valign="top" class="labkey-form-label">Values:</td>
         <td>
-            <textarea name="values" id="values"><%=text(values == null ? "" : values.toString(OlapController.APP_CONTEXT_JSON_INDENT))%></textarea>
+            <textarea name="values" id="values"><%=values == null ? HtmlString.EMPTY_STRING : values.getHtmlString(OlapController.APP_CONTEXT_JSON_INDENT)%></textarea>
         </td>
     </tr>
 </p>

--- a/search/src/org/labkey/search/view/search.jsp
+++ b/search/src/org/labkey/search/view/search.jsp
@@ -525,7 +525,7 @@
                         int newOffset = offset - hitsPerPage;
 
                         if (newOffset > 0)
-                            previousURL.replaceParameter("offset", String.valueOf(newOffset));
+                            previousURL.replaceParameter("offset", newOffset);
                         else
                             previousURL.deleteParameter("offset");
                 %>
@@ -542,7 +542,7 @@
                     if (pageNo < pageCount)
                     {
                 %>
-                <a href="<%=h(currentURL.clone().replaceParameter("offset", String.valueOf(offset + hitsPerPage)))%>">Next &gt;</a>
+                <a href="<%=h(currentURL.clone().replaceParameter("offset", offset + hitsPerPage))%>">Next &gt;</a>
                 <%
                     }
                 %>

--- a/study/src/org/labkey/study/SingleCohortFilter.java
+++ b/study/src/org/labkey/study/SingleCohortFilter.java
@@ -172,7 +172,7 @@ public class SingleCohortFilter extends BaseCohortFilter
         else
         {
             url.replaceParameter(dataregion + "." + CohortFilterFactory.Params.cohortFilterType, getType().name());
-            url.replaceParameter(dataregion + "." + CohortFilterFactory.Params.cohortId, "" + getCohortId());
+            url.replaceParameter(dataregion + "." + CohortFilterFactory.Params.cohortId, getCohortId());
         }
         return url;
     }

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -718,7 +718,7 @@ public class StudyController extends BaseStudyController
             {
                 ActionURL url = getViewContext().cloneActionURL().setAction(StudyController.DatasetAction.class).
                                         replaceParameter(DATASET_REPORT_ID_PARAMETER_NAME, report.getDescriptor().getReportId().toString()).
-                                        replaceParameter(DatasetDefinition.DATASETKEY, String.valueOf(def.getDatasetId()));
+                                        replaceParameter(DatasetDefinition.DATASETKEY, def.getDatasetId());
 
                 return HttpView.redirect(url);
             }
@@ -5070,8 +5070,8 @@ public class StudyController extends BaseStudyController
                     {
                         ActionURL returnUrl = getViewContext().cloneActionURL()
                             .replaceParameter("ff_snapshotName", form.getSnapshotName())
-                            .replaceParameter("ff_updateDelay", String.valueOf(form.getUpdateDelay()))
-                            .replaceParameter("ff_snapshotDatasetId", String.valueOf(form.getSnapshotDatasetId()));
+                            .replaceParameter("ff_updateDelay", form.getUpdateDelay())
+                            .replaceParameter("ff_snapshotDatasetId", form.getSnapshotDatasetId());
 
                         _successURL = new ActionURL(StudyController.EditTypeAction.class, getContainer())
                                 .addParameter("datasetId", def.getDatasetId())

--- a/study/src/org/labkey/study/controllers/reports/ReportsController.java
+++ b/study/src/org/labkey/study/controllers/reports/ReportsController.java
@@ -403,8 +403,8 @@ public class ReportsController extends BaseStudyController
         ActionURL url = getViewContext().cloneActionURL();
         url.setAction(StudyController.DatasetReportAction.class);
 
-        url.replaceParameter(StudyController.DATASET_REPORT_ID_PARAMETER_NAME, String.valueOf(reportId));
-        url.replaceParameter(DatasetDefinition.DATASETKEY, String.valueOf(dataset));
+        url.replaceParameter(StudyController.DATASET_REPORT_ID_PARAMETER_NAME, reportId);
+        url.replaceParameter(DatasetDefinition.DATASETKEY, dataset);
 
         return url;
     }
@@ -1331,7 +1331,7 @@ public class ReportsController extends BaseStudyController
             {
                 ActionURL url = getViewContext().cloneActionURL().setAction(StudyController.DatasetAction.class).
                         replaceParameter(StudyController.DATASET_REPORT_ID_PARAMETER_NAME, _report.getDescriptor().getReportId().toString()).
-                        replaceParameter(DatasetDefinition.DATASETKEY, String.valueOf(def.getDatasetId()));
+                        replaceParameter(DatasetDefinition.DATASETKEY, def.getDatasetId());
 
                 return HttpView.redirect(url);
             }

--- a/study/src/org/labkey/study/designer/view/studyDesignSummary.jsp
+++ b/study/src/org/labkey/study/designer/view/studyDesignSummary.jsp
@@ -108,7 +108,7 @@ This study was created from a vaccine study protocol with the following descript
     <br>
 <%
     ActionURL url = new ActionURL(DesignerController.DesignerAction.class, info.getContainer());
-    url.replaceParameter("studyId", String.valueOf(info.getStudyId()));
+    url.replaceParameter("studyId", info.getStudyId());
 %>
 <%=link("View Complete Protocol", url)%>
 <%

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -4460,7 +4460,7 @@ public class StudyManager
         }
 
         ActionURL view = new ActionURL(StudyController.DatasetAction.class, null);
-        view.replaceParameter("datasetId", String.valueOf(dsd.getDatasetId()));
+        view.replaceParameter("datasetId", dsd.getDatasetId());
         view.setExtraPath(dsd.getContainer().getId());
 
         SimpleDocumentResource r = new SimpleDocumentResource(new Path(docid), docid,

--- a/study/src/org/labkey/study/view/bulkDatasetDelete.jsp
+++ b/study/src/org/labkey/study/view/bulkDatasetDelete.jsp
@@ -53,16 +53,15 @@
     {
         ActionURL detailsURL = new ActionURL(StudyController.DefaultDatasetReportAction.class, study.getContainer());
         detailsURL.addParameter("datasetId", def.getDatasetId());
-        String detailsLink = detailsURL.getLocalURIString();
         rowCount++;
     %>
 
     <tr class="<%=h(rowCount % 2 == 1 ? "labkey-alternate-row" : "labkey-row")%>">
         <td><input type="checkbox" name="datasetIds" value="<%=def.getDatasetId()%>"></td>
-        <td><a href="<%=detailsLink%>"><%=def.getDatasetId()%></a></td>
-        <td><a href="<%=detailsLink%>"><%= h(def.getLabel()) %></a></td>
+        <td><a href="<%=h(detailsURL)%>"><%=def.getDatasetId()%></a></td>
+        <td><a href="<%=h(detailsURL)%>"><%= h(def.getLabel()) %></a></td>
         <td><%= h(def.getViewCategory() != null ? def.getViewCategory().getLabel() : null) %></td>
-        <td><%= def.getType() %></td>
+        <td><%= h(def.getType()) %></td>
         <td align="right"><%=StudyManager.getInstance().getNumDatasetRows(getUser(), def)%></td>
     </tr>
     <%

--- a/study/src/org/labkey/study/view/createVisit.jsp
+++ b/study/src/org/labkey/study/view/createVisit.jsp
@@ -17,6 +17,7 @@
 %>
 <%@ page import="org.labkey.api.study.TimepointType"%>
 <%@ page import="org.labkey.api.study.Visit"%>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
@@ -71,7 +72,7 @@ is uploaded along with the data. This form allows you to define a range of seque
         <tr>
             <td class="labkey-form-label"><%=h(isDateBased ? "Day Range" : "VisitId/Sequence Range")%></td>
             <td>
-                <input type="text" size="26" name="sequenceNumMin" value="<%=v.getFormattedSequenceNumMin()%>">-<input type="text" size="26" name="sequenceNumMax" value="<%=v.getSequenceNumMin().equals(v.getSequenceNumMax()) ? "" : v.getFormattedSequenceNumMax()%>">
+                <input type="text" size="26" name="sequenceNumMin" value="<%=h(v.getFormattedSequenceNumMin())%>">-<input type="text" size="26" name="sequenceNumMax" value="<%=v.getSequenceNumMin().equals(v.getSequenceNumMax()) ? HtmlString.EMPTY_STRING : h(v.getFormattedSequenceNumMax())%>">
             </td>
         </tr>
         <tr>

--- a/study/src/org/labkey/study/view/customizeParticipantView.jsp
+++ b/study/src/org/labkey/study/view/customizeParticipantView.jsp
@@ -91,7 +91,7 @@
 %>
         <tr>
             <td>
-                This custom participant view is defined in an active module.  It cannot be edited via this interface.
+                This custom participant view is defined in an active module. It cannot be edited via this interface.
             </td>
         </tr>
         <tr>
@@ -110,11 +110,11 @@
 %>
 <table width="100%">
     <tr class="labkey-wp-header">
-        <th><%= h(subjectNoun) %> View Preview <%= bean.isEditable() ? "(Save to refresh)" : "" %></th>
+        <th><%= h(subjectNoun) %> View Preview <%= h(bean.isEditable() ? "(Save to refresh)" : "") %></th>
     </tr>
     <tr>
         <td>
-            <%= useCustomView ? bean.getCustomScript() : bean.getDefaultScript() %>
+            <%= unsafe(useCustomView ? bean.getCustomScript() : bean.getDefaultScript()) %>
         </td>
     </tr>
 </table>

--- a/study/src/org/labkey/study/view/customizeParticipantWebPart.jsp
+++ b/study/src/org/labkey/study/view/customizeParticipantWebPart.jsp
@@ -19,13 +19,16 @@
 <%@ page import="org.labkey.api.qc.QCStateManager" %>
 <%@ page import="org.labkey.api.study.SpecimenService" %>
 <%@ page import="org.labkey.api.study.StudyService" %>
+<%@ page import="org.labkey.api.util.element.Option.OptionBuilder" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.api.view.Portal" %>
 <%@ page import="org.labkey.api.view.ViewContext" %>
 <%@ page import="org.labkey.study.view.SubjectDetailsWebPartFactory" %>
-<%@ page import="java.util.EnumSet" %>
+<%@ page import="org.labkey.study.view.SubjectDetailsWebPartFactory.DataType" %>
+<%@ page import="java.util.Arrays" %>
+<%@ page import="java.util.Map" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -39,7 +42,7 @@
 
     String selectedData = bean.getPropertyMap().get(SubjectDetailsWebPartFactory.DATA_TYPE_KEY);
     if (selectedData == null)
-        selectedData = SubjectDetailsWebPartFactory.DataType.ALL.name();
+        selectedData = DataType.ALL.name();
     
     boolean includePrivateData = Boolean.parseBoolean(bean.getPropertyMap().get(SubjectDetailsWebPartFactory.QC_STATE_INCLUDE_PRIVATE_DATA_KEY));
     String subjectNoun = StudyService.get().getSubjectNounSingular(getContainer());
@@ -50,7 +53,7 @@
 <table>
     <tr>
         <td>
-            <%= StudyService.get().getSubjectColumnName(getContainer()) %>:
+            <%=h(StudyService.get().getSubjectColumnName(getContainer()))%>:
         </td>
         <td>
             <labkey:autoCompleteText name="<%= SubjectDetailsWebPartFactory.PARTICIPANT_ID_KEY %>"
@@ -61,17 +64,12 @@
     <tr>
         <td>Data type to display:</td>
         <td>
-            <select name="<%=SubjectDetailsWebPartFactory.DATA_TYPE_KEY%>">
-                <%
-                    for (SubjectDetailsWebPartFactory.DataType type : EnumSet.allOf(SubjectDetailsWebPartFactory.DataType.class))
-                    {
-                        %>
-                <option value="<%=type.name()%>"<%=selected(selectedData.equals(type.name()))%>><%=type.toString()%></option>
-                        <%
-                    }
-                %>
-
-            </select>
+            <%=select().name(SubjectDetailsWebPartFactory.DATA_TYPE_KEY)
+                .addOptions(Arrays.stream(DataType.values())
+                    .map(dt->new OptionBuilder(dt.getDescription(), dt.name())))
+                .selected(selectedData)
+                .className(null)
+            %>
         </td>
     </tr>
     <%
@@ -81,10 +79,11 @@
     <tr>
         <td>QC state to display:</td>
         <td>
-            <select name="<%=SubjectDetailsWebPartFactory.QC_STATE_INCLUDE_PRIVATE_DATA_KEY%>">
-                <option value="false">Public data</option>
-                <option value="true"<%=selected(includePrivateData)%>>All data</option>
-            </select>
+            <%=select().name(SubjectDetailsWebPartFactory.QC_STATE_INCLUDE_PRIVATE_DATA_KEY)
+                .addOptions(Map.of(false, "Public data", true, "All Data"))
+                .selected(includePrivateData)
+                .className(null)
+            %>
         </td>
     </tr>
     <%

--- a/study/src/org/labkey/study/view/datasets.jsp
+++ b/study/src/org/labkey/study/view/datasets.jsp
@@ -110,7 +110,7 @@
             }
 
             String datasetLabel = (dataset.getLabel() != null ? dataset.getLabel() : "" + dataset.getDatasetId());
-            tds.add(TR(TD(link(datasetLabel).href(datasetURL.replaceParameter("datasetId", String.valueOf(dataset.getDatasetId()))).clearClasses())));
+            tds.add(TR(TD(link(datasetLabel).href(datasetURL.replaceParameter("datasetId", dataset.getDatasetId())).clearClasses())));
         }
 
         TABLE(tds.toArray()).appendTo(out);

--- a/study/src/org/labkey/study/view/manageTimepoints.jsp
+++ b/study/src/org/labkey/study/view/manageTimepoints.jsp
@@ -112,7 +112,7 @@ to assign dataset data to the correct timepoints.</p>
         rowCount++;
 %>
     <tr class="<%=h(rowCount % 2 == 1 ? "labkey-alternate-row" : "labkey-row")%>">
-        <td width="20"><%= iconLink("fa fa-pencil", "edit", editTimepointURL.replaceParameter("id", String.valueOf(timepoint.getRowId()))) %></td>
+        <td width="20"><%= iconLink("fa fa-pencil", "edit", editTimepointURL.replaceParameter("id", timepoint.getRowId())) %></td>
         <td><%=h(timepoint.getLabel())%></td>
         <td><%=h(timepoint.getFormattedSequenceNumMin())%></td>
         <td><%=h(timepoint.getFormattedSequenceNumMax())%></td>

--- a/study/src/org/labkey/study/view/manageTypes.jsp
+++ b/study/src/org/labkey/study/view/manageTypes.jsp
@@ -160,7 +160,7 @@
     ActionURL details = new ActionURL(DatasetDetailsAction.class, c);
     for (Dataset def : datasets)
     {
-        details.replaceParameter("id",String.valueOf(def.getDatasetId()));
+        details.replaceParameter("id", def.getDatasetId());
         ViewCategory viewCategory = def.getViewCategory();
         Cohort cohort = def.getCohort();
         boolean isShared = def.isShared();

--- a/study/src/org/labkey/study/view/manageUndefinedTypes.jsp
+++ b/study/src/org/labkey/study/view/manageUndefinedTypes.jsp
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 %>
+<%@ page import="org.labkey.api.util.HtmlString"%>
 <%@ page import="org.labkey.study.controllers.StudyController.BulkImportDataTypesAction"%>
 <%@ page import="org.labkey.study.model.DatasetDefinition"%>
-<%@ page import="java.util.ArrayList"%>
+<%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.List" %>
 <%@ page extends="org.labkey.study.view.BaseStudyPage" %>
 <%
@@ -55,7 +56,7 @@
 %>
     <tr>
         <td><%= def.getDatasetId() %></td>
-        <td><%= def.getLabel() != null ? def.getLabel() : "" %></td>
+        <td><%= def.getLabel() != null ? h(def.getLabel()) : HtmlString.EMPTY_STRING %></td>
     </tr>
 <%
     }

--- a/study/src/org/labkey/study/view/manageVisits.jsp
+++ b/study/src/org/labkey/study/view/manageVisits.jsp
@@ -104,7 +104,7 @@
             rowCount++;
     %>
         <tr class="visit-row <%=h(rowCount % 2 == 1 ? "labkey-alternate-row" : "labkey-row")%>">
-            <td width="20"><%= iconLink("fa fa-pencil", "edit", editTimepointURL.replaceParameter("id", String.valueOf(visit.getRowId()))) %></td>
+            <td width="20"><%= iconLink("fa fa-pencil", "edit", editTimepointURL.replaceParameter("id", visit.getRowId())) %></td>
             <td align=left><%= h(visit.getDisplayString()) %></td>
             <td class="visit-range-cell"><%=h(visit.getSequenceString())%></td>
             <td><%= h(visit.getCohort() != null ? h(visit.getCohort().getLabel()) : "All") %></td>

--- a/study/src/org/labkey/study/view/saveReportView.jsp
+++ b/study/src/org/labkey/study/view/saveReportView.jsp
@@ -75,7 +75,7 @@
     if (confirm)
     {
 %>
-        <td>There is already a report called: <i><%=report.getDescriptor().getReportName()%></i>.<br/>Overwrite the existing report?
+        <td>There is already a report called: <i><%=h(report.getDescriptor().getReportName())%></i>.<br/>Overwrite the existing report?
         <input type=hidden name=confirmed value=1>
         <input type=hidden name=label value="<%=h(bean.getLabel())%>">
 <%

--- a/study/src/org/labkey/study/view/saveReportView.jsp
+++ b/study/src/org/labkey/study/view/saveReportView.jsp
@@ -65,10 +65,10 @@
 </table>
 
 <labkey:form method="post" action="<%=new ActionURL(ReportsController.SaveReportViewAction.class, getContainer())%>" onsubmit="return validateForm();">
-    <input type="hidden" name="<%=QueryParam.schemaName%>" value="<%=StringUtils.trimToEmpty(bean.getSchemaName())%>">
-    <input type="hidden" name="<%=QueryParam.queryName%>" value="<%=StringUtils.trimToEmpty(bean.getQueryName())%>">
-    <input type="hidden" name="<%=QueryParam.viewName%>" value="<%=StringUtils.trimToEmpty(bean.getViewName())%>">
-    <input type="hidden" name="redirectUrl" value="<%=bean.getRedirectUrl()%>">
+    <input type="hidden" name="<%=QueryParam.schemaName%>" value="<%=h(StringUtils.trimToEmpty(bean.getSchemaName()))%>">
+    <input type="hidden" name="<%=QueryParam.queryName%>" value="<%=h(StringUtils.trimToEmpty(bean.getQueryName()))%>">
+    <input type="hidden" name="<%=QueryParam.viewName%>" value="<%=h(StringUtils.trimToEmpty(bean.getViewName()))%>">
+    <input type="hidden" name="redirectUrl" value="<%=h(bean.getRedirectUrl())%>">
     <table>
     <tr>
 <%
@@ -77,17 +77,17 @@
 %>
         <td>There is already a report called: <i><%=report.getDescriptor().getReportName()%></i>.<br/>Overwrite the existing report?
         <input type=hidden name=confirmed value=1>
-        <input type=hidden name=label value="<%=bean.getLabel()%>">
+        <input type=hidden name=label value="<%=h(bean.getLabel())%>">
 <%
     } else {
 %>
         <td><b>Save Report</b></td>
         <td>Name:&nbsp;<input id="reportName" name="label" value="<%=h(bean.getLabel())%>">
-        <input type=hidden name=srcURL value="<%=getActionURL().getLocalURIString()%>">
+        <input type=hidden name=srcURL value="<%=h(getActionURL())%>">
 <%
     }
 %>
-        <input type=hidden name=reportType value="<%=report.getDescriptor().getReportType()%>">
+        <input type=hidden name=reportType value="<%=h(report.getDescriptor().getReportType())%>">
         <input type=hidden name=params value="<%=h(bean.getParams())%>"></td>
 
 <%--
@@ -121,14 +121,14 @@
 %>
         <tr>
             <td><input type="checkbox" value="true" name="shareReport"<%=checked(bean.getShareReport())%>>Make this report available to all users.</td>
-            <td colspan=2>description:<textarea name="description" style="width: 100%;" rows="2"><%=StringUtils.trimToEmpty(bean.getDescription())%></textarea></td>
+            <td colspan=2>description:<textarea name="description" style="width: 100%;" rows="2"><%=h(StringUtils.trimToEmpty(bean.getDescription()))%></textarea></td>
         </tr>
 <%
     } else {
 %>
         <tr>
             <td></td>
-            <td colspan=2>description:&nbsp;<textarea name="description" style="width: 100%;" rows="2"><%=StringUtils.trimToEmpty(bean.getDescription())%></textarea></td>
+            <td colspan=2>description:&nbsp;<textarea name="description" style="width: 100%;" rows="2"><%=h(StringUtils.trimToEmpty(bean.getDescription()))%></textarea></td>
         </tr>
 <%
     }

--- a/study/src/org/labkey/study/view/saveReportView.jsp
+++ b/study/src/org/labkey/study/view/saveReportView.jsp
@@ -35,7 +35,7 @@
     ViewContext context = getViewContext();
 
     Report report = bean.getReport(context);
-    boolean confirm = bean.getConfirmed() != null ? Boolean.parseBoolean(bean.getConfirmed()) : false;
+    boolean confirm = bean.getConfirmed() != null && Boolean.parseBoolean(bean.getConfirmed());
 %>
 
 <script type="text/javascript">

--- a/study/src/org/labkey/study/view/specimen/manageActors.jsp
+++ b/study/src/org/labkey/study/view/specimen/manageActors.jsp
@@ -88,7 +88,7 @@
                         <%
                             for (LocationImpl location : study.getLocations())
                             {
-                            %><a href="<%= h(buildURL(ShowGroupMembersAction.class)) + "id=" + actor.getRowId() + "&locationId=" + location.getRowId() %>"><%= h(location.getDisplayName()) %></a><br><%
+                            %><a href="<%=h(urlFor(ShowGroupMembersAction.class).addParameter("id", actor.getRowId()).addParameter("locationId", location.getRowId()))%>"><%= h(location.getDisplayName()) %></a><br><%
                             }
                         }
                         else

--- a/study/src/org/labkey/study/view/specimen/manageDefaultReqs.jsp
+++ b/study/src/org/labkey/study/view/specimen/manageDefaultReqs.jsp
@@ -225,6 +225,6 @@ function verifyNewRequirement(prefix)
                 </tr>
             </table>
         </labkey:panel>
-    <input type="hidden" name="nextPage" value="<%=new ActionURL(SpecimenController.ManageDefaultReqsAction.class, getContainer()).getLocalURIString()%>">
+    <input type="hidden" name="nextPage" value="<%=h(urlFor(SpecimenController.ManageDefaultReqsAction.class))%>">
 </labkey:form>
 <%= link("manage study", StudyController.ManageStudyAction.class) %>

--- a/study/src/org/labkey/study/view/specimen/manageDefaultReqs.jsp
+++ b/study/src/org/labkey/study/view/specimen/manageDefaultReqs.jsp
@@ -66,7 +66,7 @@ function verifyNewRequirement(prefix)
                     {
                 %>
                 <tr>
-                    <td><%= link("Delete", deleteDefaultRequirement.replaceParameter("id", String.valueOf(requirement.getRowId()))).usePost() %></td>
+                    <td><%= link("Delete", deleteDefaultRequirement.replaceParameter("id", requirement.getRowId())).usePost() %></td>
                     <td><%= h(requirement.getActor().getLabel()) %></td>
                     <td colspan="2"><%= requirement.getDescription() != null ? h(requirement.getDescription()) : "&nbsp;" %></td>
                 </tr>
@@ -109,7 +109,7 @@ function verifyNewRequirement(prefix)
                     {
                 %>
                 <tr>
-                    <td><%= link("Delete", deleteDefaultRequirement.replaceParameter("id", String.valueOf(requirement.getRowId()))).usePost() %></td>
+                    <td><%= link("Delete", deleteDefaultRequirement.replaceParameter("id", requirement.getRowId())).usePost() %></td>
                     <td><%= h(requirement.getActor().getLabel()) %></td>
                     <td colspan="2"><%= requirement.getDescription() != null ? h(requirement.getDescription()) : "&nbsp;" %></td>
                 </tr>
@@ -152,7 +152,7 @@ function verifyNewRequirement(prefix)
                     {
                 %>
                 <tr>
-                    <td><%= link("Delete", deleteDefaultRequirement.replaceParameter("id", String.valueOf(requirement.getRowId()))).usePost() %></td>
+                    <td><%= link("Delete", deleteDefaultRequirement.replaceParameter("id", requirement.getRowId())).usePost() %></td>
                     <td><%= h(requirement.getActor().getLabel()) %></td>
                     <td colspan="2"><%= requirement.getDescription() != null ? h(requirement.getDescription()) : "&nbsp;" %></td>
                 </tr>
@@ -195,7 +195,7 @@ function verifyNewRequirement(prefix)
                     {
                 %>
                 <tr>
-                    <td><%= link("Delete", deleteDefaultRequirement.replaceParameter("id", String.valueOf(requirement.getRowId()))).usePost() %></td>
+                    <td><%= link("Delete", deleteDefaultRequirement.replaceParameter("id", requirement.getRowId())).usePost() %></td>
                     <td><%= h(requirement.getActor().getLabel()) %></td>
                     <td colspan="2"><%= requirement.getDescription() != null ? h(requirement.getDescription()) : "&nbsp;" %></td>
                 </tr>

--- a/study/src/org/labkey/study/view/specimen/pivot.jsp
+++ b/study/src/org/labkey/study/view/specimen/pivot.jsp
@@ -1,19 +1,19 @@
 <%
-    /*
-     * Copyright (c) 2015-2017 LabKey Corporation
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     http://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
+/*
+ * Copyright (c) 2015-2017 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
@@ -30,7 +30,7 @@
     String configId = "Study:/specimens";
     String schemaName = "Study";
     String cubeName = "SpecimenCube";
-    int uid =  getRequestScopedUID();
+    int uid = getRequestScopedUID();
     String pivotDesignerId = "pivotDesigner" + uid;
     String cellsetId = "cellset" + uid;
 %>
@@ -56,11 +56,11 @@ var starttime;
     Ext4.onReady(function ()
     {
         cube = LABKEY.query.olap.CubeManager.getCube(
-                {
-                    name:cubeName,
-                    configId:configId,
-                    schemaName:schemaName
-                });
+        {
+            name:cubeName,
+            configId:configId,
+            schemaName:schemaName
+        });
         cube.on('onready', function (m)
         {
             mdx = m;
@@ -491,7 +491,7 @@ var starttime;
 
 <select><option>filter me</option></select>
 <hr>
-<div id="<%=pivotDesignerId%>.filterArea"></div>
+<div id="<%=text(pivotDesignerId)%>.filterArea"></div>
 <h3>I'm a page header</h3>
 <div id="<%=text(cellsetId)%>">
 </div>

--- a/study/src/org/labkey/study/view/studydesign/immunizationScheduleWebpart.jsp
+++ b/study/src/org/labkey/study/view/studydesign/immunizationScheduleWebpart.jsp
@@ -118,7 +118,7 @@
                         visitTreatments.put(treatmentVisitMap.getVisitId(), treatmentVisitMap.getTreatmentId());
                     }
 %>
-                    <tr class="row-outer <%=index % 2 == 0 ? "alternate-row" : ""%>" outer-index="<%=index-1%>">
+                    <tr class="row-outer <%=h(index % 2 == 0 ? "alternate-row" : "")%>" outer-index="<%=index-1%>">
                         <td class="cell-display " data-index="Label"><%=h(cohort.getLabel())%></td>
                         <td class="cell-display " data-index="SubjectCount"><%=cohort.getSubjectCount() != null ? cohort.getSubjectCount() : HtmlString.EMPTY_STRING%></td>
 <%

--- a/wiki/src/org/labkey/wiki/WikiController.java
+++ b/wiki/src/org/labkey/wiki/WikiController.java
@@ -1086,7 +1086,7 @@ public class WikiController extends SpringActionController
             ct.setInitialLevel(1);
 
             CopyBean bean = new CopyBean();
-            bean.folderList = ct.render().toString();           // folder tree
+            bean.folderList = ct.getHtmlString();               // folder tree
             bean.destContainer = c.getPath();                   // hidden input
             bean.sourceContainer = form.getSourceContainer();   // hidden input
             Container sourceContainer = getSourceContainer(form.getSourceContainer());
@@ -1110,7 +1110,7 @@ public class WikiController extends SpringActionController
 
     public class CopyBean
     {
-        public String folderList;
+        public HtmlString folderList;
         public String destContainer;
         public String sourceContainer;
         public ActionURL cancelURL;

--- a/wiki/src/org/labkey/wiki/view/wikiCopy.jsp
+++ b/wiki/src/org/labkey/wiki/view/wikiCopy.jsp
@@ -34,7 +34,7 @@
 Note that only the latest version of each wiki page is copied.    
 </td></tr>
 <tr><td>&nbsp;</td></tr>
-<%=text(bean.folderList)%>
+<%=bean.folderList%>
 </table><br>
 
 <table>


### PR DESCRIPTION
#### Rationale
We want to eliminate all calls to `out.print(String)` from JSPs.

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/225

#### Changes
* Eliminate all calls to `out.print(String)` from platform code. This addresses nearly all JSP warnings emanating from Daily test suite runs.
* Add `URLHelper.addParameter(String, long)` convenience method and use it.