### PR TITLE
41532: Initialize Ext4 quicktips for surveys

### DIFF
--- a/survey/src/org/labkey/survey/view/surveyWizard.jsp
+++ b/survey/src/org/labkey/survey/view/surveyWizard.jsp
@@ -84,6 +84,7 @@
 
     Ext4.onReady(function(){
 
+        Ext4.QuickTips.init();
         var panel = Ext4.create('LABKEY.ext4.SurveyDisplayPanel', {
             cls             : 'lk-survey-panel themed-panel',
             rowId           : <%=rowId%>,


### PR DESCRIPTION
#### Rationale
Users can add tooltips to survey form elements using the extConfig labelAttrTpl property. However, since quicktips are not enabled on the page, a user would have to inject Ext4.QuickTips.init() into the before load function in their survey design.

In order to make this easier, we should just invoke the initialization on the page by default.

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41532)

