### PR TITLE
41618: provenance: delete performance while deleting large assay run

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -89,6 +89,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toList;
+
 /**
  * User: jeckels
  * Date: Jan 3, 2008
@@ -281,114 +283,130 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
     @Override
     public void beforeDeleteData(List<ExpData> data, User user) throws ExperimentException
     {
+        // Group data by source run
+        Map<ExpRun, List<ExpData>> grouping = new HashMap<>();
         for (ExpData d : data)
         {
+            String protocolLsid;
+            Container runContainer;
+
             ExpProtocolApplication sourceApplication = d.getSourceApplication();
             if (sourceApplication != null)
             {
                 ExpRun run = sourceApplication.getRun();
                 if (run != null)
                 {
-                    ExpProtocol protocol = run.getProtocol();
-                    AssayProvider provider = AssayService.get().getProvider(protocol);
-                    FieldKey assayResultLsidFieldKey = provider.getTableMetadata(protocol).getResultLsidFieldKey();
+                    var dataForRun = grouping.computeIfAbsent(run, x -> new ArrayList<>());
+                    dataForRun.add(d);
+                }
+            }
+        }
 
-                    SQLFragment assayResultLsidSql = null;
+        for (Map.Entry<ExpRun, List<ExpData>> entry : grouping.entrySet())
+        {
+            ExpRun run = entry.getKey();
+            List<ExpData> dataForRun = entry.getValue();
+            List<Integer> dataIds = dataForRun.stream().map(ExpData::getRowId).collect(toList());
 
-                    Domain domain;
-                    if (provider != null && assayResultLsidFieldKey != null)
+            ExpProtocol protocol = run.getProtocol();
+            AssayProvider provider = AssayService.get().getProvider(protocol);
+            FieldKey assayResultLsidFieldKey = provider.getTableMetadata(protocol).getResultLsidFieldKey();
+
+            SQLFragment assayResultLsidSql = null;
+
+            Domain domain;
+            if (provider != null && assayResultLsidFieldKey != null)
+            {
+                domain = provider.getResultsDomain(protocol);
+
+                AssayProtocolSchema assayProtocolSchema = provider.createProtocolSchema(user, protocol.getContainer(), protocol, null);
+                TableInfo assayDataTable = assayProtocolSchema.createDataTable(ContainerFilter.EVERYTHING, false);
+                if (assayDataTable != null)
+                {
+                    ColumnInfo lsidCol = assayDataTable.getColumn(assayResultLsidFieldKey);
+                    ColumnInfo dataIdCol = assayDataTable.getColumn("DataId");
+                    if (lsidCol == null || dataIdCol == null)
+                        throw new IllegalStateException("Assay results table expected to have dataId lookup column and " + assayResultLsidFieldKey + " column");
+
+                    // select the assay results LSID column for all rows referenced by the data
+                    assayResultLsidSql = new SQLFragment("SELECT ").append(lsidCol.getValueSql("X")).append(" AS ObjectURI")
+                            .append(" FROM ").append(assayDataTable.getFromSQL("X"))
+                            .append(" WHERE ").append(dataIdCol.getValueSql("X")).appendInClause(dataIds, assayDataTable.getSqlDialect());
+                }
+            }
+            else
+            {
+                // Be tolerant of the AssayProvider no longer being available. See if we have the default
+                // results/data domain for TSV-style assays
+                try
+                {
+                    domain = AbstractAssayProvider.getDomainByPrefix(protocol, ExpProtocol.ASSAY_DOMAIN_DATA);
+                }
+                catch (IllegalStateException ignored)
+                {
+                    domain = null;
+                    // Be tolerant of not finding a domain anymore, if the provider has gone away
+                }
+
+                // TODO: create assayResultLsidSql when provider no longer exists
+            }
+
+            // delete the assay result row exp.objects
+            if (assayResultLsidSql != null)
+            {
+                if (LOG.isTraceEnabled())
+                {
+                    SQLFragment t = new SQLFragment("SELECT o.*")
+                            .append(" FROM ").append(OntologyManager.getTinfoObject(), "o")
+                            .append(" WHERE Container = ?").add(run.getContainer())
+                            .append(" AND ObjectURI IN (")
+                            .append(assayResultLsidSql)
+                            .append(")");
+                    SqlSelector ss = new SqlSelector(ExperimentService.get().getSchema(), t);
+                    try (TableResultSet rs = ss.getResultSet())
                     {
-                        domain = provider.getResultsDomain(protocol);
-
-                        AssayProtocolSchema assayProtocolSchema = provider.createProtocolSchema(user, protocol.getContainer(), protocol, null);
-                        TableInfo assayDataTable = assayProtocolSchema.createDataTable(ContainerFilter.EVERYTHING, false);
-                        if (assayDataTable != null)
-                        {
-                            ColumnInfo lsidCol = assayDataTable.getColumn(assayResultLsidFieldKey);
-                            ColumnInfo dataIdCol = assayDataTable.getColumn("DataId");
-                            if (lsidCol == null || dataIdCol == null)
-                                throw new IllegalStateException("Assay results table expected to have dataId lookup column and " + assayResultLsidFieldKey + " column");
-
-                            // select the assay results LSID column for all rows referenced by the data
-                            assayResultLsidSql = new SQLFragment("SELECT ").append(lsidCol.getValueSql("X")).append(" AS ObjectURI")
-                                    .append(" FROM ").append(assayDataTable.getFromSQL("X"))
-                                    .append(" WHERE ").append(dataIdCol.getValueSql("X")).append(" = ").append(d.getRowId());
-                        }
+                        ResultSetUtil.logData(rs, LOG);
                     }
-                    else
+                    catch (SQLException x)
                     {
-                        // Be tolerant of the AssayProvider no longer being available. See if we have the default
-                        // results/data domain for TSV-style assays
-                        try
-                        {
-                            domain = AbstractAssayProvider.getDomainByPrefix(protocol, ExpProtocol.ASSAY_DOMAIN_DATA);
-                        }
-                        catch (IllegalStateException ignored)
-                        {
-                            domain = null;
-                            // Be tolerant of not finding a domain anymore, if the provider has gone away
-                        }
-
-                        // TODO: create assayResultLsidSql when provider no longer exists
+                        throw new RuntimeSQLException(x);
                     }
+                }
 
-                    // delete the assay result row exp.objects
-                    if (assayResultLsidSql != null)
+                // call pvs to delete assay result rows provenance
+                ProvenanceService pvs = ProvenanceService.get();
+                if (null != pvs)
+                {
+                    pvs.deleteAssayResultProvenance(assayResultLsidSql);
+                }
+
+                int count = OntologyManager.deleteOntologyObjects(ExperimentService.get().getSchema(), assayResultLsidSql, run.getContainer(), false);
+                LOG.debug("AbstractAssayTsvDataHandler.beforeDeleteData: deleted " + count + " ontology objects for assay result lsids");
+            }
+
+            if (domain != null && domain.getStorageTableName() != null)
+            {
+                SQLFragment deleteSQL = new SQLFragment("DELETE FROM ");
+                deleteSQL.append(domain.getDomainKind().getStorageSchemaName());
+                deleteSQL.append(".");
+                deleteSQL.append(domain.getStorageTableName());
+                deleteSQL.append(" WHERE DataId ").appendInClause(dataIds, ExperimentService.get().getSchema().getSqlDialect());
+
+                try
+                {
+                    int count = new SqlExecutor(DbSchema.get(domain.getDomainKind().getStorageSchemaName())).execute(deleteSQL);
+                    LOG.debug("AbstractAssayTsvDataHandler.beforeDeleteData: deleted " + count + " assay result rows");
+                }
+                catch (BadSqlGrammarException x)
+                {
+                    // (18035) presumably this is an optimistic concurrency problem and the table is gone
+                    // postgres returns 42P01 in this case... SQL Server?
+                    if (SqlDialect.isObjectNotFoundException(x))
                     {
-                        if (LOG.isDebugEnabled())
-                        {
-                            SQLFragment t = new SQLFragment("SELECT o.*")
-                                    .append(" FROM ").append(OntologyManager.getTinfoObject(), "o")
-                                    .append(" WHERE Container = ?").add(run.getContainer())
-                                    .append(" AND ObjectURI IN (")
-                                    .append(assayResultLsidSql)
-                                    .append(")");
-                            SqlSelector ss = new SqlSelector(ExperimentService.get().getSchema(), t);
-                            try (TableResultSet rs = ss.getResultSet())
-                            {
-                                ResultSetUtil.logData(rs, LOG);
-                            }
-                            catch (SQLException x)
-                            {
-                                throw new RuntimeSQLException(x);
-                            }
-                        }
-
-                        // call pvs to delete assay result rows provenance
-                        ProvenanceService pvs = ProvenanceService.get();
-                        if (null != pvs)
-                        {
-                            pvs.deleteAssayResultProvenance(assayResultLsidSql);
-                        }
-
-                        OntologyManager.deleteOntologyObjects(ExperimentService.get().getSchema(), assayResultLsidSql, run.getContainer(), false);
+                        // CONSIDER: unfortunately we can't swallow this exception, because Postgres leaves
+                        // the connection in an unusable state
                     }
-
-                    if (domain != null && domain.getStorageTableName() != null)
-                    {
-                        SQLFragment deleteSQL = new SQLFragment("DELETE FROM ");
-                        deleteSQL.append(domain.getDomainKind().getStorageSchemaName());
-                        deleteSQL.append(".");
-                        deleteSQL.append(domain.getStorageTableName());
-                        deleteSQL.append(" WHERE DataId = ?");
-                        deleteSQL.add(d.getRowId());
-
-                        try
-                        {
-                            new SqlExecutor(DbSchema.get(domain.getDomainKind().getStorageSchemaName())).execute(deleteSQL);
-                        }
-                        catch (BadSqlGrammarException x)
-                        {
-                            // (18035) presumably this is an optimistic concurrency problem and the table is gone
-                            // postgres returns 42P01 in this case... SQL Server?
-                            if (SqlDialect.isObjectNotFoundException(x))
-                            {
-                                // CONSIDER: unfortunately we can't swallow this exception, because Postgres leaves
-                                // the connection in an unusable state
-                            }
-                            throw x;
-                        }
-                    }
+                    throw x;
                 }
             }
         }
@@ -496,7 +514,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         if (rowIdCol == null)
             throw new IllegalStateException("Assay results table RowId column required to attach provenance");
 
-        List<Integer> rowIds = insertedData.stream().map(row -> (Integer)row.get("rowId")).collect(Collectors.toList());
+        List<Integer> rowIds = insertedData.stream().map(row -> (Integer)row.get("rowId")).collect(toList());
 
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("run"), run.getRowId());
         filter.addCondition(rowIdCol, rowIds, CompareType.IN);

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -820,7 +820,7 @@ public class OntologyManager
     }
 
 
-    public static void deleteOntologyObjects(DbSchema schema, SQLFragment sub, Container c, boolean deleteOwnedObjects)
+    public static int deleteOntologyObjects(DbSchema schema, SQLFragment sub, Container c, boolean deleteOwnedObjects)
     {
         // we have different levels of optimization possible here deleteOwned=true/false, scope=/<>exp
 
@@ -848,7 +848,7 @@ public class OntologyManager
             sqlDeleteObjects.add(c.getId());
             sqlDeleteObjects.append(sub);
             sqlDeleteObjects.append(")");
-            new SqlExecutor(getExpSchema()).execute(sqlDeleteObjects);
+            return new SqlExecutor(getExpSchema()).execute(sqlDeleteObjects);
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
@@ -543,11 +543,11 @@ public class ExpRunImpl extends ExpIdentifiableEntityImpl<ExperimentRun> impleme
         final ExperimentServiceImpl svc = ExperimentServiceImpl.get();
         final SqlDialect dialect = svc.getSchema().getSqlDialect();
 
+        deleteProtocolApplicationProvenance();
+
         svc.beforeDeleteData(user, getContainer(), datasToDelete);
 
         deleteInputObjects(svc, dialect);
-
-        deleteProtocolApplicationProvenance();
 
         deleteAppParametersAndInputs();
 


### PR DESCRIPTION
#### Rationale
When deleting a exp.data input or a set of assay result rows in an assay run, we clean up any associated exp.edge and provenance map rows.  Instead of iterating over each ExpData individually, we can use an IN clause to delete all rows at once.  In addition, issuing separate DELETE requests is much faster than using a WHERE clause with OR.

#### Related Pull Requests
* https://github.com/LabKey/provenance/pull/41

#### Changes
- use IN clause to delete ExpData grouped by source run in AbstractAssayTsvDataHandler.beforeDeleteData
- delete run provenance data before deleting ExpData
- avoid using OR when deleting edges and provenance