### PR TITLE
Add convenience method JspBase.formatDateTime(Date date, String pattern)

### DIFF
--- a/api/src/org/labkey/api/jsp/JspBase.java
+++ b/api/src/org/labkey/api/jsp/JspBase.java
@@ -526,6 +526,12 @@ public abstract class JspBase extends JspContext implements HasViewContext
         return HtmlString.of(null == date ? "" : DateUtil.formatDateTime(getContainer(), date));
     }
 
+    // Format date & time using the specified date & time format and HTML filter the result
+    public HtmlString formatDateTime(Date date, String pattern)
+    {
+        return HtmlString.of(null == date ? "" : DateUtil.formatDateTime(date, pattern));
+    }
+
     public String getMessage(ObjectError e)
     {
         if (e == null)

--- a/api/src/org/labkey/api/jsp/taglib/ErrorsTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/ErrorsTag.java
@@ -21,7 +21,6 @@ import org.apache.logging.log4j.Logger;
 import org.labkey.api.action.LabKeyError;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.HtmlString;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
 import org.springframework.context.NoSuchMessageException;

--- a/api/src/org/labkey/api/jsp/taglib/PanelTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/PanelTag.java
@@ -17,7 +17,6 @@ package org.labkey.api.jsp.taglib;
 
 import org.labkey.api.util.DOM;
 import org.labkey.api.util.HtmlString;
-import org.labkey.api.util.Pair;
 import org.labkey.api.util.UnexpectedException;
 
 import javax.servlet.jsp.tagext.BodyTagSupport;

--- a/api/src/org/labkey/api/jsp/taglib/SimpleTagBase.java
+++ b/api/src/org/labkey/api/jsp/taglib/SimpleTagBase.java
@@ -17,7 +17,6 @@
 package org.labkey.api.jsp.taglib;
 
 import org.labkey.api.util.HtmlString;
-import org.labkey.api.util.PageFlowUtil;
 
 import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.tagext.SimpleTagSupport;

--- a/api/src/org/labkey/api/util/Link.java
+++ b/api/src/org/labkey/api/util/Link.java
@@ -64,7 +64,7 @@ public class Link extends DisplayElement implements HasHtmlString
         return out;
     }
 
-    @Override // TODO: HtmlString - remove this
+    @Override
     public String toString()
     {
         return getHtmlString().toString();

--- a/api/src/org/labkey/api/util/URLHelper.java
+++ b/api/src/org/labkey/api/util/URLHelper.java
@@ -30,6 +30,7 @@ import org.labkey.api.data.CompareType;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.settings.AppProps;
+import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
 import org.springframework.beans.MutablePropertyValues;

--- a/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
+++ b/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
@@ -16,7 +16,6 @@
 package org.labkey.core.analytics;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.labkey.api.analytics.AnalyticsService;
 import org.labkey.api.data.Container;
@@ -28,7 +27,6 @@ import org.labkey.api.security.UserManager;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.settings.AbstractWriteableSettingsGroup;
 import org.labkey.api.settings.AppProps;
-import org.labkey.api.settings.ConfigProperty;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.StringExpressionFactory;


### PR DESCRIPTION
#### Rationale
`JspBase.formatDateTime(Date date, String pattern)` formats a date with the specified format pattern and then HTML encodes the result

#### Related Pull Requests
https://github.com/LabKey/harvest/pull/123