### PR TITLE
Issue 41454: Problem with adding > 100 vials to a request

### DIFF
--- a/study/src/org/labkey/study/controllers/specimen/SpecimenUtils.java
+++ b/study/src/org/labkey/study/controllers/specimen/SpecimenUtils.java
@@ -228,8 +228,8 @@ public class SpecimenUtils
                     {
                         requestMenuButton.addMenuItem("Add To Existing Request", null,
                                 "if (verifySelected(" + jsRegionObject + ".form, '#', " +
-                                "'get', 'rows')) showRequestWindow(" + jsRegionObject + ".getChecked(), '" + (showVials ? SpecimenApiController.VialRequestForm.IdTypes.RowId
-                                : SpecimenApiController.VialRequestForm.IdTypes.SpecimenHash) + "');");
+                                "'get', 'rows')) { " + jsRegionObject + ".getSelected({success: function (data) { showRequestWindow(data.selected, '" + (showVials ? SpecimenApiController.VialRequestForm.IdTypes.RowId
+                                : SpecimenApiController.VialRequestForm.IdTypes.SpecimenHash) + "');}})}");
                     }
                 }
             }


### PR DESCRIPTION
#### Rationale
We've switched our UX to act on all of the rows in a selection, even if they span multiple pages of a grid. This JS-based code wasn't following the same approach, so attempting to add > 100 vials to a request would drop those that aren't visible

#### Changes
* Use API call to get the full selection state to find the selected IDs that aren't on the current grid page