### PR TITLE
Position XSD deprecation comments correctly

### DIFF
--- a/api/schemas/expTypes.xsd
+++ b/api/schemas/expTypes.xsd
@@ -452,7 +452,8 @@
                     <xs:documentation>If not present, equivalent to enclosing Domain's DomainURI + "#" + Name</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="OntologyURI" type="string" minOccurs="0" maxOccurs="1" /><!-- deprecated/not used -->
+            <!-- deprecated - not used -->
+            <xs:element name="OntologyURI" type="string" minOccurs="0" maxOccurs="1" />
             <xs:element name="Name" type="string" minOccurs="1" maxOccurs="1"/>
             <xs:element name="Description" type="string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="Required" type="boolean" minOccurs="0" maxOccurs="1"/>
@@ -463,8 +464,10 @@
             <xs:element name="RangeURI" type="string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="ConceptURI" type="string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="Label" type="string" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="SearchTerms" type="string" minOccurs="0" maxOccurs="1"/><!-- deprecated/not used -->
-            <xs:element name="SemanticType" type="string" minOccurs="0" maxOccurs="1"/><!-- deprecated/not used -->
+            <!-- deprecated - not used -->
+            <xs:element name="SearchTerms" type="string" minOccurs="0" maxOccurs="1"/>
+            <!-- deprecated - not used -->
+            <xs:element name="SemanticType" type="string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="Format" type="string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="URL" type="string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="FK" minOccurs="0">


### PR DESCRIPTION
#### Rationale
Bumped in to this randomly while poking around the miniassay test module.
XSD `<!-- deprecated -->` notation seems to apply to the subsequent element. If you open `testAutomation/modules/miniassay/resources/assay/simple/domains/result.xml` in IntelliJ, all of the PropertyDescriptor names are marked as deprecated.

#### Related Pull Requests
* #1524

#### Changes
* Move deprecation comments so that the correct elements are deprecated
