### PR TITLE
41555: Specimen file watcher show up in non-study folders

### DIFF
--- a/study/webapp/WEB-INF/study/studyContext.xml
+++ b/study/webapp/WEB-INF/study/studyContext.xml
@@ -167,7 +167,6 @@
                     <property name="protocolFactoryName" value="specimenImport"/>
                     <property name="defaultDisplayState" value="hidden"/>
                     <property name="allowForTriggerConfiguration" value="true"/>
-                    <property name="activeModuleRequired" value="false"/>
                     <property name="initialInputExts">
                         <list>
                             <ref bean="zipFileType"/>


### PR DESCRIPTION
#### Rationale
Requires the study module to expose the specimen file watcher.

[issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41555)

