### PR TITLE
Catch and add BadRequestException message in jsp views

### DIFF
--- a/api/src/org/labkey/api/view/WebPartView.java
+++ b/api/src/org/labkey/api/view/WebPartView.java
@@ -387,6 +387,10 @@ public abstract class WebPartView<ModelBean> extends HttpView<ModelBean>
                 {
                     errorHtml = HtmlString.of("Not Found : " + x.getMessage());
                 }
+                catch (BadRequestException x)
+                {
+                    errorHtml = HtmlString.of(x.getMessage());
+                }
                 catch (Throwable t)
                 {
                     exceptionToRender = ExceptionUtil.unwrapException(t);


### PR DESCRIPTION
#### Rationale
This branch catches the BadRequestException in WebPartView returned via JSPs when query or data grids are called with bad query parameters.


