### PR TITLE
Fb coalesce wiki

### DIFF
--- a/api/src/org/labkey/api/wiki/WikiService.java
+++ b/api/src/org/labkey/api/wiki/WikiService.java
@@ -18,6 +18,7 @@ package org.labkey.api.wiki;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.attachments.AttachmentFile;
+import org.labkey.api.attachments.AttachmentParent;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.security.User;
@@ -74,6 +75,12 @@ public interface WikiService
     boolean updateContent(Container c, User user, String wikiName, String content);
 
     void deleteWiki(Container c, User user, String wikiName, boolean deleteSubtree) throws SQLException;
+
+    /**
+     * Retrieve the attachment parent of a wiki
+     */
+    @Nullable
+    AttachmentParent getAttachmentParent(Container c, User user, String wikiName);
 
     /**
      * Update the attachments on a wiki. Note, attachment changes do not update the wiki version.

--- a/api/src/org/labkey/api/wiki/WikiService.java
+++ b/api/src/org/labkey/api/wiki/WikiService.java
@@ -17,6 +17,7 @@
 package org.labkey.api.wiki;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.attachments.AttachmentFile;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.security.User;
@@ -75,7 +76,7 @@ public interface WikiService
     void deleteWiki(Container c, User user, String wikiName, boolean deleteSubtree) throws SQLException;
 
     /**
-     * Retrieves a Wiki's EntityId.
+     * Update the attachments on a wiki. Note, attachment changes do not update the wiki version.
      */
-    @Nullable String getWikiEntityId(Container c, User user, String wikiName);
+    void updateAttachments(Container c, User user, String wikiName, @Nullable List<AttachmentFile> attachmentFiles, @Nullable List<String> deleteAttachmentNames);
 }

--- a/api/src/org/labkey/api/wiki/WikiService.java
+++ b/api/src/org/labkey/api/wiki/WikiService.java
@@ -73,4 +73,9 @@ public interface WikiService
     boolean updateContent(Container c, User user, String wikiName, String content);
 
     void deleteWiki(Container c, User user, String wikiName, boolean deleteSubtree) throws SQLException;
+
+    /**
+     * Retrieves a Wiki's EntityId.
+     */
+    @Nullable String getWikiEntityId(Container c, User user, String wikiName);
 }

--- a/api/src/org/labkey/api/wiki/WikiService.java
+++ b/api/src/org/labkey/api/wiki/WikiService.java
@@ -71,8 +71,15 @@ public interface WikiService
 
     /**
      * Update the content of a wiki
+     *
+     * @param wikiName The name of the wiki to update
+     * @param content The new String content
+     * @param newVersionThreshold The interval in milliseconds since the last update that will trigger a new wiki version
+     *                            to be created. This can be useful when frequent updates are made but we want to avoid
+     *                            the proliferation of individual wiki versions.
+     * @return
      */
-    boolean updateContent(Container c, User user, String wikiName, String content);
+    boolean updateContent(Container c, User user, String wikiName, String content, @Nullable Integer newVersionThreshold);
 
     void deleteWiki(Container c, User user, String wikiName, boolean deleteSubtree) throws SQLException;
 

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -533,7 +533,7 @@ public class WikiManager implements WikiService
     }
 
 
-    public String updateAttachments(User user, Wiki wiki, List<String> deleteNames, List<AttachmentFile> files)
+    public String updateAttachments(User user, Wiki wiki, @Nullable List<String> deleteNames, @Nullable List<AttachmentFile> files)
     {
         AttachmentService attsvc = getAttachmentService();
         boolean changes = false;
@@ -946,15 +946,11 @@ public class WikiManager implements WikiService
     }
 
     @Override
-    @Nullable
-    public String getWikiEntityId(Container c, User user, String wikiName)
+    public void updateAttachments(Container c, User user, String wikiName, @Nullable List<AttachmentFile> attachmentFiles, @Nullable List<String> deleteAttachmentNames)
     {
         Wiki wiki = WikiSelectManager.getWiki(c, wikiName);
-        if (null != wiki)
-        {
-            return wiki.getEntityId();
-        }
-        return null;
+        if (wiki != null)
+            updateAttachments(user, wiki, deleteAttachmentNames, attachmentFiles);
     }
 
     public static class TestCase extends Assert

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -946,6 +946,15 @@ public class WikiManager implements WikiService
     }
 
     @Override
+    public @Nullable AttachmentParent getAttachmentParent(Container c, User user, String wikiName)
+    {
+        Wiki wiki = WikiSelectManager.getWiki(c, wikiName);
+        if (wiki != null)
+            return wiki.getAttachmentParent();
+        return null;
+    }
+
+    @Override
     public void updateAttachments(Container c, User user, String wikiName, @Nullable List<AttachmentFile> attachmentFiles, @Nullable List<String> deleteAttachmentNames)
     {
         Wiki wiki = WikiSelectManager.getWiki(c, wikiName);

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -945,6 +945,18 @@ public class WikiManager implements WikiService
         }
     }
 
+    @Override
+    @Nullable
+    public String getWikiEntityId(Container c, User user, String wikiName)
+    {
+        Wiki wiki = WikiSelectManager.getWiki(c, wikiName);
+        if (null != wiki)
+        {
+            return wiki.getEntityId();
+        }
+        return null;
+    }
+
     public static class TestCase extends Assert
     {
         WikiManager _m = null;


### PR DESCRIPTION
#### Rationale
The default wiki behavior is to create a new wiki version each time the wiki is updated. ELN backs notebook entries with wikis and the default editor interval is 250 ms. This results in many distinct wiki versions getting created for modest editing.

To reduce wiki version proliferation, we introduce a setting to allow updating wikis without creating a new version.

#### Related Pull Requests
https://github.com/LabKey/labbook/pull/41

#### Changes
- Modify WikiService.updateContent to accept an optional newVersionThreshold in milliseconds. If the previous update was within the range of the new update, then the latest wiki version will be reused. This means that for a threshold of 1 minute, as long as the user saves within a minute, no new version will be created.
