### PR TITLE
Use apiRuntime instead of apiElements because consumers need the runtime variant (apparently)

### DIFF
--- a/internal/build.gradle
+++ b/internal/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'java-library'
 apply plugin: 'org.labkey.javaModule'
 
 dependencies {
-   BuildUtils.addLabKeyDependency(project: project, config: "api", depProjectPath: BuildUtils.getApiProjectPath(project.gradle), depProjectConfig: "apiElements")
+   BuildUtils.addLabKeyDependency(project: project, config: "api", depProjectPath: BuildUtils.getApiProjectPath(project.gradle), depProjectConfig: "runtimeElements")
    if (project.configurations.findByName("dedupe") != null)
       BuildUtils.addLabKeyDependency(project: project, config: "dedupe", depProjectPath: BuildUtils.getApiProjectPath(project.gradle), depProjectConfig: "external")
    implementation "org.apache.tomcat:tomcat-jsp-api:${apacheTomcatVersion}"


### PR DESCRIPTION

#### Rationale
When running the 'moduleUiTests' task (at least, but perhaps also other tasks) for an individual module and when building platform from source, the following error results:

```
Wed Aug 19 14:14:47 [develop !?] core$ gradlew moduleUiTest

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':server:modules:platform:core:moduleUiTests'.
> Could not resolve all task dependencies for configuration ':server:modules:platform:core:uiTestRuntimeClasspath'.
   > Could not resolve project :server:modules:platform:api.
     Required by:
         project :server:modules:platform:core > project :server:modules:platform:internal
      > Variant 'apiElements' in project :server:modules:platform:api does not match the consumer attributes
        Variant 'apiElements' capability org.labkey:api:20.9-SNAPSHOT declares a library compatible with Java 13, packaged as a jar, and its dependencies declared externally:
          - Incompatible because this component declares an API of a component and the consumer needed a runtime of a component
```

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* use `runtimeElements` instead of `apiElements` in dependency declaration.
