### PR TITLE
41131: Change permission required for CreateNewUserAction & AddUsersAction

### DIFF
--- a/api/src/org/labkey/api/security/permissions/AddNewUserPermission.java
+++ b/api/src/org/labkey/api/security/permissions/AddNewUserPermission.java
@@ -1,0 +1,9 @@
+package org.labkey.api.security.permissions;
+
+public class AddNewUserPermission extends AdminPermission
+{
+    public AddNewUserPermission()
+    {
+        super("Add New User", "Allows a role to create new users for the server");
+    }
+}

--- a/api/src/org/labkey/api/security/permissions/AddUserPermission.java
+++ b/api/src/org/labkey/api/security/permissions/AddUserPermission.java
@@ -1,8 +1,8 @@
 package org.labkey.api.security.permissions;
 
-public class AddNewUserPermission extends AdminPermission
+public class AddUserPermission extends AdminPermission
 {
-    public AddNewUserPermission()
+    public AddUserPermission()
     {
         super("Add New User", "Allows a role to create new users for the server");
     }

--- a/api/src/org/labkey/api/security/permissions/UserManagementPermission.java
+++ b/api/src/org/labkey/api/security/permissions/UserManagementPermission.java
@@ -22,6 +22,6 @@ public class UserManagementPermission extends AdminPermission
 {
     public UserManagementPermission()
     {
-        super("User Management", "Allows a role to manage users (create, delete, deactivate) for the server");
+        super("User Management", "Allows a role to manage users (delete, deactivate) for the server");
     }
 }

--- a/api/src/org/labkey/api/security/roles/ApplicationAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/ApplicationAdminRole.java
@@ -31,7 +31,8 @@ public class ApplicationAdminRole extends AbstractRootContainerRole
         ApplicationAdminPermission.class,
         TroubleShooterPermission.class,
         EnableRestrictedModules.class,
-        UserManagementPermission.class
+        UserManagementPermission.class,
+        AddNewUserPermission.class
     );
 
     public ApplicationAdminRole()

--- a/api/src/org/labkey/api/security/roles/ApplicationAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/ApplicationAdminRole.java
@@ -32,7 +32,7 @@ public class ApplicationAdminRole extends AbstractRootContainerRole
         TroubleShooterPermission.class,
         EnableRestrictedModules.class,
         UserManagementPermission.class,
-        AddNewUserPermission.class
+        AddUserPermission.class
     );
 
     public ApplicationAdminRole()

--- a/api/src/org/labkey/api/security/roles/ProjectAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/ProjectAdminRole.java
@@ -20,6 +20,7 @@ import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicy;
+import org.labkey.api.security.permissions.AddNewUserPermission;
 import org.labkey.api.security.permissions.UserManagementPermission;
 
 import java.util.Collections;
@@ -36,7 +37,7 @@ public class ProjectAdminRole extends AbstractRole
         super("Project Administrator",
             "Project Administrators have full control over the project, but not the entire system.",
             FolderAdminRole.PERMISSIONS,
-            Collections.singletonList(UserManagementPermission.class)
+            Collections.singletonList(AddNewUserPermission.class)
         );
 
         excludeGuests();

--- a/api/src/org/labkey/api/security/roles/ProjectAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/ProjectAdminRole.java
@@ -20,6 +20,9 @@ import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicy;
+import org.labkey.api.security.permissions.UserManagementPermission;
+
+import java.util.Collections;
 
 /*
 * User: Dave
@@ -32,7 +35,8 @@ public class ProjectAdminRole extends AbstractRole
     {
         super("Project Administrator",
             "Project Administrators have full control over the project, but not the entire system.",
-            FolderAdminRole.PERMISSIONS
+            FolderAdminRole.PERMISSIONS,
+            Collections.singletonList(UserManagementPermission.class)
         );
 
         excludeGuests();

--- a/api/src/org/labkey/api/security/roles/ProjectAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/ProjectAdminRole.java
@@ -20,7 +20,7 @@ import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicy;
-import org.labkey.api.security.permissions.AddNewUserPermission;
+import org.labkey.api.security.permissions.AddUserPermission;
 
 import java.util.Collections;
 
@@ -36,7 +36,7 @@ public class ProjectAdminRole extends AbstractRole
         super("Project Administrator",
             "Project Administrators have full control over the project, but not the entire system.",
             FolderAdminRole.PERMISSIONS,
-            Collections.singletonList(AddNewUserPermission.class)
+            Collections.singletonList(AddUserPermission.class)
         );
 
         excludeGuests();

--- a/api/src/org/labkey/api/security/roles/ProjectAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/ProjectAdminRole.java
@@ -21,7 +21,6 @@ import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.permissions.AddNewUserPermission;
-import org.labkey.api.security.permissions.UserManagementPermission;
 
 import java.util.Collections;
 

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -54,6 +54,7 @@ import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.ValidEmail;
 import org.labkey.api.security.ValidEmail.InvalidEmailException;
 import org.labkey.api.security.permissions.AbstractActionPermissionTest;
+import org.labkey.api.security.permissions.AddNewUserPermission;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
@@ -2070,9 +2071,9 @@ public class SecurityApiActions
             Container c = getContainer();
             if (!c.isRoot() && !c.getProject().hasPermission(getUser(), AdminPermission.class))
                 throw new UnauthorizedException("You must be an administrator at the project level to add new users.");
-            else if (!c.isRoot() && !c.getProject().hasPermission(getUser(), UserManagementPermission.class))
+            else if (!c.isRoot() && !c.getProject().hasPermission(getUser(), AddNewUserPermission.class))
                 throw new UnauthorizedException("You do not have permissions to create new users.");
-            else if (c.isRoot() && !getUser().hasRootPermission(UserManagementPermission.class))
+            else if (c.isRoot() && !getUser().hasRootPermission(AddNewUserPermission.class))
                 throw new UnauthorizedException("You do not have permissions to create new users.");
 
             String[] rawEmails = form.getEmail() == null ? null : form.getEmail().split(";");

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -2070,6 +2070,8 @@ public class SecurityApiActions
             Container c = getContainer();
             if (!c.isRoot() && !c.getProject().hasPermission(getUser(), AdminPermission.class))
                 throw new UnauthorizedException("You must be an administrator at the project level to add new users.");
+            else if (!c.isRoot() && !c.getProject().hasPermission(getUser(), UserManagementPermission.class))
+                throw new UnauthorizedException("You do not have permissions to create new users.");
             else if (c.isRoot() && !getUser().hasRootPermission(UserManagementPermission.class))
                 throw new UnauthorizedException("You do not have permissions to create new users.");
 

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -54,7 +54,7 @@ import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.ValidEmail;
 import org.labkey.api.security.ValidEmail.InvalidEmailException;
 import org.labkey.api.security.permissions.AbstractActionPermissionTest;
-import org.labkey.api.security.permissions.AddNewUserPermission;
+import org.labkey.api.security.permissions.AddUserPermission;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
@@ -2071,9 +2071,9 @@ public class SecurityApiActions
             Container c = getContainer();
             if (!c.isRoot() && !c.getProject().hasPermission(getUser(), AdminPermission.class))
                 throw new UnauthorizedException("You must be an administrator at the project level to add new users.");
-            else if (!c.isRoot() && !c.getProject().hasPermission(getUser(), AddNewUserPermission.class))
+            else if (!c.isRoot() && !c.getProject().hasPermission(getUser(), AddUserPermission.class))
                 throw new UnauthorizedException("You do not have permissions to create new users.");
-            else if (c.isRoot() && !getUser().hasRootPermission(AddNewUserPermission.class))
+            else if (c.isRoot() && !getUser().hasRootPermission(AddUserPermission.class))
                 throw new UnauthorizedException("You do not have permissions to create new users.");
 
             String[] rawEmails = form.getEmail() == null ? null : form.getEmail().split(";");

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -61,6 +61,7 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.*;
 import org.labkey.api.security.permissions.AbstractActionPermissionTest;
+import org.labkey.api.security.permissions.AddNewUserPermission;
 import org.labkey.api.security.permissions.AdminOperationsPermission;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DeletePermission;
@@ -1303,7 +1304,7 @@ public class SecurityController extends SpringActionController
     }
 
 
-    @RequiresPermission(UserManagementPermission.class)
+    @RequiresPermission(AddNewUserPermission.class)
     public class AddUsersAction extends FormViewAction<AddUsersForm>
     {
         @Override

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -61,7 +61,7 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.*;
 import org.labkey.api.security.permissions.AbstractActionPermissionTest;
-import org.labkey.api.security.permissions.AddNewUserPermission;
+import org.labkey.api.security.permissions.AddUserPermission;
 import org.labkey.api.security.permissions.AdminOperationsPermission;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DeletePermission;
@@ -97,7 +97,6 @@ import org.labkey.api.view.HttpView;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
-import org.labkey.api.view.PopupUserView;
 import org.labkey.api.view.RedirectException;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.VBox;
@@ -1304,7 +1303,7 @@ public class SecurityController extends SpringActionController
     }
 
 
-    @RequiresPermission(AddNewUserPermission.class)
+    @RequiresPermission(AddUserPermission.class)
     public class AddUsersAction extends FormViewAction<AddUsersForm>
     {
         @Override


### PR DESCRIPTION
#### Rationale
We need to support scenarios where a client is able to create and register a custom security role that grants all permissions associated with a project admin but doesn't allow them to create new users.

#### Changes
- Create new permission : AddUserPermission
- Add new permission to the ProjectAdminRole as well as AppAdminRole
- Check for this permission in the CreateNewUserAction and AddUsersAction