### PR TITLE
Issue 41512: IntelliJ sync fails, not finding the api project required by internal

### DIFF
--- a/internal/build.gradle
+++ b/internal/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'java-library'
 apply plugin: 'org.labkey.javaModule'
 
 dependencies {
-   BuildUtils.addLabKeyDependency(project: project, config: "api", depProjectPath: BuildUtils.getApiProjectPath(project.gradle), depProjectConfig: "apiElements")
+   BuildUtils.addLabKeyDependency(project: project, config: "api", depProjectPath: BuildUtils.getApiProjectPath(project.gradle), depProjectConfig: "runtimeElements")
    if (project.configurations.findByName("dedupe") != null)
       BuildUtils.addLabKeyDependency(project: project, config: "dedupe", depProjectPath: BuildUtils.getApiProjectPath(project.gradle), depProjectConfig: "external")
    implementation "org.apache.tomcat:tomcat-jsp-api:${apacheTomcatVersion}"


### PR DESCRIPTION
#### Rationale
Apparently the `apiElements` is a configuration that is not consumable by other projects.  The preferred configuration is runtimeElements.   I think this works on the command line because we are depending on the default output (jar) of the api project, but I'm not 100% sure.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1498

#### Changes
* Update dependency declaration for api module
