### PR TITLE
Remove deprecated properties

### DIFF
--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -317,9 +317,7 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         {
             if (null == getSchemaVersion())
             {
-                // TODO: Change to an assert or exception once we no longer support old version methods/properties
-                _log.warn("getSchemaVersion() was null for module: " + getName() + " even though hasScripts() was true");
-                return;
+                throw new IllegalStateException("getSchemaVersion() was null for module: " + getName() + " even though hasScripts() was true");
             }
 
             SqlScriptProvider provider = new FileSqlScriptProvider(this);
@@ -582,17 +580,7 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        // For now, delegate to getVersion() for modules that still override that method
-        if (-1 != getVersion())
-        {
-            _log.warn("The \"" + getName() + "\" module overrides the getVersion() method, which is no longer supported. Please override getSchemaVersion() instead.");
-
-            return getVersion();
-        }
-        else
-        {
-            return _schemaVersion;
-        }
+        return _schemaVersion;
     }
 
     public final void setSchemaVersion(Double schemaVersion)
@@ -1497,80 +1485,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
             throw new IllegalStateException("Module info setters can only be called in constructor.");
     }
 
-    // TODO: Delete these getters/setters once we no longer want to support modules built with the old properties.
-    // Note that spring explodes if it sees a property in module.xml without a corresponding getter/setter pair.
-
-    @Deprecated
-    public double getVersion()
-    {
-        return -1;
-    }
-
-    public final void setVersion(double version)
-    {
-        _log.warn("Module \"" + getName() + "\" still specifies the \"version\" property; this module needs to be recompiled.");
-        setSchemaVersion(version);
-    }
-
-    // consolidateScripts property is no longer read or used. But, leave getter and setter behind for now so Spring
-    // doesn't explode if it sees this property in an old module.
-    @SuppressWarnings("unused")
-    public Boolean getConsolidateScripts()
-    {
-        return false;
-    }
-
-    @SuppressWarnings("unused")
-    public void setConsolidateScripts(Boolean consolidate)
-    {
-        _log.warn("Module \"" + getName() + "\" still specifies the \"consolidateScripts\" property; this module needs to be recompiled.");
-    }
-
-    @SuppressWarnings("unused")  // "labkeyVersion" is the old name of the property in module.xml
-    public String getLabkeyVersion()
-    {
-        return _releaseVersion;
-    }
-
-    @SuppressWarnings("unused")  // "labkeyVersion" is the old name of the property in module.xml
-    public void setLabkeyVersion(String labkeyVersion)
-    {
-        _log.warn("Module \"" + getName() + "\" still specifies the \"labkeyVersion\" property; this module needs to be recompiled.");
-        _releaseVersion = labkeyVersion;
-    }
-
-    /** @deprecated Use getVcsRevision() instead. */
-    @Deprecated
-    public final String getSvnRevision()
-    {
-        return _vcsRevision;
-    }
-
-    /** @deprecated Use setVcsRevision() instead. Available only for initializing from module.properties and config/module.xml file. */
-    @Deprecated
-    @SuppressWarnings({"UnusedDeclaration"})
-    public final void setSvnRevision(String svnRevision)
-    {
-        checkLocked();
-        _vcsRevision = svnRevision;
-    }
-
-    /** @deprecated  Use getVcsUrl() instead. */
-    @Deprecated
-    public final String getSvnUrl()
-    {
-        return _vcsUrl;
-    }
-
-    /** @deprecated Use setVcsUrl() instead. Available only for initializing from module.properties and config/module.xml file. */
-    @Deprecated
-    @SuppressWarnings({"UnusedDeclaration"})
-    public final void setSvnUrl(String svnUrl)
-    {
-        checkLocked();
-        _vcsUrl = svnUrl;
-    }
-
     public void copyPropertiesFrom(DefaultModule from)
     {
         this.setAuthor(from.getAuthor());
@@ -1583,7 +1497,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         this.setDescription(from.getDescription());
         this.setEnlistmentId(from.getEnlistmentId());
         this.setLabel(from.getLabel());
-        this.setLabkeyVersion(from.getLabkeyVersion());
         this.setLicense(from.getLicense());
         this.setLicenseUrl(from.getLicenseUrl());
         this.setMaintainer(from.getMaintainer());
@@ -1594,7 +1507,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         this.setVcsRevision(from.getVcsRevision());
         this.setVcsTag(from.getVcsTag());
         this.setVcsUrl(from.getVcsUrl());
-        this.setVersion(from.getVersion());
         this.setZippedPath(from.getZippedPath());
     }
 }


### PR DESCRIPTION
#### Rationale
In 2015, `SvnUrl` was replaced with `VcsUrl` and `SvnRevision` was replaced with `VcsRevision`. In early 2020, `Version` was replaced with `SchemaVersion`, `LabkeyVersion` was replaced with `ReleaseVersion`, and `ConsolidateScripts` was removed. We've continued to accept the old property names from `module.properties` and `config/module.xml` to maintain backward compatibility, but it's time to remove this support. Spring will now refuse to load modules that use the old property names. Module developers may need to update `module.properties` and `module.xml` files then recompile their modules to adopt to the current names.

#### Changes
* Remove DefaultModule getters and setters for five old, deprecated properties
