### PR TITLE
Issue 41281: QueryWebPart importURL parameter ignored for study datasets

### DIFF
--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -401,8 +401,7 @@ public class DatasetQueryView extends StudyQueryView
                 if (canWrite)
                 {
                     // insert menu button contain Insert New and Bulk import, or button for either option
-                    ActionURL importURL = view.getTable().getImportDataURL(getContainer());
-                    ActionButton insertButton = createInsertMenuButton(null, importURL);
+                    ActionButton insertButton = createInsertMenuButton();
                     if (insertButton != null)
                     {
                         insertButton.setDisplayPermission(InsertPermission.class);


### PR DESCRIPTION
#### Rationale
QueryWebPart supports an importURL to override the table's default action, but it's broken for study datasets

#### Changes
* Don't pass in the table's configured URL as if it were an override - let the code pull it as needed