### PR TITLE
Mechanism that lets JSPs turn off warnings/exceptions for unencoded output

### DIFF
--- a/api/src/org/labkey/api/jsp/JspBase.java
+++ b/api/src/org/labkey/api/jsp/JspBase.java
@@ -31,7 +31,6 @@ import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.Button.ButtonBuilder;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.DemoMode;
-import org.labkey.api.util.HasHtmlString;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
@@ -176,32 +175,6 @@ public abstract class JspBase extends JspContext implements HasViewContext
     }
 
     /**
-     * Pass-through -- this eases the process of migrating our helpers from String to HtmlString, since existing
-     * code that uses text(String) will continue to compile and run when the parameter becomes an HtmlString.
-     * TODO: HtmlString - Eventually, remove this method and all usages.
-     * @param s An HtmlString
-     * @return The HtmlString
-     */
-    @Deprecated
-    public HtmlString text(HtmlString s)
-    {
-        return s;
-    }
-
-    /**
-     * Pass-through -- this eases the process of migrating our helpers from String to HasHtmlString, since existing
-     * code that uses text(String) will continue to compile and run when the parameter becomes a HasHtmlString.
-     * TODO: HtmlString - Eventually, remove this method and all usages.
-     * @param s Any object that implements HasHtmlString
-     * @return The parameter's HtmlString
-     */
-    @Deprecated
-    public HtmlString text(HasHtmlString s)
-    {
-        return s.getHtmlString();
-    }
-
-    /**
      * Html escape a string.
      * The name comes from Embedded Ruby.
      */
@@ -215,13 +188,6 @@ public abstract class JspBase extends JspContext implements HasViewContext
      * The name comes from Embedded Ruby.
      */
     public HtmlString h(Object o)
-    {
-        return HtmlString.of(o == null ? null : o.toString());
-    }
-
-    // TODO: Remove this
-    @Deprecated
-    public HtmlString h(HtmlString o)
     {
         return HtmlString.of(o == null ? null : o.toString());
     }

--- a/api/src/org/labkey/api/jsp/JspContext.java
+++ b/api/src/org/labkey/api/jsp/JspContext.java
@@ -19,6 +19,8 @@ import org.apache.jasper.runtime.HttpJspBase;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.view.HttpView;
 
+import javax.servlet.jsp.JspWriter;
+
 /**
  * User: adam
  * Date: Aug 10, 2010
@@ -46,5 +48,17 @@ public abstract class JspContext extends HttpJspBase
     public Object getModelBean()
     {
         return HttpView.currentModel();
+    }
+
+    /**
+     * Call this to allow unencoded String and Object output in development mode. Typically, this would be the first line
+     * of code in a JSP that generates non-HTML content:<br><br>
+     *     {@code out = getPermissiveJspWriter(out);}
+     * @param out Current JspWriter
+     * @return A JspWriter that doesn't log warnings or throw exceptions when rendering unencoded Strings and unsafe Objects
+     */
+    protected JspWriter getPermissiveJspWriter(JspWriter out)
+    {
+        return out instanceof LabKeyJspWriter ? ((LabKeyJspWriter) out).getWrappedJspWriter() : out;
     }
 }

--- a/api/src/org/labkey/api/jsp/JspWriterWrapper.java
+++ b/api/src/org/labkey/api/jsp/JspWriterWrapper.java
@@ -31,6 +31,11 @@ public class JspWriterWrapper extends JspWriter
         _jspWriter = jspWriter;
     }
 
+    public JspWriter getWrappedJspWriter()
+    {
+        return _jspWriter;
+    }
+
     @Override
     public void newLine() throws IOException
     {


### PR DESCRIPTION
#### Rationale
We need a way to suppress our cranky logging and exceptions, since some JSPs don't render HTML.

#### Related Pull Requests
* https://github.com/LabKey/OConnorLabModules/pull/53

#### Changes
* Specific JSPs can call `getPermissiveJspWriter(JspWriter)` to replace `out` with a warning-free JspWriter
* Remove some deprecated, unused methods
