### PR TITLE
mark wrapped column as hidden

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -326,6 +326,8 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
             // Can't use addWrapColumn here since 'col' isn't from the parent table
             var wrapped = wrapColumnFromJoinedTable(col.getName(), col);
+            if (col.isHidden())
+                wrapped.setHidden(true);
             addColumn(wrapped);
             cols.add(wrapped);
         }


### PR DESCRIPTION
#### Rationale
When fixing [Issue 40239](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40239) in #1635, the hidden bit was not propagated from the underlying column to the wrapped column.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1635

#### Changes
* mark wrapped column as hidden