### PR TITLE
JspBase changes

### DIFF
--- a/api/src/org/labkey/api/jsp/JspBase.java
+++ b/api/src/org/labkey/api/jsp/JspBase.java
@@ -27,7 +27,6 @@ import org.labkey.api.action.SpringActionController;
 import org.labkey.api.action.UrlProvider;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
-import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.Button.ButtonBuilder;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.DemoMode;
@@ -710,30 +709,6 @@ public abstract class JspBase extends JspContext implements HasViewContext
     protected int getRequestScopedUID()
     {
         return UniqueID.getRequestScopedUID(getViewContext().getRequest());
-    }
-
-    /** simple link to different action in same container w/no parameters */
-    @Deprecated // Eliminate usages and delete
-    protected String buildURL(Class<? extends Controller> actionClass)
-    {
-        if (AppProps.getInstance().getUseContainerRelativeURL())
-        {
-            return new ActionURL(actionClass, getContainer()).toContainerRelativeURL();
-        }
-        ActionURL v = getActionURL();
-        ActionURL u = new ActionURL(actionClass, getContainer());
-        String full = u.getLocalURIString();
-        if (v.isCanonical() && v.getController().equals(u.getController()))
-            return full.substring(full.lastIndexOf('/')+1);
-        return full;
-    }
-
-    /** simple link to different action w/no parameters */
-    @Deprecated // Eliminate usages and delete
-    protected String buildURL(Class<? extends Controller> actionClass, String query)
-    {
-        String result = buildURL(actionClass);
-        return result + (result.endsWith("?") ? "" : "?") + query;
     }
 
     // JSPs must override addClientDependencies(ClientDependencies) to add their own dependencies.

--- a/api/src/org/labkey/api/jsp/JspContext.java
+++ b/api/src/org/labkey/api/jsp/JspContext.java
@@ -57,7 +57,7 @@ public abstract class JspContext extends HttpJspBase
      * @param out Current JspWriter
      * @return A JspWriter that doesn't log warnings or throw exceptions when rendering unencoded Strings and unsafe Objects
      */
-    protected JspWriter getPermissiveJspWriter(JspWriter out)
+    protected JspWriter getUnsafeJspWriter(JspWriter out)
     {
         return out instanceof LabKeyJspWriter ? ((LabKeyJspWriter) out).getWrappedJspWriter() : out;
     }


### PR DESCRIPTION
#### Rationale
Rename `JspBase.getPermissiveJspWriter(out)` to `getUnsafeJspWriter(out)` for consistency with other `unsafe*` methods. Remove unused `JspBase.buildURL()` methods.

#### Related Pull Requests
* https://github.com/LabKey/OConnorLabModules/pull/56
