### PR TITLE
Issue 41721: Add precision to BaseColumnInfo.copyAttributesFrom()

### DIFF
--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -292,6 +292,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
         setRequired(col.isRequiredSet());
         setAutoIncrement(col.isAutoIncrement());
         setScale(col.getScale());
+        setPrecision(col.getPrecision());
         if (col instanceof BaseColumnInfo)
         {
             _sqlTypeName = ((BaseColumnInfo) col)._sqlTypeName;
@@ -1907,6 +1908,13 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     {
         checkLocked();
         super.setScale(scale);
+    }
+
+    @Override
+    public void setPrecision(int precision)
+    {
+        checkLocked();
+        super.setPrecision(precision);
     }
 
 


### PR DESCRIPTION
#### Rationale
Precision not getting copied over into wrapped columns

#### Changes
* Set precision in BaseColumnInfo.copyAttributesFrom()