### PR TITLE
41472: Copied to study assay results column names can change

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -843,7 +843,9 @@ public abstract class AssayProtocolSchema extends AssaySchema
                 String studyName = assayDataset.getStudy().getLabel();
                 if (studyName == null)
                     continue; // No study in that folder
-                String studyColumnName = "copied_to_" + sanitizeName(studyName);
+
+                // issue 41472 include the prefix as part of the sanitization process
+                String studyColumnName = sanitizeName("copied_to_" + studyName);
 
                 // column names must be unique. Prevent collisions
                 while (usedColumnNames.contains(studyColumnName))

--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -844,8 +844,14 @@ public abstract class AssayProtocolSchema extends AssaySchema
                 if (studyName == null)
                     continue; // No study in that folder
 
-                // issue 41472 include the prefix as part of the sanitization process
-                String studyColumnName = sanitizeName("copied_to_" + studyName);
+                String studyColumnName;
+                if (sanitizeName(assayDataset.getStudy().getContainer().getName()).isEmpty())
+                {
+                    // issue 41472 include the prefix as part of the sanitization process
+                    studyColumnName = sanitizeName("copied_to_" + studyName);
+                }
+                else
+                    studyColumnName = "copied_to_" + sanitizeName(studyName);
 
                 // column names must be unique. Prevent collisions
                 while (usedColumnNames.contains(studyColumnName))

--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -845,7 +845,7 @@ public abstract class AssayProtocolSchema extends AssaySchema
                     continue; // No study in that folder
 
                 String studyColumnName;
-                if (sanitizeName(assayDataset.getStudy().getContainer().getName()).isEmpty())
+                if (sanitizeName(studyName).isEmpty())
                 {
                     // issue 41472 include the prefix as part of the sanitization process
                     studyColumnName = sanitizeName("copied_to_" + studyName);


### PR DESCRIPTION

#### Rationale
This change fixes issue [41472](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41472). While this change does alter the generated copied to study column names, it only does so for the previously broken case where a study name consisted entirely of numbers. This scenario resulted in unstable column names when multiple copied to study names were added that only consisted of numbers in the name.


