### PR TITLE
Fix NPE when adding tracking analytic script on not found error page

### DIFF
--- a/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
+++ b/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
@@ -220,6 +220,10 @@ public class AnalyticsServiceImpl implements AnalyticsService
         if (!showTrackingScript(context))
             return "";
 
+        ActionURL url = context.getActionURL();
+        if (null == url)
+            return "";
+
         boolean isSecure = context.getActionURL().getScheme().startsWith("https");
         String gaJS = (isSecure ? "https://ssl" : "http://www") + ".google-analytics.com/ga.js";
 


### PR DESCRIPTION
#### Rationale
This issue fixes NPE when adding tracking analytic script on error page where it is not supposed to run.
