### PR TITLE
Issue 41472: Include study name in copied to study assay column name when sanitized name equals "study"

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -845,7 +845,8 @@ public abstract class AssayProtocolSchema extends AssaySchema
                     continue; // No study in that folder
 
                 String studyColumnName;
-                if (sanitizeName(studyName).isEmpty())
+                String sanitizedStudyName = sanitizeName(studyName);
+                if (sanitizedStudyName.isEmpty() || "study".equalsIgnoreCase(sanitizedStudyName))
                 {
                     // issue 41472 include the prefix as part of the sanitization process
                     studyColumnName = sanitizeName("copied_to_" + studyName);


### PR DESCRIPTION
#### Rationale
Issue [41472](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41472): Copied to study assay results column names can change when multiple studies are used for the same assay

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1605

#### Changes
* Add check for if the sanitized study name equals "study", ignoring case, when prepending "copied_to_study"
