### PR TITLE
Mark PostgreSQL 13.x as tested. Add enum constant for JDK 16.

### DIFF
--- a/api/src/org/labkey/api/module/JavaVersion.java
+++ b/api/src/org/labkey/api/module/JavaVersion.java
@@ -34,6 +34,7 @@ public enum JavaVersion
     JAVA_13(13, true, true),
     JAVA_14(14, false, true),
     JAVA_15(15, false, true),
+    JAVA_16(16, false, false),
     JAVA_FUTURE(Integer.MAX_VALUE, false, false);
 
     private final int _version;
@@ -68,9 +69,9 @@ public enum JavaVersion
 
     public static JavaVersion get()
     {
-        // Determine current Java specification version, normalized to an int (e.g., 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16...). Commons lang
-        // methods like SystemUtils.isJavaVersionAtLeast() aren't an option because that library isn't released often enough
-        // to keep up with the Java rapid release cadence.
+        // Determine current Java specification version, normalized to an int (e.g., 10, 11, 12, 13, 14, 15, 16...).
+        // Commons lang methods like SystemUtils.isJavaVersionAtLeast() aren't an option because that library isn't
+        // released often enough to keep up with the Java rapid release cadence.
         String[] versionArray = SystemUtils.JAVA_SPECIFICATION_VERSION.split("\\.");
 
         int version = Integer.parseInt("1".equals(versionArray[0]) ? versionArray[1] : versionArray[0]);
@@ -116,9 +117,9 @@ public enum JavaVersion
             test(13, JAVA_13);
             test(14, JAVA_14);
             test(15, JAVA_15);
+            test(16, JAVA_16);
 
             // Future
-            test(16, JAVA_FUTURE);
             test(17, JAVA_FUTURE);
             test(18, JAVA_FUTURE);
             test(19, JAVA_FUTURE);

--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -21,7 +21,7 @@ public enum PostgreSqlVersion
     POSTGRESQL_10(100, false, true, PostgreSql_10_Dialect::new),
     POSTGRESQL_11(110, false, true, PostgreSql_11_Dialect::new),
     POSTGRESQL_12(120, false, true, PostgreSql_12_Dialect::new),
-    POSTGRESQL_13(130, false, false, PostgreSql_13_Dialect::new),
+    POSTGRESQL_13(130, false, true, PostgreSql_13_Dialect::new),
     POSTGRESQL_FUTURE(Integer.MAX_VALUE, true, false, PostgreSql_13_Dialect::new);
 
     private final int _version;


### PR DESCRIPTION
#### Rationale
PostgreSQL 13.x is near release (in release candidate mode) and we're in the process of testing it on TeamCity. OpenJDK 16 is currently available as an Early-Access Release.

Note: Merge will wait for PostgreSQL 13.x to be installed on TeamCity and test results confirming no major issues with PostgreSQL 13.x.

#### Changes
* Mark PostgreSQL 13.x as tested
* Add an enum constant for JDK 16 (currently marked untested)
