### PR TITLE
Fix crawler error in mothership data

### DIFF
--- a/mothership/src/org/labkey/mothership/query/MothershipSchema.java
+++ b/mothership/src/org/labkey/mothership/query/MothershipSchema.java
@@ -333,15 +333,14 @@ public class MothershipSchema extends UserSchema
         issueURL.addParameter("issueId", "${BugNumber}");
         result.getMutableColumn("BugNumber").setURL(StringExpressionFactory.createURL(issueURL));
 
-        ActionURL stack = new ActionURL(MothershipController.ShowStackTraceDetailAction.class, getContainer());
-        stack.addParameter("exceptionStackTraceId","${ExceptionStackTraceId}");
-        result.getMutableColumn("ExceptionStackTraceId").setURL(StringExpressionFactory.createURL(stack));
+        result.setTitleColumn("ExceptionStackTraceId");
+        DetailsURL url = new DetailsURL(new ActionURL(MothershipController.ShowStackTraceDetailAction.class, getContainer()), Collections.singletonMap("exceptionStackTraceId", "ExceptionStackTraceId"));
+        result.setDetailsURL(url);
+
+        result.getMutableColumn("ExceptionStackTraceId").setURL(url);
         result.getMutableColumn("ExceptionStackTraceId").setLabel("Exception");
         result.getMutableColumn("ExceptionStackTraceId").setFormat("'#'0");
         result.getMutableColumn("ExceptionStackTraceId").setExcelFormatString("0");
-
-        result.setTitleColumn("ExceptionStackTraceId");
-        result.setDetailsURL(new DetailsURL(new ActionURL(MothershipController.ShowStackTraceDetailAction.class, getContainer()), Collections.singletonMap("exceptionStackTraceId", "ExceptionStackTraceId")));
 
         result.getMutableColumn("ModifiedBy").setFk(new UserIdQueryForeignKey(this, true));
 


### PR DESCRIPTION
#### Rationale
If you go to /home/mothership-begin.view in the /Home project and change the folder filter to All Folders, you can see data from /_mothership. Clicking on a link to an exception will give you a 404 because it's targeting the current container instead of row's owning container

#### Changes
* Switch to fancier URL generation approach already in use for the details URL