### PR TITLE
build.gradle no longer required for platform.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,1 +1,0 @@
-apply plugin: 'org.labkey.npmRun'


### PR DESCRIPTION
#### Rationale
We no longer require a build.gradle file for platform since the advent of the @labkey/build package


#### Changes
*  remove build.gradle file
