### PR TITLE
Allow enabling troubleshooting stacktraces on TeamCity

### DIFF
--- a/core/src/org/labkey/core/admin/miniprofiler/MiniProfilerController.java
+++ b/core/src/org/labkey/core/admin/miniprofiler/MiniProfilerController.java
@@ -169,6 +169,18 @@ public class MiniProfilerController extends SpringActionController
         }
     }
 
+    // Invoked by test framework
+    @RequiresSiteAdmin
+    public class EnableTroubleshootingStacktracesAction extends MutatingApiAction<EnableForm>
+    {
+        @Override
+        public Object execute(EnableForm form, BindException errors)
+        {
+            MiniProfiler.setCollectTroubleshootingStackTraces(form.isEnabled());
+            return success(Collections.singletonMap("enabled", MiniProfiler.isCollectTroubleshootingStackTraces()));
+        }
+    }
+
     @JsonIgnoreProperties("apiVersion")
     public static class EnableForm
     {


### PR DESCRIPTION
#### Rationale
We encounter occasional memory leaks on TeamCity. Being able to quickly enable stacktraces would be useful for debugging such failures.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/493

#### Changes
* New action to enable troubleshooting stacktraces via API
