### PR TITLE
Add optional container to BulkEmailer.addMessage

### DIFF
--- a/api/src/org/labkey/api/util/MailHelper.java
+++ b/api/src/org/labkey/api/util/MailHelper.java
@@ -505,7 +505,8 @@ public class MailHelper
      */
     public static class BulkEmailer extends Thread
     {
-        private final Map<Collection<String>, MimeMessage> _map = new HashMap<>(10);
+        private final Map<Collection<String>, MimeMessage> _messageMap = new HashMap<>(10);
+        private final Map<Collection<String>, Container> _containerMap = new HashMap<>(10);
         private final User _user;
 
         // User is for audit purposes
@@ -515,31 +516,45 @@ public class MailHelper
         }
 
         // Send message to multiple recipients
+        public void addMessage(Collection<String> emails, MimeMessage m, @Nullable Container c)
+        {
+            _messageMap.put(emails, m);
+            _containerMap.put(emails, c);
+        }
+
+        // Send message to multiple recipients
         public void addMessage(Collection<String> emails, MimeMessage m)
         {
-            _map.put(emails, m);
+            addMessage(emails, m, null);
         }
 
         // Send message to single recipient
         public void addMessage(String email, MimeMessage m)
         {
-            _map.put(Collections.singleton(email), m);
+            addMessage(Collections.singleton(email), m, null);
+        }
+
+        // Send message to single recipient
+        public void addMessage(String email, MimeMessage m, Container c)
+        {
+            addMessage(Collections.singleton(email), m, c);
         }
 
         @Override
         public void run()
         {
-            for (Map.Entry<Collection<String>, MimeMessage> entry : _map.entrySet())
+            for (Map.Entry<Collection<String>, MimeMessage> entry : _messageMap.entrySet())
             {
                 Collection<String> emails = entry.getKey();
                 MimeMessage m = entry.getValue();
+                Container c = _containerMap.get(emails);
 
                 for (String email : emails)
                 {
                     try
                     {
                         m.setRecipient(Message.RecipientType.TO, new InternetAddress(email));
-                        MailHelper.send(m, _user, null);
+                        MailHelper.send(m, _user, c);
                     }
                     catch (MessagingException e)
                     {

--- a/api/src/org/labkey/api/util/MailHelper.java
+++ b/api/src/org/labkey/api/util/MailHelper.java
@@ -506,7 +506,7 @@ public class MailHelper
     public static class BulkEmailer extends Thread
     {
         private final Map<Collection<String>, MimeMessage> _messageMap = new HashMap<>(10);
-        private final Map<Collection<String>, Container> _containerMap = new HashMap<>(10);
+        private final Map<Collection<String>, String> _containerMap = new HashMap<>(10);
         private final User _user;
 
         // User is for audit purposes
@@ -519,7 +519,7 @@ public class MailHelper
         public void addMessage(Collection<String> emails, MimeMessage m, @Nullable Container c)
         {
             _messageMap.put(emails, m);
-            _containerMap.put(emails, c);
+            _containerMap.put(emails, c.getId());
         }
 
         // Send message to multiple recipients
@@ -547,7 +547,7 @@ public class MailHelper
             {
                 Collection<String> emails = entry.getKey();
                 MimeMessage m = entry.getValue();
-                Container c = _containerMap.get(emails);
+                Container c = ContainerManager.getForId(_containerMap.get(emails));
 
                 for (String email : emails)
                 {


### PR DESCRIPTION
#### Rationale
The bulk emailer doesn't associate a container with an email message, even though the MailHelper.send method supports passing a container in for auditing purposes. This PR adds an optional container to addMessage which we thread through to MailerHelper.send. 

#### Related Pull Requests
* https://github.com/LabKey/labbook/pull/66

#### Changes
* Add  optional container arg to BulkEmailer.addMessage
