### PR TITLE
Item 7904: Introduce webpack aliasing for easier hot reloading of multiple packages

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "types": [], // don't implicitly include any @types, only those included via import
     "baseUrl": ".",
     "paths": {
+      "immutable": ["../../../../labkey-ui-components/packages/components/node_modules/immutable"],
       "@labkey/components": ["../../../../labkey-ui-components/packages/components"]
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,11 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "types": [] // don't implicitly include any @types, only those included via import
+    "types": [], // don't implicitly include any @types, only those included via import
+    "baseUrl": ".",
+    "paths": {
+      "@labkey/components": ["../../../../labkey-ui-components/packages/components"]
+    }
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,12 +6,7 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "types": [], // don't implicitly include any @types, only those included via import
-    "baseUrl": ".",
-    "paths": {
-      "immutable": ["../../../../labkey-ui-components/packages/components/node_modules/immutable"],
-      "@labkey/components": ["../../../../labkey-ui-components/packages/components"]
-    }
+    "types": [] // don't implicitly include any @types, only those included via import
   }
 }
 

--- a/webpack/constants.js
+++ b/webpack/constants.js
@@ -9,7 +9,13 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
+// This path assumes the enlistment in labkey-ui-components is a sibling of the root of the LabKey enlistment.
+// Adjust as necessary for your enlistment in order to use hot reloading that picks up changes from @labkey/components
+const labkeyUIComponentsPath = path.resolve("../../../../../labkey-ui-components/packages/components");
+console.log("Using @labkey/components path: " + labkeyUIComponentsPath);
+
 module.exports = {
+    labkeyUIComponentsPath: labkeyUIComponentsPath,
     context: function(dir) {
         return path.resolve(dir, '..');
     },
@@ -114,6 +120,14 @@ module.exports = {
                 },{
                     loader: 'ts-loader',
                     options: {
+                        // override default "compilerOptions" declared in tsconfig.json
+                        compilerOptions: {
+                            "baseUrl": ".",
+                            "paths": {
+                                "immutable": [labkeyUIComponentsPath + "/node_modules/immutable"],
+                                "@labkey/components": [labkeyUIComponentsPath]
+                            }
+                        },
                         onlyCompileBundledFiles: true
                         // this flag and the test regex will make sure that test files do not get bundled
                         // see: https://github.com/TypeStrong/ts-loader/issues/267

--- a/webpack/watch.config.js
+++ b/webpack/watch.config.js
@@ -70,7 +70,7 @@ module.exports = {
         alias: {
             // uncomment and adjust the relative path for your enlistment to enable hot reloading of the app when
             // new builds happen in @labkey/components
-            // '@labkey/components': path.resolve(__dirname, "../../../../../../labkey-ui-components/packages/components"),
+            // '@labkey/components': constants.labkeyUIComponentsPath,
 
             // This assures there is only one copy of react in the application
             react: path.resolve(__dirname, "../node_modules/react")

--- a/webpack/watch.config.js
+++ b/webpack/watch.config.js
@@ -7,6 +7,7 @@ const lkModule = process.env.LK_MODULE;
 const webpack = require('webpack');
 const entryPoints = require('../' + lkModule + '/src/client/entryPoints');
 const constants = require('./constants');
+const path = require('path');
 
 // set based on the lk module calling this config
 __dirname = lkModule;
@@ -65,8 +66,14 @@ module.exports = {
 
     resolve: {
         extensions: constants.extensions.TYPESCRIPT,
+
         alias: {
-            'react-dom': '@hot-loader/react-dom'
+            // uncomment and adjust the relative path for your enlistment to enable hot reloading of the app when
+            // new builds happen in @labkey/components
+            // '@labkey/components': path.resolve(__dirname, "../../../../../../labkey-ui-components/packages/components"),
+
+            // This assures there is only one copy of react in the application
+            react: path.resolve(__dirname, "../node_modules/react")
         }
     },
 


### PR DESCRIPTION
#### Rationale
We are introducing the use of webpack aliases for better hot-reloading of changes from this package and other premium packages within module applications.  By using aliases, and adjusting the typescript configuration to assure we resolve to a single directory for the type definitions, we are able to make changes to packages in multiple directories and have them hot reloaded by an application without having to copy individual `dist` directories over to the `node_modules` directories.  The changes from the ui-components package are properly loaded for both the direct dependency and the transitive dependency (@labkey/freezermanager) when aliases are set up in both places.

See also: [Sharing Premium Components](https://docs.google.com/document/d/1yPNqONxO23BFPNdyZbLXMlYwinDBTgzbimKSyhuvOUI/edit#)

The changes in `tsconfig.json` and the webpack config file assume that the enlistment in `labkey-ui-components` is a sibling of the `trunk` enlistment.  If this is not the case, the relative path to the `labkey-ui-components` enlistment will need to be adjusted locally.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/357
* https://github.com/LabKey/inventory/pull/104

#### Changes
* update tsconfig.js to resolve to single paths for various type references
* Add commented out aliases in hot reloading webpack config to be able to pick up changes from dependent packages automatically