### PR TITLE
7857: Apply moduleEditor feedback

### DIFF
--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -1212,16 +1212,16 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         return NULL_FILE==_resourceDirectory ? null : _resourceDirectory;
     }
 
-    // The source directory is valid if all of the following conditions are true:
-    //
-    // - devmode = true
-    // - The module's source path is a directory that exists on the web server
-    // - The module has an enlistment ID set
-    // - The module's enlistment ID matches EITHER the enlistment ID in the web server's source root OR the enlistment ID in
-    //   the module's sourcePath
-    //
-    public boolean isValidSourceDirectory()
+    protected File computeResourceDirectory()
     {
+        // We load resources from the module's source directory if all of the following conditions are true:
+        //
+        // - devmode = true
+        // - The module's source path is a directory that exists on the web server
+        // - The module has an enlistment ID set
+        // - The module's enlistment ID matches EITHER the enlistment ID in the web server's source root OR the enlistment ID in
+        //   the module's sourcePath
+        //
         if (AppProps.getInstance().isDevMode())
         {
             String sourcePath = getSourcePath();
@@ -1232,6 +1232,7 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
 
                 if (sourceDir.isDirectory())
                 {
+                    _sourcePathMatched = true;
                     String moduleEnlistmentId = getEnlistmentId();
 
                     if (StringUtils.isNotBlank(moduleEnlistmentId))
@@ -1247,22 +1248,13 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
                         }
 
                         if (useSource)
-                            return true;
+                        {
+                            _sourceEnlistmentIdMatched = true;
+                            return getResourceDirectory(sourceDir);
+                        }
                     }
                 }
             }
-        }
-        return false;
-    }
-
-    protected File computeResourceDirectory()
-    {
-        if (isValidSourceDirectory())
-        {
-            File sourceDir = new File(getSourcePath());
-            _sourcePathMatched = true;
-            _sourceEnlistmentIdMatched = true;
-            return getResourceDirectory(sourceDir);
         }
 
         File exploded = getExplodedPath();

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -1212,16 +1212,16 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         return NULL_FILE==_resourceDirectory ? null : _resourceDirectory;
     }
 
-    protected File computeResourceDirectory()
+    // The source directory is valid if all of the following conditions are true:
+    //
+    // - devmode = true
+    // - The module's source path is a directory that exists on the web server
+    // - The module has an enlistment ID set
+    // - The module's enlistment ID matches EITHER the enlistment ID in the web server's source root OR the enlistment ID in
+    //   the module's sourcePath
+    //
+    public boolean isValidSourceDirectory()
     {
-        // We load resources from the module's source directory if all of the following conditions are true:
-        //
-        // - devmode = true
-        // - The module's source path is a directory that exists on the web server
-        // - The module has an enlistment ID set
-        // - The module's enlistment ID matches EITHER the enlistment ID in the web server's source root OR the enlistment ID in
-        //   the module's sourcePath
-        //
         if (AppProps.getInstance().isDevMode())
         {
             String sourcePath = getSourcePath();
@@ -1232,7 +1232,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
 
                 if (sourceDir.isDirectory())
                 {
-                    _sourcePathMatched = true;
                     String moduleEnlistmentId = getEnlistmentId();
 
                     if (StringUtils.isNotBlank(moduleEnlistmentId))
@@ -1248,13 +1247,22 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
                         }
 
                         if (useSource)
-                        {
-                            _sourceEnlistmentIdMatched = true;
-                            return getResourceDirectory(sourceDir);
-                        }
+                            return true;
                     }
                 }
             }
+        }
+        return false;
+    }
+
+    protected File computeResourceDirectory()
+    {
+        if (isValidSourceDirectory())
+        {
+            File sourceDir = new File(getSourcePath());
+            _sourcePathMatched = true;
+            _sourceEnlistmentIdMatched = true;
+            return getResourceDirectory(sourceDir);
         }
 
         File exploded = getExplodedPath();

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -8111,9 +8111,7 @@ public class AdminController extends SpringActionController
                                         if (!rel.startsWith(".."))
                                             shortPathToModule = rel.toString();
                                     }
-                                    boolean modIsValid = (module instanceof DefaultModule) && ((DefaultModule) module).isValidSourceDirectory();
                                     ActionURL moduleEditorUrl = getModuleEditorURL(moduleContext.getName());
-                                    boolean showModuleEditor = ModuleLoader.getInstance().hasModule("ModuleEditor") && (null != moduleEditorUrl) && modIsValid;
 
                                     return TR(cl(rowCount.getAndIncrement()%2==0 ? "labkey-alternate-row" : "labkey-row").at(style,"vertical-align:top;"),
                                         TD(moduleContext.getName()),
@@ -8122,7 +8120,7 @@ public class AdminController extends SpringActionController
                                         TD(SPAN(at(title,className), className.substring(className.lastIndexOf(".")+1))),
                                         TD(SPAN(at(title,fullPathToModule),shortPathToModule)),
                                         TD(schemas.stream().map(s -> createHtmlFragment(s, BR()))),
-                                        !AppProps.getInstance().isDevMode() ? null : TD(!showModuleEditor ? NBSP : PageFlowUtil.link("Edit module").href(moduleEditorUrl)),
+                                        !AppProps.getInstance().isDevMode() ? null : TD((null == moduleEditorUrl) ? NBSP : PageFlowUtil.link("Edit module").href(moduleEditorUrl)),
                                         null == externalModulesDir ? null : TD(!replaceableModule ? NBSP : PageFlowUtil.link("Upload Module").href(getUpdateURL(moduleContext.getName()))),
                                         !hasAdminOpsPerm ? null : TD(!deleteableModule ? NBSP :  PageFlowUtil.link("Delete Module" + (schemas.isEmpty() ? "" : (" and Schema" + (schemas.size() > 1 ? "s" : "")))).href(getDeleteURL(moduleContext.getName())))
                                     );

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -8112,7 +8112,8 @@ public class AdminController extends SpringActionController
                                             shortPathToModule = rel.toString();
                                     }
                                     boolean modIsValid = (module instanceof DefaultModule) && ((DefaultModule) module).isValidSourceDirectory();
-                                    boolean showModuleEditor = ModuleLoader.getInstance().hasModule("ModuleEditor") && modIsValid;
+                                    ActionURL moduleEditorUrl = getModuleEditorURL(moduleContext.getName());
+                                    boolean showModuleEditor = ModuleLoader.getInstance().hasModule("ModuleEditor") && (null != moduleEditorUrl) && modIsValid;
 
                                     return TR(cl(rowCount.getAndIncrement()%2==0 ? "labkey-alternate-row" : "labkey-row").at(style,"vertical-align:top;"),
                                         TD(moduleContext.getName()),
@@ -8121,7 +8122,7 @@ public class AdminController extends SpringActionController
                                         TD(SPAN(at(title,className), className.substring(className.lastIndexOf(".")+1))),
                                         TD(SPAN(at(title,fullPathToModule),shortPathToModule)),
                                         TD(schemas.stream().map(s -> createHtmlFragment(s, BR()))),
-                                        !AppProps.getInstance().isDevMode() ? null : TD(!showModuleEditor ? NBSP : PageFlowUtil.link("Edit module").href(getModuleEditorURL(moduleContext.getName()))),
+                                        !AppProps.getInstance().isDevMode() ? null : TD(!showModuleEditor ? NBSP : PageFlowUtil.link("Edit module").href(moduleEditorUrl)),
                                         null == externalModulesDir ? null : TD(!replaceableModule ? NBSP : PageFlowUtil.link("Upload Module").href(getUpdateURL(moduleContext.getName()))),
                                         !hasAdminOpsPerm ? null : TD(!deleteableModule ? NBSP :  PageFlowUtil.link("Delete Module" + (schemas.isEmpty() ? "" : (" and Schema" + (schemas.size() > 1 ? "s" : "")))).href(getDeleteURL(moduleContext.getName())))
                                     );

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -8111,6 +8111,8 @@ public class AdminController extends SpringActionController
                                         if (!rel.startsWith(".."))
                                             shortPathToModule = rel.toString();
                                     }
+                                    boolean modIsValid = (module instanceof DefaultModule) && ((DefaultModule) module).isValidSourceDirectory();
+                                    boolean showModuleEditor = ModuleLoader.getInstance().hasModule("ModuleEditor") && modIsValid;
 
                                     return TR(cl(rowCount.getAndIncrement()%2==0 ? "labkey-alternate-row" : "labkey-row").at(style,"vertical-align:top;"),
                                         TD(moduleContext.getName()),
@@ -8119,7 +8121,7 @@ public class AdminController extends SpringActionController
                                         TD(SPAN(at(title,className), className.substring(className.lastIndexOf(".")+1))),
                                         TD(SPAN(at(title,fullPathToModule),shortPathToModule)),
                                         TD(schemas.stream().map(s -> createHtmlFragment(s, BR()))),
-                                        !AppProps.getInstance().isDevMode() ? null : TD(PageFlowUtil.link("Edit module").href(getModuleEditorURL(moduleContext.getName()))),
+                                        !AppProps.getInstance().isDevMode() ? null : TD(!showModuleEditor ? NBSP : PageFlowUtil.link("Edit module").href(getModuleEditorURL(moduleContext.getName()))),
                                         null == externalModulesDir ? null : TD(!replaceableModule ? NBSP : PageFlowUtil.link("Upload Module").href(getUpdateURL(moduleContext.getName()))),
                                         !hasAdminOpsPerm ? null : TD(!deleteableModule ? NBSP :  PageFlowUtil.link("Delete Module" + (schemas.isEmpty() ? "" : (" and Schema" + (schemas.size() > 1 ? "s" : "")))).href(getDeleteURL(moduleContext.getName())))
                                     );


### PR DESCRIPTION
#### Rationale
On Known Modules page, 'Edit Module' link should only be shown if moduleEditor is not included in the build, or if the relevant module is not editable.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/345
* https://github.com/LabKey/moduleEditor/pull/12

#### Changes
* Add helper function to DefaultModule
* Add checks for moduleEditor's existence and module validity before displaying 'Edit Module' link
