### PR TITLE
Issue 41681: Point context-sensitive-help link for file browser to "fileSharing" page

### DIFF
--- a/filecontent/src/org/labkey/filecontent/FileContentController.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentController.java
@@ -87,6 +87,7 @@ import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.MimeMap;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.PageFlowUtil;
@@ -489,6 +490,7 @@ public class FileContentController extends SpringActionController
             part.setFrame(WebPartView.FrameType.NONE);
             part.getModelBean().setAutoResize(true);
             part.getModelBean().setShowDetails(true);
+            getPageConfig().setHelpTopic(new HelpTopic("fileSharing"));
             return part;
         }
 

--- a/pipeline/src/org/labkey/pipeline/PipelineController.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineController.java
@@ -409,6 +409,7 @@ public class PipelineController extends SpringActionController
             BrowseWebPart wp = new BrowseWebPart(path);
             wp.getModelBean().setAutoResize(true);
             wp.setFrame(WebPartView.FrameType.NONE);
+            getPageConfig().setHelpTopic(new HelpTopic("fileSharing"));
             return wp;
         }
 


### PR DESCRIPTION
#### Rationale
The file browser page is pointing to the doc root, and we can point them to a more relevant topic

#### Changes
* Make both filecontent-begin.view and pipeline-browse.view point to the fileSharing doc page