### PR TITLE
Issue 41215: Groups column not available in user list on notifications page

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -244,6 +244,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.labkey.api.data.MultiValuedRenderContext.VALUE_DELIMITER_REGEX;
 import static org.labkey.api.settings.AdminConsole.SettingsLinkType.Configuration;
 import static org.labkey.api.settings.AdminConsole.SettingsLinkType.Diagnostics;
 import static org.labkey.api.util.DOM.A;
@@ -5788,7 +5789,7 @@ public class AdminController extends SpringActionController
         }
     }
 
-
+    /** Renders only the groups that are assigned roles in this container */
     private static class FolderGroupColumn extends DataColumn
     {
         private final Set<String> _assignmentSet;
@@ -5809,7 +5810,7 @@ public class AdminController extends SpringActionController
                 StringBuilder sb = new StringBuilder();
                 String delim = "";
 
-                for (String name : value.split(","))
+                for (String name : value.split(VALUE_DELIMITER_REGEX))
                 {
                     if (_assignmentSet.contains(name))
                     {

--- a/core/src/org/labkey/core/query/CoreQuerySchema.java
+++ b/core/src/org/labkey/core/query/CoreQuerySchema.java
@@ -148,7 +148,12 @@ public class CoreQuerySchema extends UserSchema
         if (CONTAINERS_TABLE_NAME.equalsIgnoreCase(name))
             return getContainers(cf);
         if (USERS_MSG_SETTINGS_TABLE_NAME.equalsIgnoreCase(name) && getContainer().hasPermission(getUser(), AdminPermission.class))
-            return new UsersMsgPrefTable(this, CoreSchema.getInstance().getSchema().getTable(USERS_TABLE_NAME)).init();
+        {
+            UsersMsgPrefTable result = new UsersMsgPrefTable(this, CoreSchema.getInstance().getSchema().getTable(USERS_TABLE_NAME));
+            result.init();
+            addGroupsColumn(result);
+            return result;
+        }
         // Files table is not visible
         if (FILES_TABLE_NAME.equalsIgnoreCase(name))
             return getFilesTable();


### PR DESCRIPTION
#### Rationale
Clearly we're trying to offer the Groups column in the folder management Notifications tab, but subsequent refactors have broken it

#### Changes
* Restore the Groups column
* Fix rendering of the group names