### PR TITLE
Fix DataClassSearchTest

### DIFF
--- a/study/test/src/org/labkey/test/tests/search/DataClassSearchTest.java
+++ b/study/test/src/org/labkey/test/tests/search/DataClassSearchTest.java
@@ -31,6 +31,7 @@ import org.labkey.remoteapi.query.UpdateRowsCommand;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.DailyA;
 import org.labkey.test.categories.Search;
 import org.labkey.test.util.SearchHelper;
@@ -132,6 +133,7 @@ public class DataClassSearchTest extends BaseWebDriverTest
         _containerHelper.deleteProject(getProjectName(), afterTest);
         if (afterTest)
         {
+            beginAt(WebTestHelper.buildURL("search", "search"));
             _searchHelper.assertNoSearchResult(DATA_CLASS_2_NAME);
         }
     }


### PR DESCRIPTION
#### Rationale
Slight changes to test preamble/postamble have caused the post-test check for this test to fail because it is on the wrong page.

#### Related Pull Requests
* LabKey/testAutomation#431

#### Changes
* Navigate to search page before verifying search results
