### PR TITLE
Item 7541: correct type value of inner result set

### DIFF
--- a/api/src/org/labkey/api/data/NestableDataRegion.java
+++ b/api/src/org/labkey/api/data/NestableDataRegion.java
@@ -94,7 +94,15 @@ public class NestableDataRegion extends AbstractNestableDataRegion
             while (nestedRS.next())
             {
                 Object outerValue = ctx.getRow().get(_uniqueColumnName);
-                Object innerValue = nestedRS.getInt(_uniqueColumnName);
+                Object innerValue = null;
+                if (outerValue instanceof Integer)
+                {
+                    innerValue = nestedRS.getInt(_uniqueColumnName);
+                }
+                if (outerValue instanceof Long)
+                {
+                    innerValue = nestedRS.getLong(_uniqueColumnName);
+                }
                 if (!Objects.equals(outerValue, innerValue))
                 {
                     throw new IllegalArgumentException("Ids do not match for the outer and inner result sets for column " + _uniqueColumnName + " - " + outerValue + " vs " + innerValue);

--- a/api/src/org/labkey/api/data/NestableDataRegion.java
+++ b/api/src/org/labkey/api/data/NestableDataRegion.java
@@ -94,15 +94,7 @@ public class NestableDataRegion extends AbstractNestableDataRegion
             while (nestedRS.next())
             {
                 Object outerValue = ctx.getRow().get(_uniqueColumnName);
-                Object innerValue = null;
-                if (outerValue instanceof Integer)
-                {
-                    innerValue = nestedRS.getInt(_uniqueColumnName);
-                }
-                if (outerValue instanceof Long)
-                {
-                    innerValue = nestedRS.getLong(_uniqueColumnName);
-                }
+                Object innerValue = nestedRS.getObject(_uniqueColumnName);
                 if (!Objects.equals(outerValue, innerValue))
                 {
                     throw new IllegalArgumentException("Ids do not match for the outer and inner result sets for column " + _uniqueColumnName + " - " + outerValue + " vs " + innerValue);


### PR DESCRIPTION
#### Rationale
As we are updating targetedms tables pks to be of type bigint, we need to grab the correct type of unique column in NestedDataRegion.

#### Related Pull Requests
https://github.com/LabKey/targetedms/pull/243

