### PR TITLE
Fix ContainerFilterQueryTest

### DIFF
--- a/query/test/src/org/labkey/test/tests/query/ContainerFilterQueryTest.java
+++ b/query/test/src/org/labkey/test/tests/query/ContainerFilterQueryTest.java
@@ -20,9 +20,9 @@ import org.openqa.selenium.WebElement;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -110,19 +110,19 @@ public class ContainerFilterQueryTest extends BaseWebDriverTest
     {
         final String sql = "SELECT Containers.Name FROM Containers[ContainerFilter='CurrentAndSubfolders']";
         String queryName = "testCurrentAndSubfoldersAnnotation";
-        List<String> expectedFolders = List.of(getProjectName(), FOLDER_NAME);
+        List<String> expectedFolders = List.of(getProjectName(), FOLDER_NAME).stream().sorted().collect(Collectors.toList());
 
         DataRegionTable table = createQuery(getProjectName(), queryName, "core", sql);
-        List<String> containerNames = table.getColumnDataAsText("Name");
+        List<String> containerNames = table.getColumnDataAsText("Name").stream().sorted().collect(Collectors.toList());
         assertEquals("Wrong containers for 'CurrentAndSubfolders' container filter.",
             expectedFolders, containerNames);
 
         table.setContainerFilter(DataRegionTable.ContainerFilterType.CURRENT_FOLDER);
-        containerNames = table.getColumnDataAsText("Name");
+        containerNames = table.getColumnDataAsText("Name").stream().sorted().collect(Collectors.toList());
         assertEquals("ContainerFilter annotation should ignore data region container filter.", expectedFolders, containerNames);
 
         table.setContainerFilter(DataRegionTable.ContainerFilterType.ALL_FOLDERS);
-        containerNames = table.getColumnDataAsText("Name");
+        containerNames = table.getColumnDataAsText("Name").stream().sorted().collect(Collectors.toList());
         assertEquals("ContainerFilter annotation should ignore data region container filter.", expectedFolders, containerNames);
     }
 
@@ -205,8 +205,7 @@ public class ContainerFilterQueryTest extends BaseWebDriverTest
         new SchemaHelper(this).createLinkedSchema(getProjectName(), linkedSchemaName, getFolderPath(), null, "lists", null, null);
 
         DataRegionTable table = createQuery(getProjectName(), queryName, "linkedLizts", sql);
-        List<String> names = table.getColumnDataAsText("Name");
-        Collections.sort(names);
+        List<String> names = table.getColumnDataAsText("Name").stream().sorted().collect(Collectors.toList());
         assertEquals("Wrong data in container filtered linked schema.", List.of("Geoffrey", "James", "William"), names);
     }
 

--- a/query/test/src/org/labkey/test/tests/query/ContainerFilterQueryTest.java
+++ b/query/test/src/org/labkey/test/tests/query/ContainerFilterQueryTest.java
@@ -20,6 +20,7 @@ import org.openqa.selenium.WebElement;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -201,11 +202,12 @@ public class ContainerFilterQueryTest extends BaseWebDriverTest
         list1.createList(connection, "Key");
         list1.insertRows(connection);
 
-        new SchemaHelper(this).createLinkedSchema(getProjectName(), null, linkedSchemaName, getFolderPath(), null, "lists", null, null);
+        new SchemaHelper(this).createLinkedSchema(getProjectName(), linkedSchemaName, getFolderPath(), null, "lists", null, null);
 
         DataRegionTable table = createQuery(getProjectName(), queryName, "linkedLizts", sql);
         List<String> names = table.getColumnDataAsText("Name");
-        assertEquals("Wrong data in container filtered linked schema.", List.of("Geoffrey", "William", "James"), names);
+        Collections.sort(names);
+        assertEquals("Wrong data in container filtered linked schema.", List.of("Geoffrey", "James", "William"), names);
     }
 
     @NotNull


### PR DESCRIPTION
#### Rationale
I thought the row order would be predictable. It is not.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/485

#### Changes
* Sort results to ensure consistent results
* Don't use deprecated `createLinkedSchema` method
