### PR TITLE
Alphabetize by name in thread dumps

### DIFF
--- a/api/src/org/labkey/api/util/DebugInfoDumper.java
+++ b/api/src/org/labkey/api/util/DebugInfoDumper.java
@@ -36,10 +36,12 @@ import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
 import java.text.DecimalFormat;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 
 /**
  * Monitors the timestamp of the heapDumpRequest and threadDumpRequest files to see if an admin has requested
@@ -243,11 +245,13 @@ public class DebugInfoDumper
                 FileUtils.byteCountToDisplaySize(used) + " from a max of " +
                 FileUtils.byteCountToDisplaySize(max) + " (" + DecimalFormat.getInstance().format(used) + " / " + DecimalFormat.getInstance().format(max) + " bytes)");
         logWriter.debug("*********************************************");
-        Map<Thread,StackTraceElement[]> threads = new TreeMap<>(Thread.getAllStackTraces());
-        for (Map.Entry<Thread, StackTraceElement[]> threadEntry : threads.entrySet())
+        Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
+        List<Thread> threads = new ArrayList<>(stackTraces.keySet());
+        threads.sort(Comparator.comparing(Thread::getName, String.CASE_INSENSITIVE_ORDER));
+
+        for (Thread thread : threads)
         {
             logWriter.debug("");
-            Thread thread = threadEntry.getKey();
             StringBuilder threadInfo = new StringBuilder(thread.getName());
             threadInfo.append(" (");
             threadInfo.append(thread.getState());
@@ -263,7 +267,7 @@ public class DebugInfoDumper
             String uri = ViewServlet.getRequestURL(thread);
             if (null != uri)
                 logWriter.debug(uri);
-            for (StackTraceElement stackTraceElement : threadEntry.getValue())
+            for (StackTraceElement stackTraceElement : stackTraces.get(thread))
             {
                 logWriter.debug("\t" + stackTraceElement.toString());
             }

--- a/api/src/org/labkey/api/util/DebugInfoDumper.java
+++ b/api/src/org/labkey/api/util/DebugInfoDumper.java
@@ -39,6 +39,7 @@ import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * Monitors the timestamp of the heapDumpRequest and threadDumpRequest files to see if an admin has requested
@@ -242,7 +243,7 @@ public class DebugInfoDumper
                 FileUtils.byteCountToDisplaySize(used) + " from a max of " +
                 FileUtils.byteCountToDisplaySize(max) + " (" + DecimalFormat.getInstance().format(used) + " / " + DecimalFormat.getInstance().format(max) + " bytes)");
         logWriter.debug("*********************************************");
-        Map<Thread,StackTraceElement[]> threads = Thread.getAllStackTraces();
+        Map<Thread,StackTraceElement[]> threads = new TreeMap<>(Thread.getAllStackTraces());
         for (Map.Entry<Thread, StackTraceElement[]> threadEntry : threads.entrySet())
         {
             logWriter.debug("");


### PR DESCRIPTION
#### Rationale
In the Admin Console's running threads page, we alphabetize threads to groups like with like. We don't do that for the thread dumps we write to log files.

#### Changes
* Let a TreeMap do the hard work of sorting by name