### PR TITLE
40664: Add startup property that creates API keys

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -125,6 +125,7 @@ public class ApiModule extends CodeOnlyModule
         SystemMaintenance.addTask(new ApiKeyMaintenanceTask());
         AuthenticationManager.registerMetricsProvider();
         LabKeyJspWriter.registerExperimentalFeature();
+        ApiKeyManager.get().handleStartupProperties();
     }
 
     @Override

--- a/api/src/org/labkey/api/security/ApiKeyManager.java
+++ b/api/src/org/labkey/api/security/ApiKeyManager.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.security;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -151,7 +152,12 @@ public class ApiKeyManager
                 if (null == user)
                     throw new ConfigurationException("Unrecognized user specified in ApiKey startup property: " + prop.getName());
 
-                createKey(user, -1, prop.getValue());
+                String apiKey = prop.getValue();
+
+                if (!StringUtils.startsWith(apiKey, "apikey|"))
+                    throw new ConfigurationException("Invalid API key specified in ApiKey startup property; API keys must start with \"apikey|\": " + apiKey);
+
+                createKey(user, -1, apiKey);
             }
             catch (InvalidEmailException e)
             {


### PR DESCRIPTION
#### Rationale
Providing a mechanism to create API keys and associate them with specific users at bootstrap time would be useful for testing remote LabKey instances plus other scenarios.

#### Changes
* Add startup property that creates API keys. Example: `ApiKey.info@labkey.com = apikey|9d6036f5e4d910a4365b4cae03b169b2`
