### PR TITLE
WikiService: attachment handling

### DIFF
--- a/api/src/org/labkey/api/wiki/WikiService.java
+++ b/api/src/org/labkey/api/wiki/WikiService.java
@@ -18,6 +18,7 @@ package org.labkey.api.wiki;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.attachments.AttachmentFile;
+import org.labkey.api.attachments.AttachmentParent;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.security.User;
@@ -74,6 +75,12 @@ public interface WikiService
     boolean updateContent(Container c, User user, String wikiName, String content);
 
     void deleteWiki(Container c, User user, String wikiName, boolean deleteSubtree) throws SQLException;
+
+    /**
+     * Retrieve the attachment parent of a wiki
+     */
+    @Nullable
+    AttachmentParent getAttachmentParent(Container c, User user, String wikiName);
 
     /**
      * Update the attachments on a wiki. Note, attachment changes do not update the wiki version.

--- a/api/src/org/labkey/api/wiki/WikiService.java
+++ b/api/src/org/labkey/api/wiki/WikiService.java
@@ -17,6 +17,7 @@
 package org.labkey.api.wiki;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.attachments.AttachmentFile;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.security.User;
@@ -75,7 +76,7 @@ public interface WikiService
     void deleteWiki(Container c, User user, String wikiName, boolean deleteSubtree) throws SQLException;
 
     /**
-     * Retrieves a Wiki's EntityId.
+     * Update the attachments on a wiki. Note, attachment changes do not update the wiki version.
      */
-    @Nullable String getWikiEntityId(Container c, User user, String wikiName);
+    void updateAttachments(Container c, User user, String wikiName, @Nullable List<AttachmentFile> attachmentFiles, @Nullable List<String> deleteAttachmentNames);
 }

--- a/api/src/org/labkey/api/wiki/WikiService.java
+++ b/api/src/org/labkey/api/wiki/WikiService.java
@@ -73,4 +73,9 @@ public interface WikiService
     boolean updateContent(Container c, User user, String wikiName, String content);
 
     void deleteWiki(Container c, User user, String wikiName, boolean deleteSubtree) throws SQLException;
+
+    /**
+     * Retrieves a Wiki's EntityId.
+     */
+    @Nullable String getWikiEntityId(Container c, User user, String wikiName);
 }

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -533,7 +533,7 @@ public class WikiManager implements WikiService
     }
 
 
-    public String updateAttachments(User user, Wiki wiki, List<String> deleteNames, List<AttachmentFile> files)
+    public String updateAttachments(User user, Wiki wiki, @Nullable List<String> deleteNames, @Nullable List<AttachmentFile> files)
     {
         AttachmentService attsvc = getAttachmentService();
         boolean changes = false;
@@ -946,15 +946,11 @@ public class WikiManager implements WikiService
     }
 
     @Override
-    @Nullable
-    public String getWikiEntityId(Container c, User user, String wikiName)
+    public void updateAttachments(Container c, User user, String wikiName, @Nullable List<AttachmentFile> attachmentFiles, @Nullable List<String> deleteAttachmentNames)
     {
         Wiki wiki = WikiSelectManager.getWiki(c, wikiName);
-        if (null != wiki)
-        {
-            return wiki.getEntityId();
-        }
-        return null;
+        if (wiki != null)
+            updateAttachments(user, wiki, deleteAttachmentNames, attachmentFiles);
     }
 
     public static class TestCase extends Assert

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -946,6 +946,15 @@ public class WikiManager implements WikiService
     }
 
     @Override
+    public @Nullable AttachmentParent getAttachmentParent(Container c, User user, String wikiName)
+    {
+        Wiki wiki = WikiSelectManager.getWiki(c, wikiName);
+        if (wiki != null)
+            return wiki.getAttachmentParent();
+        return null;
+    }
+
+    @Override
     public void updateAttachments(Container c, User user, String wikiName, @Nullable List<AttachmentFile> attachmentFiles, @Nullable List<String> deleteAttachmentNames)
     {
         Wiki wiki = WikiSelectManager.getWiki(c, wikiName);

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -945,6 +945,18 @@ public class WikiManager implements WikiService
         }
     }
 
+    @Override
+    @Nullable
+    public String getWikiEntityId(Container c, User user, String wikiName)
+    {
+        Wiki wiki = WikiSelectManager.getWiki(c, wikiName);
+        if (null != wiki)
+        {
+            return wiki.getEntityId();
+        }
+        return null;
+    }
+
     public static class TestCase extends Assert
     {
         WikiManager _m = null;


### PR DESCRIPTION
#### Rationale
This surfaces new methods on the `WikiService` to expose handling for attachments.

#### Related Pull Requests
* https://github.com/LabKey/labbook/pull/40

#### Changes
* `getAttachmentParent` allows users to access the attachment parent for a Wiki.
* `updateAttachments` allows users to programmatically mutate the attachments on a Wiki.