### PR TITLE
Make getThreadURL() work correctly in more cases

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -1300,11 +1300,23 @@ public class AnnouncementsController extends SpringActionController
         }
     }
 
-    public static ActionURL getThreadURL(Container c, String threadId, int rowId)
+    public static ActionURL getThreadURL(Container c, @Nullable String threadEntityId, int rowId)
     {
-        ActionURL url = new ActionURL(ThreadAction.class, c);
-        url.addParameter("entityId", threadId);
-        url.addParameter("_anchor", rowId);
+        final ActionURL url;
+
+        // threadEntityId is null if called on the parent message with ann.getParent(), which several actions like doing.
+        // In this case, just pass the rowId. #41040
+        if (null == threadEntityId)
+        {
+            url = getThreadURL(c, rowId);
+        }
+        else
+        {
+            url = new ActionURL(ThreadAction.class, c);
+            url.addParameter("entityId", threadEntityId);
+            url.addParameter("_anchor", rowId);
+        }
+
         return url;
     }
 
@@ -1410,7 +1422,7 @@ public class AnnouncementsController extends SpringActionController
             // TODO: This only grabs announcementModels... add responses too?
             Pair<Collection<AnnouncementModel>, Boolean> pair = AnnouncementManager.getAnnouncements(c, filter, getSettings().getSort(), 100);
 
-            ActionURL url = getThreadURL(c, "", 0).deleteParameters().addParameter("rowId", null);
+            ActionURL url = new ActionURL(ThreadAction.class, c).addParameter("rowId", null);
 
             WebPartView v = new RssView(pair.first, url.getURIString());
 


### PR DESCRIPTION
#### Rationale
We generate incorrect announcement URLs in certain cases, particularly when dealing with the initial message, which results in bogus navtrail and redirect URLs. With this PR, `getThreadURL()` correctly handles more cases.

See https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41040