### PR TITLE
Issue 41132: XML formatted responses from query API's shouldn't run async

### DIFF
--- a/api/src/org/labkey/api/action/ApiQueryResponse.java
+++ b/api/src/org/labkey/api/action/ApiQueryResponse.java
@@ -85,6 +85,8 @@ public class ApiQueryResponse implements ApiResponse
     private List<FieldKey> _columnFilter;
     private boolean _includeMetaData;
 
+    private ApiResponseWriter.Format _format = ApiResponseWriter.Format.JSON;
+
     // TODO: This is silly... switch to builder pattern, or at least a constructor that takes reasonable strategies
     public ApiQueryResponse(QueryView view, boolean schemaEditable, boolean includeLookupInfo,
                             String schemaName, String queryName, long offset, List<FieldKey> fieldKeys, boolean metaDataOnly,
@@ -114,7 +116,6 @@ public class ApiQueryResponse implements ApiResponse
 
     public ApiQueryResponse()
     {
-        _includeLookupInfo = true;
         _metaDataOnly = true;
     }
 
@@ -226,9 +227,9 @@ public class ApiQueryResponse implements ApiResponse
 
     protected Results getResults() throws Exception
     {
-        // We're going to be writing JSON back, which is tolerant of extra spaces, so allow async so we
-        // can monitor if the client has stopped listening
-        _dataRegion.setAllowAsync(true);
+        // If we're going to be writing JSON back, which is tolerant of extra spaces, allow async so we
+        // can monitor if the client has stopped listening. XML doesn't take kindly to leading spaces
+        _dataRegion.setAllowAsync(_format.isJson());
         try
         {
             return _dataRegion.getResults(_ctx);
@@ -641,5 +642,10 @@ public class ApiQueryResponse implements ApiResponse
     public void setColumnFilter(List<FieldKey> columnFilter)
     {
         _columnFilter = columnFilter;
+    }
+
+    public void setFormat(ApiResponseWriter.Format format)
+    {
+        _format = format;
     }
 }

--- a/api/src/org/labkey/api/action/ApiQueryResponse.java
+++ b/api/src/org/labkey/api/action/ApiQueryResponse.java
@@ -67,7 +67,7 @@ public class ApiQueryResponse implements ApiResponse
     protected RenderContext _ctx = null;
     private ViewContext _viewContext;
     private boolean _schemaEditable = false;
-    private boolean _includeLookupInfo = true;
+    private final boolean _includeLookupInfo;
     private String _schemaName = null;
     protected String _queryName = null;
     protected long _offset = 0;                   //starting offset row number
@@ -116,6 +116,7 @@ public class ApiQueryResponse implements ApiResponse
 
     public ApiQueryResponse()
     {
+        _includeLookupInfo = true;
         _metaDataOnly = true;
     }
 

--- a/api/src/org/labkey/api/action/ApiResponseWriter.java
+++ b/api/src/org/labkey/api/action/ApiResponseWriter.java
@@ -102,6 +102,12 @@ public abstract class ApiResponseWriter implements AutoCloseable
             {
                 return new ApiJsonWriter(response, contentTypeOverride, objectMapper, true); // TODO: FOR DEBUGGING. Before final commit, decide if pretty or compact should be default.
             }
+
+            @Override
+            public boolean isJson()
+            {
+                return true;
+            }
         },
         XML
         {
@@ -111,6 +117,12 @@ public abstract class ApiResponseWriter implements AutoCloseable
                 // TODO: Use Jackson for object -> XML serialization
                 return new ApiXmlWriter(response, contentTypeOverride);
             }
+
+            @Override
+            public boolean isJson()
+            {
+                return false;
+            }
         },
         JSON_COMPACT
         {
@@ -119,9 +131,17 @@ public abstract class ApiResponseWriter implements AutoCloseable
             {
                 return new ApiJsonWriter(response, contentTypeOverride, objectMapper, false);
             }
+
+            @Override
+            public boolean isJson()
+            {
+                return true;
+            }
         };
 
         public abstract ApiResponseWriter createWriter(HttpServletResponse response, String contentTypeOverride, ObjectMapper objectMapper) throws IOException;
+
+        public abstract boolean isJson();
     }
 
     private final HttpServletResponse _response;

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -3104,8 +3104,8 @@ public class QueryController extends SpringActionController
                         metaDataOnly, form.isIncludeDetailsColumn(), form.isIncludeUpdateColumn(),
                         form.isIncludeDisplayValues());
             }
-            response.includeStyle(form.isIncludeStyle());
             response.setFormat(getResponseFormat());
+            response.includeStyle(form.isIncludeStyle());
 
             return response;
         }

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2880,6 +2880,7 @@ public class QueryController extends SpringActionController
                         metaDataOnly, form.isIncludeDetailsColumn(), form.isIncludeUpdateColumn(),
                         form.isIncludeDisplayValues());
             }
+            response.setFormat(getResponseFormat());
             response.includeStyle(form.isIncludeStyle());
 
             // Issues 29515 and 32269 - force key and other non-requested columns to be sent back, but only if the client has
@@ -3104,6 +3105,7 @@ public class QueryController extends SpringActionController
                         form.isIncludeDisplayValues());
             }
             response.includeStyle(form.isIncludeStyle());
+            response.setFormat(getResponseFormat());
 
             return response;
         }


### PR DESCRIPTION
… and write leading spaces to the stream

#### Rationale
Async queries are good, allowing us to free up database resources if the client disconnects before the query has finished running. But they're no good if we return malformed XML to the request

#### Changes
* Run API queries as async if we're writing back JSON, but not XML