### PR TITLE
Issue 40824: Resolve email address from uid field on core.SiteUsers - case insensitive

### DIFF
--- a/api/src/org/labkey/api/security/ValidEmail.java
+++ b/api/src/org/labkey/api/security/ValidEmail.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
@@ -125,7 +126,8 @@ public class ValidEmail
             if (uidColumn != null)
             {
                 LOG.debug("Found field in users table to use to match against login form: " + uidColumn.getName());
-                Collection<Map<String, Object>> matchingUsers = new TableSelector(usersTable, new SimpleFilter(uidColumn.getFieldKey(), rawEmail), null).getMapCollection();
+                // Do a case-insensitive search for the username
+                Collection<Map<String, Object>> matchingUsers = new TableSelector(usersTable, new SimpleFilter(new SimpleFilter.SQLClause(new SQLFragment("LOWER(uid) = LOWER(?)", rawEmail), uidColumn.getFieldKey())), null).getMapCollection();
                 if (matchingUsers.size() == 1)
                 {
                     String fullEmail = (String) matchingUsers.iterator().next().get("Email");


### PR DESCRIPTION
#### Rationale
We recently added the ability to resolve an email address from a custom field in the SiteUsers table, but the filtering should be case-insensitive

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1365

#### Changes
* Do a case-insensitive query on the uid column, when present
