### PR TITLE
fix the logging level comparisons

### DIFF
--- a/api/src/org/labkey/api/query/QueryParseException.java
+++ b/api/src/org/labkey/api/query/QueryParseException.java
@@ -52,7 +52,7 @@ public class QueryParseException extends QueryException
 
     public boolean isWarning()
     {
-        return _level.isLessSpecificThan(Level.ERROR);
+        return Level.ERROR.intLevel() > _level.intLevel();
     }
 
 


### PR DESCRIPTION
#### Rationale
This PR fixes analyze query assertions started happening after log4j upgrade. 

