### PR TITLE
Fix ResourceEncodingTest - set response status explicitly in dav controller

### DIFF
--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -946,6 +946,7 @@ public class ExceptionUtil
             title += " -- " + ex.getMessage();
         }
         pageConfig.setTitle(title, false);
+        response.setStatus(responseStatus);
         errorView.getView().render(errorView.getModel(), request, response);
     }
 

--- a/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
+++ b/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
@@ -162,7 +162,9 @@ public class AnalyticsServiceImpl implements AnalyticsService
     {
         ActionURL actionUrl = context.cloneActionURL();
         Container container = context.getContainer();
-        if (!container.hasPermission(UserManager.getGuestUser(), ReadPermission.class))
+
+        // Adding a null check for container as on rendering the error page, container can be null for a not found page
+        if (null != container && !container.hasPermission(UserManager.getGuestUser(), ReadPermission.class))
         {
             actionUrl.deleteParameters();
             actionUrl.setExtraPath(container.getId());


### PR DESCRIPTION
#### Rationale
This PR :
* fixes the ResourceEncodingTest by setting the response status code coming while rendering ErrorPage.
* fixes the test failures due to Analytics scripts being called on Not found/Error pages where the container is null.

#### Changes
* set response status in ExceptionUtil.renderErrorPage
* null check for container in AnalyticsServiceImpl