### PR TITLE
Item 7915: Updates to allow adding and updating sample storage data during import

### DIFF
--- a/api/src/org/labkey/api/inventory/InventoryService.java
+++ b/api/src/org/labkey/api/inventory/InventoryService.java
@@ -52,5 +52,5 @@ public interface InventoryService
 
     List<FieldKey> addInventoryStatusColumns(@Nullable String sampleTypeMetricUnit, ExpMaterialTable table, Container container);
 
-    DataIteratorBuilder getStorageDataIteratorBuilder(DataIteratorBuilder data, Container container, User user);
+    DataIteratorBuilder getStorageDataIteratorBuilder(DataIteratorBuilder data, Container container, User user, String metricUnit);
 }

--- a/api/src/org/labkey/api/inventory/InventoryService.java
+++ b/api/src/org/labkey/api/inventory/InventoryService.java
@@ -52,5 +52,5 @@ public interface InventoryService
 
     List<FieldKey> addInventoryStatusColumns(@Nullable String sampleTypeMetricUnit, ExpMaterialTable table, Container container);
 
-    DataIteratorBuilder getStorageDataIteratorBuilder(DataIteratorBuilder data, Container container, User user, String metricUnit);
+    DataIteratorBuilder getPersistStorageItemDataIteratorBuilder(DataIteratorBuilder data, Container container, User user, String metricUnit);
 }

--- a/api/src/org/labkey/api/inventory/InventoryService.java
+++ b/api/src/org/labkey/api/inventory/InventoryService.java
@@ -52,5 +52,5 @@ public interface InventoryService
 
     List<FieldKey> addInventoryStatusColumns(@Nullable String sampleTypeMetricUnit, ExpMaterialTable table, Container container);
 
-    DataIteratorBuilder getPersistSampleDataIteratorBuilder(DataIteratorBuilder data, Container container, User user);
+    DataIteratorBuilder getStorageDataIteratorBuilder(DataIteratorBuilder data, Container container, User user);
 }

--- a/api/src/org/labkey/api/inventory/InventoryService.java
+++ b/api/src/org/labkey/api/inventory/InventoryService.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.query.FieldKey;
@@ -50,4 +51,6 @@ public interface InventoryService
     List<Map<String, Object>> getSampleStorageLocationData(User user, Container container, int sampleId);
 
     List<FieldKey> addInventoryStatusColumns(@Nullable String sampleTypeMetricUnit, ExpMaterialTable table, Container container);
+
+    DataIteratorBuilder getPersistSampleDataIteratorBuilder(DataIteratorBuilder data, Container container, User user);
 }

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -151,7 +151,7 @@ public class ExpDataIterators
                     }
                 }
 
-                // add a sequence column for each for each of the attached columns
+                // add a sequence column for each of the attached columns
                 for (String columnName : attachedColumnNames)
                 {
                     Integer i = columnNameMap.get(columnName);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -792,7 +792,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
             builder = LoggingDataIterator.wrap(new AliasDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser(), ExperimentService.get().getTinfoMaterialAliasMap()));
             if (InventoryService.get() != null && ExperimentalFeatureService.get().isFeatureEnabled("experimental_freezerManagement"))
-                return LoggingDataIterator.wrap(InventoryService.get().getStorageDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser()));
+                return LoggingDataIterator.wrap(InventoryService.get().getStorageDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser(), _ss.getMetricUnit()));
             else
                 return builder;
         }

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -792,7 +792,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
             builder = LoggingDataIterator.wrap(new AliasDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser(), ExperimentService.get().getTinfoMaterialAliasMap()));
             if (InventoryService.get() != null && ExperimentalFeatureService.get().isFeatureEnabled("experimental_freezerManagement"))
-                return LoggingDataIterator.wrap(InventoryService.get().getStorageDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser(), _ss.getMetricUnit()));
+                return LoggingDataIterator.wrap(InventoryService.get().getPersistStorageItemDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser(), _ss.getMetricUnit()));
             else
                 return builder;
         }

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -792,7 +792,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
             builder = LoggingDataIterator.wrap(new AliasDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser(), ExperimentService.get().getTinfoMaterialAliasMap()));
             if (InventoryService.get() != null && ExperimentalFeatureService.get().isFeatureEnabled("experimental_freezerManagement"))
-                return LoggingDataIterator.wrap(InventoryService.get().getPersistSampleDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser()));
+                return LoggingDataIterator.wrap(InventoryService.get().getStorageDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser()));
             else
                 return builder;
         }


### PR DESCRIPTION
#### Rationale
When sample data from an existing freezer or sample manager system into LabKey, we want to allow users to also add the samples being created to a freezer in a particular location.  For this, we add a new data iterator, provided by the inventory service, into the mix when importing samples.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/396

#### Changes
* Add StorageDataIteratoBuilder into the import iterator chain when the inventory module is present and the freezer manager experimental feature has been turned on.
