### PR TITLE
Issue 41560: Switch Selector forEach() and forEachBatch() parameter order

### DIFF
--- a/api/src/org/labkey/api/data/AbstractSelectorTestCase.java
+++ b/api/src/org/labkey/api/data/AbstractSelectorTestCase.java
@@ -53,23 +53,23 @@ public abstract class AbstractSelectorTestCase<SELECTOR extends Selector> extend
         assertEquals(count, selector.getArray(clazz).length);
 
         rowCount.setValue(0);
-        selector.forEach(bean -> rowCount.increment(), clazz);
+        selector.forEach(clazz, bean -> rowCount.increment());
         assertEquals(count, rowCount.intValue());
 
         rowCount.setValue(0);
-        selector.forEachBatch(batch -> {
+        selector.forEachBatch(clazz, 3, batch -> {
             assertFalse(batch.isEmpty());
             assertTrue(batch.size() <= 3);
             rowCount.add(batch.size());
-        }, clazz, 3);
+        });
         assertEquals(count, rowCount.intValue());
 
         rowCount.setValue(0);
-        selector.forEachMapBatch(batch -> {
+        selector.forEachMapBatch(5, batch -> {
             assertFalse(batch.isEmpty());
             assertTrue(batch.size() <= 5);
             rowCount.add(batch.size());
-        }, 5);
+        });
         assertEquals(count, rowCount.intValue());
 
         // Test ResultSet operations

--- a/api/src/org/labkey/api/data/NonSqlExecutingSelector.java
+++ b/api/src/org/labkey/api/data/NonSqlExecutingSelector.java
@@ -26,7 +26,7 @@ import java.sql.Connection;
  * Date: 7/11/2014
  * Time: 6:51 AM
  */
-public abstract class NonSqlExecutingSelector<SELECTOR extends NonSqlExecutingSelector> extends BaseSelector<SELECTOR>
+public abstract class NonSqlExecutingSelector<SELECTOR extends NonSqlExecutingSelector<?>> extends BaseSelector<SELECTOR>
 {
     protected NonSqlExecutingSelector(@NotNull DbScope scope, @Nullable Connection conn)
     {

--- a/api/src/org/labkey/api/data/ObjectFactory.java
+++ b/api/src/org/labkey/api/data/ObjectFactory.java
@@ -48,7 +48,7 @@ public interface ObjectFactory<K>
     K[] handleArray(ResultSet rs) throws SQLException;
 
 
-    public static class Registry
+    class Registry
     {
         private static final Logger _log = LogManager.getLogger(Registry.class);
         private static final Map<Class, ObjectFactory> _registry = new ConcurrentHashMap<>(64);

--- a/api/src/org/labkey/api/data/Selector.java
+++ b/api/src/org/labkey/api/data/Selector.java
@@ -134,17 +134,35 @@ public interface Selector
      *  larger than batchSize. This is convenient for cases where streaming is desired, but processing in batches is more
      *  efficient than one-by-one. All batches are of size batchSize, except the last batch which is typically smaller.
      */
-    void forEachMapBatch(ForEachBatchBlock<Map<String, Object>> batchBlock, int batchSize);
+    void forEachMapBatch(int batchSize, ForEachBatchBlock<Map<String, Object>> batchBlock);
+
+    @Deprecated // Use variant above instead. This will be removed soon.
+    default void forEachMapBatch(ForEachBatchBlock<Map<String, Object>> batchBlock, int batchSize)
+    {
+        forEachMapBatch(batchSize, batchBlock);
+    }
 
     /** Stream objects from the database. Convert each result row into an object specified by clazz and invoke block.exec() on it. */
-    <T> void forEach(ForEachBlock<T> block, Class<T> clazz);
+    <T> void forEach(Class<T> clazz, ForEachBlock<T> block);
+
+    @Deprecated // Use variant above instead. This will be removed soon.
+    default <T> void forEach(ForEachBlock<T> block, Class<T> clazz)
+    {
+        forEach(clazz, block);
+    }
 
     /**
      *  Stream objects from the database in batches. Convert rows to objects and pass them to batchBlock.exec() in batches
      *  no larger than batchSize. This is convenient for cases where streaming is desired, but processing in batches is more
      *  efficient than one-by-one. All batches are of size batchSize, except the last batch which is typically smaller.
      */
-    <T> void forEachBatch(ForEachBatchBlock<T> batchBlock, Class<T> clazz, int batchSize);
+    <T> void forEachBatch(Class<T> clazz, int batchSize, ForEachBatchBlock<T> batchBlock);
+
+    @Deprecated // Use variant above instead. This will be removed soon.
+    default <T> void forEachBatch(ForEachBatchBlock<T> batchBlock, Class<T> clazz, int batchSize)
+    {
+        forEachBatch(clazz, batchSize, batchBlock);
+    }
 
     /** Return a new map from a two-column query; the first column is the key, the second column is the value. */
     @NotNull <K, V> Map<K, V> getValueMap();

--- a/api/src/org/labkey/api/data/TableSelector.java
+++ b/api/src/org/labkey/api/data/TableSelector.java
@@ -251,10 +251,10 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
     }
 
     @Override
-    protected void forEach(ForEachBlock<ResultSet> block, ResultSetFactory factory)
+    protected void forEach(ResultSetFactory factory, ForEachBlock<ResultSet> block)
     {
         ensureStableColumnOrder("forEach(ForEachBlock<ResultSet> block)");
-        super.forEach(block, factory);
+        super.forEach(factory, block);
     }
 
     public void forEachResults(ForEachBlock<Results> block)

--- a/api/src/org/labkey/api/data/TableSelectorTestCase.java
+++ b/api/src/org/labkey/api/data/TableSelectorTestCase.java
@@ -135,7 +135,7 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
         assertEquals(count, selector.getCollection(User.class).size());
 
         final MutableInt forEachCount = new MutableInt(0);
-        selector.forEach(user -> forEachCount.increment(), User.class);
+        selector.forEach(User.class, user -> forEachCount.increment());
         assertEquals(count, forEachCount.intValue());
 
         final MutableInt forEachMapCount = new MutableInt(0);
@@ -143,11 +143,11 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
         assertEquals(count, forEachMapCount.intValue());
 
         final MutableInt forEachBatchCount = new MutableInt(0);
-        selector.forEachBatch(batch -> {
+        selector.forEachBatch(User.class, 3, batch -> {
             assertFalse(batch.isEmpty());
             assertTrue(batch.size() <= 3);
             forEachBatchCount.add(batch.size());
-        }, User.class, 3);
+        });
         assertEquals(count, forEachBatchCount.intValue());
 
         assertEquals(count, selector.stream(User.class).count());
@@ -346,7 +346,7 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
             int offset = 2;
 
             MutableInt testCount = new MutableInt(0);
-            selector.forEach(new ForEachBlock<K>()
+            selector.forEach(clazz, new ForEachBlock<K>()
             {
                 @Override
                 public void exec(K object) throws StopIteratingException
@@ -356,7 +356,7 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
                     if (testCount.intValue() == rowCount)
                         stopIterating();
                 }
-            }, clazz);
+            });
             assertEquals(rowCount, testCount.intValue());
 
             selector.setMaxRows(Table.ALL_ROWS);

--- a/api/src/org/labkey/api/qc/QCStateManager.java
+++ b/api/src/org/labkey/api/qc/QCStateManager.java
@@ -59,13 +59,13 @@ public class QCStateManager
             Map<Integer, QCState> qcStateIdMap = new HashMap<>();
             Map<String, QCState>  qcStateLabelMap = new HashMap<>();
 
-            new TableSelector(CoreSchema.getInstance().getTableInfoQCState(), SimpleFilter.createContainerFilter(c), new Sort("Label")).forEach(qcState -> {
+            new TableSelector(CoreSchema.getInstance().getTableInfoQCState(), SimpleFilter.createContainerFilter(c), new Sort("Label")).forEach(QCState.class, qcState -> {
 
                 qcStates.add(qcState);
                 qcStateIdMap.put(qcState.getRowId(), qcState);
                 qcStateLabelMap.put(qcState.getLabel(), qcState);
 
-            }, QCState.class);
+            });
 
             _qcStates = Collections.unmodifiableList(qcStates);
             _qcStateIdMap = Collections.unmodifiableMap(qcStateIdMap);

--- a/api/src/org/labkey/api/util/MemTracker.java
+++ b/api/src/org/labkey/api/util/MemTracker.java
@@ -118,7 +118,7 @@ public class MemTracker
 
     public static class HeldReference extends AllocationInfo
     {
-        private Object _reference;
+        private final Object _reference;
 
         private HeldReference(Object held, AllocationInfo allocationInfo)
         {

--- a/api/src/org/labkey/api/view/WebPartCache.java
+++ b/api/src/org/labkey/api/view/WebPartCache.java
@@ -122,14 +122,14 @@ public class WebPartCache
 
             SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("Container"), containerId);
 
-            new TableSelector(Portal.getTableInfoPortalWebParts(), filter, new Sort("Index")).forEach(wp -> {
+            new TableSelector(Portal.getTableInfoPortalWebParts(), filter, new Sort("Index")).forEach(WebPart.class, wp -> {
                 Portal.PortalPage p = pagesByRowId.get(wp.getPortalPageId());
                 if (null != p)
                 {
                     p.addWebPart(wp);
                     wp.setPageId(p.getPageId());
                 }
-            }, WebPart.class);
+            });
 
             // create immutable PortalPage objects for caching
             CaseInsensitiveHashMap<Portal.PortalPage> ret = new CaseInsensitiveHashMap<>();

--- a/assay/api-src/org/labkey/api/assay/dilution/DilutionDataHandler.java
+++ b/assay/api-src/org/labkey/api/assay/dilution/DilutionDataHandler.java
@@ -724,8 +724,8 @@ public abstract class DilutionDataHandler extends AbstractExperimentDataHandler
     {
         Map<String, Pair<Integer, String>> wellGroupNameToNabSpecimen = new HashMap<>();
         SimpleFilter filter = new SimpleFilter(FieldKey.fromString("RunId"), run.getRowId());
-        new TableSelector(DilutionManager.getTableInfoNAbSpecimen(), filter, null).forEach((NabSpecimen nabSpecimen) ->
-                wellGroupNameToNabSpecimen.put(nabSpecimen.getWellgroupName(), new Pair<>(nabSpecimen.getRowId(), nabSpecimen.getSpecimenLsid())), NabSpecimen.class);
+        new TableSelector(DilutionManager.getTableInfoNAbSpecimen(), filter, null).forEach(NabSpecimen.class, (NabSpecimen nabSpecimen) ->
+                wellGroupNameToNabSpecimen.put(nabSpecimen.getWellgroupName(), new Pair<>(nabSpecimen.getRowId(), nabSpecimen.getSpecimenLsid())));
 
         populateWellData(protocol, run, user, getCutoffFormats(protocol, run), wellGroupNameToNabSpecimen);
     }
@@ -750,8 +750,8 @@ public abstract class DilutionDataHandler extends AbstractExperimentDataHandler
     {
         Map<String, Pair<Integer, String>> wellGroupNameToNabSpecimen = new HashMap<>();
         SimpleFilter filter = new SimpleFilter(FieldKey.fromString("RunId"), run.getRowId());
-        new TableSelector(DilutionManager.getTableInfoNAbSpecimen(), filter, null).forEach((NabSpecimen nabSpecimen) ->
-                wellGroupNameToNabSpecimen.put(nabSpecimen.getWellgroupName(), new Pair<>(nabSpecimen.getRowId(), nabSpecimen.getSpecimenLsid())), NabSpecimen.class);
+        new TableSelector(DilutionManager.getTableInfoNAbSpecimen(), filter, null).forEach(NabSpecimen.class, (NabSpecimen nabSpecimen) ->
+                wellGroupNameToNabSpecimen.put(nabSpecimen.getWellgroupName(), new Pair<>(nabSpecimen.getRowId(), nabSpecimen.getSpecimenLsid())));
 
         _populateWellData(protocol, run, user, getCutoffFormats(protocol, run), wellGroupNameToNabSpecimen, false, false, dilutionData, wellData);
     }

--- a/assay/src/org/labkey/assay/plate/query/PlateTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateTable.java
@@ -68,13 +68,13 @@ public class PlateTable extends BasePlateTable
         filter.addCondition(FieldKey.fromParts("PropertyURI"), propPrefix, CompareType.STARTS_WITH);
         final Map<String, PropertyDescriptor> map = new TreeMap<>();
 
-        new TableSelector(OntologyManager.getTinfoPropertyDescriptor(), filter, null).forEach(pd -> {
+        new TableSelector(OntologyManager.getTinfoPropertyDescriptor(), filter, null).forEach(PropertyDescriptor.class, pd -> {
             if (pd.getPropertyType() == PropertyType.DOUBLE)
                 pd.setFormat("0.##");
             map.put(pd.getName(), pd);
             visibleColumns.add(new FieldKey(keyProp, pd.getName()));
 
-        }, PropertyDescriptor.class);
+        });
 
         colProperty.setFk(new PropertyForeignKey(schema, null, map));
         colProperty.setIsUnselectable(true);

--- a/assay/src/org/labkey/assay/plate/query/WellGroupTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellGroupTable.java
@@ -82,13 +82,13 @@ public class WellGroupTable extends BasePlateTable
         filter.addCondition(FieldKey.fromParts("PropertyURI"), propPrefix, CompareType.STARTS_WITH);
         final Map<String, PropertyDescriptor> map = new TreeMap<>();
 
-        new TableSelector(OntologyManager.getTinfoPropertyDescriptor(), filter, null).forEach(pd -> {
+        new TableSelector(OntologyManager.getTinfoPropertyDescriptor(), filter, null).forEach(PropertyDescriptor.class, pd -> {
             if (pd.getPropertyType() == PropertyType.DOUBLE)
                 pd.setFormat("0.##");
             map.put(pd.getName(), pd);
             visibleColumns.add(new FieldKey(keyProp, pd.getName()));
 
-        }, PropertyDescriptor.class);
+        });
 
         colProperty.setFk(new PropertyForeignKey(schema, null, map));
         colProperty.setIsUnselectable(true);

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -227,7 +227,7 @@ public class ExperimentServiceImpl implements ExperimentService
         TableSelector selector = new TableSelector(getTinfoExperimentRun(), filter, null);
 
         final List<ExpRunImpl> runs = new ArrayList<>(rowids.size());
-        selector.forEach(run -> runs.add(new ExpRunImpl(run)), ExperimentRun.class);
+        selector.forEach(ExperimentRun.class, run -> runs.add(new ExpRunImpl(run)));
 
         return runs;
     }
@@ -619,7 +619,7 @@ public class ExperimentServiceImpl implements ExperimentService
         TableSelector selector = new TableSelector(getTinfoMaterial(), filter, null);
 
         final List<ExpMaterialImpl> materials = new ArrayList<>(rowids.size());
-        selector.forEach(material -> materials.add(new ExpMaterialImpl(material)), Material.class);
+        selector.forEach(Material.class, material -> materials.add(new ExpMaterialImpl(material)));
 
         return materials;
     }
@@ -631,7 +631,7 @@ public class ExperimentServiceImpl implements ExperimentService
         TableSelector selector = new TableSelector(getTinfoMaterial(), filter, null);
 
         final List<ExpMaterialImpl> materials = new ArrayList<>(lsids.size());
-        selector.forEach(material -> materials.add(new ExpMaterialImpl(material)), Material.class);
+        selector.forEach(Material.class, material -> materials.add(new ExpMaterialImpl(material)));
 
         return materials;
     }
@@ -879,13 +879,13 @@ public class ExperimentServiceImpl implements ExperimentService
                 .append(" AND (d.lastIndexed IS NULL OR d.lastIndexed < ? OR (d.modified IS NOT NULL AND d.lastIndexed < d.modified))")
                 .add(dataClass.getModified());
 
-        new SqlSelector(table.getSchema().getScope(), sql).forEachBatch(batch -> {
+        new SqlSelector(table.getSchema().getScope(), sql).forEachBatch(Data.class, 1000, batch -> {
             for (Data data : batch)
             {
                 ExpDataImpl impl = new ExpDataImpl(data);
                 impl.index(task);
             }
-        }, Data.class, 1000);
+        });
     }
 
     private void indexDataClass(ExpDataClass expDataClass, SearchService.IndexTask task)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -247,13 +247,13 @@ public class SampleTypeServiceImpl extends AuditHandler implements SampleTypeSer
                 .append(" AND (m.lastIndexed IS NULL OR m.lastIndexed < ? OR (m.modified IS NOT NULL AND m.lastIndexed < m.modified))")
                 .add(sampleType.getModified());
 
-        new SqlSelector(getExpSchema().getScope(), sql).forEachBatch(batch -> {
+        new SqlSelector(getExpSchema().getScope(), sql).forEachBatch(Material.class, 1000, batch -> {
             for (Material m : batch)
             {
                 ExpMaterialImpl impl = new ExpMaterialImpl(m);
                 impl.index(task);
             }
-        }, Material.class, 1000);
+        });
     }
 
 

--- a/experiment/src/org/labkey/experiment/api/property/DomainPropertyManager.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainPropertyManager.java
@@ -169,7 +169,7 @@ public class DomainPropertyManager
 
         final MultiValuedMap<Integer, PropertyValidator> validators = new ArrayListValuedHashMap<>();
 
-        new SqlSelector(getExpSchema(), sql, containerId).forEach(pv -> validators.put(pv.getPropertyId(), pv), PropertyValidator.class);
+        new SqlSelector(getExpSchema(), sql, containerId).forEach(PropertyValidator.class, pv -> validators.put(pv.getPropertyId(), pv));
 
         return validators.isEmpty() ? MultiMapUtils.emptyMultiValuedMap() : MultiMapUtils.unmodifiableMultiValuedMap(validators);
     };

--- a/issues/src/org/labkey/issue/model/IssueListDefCache.java
+++ b/issues/src/org/labkey/issue/model/IssueListDefCache.java
@@ -58,7 +58,7 @@ public class IssueListDefCache
             Map<String, IssueListDef> nameMap = new HashMap<>();
             Map<String, List<IssueListDef>> domainKindMap = new HashMap<>();
 
-            new TableSelector(IssuesSchema.getInstance().getTableInfoIssueListDef(), SimpleFilter.createContainerFilter(c), null).forEach(issueDef -> {
+            new TableSelector(IssuesSchema.getInstance().getTableInfoIssueListDef(), SimpleFilter.createContainerFilter(c), null).forEach(IssueListDef.class, issueDef -> {
 
                 rowIdMap.put(issueDef.getRowId(), issueDef);
                 nameMap.put(issueDef.getName(), issueDef);
@@ -68,7 +68,7 @@ public class IssueListDefCache
 
                 domainKindMap.get(issueDef.getKind()).add(issueDef);
 
-            }, IssueListDef.class);
+            });
 
             _rowIdMap = Collections.unmodifiableMap(rowIdMap);
             _nameMap = Collections.unmodifiableMap(nameMap);

--- a/issues/src/org/labkey/issue/model/IssueManager.java
+++ b/issues/src/org/labkey/issue/model/IssueManager.java
@@ -986,7 +986,7 @@ public class IssueManager
 
         // Index issues in batches of 100
         new TableSelector(_issuesSchema.getTableInfoIssues(), PageFlowUtil.set("issueid"), f, null)
-                .forEachBatch(batch -> task.addRunnable(new IndexGroup(task, batch), SearchService.PRIORITY.group), Integer.class, 100);
+            .forEachBatch(Integer.class, 100, batch -> task.addRunnable(new IndexGroup(task, batch), SearchService.PRIORITY.group));
     }
 
     private static class IndexGroup implements Runnable
@@ -1265,10 +1265,10 @@ public class IssueManager
                 append(" WHERE IssueId IN (SELECT IssueId FROM ").append(IssuesSchema.getInstance().getTableInfoIssues(), "").
                 append(" WHERE IssueDefId = ?)");
         commentsSQL.add(issueDef.getRowId());
-        new SqlSelector(IssuesSchema.getInstance().getSchema(), commentsSQL).forEach(entityId -> {
+        new SqlSelector(IssuesSchema.getInstance().getSchema(), commentsSQL).forEach(String.class, entityId -> {
             CommentAttachmentParent parent = new CommentAttachmentParent(c.getId(), entityId);
             attachmentParents.add(parent);
-        }, String.class);
+        });
 
         AttachmentService.get().deleteAttachments(attachmentParents);
 

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -1058,12 +1058,12 @@ public class ListManager implements SearchService.DocumentProvider
         String listSchemaName = ListSchema.getInstance().getSchemaName();
 
         // Now clear LastIndexed column of every underlying list table, which addresses the "index each list item as a separate document" case. See #28748.
-        new TableSelector(getListMetadataTable()).forEach(listDef -> {
+        new TableSelector(getListMetadataTable()).forEach(ListDef.class, listDef -> {
             ListDefinition list = new ListDefinitionImpl(listDef);
             Domain domain = list.getDomain();
             if (null != domain && null != domain.getStorageTableName())
                 clearLastIndexed(scope, listSchemaName + "." + domain.getStorageTableName());
-        }, ListDef.class);
+        });
     }
 
     private void clearLastIndexed(DbScope scope, String selectName)

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -442,7 +442,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
         ListManager.get().deleteIndexedList(_list);
 
         // Delete attachments and discussions associated with a list in batches of 1,000
-        new TableSelector(getDbTable(), new CaseInsensitiveHashSet("entityId")).forEachBatch(new ForEachBatchBlock<String>()
+        new TableSelector(getDbTable(), new CaseInsensitiveHashSet("entityId")).forEachBatch(String.class, 1000, new ForEachBatchBlock<String>()
         {
             @Override
             public boolean accept(String entityId)
@@ -456,7 +456,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
                 // delete the related list data for this block
                 deleteRelatedListData(user, container, entityIds);
             }
-        }, String.class, 1000);
+        });
     }
 
     // delete the related list data for this block of entityIds

--- a/query/src/org/labkey/query/olap/ServerManager.java
+++ b/query/src/org/labkey/query/olap/ServerManager.java
@@ -179,7 +179,7 @@ public class ServerManager
             SimpleFilter filter = SimpleFilter.createContainerFilter(c);
 
             new TableSelector(QueryManager.get().getTableInfoOlapDef(), filter, null)
-                .forEach(def -> map.put(def.getName(), new CustomOlapSchemaDescriptor(def)), OlapDef.class);
+                .forEach(OlapDef.class, def -> map.put(def.getName(), new CustomOlapSchemaDescriptor(def)));
 
             return map.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(map);
         }

--- a/query/src/org/labkey/query/persist/CustomViewCache.java
+++ b/query/src/org/labkey/query/persist/CustomViewCache.java
@@ -61,7 +61,7 @@ public class CustomViewCache
             Map<Integer, CstmView> rowIdMap = new HashMap<>();
             Map<String, CstmView> entityIdMap = new HashMap<>();
 
-            new TableSelector(QueryManager.get().getTableInfoCustomView(), SimpleFilter.createContainerFilter(c), null).forEach(cstmView -> {
+            new TableSelector(QueryManager.get().getTableInfoCustomView(), SimpleFilter.createContainerFilter(c), null).forEach(CstmView.class, cstmView -> {
 
                 MultiValuedMap<String, CstmView> viewMap = ensureViewMultiMap(customViews, cstmView.getSchema());
 
@@ -74,7 +74,7 @@ public class CustomViewCache
                     inheritableViewMap.put(cstmView.getQueryName(), cstmView);
                 }
 
-            }, CstmView.class);
+            });
 
             _customViews = getUnmodifiable(customViews);
             _rowIdMap = Collections.unmodifiableMap(rowIdMap);

--- a/query/src/org/labkey/query/persist/QueryDefCache.java
+++ b/query/src/org/labkey/query/persist/QueryDefCache.java
@@ -61,7 +61,7 @@ public class QueryDefCache
             Map<String, Map<String, QueryDef>> customQueryDefs = new CaseInsensitiveHashMap<>();
             Map<Integer, QueryDef> queryDefIdMap = new HashMap<>();
 
-            new TableSelector(QueryManager.get().getTableInfoQueryDef(), SimpleFilter.createContainerFilter(c), null).forEach(queryDef -> {
+            new TableSelector(QueryManager.get().getTableInfoQueryDef(), SimpleFilter.createContainerFilter(c), null).forEach(QueryDef.class, queryDef -> {
 
                 if (queryDef.getSql() != null)
                 {
@@ -75,7 +75,7 @@ public class QueryDefCache
                 }
                 queryDefIdMap.put(queryDef.getQueryDefId(), queryDef);
 
-            }, QueryDef.class);
+            });
 
             _queryDefs = Collections.unmodifiableMap(queryDefs);
             _customQueryDefs = Collections.unmodifiableMap(customQueryDefs);

--- a/query/src/org/labkey/query/reports/DatabaseReportCache.java
+++ b/query/src/org/labkey/query/reports/DatabaseReportCache.java
@@ -59,7 +59,7 @@ public class DatabaseReportCache
             MultiValuedMap<String, Report> reportKeyMap = new CaseInsensitiveArrayListValuedMap<>(); // Issue 36199: change map to by case insensitive
             List<Report> inheritableReports = new LinkedList<>();
 
-            new TableSelector(CoreSchema.getInstance().getTableInfoReport(), SimpleFilter.createContainerFilter(c, "ContainerId"), null).forEach(reportDB -> {
+            new TableSelector(CoreSchema.getInstance().getTableInfoReport(), SimpleFilter.createContainerFilter(c, "ContainerId"), null).forEach(ReportDB.class, reportDB -> {
                 Report report = svc._getInstance(reportDB);
 
                 // Reports can be null if type is unknown (e.g., defining module disappears)
@@ -72,7 +72,7 @@ public class DatabaseReportCache
                     if ((reportDB.getFlags() & ReportDescriptor.FLAG_INHERITABLE) != 0)
                         inheritableReports.add(report);
                 }
-            }, ReportDB.class);
+            });
 
             _rowIdMap = Collections.unmodifiableMap(rowIdMap);
             _entityIdMap = Collections.unmodifiableMap(entityIdMap);

--- a/query/src/org/labkey/query/reports/ReportNotificationInfoProvider.java
+++ b/query/src/org/labkey/query/reports/ReportNotificationInfoProvider.java
@@ -42,7 +42,7 @@ public final class ReportNotificationInfoProvider extends NotificationInfoProvid
         filter.addBetween(FieldKey.fromString("Modified"), modifiedRangeStart, modifiedRangeEnd);
         Sort sort = new Sort("DisplayOrder");
         TableSelector selector = new TableSelector(reportTableInfo, filter, sort);
-        selector.forEach(report ->
+        selector.forEach(ReportDB.class, report ->
         {
             String containerId = report.getContainerId();
             if (!reportInfoMap.containsKey(containerId))
@@ -57,7 +57,7 @@ public final class ReportNotificationInfoProvider extends NotificationInfoProvid
                     subMap.put(categoryId, new ArrayList<>());
                 subMap.get(categoryId).add(notificationInfo);
             }
-        }, ReportDB.class);
+        });
         return reportInfoMap;
     }
 }

--- a/study/src/org/labkey/study/SpecimenManager.java
+++ b/study/src/org/labkey/study/SpecimenManager.java
@@ -2770,10 +2770,10 @@ public class SpecimenManager implements ContainerManager.ContainerListener
             SimpleFilter filter = SimpleFilter.createContainerFilter(container);
             filter.addInClause(FieldKey.fromParts("GlobalUniqueId"), idToVial.keySet());
 
-            new TableSelector(StudySchema.getInstance().getTableInfoSpecimenComment(), filter, null).forEach(comment -> {
+            new TableSelector(StudySchema.getInstance().getTableInfoSpecimenComment(), filter, null).forEach(SpecimenComment.class, comment -> {
                 Vial vial = idToVial.get(comment.getGlobalUniqueId());
                 result.put(vial, comment);
-            }, SpecimenComment.class);
+            });
 
             offset += GET_COMMENT_BATCH_SIZE;
         }

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -28,7 +28,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
@@ -44,7 +43,6 @@ import org.labkey.api.action.MutatingApiAction;
 import org.labkey.api.action.QueryViewAction;
 import org.labkey.api.action.ReadOnlyApiAction;
 import org.labkey.api.action.ReturnUrlForm;
-import org.labkey.api.action.SimpleApiJsonForm;
 import org.labkey.api.action.SimpleErrorView;
 import org.labkey.api.action.SimpleRedirectAction;
 import org.labkey.api.action.SimpleViewAction;
@@ -72,7 +70,6 @@ import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.gwt.client.AuditBehaviorType;
-import org.labkey.api.module.FolderTypeManager;
 import org.labkey.api.module.ModuleHtmlView;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.PipeRoot;
@@ -181,7 +178,6 @@ import org.labkey.study.CohortFilter;
 import org.labkey.study.CohortFilterFactory;
 import org.labkey.study.MasterPatientIndexMaintenanceTask;
 import org.labkey.study.SpecimenManager;
-import org.labkey.study.StudyFolderType;
 import org.labkey.study.StudyModule;
 import org.labkey.study.StudySchema;
 import org.labkey.study.StudyServiceImpl;
@@ -2215,12 +2211,12 @@ public class StudyController extends BaseStudyController
                     "SELECT v.RowId FROM study.Visit v WHERE Container = ? AND NOT EXISTS (SELECT * FROM study.ParticipantVisit pv WHERE pv.Container = ? and pv.VisitRowId = v.RowId)",
                     getContainer(), getContainer()
                 )
-            ).forEach(rowId -> {
+            ).forEach(Integer.class, rowId -> {
                 VisitImpl visit = StudyManager.getInstance().getVisitForRowId(study, rowId);
 
                 if (null != visit)
                     visits.add(visit);
-            }, Integer.class);
+            });
 
             return visits;
         }

--- a/study/src/org/labkey/study/dataset/DatasetNotificationInfoProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetNotificationInfoProvider.java
@@ -47,7 +47,7 @@ public final class DatasetNotificationInfoProvider extends NotificationInfoProvi
         filter.addBetween(FieldKey.fromString("Modified"), modifiedRangeStart, modifiedRangeEnd);
         Sort sort = new Sort("DisplayOrder");
         TableSelector selector = new TableSelector(reportTableInfo, filter, sort);
-        selector.forEach(report -> {
+        selector.forEach(DatasetDB.class, report -> {
             String containerId = report.getContainer();
             if (!notificationInfoMap.containsKey(containerId))
                 notificationInfoMap.put(containerId, new HashMap<>());
@@ -72,7 +72,7 @@ public final class DatasetNotificationInfoProvider extends NotificationInfoProvi
                     }
                 }
             }
-        }, DatasetDB.class);
+        });
         return notificationInfoMap;
     }
 }

--- a/study/src/org/labkey/study/importer/XmlVisitMapReader.java
+++ b/study/src/org/labkey/study/importer/XmlVisitMapReader.java
@@ -23,13 +23,16 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.study.TimepointType;
 import org.labkey.api.util.XmlBeansUtil;
 import org.labkey.api.util.XmlValidationException;
-import org.labkey.study.model.StudyManager;
+import org.labkey.study.importer.VisitMapRecord.VisitTagRecord;
+import org.labkey.study.model.StudyManager.VisitAlias;
 import org.labkey.study.model.VisitImpl;
 import org.labkey.study.model.VisitTag;
 import org.labkey.study.xml.DatasetType;
 import org.labkey.study.xml.VisitMapDocument;
+import org.labkey.study.xml.VisitMapDocument.VisitMap;
 import org.labkey.study.xml.VisitMapDocument.VisitMap.ImportAliases;
 import org.labkey.study.xml.VisitMapDocument.VisitMap.ImportAliases.Alias;
+import org.labkey.study.xml.VisitMapDocument.VisitMap.Visit;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -43,7 +46,7 @@ import java.util.List;
  */
 public class XmlVisitMapReader implements VisitMapReader
 {
-    private final VisitMapDocument.VisitMap _visitMapXml;
+    private final VisitMap _visitMapXml;
 
     public XmlVisitMapReader(String xml) throws VisitMapParseException
     {
@@ -88,10 +91,10 @@ public class XmlVisitMapReader implements VisitMapReader
     @NotNull
     public List<VisitMapRecord> getVisitMapRecords(TimepointType timepointType)
     {
-        VisitMapDocument.VisitMap.Visit[] visitsXml = _visitMapXml.getVisitArray();
+        Visit[] visitsXml = _visitMapXml.getVisitArray();
         List<VisitMapRecord> visits = new ArrayList<>(visitsXml.length);
 
-        for (VisitMapDocument.VisitMap.Visit visitXml : visitsXml)
+        for (Visit visitXml : visitsXml)
         {
             BigDecimal maxSequenceNum = visitXml.isSetMaxSequenceNum() ? visitXml.getMaxSequenceNum() : visitXml.getSequenceNum();
             BigDecimal protocolDay = null;
@@ -105,7 +108,7 @@ public class XmlVisitMapReader implements VisitMapReader
 
             if (null != visitXml.getDatasets())
             {
-                for (VisitMapDocument.VisitMap.Visit.Datasets.Dataset dataset : visitXml.getDatasets().getDatasetArray())
+                for (Visit.Datasets.Dataset dataset : visitXml.getDatasets().getDatasetArray())
                 {
                     if (dataset.getType() == DatasetType.REQUIRED)
                         required.add(dataset.getId());
@@ -115,9 +118,9 @@ public class XmlVisitMapReader implements VisitMapReader
             }
 
             VisitMapRecord record = new VisitMapRecord(visitXml.getSequenceNum(), maxSequenceNum, protocolDay, visitXml.getTypeCode(),
-                    visitXml.getLabel(), visitXml.getDescription(), visitXml.getCohort(), visitXml.getVisitDateDatasetId(), required,
-                    optional, visitXml.getShowByDefault(), visitXml.getDisplayOrder(), visitXml.getChronologicalOrder(),
-                    visitXml.getSequenceNumHandling(), getVisitTagRecords(visitXml));
+                visitXml.getLabel(), visitXml.getDescription(), visitXml.getCohort(), visitXml.getVisitDateDatasetId(), required,
+                optional, visitXml.getShowByDefault(), visitXml.getDisplayOrder(), visitXml.getChronologicalOrder(),
+                visitXml.getSequenceNumHandling(), getVisitTagRecords(visitXml));
 
             visits.add(record);
         }
@@ -128,9 +131,9 @@ public class XmlVisitMapReader implements VisitMapReader
 
     @Override
     @NotNull
-    public List<StudyManager.VisitAlias> getVisitImportAliases()
+    public List<VisitAlias> getVisitImportAliases()
     {
-        List<StudyManager.VisitAlias> ret = new LinkedList<>();
+        List<VisitAlias> ret = new LinkedList<>();
         ImportAliases importAliasesXml = _visitMapXml.getImportAliases();
 
         if (null != importAliasesXml)
@@ -138,7 +141,7 @@ public class XmlVisitMapReader implements VisitMapReader
             Alias[] aliases = importAliasesXml.getAliasArray();
 
             for (Alias alias : aliases)
-                ret.add(new StudyManager.VisitAlias(alias.getName(), alias.getSequenceNum()));
+                ret.add(new VisitAlias(alias.getName(), alias.getSequenceNum()));
         }
 
         return ret;
@@ -148,10 +151,10 @@ public class XmlVisitMapReader implements VisitMapReader
     @NotNull
     public List<VisitTag> getVisitTags()
     {
-        VisitMapDocument.VisitMap.VisitTag[] visitTagsXml = _visitMapXml.getVisitTagArray();
+        VisitMap.VisitTag[] visitTagsXml = _visitMapXml.getVisitTagArray();
         List<VisitTag> visitTags = new ArrayList<>(visitTagsXml.length);
 
-        for (VisitMapDocument.VisitMap.VisitTag visitTagXml : visitTagsXml)
+        for (VisitMap.VisitTag visitTagXml : visitTagsXml)
         {
             VisitTag visitTag = new VisitTag(visitTagXml.getName(), visitTagXml.getCaption(),
                                              visitTagXml.getDescription(), visitTagXml.getSingleUse());
@@ -161,12 +164,12 @@ public class XmlVisitMapReader implements VisitMapReader
         return visitTags;
     }
 
-    private List<VisitMapRecord.VisitTagRecord> getVisitTagRecords(VisitMapDocument.VisitMap.Visit visitXml)
+    private List<VisitTagRecord> getVisitTagRecords(Visit visitXml)
     {
-        List<VisitMapRecord.VisitTagRecord> visitTagRecords = new ArrayList<>();
+        List<VisitTagRecord> visitTagRecords = new ArrayList<>();
         if (null != visitXml.getVisitTags())
-            for (VisitMapDocument.VisitMap.Visit.VisitTags.VisitTag visitTag : visitXml.getVisitTags().getVisitTagArray())
-                visitTagRecords.add(new VisitMapRecord.VisitTagRecord(visitTag.getName(), visitTag.getCohort()));
+            for (Visit.VisitTags.VisitTag visitTag : visitXml.getVisitTags().getVisitTagArray())
+                visitTagRecords.add(new VisitTagRecord(visitTag.getName(), visitTag.getCohort()));
 
         return visitTagRecords;
     }

--- a/study/src/org/labkey/study/model/ParticipantGroupManager.java
+++ b/study/src/org/labkey/study/model/ParticipantGroupManager.java
@@ -917,7 +917,7 @@ public class ParticipantGroupManager
         final List<ParticipantGroup> groups = new ArrayList<>();
 
         Filter filter = new SimpleFilter(FieldKey.fromParts("categoryId"), def.getRowId());
-        new TableSelector(StudySchema.getInstance().getTableInfoParticipantGroup(), filter, new Sort("rowId")).forEach(group -> {
+        new TableSelector(StudySchema.getInstance().getTableInfoParticipantGroup(), filter, new Sort("rowId")).forEach(ParticipantGroup.class, group -> {
             // get the participants assigned to this group
             Filter filter1 = new SimpleFilter(FieldKey.fromParts("groupId"), group.getRowId());
             Set<String> participants = new HashSet<>();
@@ -926,7 +926,7 @@ public class ParticipantGroupManager
             group.setParticipantSet(participants);
             group.setCategoryLabel(def.getLabel());
             groups.add(group);
-        }, ParticipantGroup.class);
+        });
 
         return Collections.unmodifiableList(groups);
     };

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -1396,10 +1396,10 @@ public class StudyManager
             throw new IllegalStateException("Study Import/Export expected TableInfo.");
 
         TableSelector selector = new TableSelector(tinfo, containerFilter, null);
-        selector.forEach(visitTag -> {
+        selector.forEach(VisitTag.class, visitTag -> {
             allVisitTagMap.put(visitTag.getName(), visitTag);
             newVisitTagMap.remove(visitTag.getName());
-        }, VisitTag.class);
+        });
 
         List<VisitTag> newVisitTags = new ArrayList<>();
         newVisitTags.addAll(newVisitTagMap.values());
@@ -1459,7 +1459,7 @@ public class StudyManager
         final Map<String, VisitTag> visitTags = new HashMap<>();
         SimpleFilter containerFilter = SimpleFilter.createContainerFilter(study.getContainer());
         TableInfo tinfo = StudySchema.getInstance().getTableInfoVisitTag();
-        new TableSelector(tinfo, containerFilter, null).forEach(visitTag -> visitTags.put(visitTag.getName(), visitTag), VisitTag.class);
+        new TableSelector(tinfo, containerFilter, null).forEach(VisitTag.class, visitTag -> visitTags.put(visitTag.getName(), visitTag));
         return visitTags;
     }
 
@@ -1471,7 +1471,7 @@ public class StudyManager
         SimpleFilter filter = SimpleFilter.createContainerFilter(study.getContainer());
         filter.addCondition(FieldKey.fromString("Name"), visitTagName);
         TableInfo tinfo = StudySchema.getInstance().getTableInfoVisitTag();
-        new TableSelector(tinfo, filter, null).forEach(visitTags::add, VisitTag.class);
+        new TableSelector(tinfo, filter, null).forEach(VisitTag.class, visitTags::add);
 
         if (visitTags.isEmpty())
             return null;
@@ -1485,11 +1485,11 @@ public class StudyManager
         final Map<Integer, List<VisitTagMapEntry>> visitTagMapMap = new HashMap<>();
         SimpleFilter containerFilter = SimpleFilter.createContainerFilter(study.getContainer());
         TableInfo tinfo = StudySchema.getInstance().getTableInfoVisitTagMap();
-        new TableSelector(tinfo, containerFilter, null).forEach(visitTagMapEntry -> {
+        new TableSelector(tinfo, containerFilter, null).forEach(VisitTagMapEntry.class, visitTagMapEntry -> {
             if (!visitTagMapMap.containsKey(visitTagMapEntry.getVisitId()))
                 visitTagMapMap.put(visitTagMapEntry.getVisitId(), new ArrayList<>());
             visitTagMapMap.get(visitTagMapEntry.getVisitId()).add(visitTagMapEntry);
-        }, VisitTagMapEntry.class);
+        });
 
         return visitTagMapMap;
     }
@@ -1499,11 +1499,11 @@ public class StudyManager
         final Map<String, List<VisitTagMapEntry>> visitTagToVisitTagMapEntries = new HashMap<>();
         SimpleFilter containerFilter = SimpleFilter.createContainerFilter(study.getContainer());
         TableInfo tinfo = StudySchema.getInstance().getTableInfoVisitTagMap();
-        new TableSelector(tinfo, containerFilter, null).forEach(visitTagMapEntry -> {
+        new TableSelector(tinfo, containerFilter, null).forEach(VisitTagMapEntry.class, visitTagMapEntry -> {
             if (!visitTagToVisitTagMapEntries.containsKey(visitTagMapEntry.getVisitTag()))
                 visitTagToVisitTagMapEntries.put(visitTagMapEntry.getVisitTag(), new ArrayList<>());
             visitTagToVisitTagMapEntries.get(visitTagMapEntry.getVisitTag()).add(visitTagMapEntry);
-        }, VisitTagMapEntry.class);
+        });
 
         return visitTagToVisitTagMapEntries;
     }
@@ -1514,7 +1514,7 @@ public class StudyManager
         SimpleFilter filter = SimpleFilter.createContainerFilter(study.getContainer());
         filter.addCondition(FieldKey.fromString("VisitTag"), visitTagName);
         TableInfo tinfo = StudySchema.getInstance().getTableInfoVisitTagMap();
-        new TableSelector(tinfo, filter, null).forEach(visitTagMapEntries::add, VisitTagMapEntry.class);
+        new TableSelector(tinfo, filter, null).forEach(VisitTagMapEntry.class, visitTagMapEntries::add);
 
         return visitTagMapEntries;
     }

--- a/study/src/org/labkey/study/reports/ReportQueryViewFactory.java
+++ b/study/src/org/labkey/study/reports/ReportQueryViewFactory.java
@@ -56,7 +56,7 @@ import java.util.Map;
  */
 public class ReportQueryViewFactory
 {
-    private static ReportQueryViewFactory _instance = new ReportQueryViewFactory();
+    private static final ReportQueryViewFactory _instance = new ReportQueryViewFactory();
 
     public static ReportQueryViewFactory get()
     {
@@ -79,7 +79,6 @@ public class ReportQueryViewFactory
             // by default we want all rows since the data may be used for a chart, grid based reports will ask for paging
             // at the report level.
             settings.setMaxRows(Table.ALL_ROWS);
-
 
             ReportQueryView view = new StudyReportQueryView(schema, settings);
             view.setButtonBarPosition(DataRegion.ButtonBarPosition.TOP);

--- a/study/src/org/labkey/study/visitmanager/RelativeDateVisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/RelativeDateVisitManager.java
@@ -275,10 +275,10 @@ public class RelativeDateVisitManager extends VisitManager
         // Build up a set so that we can create all of them in bulk
         Set<Double> daysToEnsure = new HashSet<>();
 
-        new SqlSelector(schema, sql).forEach(day -> {
+        new SqlSelector(schema, sql).forEach(Integer.class, day -> {
             double seqNum = null != day ? day : 0;
             daysToEnsure.add(seqNum);
-        }, Integer.class);
+        });
 
         StudyManager.getInstance().ensureVisits(getStudy(), user, daysToEnsure, null);
 


### PR DESCRIPTION
#### Rationale
Moving the lambda parameter of `forEach()`, `forEachBatch()`, and related methods to the end improves formatting and readability of their callers. Leave the old variants in place for now, for backward compatibility. See https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41560

#### Related Pull Requests
* See list below

#### Changes
* Simple signature changes to `forEach()`, `forEachBatch()`, and `forEachMapBatch()` public methods and several related private/protected methods.
