### PR TITLE
Issue 41226: status details expand/collapse target too large

### DIFF
--- a/core/resources/styles/scss/labkey/_labkey.scss
+++ b/core/resources/styles/scss/labkey/_labkey.scss
@@ -225,6 +225,7 @@ pre.labkey-log-text.multiline.expanded::before {
   content: '\f147'; /* fa-minus-square-o */
   float: left;
   margin-left: -1.4em;
+  cursor: pointer;
 }
 
 // add [+] icon before multiline block
@@ -233,6 +234,7 @@ pre.labkey-log-text.multiline.collapsed::before {
   content: '\f196'; /* fa-plus-square-o */
   float: left;
   margin-left: -1.4em;
+  cursor: pointer;
 }
 
 //TODO: Can remove if _frameNavigation is removed

--- a/pipeline/src/org/labkey/pipeline/status/details.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/details.jsp
@@ -239,7 +239,7 @@
                      data-multiline="<%=h(record.isMultiline())%>"
                      data-stacktrace="<%=h(record.isStackTrace())%>"
                      data-level="<%=h(record.getLevel())%>"
-                ><%=h(record.getLines())%></pre>
+                ><div><%=h(record.getLines())%></div></pre>
                 <% } %>
         </div>
             <% } %>
@@ -541,7 +541,9 @@
                         'data-multiline="' + record.multiline + '"' +
                         'data-stacktrace="' + record.stackTrace + '"' +
                         'data-level="' + LABKEY.Utils.encodeHtml(record.level) + '">' +
+                        '<div>' +
                         LABKEY.Utils.encodeHtml(record.lines) +
+                        '</div>' +
                         '</pre>';
 
                 nodes.push(createDomNode(html));


### PR DESCRIPTION
- make only the padding area of the multiline log text clickable
- add a pointer cursor to the plus/minus box

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1420