### PR TITLE
Issue 40239: DataClass: grid not rendering link for column URL property

### DIFF
--- a/api/src/org/labkey/api/collections/CaseInsensitiveHashSet.java
+++ b/api/src/org/labkey/api/collections/CaseInsensitiveHashSet.java
@@ -85,6 +85,36 @@ public class CaseInsensitiveHashSet extends HashSet<String>
         return modified;
     }
 
+    public static CaseInsensitiveHashSet of()
+    {
+        return new CaseInsensitiveHashSet();
+    }
+
+    public static CaseInsensitiveHashSet of(String s1)
+    {
+        return new CaseInsensitiveHashSet(s1);
+    }
+
+    public static CaseInsensitiveHashSet of(String s1, String s2)
+    {
+        return new CaseInsensitiveHashSet(s1, s2);
+    }
+
+    public static CaseInsensitiveHashSet of(String s1, String s2, String s3)
+    {
+        return new CaseInsensitiveHashSet(s1, s2);
+    }
+
+    public static CaseInsensitiveHashSet of(String s1, String s2, String s3, String s4)
+    {
+        return new CaseInsensitiveHashSet(s1, s2, s3, s4);
+    }
+
+    public static CaseInsensitiveHashSet of(String s1, String s2, String s3, String s4, String s5)
+    {
+        return new CaseInsensitiveHashSet(s1, s2, s3, s4, s5);
+    }
+
 
     public static class TestCase extends Assert
     {

--- a/api/src/org/labkey/api/collections/CaseInsensitiveHashSet.java
+++ b/api/src/org/labkey/api/collections/CaseInsensitiveHashSet.java
@@ -20,8 +20,12 @@ import org.junit.Test;
 import org.labkey.api.util.PageFlowUtil;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableSet;
 
 /**
  * Simple case-insensitive version of HashSet -- simply forces all Strings to lowercase before adding, removing,
@@ -85,34 +89,34 @@ public class CaseInsensitiveHashSet extends HashSet<String>
         return modified;
     }
 
-    public static CaseInsensitiveHashSet of()
+    public static Set<String> of()
     {
-        return new CaseInsensitiveHashSet();
+        return emptySet();
     }
 
-    public static CaseInsensitiveHashSet of(String s1)
+    public static Set<String> of(String s1)
     {
-        return new CaseInsensitiveHashSet(s1);
+        return unmodifiableSet(new CaseInsensitiveHashSet(s1));
     }
 
-    public static CaseInsensitiveHashSet of(String s1, String s2)
+    public static Set<String> of(String s1, String s2)
     {
-        return new CaseInsensitiveHashSet(s1, s2);
+        return unmodifiableSet(new CaseInsensitiveHashSet(s1, s2));
     }
 
-    public static CaseInsensitiveHashSet of(String s1, String s2, String s3)
+    public static Set<String> of(String s1, String s2, String s3)
     {
-        return new CaseInsensitiveHashSet(s1, s2);
+        return unmodifiableSet(new CaseInsensitiveHashSet(s1, s2, s3));
     }
 
-    public static CaseInsensitiveHashSet of(String s1, String s2, String s3, String s4)
+    public static Set<String> of(String s1, String s2, String s3, String s4)
     {
-        return new CaseInsensitiveHashSet(s1, s2, s3, s4);
+        return unmodifiableSet(new CaseInsensitiveHashSet(s1, s2, s3, s4));
     }
 
-    public static CaseInsensitiveHashSet of(String s1, String s2, String s3, String s4, String s5)
+    public static Set<String> of(String s1, String s2, String s3, String s4, String s5)
     {
-        return new CaseInsensitiveHashSet(s1, s2, s3, s4, s5);
+        return unmodifiableSet(new CaseInsensitiveHashSet(s1, s2, s3, s4, s5));
     }
 
 
@@ -154,6 +158,29 @@ public class CaseInsensitiveHashSet extends HashSet<String>
             assertEquals(4, set.size());
             set.removeAll(PageFlowUtil.set("foo", "BAR", "FLIP", "FLAP", "FLOP", "THIS", "ThAt"));
             assertEquals(1, set.size());
+        }
+
+        @Test
+        public void testUnmodifiable()
+        {
+            Set<String> set = CaseInsensitiveHashSet.of("This", "that", "TOTHER");
+            assertTrue(set.contains("This"));
+            assertTrue(set.contains("this"));
+            assertTrue(set.contains("That"));
+            assertTrue(set.contains("that"));
+            assertTrue(set.contains("Tother"));
+            assertTrue(set.contains("tother"));
+            assertTrue(set.contains("tOtHeR"));
+
+            try
+            {
+                set.add("BAH");
+                fail("Should be unmodifiableSet");
+            }
+            catch (UnsupportedOperationException e)
+            {
+                // expected
+            }
         }
     }
 }

--- a/api/src/org/labkey/api/query/FilteredTable.java
+++ b/api/src/org/labkey/api/query/FilteredTable.java
@@ -304,6 +304,17 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
         _filter.addAllClauses(filter);
     }
 
+    /**
+     * Create a wrapped copy of the underlying column.
+     *
+     * wrapColumnFromJoinedTable is just like {@link #wrapColumn(ColumnInfo)} except the underlying
+     * column may come from a table that is joined to the FilteredTable's parent table.
+     *
+     * For example, the {@link org.labkey.api.exp.query.ExpDataClassDataTable} query table joins
+     * together the exp.data table and the provisioned expdataclass.* table. To create wrapped
+     * columns from the provisioned SchemaTableInfo, we must use {@link #wrapColumnFromJoinedTable(String, ColumnInfo)}
+     * instead of {@link #wrapColumn(ColumnInfo)} since ExpDataClassDataTable uses exp.data as it's root table.
+     */
     public MutableColumnInfo wrapColumnFromJoinedTable(String alias, ColumnInfo underlyingColumn)
     {
         return copyColumnFromJoinedTable(alias, underlyingColumn);
@@ -325,13 +336,21 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
         return ret;
     }
 
+    /**
+     * Create a wrapped copy of the underlying column.
+     * TODO: Describe how this is different from {@link #addWrapColumn(ColumnInfo)}
+     */
     public MutableColumnInfo wrapColumn(String alias, ColumnInfo underlyingColumn)
     {
         assert underlyingColumn.getParentTable() == _rootTable;
         return wrapColumnFromJoinedTable(alias, underlyingColumn);
     }
 
-    public MutableColumnInfo wrapColumn(ColumnInfo underlyingColumn)
+    /**
+     * Create a wrapped copy of the underlying column.
+     * TODO: Describe how this is different from {@link #addWrapColumn(ColumnInfo)}
+     */
+     public MutableColumnInfo wrapColumn(ColumnInfo underlyingColumn)
     {
         return wrapColumn(underlyingColumn.getName(), underlyingColumn);
     }
@@ -516,6 +535,10 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
         return result;
     }
 
+    /**
+     * Create a new AliasColumn over the underlying column and add it to this table.
+     * TODO: Describe how this is different from {@link #wrapColumn(ColumnInfo)}
+     */
     public MutableColumnInfo addWrapColumn(String name, ColumnInfo column)
     {
         assert column.getParentTable() == getRealTable() : "Column is not from the same \"real\" table";
@@ -548,6 +571,10 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
         return null;
     }
 
+    /**
+     * Create a new AliasColumn over the underlying column and add it to this table.
+     * TODO: Describe how this is different from {@link #wrapColumn(ColumnInfo)}
+     */
     public MutableColumnInfo addWrapColumn(ColumnInfo column)
     {
         return addWrapColumn(column.getName(), column);


### PR DESCRIPTION
#### Rationale
DataClass table was manually constructing `ExprColumn` for each of the domain columns instead of using `addWrapColumn` since it can only be used for columns on the same table.  Sadly, the the URL from the wrapped column wasn't propagated to the `ExprColumn`.  The fix is to use the new `wrapColumnFromJoinedTable` helper method which create the wrapped column correctly.