### PR TITLE
Expose exception list as a web part

### DIFF
--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -432,7 +432,7 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
 
     /** Override this method to return a schema specific QueryView for the given QuerySettings. */
     @NotNull
-    public QueryView createView(ViewContext context, @NotNull QuerySettings settings, BindException errors)
+    public QueryView createView(ViewContext context, @NotNull QuerySettings settings, @Nullable BindException errors)
     {
         QueryDefinition qdef = settings.getQueryDef(this);
         if (qdef != null)

--- a/mothership/src/org/labkey/mothership/MothershipController.java
+++ b/mothership/src/org/labkey/mothership/MothershipController.java
@@ -78,6 +78,8 @@ import org.labkey.api.view.UpdateView;
 import org.labkey.api.view.VBox;
 import org.labkey.api.view.ViewServlet;
 import org.labkey.mothership.query.MothershipSchema;
+import org.labkey.mothership.view.ExceptionListWebPart;
+import org.labkey.mothership.view.LinkBar;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
@@ -188,7 +190,7 @@ public class MothershipController extends SpringActionController
             settings.getBaseSort().insertSortColumn(FieldKey.fromParts("BuildTime"), Sort.SortDirection.DESC);
 
             QueryView queryView = schema.createView(getViewContext(), settings, errors);
-            return new VBox(getLinkBar(), queryView);
+            return new VBox(new LinkBar(), queryView);
         }
 
         @Override
@@ -364,16 +366,7 @@ public class MothershipController extends SpringActionController
         @Override
         public ModelAndView getView(Object o, BindException errors)
         {
-            MothershipSchema schema = new MothershipSchema(getUser(), getContainer());
-            QuerySettings settings = schema.getSettings(getViewContext(), "ExceptionSummary", MothershipSchema.EXCEPTION_STACK_TRACE_TABLE_NAME);
-            settings.getBaseSort().insertSortColumn(FieldKey.fromParts("ExceptionStackTraceId"), Sort.SortDirection.DESC);
-
-            QueryView queryView = schema.createView(getViewContext(), settings, errors);
-            queryView.setShowDetailsColumn(false);
-            queryView.setShadeAlternatingRows(true);
-            queryView.setShowBorders(true);
-
-            return new VBox(getLinkBar(), queryView);
+            return new ExceptionListWebPart(getUser(), getContainer(), errors);
         }
 
         @Override
@@ -401,7 +394,7 @@ public class MothershipController extends SpringActionController
 
             QueryView gridView = schema.createView(getViewContext(), settings, errors);
 
-            return new VBox(getLinkBar(), gridView);
+            return new VBox(new LinkBar(), gridView);
         }
 
         @Override
@@ -450,7 +443,7 @@ public class MothershipController extends SpringActionController
             form.setCreateIssueURL(MothershipManager.get().getCreateIssueURL(getContainer()));
             form.setIssuesContainer(MothershipManager.get().getIssuesContainer(getContainer()));
 
-            return new VBox(getLinkBar(), new JspView<>("/org/labkey/mothership/editUpgradeMessage.jsp", form));
+            return new VBox(new LinkBar(), new JspView<>("/org/labkey/mothership/editUpgradeMessage.jsp", form));
         }
 
         @Override
@@ -915,7 +908,7 @@ public class MothershipController extends SpringActionController
         public ModelAndView getView(Object o, BindException errors) throws Exception
         {
             HtmlView graphView = new HtmlView("Installations", "<img src=\"mothership-showActiveInstallationGraph.view\" height=\"400\" width=\"800\" /><br/><br/><img src=\"mothership-showRegistrationInstallationGraph.view\" height=\"400\" width=\"800\" />");
-            return new VBox(getLinkBar(), new UnbuggedExceptionsGridView(), new UnassignedExceptionsGridView(), graphView);
+            return new VBox(new LinkBar(), new UnbuggedExceptionsGridView(), new UnassignedExceptionsGridView(), graphView);
         }
     }
 
@@ -977,11 +970,6 @@ public class MothershipController extends SpringActionController
             return MothershipManager.get().getUpgradeMessage(getContainer());
         }
         return "";
-    }
-
-    private JspView getLinkBar()
-    {
-        return new JspView("/org/labkey/mothership/view/linkBar.jsp");
     }
 
     public static abstract class ServerInfoForm

--- a/mothership/src/org/labkey/mothership/MothershipModule.java
+++ b/mothership/src/org/labkey/mothership/MothershipModule.java
@@ -36,8 +36,14 @@ import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.MothershipReport;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.view.BaseWebPartFactory;
+import org.labkey.api.view.Portal;
+import org.labkey.api.view.ViewContext;
+import org.labkey.api.view.WebPartConfigurationException;
 import org.labkey.api.view.WebPartFactory;
+import org.labkey.api.view.WebPartView;
 import org.labkey.mothership.query.MothershipSchema;
+import org.labkey.mothership.view.ExceptionListWebPart;
 
 import java.beans.PropertyChangeEvent;
 import java.util.Collection;
@@ -76,7 +82,16 @@ public class MothershipModule extends DefaultModule
     @NotNull
     protected Collection<WebPartFactory> createWebPartFactories()
     {
-        return Collections.emptyList();
+        return Collections.singletonList(
+                new BaseWebPartFactory("Exception List", false, false)
+                {
+                    @Override
+                    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, Portal.@NotNull WebPart webPart) throws WebPartConfigurationException
+                    {
+                        return new ExceptionListWebPart(portalCtx.getUser(), portalCtx.getContainer(), null);
+                    }
+                }
+        );
     }
 
     @Override

--- a/mothership/src/org/labkey/mothership/query/MothershipSchema.java
+++ b/mothership/src/org/labkey/mothership/query/MothershipSchema.java
@@ -436,7 +436,7 @@ public class MothershipSchema extends UserSchema
     }
 
     @Override
-    public QueryView createView(ViewContext context, @NotNull QuerySettings settings, BindException errors)
+    public QueryView createView(ViewContext context, @NotNull QuerySettings settings, @Nullable BindException errors)
     {
         if (EXCEPTION_STACK_TRACE_TABLE_NAME.equals(settings.getQueryName()))
         {

--- a/mothership/src/org/labkey/mothership/view/ExceptionListWebPart.java
+++ b/mothership/src/org/labkey/mothership/view/ExceptionListWebPart.java
@@ -1,0 +1,29 @@
+package org.labkey.mothership.view;
+
+import org.labkey.api.data.Container;
+import org.labkey.api.data.Sort;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QuerySettings;
+import org.labkey.api.query.QueryView;
+import org.labkey.api.security.User;
+import org.labkey.api.view.VBox;
+import org.labkey.mothership.query.MothershipSchema;
+import org.springframework.validation.BindException;
+
+public class ExceptionListWebPart extends VBox
+{
+    public ExceptionListWebPart(User user, Container container, BindException errors)
+    {
+        MothershipSchema schema = new MothershipSchema(user, container);
+        QuerySettings settings = schema.getSettings(getViewContext(), "ExceptionSummary", MothershipSchema.EXCEPTION_STACK_TRACE_TABLE_NAME);
+        settings.getBaseSort().insertSortColumn(FieldKey.fromParts("ExceptionStackTraceId"), Sort.SortDirection.DESC);
+
+        QueryView queryView = schema.createView(getViewContext(), settings, errors);
+        queryView.setShowDetailsColumn(false);
+        queryView.setShadeAlternatingRows(true);
+        queryView.setShowBorders(true);
+
+        addView(new LinkBar());
+        addView(queryView);
+    }
+}

--- a/mothership/src/org/labkey/mothership/view/LinkBar.java
+++ b/mothership/src/org/labkey/mothership/view/LinkBar.java
@@ -1,0 +1,11 @@
+package org.labkey.mothership.view;
+
+import org.labkey.api.view.JspView;
+
+public class LinkBar extends JspView<Object>
+{
+    public LinkBar()
+    {
+        super("/org/labkey/mothership/view/linkBar.jsp");
+    }
+}


### PR DESCRIPTION
#### Rationale
Currently the mothership project is configured as a "Custom" folder type, which is limiting in terms of layout and tab navigation. We want to configure it as a regular folder type so people can find what they need

#### Changes
* Expose exception list as a web part
* Misc cleanup