### PR TITLE
Return 400 response code for invalid grid boolean parameters

### DIFF
--- a/api/src/org/labkey/api/action/BaseApiAction.java
+++ b/api/src/org/labkey/api/action/BaseApiAction.java
@@ -126,7 +126,7 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
             case GET:
                 return handleGet();
         }
-        throw new BadRequestException("Method Not Allowed: " + getViewContext().getRequest().getMethod(), HttpServletResponse.SC_METHOD_NOT_ALLOWED, null);
+        throw new BadRequestException("Method Not Allowed: " + getViewContext().getRequest().getMethod(), null, HttpServletResponse.SC_METHOD_NOT_ALLOWED);
     }
 
 

--- a/api/src/org/labkey/api/action/PermissionCheckableAction.java
+++ b/api/src/org/labkey/api/action/PermissionCheckableAction.java
@@ -165,7 +165,7 @@ public abstract class PermissionCheckableAction implements Controller, Permissio
             methodsAllowed = methodsAllowedAnnotation.value();
         if (Arrays.stream(methodsAllowed).noneMatch(s -> s.equals(method)))
         {
-            throw new BadRequestException("Method Not Allowed: " + method, HttpServletResponse.SC_METHOD_NOT_ALLOWED, null);
+            throw new BadRequestException("Method Not Allowed: " + method, null, HttpServletResponse.SC_METHOD_NOT_ALLOWED);
         }
 
         boolean requiresSiteAdmin = actionClass.isAnnotationPresent(RequiresSiteAdmin.class);

--- a/api/src/org/labkey/api/action/SimpleViewAction.java
+++ b/api/src/org/labkey/api/action/SimpleViewAction.java
@@ -89,7 +89,7 @@ public abstract class SimpleViewAction<FORM> extends BaseViewAction<FORM> implem
             String key = pv.getName();
             Object value = pv.getValue();
             if (!ViewServlet.validChars(key))
-                throw new BadRequestException("Unrecognized unicode character in request", HttpServletResponse.SC_BAD_REQUEST, null);
+                throw new BadRequestException("Unrecognized unicode character in request");
             if (null == value)
             {
                 continue;
@@ -97,7 +97,7 @@ public abstract class SimpleViewAction<FORM> extends BaseViewAction<FORM> implem
             else if (value instanceof CharSequence)
             {
                 if (!ViewServlet.validChars((CharSequence) value))
-                    throw new BadRequestException("Unrecognized unicode character in request", HttpServletResponse.SC_BAD_REQUEST, null);
+                    throw new BadRequestException("Unrecognized unicode character in request");
             }
             else if (value.getClass().isArray())
             {
@@ -106,7 +106,7 @@ public abstract class SimpleViewAction<FORM> extends BaseViewAction<FORM> implem
                 {
                     if (item instanceof CharSequence)
                         if (!ViewServlet.validChars((CharSequence)item))
-                            throw new BadRequestException("Unrecognized unicode character in request", HttpServletResponse.SC_BAD_REQUEST, null);
+                            throw new BadRequestException("Unrecognized unicode character in request");
                 }
             }
         }

--- a/api/src/org/labkey/api/query/QuerySettings.java
+++ b/api/src/org/labkey/api/query/QuerySettings.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.query;
 
+import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -233,8 +234,15 @@ public class QuerySettings
                 setViewName(viewName);
             }
             String ignoreFilter = _getParameter(param(QueryParam.ignoreFilter));
-            if (isNotBlank(ignoreFilter))
-                _ignoreUserFilter = (Boolean) ConvertUtils.convert(ignoreFilter, Boolean.class);
+            try
+            {
+                if (isNotBlank(ignoreFilter))
+                    _ignoreUserFilter = (Boolean) ConvertUtils.convert(ignoreFilter, Boolean.class);
+            }
+            catch (ConversionException e)
+            {
+                throw new BadRequestException(String.format(parseError, "ignoreFilter", ignoreFilter), SC_BAD_REQUEST, e);
+            }
 
             String reportId = _getParameter(param(QueryParam.reportId));
             if (isNotBlank(reportId))
@@ -341,7 +349,14 @@ public class QuerySettings
         String allowHeaderLock = StringUtils.trimToNull(_getParameter(param(QueryParam.allowHeaderLock)));
         if (null != allowHeaderLock)
         {
-            setAllowHeaderLock((Boolean)ConvertUtils.convert(allowHeaderLock,Boolean.class));
+            try
+            {
+                setAllowHeaderLock((Boolean) ConvertUtils.convert(allowHeaderLock, Boolean.class));
+            }
+            catch (ConversionException e)
+            {
+                throw new BadRequestException(String.format(parseError, "allowHeaderLock", allowHeaderLock), SC_BAD_REQUEST, e);
+            }
         }
     }
 

--- a/api/src/org/labkey/api/query/QuerySettings.java
+++ b/api/src/org/labkey/api/query/QuerySettings.java
@@ -54,7 +54,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class QuerySettings
@@ -179,7 +178,7 @@ public class QuerySettings
             }
             catch (IllegalArgumentException ex)
             {
-                throw new BadRequestException(String.format(parseError, QueryParam.showRows.name(), showRowsParam), SC_BAD_REQUEST, ex);
+                throw new BadRequestException(String.format(parseError, QueryParam.showRows.name(), showRowsParam), ex);
             }
         }
     }
@@ -241,7 +240,7 @@ public class QuerySettings
             }
             catch (ConversionException e)
             {
-                throw new BadRequestException(String.format(parseError, "ignoreFilter", ignoreFilter), SC_BAD_REQUEST, e);
+                throw new BadRequestException(String.format(parseError, "ignoreFilter", ignoreFilter), e);
             }
 
             String reportId = _getParameter(param(QueryParam.reportId));
@@ -268,7 +267,7 @@ public class QuerySettings
                 }
                 catch (NumberFormatException nfe)
                 {
-                    throw new BadRequestException(String.format(parseError, "offset", offsetParam), SC_BAD_REQUEST, nfe);
+                    throw new BadRequestException(String.format(parseError, "offset", offsetParam), nfe);
                 }
             }
 
@@ -288,7 +287,7 @@ public class QuerySettings
                 }
                 catch (NumberFormatException nfe)
                 {
-                    throw new BadRequestException(String.format(parseError, "maxRows", maxRowsParam), SC_BAD_REQUEST, nfe);
+                    throw new BadRequestException(String.format(parseError, "maxRows", maxRowsParam), nfe);
                 }
             }
         }
@@ -298,7 +297,7 @@ public class QuerySettings
         {
             // fail fast
             if (null == ContainerFilter.getType(containerFilterNameParam))
-                throw new BadRequestException(String.format(parseError, "containerFilterName", containerFilterNameParam), SC_BAD_REQUEST);
+                throw new BadRequestException(String.format(parseError, "containerFilterName", containerFilterNameParam));
 
             setContainerFilterName(containerFilterNameParam);
         }
@@ -322,7 +321,7 @@ public class QuerySettings
             }
             catch (URISyntaxException | IllegalArgumentException use)
             {
-                throw new BadRequestException(String.format(parseError, "returnUrl", returnURL), SC_BAD_REQUEST, use);
+                throw new BadRequestException(String.format(parseError, "returnUrl", returnURL), use);
             }
         }
 
@@ -355,7 +354,7 @@ public class QuerySettings
             }
             catch (ConversionException e)
             {
-                throw new BadRequestException(String.format(parseError, "allowHeaderLock", allowHeaderLock), SC_BAD_REQUEST, e);
+                throw new BadRequestException(String.format(parseError, "allowHeaderLock", allowHeaderLock), e);
             }
         }
     }

--- a/api/src/org/labkey/api/security/ValidEmail.java
+++ b/api/src/org/labkey/api/security/ValidEmail.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
@@ -126,7 +127,8 @@ public class ValidEmail
             if (uidColumn != null)
             {
                 LOG.debug("Found field in users table to use to match against login form: " + uidColumn.getName());
-                Collection<Map<String, Object>> matchingUsers = new TableSelector(usersTable, new SimpleFilter(uidColumn.getFieldKey(), rawEmail), null).getMapCollection();
+                // Do a case-insensitive search for the username
+                Collection<Map<String, Object>> matchingUsers = new TableSelector(usersTable, new SimpleFilter(new SimpleFilter.SQLClause(new SQLFragment("LOWER(uid) = LOWER(?)", rawEmail), uidColumn.getFieldKey())), null).getMapCollection();
                 if (matchingUsers.size() == 1)
                 {
                     String fullEmail = (String) matchingUsers.iterator().next().get("Email");

--- a/api/src/org/labkey/api/util/HttpUtil.java
+++ b/api/src/org/labkey/api/util/HttpUtil.java
@@ -78,7 +78,7 @@ public class HttpUtil
             }
             catch (IllegalArgumentException x)
             {
-                throw new BadRequestException("Method Not Allowed", HttpServletResponse.SC_METHOD_NOT_ALLOWED, null);
+                throw new BadRequestException("Method Not Allowed", null, HttpServletResponse.SC_METHOD_NOT_ALLOWED);
             }
         }
     }

--- a/api/src/org/labkey/api/view/BadRequestException.java
+++ b/api/src/org/labkey/api/view/BadRequestException.java
@@ -16,34 +16,33 @@
 package org.labkey.api.view;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.util.SkipMothershipLogging;
 
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * Indicates that the client made a bad HTTP request, resulting in a 400 HTTP response code and avoiding much
+ * Indicates that the client made a bad HTTP request, typically resulting in a 400 HTTP response code and avoiding much
  * of the standard exception logging code for server-side bugs.
  */
 public class BadRequestException extends RuntimeException implements SkipMothershipLogging
 {
     final int status;
-    boolean _useBasicAuthentication = false;
 
-    public BadRequestException(String message, Exception x)
+    public BadRequestException(String message)
     {
-        this(StringUtils.defaultIfEmpty(message, "BAD REQUEST"), HttpServletResponse.SC_BAD_REQUEST, x);
+        this(message, null);
     }
 
-    public BadRequestException(String message, int status)
+    public BadRequestException(String message, @Nullable Exception x)
     {
-        super(message);
-        this.status = status;
+        this(message, x, HttpServletResponse.SC_BAD_REQUEST);
     }
 
-    public BadRequestException(String message, int status, Exception x)
+    public BadRequestException(String message, @Nullable Exception x, int httpStatusCode)
     {
-        super(message, x);
-        this.status = status;
+        super(StringUtils.defaultIfEmpty(message, "BAD REQUEST"), x);
+        this.status = httpStatusCode;
     }
 
     public int getStatus()

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -166,7 +166,7 @@ public class LoginController extends SpringActionController
     {
         ActionURL url = getViewContext().getActionURL();
         if (isNotBlank(url.getParameter("password")))
-            throw new BadRequestException("password is not allowed on URL", HttpServletResponse.SC_BAD_REQUEST, null);
+            throw new BadRequestException("password is not allowed on URL");
     }
 
     public static class LoginUrlsImpl implements LoginUrls

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -2059,7 +2059,7 @@ public class ExperimentController extends SpringActionController
         public Object execute(ParseForm form, BindException errors) throws Exception
         {
             if (!(getViewContext().getRequest() instanceof MultipartHttpServletRequest))
-                throw new BadRequestException("Expected MultipartHttpServletRequest when posting files.", HttpServletResponse.SC_BAD_REQUEST, null);
+                throw new BadRequestException("Expected MultipartHttpServletRequest when posting files.");
 
             MultipartFile formFile = getFileMap().get("file");
             if (formFile == null)
@@ -3753,7 +3753,7 @@ public class ExperimentController extends SpringActionController
         public boolean handlePost(Object o, BindException errors) throws Exception
         {
             if (!(getViewContext().getRequest() instanceof MultipartHttpServletRequest))
-                throw new BadRequestException("Expected MultipartHttpServletRequest when posting files.", HttpServletResponse.SC_BAD_REQUEST, null);
+                throw new BadRequestException("Expected MultipartHttpServletRequest when posting files.");
 
             if (!PipelineService.get().hasValidPipelineRoot(getContainer()))
             {


### PR DESCRIPTION
Return 400 response code for invalid query.allowHeaderLock and query.ignoreFilter parameter values

#### Rationale
In tightening up QuerySetting validation, there are a couple of boolean properties that were allowing ConversionExceptions to propagate through

#### Changes
* Turn them into BadRequestExceptions

* Reduce need to pass in default constructor arguments