### PR TITLE
Fix WNPRC_EHRTests - don't fail query parsing on a metadata warning

### DIFF
--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -1041,7 +1041,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
             {
                 //noinspection ThrowableInstanceNeverThrown
                 String msgColumnName =
-                        (column.getParentTable()==null?"":column.getParentTable().getName()) +
+                        (column.getParentTable()==null?"":(column.getParentTable().getName() + ".")) +
                         column.getName();
                 qpe.add(new MetadataParseWarning("Schema " + xbColumn.getFk().getFkDbSchema() + " not found, in foreign key definition: " + msgColumnName));
                 return;

--- a/api/src/org/labkey/api/query/QueryParseException.java
+++ b/api/src/org/labkey/api/query/QueryParseException.java
@@ -52,7 +52,7 @@ public class QueryParseException extends QueryException
 
     public boolean isWarning()
     {
-        return Level.ERROR.intLevel() > _level.intLevel();
+        return Level.WARN.equals(_level);
     }
 
 


### PR DESCRIPTION
#### Rationale
Warnings are warnings. Report them as such. Don't worry about things that aren't warnings.
