### PR TITLE
Issue 38105: Chart x-axis visit label sorting should be based on sequenceNum not label text

### DIFF
--- a/visualization/resources/web/vis/chartWizard/genericChartPanel.js
+++ b/visualization/resources/web/vis/chartWizard/genericChartPanel.js
@@ -720,9 +720,10 @@ Ext4.define('LABKEY.ext4.GenericChartPanel', {
         var dataRegion = LABKEY.DataRegions[this.panelDataRegionName];
         var sortKey = 'lsid'; // needed to keep expected ordering for legend data
 
-        // Issue 38105: For box plot of study visit labels, sort by visit display order and then sequenceNum
-        if (this.renderType === 'box_plot' && this.measures.x && this.measures.x.fieldKey === 'ParticipantVisit/Visit') {
-            sortKey = 'ParticipantVisit/Visit/DisplayOrder, ParticipantVisit/SequenceNum';
+        // Issue 38105: For plots with of study visit labels on x-axis, sort by visit display order and then sequenceNum
+        var tableName = LABKEY.vis.GenericChartHelper.getStudySubjectInfo().tableName + 'Visit';
+        if (this.measures.x && this.measures.x.fieldKey === tableName + '/Visit') {
+            sortKey = tableName + '/Visit/DisplayOrder, ' + tableName + '/SequenceNum';
         }
 
         var config = {

--- a/visualization/resources/web/vis/chartWizard/genericChartPanel.js
+++ b/visualization/resources/web/vis/chartWizard/genericChartPanel.js
@@ -720,10 +720,12 @@ Ext4.define('LABKEY.ext4.GenericChartPanel', {
         var dataRegion = LABKEY.DataRegions[this.panelDataRegionName];
         var sortKey = 'lsid'; // needed to keep expected ordering for legend data
 
-        // Issue 38105: For plots with of study visit labels on x-axis, sort by visit display order and then sequenceNum
-        var tableName = LABKEY.vis.GenericChartHelper.getStudySubjectInfo().tableName + 'Visit';
-        if (this.measures.x && this.measures.x.fieldKey === tableName + '/Visit') {
-            sortKey = tableName + '/Visit/DisplayOrder, ' + tableName + '/SequenceNum';
+        // Issue 38105: For plots with study visit labels on the x-axis, sort by visit display order and then sequenceNum
+        var visitTableName = LABKEY.vis.GenericChartHelper.getStudySubjectInfo().tableName + 'Visit';
+        if (this.measures.x && this.measures.x.fieldKey === visitTableName + '/Visit') {
+            var displayOrderColName = visitTableName + '/Visit/DisplayOrder';
+            var seqNumColName = visitTableName + '/SequenceNum';
+            sortKey = displayOrderColName + ', ' + seqNumColName;
         }
 
         var config = {

--- a/visualization/resources/web/vis/genericChart/genericChartHelper.js
+++ b/visualization/resources/web/vis/genericChart/genericChartHelper.js
@@ -374,17 +374,18 @@ LABKEY.vis.GenericChartHelper = new function(){
         var scales = {};
         var data = LABKEY.Utils.isArray(measureStore.rows) ? measureStore.rows : measureStore.records();
         var fields = LABKEY.Utils.isObject(measureStore.metaData) ? measureStore.metaData.fields : measureStore.getResponseMetadata().fields;
-        var subjectColumn = _getStudySubjectInfo().columnName;
+        var subjectColumn = getStudySubjectInfo().columnName;
+        var tableName = getStudySubjectInfo().tableName + 'Visit';
         var valExponentialDigits = 6;
+
+        // Issue 38105: For box plot of study visit labels, don't sort alphabetically
+        var sortFnX = measures.x && measures.x.fieldKey === (tableName + '/Visit') ? undefined : LABKEY.vis.discreteSortFn;
 
         if (chartType === "box_plot")
         {
-            // Issue 38105: For box plot of study visit labels, don't sort alphabetically
-            var sortFn = measures.x && measures.x.fieldKey === 'ParticipantVisit/Visit' ? undefined : LABKEY.vis.discreteSortFn;
-
             scales.x = {
                 scaleType: 'discrete', // Force discrete x-axis scale for box plots.
-                sortFn: sortFn,
+                sortFn: sortFnX,
                 tickLabelMax: DEFAULT_TICK_LABEL_MAX
             };
 
@@ -431,7 +432,7 @@ LABKEY.vis.GenericChartHelper = new function(){
             {
                 scales.x = {
                     scaleType: 'discrete',
-                    sortFn: LABKEY.vis.discreteSortFn,
+                    sortFn: sortFnX,
                     tickLabelMax: DEFAULT_TICK_LABEL_MAX
                 };
 
@@ -1376,7 +1377,7 @@ LABKEY.vis.GenericChartHelper = new function(){
         return t == 'date';
     };
 
-    var _getStudySubjectInfo = function()
+    var getStudySubjectInfo = function()
     {
         var studyCtx = LABKEY.getModuleContext("study") || {};
         return LABKEY.Utils.isObject(studyCtx.subject) ? studyCtx.subject : {
@@ -1714,6 +1715,7 @@ LABKEY.vis.GenericChartHelper = new function(){
         getDistinctYAxisSides : getDistinctYAxisSides,
         getYMeasureAes : getYMeasureAes,
         getDefaultMeasuresLabel: getDefaultMeasuresLabel,
+        getStudySubjectInfo: getStudySubjectInfo,
         ensureMeasuresAsArray: ensureMeasuresAsArray,
         isNumericType: isNumericType,
         generateLabels: generateLabels,

--- a/visualization/resources/web/vis/genericChart/genericChartHelper.js
+++ b/visualization/resources/web/vis/genericChart/genericChartHelper.js
@@ -375,11 +375,12 @@ LABKEY.vis.GenericChartHelper = new function(){
         var data = LABKEY.Utils.isArray(measureStore.rows) ? measureStore.rows : measureStore.records();
         var fields = LABKEY.Utils.isObject(measureStore.metaData) ? measureStore.metaData.fields : measureStore.getResponseMetadata().fields;
         var subjectColumn = getStudySubjectInfo().columnName;
-        var tableName = getStudySubjectInfo().tableName + 'Visit';
+        var visitTableName = getStudySubjectInfo().tableName + 'Visit';
+        var visitColName = visitTableName + '/Visit';
         var valExponentialDigits = 6;
 
-        // Issue 38105: For box plot of study visit labels, don't sort alphabetically
-        var sortFnX = measures.x && measures.x.fieldKey === (tableName + '/Visit') ? undefined : LABKEY.vis.discreteSortFn;
+        // Issue 38105: For plots with study visit labels on the x-axis, don't sort alphabetically
+        var sortFnX = measures.x && measures.x.fieldKey === visitColName ? undefined : LABKEY.vis.discreteSortFn;
 
         if (chartType === "box_plot")
         {


### PR DESCRIPTION
#### Rationale
A client notified us of an issue with the box plot charts x-axis sorting behavior which was sorting based on the visit label instead of the visit sequence number. There was an initial fix for this applied to 20.7 but that fix did not account for custom study subject information being set and was only applied to box plots. This PR fixes the hard coded subject table name issue and also applies the sortFn fix to the bar and scatter plot types.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1291

#### Changes
* Use the study context subject table name instead of hardcoding to "Participant"
* Apply x-axis sortFn changes to bar and scatter plot types in addition to box plots
