### PR TITLE
Attachments: document size and errors wiki attachment upon update

### DIFF
--- a/api/src/org/labkey/api/attachments/Attachment.java
+++ b/api/src/org/labkey/api/attachments/Attachment.java
@@ -50,6 +50,7 @@ public class Attachment implements Serializable
     private String _container;   // container path
     private int _createdBy;
     private long _created;
+    private int _documentSize;
     private File _file;
     private Date _lastIndexed;
 
@@ -333,5 +334,15 @@ public class Attachment implements Serializable
     public void setFile(File file)
     {
         _file = file;
+    }
+
+    public int getDocumentSize()
+    {
+        return _documentSize;
+    }
+
+    public void setDocumentSize(int documentSize)
+    {
+        _documentSize = documentSize;
     }
 }

--- a/api/src/org/labkey/api/wiki/WikiService.java
+++ b/api/src/org/labkey/api/wiki/WikiService.java
@@ -91,6 +91,8 @@ public interface WikiService
 
     /**
      * Update the attachments on a wiki. Note, attachment changes do not update the wiki version.
+     * If an error occurs, a non-null String will be returned containing the error message.
      */
-    void updateAttachments(Container c, User user, String wikiName, @Nullable List<AttachmentFile> attachmentFiles, @Nullable List<String> deleteAttachmentNames);
+    @Nullable
+    String updateAttachments(Container c, User user, String wikiName, @Nullable List<AttachmentFile> attachmentFiles, @Nullable List<String> deleteAttachmentNames);
 }

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -555,7 +555,7 @@ public class WikiManager implements WikiService
     }
 
 
-    public String updateAttachments(User user, Wiki wiki, @Nullable List<String> deleteNames, @Nullable List<AttachmentFile> files)
+    public @Nullable String updateAttachments(User user, Wiki wiki, @Nullable List<String> deleteNames, @Nullable List<AttachmentFile> files)
     {
         AttachmentService attsvc = getAttachmentService();
         boolean changes = false;
@@ -988,11 +988,12 @@ public class WikiManager implements WikiService
     }
 
     @Override
-    public void updateAttachments(Container c, User user, String wikiName, @Nullable List<AttachmentFile> attachmentFiles, @Nullable List<String> deleteAttachmentNames)
+    public @Nullable String updateAttachments(Container c, User user, String wikiName, @Nullable List<AttachmentFile> attachmentFiles, @Nullable List<String> deleteAttachmentNames)
     {
         Wiki wiki = WikiSelectManager.getWiki(c, wikiName);
         if (wiki != null)
-            updateAttachments(user, wiki, deleteAttachmentNames, attachmentFiles);
+            return updateAttachments(user, wiki, deleteAttachmentNames, attachmentFiles);
+        return null;
     }
 
     public static class TestCase extends Assert


### PR DESCRIPTION
#### Related Pull Requests
* https://github.com/LabKey/labbook/pull/43

#### Changes
* Expose `documentSize` on the `Attachment` bean which is already a database field on `core.documents`.
* Propagate attachment error messaging via `WikiService.updateAttachments()`.