### PR TITLE
41518: Update documentation version in Constants

### DIFF
--- a/api/src/org/labkey/api/Constants.java
+++ b/api/src/org/labkey/api/Constants.java
@@ -49,7 +49,7 @@ public class Constants
      */
     public static String getDocumentationVersion()
     {
-        return "20.7";
+        return "20.11";
     }
 
     /**


### PR DESCRIPTION
#### Rationale
Now that the LabKey version on develop has been bumped to 20.11-SNAPSHOT, we need to bump the documentation version to 20.11 to prepare for the 20.11 release next month.

This [issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41518) has been opened to track the unit test failure.