### PR TITLE
Fix HTML link generation to avoid extra quote

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -103,6 +103,7 @@ import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.GUID;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.URLHelper;
@@ -2358,7 +2359,7 @@ public class AnnouncementsController extends SpringActionController
 
 
             @Override @NotNull
-            public String getFormattedValue(RenderContext ctx)
+            public HtmlString getFormattedHtml(RenderContext ctx)
             {
                 Integer userId = (Integer)getValue(ctx);
 
@@ -2367,10 +2368,10 @@ public class AnnouncementsController extends SpringActionController
                     User user = UserManager.getUser(userId);
 
                     if (null != user)
-                        return SecurityManager.getGroupList(ctx.getContainer(), user);
+                        return HtmlString.of(SecurityManager.getGroupList(ctx.getContainer(), user));
                 }
 
-                return "";
+                return HtmlString.EMPTY_STRING;
             }
         }
     }

--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -85,6 +85,8 @@ import org.labkey.api.study.assay.StudyContainerFilter;
 import org.labkey.api.study.assay.StudyDatasetColumn;
 import org.labkey.api.study.assay.ThawListResolverType;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.StringExpressionFactory;
@@ -981,7 +983,7 @@ public abstract class AssayProtocolSchema extends AssaySchema
 
         @NotNull
         @Override
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
             // Value may be a simple string (legacy), or JSON.
 
@@ -990,7 +992,7 @@ public abstract class AssayProtocolSchema extends AssaySchema
             try
             {
                 Map<String, String> decodedVals = new ObjectMapper().readValue(val.toString(), Map.class);
-                StringBuilder sb = new StringBuilder(decodedVals.remove(ParticipantVisitResolverType.Serializer.STRING_VALUE_PROPERTY_NAME));
+                HtmlStringBuilder sb = HtmlStringBuilder.of(decodedVals.remove(ParticipantVisitResolverType.Serializer.STRING_VALUE_PROPERTY_NAME));
 
                 // Issue 21126 If lookup was pasted tsv, could still get a default list entry in properties list. Fix the redisplay
                 // This addresses the issue for existing runs. New runs avoid the problem with corresponding change in ParticipantResolverType.Serializer.encode
@@ -1001,18 +1003,18 @@ public abstract class AssayProtocolSchema extends AssaySchema
                 }
                 for (Map.Entry<String, String> decodedVal : decodedVals.entrySet())
                 {
-                    sb.append("<br/>");
+                    sb.append(HtmlString.unsafe("<br/>"));
                     sb.append(StringUtils.substringAfter(decodedVal.getKey(), ThawListResolverType.NAMESPACE_PREFIX));
                     sb.append(" : ");
                     sb.append(decodedVal.getValue());
                 }
 
-                return sb.toString();
+                return sb.getHtmlString();
             }
             catch (IOException e)
             {
                 // Value wasn't JSON, was a legacy simple string. Output it
-                return  val.toString();
+                return HtmlString.of(val.toString());
             }
         }
     }

--- a/api/src/org/labkey/api/audit/data/DataMapColumn.java
+++ b/api/src/org/labkey/api/audit/data/DataMapColumn.java
@@ -15,13 +15,19 @@
  */
 package org.labkey.api.audit.data;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.AbstractAuditTypeProvider;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.RenderContext;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -35,21 +41,29 @@ public class DataMapColumn extends DataColumn
     }
 
     @Override @NotNull
-    public String getFormattedValue(RenderContext ctx)
+    public HtmlString getFormattedHtml(RenderContext ctx)
     {
-        return formatColumn(getValue(ctx), "<br>");
+        HtmlStringBuilder b = HtmlStringBuilder.of();
+        HtmlString separator = HtmlString.EMPTY_STRING;
+        for (String s : formatColumn(getValue(ctx)))
+        {
+            b.append(separator);
+            separator = HtmlString.BR;
+            b.append(s);
+        }
+        return b.getHtmlString();
     }
 
     @Override
     public String getTsvFormattedValue(RenderContext ctx)
     {
-        return formatColumn(getValue(ctx), "\n");
+        return StringUtils.join(formatColumn(getValue(ctx)), "\n");
     }
 
     @Override
     public Object getDisplayValue(RenderContext ctx)
     {
-        return formatColumn(getValue(ctx), "\n");
+        return StringUtils.join(formatColumn(getValue(ctx)), "\n");
     }
 
     @Override
@@ -64,22 +78,18 @@ public class DataMapColumn extends DataColumn
     }
 
     @NotNull
-    private String formatColumn(@Nullable Object contents, String lineBreak)
+    private List<String> formatColumn(@Nullable Object contents)
     {
         if (contents instanceof String)
         {
-            String delim = "";
-            StringBuilder sb = new StringBuilder();
+            List<String> result = new ArrayList<>();
 
             for (Map.Entry<String, String> entry : AbstractAuditTypeProvider.decodeFromDataMap((String) contents).entrySet())
             {
-                sb.append(delim);
-                sb.append(entry.getKey()).append(": ").append(entry.getValue());
-
-                delim = lineBreak;
+                result.add(entry.getKey() + ": " + entry.getValue());
             }
-            return sb.toString();
+            return result;
         }
-        return "";
+        return Collections.emptyList();
     }
 }

--- a/api/src/org/labkey/api/audit/data/DataMapDiffColumn.java
+++ b/api/src/org/labkey/api/audit/data/DataMapDiffColumn.java
@@ -24,6 +24,8 @@ import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.AliasedColumn;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.PageFlowUtil;
 
 import java.util.Collections;
 import java.util.Map;
@@ -70,21 +72,21 @@ public class DataMapDiffColumn extends AliasedColumn
         }
 
         @Override @NotNull
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
-            return formatColumn(ctx.get(_oldValues.getFieldKey()), ctx.get(_newValues.getFieldKey()), "<br>");
+            return HtmlString.unsafe(formatColumn(ctx.get(_oldValues.getFieldKey()), ctx.get(_newValues.getFieldKey()), true));
         }
 
         @Override
         public String getTsvFormattedValue(RenderContext ctx)
         {
-            return formatColumn(ctx.get(_oldValues.getFieldKey()), ctx.get(_newValues.getFieldKey()), "\n");
+            return formatColumn(ctx.get(_oldValues.getFieldKey()), ctx.get(_newValues.getFieldKey()), false);
         }
 
         @Override
         public Object getDisplayValue(RenderContext ctx)
         {
-            return formatColumn(ctx.get(_oldValues.getFieldKey()), ctx.get(_newValues.getFieldKey()), "\n");
+            return formatColumn(ctx.get(_oldValues.getFieldKey()), ctx.get(_newValues.getFieldKey()), false);
         }
 
         @Override
@@ -109,8 +111,11 @@ public class DataMapDiffColumn extends AliasedColumn
         }
 
         @NotNull
-        private String formatColumn(Object oldContent, Object newContent, String lineBreak)
+        private String formatColumn(Object oldContent, Object newContent, boolean html)
         {
+            String arrow = html ? "&nbsp;&raquo;&nbsp;" : " > ";
+            String lineBreak = html ? "<br/>" : "\n";
+
             if (oldContent != null || newContent != null)
             {
                 String delim = "";
@@ -138,8 +143,11 @@ public class DataMapDiffColumn extends AliasedColumn
                     if (!newValue.equals(oldValue))
                     {
                         sb.append(delim);
-                        sb.append(entry.getKey()).append(": ").append(oldValue);
-                        sb.append("&nbsp;&raquo;&nbsp;").append(newValue);
+                        sb.append(html ? PageFlowUtil.filter(entry.getKey()) : entry.getKey());
+                        sb.append(": ");
+                        sb.append(html ? PageFlowUtil.filter(oldValue) : oldValue);
+                        sb.append(arrow);
+                        sb.append(html ? PageFlowUtil.filter(newValue) : newValue);
 
                         delim = lineBreak;
                     }
@@ -148,14 +156,15 @@ public class DataMapDiffColumn extends AliasedColumn
                 for (Map.Entry<String, String> entry : newValues.entrySet())
                 {
                     sb.append(delim);
-                    sb.append(entry.getKey()).append(": ");
+                    sb.append(html ? PageFlowUtil.filter(entry.getKey()) : entry.getKey());
+                    sb.append(": ");
 
                     String newValue = entry.getValue();
                     if (newValue == null)
                         newValue = "";
 
-                    sb.append("&nbsp;&raquo;&nbsp;");
-                    sb.append(newValue);
+                    sb.append(arrow);
+                    sb.append(html ? PageFlowUtil.filter(newValue) : newValue);
 
                     delim = lineBreak;
                 }

--- a/api/src/org/labkey/api/data/AbstractValueTransformingDisplayColumn.java
+++ b/api/src/org/labkey/api/data/AbstractValueTransformingDisplayColumn.java
@@ -16,6 +16,7 @@
 package org.labkey.api.data;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 
 /**
@@ -78,9 +79,9 @@ public abstract class AbstractValueTransformingDisplayColumn<RawDataType, Transf
     }
 
     @Override
-    public @NotNull String getFormattedValue(RenderContext ctx)
+    public @NotNull HtmlString getFormattedHtml(RenderContext ctx)
     {
-        return PageFlowUtil.filter(getDisplayValue(ctx));
+        return HtmlString.of(getDisplayValue(ctx));
     }
 
     /** Convert from the raw database value to however it should be presented */

--- a/api/src/org/labkey/api/data/ContainerDisplayColumn.java
+++ b/api/src/org/labkey/api/data/ContainerDisplayColumn.java
@@ -34,6 +34,7 @@ import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.test.TestWhen;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.view.ActionURL;
@@ -179,12 +180,12 @@ public class ContainerDisplayColumn extends DataColumn
     }
 
     @Override @NotNull
-    public String getFormattedValue(RenderContext ctx)
+    public HtmlString getFormattedHtml(RenderContext ctx)
     {
         String displayValue = getDisplayValue(ctx).toString();
         if (getRequiresHtmlFiltering())
-            displayValue = PageFlowUtil.filter(displayValue);
-        return displayValue;
+            return HtmlString.of(displayValue);
+        return HtmlString.unsafe(displayValue);
     }
 
     @Override

--- a/api/src/org/labkey/api/data/ContainerTable.java
+++ b/api/src/org/labkey/api/data/ContainerTable.java
@@ -33,6 +33,8 @@ import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.UserIdQueryForeignKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.settings.AppProps;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.SimpleNamedObject;
@@ -309,13 +311,18 @@ public class ContainerTable extends FilteredTable<UserSchema>
         }
 
         @Override
-        public @NotNull String getFormattedValue(RenderContext ctx)
+        public @NotNull HtmlString getFormattedHtml(RenderContext ctx)
         {
             String img = (String)getValue(ctx);
             String a = renderURL(ctx);
             if (null == img || null == a)
-                return "";
-            return "<div class=\"tool-icon thumb-wrap thumb-wrap-bottom\"><a href=\"" + PageFlowUtil.filter(a) + "\"><div class=\"thumb-img-bottom\"><img class=\"thumb-large\" src=\"" + PageFlowUtil.filter(img) + "\"></div></a></div>";
+                return HtmlString.EMPTY_STRING;
+            return
+                    HtmlStringBuilder.of(HtmlString.unsafe("<div class=\"tool-icon thumb-wrap thumb-wrap-bottom\"><a href=\"")).
+                            append(a).
+                            append(HtmlString.unsafe("\"><div class=\"thumb-img-bottom\"><img class=\"thumb-large\" src=\"")).
+                            append(img).
+                            append(HtmlString.unsafe("\"></div></a></div>")).getHtmlString();
         }
     }
 

--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -34,6 +34,7 @@ import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.stats.AnalyticsProviderRegistry;
 import org.labkey.api.stats.ColumnAnalyticsProvider;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.Link;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringExpression;
@@ -373,7 +374,7 @@ public class DataColumn extends DisplayColumn
         {
             String url = renderURLorValueURL(ctx);
 
-            HtmlString formattedValue = HtmlString.unsafe(getFormattedValue(ctx));
+            HtmlString formattedValue = getFormattedHtml(ctx);
 
             if (StringUtils.isNotBlank(url))
             {
@@ -527,9 +528,9 @@ public class DataColumn extends DisplayColumn
     }
 
     @Override @NotNull
-    public String getFormattedValue(RenderContext ctx)
+    public HtmlString getFormattedHtml(RenderContext ctx)
     {
-        StringBuilder sb = new StringBuilder();
+        HtmlStringBuilder hsb = HtmlStringBuilder.of();
         Object value = ctx.get(_displayColumn.getFieldKey());
         if (value == null)
         {
@@ -544,11 +545,11 @@ public class DataColumn extends DisplayColumn
                 // In many entry paths we've already checked for null, but not all (for example, MVDisplayColumn or when the TargetStudy no longer exists or is empty string)
                 if (boundValue == null || "".equals(boundValue))
                 {
-                    sb.append("&nbsp;");
+                    hsb.append(HtmlString.NBSP);
                 }
                 else
                 {
-                    sb.append(PageFlowUtil.filter("<" + boundValue + ">"));
+                    hsb.append("<" + boundValue + ">");
                 }
             }
         }
@@ -560,16 +561,16 @@ public class DataColumn extends DisplayColumn
                 formatted = PageFlowUtil.filter(formatted);
 
             if (formatted.length() == 0)
-                formatted = "&nbsp;";
+                hsb.append(HtmlString.NBSP);
             else if (isPreserveNewlines())
                 formatted = formatted.replaceAll("\\n", "<br>\n");
             else if (value instanceof Date)
-                formatted = "<nobr>" + formatted + "</nobr>";
+                hsb.append("<nobr>" + formatted + "</nobr>");
 
-            sb.append(formatted);
+            hsb.append(HtmlString.unsafe(formatted));
         }
 
-        return sb.toString();
+        return hsb.getHtmlString();
     }
 
     protected boolean isDisabledInput()

--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -34,6 +34,7 @@ import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.stats.AnalyticsProviderRegistry;
 import org.labkey.api.stats.ColumnAnalyticsProvider;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.Link;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.StringExpressionFactory;
@@ -372,54 +373,48 @@ public class DataColumn extends DisplayColumn
         {
             String url = renderURLorValueURL(ctx);
 
+            HtmlString formattedValue = HtmlString.unsafe(getFormattedValue(ctx));
+
             if (StringUtils.isNotBlank(url))
             {
-                out.write("<a href=\"");
-                out.write(PageFlowUtil.filter(url));
+                Link.LinkBuilder link = new Link.LinkBuilder(formattedValue).href(url).clearClasses();
 
                 String linkTitle = renderURLTitle(ctx);
                 if (null != linkTitle)
                 {
-                    out.write("\" title=\"");
-                    out.write(linkTitle);
+                    link.title(linkTitle);
                 }
 
                 String linkTarget = getLinkTarget();
                 if (null != linkTarget)
                 {
-                    out.write("\" target=\"");
-                    out.write(linkTarget);
-                    out.write("\" rel=\"noopener noreferrer");
+                    link.target(linkTarget).rel("noopener noreferrer");
                 }
 
                 String linkCls = getLinkCls();
                 if (null != linkCls)
                 {
-                    out.write("\" class=\"");
-                    out.write(linkCls);
+                    link.addClass(linkCls);
                 }
 
                 String onClick = getOnClick();
                 if (null != onClick)
                 {
-                    out.write("\" onclick=\"");
-                    out.write(onClick);
+                    link.onClick(onClick);
                 }
 
                 String css = getCssStyle(ctx);
                 if (!css.isEmpty())
                 {
-                    out.write("\" style=\"");
-                    out.write(css);
+                    link.style(css);
                 }
 
-                out.write("\">");
+                link.build().appendTo(out);
             }
-
-            out.write(getFormattedValue(ctx));
-
-            if (null != url)
-                out.write("</a>");
+            else
+            {
+                formattedValue.appendTo(out);
+            }
         }
         else
             out.write("&nbsp;");

--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -389,7 +389,7 @@ public class DataColumn extends DisplayColumn
                 {
                     out.write("\" target=\"");
                     out.write(linkTarget);
-                    out.write("\" rel=\"noopener noreferrer\"");
+                    out.write("\" rel=\"noopener noreferrer");
                 }
 
                 String linkCls = getLinkCls();

--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -561,7 +561,7 @@ public class DataColumn extends DisplayColumn
                 formatted = PageFlowUtil.filter(formatted);
 
             if (formatted.length() == 0)
-                hsb.append(HtmlString.NBSP);
+                formatted = "&nbsp;";
             else if (isPreserveNewlines())
                 formatted = formatted.replaceAll("\\n", "<br>\n");
             else if (value instanceof Date)

--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -565,7 +565,7 @@ public class DataColumn extends DisplayColumn
             else if (isPreserveNewlines())
                 formatted = formatted.replaceAll("\\n", "<br>\n");
             else if (value instanceof Date)
-                hsb.append("<nobr>" + formatted + "</nobr>");
+                formatted = "<nobr>" + formatted + "</nobr>";
 
             hsb.append(HtmlString.unsafe(formatted));
         }

--- a/api/src/org/labkey/api/data/DisplayColumn.java
+++ b/api/src/org/labkey/api/data/DisplayColumn.java
@@ -30,6 +30,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.stats.ColumnAnalyticsProvider;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.Formats;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.StringExpressionFactory;
@@ -413,27 +414,13 @@ public abstract class DisplayColumn extends RenderColumn
      * Format the display value as html for rendering within the DataRegion grid,
      * including encoding html.
      *
-     * @deprecated Use getFormattedHtml instead.
      * @return the HTML version of this column's value.
      */
-    @Deprecated
     @NotNull
-    public String getFormattedValue(RenderContext ctx)
+    public HtmlString getFormattedHtml(RenderContext ctx)
     {
         Format format = getFormat();
-        return formatValue(ctx, getDisplayValue(ctx), getTextExpressionCompiled(ctx), format);
-    }
-
-    /**
-     * Format the display value as html for rendering within the DataRegion grid,
-     * including encoding html.
-     *
-     * @see #getFormattedText(RenderContext)
-     */
-    @NotNull
-    public String getFormattedHtml(RenderContext ctx)
-    {
-        return getFormattedValue(ctx);
+        return HtmlString.of(formatValue(ctx, getDisplayValue(ctx), getTextExpressionCompiled(ctx), format));
     }
 
     /**

--- a/api/src/org/labkey/api/data/DisplayColumnDecorator.java
+++ b/api/src/org/labkey/api/data/DisplayColumnDecorator.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.roles.Role;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.view.ViewContext;
 
@@ -291,9 +292,9 @@ public class DisplayColumnDecorator extends DisplayColumn
     }
 
     @Override @NotNull
-    public String getFormattedValue(RenderContext ctx)
+    public HtmlString getFormattedHtml(RenderContext ctx)
     {
-        return _column.getFormattedValue(ctx);
+        return _column.getFormattedHtml(ctx);
     }
 
     @Override

--- a/api/src/org/labkey/api/data/ExcelColumn.java
+++ b/api/src/org/labkey/api/data/ExcelColumn.java
@@ -431,7 +431,7 @@ public class ExcelColumn extends RenderColumn
                     break;
 
                 case TYPE_BOOLEAN:
-                    String s = _dc.getFormattedValue(ctx);
+                    String s = _dc.getTsvFormattedValue(ctx);
                     cell.setCellValue(s);
                     if (_style != null)
                         cell.setCellStyle(_style);

--- a/api/src/org/labkey/api/data/ExpandableTextDisplayColumnFactory.java
+++ b/api/src/org/labkey/api/data/ExpandableTextDisplayColumnFactory.java
@@ -17,6 +17,7 @@ package org.labkey.api.data;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.template.ClientDependency;
 
@@ -41,11 +42,11 @@ public class ExpandableTextDisplayColumnFactory implements DisplayColumnFactory
 
         @NotNull
         @Override
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
             Object value = getValueFromCtx(ctx);
             if (null == value)
-                return "";
+                return HtmlString.EMPTY_STRING;
 
             return getFormattedOutputText(value.toString(), 10, 500);
         }
@@ -61,7 +62,7 @@ public class ExpandableTextDisplayColumnFactory implements DisplayColumnFactory
             return value;
         }
 
-        protected String getFormattedOutputText(String value, @Nullable Integer maxLineCount, @Nullable Integer maxCharCount)
+        protected HtmlString getFormattedOutputText(String value, @Nullable Integer maxLineCount, @Nullable Integer maxCharCount)
         {
             // Too bad there's no way to configure EOL characters for the Jackson pretty printer.
             // It seems to use system defaults.
@@ -84,7 +85,7 @@ public class ExpandableTextDisplayColumnFactory implements DisplayColumnFactory
                         + "</div>";
             }
 
-            return outputTxt;
+            return HtmlString.unsafe(outputTxt);
         }
 
         @NotNull

--- a/api/src/org/labkey/api/data/HtmlDisplayColumnFactory.java
+++ b/api/src/org/labkey/api/data/HtmlDisplayColumnFactory.java
@@ -16,6 +16,7 @@
 package org.labkey.api.data;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 
 import java.util.ArrayList;
@@ -43,18 +44,18 @@ public class HtmlDisplayColumnFactory implements DisplayColumnFactory
 
         @NotNull
         @Override
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
             Object value = ctx.get(getBoundColumn().getFieldKey());
             if (null == value)
-                return "";
+                return HtmlString.EMPTY_STRING;
             String rawHtml = String.valueOf(value);
             ArrayList<String> errors = new ArrayList<>();
             String tidyHtml = PageFlowUtil.validateHtml(rawHtml, errors, false);
             if (errors.isEmpty())
-                return tidyHtml;
+                return HtmlString.unsafe(tidyHtml);
             else
-                return PageFlowUtil.filter(errors.get(0));
+                return HtmlString.of(errors.get(0));
         }
     }
 }

--- a/api/src/org/labkey/api/data/JavaScriptDisplayColumn.java
+++ b/api/src/org/labkey/api/data/JavaScriptDisplayColumn.java
@@ -74,7 +74,7 @@ public class JavaScriptDisplayColumn extends DataColumn
             if (eventExpressionEvalResult != null)
                 out.write(eventExpressionEvalResult);
             out.write(">");
-            out.write(getFormattedValue(ctx));
+            getFormattedHtml(ctx).appendTo(out);
             out.write("</a>");
         }
         else

--- a/api/src/org/labkey/api/data/JsonPrettyPrintDisplayColumnFactory.java
+++ b/api/src/org/labkey/api/data/JsonPrettyPrintDisplayColumnFactory.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.util.HtmlString;
 
 import java.io.IOException;
 
@@ -44,11 +45,11 @@ public class JsonPrettyPrintDisplayColumnFactory extends ExpandableTextDisplayCo
 
         @NotNull
         @Override
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
             Object value = getValueFromCtx(ctx);
             if (null == value)
-                return "";
+                return HtmlString.EMPTY_STRING;
 
             ObjectMapper mapper = new ObjectMapper();
             DefaultPrettyPrinter pp = new DefaultPrettyPrinter();
@@ -61,7 +62,7 @@ public class JsonPrettyPrintDisplayColumnFactory extends ExpandableTextDisplayCo
             }
             catch (IOException e)
             {
-                return "Bad JSON object";
+                return HtmlString.of("Bad JSON object");
             }
         }
     }

--- a/api/src/org/labkey/api/data/MVDisplayColumn.java
+++ b/api/src/org/labkey/api/data/MVDisplayColumn.java
@@ -17,6 +17,7 @@
 package org.labkey.api.data;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 
 import java.io.IOException;
@@ -73,9 +74,9 @@ public class MVDisplayColumn extends DataColumn
             String popupText = PageFlowUtil.filter(MvUtil.getMvLabel(mvIndicator, ctx.getContainer()));
 
             // If we have a raw value, include it in the popup
-            String value = super.getFormattedValue(ctx);
-            if (!"".equals(value))
-                popupText += ("<p>The value as originally entered was: '" + PageFlowUtil.filter(value) + "'.</p>");
+            HtmlString value = super.getFormattedHtml(ctx);
+            if (value.length() != 0)
+                popupText += ("<p>The value as originally entered was: '" + value.toString() + "'.</p>");
 
             out.write("<font class=\"labkey-mv\">");
             out.write(PageFlowUtil.helpPopup("Missing Value Indicator: " + mvIndicator, popupText, true, h(mvIndicator)));
@@ -127,11 +128,11 @@ public class MVDisplayColumn extends DataColumn
     }
 
     @Override @NotNull
-    public String getFormattedValue(RenderContext ctx)
+    public HtmlString getFormattedHtml(RenderContext ctx)
     {
         if (getMvIndicator(ctx) != null)
-            return "";
-        return super.getFormattedValue(ctx);
+            return HtmlString.EMPTY_STRING;
+        return super.getFormattedHtml(ctx);
     }
 
     @Override

--- a/api/src/org/labkey/api/data/OutOfRangeDisplayColumn.java
+++ b/api/src/org/labkey/api/data/OutOfRangeDisplayColumn.java
@@ -19,6 +19,8 @@ package org.labkey.api.data;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -70,7 +72,13 @@ public class OutOfRangeDisplayColumn extends DataColumn
     }
 
     @Override @NotNull
-    public String getFormattedValue(RenderContext ctx)
+    public HtmlString getFormattedHtml(RenderContext ctx)
+    {
+        return HtmlStringBuilder.of(getOORPrefix(ctx)).append(super.getFormattedHtml(ctx)).getHtmlString();
+    }
+
+    @NotNull
+    private String getOORPrefix(RenderContext ctx)
     {
         StringBuilder result = new StringBuilder();
         if (_oorIndicatorColumn != null)
@@ -78,10 +86,7 @@ public class OutOfRangeDisplayColumn extends DataColumn
             Object oorValue = _oorIndicatorColumn.getValue(ctx);
             if (oorValue != null)
             {
-                if (getRequiresHtmlFiltering())
-                    result.append(h(oorValue));
-                else
-                    result.append(oorValue);
+                result.append(oorValue);
             }
         }
         else
@@ -101,41 +106,22 @@ public class OutOfRangeDisplayColumn extends DataColumn
             if (row == 1)
             {
                 String msg = "<missing column " + getColumnInfo().getName() + OORDisplayColumnFactory.OOR_INDICATOR_COLUMN_SUFFIX + ">";
-                if (getRequiresHtmlFiltering())
-                    result.append(h(msg));
-                else
-                    result.append(msg);
+                result.append(msg);
             }
         }
-        result.append(super.getFormattedValue(ctx));
         return result.toString();
     }
 
     @Override
     public Object getDisplayValue(RenderContext ctx)
     {
-        return getFormattedValue(ctx);
+        return getOORPrefix(ctx) + super.getDisplayValue(ctx);
     }
 
     @Override
     public String getTsvFormattedValue(RenderContext ctx)
     {
-        return getFormattedValue(ctx);
-    }
-
-    @Override
-    public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
-    {
-        String value = getFormattedValue(ctx);
-
-        if ("".equals(value.trim()))
-        {
-            out.write("&nbsp;");
-        }
-        else
-        {
-            out.write(value);
-        }
+        return getOORPrefix(ctx) + super.getTsvFormattedValue(ctx);
     }
 
     @Override

--- a/api/src/org/labkey/api/data/WhitespacePreservingDisplayColumnFactory.java
+++ b/api/src/org/labkey/api/data/WhitespacePreservingDisplayColumnFactory.java
@@ -16,6 +16,7 @@
 package org.labkey.api.data;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 
 /**
@@ -41,7 +42,7 @@ public class WhitespacePreservingDisplayColumnFactory implements DisplayColumnFa
 
         @NotNull
         @Override
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
             Object value = ctx.get(getDisplayColumn().getFieldKey());
             if (value == null)
@@ -52,9 +53,9 @@ public class WhitespacePreservingDisplayColumnFactory implements DisplayColumnFa
 
             if (value == null)
             {
-                return "&nbsp;";
+                return HtmlString.NBSP;
             }
-            return PageFlowUtil.filter(value.toString(), true, false);
+            return HtmlString.of(value.toString(), true);
         }
     }
 }

--- a/api/src/org/labkey/api/query/UserIdRenderer.java
+++ b/api/src/org/labkey/api/query/UserIdRenderer.java
@@ -21,6 +21,7 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.security.UserManager;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.view.ActionURL;
 
 import java.util.Objects;
@@ -44,11 +45,11 @@ public class UserIdRenderer extends DataColumn
         }
 
         @Override @NotNull
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
             if (isGuestUserId(getBoundColumn().getValue(ctx)))
-                return "&nbsp;";
-            return super.getFormattedValue(ctx);
+                return HtmlString.NBSP;
+            return super.getFormattedHtml(ctx);
         }
     }
 
@@ -58,13 +59,13 @@ public class UserIdRenderer extends DataColumn
     }
 
     @Override @NotNull
-    public String getFormattedValue(RenderContext ctx)
+    public HtmlString getFormattedHtml(RenderContext ctx)
     {
         if (isGuestUserId(getBoundColumn().getValue(ctx)))
         {
-            return "Guest";
+            return HtmlString.of("Guest");
         }
-        return super.getFormattedValue(ctx);
+        return super.getFormattedHtml(ctx);
     }
 
     @Override

--- a/api/src/org/labkey/api/util/HtmlString.java
+++ b/api/src/org/labkey/api/util/HtmlString.java
@@ -25,9 +25,10 @@ import java.util.Objects;
 public final class HtmlString implements SafeToRender, DOM.Renderable, Comparable<HtmlString>
 {
     // Helpful constants for convenience (and efficiency)
-    public static HtmlString EMPTY_STRING = HtmlString.of("");
-    public static HtmlString NBSP = HtmlString.unsafe("&nbsp;");
-    public static HtmlString NDASH = HtmlString.unsafe("&ndash;");
+    public static final HtmlString EMPTY_STRING = HtmlString.of("");
+    public static final HtmlString NBSP = HtmlString.unsafe("&nbsp;");
+    public static final HtmlString NDASH = HtmlString.unsafe("&ndash;");
+    public static final HtmlString BR = HtmlString.unsafe("<br/>");
 
     private final @NotNull String _s;
 
@@ -36,9 +37,14 @@ public final class HtmlString implements SafeToRender, DOM.Renderable, Comparabl
      * @param s A String. A null value results in an empty HtmlString (equivalent of HtmlString.of("")).
      * @return An HtmlString that encodes and wraps the String.
      */
-    public static @NotNull HtmlString of(@Nullable String s)
+    public static @NotNull HtmlString of(@Nullable CharSequence s)
     {
         return new HtmlString(PageFlowUtil.filter(s));
+    }
+
+    public static @NotNull HtmlString of(@Nullable Object o)
+    {
+        return of(o == null ? null : o.toString());
     }
 
     /**
@@ -48,7 +54,7 @@ public final class HtmlString implements SafeToRender, DOM.Renderable, Comparabl
      * @param translateWhiteSpace A flag that determines whether whitespace should be encoded or not
      * @return An HtmlString that encodes and wraps the String, respecting the translateWhiteSpace flag.
      */
-    public static @NotNull HtmlString of(@Nullable String s, boolean translateWhiteSpace)
+    public static @NotNull HtmlString of(@Nullable CharSequence s, boolean translateWhiteSpace)
     {
         return new HtmlString(PageFlowUtil.filter(s, translateWhiteSpace));
     }

--- a/api/src/org/labkey/api/util/HtmlString.java
+++ b/api/src/org/labkey/api/util/HtmlString.java
@@ -34,7 +34,7 @@ public final class HtmlString implements SafeToRender, DOM.Renderable, Comparabl
 
     /**
      * Returns an HtmlString that wraps an HTML encoded version of the passed in String.
-     * @param s A String. A null value results in an empty HtmlString (equivalent of HtmlString.of("")).
+     * @param s A char sequence. A null value results in an empty HtmlString (equivalent of HtmlString.of("")).
      * @return An HtmlString that encodes and wraps the String.
      */
     public static @NotNull HtmlString of(@Nullable CharSequence s)

--- a/api/src/org/labkey/api/util/HtmlString.java
+++ b/api/src/org/labkey/api/util/HtmlString.java
@@ -50,7 +50,7 @@ public final class HtmlString implements SafeToRender, DOM.Renderable, Comparabl
     /**
      * Returns an HtmlString that wraps an HTML encoded version of the passed in String, with the option to preserve
      * whitespace.
-     * @param s A String. A null value results in an empty HtmlString (equivalent of HtmlString.of("")).
+     * @param s A char sequence. A null value results in an empty HtmlString (equivalent of HtmlString.of("")).
      * @param translateWhiteSpace A flag that determines whether whitespace should be encoded or not
      * @return An HtmlString that encodes and wraps the String, respecting the translateWhiteSpace flag.
      */

--- a/api/src/org/labkey/api/util/HtmlStringBuilder.java
+++ b/api/src/org/labkey/api/util/HtmlStringBuilder.java
@@ -50,6 +50,16 @@ public class HtmlStringBuilder implements HasHtmlString, SafeToRender
         return this;
     }
 
+    public HtmlStringBuilder append(int i)
+    {
+        return append(Integer.toString(i));
+    }
+
+    public HtmlStringBuilder append(long l)
+    {
+        return append(Long.toString(l));
+    }
+
     public HtmlStringBuilder append(HtmlString hs)
     {
         _sb.append(hs.toString());

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -200,7 +200,7 @@ public class PageFlowUtil
 
 
     /** HTML encode a string */
-    static public String filter(String s, boolean encodeSpace, boolean encodeLinks)
+    static public String filter(CharSequence s, boolean encodeSpace, boolean encodeLinks)
     {
         if (null == s || 0 == s.length())
             return "";
@@ -262,7 +262,7 @@ public class PageFlowUtil
                 case 'm':
                     if (encodeLinks)
                     {
-                        String sub = s.substring(i);
+                        CharSequence sub = s.subSequence(i, s.length() - 1);
                         if (StringUtilsLabKey.startsWithURL(sub))
                         {
                             Matcher m = urlPatternStart.matcher(sub);
@@ -309,14 +309,14 @@ public class PageFlowUtil
     /**
      * HTML encode a string
      */
-    public static String filter(String s)
+    public static String filter(CharSequence s)
     {
         return filter(s, false, false);
     }
 
 
     /** HTML encode a string */
-    static public String filter(String s, boolean translateWhiteSpace)
+    static public String filter(CharSequence s, boolean translateWhiteSpace)
     {
         return filter(s, translateWhiteSpace, false);
     }

--- a/api/src/org/labkey/api/util/StringUtilsLabKey.java
+++ b/api/src/org/labkey/api/util/StringUtilsLabKey.java
@@ -142,7 +142,7 @@ public class StringUtilsLabKey
     /** Recognizes strings that start with http://, https://, ftp://, or mailto: */
     private static final String[] URL_PREFIXES = {"http://", "https://", "ftp://", "mailto:"};
 
-    public static boolean startsWithURL(String s)
+    public static boolean startsWithURL(CharSequence s)
     {
         if (s != null)
         {

--- a/api/src/org/labkey/api/wiki/WikiRendererDisplayColumn.java
+++ b/api/src/org/labkey/api/wiki/WikiRendererDisplayColumn.java
@@ -22,6 +22,7 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.HtmlString;
 
 import java.util.Set;
 
@@ -49,16 +50,16 @@ public class WikiRendererDisplayColumn extends DataColumn
     @Override
     public Object getDisplayValue(RenderContext ctx)
     {
-        return getFormattedValue(ctx);
+        return getFormattedHtml(ctx);
     }
 
     @Override @NotNull
-    public String getFormattedValue(RenderContext ctx)
+    public HtmlString getFormattedHtml(RenderContext ctx)
     {
         WikiRenderingService wikiService = WikiRenderingService.get();
         String content = (String) getValue(ctx);
         if (null == content)
-            return "&nbsp";
+            return HtmlString.NBSP;
 
         WikiRendererType rendererType = _defaultRenderer;
         Object rendererTypeName = ctx.get(getRenderTypeFieldKey());
@@ -74,7 +75,7 @@ public class WikiRendererDisplayColumn extends DataColumn
             }
         }
 
-        return wikiService.getFormattedHtml(rendererType, content).toString();
+        return wikiService.getFormattedHtml(rendererType, content);
     }
 
     private FieldKey getRenderTypeFieldKey()

--- a/issues/src/org/labkey/issue/query/CommentsTable.java
+++ b/issues/src/org/labkey/issue/query/CommentsTable.java
@@ -34,6 +34,8 @@ import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.query.UserIdForeignKey;
 import org.labkey.api.security.User;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.view.ActionURL;
 import org.labkey.issue.IssuesController;
 import org.labkey.issue.model.Issue;
@@ -84,15 +86,15 @@ public class CommentsTable extends FilteredTable<IssuesQuerySchema>
             {
                 DataColumn dc = new DataColumn(colInfo) {
                     @Override @NotNull
-                    public String getFormattedValue(RenderContext ctx)
+                    public HtmlString getFormattedHtml(RenderContext ctx)
                     {
-                        String html = super.getFormattedValue(ctx);
+                        HtmlString html = super.getFormattedHtml(ctx);
 
                         // Comment HTML is stored in the database, so use an HTML5 scoped style tag to remove the borders
                         // Unconventional, but this seems to be supported on most browsers
-                        String inline = "<style type=\"text/css\" scoped>table.issues-Changes td {border:none;}</style>";
-
-                        return "<span>" + inline + "</span>" + html;
+                        return HtmlString.unsafe(
+                                "<span><style type=\"text/css\" scoped>table.issues-Changes td {border:none;}</style></span>" +
+                                html);
                     }
                 };
                 dc.setRequiresHtmlFiltering(false);
@@ -142,10 +144,10 @@ public class CommentsTable extends FilteredTable<IssuesQuerySchema>
 
         @NotNull
         @Override
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
             String title = getIssueTitle(ctx);
-            return title != null ? title : super.getFormattedValue(ctx);
+            return title != null ? HtmlString.of(title) : super.getFormattedHtml(ctx);
         }
 
         @Nullable

--- a/mothership/src/org/labkey/mothership/MothershipController.java
+++ b/mothership/src/org/labkey/mothership/MothershipController.java
@@ -50,6 +50,7 @@ import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.GUID;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.MothershipReport;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
@@ -1439,7 +1440,7 @@ public class MothershipController extends SpringActionController
             DataColumn replacementServerInstallationColumn = new DataColumn(defaultServerInstallationColumn.getColumnInfo())
             {
                 @Override @NotNull
-                public String getFormattedValue(RenderContext ctx)
+                public HtmlString getFormattedHtml(RenderContext ctx)
                 {
                     Map<String, Object> row = ctx.getRow();
 
@@ -1448,7 +1449,7 @@ public class MothershipController extends SpringActionController
                     ServerInstallation si = MothershipManager.get().getServerInstallation(((Integer) row.get("ServerInstallationId")).intValue(), ctx.getContainer());
                     if (si != null && si.getNote() != null && si.getNote().trim().length() > 0)
                     {
-                        return PageFlowUtil.filter(si.getNote());
+                        return HtmlString.of(si.getNote());
                     }
                     else
                     {
@@ -1457,15 +1458,15 @@ public class MothershipController extends SpringActionController
                         {
                             if (si != null && si.getServerHostName() != null && si.getServerHostName().trim().length() > 0)
                             {
-                                return PageFlowUtil.filter(si.getServerHostName());
+                                return HtmlString.of(si.getServerHostName());
                             }
                             else
                             {
-                                return PageFlowUtil.filter("[Unnamed]");
+                                return HtmlString.of("[Unnamed]");
                             }
                         }
                     }
-                    return super.getFormattedValue(ctx);
+                    return super.getFormattedHtml(ctx);
                 }
             };
 

--- a/study/src/org/labkey/study/query/BaseStudyTable.java
+++ b/study/src/org/labkey/study/query/BaseStudyTable.java
@@ -50,6 +50,7 @@ import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.TimepointType;
 import org.labkey.api.util.DemoMode;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpression;
@@ -335,38 +336,23 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
         }
 
         @Override @NotNull
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
-            Object value = ctx.get(getDisplayColumn().getFieldKey());
+            Object value = getDisplayValue(ctx);
             if (value == null)
-            {
-                value = ctx.get(_seqNumMinFieldKey);
-
-                if (value == null)
-                    return super.getFormattedValue(ctx);
-            }
-            return PageFlowUtil.filter(value);
+                return super.getFormattedHtml(ctx);
+            return HtmlString.of(value);
         }
 
         @Override
         public Object getDisplayValue(RenderContext ctx)
         {
-            Object value = super.getDisplayValue(ctx);
+            Object value = ctx.get(getDisplayColumn().getFieldKey());
             if (value == null)
-                value = getFormattedValue(ctx);
+            {
+                value = ctx.get(_seqNumMinFieldKey);
+            }
             return value;
-        }
-
-        @Override
-        public String getTsvFormattedValue(RenderContext ctx)
-        {
-            return getFormattedValue(ctx);
-        }
-
-        @Override
-        public Object getExcelCompatibleValue(RenderContext ctx)
-        {
-            return getFormattedValue(ctx);
         }
 
         @Override

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -77,6 +77,8 @@ import org.labkey.api.study.TimepointType;
 import org.labkey.api.study.assay.SpecimenForeignKey;
 import org.labkey.api.util.ContainerContext;
 import org.labkey.api.util.DemoMode;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.view.ActionURL;
@@ -980,17 +982,17 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
         }
 
         @Override @NotNull
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
             Object value = getValue(ctx);
-            StringBuilder formattedValue = new StringBuilder(super.getFormattedValue(ctx));
-            if (value != null && value instanceof Integer)
+            HtmlStringBuilder formattedValue = HtmlStringBuilder.of(super.getFormattedHtml(ctx));
+            if (value instanceof Integer)
             {
                 QCState state = getStateCache(ctx).get(value);
                 if (state != null && state.getDescription() != null)
-                    formattedValue.append(PageFlowUtil.helpPopup("QC State " + state.getLabel(), state.getDescription()));
+                    formattedValue.append(HtmlString.unsafe(PageFlowUtil.helpPopup("QC State " + state.getLabel(), state.getDescription())));
             }
-            return formattedValue.toString();
+            return formattedValue.getHtmlString();
         }
 
         private Map<Integer, QCState> getStateCache(RenderContext ctx)

--- a/study/src/org/labkey/study/query/ParticipantGroupCohortUnionTable.java
+++ b/study/src/org/labkey/study/query/ParticipantGroupCohortUnionTable.java
@@ -30,6 +30,8 @@ import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.study.StudyService;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.study.CohortForeignKey;
 import org.labkey.study.StudySchema;
 import org.labkey.study.model.CohortImpl;
@@ -83,9 +85,9 @@ public class ParticipantGroupCohortUnionTable extends BaseStudyTable
                     }
 
                     @Override @NotNull
-                    public String getFormattedValue(RenderContext ctx)
+                    public HtmlString getFormattedHtml(RenderContext ctx)
                     {
-                        return _getValue(ctx) + "<br>";
+                        return HtmlStringBuilder.of(_getValue(ctx)).append(HtmlString.BR).getHtmlString();
                     }
 
                     @NotNull

--- a/study/src/org/labkey/study/query/PtidObfuscatingDisplayColumn.java
+++ b/study/src/org/labkey/study/query/PtidObfuscatingDisplayColumn.java
@@ -22,6 +22,7 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.util.DemoMode;
+import org.labkey.api.util.HtmlString;
 
 /*
 * User: adam
@@ -42,9 +43,9 @@ public class PtidObfuscatingDisplayColumn extends DataColumn
     }
 
     @Override @NotNull
-    public String getFormattedValue(RenderContext ctx)
+    public HtmlString getFormattedHtml(RenderContext ctx)
     {
-        return getValue(ctx);
+        return HtmlString.of(getValue(ctx));
     }
 
     @Override

--- a/study/src/org/labkey/study/query/SpecimenQueryView.java
+++ b/study/src/org/labkey/study/query/SpecimenQueryView.java
@@ -48,6 +48,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.EditSpecimenDataPermission;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DataView;
@@ -988,7 +989,7 @@ public class SpecimenQueryView extends BaseStudyQueryView
                 builder.append("    <td style=\"border: 1px solid #BBBBBB\">").append(row).append("</td>\n");
                 for (DisplayColumn col : columns)
                 {
-                    String value = col.getFormattedValue(renderContext);
+                    HtmlString value = col.getFormattedHtml(renderContext);
                     builder.append("    <td style=\"border: 1px solid #BBBBBB\">").append(value).append("</td>\n");
                 }
                 builder.append("  </tr>\n");

--- a/study/src/org/labkey/study/query/StudySnapshotTable.java
+++ b/study/src/org/labkey/study/query/StudySnapshotTable.java
@@ -38,6 +38,7 @@ import org.labkey.api.query.UserIdForeignKey;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.study.StudySchema;
 
@@ -152,9 +153,9 @@ public class StudySnapshotTable extends FilteredTable<StudyQuerySchema>
                 {
                     @NotNull
                     @Override
-                    public String getFormattedValue(RenderContext ctx)
+                    public HtmlString getFormattedHtml(RenderContext ctx)
                     {
-                        return "Republish";
+                        return HtmlString.of("Republish");
                     }
 
                     @Override


### PR DESCRIPTION
#### Rationale
Switch to using HtmlString when rendering a grid or details value to ensure proper encoding. Fix up many problematic subclasses.

When we have a link with a target tab/window, we're injecting an extra quote into the HTML, because we're adding a closing quote when we append the next attribute

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1317

#### Changes
* Remove deprecated getFormattedValue(), consolidate on getFormattedHtml()
* Use HtmlString to signal this is specifically for HTML
* Remove the extra quote