### PR TITLE
Item 7514: Allow users to attach comments for the audit log when inserting, updating, or deleting rows

### DIFF
--- a/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
@@ -74,6 +74,7 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
     public static final String COLUMN_NAME_ROW_ID = "RowId";
     public static final String COLUMN_NAME_CONTAINER = "Container";
     public static final String COLUMN_NAME_COMMENT = "Comment";
+    public static final String COLUMN_NAME_USER_COMMENT = "UserComment";
     public static final String COLUMN_NAME_EVENT_TYPE = "EventType";
     public static final String COLUMN_NAME_CREATED = "Created";
     public static final String COLUMN_NAME_CREATED_BY = "CreatedBy";

--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -17,9 +17,9 @@ import java.util.Set;
 
 public abstract class AuditHandler
 {
-    protected abstract AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, int rowCount, @Nullable Map<String, Object> row);
+    protected abstract AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row);
 
-    protected abstract DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable Map<String, Object> row, Map<String, Object> updatedRow);
+    protected abstract DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> updatedRow);
 
     /**
      * Allow for adding fields that may be present in the updated row but not represented in the original row
@@ -32,7 +32,7 @@ public abstract class AuditHandler
         // do nothing extra by default
     }
 
-    public void addAuditEvent(User user, Container c, TableInfo table, @Nullable AuditBehaviorType auditType, QueryService.AuditAction action, List<Map<String, Object>>... params)
+    public void addAuditEvent(User user, Container c, TableInfo table, @Nullable AuditBehaviorType auditType, @Nullable String userComment, QueryService.AuditAction action, List<Map<String, Object>>... params)
     {
         if (table.supportsAuditTracking())
         {
@@ -51,9 +51,8 @@ public abstract class AuditHandler
 
                     case SUMMARY:
                     case DETAILED:
-                        AuditTypeEvent event = createSummaryAuditRecord(user, c, auditConfigurable, action, 0, null);
+                        AuditTypeEvent event = createSummaryAuditRecord(user, c, auditConfigurable, action, userComment, 0, null);
                         AuditLogService.get().addEvent(user, event);
-                        return;
                 }
             }
 
@@ -67,10 +66,9 @@ public abstract class AuditHandler
                     assert (params.length > 0);
 
                     List<Map<String, Object>> rows = params[0];
-                    AuditTypeEvent event = createSummaryAuditRecord(user, c, auditConfigurable, action, rows.size(), rows.get(0));
+                    AuditTypeEvent event = createSummaryAuditRecord(user, c, auditConfigurable, action, userComment, rows.size(), rows.get(0));
 
                     AuditLogService.get().addEvent(user, event);
-                    break;
                 }
                 case DETAILED:
                 {
@@ -83,7 +81,7 @@ public abstract class AuditHandler
                     {
                         Map<String, Object> row = rows.get(i);
                         Map<String, Object> updatedRow = updatedRows.isEmpty() ? Collections.emptyMap() : updatedRows.get(i);
-                        DetailedAuditTypeEvent event = createDetailedAuditRecord(user, c, auditConfigurable, action, row, updatedRow);
+                        DetailedAuditTypeEvent event = createDetailedAuditRecord(user, c, auditConfigurable, action, userComment, row, updatedRow);
 
                         switch (action)
                         {

--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -53,6 +53,7 @@ public abstract class AuditHandler
                     case DETAILED:
                         AuditTypeEvent event = createSummaryAuditRecord(user, c, auditConfigurable, action, userComment, 0, null);
                         AuditLogService.get().addEvent(user, event);
+                        return;
                 }
             }
 

--- a/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
+++ b/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
@@ -20,8 +20,8 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
         MERGE("Sample was registered or updated.", "Registered"),
         UPDATE("Sample was updated.", "Updated");
 
-        private String _comment;
-        private String _actionLabel;
+        private final String _comment;
+        private final String _actionLabel;
 
         SampleTimelineEventType(String comment, String actionLabel)
         {
@@ -75,6 +75,7 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
     private boolean _isLineageUpdate;
     private String _metadata;
     private String _inventoryUpdateType;
+    private String _userComment;
 
     public SampleTimelineAuditEvent()
     {
@@ -164,6 +165,16 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
     public void setInventoryUpdateType(String inventoryUpdateType)
     {
         _inventoryUpdateType = inventoryUpdateType;
+    }
+
+    public String getUserComment()
+    {
+        return _userComment;
+    }
+
+    public void setUserComment(String userComment)
+    {
+        _userComment = userComment;
     }
 
     @Override

--- a/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
+++ b/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
@@ -12,7 +12,7 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
     public static final String EVENT_TYPE = "SampleTimelineEvent";
 
     public static final String SAMPLE_TIMELINE_EVENT_TYPE = "SampleTimelineEventType";
-    public static final String AUDIT_USER_COMMENT = "userComment";
+
     public enum SampleTimelineEventType
     {
         INSERT("Sample was registered.", "Registered"),

--- a/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
+++ b/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
@@ -12,6 +12,7 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
     public static final String EVENT_TYPE = "SampleTimelineEvent";
 
     public static final String SAMPLE_TIMELINE_EVENT_TYPE = "SampleTimelineEventType";
+    public static final String AUDIT_USER_COMMENT = "userComment";
     public enum SampleTimelineEventType
     {
         INSERT("Sample was registered.", "Registered"),
@@ -75,7 +76,6 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
     private boolean _isLineageUpdate;
     private String _metadata;
     private String _inventoryUpdateType;
-    private String _userComment;
 
     public SampleTimelineAuditEvent()
     {
@@ -165,16 +165,6 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
     public void setInventoryUpdateType(String inventoryUpdateType)
     {
         _inventoryUpdateType = inventoryUpdateType;
-    }
-
-    public String getUserComment()
-    {
-        return _userComment;
-    }
-
-    public void setUserComment(String userComment)
-    {
-        _userComment = userComment;
     }
 
     @Override

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -116,15 +116,15 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
     Map<String, Pair<IndexType, List<ColumnInfo>>> getAllIndices();
 
     /** Log an audit event to capture a data change made to this table */
-    default void addAuditEvent(User user, Container container, AuditBehaviorType auditBehavior, QueryService.AuditAction auditAction, List<Map<String, Object>>[] parameters)
+    default void addAuditEvent(User user, Container container, AuditBehaviorType auditBehavior, @Nullable String userComment, QueryService.AuditAction auditAction, List<Map<String, Object>>[] parameters)
     {
-        QueryService.get().addAuditEvent(user, container, this, auditBehavior, auditAction, parameters);
+        QueryService.get().addAuditEvent(user, container, this, auditBehavior, userComment, auditAction, parameters);
     }
 
     @SuppressWarnings("unchecked")
-    default void addAuditEvent(User user, Container container, AuditBehaviorType auditBehavior, QueryService.AuditAction auditAction, Map<String, Object> parameters)
+    default void addAuditEvent(User user, Container container, AuditBehaviorType auditBehavior, @Nullable String userComment, QueryService.AuditAction auditAction, Map<String, Object> parameters)
     {
-        QueryService.get().addAuditEvent(user, container, this, auditBehavior, auditAction, Collections.singletonList(parameters));
+        QueryService.get().addAuditEvent(user, container, this, auditBehavior, userComment, auditAction, Collections.singletonList(parameters));
     }
 
     enum IndexType

--- a/api/src/org/labkey/api/dataiterator/DetailedAuditLogDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/DetailedAuditLogDataIterator.java
@@ -38,7 +38,8 @@ import static org.labkey.api.gwt.client.AuditBehaviorType.DETAILED;
 public class DetailedAuditLogDataIterator extends AbstractDataIterator
 {
     public enum AuditConfigs {
-        AuditBehavior;
+        AuditBehavior,
+        AuditUserComment;
     }
 
     final DataIterator _data;
@@ -85,7 +86,7 @@ public class DetailedAuditLogDataIterator extends AbstractDataIterator
                 auditType = auditConfigurable.getAuditBehavior();
 
             if (auditType == DETAILED)
-                _table.addAuditEvent(_user, _container, auditType, _auditAction, ((MapDataIterator) _data).getMap());
+                _table.addAuditEvent(_user, _container, auditType, (String) _context.getConfigParameter(AuditConfigs.AuditUserComment), _auditAction, ((MapDataIterator) _data).getMap());
         }
 
         return true;

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -140,9 +140,9 @@ public interface SampleTypeService
 
     boolean parentAliasHasCorrectFormat(String parentAlias);
 
-    void addAuditEvent(User user, Container c, TableInfo table, AuditBehaviorType auditBehaviorType, QueryService.AuditAction action, List<Map<String, Object>>... params);
+    void addAuditEvent(User user, Container c, TableInfo table, AuditBehaviorType auditBehaviorType, @Nullable String userComment, QueryService.AuditAction action, List<Map<String, Object>>... params);
 
-    void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata);
+    void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, @Nullable String userComment);
 
-    void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, String updateType);
+    void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, String updateType, @Nullable String userComment);
 }

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -142,7 +142,7 @@ public interface SampleTypeService
 
     void addAuditEvent(User user, Container c, TableInfo table, AuditBehaviorType auditBehaviorType, @Nullable String userComment, QueryService.AuditAction action, List<Map<String, Object>>... params);
 
-    void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, @Nullable String userComment);
+    void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata);
 
-    void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, String updateType, @Nullable String userComment);
+    void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, String updateType);
 }

--- a/api/src/org/labkey/api/inventory/InventoryService.java
+++ b/api/src/org/labkey/api/inventory/InventoryService.java
@@ -16,6 +16,7 @@
 package org.labkey.api.inventory;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.query.ExpMaterialTable;
@@ -43,7 +44,7 @@ public interface InventoryService
 
     static InventoryService get() { return ServiceRegistry.get().getService(InventoryService.class); }
 
-    void addAuditEvent(User user, Container c, TableInfo table, AuditBehaviorType auditBehaviorType, QueryService.AuditAction action, List<Map<String, Object>>... params);
+    void addAuditEvent(User user, Container c, TableInfo table, AuditBehaviorType auditBehaviorType, @Nullable String userComment, QueryService.AuditAction action, List<Map<String, Object>>... params);
 
     @NotNull
     List<Map<String, Object>> getSampleStorageLocationData(User user, Container container, int sampleId);

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -96,6 +96,7 @@ import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 import static org.labkey.api.dataiterator.DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior;
+import static org.labkey.api.dataiterator.DetailedAuditLogDataIterator.AuditConfigs.AuditUserComment;
 
 public abstract class AbstractQueryUpdateService implements QueryUpdateService
 {
@@ -444,8 +445,8 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         if (!isBulkLoad())
         {
             AuditBehaviorType auditBehavior = configParameters != null ? (AuditBehaviorType) configParameters.get(AuditBehavior) : null;
-
-            getQueryTable().addAuditEvent(user, container, auditBehavior, auditAction, parameters);
+            String userComment = configParameters == null ? null : (String) configParameters.get(AuditUserComment);
+            getQueryTable().addAuditEvent(user, container, auditBehavior, userComment, auditAction, parameters);
         }
     }
 

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -442,7 +442,7 @@ public interface QueryService
      */
     void addAuditEvent(QueryView queryView, String comment, @Nullable Integer dataRowCount);
     void addAuditEvent(User user, Container c, String schemaName, String queryName, ActionURL sortFilter, String comment, @Nullable Integer dataRowCount);
-    void addAuditEvent(User user, Container c, TableInfo table, AuditBehaviorType auditBehaviorType, AuditAction action, List<Map<String, Object>>... params);
+    void addAuditEvent(User user, Container c, TableInfo table, AuditBehaviorType auditBehaviorType, @Nullable String userComment, AuditAction action, List<Map<String, Object>>... params);
     void addSummaryAuditEvent(User user, Container c, TableInfo table, AuditAction action, Integer dataRowCount);
 
     /**

--- a/api/webapp/clientapi/core/Query.js
+++ b/api/webapp/clientapi/core/Query.js
@@ -706,7 +706,7 @@ LABKEY.Query = new function()
         * @param {boolean} [config.transacted] Whether all of the updates should be done in a single transaction, so they all succeed or all fail. Defaults to true
          * @param {string} [config.auditBehavior] Audit behavior for this particular action, used to override behavior
          * set on the underlying table.
-         * @param {string} [config.auditUserComment] Can be used to provide a comment from the user that will be attached to certain detailed audit logs.
+         * @param {string} [config.auditUserComment] Can be used to provide a comment from the user that will be attached to certain detailed audit log records.
          * @param {Object} [config.scope] A scope for the callback functions. Defaults to "this"
          * @returns {Mixed} In client-side scripts, this method will return a transaction id
          * for the async request that can be used to cancel the request

--- a/api/webapp/clientapi/core/Query.js
+++ b/api/webapp/clientapi/core/Query.js
@@ -44,6 +44,7 @@ LABKEY.Query = new function()
             rows : config.rows || config.rowDataArray,
             transacted : config.transacted,
             auditBehavior: config.auditBehavior,
+            auditUserComment: config.auditUserComment,
             extraContext : config.extraContext,
             provenance : config.provenance
         };
@@ -703,8 +704,9 @@ LABKEY.Query = new function()
         * @param {Integer} [config.timeout] The maximum number of milliseconds to allow for this operation before
         *       generating a timeout error (defaults to 30000).
         * @param {boolean} [config.transacted] Whether all of the updates should be done in a single transaction, so they all succeed or all fail. Defaults to true
-         * @param {string} [config.auditBehavior] Audit behavior for this particular action, used to override behavio
+         * @param {string} [config.auditBehavior] Audit behavior for this particular action, used to override behavior
          * set on the underlying table.
+         * @param {string} [config.auditUserComment] Can be used to provide a comment from the user that will be attached to certain detailed audit logs.
          * @param {Object} [config.scope] A scope for the callback functions. Defaults to "this"
          * @returns {Mixed} In client-side scripts, this method will return a transaction id
          * for the async request that can be used to cancel the request

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -126,21 +126,21 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     }
 
     @Override
-    public void addAuditEvent(User user, Container container, AuditBehaviorType auditBehavior, QueryService.AuditAction auditAction, List<Map<String, Object>>[] parameters)
+    public void addAuditEvent(User user, Container container, AuditBehaviorType auditBehavior, @Nullable String userComment, QueryService.AuditAction auditAction, List<Map<String, Object>>[] parameters)
     {
         if (getUserSchema().getName().equalsIgnoreCase(SamplesSchema.SCHEMA_NAME))
         {
             // Special case sample auditing to help build a useful timeline view
-            SampleTypeService.get().addAuditEvent(user, container, this, auditBehavior, auditAction, parameters);
+            SampleTypeService.get().addAuditEvent(user, container, this, auditBehavior, userComment, auditAction, parameters);
         }
         else
         {
-            super.addAuditEvent(user, container, auditBehavior, auditAction, parameters);
+            super.addAuditEvent(user, container, auditBehavior, userComment, auditAction, parameters);
         }
     }
 
     @Override
-    public void addAuditEvent(User user, Container container, AuditBehaviorType auditBehavior, QueryService.AuditAction auditAction, Map<String, Object> parameters)
+    public void addAuditEvent(User user, Container container, AuditBehaviorType auditBehavior, @Nullable String userComment, QueryService.AuditAction auditAction, Map<String, Object> parameters)
     {
         // Special case sample auditing to help build a useful timeline view
         if (getUserSchema().getName().equalsIgnoreCase(SamplesSchema.SCHEMA_NAME))
@@ -164,11 +164,11 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                     }
                 }
             }
-            SampleTypeService.get().addAuditEvent(user, container, this, auditBehavior, auditAction, Collections.singletonList(params));
+            SampleTypeService.get().addAuditEvent(user, container, this, auditBehavior, userComment, auditAction, Collections.singletonList(params));
         }
         else
         {
-            super.addAuditEvent(user, container, auditBehavior, auditAction, parameters);
+            super.addAuditEvent(user, container, auditBehavior, userComment, auditAction, parameters);
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -900,15 +900,16 @@ public class SampleTypeServiceImpl extends AuditHandler implements SampleTypeSer
     }
 
     @Override
-    public DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable Map<String, Object> row, Map<String, Object> updatedRow)
+    public DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> updatedRow)
     {
-        return createAuditRecord(c, getCommentDetailed(action), row, updatedRow, action);
+        // not doing anything with userComment at the moment
+        return createAuditRecord(c, getCommentDetailed(action), row, updatedRow, action, userComment);
     }
 
     @Override
-    protected AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, int rowCount, @Nullable Map<String, Object> row)
+    protected AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row)
     {
-        return createAuditRecord(c, String.format(action.getCommentSummary(), rowCount), row, null);
+        return createAuditRecord(c, String.format(action.getCommentSummary(), rowCount), row, userComment);
     }
 
     @Override
@@ -925,14 +926,15 @@ public class SampleTypeServiceImpl extends AuditHandler implements SampleTypeSer
         });
     }
 
-    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable Map<String, Object> row, Map<String, Object> updatedRow)
+    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable Map<String, Object> row, @Nullable String userComment)
     {
-        return createAuditRecord(c, comment, row, updatedRow, null);
+        return createAuditRecord(c, comment, row, null, null, userComment);
     }
 
-    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable Map<String, Object> row, Map<String, Object> updatedRow, @Nullable QueryService.AuditAction action)
+    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable Map<String, Object> row, Map<String, Object> updatedRow, @Nullable QueryService.AuditAction action, @Nullable String userComment)
     {
         SampleTimelineAuditEvent event = new SampleTimelineAuditEvent(c.getId(), comment);
+        event.setUserComment(userComment);
 
         if (c.getProject() != null)
             event.setProjectId(c.getProject().getId());
@@ -980,7 +982,7 @@ public class SampleTypeServiceImpl extends AuditHandler implements SampleTypeSer
         return event;
     }
 
-    private SampleTimelineAuditEvent createAuditRecord(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata)
+    private SampleTimelineAuditEvent createAuditRecord(Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, @Nullable String userComment)
     {
         SampleTimelineAuditEvent event = new SampleTimelineAuditEvent(container.getId(), comment);
         if (container.getProject() != null)
@@ -999,15 +1001,15 @@ public class SampleTypeServiceImpl extends AuditHandler implements SampleTypeSer
     }
 
     @Override
-    public void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata)
+    public void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, @Nullable String userComment)
     {
-        AuditLogService.get().addEvent(user, createAuditRecord(user, container, comment, sample, metadata));
+        AuditLogService.get().addEvent(user, createAuditRecord(container, comment, sample, metadata, userComment));
     }
 
     @Override
-    public void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, String updateType)
+    public void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, String updateType, @Nullable String userComment)
     {
-        SampleTimelineAuditEvent event = createAuditRecord(user, container, comment, sample, metadata);
+        SampleTimelineAuditEvent event = createAuditRecord(container, comment, sample, metadata, userComment);
         event.setInventoryUpdateType(updateType);
         AuditLogService.get().addEvent(user, event);
     }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -903,13 +903,14 @@ public class SampleTypeServiceImpl extends AuditHandler implements SampleTypeSer
     public DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> updatedRow)
     {
         // not doing anything with userComment at the moment
-        return createAuditRecord(c, getCommentDetailed(action), row, updatedRow, action, userComment);
+        return createAuditRecord(c, getCommentDetailed(action), row, updatedRow, action);
     }
 
     @Override
     protected AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row)
     {
-        return createAuditRecord(c, String.format(action.getCommentSummary(), rowCount), row, userComment);
+        // not doing anything with userComment at the moment
+        return createAuditRecord(c, String.format(action.getCommentSummary(), rowCount), row);
     }
 
     @Override
@@ -926,15 +927,14 @@ public class SampleTypeServiceImpl extends AuditHandler implements SampleTypeSer
         });
     }
 
-    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable Map<String, Object> row, @Nullable String userComment)
+    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable Map<String, Object> row)
     {
-        return createAuditRecord(c, comment, row, null, null, userComment);
+        return createAuditRecord(c, comment, row, null, null);
     }
 
-    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable Map<String, Object> row, Map<String, Object> updatedRow, @Nullable QueryService.AuditAction action, @Nullable String userComment)
+    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable Map<String, Object> row, Map<String, Object> updatedRow, @Nullable QueryService.AuditAction action)
     {
         SampleTimelineAuditEvent event = new SampleTimelineAuditEvent(c.getId(), comment);
-        event.setUserComment(userComment);
 
         if (c.getProject() != null)
             event.setProjectId(c.getProject().getId());
@@ -982,7 +982,7 @@ public class SampleTypeServiceImpl extends AuditHandler implements SampleTypeSer
         return event;
     }
 
-    private SampleTimelineAuditEvent createAuditRecord(Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, @Nullable String userComment)
+    private SampleTimelineAuditEvent createAuditRecord(Container container, String comment, ExpMaterial sample, Map<String, Object> metadata)
     {
         SampleTimelineAuditEvent event = new SampleTimelineAuditEvent(container.getId(), comment);
         if (container.getProject() != null)
@@ -1001,15 +1001,15 @@ public class SampleTypeServiceImpl extends AuditHandler implements SampleTypeSer
     }
 
     @Override
-    public void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, @Nullable String userComment)
+    public void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata)
     {
-        AuditLogService.get().addEvent(user, createAuditRecord(container, comment, sample, metadata, userComment));
+        AuditLogService.get().addEvent(user, createAuditRecord(container, comment, sample, metadata));
     }
 
     @Override
-    public void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, String updateType, @Nullable String userComment)
+    public void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, String updateType)
     {
-        SampleTimelineAuditEvent event = createAuditRecord(container, comment, sample, metadata, userComment);
+        SampleTimelineAuditEvent event = createAuditRecord(container, comment, sample, metadata);
         event.setInventoryUpdateType(updateType);
         AuditLogService.get().addEvent(user, event);
     }

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -2931,7 +2931,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
 
             if (auditType == SUMMARY)
             {
-                AuditTypeEvent event = createSummaryAuditRecord(user, c, auditConfigurable, action, dataRowCount, null);
+                AuditTypeEvent event = createSummaryAuditRecord(user, c, auditConfigurable, action, null, dataRowCount, null);
 
                 AuditLogService.get().addEvent(user, event);
             }
@@ -2939,14 +2939,15 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
     }
 
     @Override
-    protected DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tinfo, AuditAction action, @Nullable Map<String, Object> row, Map<String, Object> updatedRow)
+    protected DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tinfo, AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> updatedRow)
     {
         return createAuditRecord(c, tinfo, action.getCommentDetailed(), row);
     }
 
     @Override
-    protected AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, int rowCount, @Nullable Map<String, Object> row)
+    protected AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row)
     {
+        // not doing anything with userComment at the moment
         return createAuditRecord(c, tInfo, String.format(action.getCommentSummary(), rowCount), row);
     }
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -98,7 +98,6 @@ import org.labkey.api.util.TestContext;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.XmlBeansUtil;
 import org.labkey.api.view.ActionURL;
-import org.labkey.api.view.BadRequestException;
 import org.labkey.api.view.DetailsView;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.HttpView;
@@ -3739,7 +3738,7 @@ public class QueryController extends SpringActionController
             List<Map<String, Object>> rowsToProcess = new ArrayList<>();
 
             // NOTE RowMapFactory is faster, but for update it's important to preserve missing v explicit NULL values
-            // Do we need to support some soft of UNDEFINED and NULL instance of MvFieldWrapper?
+            // Do we need to support some sort of UNDEFINED and NULL instance of MvFieldWrapper?
             RowMapFactory<Object> f = null;
             if (commandType == CommandType.insert || commandType == CommandType.insertWithKeys)
                 f = new RowMapFactory<>();
@@ -3776,6 +3775,11 @@ public class QueryController extends SpringActionController
                 {
                     AuditBehaviorType behaviorType = AuditBehaviorType.valueOf(auditBehavior);
                     configParameters.put(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior, behaviorType);
+                    String auditComment = json.getString("auditUserComment");
+                    if (!StringUtils.isEmpty(auditComment))
+                    {
+                        configParameters.put(DetailedAuditLogDataIterator.AuditConfigs.AuditUserComment, auditComment);
+                    }
                 }
                 catch (IllegalArgumentException ignored)
                 {


### PR DESCRIPTION
#### Rationale
When checking items in and out of the freezer, we want to allow users to optionally provide comments on the action.  These comments are naturally associated with the audit event, not with the sample or the inventory item.  They are to be surfaced with the sample timeline and inventory location history views within the applications.

Though I added a constant for the field name `UserComment` to `AbstractAuditTypeProvider`, I did not add this as a standard default field since the field is not useful unless there is a way for a user to provide the comment.  Only the InventoryAuditEvent uses this field at present.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/351
* https://github.com/LabKey/labkey-api-js/pull/73
* https://github.com/LabKey/labkey-ui-components/pull/324
* https://github.com/LabKey/inventory/pull/75

#### Changes
* Add an optional userComment parameter to the AuditHandler method signatures for creating log entries
* Add an AuditUserComment field that can be supplied with an update, insert, or delete rows action.
* Update `QueryController` to look for the field `auditUserComment` in the JSON payload and pass that through the context along with the AuditBehaviorType that may have been provided in the request.
