### PR TITLE
Item 7713: Add SQL dialect helper for getNumericCast()

### DIFF
--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -650,6 +650,13 @@ public abstract class SqlDialect
         return cast;
     }
 
+    public SQLFragment getNumericCast(SQLFragment expression)
+    {
+        SQLFragment cast = new SQLFragment(expression);
+        cast.setRawSQL("CAST(" + cast.getRawSQL() + " AS NUMERIC)");
+        return cast;
+    }
+
     public abstract String getRoundFunction(String valueToRound);
 
 

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -809,6 +809,13 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
         return "CONVERT(DATETIME, CONVERT(VARCHAR, (" + expression + "), 101))";
     }
 
+    public SQLFragment getNumericCast(SQLFragment expression)
+    {
+        SQLFragment cast = new SQLFragment(expression);
+        cast.setRawSQL("CAST(" + cast.getRawSQL() + " AS FLOAT)");
+        return cast;
+    }
+
     @Override
     public String getRoundFunction(String valueToRound)
     {


### PR DESCRIPTION
#### Rationale
When converting a DOUBLE PRECISION field to VARCHAR, Postgres will sometimes show extra decimal values in the resulting display value (i.e. "11.12" might become "11.11999999999999"). To work around this, you can first cast to NUMERIC and then VARCHAR, but in MSSQL that first cast type should be FLOAT.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/338
* https://github.com/LabKey/inventory/pull/86
* https://github.com/LabKey/sampleManagement/pull/360
* https://github.com/LabKey/biologics/pull/674

#### Changes
* Add SQL dialect helper for getNumericCast()
