### PR TITLE
Issue 40642: Remove support for legacy reports (Chart Views) in participant view

### DIFF
--- a/api/src/org/labkey/api/reports/report/ReportUrls.java
+++ b/api/src/org/labkey/api/reports/report/ReportUrls.java
@@ -43,7 +43,6 @@ public interface ReportUrls extends UrlProvider
     ActionURL urlStreamFile(Container c);
     ActionURL urlReportSections(Container c);
     ActionURL urlManageViews(Container c);
-    ActionURL urlDeleteReport(Container c);
     ActionURL urlExportCrosstab(Container c);
     ActionURL urlShareReport(Container c, Report r);
     // Thumbnail or icon, depending on ImageType

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -271,12 +271,6 @@ public class ReportsController extends SpringActionController
         }
 
         @Override
-        public ActionURL urlDeleteReport(Container c)
-        {
-            return new ActionURL(DeleteReportAction.class, c);
-        }
-
-        @Override
         public ActionURL urlExportCrosstab(Container c)
         {
             return new ActionURL(CrosstabExportAction.class, c);

--- a/study/src/org/labkey/study/controllers/reports/ReportsController.java
+++ b/study/src/org/labkey/study/controllers/reports/ReportsController.java
@@ -63,7 +63,6 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
@@ -111,7 +110,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.PrintWriter;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -157,53 +155,6 @@ public class ReportsController extends BaseStudyController
                 root.addChild("Manage Views", PageFlowUtil.urlProvider(ReportUrls.class).urlManageViews(getContainer()));
             else
                 root.addChild("Views");
-        }
-    }
-
-    @RequiresPermission(UpdatePermission.class)
-    public class DeleteReportAction extends FormHandlerAction<Object>
-    {
-        @Override
-        public void validateCommand(Object target, Errors errors)
-        {
-        }
-
-        @Override
-        public boolean handlePost(Object o, BindException errors) throws Exception
-        {
-            String reportIdParam = getRequest().getParameter(ReportDescriptor.Prop.reportId.name());
-            ReportIdentifier reportId = ReportService.get().getReportIdentifier(reportIdParam, getViewContext().getUser(), getViewContext().getContainer());
-
-            Report report = null;
-
-            if (reportId != null)
-                report = reportId.getReport(getViewContext());
-
-            if (report != null)
-            {
-                ReportManager.get().deleteReport(getViewContext(), report);
-            }
-
-            return true;
-        }
-
-        @Override
-        public URLHelper getSuccessURL(Object o)
-        {
-            String redirectUrl = getRequest().getParameter(ReportDescriptor.Prop.redirectUrl.name());
-            if (redirectUrl != null)
-            {
-                try
-                {
-                    return new URLHelper(redirectUrl);
-                }
-                catch (URISyntaxException e)
-                {
-                    // ignore bad URI
-                }
-            }
-
-            return PageFlowUtil.urlProvider(ReportUrls.class).urlManageViews(getContainer());
         }
     }
 
@@ -1155,107 +1106,6 @@ public class ReportsController extends BaseStudyController
         public void setRedirectUrl(String redirectUrl)
         {
             _redirectUrl = redirectUrl;
-        }
-    }
-
-    public static class PlotForm
-    {
-        private ReportIdentifier _reportId;
-        private int _datasetId = 0;
-        private int _visitRowId = 0;
-        private String _action;
-        private int _chartsPerRow = 3;
-        private Report[] _reports;
-        private boolean _isPlotView; // = true;
-        private String _participantId;
-        private String _queryName;
-        private String _schemaName;
-        private String _filterParam;
-        private String _viewName;
-
-        public int getDatasetId()
-        {
-            return _datasetId;
-        }
-
-        public void setDatasetId(int datasetId)
-        {
-            _datasetId = datasetId;
-        }
-
-        public int getVisitRowId()
-        {
-            return _visitRowId;
-        }
-
-        public void setVisitRowId(int visitRowId)
-        {
-            _visitRowId = visitRowId;
-        }
-
-        public ReportIdentifier getReportId()
-        {
-            return _reportId;
-        }
-
-        public void setReportId(ReportIdentifier reportId)
-        {
-            _reportId = reportId;
-        }
-
-        public Report[] getReports()
-        {
-            return _reports;
-        }
-
-        public void setReports(Report[] reports)
-        {
-            _reports = reports;
-        }
-
-        public void setAction(String action){_action = action;}
-        public String getAction(){return _action;}
-
-        public void setChartsPerRow(int chartsPerRow){_chartsPerRow = chartsPerRow;}
-        public int getChartsPerRow(){return _chartsPerRow;}
-
-        public void setIsPlotView(boolean isPlotView){_isPlotView = isPlotView;}
-        public boolean getIsPlotView(){return _isPlotView;}
-
-        public void setParticipantId(String participantId){_participantId = participantId;}
-        public String getParticipantId(){return _participantId;}
-
-        public void setSchemaName(String schemaName){_schemaName = schemaName;}
-        public String getSchemaName(){return _schemaName;}
-        public void setQueryName(String queryName){_queryName = queryName;}
-        public String getQueryName(){return _queryName;}
-        public void setFilterParam(String filterParam){_filterParam = filterParam;}
-        public String getFilterParam(){return _filterParam;}
-        public void setViewName(String viewName){_viewName = viewName;}
-        public String getViewName(){return _viewName;}
-    }
-
-    @RequiresPermission(ReadPermission.class)
-    public class PlotChartAction extends SimpleViewAction<PlotForm>
-    {
-        @Override
-        public ModelAndView getView(PlotForm form, BindException errors) throws Exception
-        {
-            final ViewContext context = getViewContext();
-            ReportIdentifier reportId = form.getReportId();
-
-            if (reportId != null)
-            {
-                Report report = reportId.getReport(getViewContext());
-                if (report != null)
-                    return report.renderReport(context);
-            }
-            return null;
-        }
-
-        @Override
-        public void addNavTrail(NavTree root)
-        {
         }
     }
 

--- a/study/src/org/labkey/study/view/participantCharacteristics.jsp
+++ b/study/src/org/labkey/study/view/participantCharacteristics.jsp
@@ -25,9 +25,6 @@
 <%@ page import="org.labkey.api.exp.PropertyDescriptor" %>
 <%@ page import="org.labkey.api.query.QueryService" %>
 <%@ page import="org.labkey.api.query.UserSchema" %>
-<%@ page import="org.labkey.api.reports.Report" %>
-<%@ page import="org.labkey.api.reports.ReportService" %>
-<%@ page import="org.labkey.api.reports.report.ReportDescriptor" %>
 <%@ page import="org.labkey.api.security.User" %>
 <%@ page import="org.labkey.api.security.permissions.UpdatePermission" %>
 <%@ page import="org.labkey.api.study.Dataset" %>
@@ -43,7 +40,6 @@
 <%@ page import="org.labkey.api.view.ViewContext" %>
 <%@ page import="org.labkey.study.controllers.DatasetController" %>
 <%@ page import="org.labkey.study.controllers.StudyController" %>
-<%@ page import="org.labkey.study.controllers.reports.ReportsController" %>
 <%@ page import="org.labkey.study.model.DatasetDefinition" %>
 <%@ page import="org.labkey.study.model.StudyManager" %>
 <%@ page import="java.util.Arrays" %>
@@ -118,27 +114,7 @@
         %></th>
     </tr>
     <%
-
-        for (Report report : ReportService.get().getReports(user, study.getContainer(), Integer.toString(datasetId)))
-        {
-            if (updateAccess)
-            {
-    %>
-    <tr style="<%=text(expanded ? "" : "display:none")%>">
-        <td>
-            <a href="<%=h(new ActionURL(ReportsController.DeleteReportAction.class, study.getContainer()).addParameter(ReportDescriptor.Prop.redirectUrl.name(), currentUrl).addParameter(ReportDescriptor.Prop.reportId.name(), report.getDescriptor().getReportId().toString()))%>">[remove]</a>
-        </td>
-    </tr>
-    <%
-        }
-    %>
-    <tr style="<%=text(expanded ? "" : "display:none")%>">
-        <td><img
-                src="<%=h(new ActionURL(ReportsController.PlotChartAction.class, study.getContainer()).addParameter("participantId", bean.getParticipantId()).addParameter(ReportDescriptor.Prop.reportId.name(), report.getDescriptor().getReportId().toString()))%>">
-        </td>
-    </tr>
-    <%
-        }
+        // TODO Issue 40643: Support viewing reports/charts for demographics dataset (see participantAll.jsp usages of ReportService.get().getReports())
 
         int row = 0;
 


### PR DESCRIPTION
#### Rationale
Issue [40642](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40642): Reconsider handling for legacy reports in participant view(s)

#### Changes
* skip attempt to render any legacy Chart Views for a dataset section (they should have all already been converted anyway)
* remove, now unused, ReportsController.DeleteReportAction and ReportsController.PlotChartAction