### PR TITLE
Take first step toward setting the LabKeyJspWriter via <include-prelude>

### DIFF
--- a/api/src/org/labkey/api/jsp/JspContext.java
+++ b/api/src/org/labkey/api/jsp/JspContext.java
@@ -16,6 +16,7 @@
 package org.labkey.api.jsp;
 
 import org.apache.jasper.runtime.HttpJspBase;
+import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.view.HttpView;
 
@@ -51,11 +52,21 @@ public abstract class JspContext extends HttpJspBase
     }
 
     /**
-     * Call this to allow unencoded String and Object output in development mode. Typically, this would be the first line
-     * of code in a JSP that generates non-HTML content:<br><br>
+     * This soon will be called by every JSP to get our standard JspWriter. In production mode, this is a pass-through;
+     * in dev mode, it wraps the standard JspWriter with LabKeyJspWriter, an implementation that protects against unsafe
+     * output.
+     */
+    protected JspWriter getLabKeyJspWriter(JspWriter out)
+    {
+        return AppProps.getInstance().isDevMode() ? new LabKeyJspWriter(out) : out;
+    }
+
+    /**
+     * Call this to allow String and unsafe Object output in development mode, undoing the call above. Typically, this
+     * would be the first line of code in a JSP that generates non-HTML content:<br><br>
      *     {@code out = getPermissiveJspWriter(out);}
      * @param out Current JspWriter
-     * @return A JspWriter that doesn't log warnings or throw exceptions when rendering unencoded Strings and unsafe Objects
+     * @return A JspWriter that doesn't log warnings or throw exceptions when rendering Strings and unsafe Objects
      */
     protected JspWriter getUnsafeJspWriter(JspWriter out)
     {

--- a/api/src/org/labkey/api/reports/report/view/javaScriptReportExample.jsp
+++ b/api/src/org/labkey/api/reports/report/view/javaScriptReportExample.jsp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 %>
+<%@ page extends="org.labkey.api.jsp.JspContext" %>
 var jsDiv;
 
 // When a JavaScript report is viewed, LabKey calls the render() function, passing a query config

--- a/api/src/org/labkey/api/view/jspTemplateTest.jsp
+++ b/api/src/org/labkey/api/view/jspTemplateTest.jsp
@@ -15,4 +15,5 @@
  * limitations under the License.
  */
 %>
+<%@ page extends="org.labkey.api.jsp.JspContext" %>
 This is a JSP used by the JspTemplate.TestCase

--- a/api/src/org/labkey/api/wiki/wikiHtmlHelp.jsp
+++ b/api/src/org/labkey/api/wiki/wikiHtmlHelp.jsp
@@ -16,6 +16,7 @@
  */
 %>
 <%@ page import="org.labkey.api.view.HttpView"%>
+<%@ page extends="org.labkey.api.jsp.JspContext" %>
 <%
     boolean useVisualEditor = (Boolean)HttpView.currentView().getModelBean();
 %>

--- a/api/webapp/WEB-INF/jspWriter.jspf
+++ b/api/webapp/WEB-INF/jspWriter.jspf
@@ -1,0 +1,6 @@
+<%
+    // This JSP fragment is injected into every JSP at JSP -> Java translation time (see <jsp-config> element in web.xml).
+
+    // Use our special JspWriter in dev mode to flag unsafe output from JSPs.
+    out = getLabKeyJspWriter(out);
+%>

--- a/api/webapp/WEB-INF/web.xml
+++ b/api/webapp/WEB-INF/web.xml
@@ -223,4 +223,13 @@
         <mime-type>text/xml</mime-type>
     </mime-mapping>
 
+    <jsp-config>
+        <jsp-property-group>
+            <display-name>LabKey</display-name>
+            <url-pattern>*.jsp</url-pattern>
+            <!-- We'll uncomment the line below once we update the gradle plugin to copy jspWriter.jspf to each jspTempDir -->
+            <!--include-prelude>/WEB-INF/jspWriter.jspf</include-prelude-->
+        </jsp-property-group>
+    </jsp-config>
+
 </web-app>

--- a/experiment/src/org/labkey/experiment/api/ExperimentRunGraph2.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExperimentRunGraph2.jsp
@@ -21,6 +21,7 @@
 <%@ page import="org.labkey.api.exp.api.ExpLineageOptions" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page extends="org.labkey.api.jsp.JspContext" %>
 -- CTE comments are used as a marker to split up this file
 -- we could have multiple files, or multiple multi-line string constants, but it's easier to develop this way.
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentRunGraphForLookup2.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExperimentRunGraphForLookup2.jsp
@@ -23,6 +23,7 @@
 <%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="static org.labkey.api.util.HtmlString.unsafe" %>
+<%@ page extends="org.labkey.api.jsp.JspContext" %>
 -- CTE comments are used as a marker to split up this file
 -- we could have multiple files, or multiple multi-line string constants, but it's easier to develop this way.
 

--- a/search/src/org/labkey/search/view/testJson.jsp
+++ b/search/src/org/labkey/search/view/testJson.jsp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 %>
+<%@ page extends="org.labkey.api.jsp.JspContext" %>
 <div id="searchDiv">
     
 </div>


### PR DESCRIPTION
#### Rationale
Current approach for registering `LabKeyJspWriter` with all JSPs is quirky and unreliable. A better approach is to set LabKeyJspWriter in a JSP fragment injected via a `<include-prelude>` element in web.xml. This PR updates some simple JSPs to extend `JspContext` (so the code fragment compiles everywhere) and puts most of the registration mechanism in place. It will be enabled once the gradle plugin is updated to move the JSP fragment to every jspTempDir.

See Tomcat user mailing list thread where this approach was recommended: https://markmail.org/search/?q=list%3Aorg.apache.tomcat.user/#query:list%3Aorg.apache.tomcat.user%2F+page:1+mid:bbgenwkbgghhjii6+state:results

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/231
* https://github.com/LabKey/wnprc-modules/pull/26