### PR TITLE
Issue 40668: Convert npm builds to use build-dev by default instead of build-prod for efficiency

### DIFF
--- a/assay/package.json
+++ b/assay/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "setup": "npm ci",
-    "build": "npm run build-prod",
+    "build": "npm run build-dev",
     "start": "bnr build:watch",
     "build-dev": "npm run clean && bnr build:dev",
     "build-prod": "npm run clean && bnr build:prod",

--- a/core/package.json
+++ b/core/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "setup": "npm ci",
-    "build": "bnr clean && bnr build-themes:dev && bnr build-pages:prod",
+    "build": "npm run build-dev",
     "build-dev": "bnr clean && bnr build-themes:dev && bnr build-pages:dev",
     "build-prod": "bnr clean && bnr build-themes:prod && bnr build-pages:prod",
     "clean": "bnr clean",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "setup": "npm ci",
-    "build": "npm run build-prod",
+    "build": "npm run build-dev",
     "start": "bnr build:watch",
     "build-dev": "npm run clean && bnr build:dev",
     "build-prod": "npm run clean && bnr build:prod",

--- a/issues/package.json
+++ b/issues/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "setup": "npm ci",
-    "build": "npm run build-prod",
+    "build": "npm run build-dev",
     "start": "bnr build:watch",
     "build-dev": "npm run clean && bnr build:dev",
     "build-prod": "npm run clean && bnr build:prod",

--- a/list/package.json
+++ b/list/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "setup": "npm ci",
-    "build": "npm run build-prod",
+    "build": "npm run build-dev",
     "start": "bnr build:watch",
     "build-dev": "npm run clean && bnr build:dev",
     "build-prod": "npm run clean && bnr build:prod",

--- a/query/package.json
+++ b/query/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "setup": "npm ci",
-    "build": "npm run build-prod",
+    "build": "npm run build-dev",
     "start": "bnr build:watch",
     "build-dev": "npm run clean && bnr build:dev",
     "build-prod": "npm run clean && bnr build:prod",

--- a/study/package.json
+++ b/study/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "setup": "npm ci",
-    "build": "npm run build-prod",
+    "build": "npm run build-dev",
     "start": "bnr build:watch",
     "build-dev": "npm run clean && bnr build:dev",
     "build-prod": "npm run clean && bnr build:prod",


### PR DESCRIPTION
#### Rationale
The "build-dev" target that was introduced for all platform modules that have a `package.json` is  a "development" build of the apps in a module. This build uses webpack mode: `development` and devTool: `eval` source-map configuration and does not perform optimizations (e.g. vendor bundling).

To take advantage of this we, we'll switch the default `npm run build` command to use `builid-dev` instead of `build-prod`.   This should improve build times on local development machines.  TeamCity uses `-PdeployMode=prod`, which means it already uses `npm run build-prod` so no changes are required there.  

Version 1.13.0 of the Gradle Plugins introduced the `useNpmProd` property, which can be used if a local build needs to opt into the prod build (though you can also just use `-PdeployMode=prod`).

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1182
* https://github.com/LabKey/gradlePlugin/pull/72

#### Changes
* Switch the npm `build` script to use `build-dev`
