### PR TITLE
Item 7959: NAb assay updates to for more data access from NAbSpecimen table (and copied-to-study dataset)

### DIFF
--- a/assay/api-src/org/labkey/api/assay/dilution/DilutionDataHandler.java
+++ b/assay/api-src/org/labkey/api/assay/dilution/DilutionDataHandler.java
@@ -198,6 +198,7 @@ public abstract class DilutionDataHandler extends AbstractExperimentDataHandler
                 // TODO: factor this out in the nab data handlers
                 props.put("VirusWellGroupName", group.getProperty("VirusWellGroupName"));
 
+                // TODO once 20.7 changes merged in, use fitParams.toJSON helper
                 CurveFit.Parameters fitParams = dilution.getCurveParameters(assayResults.getRenderedCurveFitType());
                 props.put(FIT_PARAMETERS_PROPERTY_NAME, fitParams != null ? new JSONObject(fitParams.toMap()) : null);
             }

--- a/assay/api-src/org/labkey/api/assay/dilution/DilutionDataHandler.java
+++ b/assay/api-src/org/labkey/api/assay/dilution/DilutionDataHandler.java
@@ -91,6 +91,7 @@ public abstract class DilutionDataHandler extends AbstractExperimentDataHandler
     public static final String DATA_ROW_LSID_PROPERTY = "Data Row LSID";
     public static final String AUC_PROPERTY_FORMAT = "0.000";
     public static final String STD_DEV_PROPERTY_NAME = "StandardDeviation";
+    public static final String FIT_PARAMETERS_PROPERTY_NAME = "FitParameters";
 
     /** Lock object to only allow one thread to be populating well data at a time */
     public static final Object WELL_DATA_LOCK_OBJECT = new Object();

--- a/assay/api-src/org/labkey/api/assay/dilution/DilutionDataHandler.java
+++ b/assay/api-src/org/labkey/api/assay/dilution/DilutionDataHandler.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.json.JSONObject;
 import org.labkey.api.assay.nab.NabSpecimen;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
@@ -27,6 +28,7 @@ import org.labkey.api.data.DbScope;
 import org.labkey.api.data.OORDisplayColumnFactory;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableSelector;
+import org.labkey.api.data.statistics.CurveFit;
 import org.labkey.api.data.statistics.FitFailedException;
 import org.labkey.api.data.statistics.StatsService;
 import org.labkey.api.exp.ExperimentException;
@@ -195,6 +197,9 @@ public abstract class DilutionDataHandler extends AbstractExperimentDataHandler
 
                 // TODO: factor this out in the nab data handlers
                 props.put("VirusWellGroupName", group.getProperty("VirusWellGroupName"));
+
+                CurveFit.Parameters fitParams = dilution.getCurveParameters(assayResults.getRenderedCurveFitType());
+                props.put(FIT_PARAMETERS_PROPERTY_NAME, fitParams != null ? new JSONObject(fitParams.toMap()) : null);
             }
             return results;
         }
@@ -524,6 +529,7 @@ public abstract class DilutionDataHandler extends AbstractExperimentDataHandler
                 DILUTION_INPUT_MATERIAL_DATA_PROPERTY.equals(propertyName) ||
                 WELLGROUP_NAME_PROPERTY.equals(propertyName) ||
                 FIT_ERROR_PROPERTY.equals(propertyName) ||
+                FIT_PARAMETERS_PROPERTY_NAME.equals(propertyName) ||
                 propertyName.startsWith(AUC_PREFIX) ||
                 propertyName.startsWith(pAUC_PREFIX) ||
                 propertyName.startsWith(CURVE_IC_PREFIX) ||

--- a/assay/api-src/org/labkey/api/assay/dilution/DilutionManager.java
+++ b/assay/api-src/org/labkey/api/assay/dilution/DilutionManager.java
@@ -200,6 +200,13 @@ public class DilutionManager
     }
 
     @Nullable
+    public NabSpecimen getNabSpecimen(String specimenLsid)
+    {
+        Filter filter = new SimpleFilter(FieldKey.fromString("SpecimenLSID"), specimenLsid);
+        return getNabSpecimen(filter);
+    }
+
+    @Nullable
     public NabSpecimen getNabSpecimen(int rowId)
     {
         Filter filter = new SimpleFilter(FieldKey.fromString("RowId"), rowId);

--- a/assay/api-src/org/labkey/api/assay/nab/NabSpecimen.java
+++ b/assay/api-src/org/labkey/api/assay/nab/NabSpecimen.java
@@ -39,6 +39,7 @@ public class NabSpecimen
     private int _objectId;          // TODO: remove when we remove use of exp.Object
     private int _protocolId;
     private String _virusLsid;
+    private String _fitParameters;
 
     public int getDataId()
     {
@@ -198,5 +199,15 @@ public class NabSpecimen
     public void setVirusLsid(String virusLsid)
     {
         _virusLsid = virusLsid;
+    }
+
+    public String getFitParameters()
+    {
+        return _fitParameters;
+    }
+
+    public void setFitParameters(String fitParameters)
+    {
+        _fitParameters = fitParameters;
     }
 }

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobStoreImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobStoreImpl.java
@@ -86,6 +86,10 @@ public class PipelineJobStoreImpl extends PipelineJobMarshaller
             if (job == null)
                 throw new NoSuchJobException("Job checkpoint does not exist.");
 
+            // If the job is already runnning (i.e. maybe it was started from a defferred upgrade script), skip requeueing it
+            if (PipelineJob.TaskStatus.running.matches(sf.getStatus()))
+                return;
+
             // If the job is being retried from a non-error status, then don't
             // increment error and retry counts.  This happens when a server restart
             // causes all previously queued jobs to be requeued.

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobStoreImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobStoreImpl.java
@@ -86,10 +86,6 @@ public class PipelineJobStoreImpl extends PipelineJobMarshaller
             if (job == null)
                 throw new NoSuchJobException("Job checkpoint does not exist.");
 
-            // If the job is already runnning (i.e. maybe it was started from a defferred upgrade script), skip requeueing it
-            if (PipelineJob.TaskStatus.running.matches(sf.getStatus()))
-                return;
-
             // If the job is being retried from a non-error status, then don't
             // increment error and retry counts.  This happens when a server restart
             // causes all previously queued jobs to be requeued.


### PR DESCRIPTION
#### Rationale
Ticket [41023](https://www.labkey.org/Atlas/support%20tickets/issues-details.view?issueId=41023): Adding full curve NAb data to export
Feature Request [41520](https://www.labkey.org/Dataspace/Feature%20Requests/issues-details.view?issueId=41520): NAb - dilution data improvements

The HVTN lab would like to be able to export all of the fields associated with the dilutions curves from NAb data from the study folders in addition to their normal “ldo_export” view, explained in ticket 41023, so that the dilution data can be submitted to the SCHARP stats team. They would like to incorporate it as a standard dataset available after the NAb data is copied to study.

Additionally, the DataSpace team has been pulling the dilution data, as well as the fit parameter data, for the CAVD DataSpace portal. Adding dilution data, cell/virus control aggregates, and fit parameter data to be accessible from the copied-to-study dataset would also benefit them as they could simplify their current process that uses the selectRows API against the study dataset and then uses the getNAbRuns API against the assay folder in a multi step process.

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/247

#### Changes
* Save fit parameters as JSON with NAbSpecimen row on new run upload and update via QC exclusion workflow
* Show "FitParameters" column (not in default view column list) for NAbSpecimen table
* DilutionManager helper to get NAbSpecimen row from a specimenLsid value
