### PR TITLE
Allow all logged in users to fetch other user's avatars

### DIFF
--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -912,15 +912,10 @@ public class UserController extends SpringActionController
         @Override
         public @Nullable Pair<AttachmentParent, String> getAttachment(AttachmentForm form)
         {
-            boolean isUserManager = getUser().hasRootPermission(UserManagementPermission.class);
             User user = form.getUserId() == null ? null : UserManager.getUser(form.getUserId());
             if (null == user)
             {
                 throw new NotFoundException("Unable to find user");
-            }
-            else if (!isUserManager && user.getUserId() != getUser().getUserId())
-            {
-                throw new IllegalArgumentException("Unable to download user attachment");
             }
 
             return new Pair<>(new AvatarThumbnailProvider(user), form.getName());


### PR DESCRIPTION
#### Rationale
Logged in users should be able to see other user's avatars. This PR eases the restriction placed on fetching avatars so that this is possible.

#### Changes
* Ease restriction on fetching user avatars.
