### PR TITLE
Update @labkey/build version to support linking via LABKEY_UI_COMPONENTS_HOME env variable

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -248,9 +248,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0-fb-webpackEnvVarForLink.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
-      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
+      "version": "0.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.2.0.tgz",
+      "integrity": "sha1-OcC1Wc801FEAPi2uo+2I+yt5ek4=",
       "dev": true
     },
     "@labkey/components": {

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -248,9 +248,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0.tgz",
-      "integrity": "sha1-K8JkWOgbyFxQhWETHHn5AvhiDnU=",
+      "version": "0.1.0-fb-webpackEnvVarForLink.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
+      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
       "dev": true
     },
     "@labkey/components": {

--- a/assay/package.json
+++ b/assay/package.json
@@ -15,7 +15,7 @@
     "@labkey/components": "0.97.0"
   },
   "devDependencies": {
-    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
+    "@labkey/build": "0.2.0",
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
     "cross-env": "7.0.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -15,7 +15,7 @@
     "@labkey/components": "0.97.0"
   },
   "devDependencies": {
-    "@labkey/build": "0.1.0",
+    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
     "cross-env": "7.0.2",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1892,9 +1892,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0-fb-webpackEnvVarForLink.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
-      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
+      "version": "0.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.2.0.tgz",
+      "integrity": "sha1-OcC1Wc801FEAPi2uo+2I+yt5ek4=",
       "dev": true
     },
     "@labkey/components": {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1892,9 +1892,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0.tgz",
-      "integrity": "sha1-K8JkWOgbyFxQhWETHHn5AvhiDnU=",
+      "version": "0.1.0-fb-webpackEnvVarForLink.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
+      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
       "dev": true
     },
     "@labkey/components": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     "@labkey/themes": "1.0.0"
   },
   "devDependencies": {
-    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
+    "@labkey/build": "0.2.0",
     "@hot-loader/react-dom": "16.13.0",
     "@labkey/eslint-config-base": "0.0.8",
     "@types/enzyme": "3.10.5",

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     "@labkey/themes": "1.0.0"
   },
   "devDependencies": {
-    "@labkey/build": "0.1.0",
+    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
     "@hot-loader/react-dom": "16.13.0",
     "@labkey/eslint-config-base": "0.0.8",
     "@types/enzyme": "3.10.5",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -248,9 +248,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0-fb-webpackEnvVarForLink.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
-      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
+      "version": "0.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.2.0.tgz",
+      "integrity": "sha1-OcC1Wc801FEAPi2uo+2I+yt5ek4=",
       "dev": true
     },
     "@labkey/components": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -248,9 +248,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0.tgz",
-      "integrity": "sha1-K8JkWOgbyFxQhWETHHn5AvhiDnU=",
+      "version": "0.1.0-fb-webpackEnvVarForLink.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
+      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
       "dev": true
     },
     "@labkey/components": {

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -15,7 +15,7 @@
     "@labkey/components": "0.97.0"
   },
   "devDependencies": {
-    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
+    "@labkey/build": "0.2.0",
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
     "cross-env": "7.0.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -15,7 +15,7 @@
     "@labkey/components": "0.97.0"
   },
   "devDependencies": {
-    "@labkey/build": "0.1.0",
+    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
     "cross-env": "7.0.2",

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -248,9 +248,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0-fb-webpackEnvVarForLink.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
-      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
+      "version": "0.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.2.0.tgz",
+      "integrity": "sha1-OcC1Wc801FEAPi2uo+2I+yt5ek4=",
       "dev": true
     },
     "@labkey/components": {

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -248,9 +248,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0.tgz",
-      "integrity": "sha1-K8JkWOgbyFxQhWETHHn5AvhiDnU=",
+      "version": "0.1.0-fb-webpackEnvVarForLink.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
+      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
       "dev": true
     },
     "@labkey/components": {

--- a/issues/package.json
+++ b/issues/package.json
@@ -15,7 +15,7 @@
     "@labkey/components": "0.97.0"
   },
   "devDependencies": {
-    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
+    "@labkey/build": "0.2.0",
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
     "cross-env": "7.0.2",

--- a/issues/package.json
+++ b/issues/package.json
@@ -15,7 +15,7 @@
     "@labkey/components": "0.97.0"
   },
   "devDependencies": {
-    "@labkey/build": "0.1.0",
+    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
     "cross-env": "7.0.2",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -248,9 +248,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0-fb-webpackEnvVarForLink.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
-      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
+      "version": "0.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.2.0.tgz",
+      "integrity": "sha1-OcC1Wc801FEAPi2uo+2I+yt5ek4=",
       "dev": true
     },
     "@labkey/components": {

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -248,9 +248,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0.tgz",
-      "integrity": "sha1-K8JkWOgbyFxQhWETHHn5AvhiDnU=",
+      "version": "0.1.0-fb-webpackEnvVarForLink.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
+      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
       "dev": true
     },
     "@labkey/components": {

--- a/list/package.json
+++ b/list/package.json
@@ -15,7 +15,7 @@
     "@labkey/components": "0.97.0"
   },
   "devDependencies": {
-    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
+    "@labkey/build": "0.2.0",
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
     "cross-env": "7.0.2",

--- a/list/package.json
+++ b/list/package.json
@@ -15,7 +15,7 @@
     "@labkey/components": "0.97.0"
   },
   "devDependencies": {
-    "@labkey/build": "0.1.0",
+    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
     "cross-env": "7.0.2",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -248,9 +248,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0-fb-webpackEnvVarForLink.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
-      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
+      "version": "0.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.2.0.tgz",
+      "integrity": "sha1-OcC1Wc801FEAPi2uo+2I+yt5ek4=",
       "dev": true
     },
     "@labkey/components": {

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -248,9 +248,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0.tgz",
-      "integrity": "sha1-K8JkWOgbyFxQhWETHHn5AvhiDnU=",
+      "version": "0.1.0-fb-webpackEnvVarForLink.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
+      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
       "dev": true
     },
     "@labkey/components": {

--- a/query/package.json
+++ b/query/package.json
@@ -15,7 +15,7 @@
     "@labkey/components": "0.97.0"
   },
   "devDependencies": {
-    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
+    "@labkey/build": "0.2.0",
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
     "cross-env": "7.0.2",

--- a/query/package.json
+++ b/query/package.json
@@ -15,7 +15,7 @@
     "@labkey/components": "0.97.0"
   },
   "devDependencies": {
-    "@labkey/build": "0.1.0",
+    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
     "cross-env": "7.0.2",

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -248,9 +248,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0-fb-webpackEnvVarForLink.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
-      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
+      "version": "0.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.2.0.tgz",
+      "integrity": "sha1-OcC1Wc801FEAPi2uo+2I+yt5ek4=",
       "dev": true
     },
     "@labkey/components": {

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -248,9 +248,9 @@
       "integrity": "sha1-q4diKlMLLdE6QjjCAhCKfz9qhNY="
     },
     "@labkey/build": {
-      "version": "0.1.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0.tgz",
-      "integrity": "sha1-K8JkWOgbyFxQhWETHHn5AvhiDnU=",
+      "version": "0.1.0-fb-webpackEnvVarForLink.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-0.1.0-fb-webpackEnvVarForLink.0.tgz",
+      "integrity": "sha1-bgLrPZXlu6GyqOA89ytASxAf0Kk=",
       "dev": true
     },
     "@labkey/components": {

--- a/study/package.json
+++ b/study/package.json
@@ -15,7 +15,7 @@
     "@labkey/components": "0.100.1"
   },
   "devDependencies": {
-    "@labkey/build": "0.1.0",
+    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
     "cross-env": "7.0.2",

--- a/study/package.json
+++ b/study/package.json
@@ -15,7 +15,7 @@
     "@labkey/components": "0.100.1"
   },
   "devDependencies": {
-    "@labkey/build": "0.1.0-fb-webpackEnvVarForLink.0",
+    "@labkey/build": "0.2.0",
     "@hot-loader/react-dom": "16.13.0",
     "@types/react": "16.9.44",
     "cross-env": "7.0.2",


### PR DESCRIPTION
#### Rationale
The initial v0.1.0 of @labkey/build was fixed on using a relative path to get to the labkey-ui-components repository when using "npm run start-link". This version update changes that to using a LABKEY_UI_COMPONENTS_HOME environment variable so that each dev can set it based on their local setup.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/379
* https://github.com/LabKey/platform/pull/1664
* https://github.com/LabKey/inventory/pull/117
* https://github.com/LabKey/provenance/pull/42
* https://github.com/LabKey/moduleEditor/pull/17
* https://github.com/LabKey/commonAssays/pull/252
* https://github.com/LabKey/tutorialModules/pull/30

#### Changes
* Update @labkey/build package version
