### PR TITLE
Post 20.11 cleanups

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -45,7 +45,6 @@ import org.labkey.api.dataiterator.StatementDataIterator;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.files.FileSystemWatcherImpl;
 import org.labkey.api.iterator.MarkableIterator;
-import org.labkey.api.jsp.LabKeyJspWriter;
 import org.labkey.api.markdown.MarkdownService;
 import org.labkey.api.module.CodeOnlyModule;
 import org.labkey.api.module.FolderTypeManager;
@@ -124,7 +123,6 @@ public class ApiModule extends CodeOnlyModule
     {
         SystemMaintenance.addTask(new ApiKeyMaintenanceTask());
         AuthenticationManager.registerMetricsProvider();
-        LabKeyJspWriter.registerExperimentalFeature();
         ApiKeyManager.get().handleStartupProperties();
     }
 

--- a/api/src/org/labkey/api/data/Selector.java
+++ b/api/src/org/labkey/api/data/Selector.java
@@ -136,20 +136,8 @@ public interface Selector
      */
     void forEachMapBatch(int batchSize, ForEachBatchBlock<Map<String, Object>> batchBlock);
 
-    @Deprecated // Use variant above instead. This will be removed soon.
-    default void forEachMapBatch(ForEachBatchBlock<Map<String, Object>> batchBlock, int batchSize)
-    {
-        forEachMapBatch(batchSize, batchBlock);
-    }
-
     /** Stream objects from the database. Convert each result row into an object specified by clazz and invoke block.exec() on it. */
     <T> void forEach(Class<T> clazz, ForEachBlock<T> block);
-
-    @Deprecated // Use variant above instead. This will be removed soon.
-    default <T> void forEach(ForEachBlock<T> block, Class<T> clazz)
-    {
-        forEach(clazz, block);
-    }
 
     /**
      *  Stream objects from the database in batches. Convert rows to objects and pass them to batchBlock.exec() in batches
@@ -157,12 +145,6 @@ public interface Selector
      *  efficient than one-by-one. All batches are of size batchSize, except the last batch which is typically smaller.
      */
     <T> void forEachBatch(Class<T> clazz, int batchSize, ForEachBatchBlock<T> batchBlock);
-
-    @Deprecated // Use variant above instead. This will be removed soon.
-    default <T> void forEachBatch(ForEachBatchBlock<T> batchBlock, Class<T> clazz, int batchSize)
-    {
-        forEachBatch(clazz, batchSize, batchBlock);
-    }
 
     /** Return a new map from a two-column query; the first column is the key, the second column is the value. */
     @NotNull <K, V> Map<K, V> getValueMap();

--- a/api/src/org/labkey/api/jsp/JspBase.java
+++ b/api/src/org/labkey/api/jsp/JspBase.java
@@ -699,6 +699,12 @@ public abstract class JspBase extends JspContext implements HasViewContext
         }
     }
 
+    @Deprecated // Use <labkey:form> instead; it takes care of CSRF and other details.
+    protected HtmlString formAction(Class<? extends Controller> actionClass, Method method)
+    {
+        return HtmlString.unsafe("action=\"" + h(urlFor(actionClass)) + "\" method=\"" + method.getMethod() + "\"");
+    }
+
     // Provides a unique integer within the context of this request. Handy for generating element ids, etc. See UniqueID for caveats and warnings.
     protected int getRequestScopedUID()
     {

--- a/api/src/org/labkey/api/jsp/JspBase.java
+++ b/api/src/org/labkey/api/jsp/JspBase.java
@@ -699,12 +699,6 @@ public abstract class JspBase extends JspContext implements HasViewContext
         }
     }
 
-    @Deprecated // Use <labkey:form> instead; it takes care of CSRF and other details.
-    protected HtmlString formAction(Class<? extends Controller> actionClass, Method method)
-    {
-        return HtmlString.unsafe("action=\"" + h(urlFor(actionClass)) + "\" method=\"" + method.getMethod() + "\"");
-    }
-
     // Provides a unique integer within the context of this request. Handy for generating element ids, etc. See UniqueID for caveats and warnings.
     protected int getRequestScopedUID()
     {

--- a/api/src/org/labkey/api/jsp/JspContext.java
+++ b/api/src/org/labkey/api/jsp/JspContext.java
@@ -28,7 +28,7 @@ import javax.servlet.jsp.JspWriter;
  * Time: 4:05:51 PM
  */
 
-// Trivially simple base class for JSP templates that aren't rendering HTML (see JspTemplate)
+// Simple base class for JSP templates that aren't rendering HTML (see JspTemplate)
 public abstract class JspContext extends HttpJspBase
 {
     protected JspContext()
@@ -65,7 +65,7 @@ public abstract class JspContext extends HttpJspBase
      * would be the first line of code in a JSP that generates non-HTML content:<br><br>
      *     {@code out = getPermissiveJspWriter(out);}
      * @param out Current JspWriter
-     * @return A JspWriter that doesn't log warnings or throw exceptions when rendering Strings and unsafe Objects
+     * @return A JspWriter that doesn't throw exceptions when rendering Strings and unsafe Objects
      */
     protected JspWriter getUnsafeJspWriter(JspWriter out)
     {

--- a/api/src/org/labkey/api/jsp/LabKeyJspWriter.java
+++ b/api/src/org/labkey/api/jsp/LabKeyJspWriter.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.jsp;
 
+import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.SafeToRender;
 
 import javax.servlet.jsp.JspWriter;
@@ -30,13 +31,13 @@ public class LabKeyJspWriter extends JspWriterWrapper
     @Override
     public void print(char[] s)
     {
-        throw new IllegalStateException("A JSP is attempting to render a character array!");
+        throwException("A JSP is attempting to render a character array!");
     }
 
     @Override
     public void print(String s) throws IOException
     {
-        throw new IllegalStateException("A JSP is attempting to render a string!");
+        throwException("A JSP is attempting to render a string!");
     }
 
     @Override
@@ -49,7 +50,12 @@ public class LabKeyJspWriter extends JspWriterWrapper
         }
         else
         {
-            throw new IllegalStateException("A JSP is attempting to render an object of class " + obj.getClass().getName() + "!");
+            throwException("A JSP is attempting to render an object of class " + obj.getClass().getName() + "!");
         }
+    }
+
+    private void throwException(String message)
+    {
+        throw new IllegalStateException(message + " For help rectifying this problem, review this page " + new HelpTopic("premServerEncoding").getHelpTopicHref() + " or contact your LabKey Account Manager.");
     }
 }

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -45,7 +45,6 @@ import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.property.TestDomainKind;
 import org.labkey.api.external.tools.ExternalToolsViewService;
 import org.labkey.api.files.FileContentService;
-import org.labkey.api.jsp.LabKeyJspWriter;
 import org.labkey.api.markdown.MarkdownService;
 import org.labkey.api.message.settings.MessageConfigService;
 import org.labkey.api.module.FolderType;
@@ -697,13 +696,6 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         if (moduleContext.getInstalledVersion() < 18.30)
         {
             new CoreUpgradeCode().purgeDeveloperRole();
-        }
-
-        // Force LabKeyJspWriter to throw exceptions for unsafe operations, dev mode only.
-        // We'll remove this after 20.11, along with the experimental feature.
-        if (moduleContext.getInstalledVersion() < 20.002)
-        {
-            LabKeyJspWriter.turnOnExperimentalFeature(moduleContext.getUpgradeUser());
         }
     }
 


### PR DESCRIPTION
#### Rationale
Remove deprecated and unused methods. Streamline `LabKeyJspWriter` checking.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/7

#### Changes
* Remove deprecated and unused methods
* Simplify `LabKeyJspWriter` checking: remove experimental feature, statistics gathering, and logging. Just throw if a JSP attempts to print a string (in dev mode).
