### PR TITLE
Issue41388: Edit Module link should only be visible if functionality is available

### DIFF
--- a/api/src/org/labkey/api/moduleeditor/api/ModuleEditorService.java
+++ b/api/src/org/labkey/api/moduleeditor/api/ModuleEditorService.java
@@ -38,6 +38,11 @@ public interface ModuleEditorService
         return null;
     }
 
+    default boolean canEditSourceModule(Module module)
+    {
+        return false;
+    }
+
     @Nullable
     default ActionURL getModuleEditorURL(String module)
     {

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -8102,7 +8102,7 @@ public class AdminController extends SpringActionController
                                         Path p = module.getExplodedPath().toPath();
                                         if (null != module.getZippedPath())
                                             p = module.getZippedPath().toPath();
-                                        if (isDevMode && module instanceof DefaultModule && ((DefaultModule)module).isSourcePathMatched())
+                                        if (isDevMode && ModuleEditorService.get().canEditSourceModule(module))
                                             if (!module.getExplodedPath().getPath().equals(module.getSourcePath()))
                                                 p = Paths.get(module.getSourcePath());
                                         fullPathToModule = p.toString();

--- a/core/src/org/labkey/core/admin/admin.jsp
+++ b/core/src/org/labkey/core/admin/admin.jsp
@@ -34,6 +34,7 @@
 <%@ page import="java.util.Date" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.TreeMap" %>
+<%@ page import="org.labkey.api.moduleeditor.api.ModuleEditorService" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -169,7 +170,7 @@
                         } %>
                         <table class="labkey-data-region-legacy labkey-show-borders">
                             <tr><td class="labkey-column-header">Property</td><td class="labkey-column-header">Value</td></tr><%
-                            boolean sourcePathMatched = module instanceof DefaultModule && ((DefaultModule)module).isSourcePathMatched();
+                            boolean sourcePathMatched = ModuleEditorService.get().canEditSourceModule(module);
                             boolean enlistmentIdMatched = module instanceof DefaultModule && ((DefaultModule)module).isSourceEnlistmentIdMatched();
 
                             Map<String, String> properties = module.getProperties();


### PR DESCRIPTION
#### Rationale
ModuleEditorService's getModuleEditorURL() needs to check for module editability before returning ActionURL.

#### Related Pull Requests
* https://github.com/LabKey/moduleEditor/pull/20

#### Changes
* Locate canEditSourceModule() within ModuleEditorService
* Modularize instances of above check into usages of canEditSourceModule()
