### PR TITLE
Announcements: Expose API endpoints

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -2890,6 +2890,11 @@ public class AnnouncementsController extends SpringActionController
                     errors.reject(ERROR_MSG, "Failed to reply to thread. Unable to find parent thread \"" + rawThread.getParent() + "\".");
                     return null;
                 }
+                else if (AnnouncementManager.getLatestPostId(parentThread) == null)
+                {
+                    errors.reject(ERROR_MSG, "Failed to reply to thread. Could not locate most recent response for thread \"" + parentThread.getEntityId() + "\".");
+                    return null;
+                }
 
                 newThread.setParent(rawThread.getParent());
             }
@@ -2922,6 +2927,13 @@ public class AnnouncementsController extends SpringActionController
     @RequiresNoPermission // Checked by action
     public class DeleteThreadAction extends MutatingApiAction<ThreadIdentityForm>
     {
+        @Override
+        public void validateForm(ThreadIdentityForm form, Errors errors)
+        {
+            if (form.getRowId() == null && form.getEntityId() == null)
+                errors.reject(ERROR_MSG, "A \"rowId\" or an \"entityId\" must be provided to delete a thread.");
+        }
+
         @Override
         public Object execute(ThreadIdentityForm form, BindException errors)
         {

--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -1604,7 +1604,6 @@ public class AnnouncementsController extends SpringActionController
     }
 
     // Used for testing announcement daily digest email notifications
-    @Marshal(Marshaller.Jackson)
     @RequiresSiteAdmin
     public class SendDailyDigestAction extends MutatingApiAction
     {

--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -3003,6 +3003,13 @@ public class AnnouncementsController extends SpringActionController
     public class UpdateThreadAction extends MutatingApiAction<ThreadForm>
     {
         @Override
+        public void validateForm(ThreadForm form, Errors errors)
+        {
+            if (form.getThread() == null)
+                errors.reject(ERROR_MSG, "A \"thread\" object is required to create a thread.");
+        }
+
+        @Override
         public Object execute(ThreadForm form, BindException errors)
         {
             var rawThread = form.getThread();

--- a/announcements/src/org/labkey/announcements/announcementThread.jsp
+++ b/announcements/src/org/labkey/announcements/announcementThread.jsp
@@ -16,7 +16,7 @@
  */
 %>
 <%@ page import="org.labkey.announcements.AnnouncementsController" %>
-<%@ page import="org.labkey.announcements.AnnouncementsController.DeleteThreadAction" %>
+<%@ page import="org.labkey.announcements.AnnouncementsController.DeleteAction" %>
 <%@ page import="org.labkey.announcements.AnnouncementsController.RespondAction" %>
 <%@ page import="org.labkey.announcements.AnnouncementsController.ThreadView" %>
 <%@ page import="org.labkey.announcements.AnnouncementsController.ThreadViewBean" %>
@@ -277,7 +277,7 @@ if (!bean.isResponse && !bean.print)
     }
     if (bean.perm.allowDeleteMessage(announcementModel))
     {
-        ActionURL deleteThread = announcementURL(c, DeleteThreadAction.class, "entityId", announcementModel.getEntityId());
+        ActionURL deleteThread = announcementURL(c, DeleteAction.class, "entityId", announcementModel.getEntityId());
         deleteThread.addCancelURL(bean.currentURL);
         if (bean.embedded)
         {

--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -236,13 +236,9 @@ public class AnnouncementManager
     }
 
 
-    public static AnnouncementModel getLatestPost(Container c, AnnouncementModel parent)
+    public static AnnouncementModel getLatestPost(Container c, AnnouncementModel parent) throws NotFoundException
     {
-        SQLFragment sql = new SQLFragment( "SELECT LatestId FROM ");
-        sql.append(_comm.getTableInfoThreads(), "t");
-        sql.append(" WHERE RowId = ?");
-        sql.add(parent.getRowId());
-        Integer postId = new SqlSelector(_comm.getSchema(), sql).getObject(Integer.class);
+        Integer postId = getLatestPostId(parent);
 
         if (null == postId)
             throw new NotFoundException("Can't find most recent post");
@@ -250,6 +246,14 @@ public class AnnouncementManager
         return getAnnouncement(c, postId);
     }
 
+    public static @Nullable Integer getLatestPostId(AnnouncementModel parent)
+    {
+        SQLFragment sql = new SQLFragment( "SELECT LatestId FROM ");
+        sql.append(_comm.getTableInfoThreads(), "t");
+        sql.append(" WHERE RowId = ?");
+        sql.add(parent.getRowId());
+        return new SqlSelector(_comm.getSchema(), sql).getObject(Integer.class);
+    }
 
     public static AnnouncementModel insertAnnouncement(Container c, User user, AnnouncementModel insert, List<AttachmentFile> files) throws IOException
     {

--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -90,6 +90,7 @@ import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -154,6 +155,18 @@ public class AnnouncementManager
         Sort sort = new Sort("-Created");
 
         return new TableSelector(_comm.getTableInfoAnnouncements(), filter, sort).getCollection(AnnouncementModel.class);
+    }
+
+    public static @NotNull List<AnnouncementModel> getDiscussions(Container c, String identifier)
+    {
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("discussionSrcIdentifier"), identifier);
+        return getAnnouncements(c, filter, new Sort("Created"));
+    }
+
+    public static @NotNull Collection<AnnouncementModel> getDiscussions(Container c, String[] identifiers)
+    {
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("discussionSrcIdentifier"), Arrays.asList(identifiers), CompareType.IN);
+        return getAnnouncements(c, filter, new Sort("Created"));
     }
 
     public static Collection<AnnouncementModel> getResponses(AnnouncementModel parent)
@@ -281,7 +294,9 @@ public class AnnouncementManager
                 notifyModerators(c, user, ann);
         }
 
-        return ann;
+        // The approval state, attachments, etc may have changed after insert.
+        // Return an up-to-date copy of the model.
+        return getAnnouncement(c, ann.getRowId());
     }
 
     public static void approve(Container c, User user, boolean sendEmailNotifications, AnnouncementModel ann, Date date)

--- a/announcements/src/org/labkey/announcements/model/AnnouncementModel.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementModel.java
@@ -18,6 +18,7 @@ package org.labkey.announcements.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -344,6 +345,12 @@ public class AnnouncementModel extends Entity implements Serializable
     public void setResponseCount(int responseCount)
     {
         _responseCount = responseCount;
+    }
+
+    @JsonProperty("author")
+    public @Nullable User getAuthor()
+    {
+        return UserManager.getUser(getCreatedBy());
     }
 
     @JsonIgnore

--- a/announcements/src/org/labkey/announcements/model/AnnouncementModel.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementModel.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.json.JSONObject;
 import org.labkey.announcements.AnnouncementsController;
 import org.labkey.announcements.AnnouncementsController.ThreadAction;
 import org.labkey.api.announcements.DiscussionService.StatusOption;
@@ -348,9 +349,12 @@ public class AnnouncementModel extends Entity implements Serializable
     }
 
     @JsonProperty("author")
-    public @Nullable User getAuthor()
+    public @Nullable JSONObject getAuthor()
     {
-        return UserManager.getUser(getCreatedBy());
+        var author = UserManager.getUser(getCreatedBy());
+        if (author != null)
+            return author.getUserProps();
+        return null;
     }
 
     @JsonIgnore

--- a/announcements/src/org/labkey/announcements/model/AnnouncementModel.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementModel.java
@@ -15,6 +15,9 @@
  */
 package org.labkey.announcements.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -49,6 +52,8 @@ import static org.labkey.announcements.model.AnnouncementManager.DEFAULT_MESSAGE
 /**
  * Bean Class for AnnouncementModel.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AnnouncementModel extends Entity implements Serializable
 {
     private int _rowId = 0;
@@ -74,7 +79,6 @@ public class AnnouncementModel extends Entity implements Serializable
     private Set<User> _authors;
     private Date _approved = null;
 
-
     /**
      * Standard constructor.
      */
@@ -92,7 +96,6 @@ public class AnnouncementModel extends Entity implements Serializable
         return _rowId;
     }
 
-
     /**
      * Sets the rowId
      *
@@ -102,7 +105,6 @@ public class AnnouncementModel extends Entity implements Serializable
     {
         _rowId = rowId;
     }
-
 
     /**
      * Returns the title
@@ -114,17 +116,15 @@ public class AnnouncementModel extends Entity implements Serializable
         return _title;
     }
 
-
     /**
      * Sets the title
      *
      * @param title the new title value
      */
-    public void setTitle(java.lang.String title)
+    public void setTitle(String title)
     {
         _title = title;
     }
-
 
     /**
      * Returns the expires
@@ -136,17 +136,15 @@ public class AnnouncementModel extends Entity implements Serializable
         return _expires;
     }
 
-
     /**
      * Sets the expires
      *
      * @param expires the new expires value
      */
-    public void setExpires(java.util.Date expires)
+    public void setExpires(Date expires)
     {
         _expires = expires;
     }
-
 
     /**
      * Returns the body
@@ -157,7 +155,6 @@ public class AnnouncementModel extends Entity implements Serializable
     {
         return _body;
     }
-
 
     /**
      * Sets the body
@@ -174,7 +171,6 @@ public class AnnouncementModel extends Entity implements Serializable
         return _parentId;
     }
 
-
     public void setParent(String parentId)
     {
         _parentId = parentId;
@@ -185,12 +181,11 @@ public class AnnouncementModel extends Entity implements Serializable
         return UserManager.getDisplayNameOrUserId(getAssignedTo(), currentUser);
     }
 
-
+    @JsonIgnore // TODO: See about making Attachment serializable
     public @NotNull Collection<Attachment> getAttachments()
     {
         return AttachmentService.get().getAttachments(getAttachmentParent());
     }
-
 
     public @NotNull Collection<AnnouncementModel> getResponses()
     {
@@ -201,12 +196,10 @@ public class AnnouncementModel extends Entity implements Serializable
         return _responses;
     }
 
-
     public void setResponses(Collection<AnnouncementModel> responses)
     {
         _responses = responses;
     }
-
 
     public ActionURL getThreadURL(Container container)
     {
@@ -277,6 +270,7 @@ public class AnnouncementModel extends Entity implements Serializable
     }
 
     @NotNull
+    @JsonIgnore
     public List<Integer> getMemberListIds()
     {
         if (_memberListIds == null)
@@ -291,6 +285,7 @@ public class AnnouncementModel extends Entity implements Serializable
         _memberListIds = memberListIds;
     }
 
+    @JsonIgnore
     public String getMemberListInput()
     {
         return _memberListInput;
@@ -301,6 +296,7 @@ public class AnnouncementModel extends Entity implements Serializable
         _memberListInput = memberListInput;
     }
 
+    @JsonIgnore
     public List<String> getMemberListDisplay(Container c, User currentUser)
     {
         if (_memberListDisplay == null)
@@ -324,7 +320,6 @@ public class AnnouncementModel extends Entity implements Serializable
         return _discussionSrcIdentifier;
     }
 
-    @SuppressWarnings({"UnusedDeclaration"})
     public void setDiscussionSrcIdentifier(String discussionSrcIdentifier)
     {
         _discussionSrcIdentifier = discussionSrcIdentifier;
@@ -340,17 +335,18 @@ public class AnnouncementModel extends Entity implements Serializable
         _discussionSrcURL = discussionSrcURL;
     }
 
+    @JsonIgnore
     public int getResponseCount()
     {
         return _responseCount;
     }
 
-    @SuppressWarnings({"UnusedDeclaration"})
     public void setResponseCount(int responseCount)
     {
         _responseCount = responseCount;
     }
 
+    @JsonIgnore
     public Set<User> getAuthors()
     {
         if (null == _authors)
@@ -403,6 +399,7 @@ public class AnnouncementModel extends Entity implements Serializable
         }
     }
 
+    @JsonIgnore
     public AttachmentParent getAttachmentParent()
     {
         return new AnnouncementAttachmentParent(this);
@@ -418,6 +415,7 @@ public class AnnouncementModel extends Entity implements Serializable
         _approved = approved;
     }
 
+    @JsonIgnore
     public boolean isSpam()
     {
         return AnnouncementManager.isSpam(this);

--- a/announcements/src/org/labkey/announcements/model/DiscussionServiceImpl.java
+++ b/announcements/src/org/labkey/announcements/model/DiscussionServiceImpl.java
@@ -21,12 +21,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.announcements.AnnouncementsController;
 import org.labkey.api.announcements.DiscussionService;
-import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.SimpleFilter;
-import org.labkey.api.data.Sort;
-import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.LookAndFeelProperties;
@@ -46,7 +42,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -64,7 +59,7 @@ public class DiscussionServiceImpl implements DiscussionService
     {
         if (!allowMultipleDiscussions)
         {
-            List<AnnouncementModel> discussions = getDiscussions(c, identifier);
+            List<AnnouncementModel> discussions = AnnouncementManager.getDiscussions(c, identifier);
 
             if (!discussions.isEmpty())
                 return getDiscussion(c, cancelURL, discussions.get(0), user); // TODO: cancelURL is probably not right
@@ -109,18 +104,6 @@ public class DiscussionServiceImpl implements DiscussionService
     }
 
 
-    public @NotNull List<AnnouncementModel> getDiscussions(Container c, String identifier)
-    {
-        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("discussionSrcIdentifier"), identifier);
-        return AnnouncementManager.getAnnouncements(c, filter, new Sort("Created"));
-    }
-
-    public @NotNull Collection<AnnouncementModel> getDiscussions(Container c, String[] identifiers)
-    {
-        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("discussionSrcIdentifier"), Arrays.asList(identifiers), CompareType.IN);
-        return AnnouncementManager.getAnnouncements(c, filter, new Sort("Created"));
-    }
-
     public WebPartView getDiscussion(Container c, URLHelper currentURL, AnnouncementModel ann, User user)
     {
         // NOTE: don't pass in AnnouncementModel, it came from getBareAnnouncements()
@@ -148,7 +131,7 @@ public class DiscussionServiceImpl implements DiscussionService
 
         // get discussion parameters
         Map<String, String> params = currentURL.getScopeParameters("discussion");
-        List<AnnouncementModel> discussions = getDiscussions(c, objectId);
+        List<AnnouncementModel> discussions = AnnouncementManager.getDiscussions(c, objectId);
 
         int discussionId = 0;
         try
@@ -247,7 +230,7 @@ public class DiscussionServiceImpl implements DiscussionService
     @Override
     public void deleteDiscussions(Container c, User user, String... identifiers)
     {
-        Collection<AnnouncementModel> discussions = getDiscussions(c, identifiers);
+        Collection<AnnouncementModel> discussions = AnnouncementManager.getDiscussions(c, identifiers);
         for (AnnouncementModel ann : discussions)
         {
             AnnouncementManager.deleteAnnouncement(c, ann.getRowId());
@@ -257,7 +240,7 @@ public class DiscussionServiceImpl implements DiscussionService
     @Override
     public void deleteDiscussions(Container container, User user, Collection<String> identifiers)
     {
-        Collection<AnnouncementModel> discussions = getDiscussions(container, identifiers.toArray(new String[identifiers.size()]));
+        Collection<AnnouncementModel> discussions = AnnouncementManager.getDiscussions(container, identifiers.toArray(new String[identifiers.size()]));
         for (AnnouncementModel ann : discussions)
         {
             AnnouncementManager.deleteAnnouncement(container, ann.getRowId());
@@ -267,7 +250,7 @@ public class DiscussionServiceImpl implements DiscussionService
     @Override
     public void unlinkDiscussions(Container c, String identifier, User user)
     {
-        Collection<AnnouncementModel> discussions = getDiscussions(c, identifier);
+        Collection<AnnouncementModel> discussions = AnnouncementManager.getDiscussions(c, identifier);
         for (AnnouncementModel ann : discussions)
         {
             try
@@ -286,7 +269,7 @@ public class DiscussionServiceImpl implements DiscussionService
     @Override
     public boolean hasDiscussions(Container container, String identifier)
     {
-        return !getDiscussions(container, identifier).isEmpty();
+        return !AnnouncementManager.getDiscussions(container, identifier).isEmpty();
     }
 
 

--- a/announcements/src/org/labkey/announcements/model/NormalMessageBoardPermissions.java
+++ b/announcements/src/org/labkey/announcements/model/NormalMessageBoardPermissions.java
@@ -27,8 +27,6 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
-import org.labkey.api.security.roles.OwnerRole;
-import org.labkey.api.security.roles.RoleManager;
 
 /**
  * User: adam
@@ -58,7 +56,7 @@ public class NormalMessageBoardPermissions implements Permissions
     @Override
     public boolean allowInsert()
     {
-        return hasPermission(InsertPermission.class)|| hasPermission(InsertMessagePermission.class);
+        return hasPermission(InsertPermission.class) || hasPermission(InsertMessagePermission.class);
     }
 
     @Override
@@ -70,16 +68,14 @@ public class NormalMessageBoardPermissions implements Permissions
     @Override
     public boolean allowUpdate(AnnouncementModel ann)
     {
-        return _c.hasPermission(_user, UpdatePermission.class,
-                (ann.getCreatedBy() == _user.getUserId() && !_user.isGuest() ? RoleManager.roleSet(OwnerRole.class) : null));
+        return hasPermission(UpdatePermission.class);
     }
 
     @Override
     public boolean allowDeleteMessage(AnnouncementModel ann)
     {
-        //to delete, user must have delete permission for this message and all responses
-        if (_c.hasPermission(_user, DeletePermission.class,
-                (ann.getCreatedBy() == _user.getUserId() && !_user.isGuest() ? RoleManager.roleSet(OwnerRole.class) : null)))
+        // To delete, user must have delete permission for this message and all responses
+        if (hasPermission(DeletePermission.class))
         {
             for (AnnouncementModel a : ann.getResponses())
                 if (!allowDeleteMessage(a))
@@ -87,8 +83,8 @@ public class NormalMessageBoardPermissions implements Permissions
 
             return true;
         }
-        else
-            return false;
+
+        return false;
     }
 
     @Override

--- a/announcements/src/org/labkey/announcements/query/AnnouncementTable.java
+++ b/announcements/src/org/labkey/announcements/query/AnnouncementTable.java
@@ -33,6 +33,7 @@ import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
+import org.labkey.api.query.RuntimeValidationException;
 import org.labkey.api.query.UserIdQueryForeignKey;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
@@ -186,7 +187,7 @@ public class AnnouncementTable extends FilteredTable<AnnouncementSchema>
             {
                 return AnnouncementManager.insertAnnouncement(container, user, bean, Collections.emptyList());
             }
-            catch (IOException e)
+            catch (RuntimeValidationException | IOException e)
             {
                 throw new QueryUpdateServiceException(e);
             }
@@ -200,7 +201,7 @@ public class AnnouncementTable extends FilteredTable<AnnouncementSchema>
             {
                 return AnnouncementManager.updateAnnouncement(user, bean, Collections.emptyList());
             }
-            catch (IOException e)
+            catch (RuntimeValidationException | IOException e)
             {
                 throw new QueryUpdateServiceException(e);
             }

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -16,6 +16,8 @@
 
 package org.labkey.api.security;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -387,6 +389,13 @@ public class User extends UserPrincipal implements Serializable, Cloneable
         return _impersonationContext.getContextualRoles(this, policy);
     }
 
+    @JsonValue
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public JSONObject getUserProps()
+    {
+        return User.getUserProps(this);
+    }
+
     // Return the usual contextual roles
     public Set<Role> getStandardContextualRoles()
     {
@@ -577,6 +586,11 @@ public class User extends UserPrincipal implements Serializable, Cloneable
     public String getAvatarThumbnailPath()
     {
         return getAvatarUrl() != null ? getAvatarUrl().toString() : AvatarThumbnailProvider.THUMBNAIL_PATH;
+    }
+
+    public static JSONObject getUserProps(User user)
+    {
+        return getUserProps(user, user, null, false);
     }
 
     public static JSONObject getUserProps(User user, @Nullable Container container)

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.security;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.commons.lang3.StringUtils;
@@ -391,6 +392,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable
     }
 
     @JsonValue
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public JSONObject getUserProps()
     {
         return User.getUserProps(this);

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -16,9 +16,6 @@
 
 package org.labkey.api.security;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -63,7 +60,6 @@ import java.util.Set;
  * Represents a user in the LabKey system, typically tied to a specific individual, but see {@link GuestUser} for a
  * catch-all implementation representing anonymous users.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class User extends UserPrincipal implements Serializable, Cloneable
 {
     private String _firstName = null;
@@ -391,8 +387,6 @@ public class User extends UserPrincipal implements Serializable, Cloneable
         return _impersonationContext.getContextualRoles(this, policy);
     }
 
-    @JsonValue
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     public JSONObject getUserProps()
     {
         return User.getUserProps(this);

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -16,7 +16,7 @@
 
 package org.labkey.api.security;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -62,6 +62,7 @@ import java.util.Set;
  * Represents a user in the LabKey system, typically tied to a specific individual, but see {@link GuestUser} for a
  * catch-all implementation representing anonymous users.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class User extends UserPrincipal implements Serializable, Cloneable
 {
     private String _firstName = null;
@@ -390,7 +391,6 @@ public class User extends UserPrincipal implements Serializable, Cloneable
     }
 
     @JsonValue
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     public JSONObject getUserProps()
     {
         return User.getUserProps(this);

--- a/api/src/org/labkey/api/util/HtmlString.java
+++ b/api/src/org/labkey/api/util/HtmlString.java
@@ -15,14 +15,16 @@
  */
 package org.labkey.api.util;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Objects;
 
-public final class HtmlString implements SafeToRender, DOM.Renderable, Comparable<HtmlString>
+public final class HtmlString implements SafeToRender, DOM.Renderable, Comparable<HtmlString>, Serializable
 {
     // Helpful constants for convenience (and efficiency)
     public static final HtmlString EMPTY_STRING = HtmlString.of("");
@@ -110,6 +112,7 @@ public final class HtmlString implements SafeToRender, DOM.Renderable, Comparabl
         _s = null==s ? "" : s;
     }
 
+    @JsonValue
     @Override
     public String toString()
     {


### PR DESCRIPTION
#### Rationale
In our applications we've decided to leverage Announcements to support the commenting architecture. This PR allows us to use API endpoints to perform CRUD operations on announcements.

* [Specification](https://docs.google.com/document/d/13kchO4S4OgmWjAswXS35YrATU9j7Ko7i-1weG8WxOic/edit)

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/505
* https://github.com/LabKey/biologics/pull/718

#### Changes
* Validate `AnnouncementModel` upon insert and update in `AnnouncementManager`. This was formerly done in the form validation of `AnnouncementForm`. This means that all inserts/updates from the UI, API endpoints, or the Query Update Service will run through the same validation. This validation will throw `RuntimeValidationException` if validation fails.
* Title validation address issue [#41611](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41611).
* Renamed `DeleteThreadAction` to `DeleteAction`. Implemented new `DeleteThreadAction` as an API endpoint.
* Update `AnnouncementModel`, `HtmlString`, and `User` models to be serializable by Jackson.
* Address issue [#41616](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=41616) to allow owners to update/delete messages or users with read & insert permissions (mimic behavior from wiki and issues).