### PR TITLE
Fix 40917

### DIFF
--- a/assay/src/org/labkey/assay/TsvProviderSchema.java
+++ b/assay/src/org/labkey/assay/TsvProviderSchema.java
@@ -48,6 +48,8 @@ public class TsvProviderSchema extends AssayProviderSchema
         public PlateTemplateTable(TsvProviderSchema schema, ContainerFilter cf)
         {
             super(AssayDbSchema.getInstance().getTableInfoPlate(), schema, cf);
+            // Issue 40917
+            setName(PLATE_TEMPLATE_TABLE);
 
             var column = addWrapColumn(_rootTable.getColumn(FieldKey.fromParts("Lsid")));
             column.setKeyField(true);


### PR DESCRIPTION
#### Rationale
The PlateTemplate table needs to set the query name to the virtual table PlateTemplate otherwise the client (in this case Biologics) issues queries against a query that is not exposed. Patch provided by @labkey-kevink and fix confirmed by me.

#### Related Pull Requests
* n/a

#### Changes
* Set PlateTemplateTable name to PlateTemplate
