### PR TITLE
Issue 41530: Changes to domain property DefaultValueType no persisted when it is changed by itself

### DIFF
--- a/api/src/org/labkey/api/exp/property/DomainProperty.java
+++ b/api/src/org/labkey/api/exp/property/DomainProperty.java
@@ -90,6 +90,7 @@ public interface DomainProperty extends ImportAliasable
 
     DefaultValueType getDefaultValueTypeEnum();
     void setDefaultValueTypeEnum(DefaultValueType defaultValueType);
+    void setDefaultValueType(String defaultValueTypeName);
     void setDefaultValue(String value);
 
     PropertyType getPropertyType();

--- a/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
@@ -547,7 +547,10 @@ public class DomainPropertyImpl implements DomainProperty
 
     public void setDefaultValueType(String defaultValueTypeName)
     {
-        _pd.setDefaultValueType(defaultValueTypeName);
+        if (getDefaultValueType() != null && getDefaultValueType().equals(defaultValueTypeName))
+            return;
+
+        edit().setDefaultValueType(defaultValueTypeName);
     }
 
     @Override

--- a/internal/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/internal/src/org/labkey/api/exp/property/DomainUtil.java
@@ -881,6 +881,9 @@ public class DomainUtil
 
         if (from.getScale() != null)
             to.setScale(from.getScale());
+
+        if (from.getDefaultValueType() != null)
+            to.setDefaultValueType(from.getDefaultValueType().toString());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
#### Rationale
Issue [41530](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41530): Not able to change Default Type in General Assay Designer

If the domain property "Default Value Type" is changed in conjunction with other advanced settings, it will be saved, but when changed on its own, the change is not persisted. 

#### Changes
* DomainPropertyImple.setDefaultValueType check to call edit() when changing value
* Check for change to DefaultValueType during DomainUtil._copyProperties()
