### PR TITLE
Issue 40081: Switch mothership to non-SVN-based upgrade signaling

### DIFF
--- a/mothership/src/org/labkey/mothership/MothershipController.java
+++ b/mothership/src/org/labkey/mothership/MothershipController.java
@@ -52,7 +52,6 @@ import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.MothershipReport;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
@@ -262,7 +261,7 @@ public class MothershipController extends SpringActionController
         {
             UpgradeMessageForm form = new UpgradeMessageForm();
 
-            form.setCurrentRevision(MothershipManager.get().getCurrentRevision(getContainer()));
+            form.setCurrentBuildDate(MothershipManager.get().getCurrentBuildDate(getContainer()));
             form.setMessage(MothershipManager.get().getUpgradeMessage(getContainer()));
             form.setCreateIssueURL(MothershipManager.get().getCreateIssueURL(getContainer()));
             form.setIssuesContainer(MothershipManager.get().getIssuesContainer(getContainer()));
@@ -289,7 +288,7 @@ public class MothershipController extends SpringActionController
         @Override
         public boolean handlePost(UpgradeMessageForm form, BindException errors)
         {
-            MothershipManager.get().setCurrentRevision(getContainer(), form.getCurrentRevision());
+            MothershipManager.get().setCurrentBuildDate(getContainer(), form.getCurrentBuildDate());
             MothershipManager.get().setUpgradeMessage(getContainer(), form.getMessage());
             MothershipManager.get().setCreateIssueURL(getContainer(), form.getCreateIssueURL());
             MothershipManager.get().setIssuesContainer(getContainer(), form.getIssuesContainer());
@@ -721,12 +720,10 @@ public class MothershipController extends SpringActionController
 
     private String getUpgradeMessage(@NotNull SoftwareRelease release)
     {
-        // We still key off the SVN revision to determine if a build is current, though we should soon
-        // migrate to looking at the version number we're assigning for maintenance releases or SNAPSHOT, etc
-        int currentRevision = MothershipManager.get().getCurrentRevision(getContainer());
-        Integer reportedRevision = release.getSVNRevision();
+        Date currentBuildDate = MothershipManager.get().getCurrentBuildDate(getContainer());
+        Date reportedBuildDate = release.getBuildTime();
 
-        if (reportedRevision != null && reportedRevision.intValue() < currentRevision)
+        if (reportedBuildDate != null && reportedBuildDate.before(currentBuildDate))
         {
             return MothershipManager.get().getUpgradeMessage(getContainer());
         }
@@ -1674,19 +1671,19 @@ public class MothershipController extends SpringActionController
 
     public static class UpgradeMessageForm
     {
-        private int _currentRevision;
+        private Date _currentBuildDate;
         private String _message;
         private String _createIssueURL;
         private String _issuesContainer;
 
-        public int getCurrentRevision()
+        public Date getCurrentBuildDate()
         {
-            return _currentRevision;
+            return _currentBuildDate;
         }
 
-        public void setCurrentRevision(int currentRevision)
+        public void setCurrentBuildDate(Date currentBuildDate)
         {
-            _currentRevision = currentRevision;
+            _currentBuildDate = currentBuildDate;
         }
 
         public String getMessage()

--- a/mothership/src/org/labkey/mothership/MothershipController.java
+++ b/mothership/src/org/labkey/mothership/MothershipController.java
@@ -723,7 +723,7 @@ public class MothershipController extends SpringActionController
         Date currentBuildDate = MothershipManager.get().getCurrentBuildDate(getContainer());
         Date reportedBuildDate = release.getBuildTime();
 
-        if (reportedBuildDate != null && reportedBuildDate.before(currentBuildDate))
+        if (reportedBuildDate != null && currentBuildDate != null && reportedBuildDate.before(currentBuildDate))
         {
             return MothershipManager.get().getUpgradeMessage(getContainer());
         }

--- a/mothership/src/org/labkey/mothership/MothershipManager.java
+++ b/mothership/src/org/labkey/mothership/MothershipManager.java
@@ -66,7 +66,7 @@ public class MothershipManager
     private static final MothershipManager INSTANCE = new MothershipManager();
     private static final String SCHEMA_NAME = "mothership";
     private static final String UPGRADE_MESSAGE_PROPERTY_CATEGORY = "upgradeMessage";
-    private static final String CURRENT_REVISION_PROP = "currentRevision";
+    private static final String CURRENT_BUILD_DATE_PROP = "currentBuildDate";
     private static final String UPGRADE_MESSAGE_PROP = "upgradeMessage";
     private static final String CREATE_ISSUE_URL_PROP = "createIssueURL";
     private static final String ISSUES_CONTAINER_PROP = "issuesContainer";
@@ -476,15 +476,11 @@ public class MothershipManager
         return PropertyManager.getProperties(c, UPGRADE_MESSAGE_PROPERTY_CATEGORY);
     }
 
-    public int getCurrentRevision(Container c)
+    public Date getCurrentBuildDate(Container c)
     {
         Map<String, String> props = getProperties(c);
-        String rev = props.get(CURRENT_REVISION_PROP);
-        if (rev == null)
-        {
-            return 0;
-        }
-        return Integer.parseInt(rev);
+        String buildDate = props.get(CURRENT_BUILD_DATE_PROP);
+        return  null == buildDate ? null : new Date(DateUtil.parseDateTime(c, buildDate));
     }
 
     private String getStringProperty(Container c, String name)
@@ -510,9 +506,9 @@ public class MothershipManager
         props.save();
     }
 
-    public void setCurrentRevision(Container c, int revision)
+    public void setCurrentBuildDate(Container c, Date buildDate)
     {
-        saveProperty(c, CURRENT_REVISION_PROP, String.valueOf(revision));
+        saveProperty(c, CURRENT_BUILD_DATE_PROP, String.valueOf(buildDate));
     }
 
     public void setUpgradeMessage(Container c, String message)

--- a/mothership/src/org/labkey/mothership/editUpgradeMessage.jsp
+++ b/mothership/src/org/labkey/mothership/editUpgradeMessage.jsp
@@ -19,6 +19,9 @@
 <%@ page import="org.labkey.api.view.JspView"%>
 <%@ page import="org.labkey.mothership.MothershipController.SaveUpgradeMessageAction"%>
 <%@ page import="org.labkey.mothership.MothershipController.UpgradeMessageForm" %>
+<%@ page import="org.labkey.api.util.DateUtil" %>
+<%@ page import="java.util.Date" %>
+<%@ page import="java.text.SimpleDateFormat" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
@@ -30,10 +33,15 @@
     <table>
         <tr>
             <td>
-                Current SVN revision:
+                Current build date:
             </td>
+            <%
+                Date buildDate = DateUtil.getDateOnly(form.getCurrentBuildDate());
+                SimpleDateFormat sdf = new SimpleDateFormat(DateUtil.getStandardDateFormatString()); // HTML5 input type date recognizes this format
+                String strDate = sdf.format(buildDate);
+            %>
             <td>
-                <input type="text" size="6" name="currentRevision" value="<%= form.getCurrentRevision() %>"/>
+                <input type="date" size="6" name="currentBuildDate" value="<%= h(strDate) %>"/>
             </td>
         </tr>
         <tr>

--- a/mothership/src/org/labkey/mothership/editUpgradeMessage.jsp
+++ b/mothership/src/org/labkey/mothership/editUpgradeMessage.jsp
@@ -38,7 +38,7 @@
             <%
                 Date buildDate = DateUtil.getDateOnly(form.getCurrentBuildDate());
                 SimpleDateFormat sdf = new SimpleDateFormat(DateUtil.getStandardDateFormatString()); // HTML5 input type date recognizes this format
-                String strDate = sdf.format(buildDate);
+                String strDate = null != buildDate ? sdf.format(buildDate) : "";
             %>
             <td>
                 <input type="date" size="6" name="currentBuildDate" value="<%= h(strDate) %>"/>


### PR DESCRIPTION
#### Rationale
We report to the LabKey installations about the new builds based on latest SVN version through mothership, but as we have moved away from SVN in 20.11, this PR switches the check to report the update message based on build date instead of SVN version.

