### PR TITLE
Issue 40302: Unable to use samples or data class with integer like names as material or data input

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -990,7 +990,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                 {
                     String ssName = byNameSS != null ? byNameSS.getName() : null;
                     Container lookupContainer = byNameSS != null ? byNameSS.getContainer() : container;
-                    ExpMaterial material = exp.findExpMaterial(lookupContainer, user, ssName, (String)o, cache, materialCache);
+                    ExpMaterial material = exp.findExpMaterial(lookupContainer, user, byNameSS, ssName, (String)o, cache, materialCache);
                     if (material != null)
                     {
                         materialInputs.putIfAbsent(material, pd.getName());

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -246,6 +246,16 @@ public interface ExperimentService extends ExperimentRunTypeSource
     ExpDataClass getDataClass(int rowId);
 
     /**
+     * Get materials by rowId in this, project, or shared container and within the provided sample type.
+     *
+     * @param container       Samples will be found within this container, project, or shared container.
+     * @param user            Samples will only be resolved within containers that the user has ReadPermission.
+     * @param rowIds          The set of samples rowIds.
+     * @param sampleType      Optional sample type that the samples must live in.
+     */
+    List<? extends ExpMaterial> getExpMaterials(Container container, User user, Collection<Integer> rowIds, @Nullable ExpSampleType sampleType);
+
+    /**
      * Get materials with the given names, optionally within the provided sample type.
      * If the materials don't exist, throw an exception if <code>throwIfMissing</code> is true
      * or create new materials if <code>createIfMissing</code> is true, otherwise missing samples
@@ -270,6 +280,16 @@ public interface ExperimentService extends ExperimentRunTypeSource
     @Nullable
     ExpMaterial getExpMaterial(int rowid);
 
+    /**
+     * Get material by rowId in this, project, or shared container and within the provided sample type.
+     *
+     * @param container       Sample will be found within this container, project, or shared container.
+     * @param user            Sample will only be resolved within containers that the user has ReadPermission.
+     * @param rowId           The sample rowId.
+     * @param sampleType      Optional sample type that the sample must live in.
+     */
+    ExpMaterial getExpMaterial(Container c, User u, int rowId, @Nullable ExpSampleType sampleType);
+
     @NotNull List<? extends ExpMaterial> getExpMaterials(Collection<Integer> rowids);
 
     ExpMaterial getExpMaterial(String lsid);
@@ -280,11 +300,13 @@ public interface ExperimentService extends ExperimentRunTypeSource
     @NotNull List<? extends ExpMaterial> getExpMaterialsByName(String name, Container container, User user);
 
     @Nullable ExpData findExpData(Container c, User user,
+                                  @NotNull ExpDataClass dataClass,
                                   @NotNull String dataClassName, String dataName,
                                   RemapCache cache, Map<Integer, ExpData> dataCache)
             throws ValidationException;
 
     @Nullable ExpMaterial findExpMaterial(Container c, User user,
+                                          ExpSampleType sampleType,
                                           String sampleTypeName, String sampleName,
                                           RemapCache cache, Map<Integer, ExpMaterial> materialCache)
             throws ValidationException;

--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -407,22 +407,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
             //di = wrap(di, ve);
             //importData(di, ve);
 
-            //apply known columns so loader can do better type conversion
-            if (loader != null && _target != null)
-                loader.setKnownColumns(_target.getColumns());
-
-            Map<String, String> renamedColumns = getRenamedColumns();
-            if (loader != null && renamedColumns != null)
-            {
-                ColumnDescriptor[]  columnDescriptors = loader.getColumns();
-                for (ColumnDescriptor columnDescriptor : columnDescriptors)
-                {
-                    if (renamedColumns.containsKey(columnDescriptor.getColumnName()))
-                    {
-                        columnDescriptor.name = renamedColumns.get(columnDescriptor.getColumnName());
-                    }
-                }
-            }
+            configureLoader(loader);
 
             int rowCount = importData(loader, file, originalName, ve, getAuditBehaviorType());
 
@@ -443,6 +428,26 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
                 file.closeInputStream();
             if (null != dataFile && !Boolean.parseBoolean(saveToPipeline))
                 dataFile.delete();
+        }
+    }
+
+    protected void configureLoader(DataLoader loader) throws IOException
+    {
+        //apply known columns so loader can do better type conversion
+        if (loader != null && _target != null)
+            loader.setKnownColumns(_target.getColumns());
+
+        Map<String, String> renamedColumns = getRenamedColumns();
+        if (loader != null && renamedColumns != null)
+        {
+            ColumnDescriptor[]  columnDescriptors = loader.getColumns();
+            for (ColumnDescriptor columnDescriptor : columnDescriptors)
+            {
+                if (renamedColumns.containsKey(columnDescriptor.getColumnName()))
+                {
+                    columnDescriptor.name = renamedColumns.get(columnDescriptor.getColumnName());
+                }
+            }
         }
     }
 

--- a/experiment/resources/schemas/exp.xml
+++ b/experiment/resources/schemas/exp.xml
@@ -168,7 +168,6 @@
       <column columnName="EntityId"/>
       <column columnName="Created">
         <formatString>DateTime</formatString>
-        <displayWidth>0</displayWidth>
         <description>Contains the time at which this run was created</description>
       </column>
       <column columnName="CreatedBy">

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -44,6 +44,7 @@ import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExpData;
+import org.labkey.api.exp.api.ExpDataClass;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpRunItem;
 import org.labkey.api.exp.api.ExpSampleType;
@@ -418,6 +419,7 @@ public class ExpDataIterators
         final Map<String, Set<Pair<String, String>>> _parentNames;
         /** Cache sample type lookups because even though we do caching in SampleTypeService, it's still a lot of overhead to check permissions for the user */
         final Map<String, ExpSampleType> _sampleTypes = new HashMap<>();
+        final Map<String, ExpDataClass> _dataClasses = new HashMap<>();
 
         final Container _container;
         final User _user;
@@ -553,13 +555,13 @@ public class ExpDataIterators
                         if (_isSample && _context.getInsertOption().mergeRows)
                         {
                             pair = UploadSamplesHelper.resolveInputsAndOutputs(
-                                    _user, _container, runItem, parentNames, null, cache, materialCache, dataCache, _sampleTypes);
+                                    _user, _container, runItem, parentNames, null, cache, materialCache, dataCache, _sampleTypes, _dataClasses);
 
                         }
                         else
                         {
                             pair = UploadSamplesHelper.resolveInputsAndOutputs(
-                                    _user, _container, null, parentNames, null, cache, materialCache, dataCache, _sampleTypes);
+                                    _user, _container, null, parentNames, null, cache, materialCache, dataCache, _sampleTypes, _dataClasses);
 
                         }
 

--- a/experiment/src/org/labkey/experiment/api/LineageTest.java
+++ b/experiment/src/org/labkey/experiment/api/LineageTest.java
@@ -54,8 +54,10 @@ import org.labkey.api.util.TestContext;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.api.view.ViewContext;
+import org.labkey.api.view.ViewServlet;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.api.writer.DefaultContainerUser;
+import org.labkey.experiment.controllers.exp.ExperimentController;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -236,10 +238,13 @@ public class LineageTest extends ExpProvisionedTableTestHelper
     }
 
     // Issue 29361: Support updating lineage for DataClasses
+    // Issue 40302: Unable to use samples or data class with integer like names as material or data input
     @Test
     public void testUpdateLineage() throws Exception
     {
         final User user = TestContext.get().getUser();
+
+        final String numericSampleName = "100";
 
         // setup sample type
         List<GWTPropertyDescriptor> sampleProps = new ArrayList<>();
@@ -250,7 +255,7 @@ public class LineageTest extends ExpProvisionedTableTestHelper
                 "MySamples", null, sampleProps, Collections.emptyList(),
                 -1, -1, -1, -1, null, null);
         final ExpMaterial s1 = ExperimentService.get().createExpMaterial(c,
-                st.generateSampleLSID().setObjectId("S-1").toString(), "S-1");
+                st.generateSampleLSID().setObjectId(numericSampleName).toString(), numericSampleName);
         s1.setCpasType(st.getLSID());
         s1.save(user);
 
@@ -265,12 +270,12 @@ public class LineageTest extends ExpProvisionedTableTestHelper
         final String myDataClassName = "MyData";
         final ExpDataClassImpl myDataClass = ExperimentServiceImpl.get().createDataClass(c, user, myDataClassName, null, dcProps, emptyList(), null);
 
-        // Import data and derive from "S-1"
+        // Import data and derive from "100"
         List<Map<String, Object>> rows = new ArrayList<>();
         rows.add(CaseInsensitiveHashMap.of(
                 "name", "bob",
                 "age", "10",
-                "MaterialInputs/MySamples", "S-1"
+                "MaterialInputs/MySamples", numericSampleName
         ));
 
         final UserSchema schema = QueryService.get().getUserSchema(user, c, expDataSchemaKey);


### PR DESCRIPTION
#### Rationale
The magic lineage columns used in DataClass and SampleType import may contain rowId values or string values for looking up a data or material by alternate key (typically by name.)  There were two issues with resolving:

* When using the bulk tsv import method, you would receive a "Expected comma separated list or a JSONArray of parent names" error.  Since the magic columns are not known columns on the table, TabLoader would infer types of the magic columns by attempting to parse the value.   If all values are numeric, the TabLoader would parse the values as Integer while ExpDataIterator.DerivationDataIterator expects a String value or JSONArray.

* If the String can be parsed as a number, the ExperimentService.findExpMaterial() method would attempt to parse the value as an Integer to find the material by row id and return null if not found.  If the value doesn't parse as an Integer, we attempt to find by alternate key.  If the material has a numeric name, we wouldn't resolve by name.


#### Changes
* resolve lineage parent by numeric name if resolving by rowId fails
* force TabLoader to load lineage columns as strings