### PR TITLE
Avoid logging session invalidation exceptions, caused by tests

### DIFF
--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -566,9 +566,10 @@ public class ExceptionUtil
             {
                 return true;
             }
-            if (ex.getClass().equals(IllegalStateException.class) &&
+            if (ex.getClass().equals(IllegalStateException.class) && ex.getMessage() != null &&
                     ("Cannot create a session after the response has been committed".equals(ex.getMessage()) ||
-                        "Cannot call sendError() after the response has been committed".equals(ex.getMessage())))
+                        "Cannot call sendError() after the response has been committed".equals(ex.getMessage()) ||
+                            ex.getMessage().contains("Session already invalidated")))
 
             {
                 return true;


### PR DESCRIPTION
Reasonably common from the crawler other automated test activity, such as:

java.lang.IllegalStateException: isNew: Session already invalidated
	at org.apache.catalina.session.StandardSession.isNew(StandardSession.java:1248) ~[catalina.jar:9.0.27]
	at org.apache.catalina.session.StandardSessionFacade.isNew(StandardSessionFacade.java:177) ~[catalina.jar:9.0.27]
	at org.labkey.api.security.AuthenticatedRequest.makeRealSession(AuthenticatedRequest.java:218) [api-20.10-SNAPSHOT.jar:20.10-SNAPSHOT]
	at org.labkey.api.security.AuthenticatedRequest.guestSession(AuthenticatedRequest.java:481) [api-20.10-SNAPSHOT.jar:20.10-SNAPSHOT]
	at org.labkey.api.security.AuthenticatedRequest.getSession(AuthenticatedRequest.java:170) [api-20.10-SNAPSHOT.jar:20.10-SNAPSHOT]

#### Rationale
These are race conditions when a request is mid-processing when the user logs out or logs in, invalidating the session that was available at the start of the request

#### Changes
* Swallow the exception in more places