### PR TITLE
7711: Surface 'add user' button on project users page

### DIFF
--- a/api/src/org/labkey/api/security/SecurityUrls.java
+++ b/api/src/org/labkey/api/security/SecurityUrls.java
@@ -38,7 +38,7 @@ public interface SecurityUrls extends UrlProvider
     ActionURL getSiteGroupsURL(Container container, URLHelper returnURL);
     ActionURL getContainerURL(Container container);
     ActionURL getShowRegistrationEmailURL(Container container, ValidEmail email, String mailPrefix);
-    ActionURL getAddUsersURL();
+    ActionURL getAddUsersURL(Container container);
     ActionURL getFolderAccessURL(Container container);
     ActionURL getExternalToolsViewURL(User user, URLHelper returnURL); // Always root
     String getCompleteUserURLPrefix(Container container);

--- a/api/src/org/labkey/api/security/roles/FolderAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/FolderAdminRole.java
@@ -21,7 +21,6 @@ import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicy;
-import org.labkey.api.security.permissions.AddUserPermission;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DesignDataClassPermission;
 import org.labkey.api.security.permissions.DesignSampleTypePermission;
@@ -42,8 +41,7 @@ public class FolderAdminRole extends AbstractRole implements AdminRoleListener
         AdminPermission.class,
         FolderExportPermission.class,
         DesignDataClassPermission.class,
-        DesignSampleTypePermission.class,
-        AddUserPermission.class
+        DesignSampleTypePermission.class
     );
 
     public FolderAdminRole()

--- a/api/src/org/labkey/api/security/roles/FolderAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/FolderAdminRole.java
@@ -21,6 +21,7 @@ import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicy;
+import org.labkey.api.security.permissions.AddUserPermission;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DesignDataClassPermission;
 import org.labkey.api.security.permissions.DesignSampleTypePermission;
@@ -41,7 +42,8 @@ public class FolderAdminRole extends AbstractRole implements AdminRoleListener
         AdminPermission.class,
         FolderExportPermission.class,
         DesignDataClassPermission.class,
-        DesignSampleTypePermission.class
+        DesignSampleTypePermission.class,
+        AddUserPermission.class
     );
 
     public FolderAdminRole()

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -1312,12 +1312,18 @@ public class SecurityController extends SpringActionController
     }
 
 
-    @RequiresPermission(AddUserPermission.class)
+    @RequiresPermission(AdminPermission.class)
     public class AddUsersAction extends FormViewAction<AddUsersForm>
     {
         @Override
         public ModelAndView getView(AddUsersForm form, boolean reshow, BindException errors)
         {
+            Container c = getContainer();
+            if (!c.isRoot() && !c.getProject().hasPermission(getUser(), AdminPermission.class))
+                throw new UnauthorizedException("You must be an administrator at the project level to add new users.");
+            else if (!c.hasPermission(getUser(), AddUserPermission.class))
+                throw new UnauthorizedException("You do not have permissions to create new users.");
+
             return new JspView<Object>("/org/labkey/core/security/addUsers.jsp", form, errors);
         }
 

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -262,9 +262,9 @@ public class SecurityController extends SpringActionController
         }
 
         @Override
-        public ActionURL getAddUsersURL()
+        public ActionURL getAddUsersURL(Container container)
         {
-            return new ActionURL(AddUsersAction.class, ContainerManager.getRoot());
+            return new ActionURL(AddUsersAction.class, container);
         }
 
         @Override
@@ -1312,18 +1312,12 @@ public class SecurityController extends SpringActionController
     }
 
 
-    @RequiresPermission(AdminPermission.class)
+    @RequiresPermission(AddUserPermission.class)
     public class AddUsersAction extends FormViewAction<AddUsersForm>
     {
         @Override
         public ModelAndView getView(AddUsersForm form, boolean reshow, BindException errors)
         {
-            Container c = getContainer();
-            if (!c.isRoot() && !c.getProject().hasPermission(getUser(), AdminPermission.class))
-                throw new UnauthorizedException("You must be an administrator at the project level to add new users.");
-            else if (!c.hasPermission(getUser(), AddUserPermission.class))
-                throw new UnauthorizedException("You do not have permissions to create new users.");
-
             return new JspView<Object>("/org/labkey/core/security/addUsers.jsp", form, errors);
         }
 

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -321,7 +321,7 @@ public class UserController extends SpringActionController
     private void populateUserGridButtonBar(ButtonBar gridButtonBar, boolean isAnyAdmin)
     {
         User user = getUser();
-        boolean canAddUser = user.hasRootPermission(AddUserPermission.class);
+        boolean canAddUser = user.hasRootPermission(AddUserPermission.class) || getContainer().hasPermission(user, AddUserPermission.class);
         boolean canDeleteUser = user.hasRootPermission(DeleteUserPermission.class);
         boolean canUpdateUser = user.hasRootPermission(UpdateUserPermission.class);
 

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -327,7 +327,7 @@ public class UserController extends SpringActionController
 
         if (canAddUser)
         {
-            ActionButton insert = new ActionButton(PageFlowUtil.urlProvider(SecurityUrls.class).getAddUsersURL(), "Add Users");
+            ActionButton insert = new ActionButton(PageFlowUtil.urlProvider(SecurityUrls.class).getAddUsersURL(getContainer()), "Add Users");
             insert.setActionType(ActionButton.Action.LINK);
             gridButtonBar.add(insert);
         }

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -325,6 +325,13 @@ public class UserController extends SpringActionController
         boolean canDeleteUser = user.hasRootPermission(DeleteUserPermission.class);
         boolean canUpdateUser = user.hasRootPermission(UpdateUserPermission.class);
 
+        if (canAddUser)
+        {
+            ActionButton insert = new ActionButton(PageFlowUtil.urlProvider(SecurityUrls.class).getAddUsersURL(), "Add Users");
+            insert.setActionType(ActionButton.Action.LINK);
+            gridButtonBar.add(insert);
+        }
+
         if (getContainer().isRoot())
         {
             if (canUpdateUser)
@@ -346,13 +353,6 @@ public class UserController extends SpringActionController
                 delete.setRequiresSelection(true);
                 delete.setActionType(ActionButton.Action.POST);
                 gridButtonBar.add(delete);
-            }
-
-            if (canAddUser)
-            {
-                ActionButton insert = new ActionButton(PageFlowUtil.urlProvider(SecurityUrls.class).getAddUsersURL(), "Add Users");
-                insert.setActionType(ActionButton.Action.LINK);
-                gridButtonBar.add(insert);
             }
 
             Domain domain = null;


### PR DESCRIPTION
#### Rationale
We want a Project Administrator to be able to add new users to their folder/project. After adding the new user, the Project Admin will then use existing functionality to configure the user's access to the folder/project.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/501

#### Changes
* Update what permissions unlock the 'Add User' button on user grid view
* Make getAddUsersURL() respect container

Note:
The two areas in which the changes within the `populateUserGridButtonBar()` surface are within ShowUsersAction, and DetailsAction. ShowUsersAction is the desired area of change, and DetailsAction specifies its button bar is read-only, and so doesn't surface the 'Add User' button (as wanted).
