### PR TITLE
Issue 41364: Having a date field in an assay run result creates a bogus entry in the materials table

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -1056,7 +1056,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
 
             if (resolveMaterials)
             {
-                ExpMaterial material = participantVisit.getMaterial();
+                ExpMaterial material = participantVisit.getMaterial(false);
                 if (material != null)
                 {
                     materialInputs.putIfAbsent(material, null);

--- a/api/src/org/labkey/api/study/ParticipantVisit.java
+++ b/api/src/org/labkey/api/study/ParticipantVisit.java
@@ -45,5 +45,5 @@ public interface ParticipantVisit
     Date getDate();
 
     @Nullable
-    ExpMaterial getMaterial();
+    ExpMaterial getMaterial(boolean createIfNeeded);
 }

--- a/api/src/org/labkey/api/study/ParticipantVisit.java
+++ b/api/src/org/labkey/api/study/ParticipantVisit.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.study;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.api.ExpMaterial;
 
@@ -43,5 +44,6 @@ public interface ParticipantVisit
 
     Date getDate();
 
+    @Nullable
     ExpMaterial getMaterial();
 }

--- a/api/src/org/labkey/api/study/assay/ParticipantVisitImpl.java
+++ b/api/src/org/labkey/api/study/assay/ParticipantVisitImpl.java
@@ -136,6 +136,7 @@ public class ParticipantVisitImpl implements ParticipantVisit
             // the study couldn't find a good material, so we'll have to mock one up
             String lsid = new Lsid(ASSAY_RUN_MATERIAL_NAMESPACE, "Folder-" + _runContainer.getRowId(), name.toString()).toString();
             _material = ExperimentService.get().getExpMaterial(lsid);
+            // Issue 41364 - don't create a material if it doesn't already exist
             _attemptedMaterialResolution = true;
         }
         return _material;

--- a/api/src/org/labkey/api/study/assay/ParticipantVisitImpl.java
+++ b/api/src/org/labkey/api/study/assay/ParticipantVisitImpl.java
@@ -90,7 +90,7 @@ public class ParticipantVisitImpl implements ParticipantVisit
     }
 
     @Override @Nullable
-    public ExpMaterial getMaterial()
+    public ExpMaterial getMaterial(boolean createIfNeeded)
     {
         if (_material == null && !_attemptedMaterialResolution)
         {
@@ -136,8 +136,13 @@ public class ParticipantVisitImpl implements ParticipantVisit
             // the study couldn't find a good material, so we'll have to mock one up
             String lsid = new Lsid(ASSAY_RUN_MATERIAL_NAMESPACE, "Folder-" + _runContainer.getRowId(), name.toString()).toString();
             _material = ExperimentService.get().getExpMaterial(lsid);
-            // Issue 41364 - don't create a material if it doesn't already exist
             _attemptedMaterialResolution = true;
+            // Issue 41364 - don't create a material if it doesn't already exist for most assays
+            if (_material == null && createIfNeeded)
+            {
+                _material = ExperimentService.get().createExpMaterial(_runContainer, lsid, name.toString());
+                _material.save(null);
+            }
         }
         return _material;
     }

--- a/assay/api-src/org/labkey/api/assay/plate/PlateBasedRunCreator.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateBasedRunCreator.java
@@ -165,7 +165,10 @@ public class PlateBasedRunCreator<ProviderType extends AbstractPlateBasedAssayPr
                     continue;
                 }
             }
-            originalMaterials.put(key, originalMaterial);
+            if (originalMaterial != null)
+            {
+                originalMaterials.put(key, originalMaterial);
+            }
         }
         if (resolverErrors.length() > 0)
             throw new ExperimentException(resolverErrors.toString());

--- a/assay/api-src/org/labkey/api/assay/plate/PlateBasedRunCreator.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateBasedRunCreator.java
@@ -145,7 +145,7 @@ public class PlateBasedRunCreator<ProviderType extends AbstractPlateBasedAssayPr
                 try
                 {
                     ParticipantVisit pv = resolver.resolve(specimenID, participantID, visitID, date, targetStudy);
-                    originalMaterial = pv.getMaterial();
+                    originalMaterial = pv.getMaterial(true);
                     Map<DomainProperty, String> wellgroupProperties = materialProperties.get(entry.getKey());
                     if (specimenIDProperty != null)
                         wellgroupProperties.put(specimenIDProperty, pv.getSpecimenID());

--- a/study/src/org/labkey/study/SpecimenServiceImpl.java
+++ b/study/src/org/labkey/study/SpecimenServiceImpl.java
@@ -164,8 +164,8 @@ public class SpecimenServiceImpl implements SpecimenService
             throw new UnsupportedOperationException("Not Implemented for StudyParticipantVisit");
         }
 
-        @Override
-        public ExpMaterial getMaterial()
+        @Override @Nullable
+        public ExpMaterial getMaterial(boolean createIfNeeded)
         {
             if (_material == null)
             {
@@ -173,7 +173,7 @@ public class SpecimenServiceImpl implements SpecimenService
                 {
                     Lsid lsid = getSpecimenMaterialLsid(_studyContainer, _specimenID);
                     _material = ExperimentService.get().getExpMaterial(lsid.toString());
-                    if (_material == null)
+                    if (_material == null && createIfNeeded)
                     {
                         _material = ExperimentService.get().createExpMaterial(_studyContainer, lsid.toString(), _specimenID);
                         _material.save(null);
@@ -183,7 +183,7 @@ public class SpecimenServiceImpl implements SpecimenService
                 {
                     String lsid = new Lsid(ParticipantVisit.ASSAY_RUN_MATERIAL_NAMESPACE, "Folder-" + _studyContainer.getRowId(), "Unknown").toString();
                     _material = ExperimentService.get().getExpMaterial(lsid);
-                    if (_material == null)
+                    if (_material == null && createIfNeeded)
                     {
                         _material = ExperimentService.get().createExpMaterial(_studyContainer, lsid, "Unknown");
                         _material.save(null);


### PR DESCRIPTION
#### Rationale
The original theory behind creating this sample records was to let you find assay data that was probably derived from the same sample, even if you don't have a sample ID. I doubt it's ever helped anyone, and ends up creating a bunch of bogus records.

#### Changes
* Match against an existing material in the exceedingly unlikely case where it already exists, but otherwise don't bother creating it, and make sure callers handle nulls.