### PR TITLE
By default, throw exceptions for unsafe JSP operations

### DIFF
--- a/api/src/org/labkey/api/jsp/LabKeyJspWriter.java
+++ b/api/src/org/labkey/api/jsp/LabKeyJspWriter.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Multiset;
 import com.google.common.collect.Multiset.Entry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.labkey.api.security.User;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.ExperimentalFeatureService;
@@ -49,6 +50,15 @@ public class LabKeyJspWriter extends JspWriterWrapper
                 "Throw exceptions for JSP warnings",
                 "Enables strict checking of JSP output. For example, calling print(String) results in an IllegalStateException.",
                 false);
+        }
+    }
+
+    public static void turnOnExperimentalFeature(User user)
+    {
+        // Don't bother setting the flag in production mode since LabKeyJspWriter is registered only in development mode
+        if (AppProps.getInstance().isDevMode())
+        {
+            ExperimentalFeatureService.get().setFeatureEnabled(EXPERIMENTAL_THROW_ON_WARNING, true, user);
         }
     }
 

--- a/api/src/org/labkey/api/settings/ExperimentalFeatureService.java
+++ b/api/src/org/labkey/api/settings/ExperimentalFeatureService.java
@@ -27,9 +27,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import static org.labkey.api.settings.AppPropsImpl.EXPERIMENTAL_FEATURE_PREFIX;
 
 /**
- * Manages the list of experimental features that can be enabled or disabled within a given deployment,
- * and their current state. Generally speaking, they are not considered production-ready to be turned on, and will
- * be disabled by default.
+ * Manages the list of experimental features that can be enabled or disabled within a given deployment, and their current
+ * state. Generally speaking, they are not considered production-ready to be turned on, and will be disabled by default.
  */
 public interface ExperimentalFeatureService
 {
@@ -111,6 +110,5 @@ public interface ExperimentalFeatureService
                 }
             }
         }
-
     }
 }

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 20.001
+SchemaVersion: 20.002
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -17,11 +17,8 @@ package org.labkey.core;
 
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.admin.AdminConsoleService;
@@ -47,6 +44,7 @@ import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.property.TestDomainKind;
 import org.labkey.api.external.tools.ExternalToolsViewService;
 import org.labkey.api.files.FileContentService;
+import org.labkey.api.jsp.LabKeyJspWriter;
 import org.labkey.api.markdown.MarkdownService;
 import org.labkey.api.message.settings.MessageConfigService;
 import org.labkey.api.module.FolderType;
@@ -488,7 +486,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
     @Override
     protected Collection<WebPartFactory> createWebPartFactories()
     {
-        return new ArrayList<>(Arrays.asList(
+        return List.of(
             new AlwaysAvailableWebPartFactory("Contacts")
             {
                 @Override
@@ -666,7 +664,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                     return false;
                 }
             }
-        ));
+        );
     }
 
     @Override
@@ -700,6 +698,13 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         if (moduleContext.getInstalledVersion() < 18.30)
         {
             new CoreUpgradeCode().purgeDeveloperRole();
+        }
+
+        // Force LabKeyJspWriter to throw exceptions for unsafe operations, dev mode only.
+        // We'll remove this after 20.11, along with the experimental feature.
+        if (moduleContext.getInstalledVersion() < 20.002)
+        {
+            LabKeyJspWriter.turnOnExperimentalFeature(moduleContext.getUpgradeUser());
         }
     }
 


### PR DESCRIPTION
#### Rationale
Unsafe JSP operations deserve an exception in dev mode, so turn on the experimental feature by default. Developers can still turn off the experimental feature, until we remove it after 20.11 ships.