### PR TITLE
Issue 41566: Standard Tomcat 404 error page on bogus file extension

### DIFF
--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -931,7 +931,7 @@ public class ExceptionUtil
         }
     }
 
-    private static void addDependenciesAndRender(int responseStatus, PageConfig pageConfig, HttpView<?> errorView, Throwable ex, HttpServletRequest request, HttpServletResponse response) throws Exception
+    private static void addDependenciesAndRender(int responseStatus, PageConfig pageConfig, HttpView<?> errorView, @Nullable Throwable ex, HttpServletRequest request, HttpServletResponse response) throws Exception
     {
         if (null == errorView)
         {
@@ -940,7 +940,11 @@ public class ExceptionUtil
         }
         pageConfig.addClientDependencies(errorView.getClientDependencies());
 
-        var title = responseStatus + ": " + ErrorView.ERROR_PAGE_TITLE + " -- " + ex.getMessage();
+        var title = responseStatus + ": " + ErrorView.ERROR_PAGE_TITLE;
+        if (null != ex)
+        {
+            title += " -- " + ex.getMessage();
+        }
         pageConfig.setTitle(title, false);
         errorView.getView().render(errorView.getModel(), request, response);
     }

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -480,6 +480,7 @@ public class DavController extends SpringActionController
                         }
                         catch (Exception e)
                         {
+                            _log.debug("Failed to render the error page.", e);
                             super.sendError(status.code, message);
                         }
                     }


### PR DESCRIPTION
#### Rationale
For invalid file extensions, we render the error page through dav controller and this fix handles the case if there is an exception after the dav controller calls the ExceptionUtil to render the error page.


