### PR TITLE
Add URL on Mem Tracker page for active HTTP request threads

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -3301,7 +3301,13 @@ public class AdminController extends SpringActionController
                     }
 
                     if (labkeyThread)
-                        activeThreads.add(thread.getName());
+                    {
+                        String threadInfo = thread.getName();
+                        String uri = ViewServlet.getRequestURL(thread);
+                        if (null != uri)
+                            threadInfo += "; processing URL " + uri;
+                        activeThreads.add(threadInfo);
+                    }
                 }
             }
 


### PR DESCRIPTION
#### Rationale
We point out when there are active HTTP threads on the mem tracker page from the admin console. We now also include the URL that's being processed to make it easier to correlate with HTTP access logs and other troubleshooting tools