### PR TITLE
Support controlling when new wiki versions are created

### DIFF
--- a/api/src/org/labkey/api/wiki/WikiService.java
+++ b/api/src/org/labkey/api/wiki/WikiService.java
@@ -71,8 +71,15 @@ public interface WikiService
 
     /**
      * Update the content of a wiki
+     *
+     * @param wikiName The name of the wiki to update
+     * @param content The new String content
+     * @param newVersionThreshold The interval in milliseconds since the last update that will trigger a new wiki version
+     *                            to be created. This can be useful when frequent updates are made but we want to avoid
+     *                            the proliferation of individual wiki versions.
+     * @return
      */
-    boolean updateContent(Container c, User user, String wikiName, String content);
+    boolean updateContent(Container c, User user, String wikiName, String content, @Nullable Integer newVersionThreshold);
 
     void deleteWiki(Container c, User user, String wikiName, boolean deleteSubtree) throws SQLException;
 

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -81,6 +81,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -219,6 +220,19 @@ public class WikiManager implements WikiService
 
     public boolean updateWiki(User user, Wiki wikiNew, WikiVersion versionNew, boolean copyHistory)
     {
+        return updateWiki(user, wikiNew, versionNew, copyHistory, true);
+    }
+
+    /**
+     * Update an existing wiki with new content.
+     *
+     * @param copyHistory true to propagate the user and date created from the previous wiki version, else just use the current user
+     *                    and current date.
+     * @param createNewVersion by default we create a new wiki version for each update, if this is set to false we will update
+     *                         the latest wiki version.
+     */
+    private boolean updateWiki(User user, Wiki wikiNew, WikiVersion versionNew, boolean copyHistory, boolean createNewVersion)
+    {
         DbScope scope = comm.getSchema().getScope();
         Container c = wikiNew.lookupContainer();
         boolean uncacheAllContent = true;
@@ -250,21 +264,29 @@ public class WikiManager implements WikiService
                 versionNew.setPageEntityId(entityId);
                 if (!copyHistory)
                 {
-                  versionNew.setCreated(new Date(System.currentTimeMillis()));
-                  versionNew.setCreatedBy(user.getUserId());
+                    versionNew.setCreated(new Date(System.currentTimeMillis()));
+                    versionNew.setCreatedBy(user.getUserId());
                 }
                 //if copying wiki with history, avoid overwriting 'created by' user
                 User userToInsert = (copyHistory) ? null : user;
-                //get version number for new version
-                versionNew.setVersion(WikiSelectManager.getNextVersionNumber(wikiNew));
-                //insert initial version for this page
-                versionNew = Table.insert(userToInsert, comm.getTableInfoPageVersions(), versionNew);
 
-                //update version reference in Pages table.
-                wikiNew.setPageVersionId(versionNew.getRowId());
-                Table.update(userToInsert, comm.getTableInfoPages(), wikiNew, wikiNew.getEntityId());
+                if (createNewVersion)
+                {
+                    //get version number for new version
+                    versionNew.setVersion(WikiSelectManager.getNextVersionNumber(wikiNew));
+                    //insert initial version for this page
+                    versionNew = Table.insert(userToInsert, comm.getTableInfoPageVersions(), versionNew);
+
+                    //update version reference in Pages table.
+                    wikiNew.setPageVersionId(versionNew.getRowId());
+                    Table.update(userToInsert, comm.getTableInfoPages(), wikiNew, wikiNew.getEntityId());
+                }
+                else
+                {
+                    versionNew.setVersion(versionOld.getVersion());
+                    Table.update(userToInsert, comm.getTableInfoPageVersions(), versionNew, versionNew.getRowId());
+                }
             }
-
             transaction.commit();
         }
         finally
@@ -913,7 +935,7 @@ public class WikiManager implements WikiService
     }
 
     @Override
-    public boolean updateContent(Container c, User user, String wikiName, String content)
+    public boolean updateContent(Container c, User user, String wikiName, String content, @Nullable Integer newVersionThreshold)
     {
         if (content != null)
         {
@@ -927,7 +949,18 @@ public class WikiManager implements WikiService
                     if (!content.equals(version.getBody()))
                     {
                         version.setBody(content);
-                        return updateWiki(user, wiki, version, false);
+                        boolean createNewVersion = true;
+
+                        if (newVersionThreshold != null)
+                        {
+                            Calendar cal = Calendar.getInstance();
+                            cal.setTime(new Date());
+                            cal.add(Calendar.MILLISECOND, - newVersionThreshold);
+
+                            // only update if the wiki was updated outside of the specified time window
+                            createNewVersion = wiki.getModified().before(cal.getTime());
+                        }
+                        return updateWiki(user, wiki, version, false, createNewVersion);
                     }
                 }
             }


### PR DESCRIPTION
#### Rationale
The default wiki behavior is to create a new wiki version each time the wiki is updated. ELN backs notebook entries with wikis and the default editor interval is 250 ms. This results in many distinct wiki versions getting created for modest editing.

To reduce wiki version proliferation, we introduce a setting to allow updating wikis without creating a new version.

#### Related Pull Requests
https://github.com/LabKey/labbook/pull/42

#### Changes
- Modify WikiService.updateContent to accept an optional newVersionThreshold in milliseconds. If the previous update was within the range of the new update, then the latest wiki version will be reused. This means that for a threshold of 1 minute, as long as the user saves within a minute, no new version will be created.
