### PR TITLE
Item 7979: Add getWellLabel() to InventoryService interface for use in LKSM audit log event details

### DIFF
--- a/api/src/org/labkey/api/inventory/InventoryService.java
+++ b/api/src/org/labkey/api/inventory/InventoryService.java
@@ -50,4 +50,7 @@ public interface InventoryService
     List<Map<String, Object>> getSampleStorageLocationData(User user, Container container, int sampleId);
 
     List<FieldKey> addInventoryStatusColumns(@Nullable String sampleTypeMetricUnit, ExpMaterialTable table, Container container);
+
+    @NotNull
+    String getWellLabel(int boxId, int row, Integer col);
 }


### PR DESCRIPTION
#### Rationale
The related PRs allow for a LKFM storage unit axis customization that can set the row/column display type and the ordering. This PR exposes a new method to the InventoryService interface so that the LKSM audit log event details can lookup the current well label display format for the given box/row/col value.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/388
* https://github.com/LabKey/inventory/pull/127
* https://github.com/LabKey/sampleManagement/pull/402
