### PR TITLE
Issue 39629: Enable setting metadata on linked schema tables

### DIFF
--- a/api/src/org/labkey/api/jsp/taglib/ButtonTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/ButtonTag.java
@@ -32,6 +32,7 @@ public class ButtonTag extends SimpleTagBase
     private String _name;
     private String _id;
     private Boolean _submit = true;
+    private Boolean _enabled;
 
     @Override
     public void doTag() throws IOException
@@ -54,6 +55,9 @@ public class ButtonTag extends SimpleTagBase
 
             button.submit(_submit).onClick(onClickScript).name(_name);
         }
+
+        if (_enabled != null)
+            button.enabled(_enabled.booleanValue());
 
         getOut().print(button);
     }
@@ -97,5 +101,10 @@ public class ButtonTag extends SimpleTagBase
     public void setSubmit(Boolean submit)
     {
         _submit = submit;
+    }
+
+    public void setEnabled(Boolean enabled)
+    {
+        _enabled = enabled;
     }
 }

--- a/api/src/org/labkey/api/query/QueryDefinition.java
+++ b/api/src/org/labkey/api/query/QueryDefinition.java
@@ -163,9 +163,9 @@ public interface QueryDefinition
     void setSchema(@NotNull UserSchema schema);
 
     /**
-     * Returns whether this is a table-based query definition (versus a custom query).
+     * Return true if this user-defined custom query definition (as oppossed to a generated wrapper over a built-in table or linked schema query.)
      */
-    boolean isTableQueryDefinition();
+    boolean isUserDefined();
     Collection<String> getDependents(User user);
 
     /**

--- a/api/src/org/labkey/api/query/QueryDefinition.java
+++ b/api/src/org/labkey/api/query/QueryDefinition.java
@@ -120,12 +120,19 @@ public interface QueryDefinition
     void setContainerFilter(ContainerFilter containerFilter);
     ContainerFilter getContainerFilter();
 
+    /**
+     * Returns true if the user has permission to edit the metadata for this query in the current container (not the definition container.)
+     * @see #isSqlEditable()
+     */
     boolean canEdit(User user);
 
-    default boolean canDelete(User user)
-    {
-        return canEdit(user);
-    }
+    /**
+     * Returns true if the user has permission to edit the metadata for this query in the current container (not the definition container.)
+     * @see #isMetadataEditable()
+     */
+    boolean canEditMetadata(User user);
+
+    boolean canDelete(User user);
 
     /**
      * Save a new QueryDefinition or update an existing QueryDefinition.
@@ -161,7 +168,18 @@ public interface QueryDefinition
     boolean isTableQueryDefinition();
     Collection<String> getDependents(User user);
 
+    /**
+     * Returns true if the sql source for this query is editable.
+     * This is a capability check, not a permissions check.
+     * @see #canEdit(User)
+     */
     boolean isSqlEditable();
+
+    /**
+     * Returns true if the metadata for this query is editable.
+     * This is a capability check, not a permissions check.
+     * @see #canEditMetadata(User)
+     */
     boolean isMetadataEditable();
     ViewOptions getViewOptions();
     void setMetadataTableMap(Map<String, TableType> metadataTableMap);

--- a/api/src/org/labkey/api/query/QueryForm.java
+++ b/api/src/org/labkey/api/query/QueryForm.java
@@ -421,6 +421,11 @@ public class QueryForm extends ReturnUrlForm implements HasViewContext, HasBindP
         return getQueryDef().canEdit(getUser());
     }
 
+    public boolean canEditMetadata()
+    {
+        return getQueryDef().canEditMetadata(getUser());
+    }
+
     public String getQueryViewActionURL()
     {
         return _queryViewActionURL;

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -335,7 +335,7 @@ public class QueryView extends WebPartView<Object>
     {
         out.write("<p class=\"labkey-error\">");
         out.print(PageFlowUtil.filter(message));
-        if (getQueryDef() != null && getQueryDef().canEdit(getUser()))
+        if (getQueryDef() != null && getQueryDef().canEdit(getUser()) && getQueryDef().isSqlEditable())
             out.write("&nbsp;<a href=\"" + getSchema().urlFor(QueryAction.sourceQuery, getQueryDef()) + "\">Edit Query</a>");
         out.write("</p>");
 
@@ -398,25 +398,22 @@ public class QueryView extends WebPartView<Object>
             String label = getCaption();
             menu.setId(getDataRegionName() + ".Menu." + label);
 
-            if (getQueryDef() != null && getQueryDef().canEdit(getUser()))
+            if (getQueryDef() != null)
             {
                 NavTree editQueryItem;
-                if (getQueryDef().isSqlEditable())
+                if (getQueryDef().isSqlEditable() && getQueryDef().canEdit(getUser()))
                     editQueryItem = new NavTree("Edit Source", getSchema().urlFor(QueryAction.sourceQuery, getQueryDef()));
                 else
                     editQueryItem = new NavTree("View Definition", getSchema().urlFor(QueryAction.schemaBrowser, getQueryDef()));
                 editQueryItem.setId(getDataRegionName() + ":Query:EditSource");
                 addMenuItem(editQueryItem);
-                if (getQueryDef().isMetadataEditable())
+
+                if (getQueryDef().isMetadataEditable() && getQueryDef().canEditMetadata(getUser()))
                 {
                     NavTree editMetadataItem = new NavTree("Edit Metadata", getSchema().urlFor(QueryAction.metadataQuery, getQueryDef()));
                     editMetadataItem.setId(getDataRegionName() + ":Query:EditMetadata");
                     addMenuItem(editMetadataItem);
                 }
-            }
-            else
-            {
-                addMenuItem("Edit Query", false, true);
             }
 
             addSeparator();

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -412,8 +412,9 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
         return true;
     }
 
+    // TODO: rename to createQueryDefForTable
     public QueryDefinition getQueryDefForTable(String name)
-    {                                                
+    {
         return QueryService.get().createQueryDefForTable(this, name);
     }
 

--- a/api/src/org/labkey/api/study/security/SecurityEscalator.java
+++ b/api/src/org/labkey/api/study/security/SecurityEscalator.java
@@ -40,7 +40,7 @@ import java.util.List;
  *
  * <p>
  *     The purpose of this is grant the application/user access to make changes to tables (or retrieve data
- *     from those tables) that they should't have permission for.  For instance, a service could use this to
+ *     from those tables) that they shouldn't have permission for.  For instance, a service could use this to
  *     allow a supervisor to edit their employee's records, without giving them access to edit any other rows
  *     in the table, or even see any other rows.  <strong>In other words, you move the security to the application,
  *     instead of the database.</strong>

--- a/api/webapp/WEB-INF/labkey.tld
+++ b/api/webapp/WEB-INF/labkey.tld
@@ -53,6 +53,10 @@
             <name>submit</name>
             <type>java.lang.Boolean</type>
         </attribute>
+        <attribute>
+            <name>enabled</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
     </tag>
     <tag>
         <name>options</name>
@@ -163,14 +167,6 @@
         </attribute>
         <attribute>
             <name>enctype</name>
-            <rtexprvalue>true</rtexprvalue>
-        </attribute>
-        <attribute>
-            <name>labelMd</name>
-            <rtexprvalue>true</rtexprvalue>
-        </attribute>
-        <attribute>
-            <name>labelLg</name>
             <rtexprvalue>true</rtexprvalue>
         </attribute>
         <attribute>

--- a/query/src/org/labkey/query/CustomQueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/CustomQueryDefinitionImpl.java
@@ -50,6 +50,12 @@ public class CustomQueryDefinitionImpl extends QueryDefinitionImpl
     }
 
     @Override
+    public boolean isUserDefined()
+    {
+        return true;
+    }
+
+    @Override
     public boolean isMetadataEditable()
     {
         return true;

--- a/query/src/org/labkey/query/LinkedSchema.java
+++ b/query/src/org/labkey/query/LinkedSchema.java
@@ -264,7 +264,7 @@ public class LinkedSchema extends ExternalSchema
                 {
                     // Apply any filters that might have been specified in the schema linking process
                     QueryDefinition filteredQueryDef = createWrapperQueryDef(key, table);
-                    assert filteredQueryDef.getMetadataXml() == null : "generated wrapped query def should't apply metadata xml";
+                    assert filteredQueryDef.getMetadataXml() == null : "generated wrapped query def shouldn't apply metadata xml";
 
                     // Get metadata override xml that may exist in the linked schema target container
                     String extraMetadata = null;
@@ -317,7 +317,7 @@ public class LinkedSchema extends ExternalSchema
             sourceTable.overlayMetadata(Collections.singletonList(metaData), _sourceSchema, errors);
 
         QueryDefinition queryDef = createWrapperQueryDef(name, sourceTable);
-        assert queryDef.getMetadataXml() == null : "generated wrapped query def should't apply metadata xml";
+        assert queryDef.getMetadataXml() == null : "generated wrapped query def shouldn't apply metadata xml";
         // Hand in entire metaDataMap (of tables) into queryDef. Then when Query.resolveTable binds to a table, apply the metadata if it exists.
         queryDef.setMetadataTableMap(_metaDataMap);
 

--- a/query/src/org/labkey/query/LinkedSchemaQueryDefinition.java
+++ b/query/src/org/labkey/query/LinkedSchemaQueryDefinition.java
@@ -314,12 +314,12 @@ public class LinkedSchemaQueryDefinition extends QueryDefinitionImpl
         return false;
     }
 
-    // Linked query defs are not really table custom query defs, however we typically use
-    // "!isTableQueryDefinition()" to mean "isUserDefined", e.g. to show the edit metadata link in the schema browser.
+    // Linked query defs are similar to table custom query defs in that they are generated wrappers over the source
+    // schema's custom query so we will consider these as not user defined.
     @Override
-    public boolean isTableQueryDefinition()
+    public boolean isUserDefined()
     {
-        return true;
+        return false;
     }
 
     @Override

--- a/query/src/org/labkey/query/LinkedSchemaQueryDefinition.java
+++ b/query/src/org/labkey/query/LinkedSchemaQueryDefinition.java
@@ -29,18 +29,23 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.view.ActionURL;
+import org.labkey.api.view.UnauthorizedException;
 import org.labkey.data.xml.TableType;
 import org.labkey.data.xml.TablesDocument;
 import org.labkey.data.xml.TablesType;
 import org.labkey.query.persist.QueryDef;
+import org.labkey.query.persist.QueryManager;
 import org.labkey.query.sql.Query;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * User: kevink
@@ -52,13 +57,13 @@ import java.util.Map;
  */
 public class LinkedSchemaQueryDefinition extends QueryDefinitionImpl
 {
-    private LinkedSchema _schema;
     private String _extraMetadata;
 
-    public LinkedSchemaQueryDefinition(LinkedSchema schema, QueryDefinition query)
+    public LinkedSchemaQueryDefinition(LinkedSchema schema, QueryDefinition query, String extraMetadata)
     {
         super(schema.getUser(), schema.getContainer(), ((QueryDefinitionImpl)query).getQueryDef());
         _schema = schema;
+        _extraMetadata = extraMetadata;
     }
 
     @Override
@@ -73,18 +78,24 @@ public class LinkedSchemaQueryDefinition extends QueryDefinitionImpl
         return _schema.getSchemaPath();
     }
 
+    @Override
+    public void setSchema(@NotNull UserSchema schema)
+    {
+        throw new UnsupportedOperationException("Linked schema queries are read-only!");
+    }
+
     @NotNull
     @Override
-    public UserSchema getSchema()
+    public LinkedSchema getSchema()
     {
-        return _schema;
+        return (LinkedSchema)_schema;
     }
 
     @Override
     public Query getQuery(@NotNull QuerySchema schema, List<QueryException> errors, Query parent, boolean includeMetadata, boolean skipSuggestedColumns, boolean allowDuplicateColumns)
     {
         // Parse/resolve the wrapped query in the context of the original source schema
-        UserSchema sourceSchema = _schema.getSourceSchema();
+        UserSchema sourceSchema = getSchema().getSourceSchema();
         return super.getQuery(sourceSchema, errors, parent, includeMetadata, skipSuggestedColumns, allowDuplicateColumns);
     }
 
@@ -93,17 +104,18 @@ public class LinkedSchemaQueryDefinition extends QueryDefinitionImpl
     {
         // First, apply original wrapped query-def's metadata from files (using original schema name and container)
         // Second, super.applyQueryMetadata() will also apply orignal wrapped query-def's metadata stored in the database (using original schema name and container)
-        UserSchema sourceSchema = _schema.getSourceSchema();
+        LinkedSchema linkedSchema = getSchema();
+        UserSchema sourceSchema = linkedSchema.getSourceSchema();
         super.applyQueryMetadata(sourceSchema, errors, query, ret);
 
         // Third, remove column URLs and some lookups using LinkedTableInfo
-        ret = new LinkedTableInfo(_schema, ret).init();
+        ret = new LinkedTableInfo(linkedSchema, ret).init();
         ret.setDetailsURL(AbstractTableInfo.LINK_DISABLER);
 
         // Fourth, apply linked schema metadata (either from template or from the linked schema instance)
-        TableType metadata = _schema.getXbTable(getName());
-        if (metadata != null || (_schema._namedFilters != null && _schema._namedFilters.size() > 0))
-            super.applyQueryMetadata(schema, errors, metadata, _schema._namedFilters, ret);
+        TableType metadata = linkedSchema.getXbTable(getName());
+        if (metadata != null || (linkedSchema._namedFilters != null && linkedSchema._namedFilters.size() > 0))
+            super.applyQueryMetadata(schema, errors, metadata, linkedSchema._namedFilters, ret);
 
         // Fifth, lookup any XML metadata that has been stored in the database (in linked schema container)
         ret.overlayMetadata(getName(), schema, errors);
@@ -127,13 +139,58 @@ public class LinkedSchemaQueryDefinition extends QueryDefinitionImpl
     @Override
     public Collection<QueryChangeListener.QueryPropertyChange> save(User user, Container container)
     {
-        throw new UnsupportedOperationException("Linked schema queries are read-only!");
+        return save(user, container, true);
     }
 
     @Override
     public Collection<QueryChangeListener.QueryPropertyChange> save(User user, Container container, boolean fireChangeEvent)
     {
-        throw new UnsupportedOperationException("Linked schema queries are read-only!");
+        if (!getContainer().equals(container))
+            throw new UnauthorizedException("Can only be saved in the linked schema container");
+
+        if (!_dirty)
+            return null;
+
+        QueryDef qdef = QueryManager.get().getQueryDef(container, getSchemaName(), getName(), false);
+        if (_extraMetadata == null)
+        {
+            if (qdef != null)
+            {
+                // delete the query in order to reset the metadata over a built-in query, but don't
+                // fire the listener because we haven't actually deleted the table. See issue 40365
+                QueryManager.get().delete(qdef);
+            }
+        }
+        else
+        {
+            if (qdef == null)
+            {
+                qdef = new QueryDef();
+                qdef.setSchema(getSchemaName());
+                qdef.setContainer(container.getId());
+                qdef.setName(this.getName());
+            }
+            assert qdef.getSql() == null : "metadata only querydef should not have sql";
+            qdef.setMetaData(_extraMetadata);
+            if (qdef.getQueryDefId() == 0)
+                QueryManager.get().insert(user, qdef);
+            else
+                QueryManager.get().update(user, qdef);
+        }
+
+        if (fireChangeEvent)
+        {
+            // Fire change event for each property change.
+            for (QueryChangeListener.QueryPropertyChange change : _changes)
+            {
+                QueryService.get().fireQueryChanged(user, container, null, _queryDef.getSchemaPath(), change.getProperty(), Collections.singleton(change));
+            }
+        }
+
+        Collection<QueryChangeListener.QueryPropertyChange> changes = _changes;
+        _changes = null;
+        _dirty = false;
+        return changes;
     }
 
     @Override
@@ -149,27 +206,45 @@ public class LinkedSchemaQueryDefinition extends QueryDefinitionImpl
     }
 
     @Override
+    public void setName(String name)
+    {
+        throw new UnsupportedOperationException("Linked schema queries are read-only!");
+    }
+
+    @Override
+    public void setDefinitionContainer(Container container)
+    {
+        throw new UnsupportedOperationException("Linked schema queries are read-only!");
+    }
+
+    @Override
     public void setCanInherit(boolean f)
     {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Linked schema queries are read-only!");
     }
 
     @Override
     public void setIsHidden(boolean f)
     {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Linked schema queries are read-only!");
     }
 
     @Override
     public void setIsTemporary(boolean temporary)
     {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Linked schema queries are read-only!");
+    }
+
+    @Override
+    public void setIsSnapshot(boolean f)
+    {
+        throw new UnsupportedOperationException("Linked schema queries are read-only!");
     }
 
     @Override
     public void setDescription(String description)
     {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Linked schema queries are read-only!");
     }
 
     @Override
@@ -181,24 +256,70 @@ public class LinkedSchemaQueryDefinition extends QueryDefinitionImpl
     @Override
     public void setSql(String sql)
     {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Linked schema queries are read-only!");
+    }
+
+    @Override
+    public String getMetadataXml()
+    {
+        return _extraMetadata;
     }
 
     @Override
     public void setMetadataXml(String xml)
     {
-        _extraMetadata = xml;
+        if (xml == null && _extraMetadata == null)
+            return;
+
+        if (_extraMetadata == null || !_extraMetadata.equals(xml))
+        {
+            _dirty = true;
+            _extraMetadata = xml;
+        }
     }
 
     public void setContainer(Container container)
     {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Linked schema queries are read-only!");
     }
 
     @Override
     public void setContainerFilter(ContainerFilter containerFilter)
     {
         // Container filter is pre-defined by linked schema
+    }
+
+    @Override
+    public boolean canEdit(User user)
+    {
+        return false;
+    }
+
+    // True if the user is allowed to edit metadata in the current container (not the source definition container)
+    @Override
+    public boolean canEditMetadata(User user)
+    {
+        return getContainer().hasPermissions(user, Set.of(EditQueriesPermission.class, UpdatePermission.class));
+    }
+
+    @Override
+    public boolean canDelete(User user)
+    {
+        return false;
+    }
+
+    @Override
+    public boolean canInherit()
+    {
+        return false;
+    }
+
+    // Linked query defs are not really table custom query defs, however we typically use
+    // "!isTableQueryDefinition()" to mean "isUserDefined", e.g. to show the edit metadata link in the schema browser.
+    @Override
+    public boolean isTableQueryDefinition()
+    {
+        return true;
     }
 
     @Override
@@ -210,7 +331,7 @@ public class LinkedSchemaQueryDefinition extends QueryDefinitionImpl
     @Override
     public boolean isMetadataEditable()
     {
-        return false;
+        return true;
     }
 
     @Override

--- a/query/src/org/labkey/query/MetadataTableJSON.java
+++ b/query/src/org/labkey/query/MetadataTableJSON.java
@@ -34,6 +34,7 @@ import org.labkey.api.exp.property.Lookup;
 import org.labkey.api.gwt.client.model.GWTConditionalFormat;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QueryDefinition;
 import org.labkey.api.query.QueryParseException;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
@@ -591,7 +592,15 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             metadataColumnJSON.setPrincipalConceptCode(columnInfo.getPrincipalConceptCode());
         }
 
-        metadataTableJSON.setUserDefinedQuery(queryDef.isUserDefined());
+        List<QueryDef> queryDefs = QueryServiceImpl.get().findMetadataOverrideImpl(schema, tableName, false, false, null);
+        if (queryDefs == null)
+        {
+            queryDefs = QueryServiceImpl.get().findMetadataOverrideImpl(schema, tableName, true, false, null);
+            if (queryDefs != null)
+            {
+                metadataTableJSON.setUserDefinedQuery(true);
+            }
+        }
 
         if (queryDefs != null && !queryDefs.isEmpty())
         {

--- a/query/src/org/labkey/query/MetadataTableJSON.java
+++ b/query/src/org/labkey/query/MetadataTableJSON.java
@@ -591,15 +591,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             metadataColumnJSON.setPrincipalConceptCode(columnInfo.getPrincipalConceptCode());
         }
 
-        List<QueryDef> queryDefs = QueryServiceImpl.get().findMetadataOverrideImpl(schema, tableName, false, false, null);
-        if (queryDefs == null)
-        {
-            queryDefs = QueryServiceImpl.get().findMetadataOverrideImpl(schema, tableName, true, false, null);
-            if (queryDefs != null)
-            {
-                metadataTableJSON.setUserDefinedQuery(true);
-            }
-        }
+        metadataTableJSON.setUserDefinedQuery(queryDef.isUserDefined());
 
         if (queryDefs != null && !queryDefs.isEmpty())
         {

--- a/query/src/org/labkey/query/ModuleCustomQueryDefinition.java
+++ b/query/src/org/labkey/query/ModuleCustomQueryDefinition.java
@@ -106,6 +106,12 @@ public class ModuleCustomQueryDefinition extends CustomQueryDefinitionImpl
     }
 
     @Override
+    public boolean canEditMetadata(User user)
+    {
+        return super.canEditMetadata(user) && user.hasRootPermission(EditModuleResourcesPermission.class) && isMetadataEditable();
+    }
+
+    @Override
     public boolean canDelete(User user)
     {
         // NYI

--- a/query/src/org/labkey/query/QueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/QueryDefinitionImpl.java
@@ -1004,12 +1004,6 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
     }
 
     @Override
-    public boolean isTableQueryDefinition()
-    {
-        return false;
-    }
-
-    @Override
     public Collection<String> getDependents(User user)
     {
         return QueryManager.get().getQueryDependents(user, getContainer(), null, getSchemaPath(), Collections.singleton(getName()));

--- a/query/src/org/labkey/query/QueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/QueryDefinitionImpl.java
@@ -16,7 +16,6 @@
 
 package org.labkey.query;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -81,6 +80,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 @SuppressWarnings({"ThrowableInstanceNeverThrown"})
 public abstract class QueryDefinitionImpl implements QueryDefinition
@@ -167,7 +167,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
     @Override
     public void delete(User user, boolean fireChangeEvent)
     {
-        if (!canEdit(user))
+        if (!canDelete(user))
         {
             throw new IllegalArgumentException("Access denied");
         }
@@ -187,7 +187,19 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
     {
         if (!getDefinitionContainer().equals(getContainer()))
             return false;
-        return getDefinitionContainer().hasPermissions(user, ImmutableSet.of(EditQueriesPermission.class, UpdatePermission.class));
+        return getDefinitionContainer().hasPermissions(user, Set.of(EditQueriesPermission.class, UpdatePermission.class));
+    }
+
+    @Override
+    public boolean canEditMetadata(User user)
+    {
+        return canEdit(user);
+    }
+
+    @Override
+    public boolean canDelete(User user)
+    {
+        return canEdit(user);
     }
 
     @Override

--- a/query/src/org/labkey/query/QuerySnapshotDefImpl.java
+++ b/query/src/org/labkey/query/QuerySnapshotDefImpl.java
@@ -64,7 +64,7 @@ public class QuerySnapshotDefImpl implements QuerySnapshotDefinition
 
         // if this is a table based query view, we just need to save the table name, else create a copy of the query
         // definition for the snapshot to refer back to on updates.
-        if (queryDef.isTableQueryDefinition())
+        if (!queryDef.isUserDefined())
         {
             _snapshotDef.setQueryTableName(queryDef.getName());
             _snapshotDef.setQueryTableContainer(queryDef.getContainer().getId());

--- a/query/src/org/labkey/query/TableQueryDefinition.java
+++ b/query/src/org/labkey/query/TableQueryDefinition.java
@@ -240,9 +240,9 @@ public class TableQueryDefinition extends QueryDefinitionImpl
 
 
     @Override
-    public boolean isTableQueryDefinition()
+    public boolean isUserDefined()
     {
-        return true;
+        return false;
     }
 
 

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -59,7 +59,6 @@ import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.query.CustomViewUtil;
-import org.labkey.query.EditQueriesPermission;
 import org.springframework.validation.BindException;
 
 import java.util.ArrayList;
@@ -112,7 +111,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
         if (null == queryDef)
             throw new NotFoundException("Could not find the query '" + form.getQueryName() + "' in the schema '" + form.getSchemaName() + "'!");
 
-        boolean isUserDefined = !queryDef.isTableQueryDefinition();
+        boolean isUserDefined = queryDef.isUserDefined();
 
         //a few basic props about the query
         //this needs to be populated before attempting to get the table info

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -59,6 +59,7 @@ import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.query.CustomViewUtil;
+import org.labkey.query.EditQueriesPermission;
 import org.springframework.validation.BindException;
 
 import java.util.ArrayList;
@@ -124,7 +125,8 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
         resp.put("canEdit", canEdit);
         resp.put("canDelete", queryDef.canDelete(user));
         resp.put("canEditSharedViews", container.hasPermission(user, EditSharedViewPermission.class));
-        resp.put("isMetadataOverrideable", canEdit); //for now, this is the same as canEdit(), but in the future we can support this for non-editable queries
+        // CONSIDER: do we want to separate the 'canEditMetadata' property and 'isMetadataOverridable' properties to differentiate between cabability and the permission check?
+        resp.put("isMetadataOverrideable", queryDef.isMetadataEditable() && queryDef.canEditMetadata(user));
 
         if (isUserDefined)
             resp.put("moduleName", queryDef.getModuleName());
@@ -146,7 +148,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
                 return resp;
             }
         }
-        catch(Exception e)
+        catch (Exception e)
         {
             resp.put("exception", e.getMessage());
             return resp;
@@ -165,8 +167,6 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
             }
         }
 
-        if (!isUserDefined && tinfo.isMetadataOverrideable())
-            resp.put("isMetadataOverrideable", true);
 
         ActionURL auditHistoryUrl = QueryService.get().getAuditHistoryURL(user, container, tinfo);
         if (auditHistoryUrl != null)

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -35,7 +35,35 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.labkey.api.action.*;
+import org.labkey.api.action.Action;
+import org.labkey.api.action.ActionType;
+import org.labkey.api.action.ApiJsonWriter;
+import org.labkey.api.action.ApiQueryResponse;
+import org.labkey.api.action.ApiResponse;
+import org.labkey.api.action.ApiResponseWriter;
+import org.labkey.api.action.ApiSimpleResponse;
+import org.labkey.api.action.ApiUsageException;
+import org.labkey.api.action.ApiVersion;
+import org.labkey.api.action.ConfirmAction;
+import org.labkey.api.action.ExportAction;
+import org.labkey.api.action.ExportException;
+import org.labkey.api.action.ExtendedApiQueryResponse;
+import org.labkey.api.action.FormHandlerAction;
+import org.labkey.api.action.FormViewAction;
+import org.labkey.api.action.HasBindParameters;
+import org.labkey.api.action.LabKeyError;
+import org.labkey.api.action.Marshal;
+import org.labkey.api.action.Marshaller;
+import org.labkey.api.action.MutatingApiAction;
+import org.labkey.api.action.NullSafeBindException;
+import org.labkey.api.action.ReadOnlyApiAction;
+import org.labkey.api.action.ReportingApiQueryResponse;
+import org.labkey.api.action.ReturnUrlForm;
+import org.labkey.api.action.SimpleApiJsonForm;
+import org.labkey.api.action.SimpleErrorView;
+import org.labkey.api.action.SimpleRedirectAction;
+import org.labkey.api.action.SimpleViewAction;
+import org.labkey.api.action.SpringActionController;
 import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.audit.AbstractAuditTypeProvider;
 import org.labkey.api.audit.TransactionAuditProvider;
@@ -185,6 +213,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.zip.GZIPOutputStream;
@@ -905,7 +934,7 @@ public class QueryController extends SpringActionController
     public class SourceQueryAction extends SimpleViewAction<SourceForm>
     {
         public SourceForm _form;
-        public QuerySchema _baseSchema;
+        public UserSchema _schema;
         public QueryDefinition _queryDef;
 
 
@@ -918,20 +947,23 @@ public class QueryController extends SpringActionController
             if (StringUtils.isEmpty(target.getQueryName()))
                 throw new NotFoundException("query name not specified");
 
-            _baseSchema = DefaultSchema.get(getUser(), getContainer(), _form.getSchemaKey());
-            if (null == _baseSchema)
+            QuerySchema querySchema = DefaultSchema.get(getUser(), getContainer(), _form.getSchemaKey());
+            if (null == querySchema)
                 throw new NotFoundException("schema not found: " + _form.getSchemaKey().toDisplayString());
+            if (!(querySchema instanceof UserSchema))
+                throw new NotFoundException("Could not find the schema '" + _form.getSchemaName() + "' in the folder '" + getContainer().getPath() + "'");
+            _schema = (UserSchema)querySchema;
         }
 
 
         @Override
         public ModelAndView getView(SourceForm form, BindException errors)
         {
-            _queryDef = QueryService.get().getQueryDef(getUser(), getContainer(), _baseSchema.getSchemaName(), form.getQueryName());
+            _queryDef = _schema.getQueryDef(form.getQueryName());
             if (null == _queryDef)
-                _queryDef = ((UserSchema)_baseSchema).getQueryDefForTable(form.getQueryName());
+                _queryDef = _schema.getQueryDefForTable(form.getQueryName());
             if (null == _queryDef)
-                throw new NotFoundException("Query not found: " + form.getQueryName());
+                throw new NotFoundException("Could not find the query '" + form.getQueryName() + "' in the schema '" + form.getSchemaName() + "'");
 
             try
             {
@@ -943,7 +975,7 @@ public class QueryController extends SpringActionController
                         form.ff_metadataText = form.getDefaultMetadataText();
                 }
 
-                for (QueryException qpe : _queryDef.getParseErrors(_baseSchema))
+                for (QueryException qpe : _queryDef.getParseErrors(_schema))
                 {
                     errors.reject(ERROR_MSG, StringUtils.defaultString(qpe.getMessage(),qpe.toString()));
                 }
@@ -1004,19 +1036,22 @@ public class QueryController extends SpringActionController
     @Action(ActionType.Configure.class)
     public static class SaveSourceQueryAction extends MutatingApiAction<SourceForm>
     {
-        private QuerySchema _baseSchema;
+        private UserSchema _schema;
 
         @Override
-        public void validateForm(SourceForm target, Errors errors)
+        public void validateForm(SourceForm form, Errors errors)
         {
-            if (StringUtils.isEmpty(target.getSchemaName()))
+            if (StringUtils.isEmpty(form.getSchemaName()))
                 throw new NotFoundException("Query definition not found, schemaName and queryName are required.");
-            if (StringUtils.isEmpty(target.getQueryName()))
+            if (StringUtils.isEmpty(form.getQueryName()))
                 throw new NotFoundException("Query definition not found, schemaName and queryName are required.");
 
-            _baseSchema = DefaultSchema.get(getUser(), getContainer(), target.getSchemaKey());
-            if (null == _baseSchema)
-                throw new NotFoundException("Schema not found: " + target.getSchemaKey().toDisplayString());
+            QuerySchema querySchema = DefaultSchema.get(getUser(), getContainer(), form.getSchemaKey());
+            if (null == querySchema)
+                throw new NotFoundException("schema not found: " + form.getSchemaKey().toDisplayString());
+            if (!(querySchema instanceof UserSchema))
+                throw new NotFoundException("Could not find the schema '" + form.getSchemaName() + "' in the folder '" + getContainer().getPath() + "'");
+            _schema = (UserSchema)querySchema;
 
             XmlOptions options = XmlBeansUtil.getDefaultParseOptions();
             List<XmlValidationError> xmlErrors = new ArrayList<>();
@@ -1024,9 +1059,9 @@ public class QueryController extends SpringActionController
             try
             {
                 // had a couple of real-world failures due to null pointers in this code, so it's time to be paranoid
-                if(target.ff_metadataText != null)
+                if (form.ff_metadataText != null)
                 {
-                    TablesDocument tablesDoc = TablesDocument.Factory.parse(target.ff_metadataText, options);
+                    TablesDocument tablesDoc = TablesDocument.Factory.parse(form.ff_metadataText, options);
                     if (tablesDoc != null)
                     {
                         tablesDoc.validate(options);
@@ -1123,59 +1158,66 @@ public class QueryController extends SpringActionController
         @Override
         public ApiResponse execute(SourceForm form, BindException errors)
         {
-            var queryDef = QueryService.get().getQueryDef(getUser(), getContainer(), _baseSchema.getSchemaName(), form.getQueryName());
+            var queryDef = _schema.getQueryDef(form.getQueryName());
             if (null == queryDef)
-                queryDef = ((UserSchema)_baseSchema).getQueryDefForTable(form.getQueryName());
+                queryDef = _schema.getQueryDefForTable(form.getQueryName());
             if (null == queryDef)
-                throw new NotFoundException("Query not found: " + form.getQueryName());
-
-            if (!queryDef.canEdit(getUser()))
-                throw new UnauthorizedException("Edit permissions are required.");
+                throw new NotFoundException("Could not find the query '" + form.getQueryName() + "' in the schema '" + form.getSchemaName() + "'");
 
             ApiSimpleResponse response = new ApiSimpleResponse();
 
             try
             {
-                queryDef.setSql(form.ff_queryText);
-
-                if (queryDef.isTableQueryDefinition() && StringUtils.trimToNull(form.ff_metadataText) == null)
+                if (form.ff_queryText != null)
                 {
-                    if (QueryManager.get().getQueryDef(getContainer(), form.getSchemaName(), form.getQueryName(), false) != null)
-                    {
-                        // delete the query in order to reset the metadata over a built-in query, but don't
-                        // fire the listener because we haven't actually deleted the table. See issue 40365
-                        queryDef.delete(getUser(), false);
-                    }
+                    if (!queryDef.isSqlEditable())
+                        throw new UnauthorizedException("Query SQL is not editable.");
+
+                    if (!queryDef.canEdit(getUser()))
+                        throw new UnauthorizedException("Edit permissions are required.");
+
+                    queryDef.setSql(form.ff_queryText);
+                }
+
+                String metadataText = StringUtils.trimToNull(form.ff_metadataText);
+                if (queryDef.isMetadataEditable())
+                {
+                    if (!Objects.equals(metadataText, queryDef.getMetadataXml()) && !queryDef.canEditMetadata(getUser()))
+                        throw new UnauthorizedException("Edit metadata permissions are required.");
+
+                    queryDef.setMetadataXml(metadataText);
                 }
                 else
                 {
-                    queryDef.setMetadataXml(form.ff_metadataText);
-                    queryDef.save(getUser(), getContainer());
+                    if (metadataText != null)
+                        throw new UnsupportedOperationException("Query metadata is not editable.");
+                }
 
-                    // the query was successfully saved, validate the query but return any errors in the success response
-                    List<QueryParseException> parseErrors = new ArrayList<>();
-                    List<QueryParseException> parseWarnings = new ArrayList<>();
-                    queryDef.validateQuery(_baseSchema, parseErrors, parseWarnings);
-                    if (!parseErrors.isEmpty())
+                queryDef.save(getUser(), getContainer());
+
+                // the query was successfully saved, validate the query but return any errors in the success response
+                List<QueryParseException> parseErrors = new ArrayList<>();
+                List<QueryParseException> parseWarnings = new ArrayList<>();
+                queryDef.validateQuery(_schema, parseErrors, parseWarnings);
+                if (!parseErrors.isEmpty())
+                {
+                    JSONArray errorArray = new JSONArray();
+
+                    for (QueryException e : parseErrors)
                     {
-                        JSONArray errorArray = new JSONArray();
-
-                        for (QueryException e : parseErrors)
-                        {
-                            errorArray.put(e.toJSON(form.ff_queryText));
-                        }
-                        response.put("parseErrors", errorArray);
+                        errorArray.put(e.toJSON(form.ff_queryText));
                     }
-                    else if (!parseWarnings.isEmpty())
+                    response.put("parseErrors", errorArray);
+                }
+                else if (!parseWarnings.isEmpty())
+                {
+                    JSONArray errorArray = new JSONArray();
+
+                    for (QueryException e : parseWarnings)
                     {
-                        JSONArray errorArray = new JSONArray();
-
-                        for (QueryException e : parseWarnings)
-                        {
-                            errorArray.put(e.toJSON(form.ff_queryText));
-                        }
-                        response.put("parseWarnings", errorArray);
+                        errorArray.put(e.toJSON(form.ff_queryText));
                     }
+                    response.put("parseWarnings", errorArray);
                 }
             }
             catch (SQLException e)
@@ -1946,6 +1988,12 @@ public class QueryController extends SpringActionController
             {
                 throw new NotFoundException("Must provide queryName.");
             }
+
+            if (!queryForm.getQueryDef().isMetadataEditable())
+                throw new UnauthorizedException("Query metadata is not editable");
+
+            if (!queryForm.canEditMetadata())
+                throw new UnauthorizedException("You do not have permission to edit the query metadata");
 
             return ModuleHtmlView.get(ModuleLoader.getInstance().getModule("query"), ModuleHtmlView.getGeneratedViewPath("queryMetadataEditor"));
         }
@@ -5751,7 +5799,8 @@ public class QueryController extends SpringActionController
             boolean canEdit = qdef.canEdit(getUser());
             qinfo.put("canEdit", canEdit);
             qinfo.put("canEditSharedViews", getContainer().hasPermission(getUser(), EditSharedViewPermission.class));
-            qinfo.put("isMetadataOverrideable", canEdit); //for now, this is the same as canEdit(), but in the future we can support this for non-editable queries
+            // CONSIDER: do we want to separate the 'canEditMetadata' property and 'isMetadataOverridable' properties to differentiate between cabability and the permission check?
+            qinfo.put("isMetadataOverrideable", qdef.isMetadataEditable() && qdef.canEditMetadata(getUser()));
 
             if (isUserDefined)
                 qinfo.put("moduleName", qdef.getModuleName());

--- a/query/src/org/labkey/query/view/propertiesQuery.jsp
+++ b/query/src/org/labkey/query/view/propertiesQuery.jsp
@@ -20,23 +20,38 @@
 <%@ page import="org.labkey.query.controllers.PropertiesForm" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
-<% PropertiesForm form = (PropertiesForm) HttpView.currentModel(); %>
+<%
+    PropertiesForm form = (PropertiesForm) HttpView.currentModel();
+    // query properties are editable only if the SQL is editable, not the metadata
+    boolean isEditable = form.getQueryDef().isSqlEditable();
+    boolean hasPerms = form.getQueryDef().canEdit(getUser());
+    boolean noEdit = !isEditable || !hasPerms;
+%>
 
 <labkey:errors />
-<labkey:form method="POST" action="<%=form.urlFor(QueryAction.propertiesQuery)%>">
+<% if (!isEditable) { %>
+<div class="alert alert-info">
+    Query properties are not editable.
+</div>
+<% } else if (!hasPerms) { %>
+<div class="alert alert-info">
+    You do not have permission to edit the query properties.
+</div>
+<% } %>
+<labkey:form method="POST" action="<%=noEdit ? form.urlFor(QueryAction.propertiesQuery) : null%>" >
     <table class="lk-fields-table">
         <tr>
             <td class="labkey-form-label">Name:</td>
-            <td><input name="rename" value="<%=h(form.getQueryDef().getName())%>"></td>
+            <td><input name="rename" value="<%=h(form.getQueryDef().getName())%>" <%=disabled(noEdit)%>></td>
         </tr>
         <tr>
             <td class="labkey-form-label">Description:</td>
-            <td width="100%"><textarea style="width: 100%;" name="description" rows="5" cols="40"><%=h(form.description)%></textarea></td>
+            <td width="100%"><textarea style="width: 100%;" name="description" rows="5" cols="40" <%=disabled(noEdit)%>><%=h(form.description)%></textarea></td>
         </tr>
         <tr>
             <td class="labkey-form-label" nowrap="true">Available in child folders?</td>
             <td>
-                <select name="inheritable">
+                <select name="inheritable" <%=disabled(noEdit)%>>
                     <option value="true"<%=selected(form.inheritable)%>>Yes</option>
                     <option value="false"<%=selected(!form.inheritable)%>>No</option>
                 </select>
@@ -45,7 +60,7 @@
         <tr>
             <td class="labkey-form-label" nowrap="true">Hidden from the user?</td>
             <td>
-                <select name="hidden">
+                <select name="hidden" <%=disabled(noEdit)%>>
                     <option value="true"<%=selected(form.hidden)%>>Yes</option>
                     <option value="false"<%=selected(!form.hidden)%>>No</option>
                 </select>
@@ -53,7 +68,7 @@
         </tr>
         <tr>
             <td/>
-            <td><labkey:button text="Save" /></td>
+            <td><labkey:button text="Save" enabled="<%=!noEdit%>"/></td>
         </tr>
     </table>
 </labkey:form>

--- a/query/src/org/labkey/query/view/sourceQuery.jsp
+++ b/query/src/org/labkey/query/view/sourceQuery.jsp
@@ -50,6 +50,7 @@
     }
 
     boolean canEdit = queryDef.canEdit(getUser());
+    boolean canEditMetadata = queryDef.canEditMetadata(getUser());
     boolean canDelete = queryDef.canDelete(getUser());
 %>
 <style type="text/css">
@@ -95,16 +96,17 @@
 
         // TODO: Replace the following object with an Ajax call
         var query = {
-            schema    : LABKEY.ActionURL.getParameter('schemaName'),
-            query     : LABKEY.ActionURL.getParameter('query.queryName'),
+            schema    : <%= q(queryDef.getSchemaPath().toString()) %>,
+            query     : <%= q(queryDef.getName()) %>,
             executeUrl: <%= q(exeUrl) %>,
             canEdit   : <%= canEdit %>,
             canDelete : <%= canDelete %>,
             canEditSql   : <%= canEdit && queryDef.isSqlEditable() %>,
-            canEditMetaData   : <%=canEdit && queryDef.isMetadataEditable() %>,
+            canEditMetadata   : <%=canEditMetadata && queryDef.isMetadataEditable() %>,
             builtIn   : <%= builtIn %>,
-            metadataEdit : <%=queryDef.isMetadataEditable()%>,
-            propEdit     : <%=queryDef.isMetadataEditable() && !builtIn%>,
+            sqlEditable  : <%=queryDef.isSqlEditable()%>,
+            metadataEditable : <%=queryDef.isMetadataEditable()%>,
+            propEdit     : <%=canEdit && !builtIn%>,
             queryText    : <%=q(action._form.ff_queryText)%>,
             metadataText : <%=q(action._form.ff_metadataText)%>,
             help         : <%=q(new HelpTopic(sqlHelpTopic).getHelpTopicHref())%>,

--- a/query/src/org/labkey/query/view/sourceQuery.jsp
+++ b/query/src/org/labkey/query/view/sourceQuery.jsp
@@ -36,7 +36,6 @@
 <%
     QueryController.SourceQueryAction action = (QueryController.SourceQueryAction)HttpView.currentModel();
     QueryDefinition queryDef = action._queryDef;
-    boolean builtIn = queryDef.isTableQueryDefinition();
     String sqlHelpTopic = "labkeySql";
     String metadataHelpTopic = "metadataSql";
     ActionURL exeUrl = null;
@@ -103,10 +102,10 @@
             canDelete : <%= canDelete %>,
             canEditSql   : <%= canEdit && queryDef.isSqlEditable() %>,
             canEditMetadata   : <%=canEditMetadata && queryDef.isMetadataEditable() %>,
-            builtIn   : <%= builtIn %>,
+            userDefined  : <%= queryDef.isUserDefined() %>,
             sqlEditable  : <%=queryDef.isSqlEditable()%>,
             metadataEditable : <%=queryDef.isMetadataEditable()%>,
-            propEdit     : <%=canEdit && !builtIn%>,
+            propEdit     : <%=queryDef.isSqlEditable() && canEdit%>,
             queryText    : <%=q(action._form.ff_queryText)%>,
             metadataText : <%=q(action._form.ff_metadataText)%>,
             help         : <%=q(new HelpTopic(sqlHelpTopic).getHelpTopicHref())%>,

--- a/query/webapp/query/QueryEditorPanel.js
+++ b/query/webapp/query/QueryEditorPanel.js
@@ -52,7 +52,7 @@ Ext4.define('LABKEY.query.SourceEditorPanel', {
                             mode            : 'text/x-plsql',
                             lineNumbers     : true,
                             lineWrapping    : true,
-                            readOnly        : this.query.builtIn || !this.query.canEditSql,
+                            readOnly        : !this.query.userDefined || !this.query.canEditSql,
                             indentUnit      : 3
                         });
 
@@ -610,7 +610,7 @@ Ext4.define('LABKEY.query.QueryEditorPanel', {
             queryName    : this.query.query
         };
 
-        if (this.query.builtIn || !this.query.canEdit)
+        if (!this.query.userDefined || !this.query.canEdit)
             json.ff_queryText = null;
         else
             json.ff_queryText = this.getSourceEditor().getValue();
@@ -742,7 +742,7 @@ Ext4.define('LABKEY.query.QueryEditorPanel', {
     onExecuteQuery : function(force)
     {
         this._executing = true;
-        var sourceDirty = !this.query.builtIn && this.getSourceEditor().isQueryDirty(true);
+        var sourceDirty = this.query.userDefined && this.getSourceEditor().isQueryDirty(true);
         var metaDirty   = this.getMetadataEditor().isQueryDirty(true);
         var dirty = sourceDirty || metaDirty;
         if (!dirty && !force && this._dataLoaded) {
@@ -792,7 +792,7 @@ Ext4.define('LABKEY.query.QueryEditorPanel', {
         };
 
         // Choose queryName or SQL as source
-        if (this.query.builtIn)
+        if (!this.query.userDefined)
         {
             config.queryName = this.query.query;
         }

--- a/query/webapp/query/browser/view/QueryDetails.js
+++ b/query/webapp/query/browser/view/QueryDetails.js
@@ -617,15 +617,20 @@ Ext4.define('LABKEY.query.browser.view.QueryDetails', {
         }
 
         if (queryDetails.isUserDefined) {
-            if (queryDetails.canEdit && !queryDetails.isInherited) {
-                children.push(this.formatQueryLink("sourceQuery", params, "edit source"));
-                children.push(this.formatQueryLink("propertiesQuery", params, "edit properties"));
-                if (queryDetails.canDelete)
+            if (!queryDetails.isInherited) {
+                if (queryDetails.canEdit) {
+                    children.push(this.formatQueryLink("sourceQuery", params, "edit source"));
+                    children.push(this.formatQueryLink("propertiesQuery", params, "edit properties"));
+                }
+                else {
+                    children.push(this.formatQueryLink('viewQuerySource', params, 'view source'));
+                }
+                if (queryDetails.canDelete) {
                     children.push(this.formatQueryLink("deleteQuery", params, "delete query"));
-                children.push(this.formatQueryLink("metadataQuery", metadataParams, "edit metadata"));
-            }
-            else {
-                children.push(this.formatQueryLink('viewQuerySource', params, 'view source'));
+                }
+                if (queryDetails.isMetadataOverrideable) {
+                    children.push(this.formatQueryLink("metadataQuery", metadataParams, "edit metadata"));
+                }
             }
         }
         else {

--- a/visualization/src/org/labkey/visualization/VisualizationServiceImpl.java
+++ b/visualization/src/org/labkey/visualization/VisualizationServiceImpl.java
@@ -224,7 +224,7 @@ public class VisualizationServiceImpl implements VisualizationService
 
     private static boolean isDemographicQueryDefinition(QueryDefinition q)
     {
-        if (!StringUtils.equalsIgnoreCase("study", q.getSchemaName()) || !q.isTableQueryDefinition())
+        if (!StringUtils.equalsIgnoreCase("study", q.getSchemaName()) || q.isUserDefined())
             return false;
 
         try
@@ -268,7 +268,7 @@ public class VisualizationServiceImpl implements VisualizationService
             props.put("queryName", getQueryName(query, false, _tableInfoMap));
             props.put("queryLabel", getQueryName(query, true, _tableInfoMap));
             props.put("queryDescription", getQueryDefinition(query, _tableInfoMap));
-            props.put("isUserDefined", !query.isTableQueryDefinition());
+            props.put("isUserDefined", query.isUserDefined());
             props.put("isDemographic", isDemographicQueryDefinition(query));
             props.put("phi", column.getPHI().name());
             props.put("hidden", column.isHidden() || (tableInfo != null && !tableInfo.getDefaultVisibleColumns().contains(column.getFieldKey())));
@@ -361,11 +361,11 @@ public class VisualizationServiceImpl implements VisualizationService
                 return VisualizationProvider.QueryType.datasets.toString();
         }
 
-        if (query.isTableQueryDefinition())
+        if (query.isUserDefined())
         {
-            return VisualizationProvider.QueryType.builtIn.toString();
+            return VisualizationProvider.QueryType.custom.toString();
         }
 
-        return VisualizationProvider.QueryType.custom.toString();
+        return VisualizationProvider.QueryType.builtIn.toString();
     }
 }


### PR DESCRIPTION
#### Rationale
Clean up handling of capabilities and permissions for custom query definition subclasses.  Disallow editing of custom query properties (name, description, inherit) for linked schema custom queries since they don't make sense.  Metadata for linked schemas was being persisted for wrapped custom queries but the saved metadata wasn't being threaded through to the editor.  The source and metadata xml editors will now display a message indicating why the editor is disabled instead of letting the user guess.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/519

#### Changes
- clean up capability and permission checks for custom queries and linked schema custom queries
- fixed loading of metadata for linked schema custom queries so saved metadata will appear in xml editor
- query editor now displays reason if source or metadata can't be modified
- ability to edit custom query properties (description, inherit, hidden) now requires canEdit permission
  since these properties are used for custom queries and not intended for built-in tables
