### PR TITLE
Just a tad less HTML encoding, thank you

### DIFF
--- a/study/src/org/labkey/study/view/specimen/manageRequest.jsp
+++ b/study/src/org/labkey/study/view/specimen/manageRequest.jsp
@@ -351,7 +351,7 @@
             }
 %>
                 <%= button("Cancel Request")
-                        .onClick("return LABKEY.Utils.confirmAndPost('" + ManageRequestBean.CANCELLATION_WARNING + "', '" + h(urlFor(DeleteRequestAction.class).addParameter("id", bean.getSpecimenRequest().getRowId()) + "')")) %>
+                        .onClick("return LABKEY.Utils.confirmAndPost('" + ManageRequestBean.CANCELLATION_WARNING + "', '" + h(urlFor(DeleteRequestAction.class).addParameter("id", bean.getSpecimenRequest().getRowId())) + "')") %>
 <%
             if (bean.getReturnUrl() != null)
             {


### PR DESCRIPTION
#### Rationale
Manage request "Cancel Request" button is unhappy, due to its JavaScript ending quote getting unintentionally HTML encoded.

#### Changes
* Move a parenthesis to stop encoding the quote
