### PR TITLE
Issue 41282: Reuse existing properties when loading domain from XML

### DIFF
--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -130,7 +130,7 @@ abstract public class DomainKind<T>  implements Handler<String>
      * @param user User
      * @return The newly created Domain.
      */
-    abstract public Domain createDomain(GWTDomain domain, T options, Container container, User user, @Nullable TemplateInfo templateInfo);
+    abstract public Domain createDomain(GWTDomain<GWTPropertyDescriptor> domain, T options, Container container, User user, @Nullable TemplateInfo templateInfo);
 
     /**
      * Update a Domain definition appropriate for this DomainKind.

--- a/internal/src/org/labkey/api/exp/property/AbstractDomainKind.java
+++ b/internal/src/org/labkey/api/exp/property/AbstractDomainKind.java
@@ -102,7 +102,7 @@ public abstract class AbstractDomainKind<T> extends DomainKind<T>
     }
 
     @Override
-    public Domain createDomain(GWTDomain domain, T arguments, Container container, User user, @Nullable TemplateInfo templateInfo)
+    public Domain createDomain(GWTDomain<GWTPropertyDescriptor> domain, T arguments, Container container, User user, @Nullable TemplateInfo templateInfo)
     {
         return null;
     }

--- a/internal/src/org/labkey/api/query/SimpleTableDomainKind.java
+++ b/internal/src/org/labkey/api/query/SimpleTableDomainKind.java
@@ -35,6 +35,7 @@ import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.xar.LsidUtils;
 import org.labkey.api.gwt.client.model.GWTDomain;
+import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.module.SimpleModule;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
@@ -252,7 +253,7 @@ public class SimpleTableDomainKind extends BaseAbstractDomainKind
     }
 
     @Override
-    public Domain createDomain(GWTDomain domain, JSONObject arguments, Container container, User user, TemplateInfo templateInfo)
+    public Domain createDomain(GWTDomain<GWTPropertyDescriptor> domain, JSONObject arguments, Container container, User user, TemplateInfo templateInfo)
     {
         String schemaName = (String)arguments.get("schemaName");
         String tableName = (String)arguments.get("tableName");


### PR DESCRIPTION
#### Rationale
The EHR makes use of extensible tables, which let each center add their own custom columns to some of the core EHR and billing tables. You can define these in XML files, which is great for initializing a new instance.

However, if you double-load the configuration from the template (perhaps because you just added a new property), it blows away all of the existing properties and recreates them, losing their data. We've had this happen a number of times already on customer servers.

#### Changes
* Reuse existing property if it's already been defined in that domain, matching on name and data type
