### PR TITLE
Remove better-npm-run, audit fix

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -3736,9 +3736,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-libs-browser": {
@@ -4970,12 +4970,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "assay",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -841,17 +841,6 @@
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
-    "better-npm-run": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/better-npm-run/-/better-npm-run-0.1.1.tgz",
-      "integrity": "sha512-SBBYsUsb6bYcUMF9QUWy39GX5kzD4CoRBP11gx/k5jYkUr4Tr+irAokIeQX5FgfCRz0Q27rt8U0J4D2TlRgQFA==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.9.0",
-        "dotenv": "^2.0.0",
-        "object-assign": "^4.0.1"
-      }
-    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -1574,6 +1563,58 @@
         }
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -1845,12 +1886,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-      "dev": true
-    },
-    "dotenv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
-      "integrity": "sha1-vXWcNXqqcDZeAclrewvsCKbg2Uk=",
       "dev": true
     },
     "duplexify": {

--- a/assay/package.json
+++ b/assay/package.json
@@ -1,40 +1,14 @@
 {
   "name": "assay",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "setup": "npm ci",
     "build": "npm run build-dev",
-    "start": "bnr build:watch",
-    "build-dev": "npm run clean && bnr build:dev",
-    "build-prod": "npm run clean && bnr build:prod",
-    "clean": "bnr clean"
-  },
-  "betterScripts": {
-    "build:watch": {
-      "command": "webpack-dev-server --config ../webpack/watch.config.js",
-      "env": {
-        "LK_MODULE": "assay",
-        "NODE_ENV": "development"
-      }
-    },
-    "build:dev": {
-      "command": "webpack --config ../webpack/dev.config.js --progress --profile --colors",
-      "env": {
-        "LK_MODULE": "assay",
-        "NODE_ENV": "development"
-      }
-    },
-    "build:prod": {
-      "command": "webpack --config ../webpack/prod.config.js --progress --profile --colors",
-      "env": {
-        "LK_MODULE": "assay",
-        "NODE_ENV": "production"
-      }
-    },
-    "clean": {
-      "command": "rimraf resources/web/assay/gen && rimraf resources/views/*.*"
-    }
+    "start": "cross-env NODE_ENV=development LK_MODULE=assay webpack-dev-server --config ../webpack/watch.config.js",
+    "build-dev": "npm run clean && cross-env NODE_ENV=development LK_MODULE=assay webpack --config ../webpack/dev.config.js --progress --profile --colors",
+    "build-prod": "npm run clean && cross-env NODE_ENV=production LK_MODULE=assay webpack --config ../webpack/prod.config.js --progress --profile --colors",
+    "clean": "rimraf resources/web/assay/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
     "@labkey/components": "0.96.2"
@@ -42,7 +16,7 @@
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
-    "better-npm-run": "0.1.1",
+    "cross-env": "7.0.2",
     "react-hot-loader": "4.12.21",
     "rimraf": "3.0.2",
     "webpack": "4.44.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -3576,17 +3576,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "better-npm-run": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/better-npm-run/-/better-npm-run-0.1.1.tgz",
-      "integrity": "sha512-SBBYsUsb6bYcUMF9QUWy39GX5kzD4CoRBP11gx/k5jYkUr4Tr+irAokIeQX5FgfCRz0Q27rt8U0J4D2TlRgQFA==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.9.0",
-        "dotenv": "^2.0.0",
-        "object-assign": "^4.0.1"
-      }
-    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -4530,6 +4519,58 @@
         }
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -4975,12 +5016,6 @@
         "dom-serializer": "0",
         "domelementtype": "1"
       }
-    },
-    "dotenv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
-      "integrity": "sha1-vXWcNXqqcDZeAclrewvsCKbg2Uk=",
-      "dev": true
     },
     "duplexify": {
       "version": "3.7.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -11847,9 +11847,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-int64": {
@@ -13613,12 +13613,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/core/package.json
+++ b/core/package.json
@@ -5,7 +5,7 @@
     "setup": "npm ci",
     "build": "npm run build-dev",
     "build-dev": "npm run copy-distributions && cross-env NODE_ENV=development LK_MODULE=core webpack --config ../webpack/dev.config.js --progress --profile --colors",
-    "build-prod": "npm run copy-distributions && cross-env NODE_ENV=development LK_MODULE=core webpack --config ../webpack/prod.config.js --progress --profile --colors",
+    "build-prod": "npm run copy-distributions && cross-env NODE_ENV=production LK_MODULE=core webpack --config ../webpack/prod.config.js --progress --profile --colors",
     "clean": "rimraf resources/web/core/gen && rimraf resources/web/core/css && rimraf resources/web/clientapi",
     "copy-distributions": "npm run clean && node copy-distributions.js",
     "start": "cross-env NODE_ENV=development LK_MODULE=core webpack-dev-server --config ../webpack/watch.config.js",

--- a/core/package.json
+++ b/core/package.json
@@ -4,58 +4,16 @@
   "scripts": {
     "setup": "npm ci",
     "build": "npm run build-dev",
-    "build-dev": "bnr clean && bnr copy-distributions && bnr build-pages:dev",
-    "build-prod": "bnr clean && bnr copy-distributions && bnr build-pages:prod",
-    "clean": "bnr clean",
-    "copy-distributions": "bnr clean && bnr copy-distributions",
-    "start": "bnr build-pages:watch",
-    "build-pages": "bnr build-pages:prod",
-    "test": "bnr build:jest-test",
-    "teamcity": "bnr build:jest-teamcity",
+    "build-dev": "npm run copy-distributions && cross-env NODE_ENV=development LK_MODULE=core webpack --config ../webpack/dev.config.js --progress --profile --colors",
+    "build-prod": "npm run copy-distributions && cross-env NODE_ENV=development LK_MODULE=core webpack --config ../webpack/prod.config.js --progress --profile --colors",
+    "clean": "rimraf resources/web/core/gen && rimraf resources/web/core/css && rimraf resources/web/clientapi",
+    "copy-distributions": "npm run clean && node copy-distributions.js",
+    "start": "cross-env NODE_ENV=development LK_MODULE=core webpack-dev-server --config ../webpack/watch.config.js",
+    "test": "cross-env NODE_ENV=test jest",
+    "teamcity": "cross-env NODE_ENV=test jest --testResultsProcessor=jest-teamcity-reporter",
     "lint": "eslint --ext '*.ts,*.tsx'",
     "lint-all": "eslint --ext '*.ts,*.tsx' src/client/**/*",
     "lint-fix": "eslint --fix --ext '*.ts,*.tsx'"
-  },
-  "betterScripts": {
-    "clean": {
-      "command": "rimraf resources/web/core/gen && rimraf resources/web/core/css && rimraf resources/web/clientapi"
-    },
-    "copy-distributions": {
-      "command": "node copy-distributions.js"
-    },
-    "build:jest-test": {
-      "command": "jest",
-      "env": {
-        "NODE_ENV": "test"
-      }
-    },
-    "build-pages:dev": {
-      "command": "webpack --config ../webpack/dev.config.js --progress --profile --colors",
-      "env": {
-        "LK_MODULE": "core",
-        "NODE_ENV": "development"
-      }
-    },
-    "build-pages:prod": {
-      "command": "webpack --config ../webpack/prod.config.js --progress --profile --colors",
-      "env": {
-        "LK_MODULE": "core",
-        "NODE_ENV": "production"
-      }
-    },
-    "build-pages:watch": {
-      "command": "webpack-dev-server --config ../webpack/watch.config.js",
-      "env": {
-        "LK_MODULE": "core",
-        "NODE_ENV": "development"
-      }
-    },
-    "build:jest-teamcity": {
-      "command": "jest --testResultsProcessor=jest-teamcity-reporter",
-      "env": {
-        "NODE_ENV": "test"
-      }
-    }
   },
   "jest": {
     "globals": {
@@ -103,7 +61,7 @@
     "@types/react": "16.9.44",
     "@typescript-eslint/eslint-plugin": "3.8.0",
     "@typescript-eslint/parser": "3.8.0",
-    "better-npm-run": "0.1.1",
+    "cross-env": "7.0.2",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",
     "enzyme-to-json": "3.5.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -3736,9 +3736,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-libs-browser": {
@@ -4970,12 +4970,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "experiment",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -841,17 +841,6 @@
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
-    "better-npm-run": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/better-npm-run/-/better-npm-run-0.1.1.tgz",
-      "integrity": "sha512-SBBYsUsb6bYcUMF9QUWy39GX5kzD4CoRBP11gx/k5jYkUr4Tr+irAokIeQX5FgfCRz0Q27rt8U0J4D2TlRgQFA==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.9.0",
-        "dotenv": "^2.0.0",
-        "object-assign": "^4.0.1"
-      }
-    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -1574,6 +1563,58 @@
         }
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -1845,12 +1886,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-      "dev": true
-    },
-    "dotenv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
-      "integrity": "sha1-vXWcNXqqcDZeAclrewvsCKbg2Uk=",
       "dev": true
     },
     "duplexify": {

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -1,40 +1,14 @@
 {
   "name": "experiment",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "setup": "npm ci",
     "build": "npm run build-dev",
-    "start": "bnr build:watch",
-    "build-dev": "npm run clean && bnr build:dev",
-    "build-prod": "npm run clean && bnr build:prod",
-    "clean": "bnr clean"
-  },
-  "betterScripts": {
-    "build:watch": {
-      "command": "webpack-dev-server --config ../webpack/watch.config.js",
-      "env": {
-        "LK_MODULE": "experiment",
-        "NODE_ENV": "development"
-      }
-    },
-    "build:dev": {
-      "command": "webpack --config ../webpack/dev.config.js --progress --profile --colors",
-      "env": {
-        "LK_MODULE": "experiment",
-        "NODE_ENV": "development"
-      }
-    },
-    "build:prod": {
-      "command": "webpack --config ../webpack/prod.config.js --progress --profile --colors",
-      "env": {
-        "LK_MODULE": "experiment",
-        "NODE_ENV": "production"
-      }
-    },
-    "clean": {
-      "command": "rimraf resources/web/experiment/gen && rimraf resources/views/*.*"
-    }
+    "start": "cross-env NODE_ENV=development LK_MODULE=experiment webpack-dev-server --config ../webpack/watch.config.js",
+    "build-dev": "npm run clean && cross-env NODE_ENV=development LK_MODULE=experiment webpack --config ../webpack/dev.config.js --progress --profile --colors",
+    "build-prod": "npm run clean && cross-env NODE_ENV=production LK_MODULE=experiment webpack --config ../webpack/prod.config.js --progress --profile --colors",
+    "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
     "@labkey/components": "0.96.2"
@@ -42,7 +16,7 @@
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
-    "better-npm-run": "0.1.1",
+    "cross-env": "7.0.2",
     "react-hot-loader": "4.12.21",
     "rimraf": "3.0.2",
     "webpack": "4.44.1",

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -3736,9 +3736,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-libs-browser": {
@@ -4970,12 +4970,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "issues",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -841,17 +841,6 @@
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
-    "better-npm-run": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/better-npm-run/-/better-npm-run-0.1.1.tgz",
-      "integrity": "sha512-SBBYsUsb6bYcUMF9QUWy39GX5kzD4CoRBP11gx/k5jYkUr4Tr+irAokIeQX5FgfCRz0Q27rt8U0J4D2TlRgQFA==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.9.0",
-        "dotenv": "^2.0.0",
-        "object-assign": "^4.0.1"
-      }
-    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -1574,6 +1563,58 @@
         }
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -1845,12 +1886,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-      "dev": true
-    },
-    "dotenv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
-      "integrity": "sha1-vXWcNXqqcDZeAclrewvsCKbg2Uk=",
       "dev": true
     },
     "duplexify": {

--- a/issues/package.json
+++ b/issues/package.json
@@ -1,40 +1,14 @@
 {
   "name": "issues",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "setup": "npm ci",
     "build": "npm run build-dev",
-    "start": "bnr build:watch",
-    "build-dev": "npm run clean && bnr build:dev",
-    "build-prod": "npm run clean && bnr build:prod",
-    "clean": "bnr clean"
-  },
-  "betterScripts": {
-    "build:watch": {
-      "command": "webpack-dev-server --config ../webpack/watch.config.js",
-      "env": {
-        "LK_MODULE": "issues",
-        "NODE_ENV": "development"
-      }
-    },
-    "build:dev": {
-      "command": "webpack --config ../webpack/dev.config.js --progress --profile --colors",
-      "env": {
-        "LK_MODULE": "issues",
-        "NODE_ENV": "development"
-      }
-    },
-    "build:prod": {
-      "command": "webpack --config ../webpack/prod.config.js --progress --profile --colors",
-      "env": {
-        "LK_MODULE": "issues",
-        "NODE_ENV": "production"
-      }
-    },
-    "clean": {
-      "command": "rimraf resources/web/issues/gen && rimraf resources/views/*.*"
-    }
+    "start": "cross-env NODE_ENV=development LK_MODULE=issues webpack-dev-server --config ../webpack/watch.config.js",
+    "build-dev": "npm run clean && cross-env NODE_ENV=development LK_MODULE=issues webpack --config ../webpack/dev.config.js --progress --profile --colors",
+    "build-prod": "npm run clean && cross-env NODE_ENV=production LK_MODULE=issues webpack --config ../webpack/prod.config.js --progress --profile --colors",
+    "clean": "rimraf resources/web/issues/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
     "@labkey/components": "0.96.2"
@@ -42,7 +16,7 @@
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
-    "better-npm-run": "0.1.1",
+    "cross-env": "7.0.2",
     "react-hot-loader": "4.12.21",
     "rimraf": "3.0.2",
     "webpack": "4.44.1",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "list",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -841,17 +841,6 @@
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
-    "better-npm-run": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/better-npm-run/-/better-npm-run-0.1.1.tgz",
-      "integrity": "sha512-SBBYsUsb6bYcUMF9QUWy39GX5kzD4CoRBP11gx/k5jYkUr4Tr+irAokIeQX5FgfCRz0Q27rt8U0J4D2TlRgQFA==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.9.0",
-        "dotenv": "^2.0.0",
-        "object-assign": "^4.0.1"
-      }
-    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -1574,6 +1563,58 @@
         }
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -1845,12 +1886,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-      "dev": true
-    },
-    "dotenv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
-      "integrity": "sha1-vXWcNXqqcDZeAclrewvsCKbg2Uk=",
       "dev": true
     },
     "duplexify": {

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -3736,9 +3736,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-libs-browser": {
@@ -4970,12 +4970,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/list/package.json
+++ b/list/package.json
@@ -1,40 +1,14 @@
 {
   "name": "list",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "setup": "npm ci",
     "build": "npm run build-dev",
-    "start": "bnr build:watch",
-    "build-dev": "npm run clean && bnr build:dev",
-    "build-prod": "npm run clean && bnr build:prod",
-    "clean": "bnr clean"
-  },
-  "betterScripts": {
-    "build:watch": {
-      "command": "webpack-dev-server --config ../webpack/watch.config.js",
-      "env": {
-        "LK_MODULE": "list",
-        "NODE_ENV": "development"
-      }
-    },
-    "build:dev": {
-      "command": "webpack --config ../webpack/dev.config.js --progress --profile --colors",
-      "env": {
-        "LK_MODULE": "list",
-        "NODE_ENV": "development"
-      }
-    },
-    "build:prod": {
-      "command": "webpack --config ../webpack/prod.config.js --progress --profile --colors",
-      "env": {
-        "LK_MODULE": "list",
-        "NODE_ENV": "production"
-      }
-    },
-    "clean": {
-      "command": "rimraf resources/web/list/gen && rimraf resources/views/*.*"
-    }
+    "start": "cross-env NODE_ENV=development LK_MODULE=list webpack-dev-server --config ../webpack/watch.config.js",
+    "build-dev": "npm run clean && cross-env NODE_ENV=development LK_MODULE=list webpack --config ../webpack/dev.config.js --progress --profile --colors",
+    "build-prod": "npm run clean && cross-env NODE_ENV=production LK_MODULE=list webpack --config ../webpack/prod.config.js --progress --profile --colors",
+    "clean": "rimraf resources/web/list/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
     "@labkey/components": "0.96.2"
@@ -42,7 +16,7 @@
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
-    "better-npm-run": "0.1.1",
+    "cross-env": "7.0.2",
     "react-hot-loader": "4.12.21",
     "rimraf": "3.0.2",
     "webpack": "4.44.1",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -841,17 +841,6 @@
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
-    "better-npm-run": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/better-npm-run/-/better-npm-run-0.1.1.tgz",
-      "integrity": "sha512-SBBYsUsb6bYcUMF9QUWy39GX5kzD4CoRBP11gx/k5jYkUr4Tr+irAokIeQX5FgfCRz0Q27rt8U0J4D2TlRgQFA==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.9.0",
-        "dotenv": "^2.0.0",
-        "object-assign": "^4.0.1"
-      }
-    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -1574,6 +1563,58 @@
         }
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -1845,12 +1886,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-      "dev": true
-    },
-    "dotenv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
-      "integrity": "sha1-vXWcNXqqcDZeAclrewvsCKbg2Uk=",
       "dev": true
     },
     "duplexify": {

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -3736,9 +3736,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-libs-browser": {
@@ -4965,12 +4965,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/query/package.json
+++ b/query/package.json
@@ -5,36 +5,10 @@
   "scripts": {
     "setup": "npm ci",
     "build": "npm run build-dev",
-    "start": "bnr build:watch",
-    "build-dev": "npm run clean && bnr build:dev",
-    "build-prod": "npm run clean && bnr build:prod",
-    "clean": "bnr clean"
-  },
-  "betterScripts": {
-    "build:watch": {
-      "command": "webpack-dev-server --config ../webpack/watch.config.js",
-      "env": {
-        "LK_MODULE": "query",
-        "NODE_ENV": "development"
-      }
-    },
-    "build:dev": {
-      "command": "webpack --config ../webpack/dev.config.js --progress --profile --colors",
-      "env": {
-        "LK_MODULE": "query",
-        "NODE_ENV": "development"
-      }
-    },
-    "build:prod": {
-      "command": "webpack --config ../webpack/prod.config.js --progress --profile --colors",
-      "env": {
-        "LK_MODULE": "query",
-        "NODE_ENV": "production"
-      }
-    },
-    "clean": {
-      "command": "rimraf resources/web/query/gen && rimraf resources/views/queryMetadataEditor*"
-    }
+    "start": "cross-env NODE_ENV=development LK_MODULE=query webpack-dev-server --config ../webpack/watch.config.js",
+    "build-dev": "npm run clean && cross-env NODE_ENV=development LK_MODULE=query webpack --config ../webpack/dev.config.js --progress --profile --colors",
+    "build-prod": "npm run clean && cross-env NODE_ENV=production LK_MODULE=query webpack --config ../webpack/prod.config.js --progress --profile --colors",
+    "clean": "rimraf resources/web/query/gen && rimraf resources/views/queryMetadataEditor*"
   },
   "dependencies": {
     "@labkey/components": "0.96.2"
@@ -42,7 +16,7 @@
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
-    "better-npm-run": "0.1.1",
+    "cross-env": "7.0.2",
     "react-hot-loader": "4.12.21",
     "rimraf": "3.0.2",
     "webpack": "4.44.1",

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -3750,9 +3750,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-libs-browser": {
@@ -4964,12 +4964,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "study",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -848,17 +848,6 @@
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
-    "better-npm-run": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/better-npm-run/-/better-npm-run-0.1.1.tgz",
-      "integrity": "sha512-SBBYsUsb6bYcUMF9QUWy39GX5kzD4CoRBP11gx/k5jYkUr4Tr+irAokIeQX5FgfCRz0Q27rt8U0J4D2TlRgQFA==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.9.0",
-        "dotenv": "^2.0.0",
-        "object-assign": "^4.0.1"
-      }
-    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -1581,6 +1570,58 @@
         }
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -1852,12 +1893,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-      "dev": true
-    },
-    "dotenv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
-      "integrity": "sha1-vXWcNXqqcDZeAclrewvsCKbg2Uk=",
       "dev": true
     },
     "duplexify": {

--- a/study/package.json
+++ b/study/package.json
@@ -1,40 +1,14 @@
 {
   "name": "study",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "setup": "npm ci",
     "build": "npm run build-dev",
-    "start": "bnr build:watch",
-    "build-dev": "npm run clean && bnr build:dev",
-    "build-prod": "npm run clean && bnr build:prod",
-    "clean": "bnr clean"
-  },
-  "betterScripts": {
-    "build:watch": {
-      "command": "webpack-dev-server --config ../webpack/watch.config.js",
-      "env": {
-        "LK_MODULE": "study",
-        "NODE_ENV": "development"
-      }
-    },
-    "build:dev": {
-      "command": "webpack --config ../webpack/dev.config.js --progress --profile --colors",
-      "env": {
-        "LK_MODULE": "study",
-        "NODE_ENV": "development"
-      }
-    },
-    "build:prod": {
-      "command": "webpack --config ../webpack/prod.config.js --progress --profile --colors",
-      "env": {
-        "LK_MODULE": "study",
-        "NODE_ENV": "production"
-      }
-    },
-    "clean": {
-      "command": "rimraf resources/web/study/gen && rimraf resources/views/datasetDesigner*"
-    }
+    "start": "cross-env NODE_ENV=development LK_MODULE=study webpack-dev-server --config ../webpack/watch.config.js",
+    "build-dev": "npm run clean && cross-env NODE_ENV=development LK_MODULE=study webpack --config ../webpack/dev.config.js --progress --profile --colors",
+    "build-prod": "npm run clean && cross-env NODE_ENV=production LK_MODULE=study webpack --config ../webpack/prod.config.js --progress --profile --colors",
+    "clean": "rimraf resources/web/study/gen && rimraf resources/views/datasetDesigner*"
   },
   "dependencies": {
     "@labkey/components": "0.96.2"
@@ -42,7 +16,7 @@
   "devDependencies": {
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
-    "better-npm-run": "0.1.1",
+    "cross-env": "7.0.2",
     "react-hot-loader": "4.12.21",
     "rimraf": "3.0.2",
     "webpack": "4.44.1",


### PR DESCRIPTION
#### Rationale
The package [better-npm-run](https://github.com/benoror/better-npm-run) was utilized by our modules to enable passing of arguments to our scripts in a more organized way. In May 2019 this package was deprecated in favor of [cross-env](https://github.com/kentcdodds/cross-env). This PR updates our platform modules to use cross-env.

#### Changes
* Remove usages of `better-npm-run` and replace with `cross-env`.
* Ran `npm audit fix` against all modules to update version of `node-forge` from `0.9.0` to `0.10.0`.
