### PR TITLE
Auth Config App: fix delete request success handler scope

### DIFF
--- a/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
+++ b/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
@@ -217,11 +217,11 @@ export class App extends PureComponent<{}, Partial<State>> {
                     error: resolveErrorMessage(error),
                 });
             }, undefined, true),
-            success: function() {
+            success: Utils.getCallbackWrapper(() => {
                 this.setState((state) => ({
                     [configType]: state[configType].filter(auth => auth.configuration !== configuration)
-                }))
-            },
+                }));
+            }),
         });
     };
 


### PR DESCRIPTION
#### Rationale
Upon successfully deleting an authentication configuration the callback was incorrectly scoped to call `this.setState` on the component. As a result, the SecondaryAuthenticationTest was failing upon clean-up due to the erroneous dereference.

#### Changes
* Use `() => {}` rather than `function() {}` to ensure component scope.
