### PR TITLE
40894: Tooltips in schema browser's tree are too narrow on Safari, truncated in Firefox

### DIFF
--- a/api/webapp/ext-4.2.1/ext-patches.js
+++ b/api/webapp/ext-4.2.1/ext-patches.js
@@ -1061,11 +1061,11 @@ Ext4.override(Ext4.tree.Column, {
 });
 
 // issue : 40894 quick tips width being set too narrow
-// This is a backport of the fix implemented in Ext 5.0.1 :
-//
+// The problem was fixed in Ext 5.0.1 but not backported to earlier versions :
 // EXTJS-12511 Narrow tooltips in Safari Mac
 // EXTJS-13334 Tooltip is horizontally squished in Safari
 //
+// This override was found in a stackoverflow posting : https://stackoverflow.com/questions/15834689/extjs-4-2-tooltips-not-wide-enough-to-see-contents
 if (Ext4.isSafari || Ext4.isGecko) {
     Ext4.override(Ext4.tip.QuickTip, {
         helperElId: 'ext-quicktips-tip-helper',

--- a/api/webapp/ext-4.2.1/ext-patches.js
+++ b/api/webapp/ext-4.2.1/ext-patches.js
@@ -1061,7 +1061,10 @@ Ext4.override(Ext4.tree.Column, {
 });
 
 // issue : 40894 quick tips width being set too narrow
-// This is a backport of the fix implemented in Ext 5.1.0
+// This is a backport of the fix implemented in Ext 5.0.1 :
+//
+// EXTJS-12511 Narrow tooltips in Safari Mac
+// EXTJS-13334 Tooltip is horizontally squished in Safari
 //
 if (Ext4.isSafari || Ext4.isGecko) {
     Ext4.override(Ext4.tip.QuickTip, {

--- a/api/webapp/ext-4.2.1/ext-patches.js
+++ b/api/webapp/ext-4.2.1/ext-patches.js
@@ -1059,3 +1059,44 @@ Ext4.override(Ext4.tree.Column, {
         '</tpl>'
     ]
 });
+
+// issue : 40894 quick tips width being set too narrow
+// This is a backport of the fix implemented in Ext 5.1.0
+//
+if (Ext4.isSafari || Ext4.isGecko) {
+    Ext4.override(Ext4.tip.QuickTip, {
+        helperElId: 'ext-quicktips-tip-helper',
+        initComponent: function ()
+        {
+            var me = this;
+
+            me.target = me.target || Ext4.getDoc();
+            me.targets = me.targets || {};
+            me.callParent();
+
+            me.on('move', function ()
+            {
+                var offset = me.hasCls('x-tip-form-invalid') ? 35 : 12,
+                        helperEl = Ext4.fly(me.helperElId) || Ext4.fly(
+                                Ext4.DomHelper.createDom({
+                                    tag: 'div',
+                                    id: me.helperElId,
+                                    style: {
+                                        position: 'absolute',
+                                        left: '-1000px',
+                                        top: '-1000px',
+                                        'font-size': '12px',
+                                        'font-family': 'tahoma, arial, verdana, sans-serif'
+                                    }
+                                }, Ext4.getBody())
+                        );
+
+                if (me.html && (me.html !== helperEl.getHTML() || me.getWidth() !== (helperEl.dom.clientWidth + offset)))
+                {
+                    helperEl.update(me.html);
+                    me.setWidth(Ext4.Number.constrain(helperEl.dom.clientWidth + offset, me.minWidth, me.maxWidth));
+                }
+            }, this);
+        }
+    });
+}


### PR DESCRIPTION
#### Rationale
Ext4 quick tips were rendering incorrectly on versions of Safari and Firefox. This was an Ext bug with dynamic sizing of tooltips where the box size wasn't calculated correctly for those browsers. Sencha fixed the problem in a subsequent release of Ext but that fix was never backported to 4.2.1

[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40894)

This affect all quick tips and is not limited to the schema browser, anywhere in the application that we used quick tips would show the problem:
- file browser
- views and scripting
- others

#### Changes
- backport the fix via ext-patches and constrain to Safari and Gecko user agents.
