### PR TITLE
Add a explicit rule for trailing ';', since this seems widespread.

### DIFF
--- a/query/src/org/labkey/query/sql/SqlBase.g
+++ b/query/src/org/labkey/query/sql/SqlBase.g
@@ -217,7 +217,7 @@ WITH : 'with';
 
 // public entry point
 parseSelect
-	: parameters? commonTableExpressions? selectStatement EOF
+	: parameters? commonTableExpressions? selectStatement SEMI? EOF
 	    -> ^(STATEMENT parameters? commonTableExpressions? selectStatement?)
 	;
 
@@ -393,7 +393,7 @@ tableAnnotations
     // | (OPEN! value=IDENT CLOSE! {addAnnotation("ContainerFilter",value);})!
 
     // Issues @ContainerFilter='CurrentAndSubfolders' R
-    / | at_annotations!
+    // | at_annotations!
     ;
 
 


### PR DESCRIPTION
#### Rationale
Allow optional ';' at end of LabKey SQL.