### PR TITLE
Issue 41708: Use a CaseInsensitiveHashMap for schema XML resource loading cache

### DIFF
--- a/api/src/org/labkey/api/data/SchemaXmlCacheHandler.java
+++ b/api/src/org/labkey/api/data/SchemaXmlCacheHandler.java
@@ -17,6 +17,7 @@ package org.labkey.api.data;
 
 import org.apache.xmlbeans.XmlException;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleResourceCacheHandler;
 import org.labkey.api.module.ModuleResourceCacheListener;
@@ -30,7 +31,6 @@ import org.labkey.data.xml.TablesDocument;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -46,7 +46,7 @@ public class SchemaXmlCacheHandler implements ModuleResourceCacheHandler<Map<Str
     @Override
     public Map<String, TablesDocument> load(Stream<? extends Resource> resources, Module module)
     {
-        Map<String, TablesDocument> map = new HashMap<>();
+        Map<String, TablesDocument> map = new CaseInsensitiveHashMap<>();
 
         resources
             .filter(resource -> isSchemaXmlFile(resource.getName()))


### PR DESCRIPTION
#### Rationale
While upgrading from LK 19.3 to 20.7, this client noticed that some of these pages were not working in their custom modules. After some investigation, the root cause was that the schema XML from the <module>/resources/schemas dir was not being applied for the given schema during the DbScope.applyMetaDataXML() call.

The example from this client, which is on Postgres only, was that their schema name from the database was all lower case (i.e. "abc") but the module resource was upper case (i.e. "ABC.xml"). This resolved fine in 19.3, but the xml file was not resolved in the DbScope.getSchemaXml() call in 20.7. 

I tracked down the regression to this PR: https://github.com/LabKey/platform/pull/1143.

#### Changes
* Use a CaseInsensitiveHashMap loading module resources for the SCHEMA_XML_CACHE
