### PR TITLE
Issue 40482: Prefer using apiKey replacement parameter

### DIFF
--- a/api/src/org/labkey/api/action/ApiResponseWriter.java
+++ b/api/src/org/labkey/api/action/ApiResponseWriter.java
@@ -26,9 +26,9 @@ import org.labkey.api.query.ValidationError;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.ExpectedException;
+import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.HttpStatusException;
-import org.labkey.api.view.NotFoundException;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
@@ -379,6 +379,10 @@ public abstract class ApiResponseWriter implements AutoCloseable
         if (error instanceof PropertyValidationError)
             key = ((PropertyValidationError) error).getProperty();
 
+        String help = null;
+        if (error.getHelp() != null)
+            help = error.getHelp().getHelpTopicHref();
+
         JSONObject jsonError = new JSONObject();
 
         // these are the Ext expected property names
@@ -387,6 +391,7 @@ public abstract class ApiResponseWriter implements AutoCloseable
         // TODO deprecate these with a new API version
         jsonError.putOpt("field", key);
         jsonError.put("message", msg);
+        jsonError.putOpt("help", help);
 
         parent.put(jsonError);
     }
@@ -453,6 +458,7 @@ public abstract class ApiResponseWriter implements AutoCloseable
             String key = error.getObjectName();
             String propertyId = (null != error.getCodes() && error.getCodes().length > 0 ? error.getCodes()[0] : key);
             String severity = ValidationException.SEVERITY.ERROR.toString();
+            String help = null;
 
             if (error instanceof FieldError)
             {
@@ -466,6 +472,8 @@ public abstract class ApiResponseWriter implements AutoCloseable
                 severity = fieldWarning.getSeverity();
                 key = fieldWarning.getField();
                 propertyId = fieldWarning.getObjectName();
+                if (fieldWarning.getHelp() != null)
+                    help = fieldWarning.getHelp().getHelpTopicHref();
             }
 
             JSONObject jsonError = new JSONObject();
@@ -476,6 +484,7 @@ public abstract class ApiResponseWriter implements AutoCloseable
             jsonError.put("field", key);
             jsonError.put("message", msg);
             jsonError.put("severity", severity);
+            jsonError.putOpt("help", help);
 
             if (null == exceptionMessage)
                 exceptionMessage = msg;

--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -81,7 +81,12 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
+import org.labkey.api.query.SimpleValidationError;
+import org.labkey.api.query.ValidationException;
+import org.labkey.api.query.ValidationException.SEVERITY;
+import org.labkey.api.reports.ExternalScriptEngine;
 import org.labkey.api.reports.LabkeyScriptEngineManager;
+import org.labkey.api.reports.report.r.ParamReplacementSvc;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DeletePermission;
@@ -98,6 +103,7 @@ import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DetailsView;
 import org.labkey.api.view.NavTree;
@@ -111,6 +117,7 @@ import javax.script.ScriptEngine;
 import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -1196,11 +1203,12 @@ public abstract class AbstractAssayProvider implements AssayProvider
     private static final String SCRIPT_PATH_DELIMITER = "|";
 
     @Override
-    public void setValidationAndAnalysisScripts(ExpProtocol protocol, @NotNull List<File> scripts) throws ExperimentException
+    public ValidationException setValidationAndAnalysisScripts(ExpProtocol protocol, @NotNull List<File> scripts) throws ExperimentException
     {
         Map<String, ObjectProperty> props = new HashMap<>(protocol.getObjectProperties());
         String propertyURI = ScriptType.TRANSFORM.getPropertyURI(protocol);
 
+        ValidationException validationErrors = new ValidationException();
         StringBuilder sb = new StringBuilder();
         String separator = "";
         for (File scriptFile : scripts)
@@ -1211,17 +1219,41 @@ public abstract class AbstractAssayProvider implements AssayProvider
                 ScriptEngine engine = ServiceRegistry.get().getService(LabkeyScriptEngineManager.class).getEngineByExtension(protocol.getContainer(), ext, LabkeyScriptEngineManager.EngineContext.pipeline);
                 if (engine != null)
                 {
+                    // check for deprecated tokens in text scripts
+                    if (!(engine instanceof ExternalScriptEngine && ((ExternalScriptEngine) engine).isBinary(scriptFile)))
+                    {
+                        String scriptText;
+                        try
+                        {
+                            scriptText = Files.readString(scriptFile.toPath(), StringUtilsLabKey.DEFAULT_CHARSET);
+                        }
+                        catch (IOException e)
+                        {
+                            throw new ExperimentException("Failed to read script: " + e.getMessage(), e);
+                        }
+
+                        validationErrors.addErrors(ParamReplacementSvc.get().validateDeprecatedReplacements(scriptText, scriptFile.getName()));
+                    }
+
                     sb.append(separator);
                     sb.append(scriptFile.getAbsolutePath());
                     separator = SCRIPT_PATH_DELIMITER;
                 }
                 else
-                    throw new ExperimentException("Script engine for the extension : " + ext + " has not been registered.\nFor documentation about how to configure a " +
-                            "scripting engine, paste this link into your browser: \"" + new HelpTopic("configureScripting") + "\".");
+                {
+                    validationErrors.addError(new SimpleValidationError("Script engine for the extension : " + ext + " has not been registered.", null, SEVERITY.ERROR, new HelpTopic("configureScripting")));
+                }
             }
             else
-                throw new ExperimentException("The transform script '" + scriptFile.getPath() + "' is invalid or does not exist");
+            {
+                validationErrors.addError(new SimpleValidationError("The transform script '" + scriptFile.getPath() + "' is invalid or does not exist", null, SEVERITY.ERROR));
+            }
         }
+
+        // don't persist if any validation error has severity=ERROR
+        if (validationErrors.getErrors().stream().anyMatch(e -> SEVERITY.ERROR == e.getSeverity()))
+            return validationErrors;
+
         if (sb.length() > 0)
         {
             ObjectProperty prop = new ObjectProperty(protocol.getLSID(), protocol.getContainer(),
@@ -1232,10 +1264,13 @@ public abstract class AbstractAssayProvider implements AssayProvider
         {
             props.remove(propertyURI);
         }
+
         // Be sure to strip out any validation scripts that were stored with the legacy propertyURI. We merge and save
         // them as a single list in the TRANSFORM 
         props.remove(ScriptType.VALIDATION.getPropertyURI(protocol));
         protocol.setObjectProperties(props);
+
+        return validationErrors;
     }
 
     /** For migrating legacy assay designs that have separate transform and validation script properties */

--- a/api/src/org/labkey/api/assay/AssayProvider.java
+++ b/api/src/org/labkey/api/assay/AssayProvider.java
@@ -39,6 +39,7 @@ import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.module.Module;
 import org.labkey.api.pipeline.PipelineProvider;
 import org.labkey.api.qc.DataExchangeHandler;
+import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.study.assay.AssayPublishKey;
 import org.labkey.api.study.assay.ParticipantVisitResolverType;
@@ -234,7 +235,7 @@ public interface AssayProvider extends Handler<ExpProtocol>
      * File based QC and analysis scripts can be added to a protocol and invoked when the validate
      * method is called. Set to an empty list if no scripts exist.
      */
-    void setValidationAndAnalysisScripts(ExpProtocol protocol, @NotNull List<File> scripts) throws ExperimentException;
+    ValidationException setValidationAndAnalysisScripts(ExpProtocol protocol, @NotNull List<File> scripts) throws ExperimentException;
 
     @NotNull
     List<File> getValidationAndAnalysisScripts(ExpProtocol protocol, Scope scope);

--- a/api/src/org/labkey/api/assay/DefaultDataTransformer.java
+++ b/api/src/org/labkey/api/assay/DefaultDataTransformer.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.assay;
 
+import org.apache.logging.log4j.Level;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
@@ -31,6 +32,7 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.Readers;
 import org.labkey.api.reports.ExternalScriptEngine;
 import org.labkey.api.reports.LabkeyScriptEngineManager;
+import org.labkey.api.reports.report.r.ParamReplacementSvc;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.settings.AppProps;
@@ -62,8 +64,9 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
     public static final String RUN_INFO_REPLACEMENT = "runInfo";
     public static final String SRC_DIR_REPLACEMENT = "srcDirectory";
     public static final String R_SESSIONID_REPLACEMENT = "rLabkeySessionId";
-    public static final String SESSION_ID_REPLACEMENT = "httpSessionId";
-    public static final String SESSION_COOKIE_NAME_REPLACEMENT = "sessionCookieName";
+    public static final String LEGACY_SESSION_ID_REPLACEMENT = "httpSessionId";
+    public static final String LEGACY_SESSION_COOKIE_NAME_REPLACEMENT = "sessionCookieName";
+    public static final String API_KEY_REPLACEMENT = "apiKey";
     public static final String BASE_SERVER_URL_REPLACEMENT = "baseServerURL";
     public static final String CONTAINER_PATH = "containerPath";
 
@@ -95,6 +98,7 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
             // read the contents of the script file
             if (scriptFile.exists())
             {
+                // TODO: don't bother slurping the contents of binary scripts
                 StringBuilder sb = new StringBuilder();
                 try (BufferedReader br = Readers.getReader(scriptFile))
                 {
@@ -116,7 +120,7 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
                     FileUtil.deleteDirectoryContents(scriptDir);
 
                     // issue 19748: need alternative to JSESSIONID for pipeline job transform script usage
-                    final String apikey = SecurityManager.beginTransformSession(context.getUser());
+                    final String apiKey = SecurityManager.beginTransformSessionApiKey(context.getUser());
 
                     try
                     {
@@ -132,7 +136,7 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
 
                         paramMap.put(RUN_INFO_REPLACEMENT, runInfo.getAbsolutePath().replaceAll("\\\\", "/"));
 
-                        addStandardParameters(context.getRequest(), context.getContainer(), scriptFile, apikey, paramMap);
+                        addStandardParameters(context.getRequest(), context.getContainer(), scriptFile, apiKey, paramMap);
 
                         bindings.put(ExternalScriptEngine.PARAM_REPLACEMENT_MAP, paramMap);
 
@@ -185,7 +189,7 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
                             }
                         }
 
-                        SecurityManager.endTransformSession(apikey);
+                        SecurityManager.endTransformSessionApiKey(apiKey);
                     }
                 }
                 else
@@ -204,7 +208,7 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
         return result;
     }
 
-    public static void addStandardParameters(@Nullable HttpServletRequest request, Container container, @Nullable File scriptFile, String transformSessionId, @NotNull Map<String, String> paramMap)
+    public static void addStandardParameters(@Nullable HttpServletRequest request, Container container, @Nullable File scriptFile, String apiKey, @NotNull Map<String, String> paramMap)
     {
         if (scriptFile != null)
         {
@@ -212,14 +216,16 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
             if (srcDir != null && srcDir.exists())
                 paramMap.put(SRC_DIR_REPLACEMENT, srcDir.getAbsolutePath().replaceAll("\\\\", "/"));
         }
-        paramMap.put(R_SESSIONID_REPLACEMENT, getSessionInfo(request, transformSessionId));
-        paramMap.put(SESSION_COOKIE_NAME_REPLACEMENT, getSessionCookieName(request));
-        paramMap.put(SESSION_ID_REPLACEMENT, getSessionId(request, transformSessionId));
+        paramMap.put(R_SESSIONID_REPLACEMENT, getSessionInfo(request, apiKey));
+        paramMap.put(LEGACY_SESSION_COOKIE_NAME_REPLACEMENT, getSessionCookieName(request));
+        paramMap.put(LEGACY_SESSION_ID_REPLACEMENT, getSessionId(request, apiKey));
+        paramMap.put(API_KEY_REPLACEMENT, apiKey);
         paramMap.put(BASE_SERVER_URL_REPLACEMENT, AppProps.getInstance().getBaseServerUrl()
                                                     + AppProps.getInstance().getContextPath());
         paramMap.put(CONTAINER_PATH, container.getPath());
     }
 
+    @Deprecated
     private static String getSessionCookieName(@Nullable HttpServletRequest request)
     {
         if (request != null)
@@ -263,18 +269,19 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
     /**
      * Creates the session information string
      */
-    private static String getSessionInfo(@Nullable HttpServletRequest request, String transformSessionId)
+    private static String getSessionInfo(@Nullable HttpServletRequest request, String apiKey)
     {
         return "labkey.sessionCookieName = \"" + getSessionCookieName(request) + "\"\n" +
-               "labkey.sessionCookieContents = \"" + getSessionId(request, transformSessionId) + "\"\n";
+               "labkey.sessionCookieContents = \"" + getSessionId(request, apiKey) + "\"\n";
     }
 
-    private static String getSessionId(@Nullable HttpServletRequest request, String transformSessionId)
+    @Deprecated
+    private static String getSessionId(@Nullable HttpServletRequest request, String apiKey)
     {
         if (request != null)
         {
             return PageFlowUtil.getCookieValue(request.getCookies(), CSRFUtil.SESSION_COOKIE_NAME, "");
         }
-        return transformSessionId;
+        return apiKey;
     }
 }

--- a/api/src/org/labkey/api/assay/DefaultDataTransformer.java
+++ b/api/src/org/labkey/api/assay/DefaultDataTransformer.java
@@ -66,7 +66,6 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
     public static final String R_SESSIONID_REPLACEMENT = "rLabkeySessionId";
     public static final String LEGACY_SESSION_ID_REPLACEMENT = "httpSessionId";
     public static final String LEGACY_SESSION_COOKIE_NAME_REPLACEMENT = "sessionCookieName";
-    public static final String API_KEY_REPLACEMENT = "apiKey";
     public static final String BASE_SERVER_URL_REPLACEMENT = "baseServerURL";
     public static final String CONTAINER_PATH = "containerPath";
 
@@ -219,7 +218,7 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
         paramMap.put(R_SESSIONID_REPLACEMENT, getSessionInfo(request, apiKey));
         paramMap.put(LEGACY_SESSION_COOKIE_NAME_REPLACEMENT, getSessionCookieName(request));
         paramMap.put(LEGACY_SESSION_ID_REPLACEMENT, getSessionId(request, apiKey));
-        paramMap.put(API_KEY_REPLACEMENT, apiKey);
+        paramMap.put(SecurityManager.API_KEY, apiKey);
         paramMap.put(BASE_SERVER_URL_REPLACEMENT, AppProps.getInstance().getBaseServerUrl()
                                                     + AppProps.getInstance().getContextPath());
         paramMap.put(CONTAINER_PATH, container.getPath());

--- a/api/src/org/labkey/api/query/ValidationError.java
+++ b/api/src/org/labkey/api/query/ValidationError.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.api.query;
 
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.util.HelpTopic;
 import org.springframework.validation.BindException;
 
 /**
@@ -28,7 +30,9 @@ public interface ValidationError
 {
     String getMessage();
 
-     ValidationException.SEVERITY getSeverity();
+    ValidationException.SEVERITY getSeverity();
+
+    @Nullable HelpTopic getHelp();
 
     void addToBindException(BindException be, String errorCode, boolean includeWarnings);
 }

--- a/api/src/org/labkey/api/query/ValidationException.java
+++ b/api/src/org/labkey/api/query/ValidationException.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.query;
 
+import org.apache.logging.log4j.Level;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.data.RuntimeSQLException;
 import org.springframework.validation.BindException;
@@ -79,14 +80,22 @@ public class ValidationException extends Exception implements Iterable<Validatio
 
     public enum SEVERITY
     {
-        ERROR("Error"),
-        WARN("Warning"),
-        INFO("Info");
+        ERROR("Error", Level.ERROR),
+        WARN("Warning", Level.WARN),
+        INFO("Info", Level.INFO);
 
         String _sevName;
-        SEVERITY(String sevName)
+        Level _level;
+
+        SEVERITY(String sevName, Level level)
         {
             _sevName = sevName;
+            _level = level;
+        }
+
+        public Level getLevel()
+        {
+            return _level;
         }
 
         public String toString()

--- a/api/src/org/labkey/api/reports/ExternalScriptEngine.java
+++ b/api/src/org/labkey/api/reports/ExternalScriptEngine.java
@@ -91,7 +91,7 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
         return new ExternalScriptEngineFactory(_def);
     }
 
-    private boolean isBinary(File file)
+    public boolean isBinary(File file)
     {
         String ext = FileUtil.getExtension(file);
 
@@ -237,7 +237,8 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
             }
         }
 
-        try {
+        try
+        {
             // see if the command contains parameter substitutions
             if (cmd != null)
             {
@@ -433,7 +434,7 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
                 {
                     for (Map.Entry<String, String> param : ((Map<String, String>)bindings.get(PARAM_REPLACEMENT_MAP)).entrySet())
                     {
-                        script = ParamReplacementSvc.get().processInputReplacement(script, param.getKey(), param.getValue());
+                        script = ParamReplacementSvc.get().processInputReplacement(script, param.getKey(), param.getValue(), false, scriptFile.getName());
                     }
                 }
 
@@ -443,7 +444,7 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
                 }
             }
         }
-        catch(Exception e)
+        catch (Exception e)
         {
             ExceptionUtil.logExceptionToMothership(null, e);
         }
@@ -461,7 +462,8 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
 
         // if additional console output is written to a file, append it to the output string.
         BufferedReader br = null;
-        try {
+        try
+        {
             String fileName = _def.getOutputFileName();
             if (fileName != null)
             {

--- a/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
@@ -18,6 +18,7 @@ package org.labkey.api.reports.report;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.assay.DefaultDataTransformer;
 import org.labkey.api.attachments.AttachmentParent;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.pipeline.PipeRoot;
@@ -34,6 +35,7 @@ import org.labkey.api.reports.report.r.ParamReplacementSvc;
 import org.labkey.api.reports.report.r.view.ConsoleOutput;
 import org.labkey.api.reports.report.view.ReportUtil;
 import org.labkey.api.reports.report.view.RunReportView;
+import org.labkey.api.security.SecurityManager;
 import org.labkey.api.thumbnail.Thumbnail;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.ExceptionUtil;
@@ -352,11 +354,17 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
 
     protected Object runScript(ScriptEngine engine, ViewContext context, List<ParamReplacement> outputSubst, File inputDataTsv, Map<String, Object> inputParameters) throws ScriptException
     {
+        final String apiKey = SecurityManager.beginTransformSessionApiKey(context.getUser());
+
         RConnectionHolder rh = null;
         try
         {
             Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
             bindings.put(ExternalScriptEngine.WORKING_DIRECTORY, getReportDir(context.getContainer().getId()).getAbsolutePath());
+
+            Map<String, String> paramMap = new HashMap<>();
+            DefaultDataTransformer.addStandardParameters(null, context.getContainer(), null, apiKey, paramMap);
+            bindings.put(ExternalScriptEngine.PARAM_REPLACEMENT_MAP, paramMap);
 
             if (engine instanceof RserveScriptEngine)
             {
@@ -401,7 +409,7 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
 
             return engine.eval(createScript(engine, context, outputSubst, inputDataTsv, inputParameters));
         }
-        catch(Exception e)
+        catch (Exception e)
         {
             throw new ScriptException(e);
         }
@@ -409,6 +417,8 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
         {
             if (rh != null)
                 rh.release();
+
+            SecurityManager.endTransformSessionApiKey(apiKey);
         }
     }
 

--- a/api/src/org/labkey/api/reports/report/RReport.java
+++ b/api/src/org/labkey/api/reports/report/RReport.java
@@ -418,9 +418,9 @@ public class RReport extends ExternalScriptEngineReport
                 labkey.append("labkey.remote.pipeline.root <- \"").append(remotePath).append("\"\n");
             }
 
-            // The ${apiKey} token will be replaced by the value in the map stashed in script context bindings ExternalScriptEngine.PARAM_REPLACEMENT_MAP
-            // CONSIDER: Should we use: labkey.setDefaults(apiKey=\"${apiKey}\")
-            labkey.append("labkey.apiKey <- \"${" + DefaultDataTransformer.API_KEY_REPLACEMENT + "}\"\n");
+            // The ${apikey} token will be replaced by the value in the map stashed in script context bindings ExternalScriptEngine.PARAM_REPLACEMENT_MAP
+            // CONSIDER: Should we use: labkey.setDefaults(apiKey=\"${apikey}\")
+            labkey.append("labkey.apiKey <- \"${" + SecurityManager.API_KEY + "}\"\n");
 
             // session information - deprecate for ${apiKey} or labkey.apiKey ?
             if (context.getRequest() != null)

--- a/api/src/org/labkey/api/reports/report/RReport.java
+++ b/api/src/org/labkey/api/reports/report/RReport.java
@@ -425,21 +425,8 @@ public class RReport extends ExternalScriptEngineReport
             // session information - deprecate for ${apiKey} or labkey.apiKey ?
             if (context.getRequest() != null)
             {
-                String session = PageFlowUtil.getCookieValue(context.getRequest().getCookies(), CSRFUtil.SESSION_COOKIE_NAME, null);
+                String session = PageFlowUtil.getCookieValue(context.getRequest().getCookies(), CSRFUtil.SESSION_COOKIE_NAME, "");
                 String sessionName = CSRFUtil.SESSION_COOKIE_NAME;
-                if (session == null)
-                {
-                    // Issue 26957 - R report running as pipeline job doesn't inherit user when making Rlabkey calls
-                    session = PageFlowUtil.getCookieValue(context.getRequest().getCookies(), SecurityManager.TRANSFORM_SESSION_ID, null);
-                    if (session != null)
-                    {
-                        sessionName = SecurityManager.TRANSFORM_SESSION_ID;
-                    }
-                    else
-                    {
-                        session = "";
-                    }
-                }
 
                 labkey.append("labkey.sessionCookieName = \"").append(sessionName).append("\"\n");
                 labkey.append("labkey.sessionCookieContents = \"");

--- a/api/src/org/labkey/api/reports/report/RReportJob.java
+++ b/api/src/org/labkey/api/reports/report/RReportJob.java
@@ -152,32 +152,12 @@ public class RReportJob extends PipelineJob implements Serializable
             // Must be a background thread... push a fake ViewContext on the HttpView stack if so HttpView.currentContext() succeeds.
             try (ViewContext.StackResetter resetter = ViewContext.pushMockViewContext(getUser(), getContainer(), getActionURL()))
             {
-                String apiKey = null;
-                if (getUser() != null && !getUser().isGuest())
-                {
-                    // Issue 26957 - since we're running in the background, we won't magically piggyback on the user's
-                    // HTTP session, so set up a transform apikey
-                    apiKey = SecurityManager.beginTransformSessionApiKey(getUser());
-                    HttpServletRequest request = resetter.getContext().getRequest();
-                    assert request instanceof MockHttpServletRequest : "Request should be a MockHttpServletRequest";
-                    if (request instanceof MockHttpServletRequest)
-                    {
-                        // It's a bit clunky to push the apikey through as a cookie on the request, but this avoids lots of
-                        // method signature changes
-                        ((MockHttpServletRequest) request).setCookies(new Cookie(TRANSFORM_SESSION_ID, apiKey));
-                    }
-                }
                 try
                 {
                     runReport(resetter.getContext(), report);
                 }
                 finally
                 {
-                    if (apiKey != null)
-                    {
-                        // Stop the transform session to revoke the apikey
-                        SecurityManager.endTransformSessionApiKey(apiKey);
-                    }
                     _jobIdentifier.remove();
                 }
             }

--- a/api/src/org/labkey/api/reports/report/RReportJob.java
+++ b/api/src/org/labkey/api/reports/report/RReportJob.java
@@ -152,19 +152,19 @@ public class RReportJob extends PipelineJob implements Serializable
             // Must be a background thread... push a fake ViewContext on the HttpView stack if so HttpView.currentContext() succeeds.
             try (ViewContext.StackResetter resetter = ViewContext.pushMockViewContext(getUser(), getContainer(), getActionURL()))
             {
-                String apikey = null;
+                String apiKey = null;
                 if (getUser() != null && !getUser().isGuest())
                 {
                     // Issue 26957 - since we're running in the background, we won't magically piggyback on the user's
                     // HTTP session, so set up a transform apikey
-                    apikey = SecurityManager.beginTransformSession(getUser());
+                    apiKey = SecurityManager.beginTransformSessionApiKey(getUser());
                     HttpServletRequest request = resetter.getContext().getRequest();
                     assert request instanceof MockHttpServletRequest : "Request should be a MockHttpServletRequest";
                     if (request instanceof MockHttpServletRequest)
                     {
                         // It's a bit clunky to push the apikey through as a cookie on the request, but this avoids lots of
                         // method signature changes
-                        ((MockHttpServletRequest) request).setCookies(new Cookie(TRANSFORM_SESSION_ID, apikey));
+                        ((MockHttpServletRequest) request).setCookies(new Cookie(TRANSFORM_SESSION_ID, apiKey));
                     }
                 }
                 try
@@ -173,10 +173,10 @@ public class RReportJob extends PipelineJob implements Serializable
                 }
                 finally
                 {
-                    if (apikey != null)
+                    if (apiKey != null)
                     {
                         // Stop the transform session to revoke the apikey
-                        SecurityManager.endTransformSession(apikey);
+                        SecurityManager.endTransformSessionApiKey(apiKey);
                     }
                     _jobIdentifier.remove();
                 }

--- a/api/src/org/labkey/api/reports/report/ScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/ScriptEngineReport.java
@@ -44,6 +44,7 @@ import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.query.AliasManager;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryView;
+import org.labkey.api.query.SimpleValidationError;
 import org.labkey.api.reader.Readers;
 import org.labkey.api.reports.LabkeyScriptEngineManager;
 import org.labkey.api.reports.Report;
@@ -650,7 +651,9 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
     protected String processScript(ScriptEngine engine, ViewContext context, String script, File inputFile, List<ParamReplacement> outputSubst, Map<String, Object> inputParameters, boolean includeProlog) throws Exception
     {
         return processScript(engine, context, script, inputFile, outputSubst, inputParameters, includeProlog, false);
-    }    /**
+    }
+
+    /**
      * Takes a script source, adds a prolog, processes any input and output replacement parameters
      * @param script
      * @param inputFile
@@ -690,7 +693,7 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
 
     protected String processInputReplacement(ScriptEngine engine, String script, @Nullable File inputFile, boolean isRStudio)
     {
-        return ParamReplacementSvc.get().processInputReplacement(script, INPUT_FILE_TSV, inputFile == null ? null : inputFile.getAbsolutePath().replaceAll("\\\\", "/"), isRStudio);
+        return ParamReplacementSvc.get().processInputReplacement(script, INPUT_FILE_TSV, inputFile == null ? null : inputFile.getAbsolutePath().replaceAll("\\\\", "/"), isRStudio, null);
     }
 
     protected String processOutputReplacements(ScriptEngine engine, String script, List<ParamReplacement> replacements, @NotNull ContainerUser context, boolean isRStudio) throws Exception

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -597,6 +597,7 @@ public class SecurityManager
 
             if (null == apiKey)
             {
+                // CONSIDER: should we deprecate using TRANSFORM_SESSION_ID cookie?
                 // issue 19748: need alternative to JSESSIONID for pipeline job transform script usage
                 apiKey = PageFlowUtil.getCookieValue(request.getCookies(), TRANSFORM_SESSION_ID, null);
                 if (null == apiKey)
@@ -628,12 +629,12 @@ public class SecurityManager
      * Callers should call {@see endTransformSession} when finished, typically in a finally block.
      * @return the apikey for the newly started session
      */
-    public static @NotNull String beginTransformSession(@NotNull User user)
+    public static @NotNull String beginTransformSessionApiKey(@NotNull User user)
     {
         return ApiKeyManager.get().createKey(user, SECONDS_PER_DAY);
     }
 
-    public static void endTransformSession(@NotNull String apikey)
+    public static void endTransformSessionApiKey(@NotNull String apikey)
     {
         ApiKeyManager.get().deleteKey(apikey);
     }

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -43,6 +43,8 @@ import org.labkey.api.module.ModuleContext;
 import org.labkey.api.module.SpringModule;
 import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.query.DefaultSchema;
+import org.labkey.api.query.ValidationException;
+import org.labkey.api.reports.report.r.ParamReplacementSvc;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
@@ -78,6 +80,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.labkey.api.assay.DefaultDataTransformer.API_KEY_REPLACEMENT;
+import static org.labkey.api.assay.DefaultDataTransformer.LEGACY_SESSION_COOKIE_NAME_REPLACEMENT;
+import static org.labkey.api.assay.DefaultDataTransformer.LEGACY_SESSION_ID_REPLACEMENT;
 
 public class AssayModule extends SpringModule
 {
@@ -140,6 +146,9 @@ public class AssayModule extends SpringModule
         PropertyService.get().registerDomainKind(new AssayBatchDomainKind());
         PropertyService.get().registerDomainKind(new AssayRunDomainKind());
         PropertyService.get().registerDomainKind(new AssayResultDomainKind());
+
+        ParamReplacementSvc.get().registerDeprecated(LEGACY_SESSION_COOKIE_NAME_REPLACEMENT, ValidationException.SEVERITY.WARN, "Use '" + API_KEY_REPLACEMENT + "' instead");
+        ParamReplacementSvc.get().registerDeprecated(LEGACY_SESSION_ID_REPLACEMENT, ValidationException.SEVERITY.WARN, "Use '" + API_KEY_REPLACEMENT + "' instead");
 
         RoleManager.registerRole(new AssayDesignerRole());
     }

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -46,6 +46,7 @@ import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reports.report.r.ParamReplacementSvc;
 import org.labkey.api.search.SearchService;
+import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.roles.RoleManager;
@@ -81,7 +82,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.labkey.api.assay.DefaultDataTransformer.API_KEY_REPLACEMENT;
 import static org.labkey.api.assay.DefaultDataTransformer.LEGACY_SESSION_COOKIE_NAME_REPLACEMENT;
 import static org.labkey.api.assay.DefaultDataTransformer.LEGACY_SESSION_ID_REPLACEMENT;
 
@@ -147,8 +147,8 @@ public class AssayModule extends SpringModule
         PropertyService.get().registerDomainKind(new AssayRunDomainKind());
         PropertyService.get().registerDomainKind(new AssayResultDomainKind());
 
-        ParamReplacementSvc.get().registerDeprecated(LEGACY_SESSION_COOKIE_NAME_REPLACEMENT, ValidationException.SEVERITY.WARN, "Use '" + API_KEY_REPLACEMENT + "' instead");
-        ParamReplacementSvc.get().registerDeprecated(LEGACY_SESSION_ID_REPLACEMENT, ValidationException.SEVERITY.WARN, "Use '" + API_KEY_REPLACEMENT + "' instead");
+        ParamReplacementSvc.get().registerDeprecated(LEGACY_SESSION_COOKIE_NAME_REPLACEMENT, ValidationException.SEVERITY.WARN, "Use '" + SecurityManager.API_KEY + "' instead");
+        ParamReplacementSvc.get().registerDeprecated(LEGACY_SESSION_ID_REPLACEMENT, ValidationException.SEVERITY.WARN, "Use '" + SecurityManager.API_KEY + "' instead");
 
         RoleManager.registerRole(new AssayDesignerRole());
     }

--- a/pipeline/src/org/labkey/pipeline/analysis/CommandTaskImpl.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/CommandTaskImpl.java
@@ -585,7 +585,7 @@ public class CommandTaskImpl extends WorkDirectoryTask<CommandTaskImpl.Factory> 
      * to replace tokens the script or the command line before executing it.
      * The replaced paths will be resolved to paths in the work directory.
      */
-    protected Map<String, String> createReplacements(@Nullable File scriptFile, String transformSessionId) throws IOException
+    protected Map<String, String> createReplacements(@Nullable File scriptFile, String apiKey) throws IOException
     {
         Map<String, String> replacements = new HashMap<>();
 
@@ -659,7 +659,7 @@ public class CommandTaskImpl extends WorkDirectoryTask<CommandTaskImpl.Factory> 
             replacements.put(PipelineJob.PIPELINE_TASK_OUTPUT_PARAMS_PARAM, taskOutputParamsRelativePath);
         }
 
-        DefaultDataTransformer.addStandardParameters(null, getJob().getContainer(), scriptFile, transformSessionId, replacements);
+        DefaultDataTransformer.addStandardParameters(null, getJob().getContainer(), scriptFile, apiKey, replacements);
 
         return replacements;
     }
@@ -674,7 +674,7 @@ public class CommandTaskImpl extends WorkDirectoryTask<CommandTaskImpl.Factory> 
     @NotNull
     public RecordedActionSet run() throws PipelineJobException
     {
-        final String apikey = SecurityManager.beginTransformSession(getJob().getUser());
+        final String apikey = SecurityManager.beginTransformSessionApiKey(getJob().getUser());
 
         try
         {
@@ -733,7 +733,7 @@ public class CommandTaskImpl extends WorkDirectoryTask<CommandTaskImpl.Factory> 
         }
         finally
         {
-            SecurityManager.endTransformSession(apikey);
+            SecurityManager.endTransformSessionApiKey(apikey);
             _wd = null;
         }
     }
@@ -741,14 +741,15 @@ public class CommandTaskImpl extends WorkDirectoryTask<CommandTaskImpl.Factory> 
     /**
      * Run the command line task.
      * @param action The recorded action.
+     * @param apiKey API key to use for the duration of the command execution
      * @return true if the task was run, false otherwise.
      * @throws IOException
      * @throws PipelineJobException
      */
     // TODO: Add task and job version information to the recorded action.
-    protected boolean runCommand(RecordedAction action, String apikey) throws IOException, PipelineJobException
+    protected boolean runCommand(RecordedAction action, String apiKey) throws IOException, PipelineJobException
     {
-        Map<String, String> replacements = createReplacements(null, apikey);
+        Map<String, String> replacements = createReplacements(null, apiKey);
 
         ProcessBuilder pb = new ProcessBuilder(_factory.toArgs(this, replacements));
         applyEnvironment(pb);

--- a/pipeline/src/org/labkey/pipeline/api/ScriptTaskImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/ScriptTaskImpl.java
@@ -82,7 +82,7 @@ public class ScriptTaskImpl extends CommandTaskImpl
     // TODO: Rhino engine.  A non-ExternalScriptEngine won't use the PARAM_REPLACEMENT_MAP binding.
     // CONSIDER: Use ScriptEngineReport to generate a script prolog
     @Override
-    protected boolean runCommand(RecordedAction action, String apikey) throws IOException, PipelineJobException
+    protected boolean runCommand(RecordedAction action, String apiKey) throws IOException, PipelineJobException
     {
         // Get the script engine
         LabkeyScriptEngineManager mgr = ServiceRegistry.get().getService(LabkeyScriptEngineManager.class);
@@ -160,7 +160,7 @@ public class ScriptTaskImpl extends CommandTaskImpl
             if (_factory.getTimeout() != null && _factory.getTimeout() > 0)
                 bindings.put(ExternalScriptEngine.TIMEOUT, _factory.getTimeout());
 
-            Map<String, String> replacements = createReplacements(scriptFile, apikey);
+            Map<String, String> replacements = createReplacements(scriptFile, apiKey);
             bindings.put(ExternalScriptEngine.PARAM_REPLACEMENT_MAP, replacements);
 
             // Write task properties file into the work directory


### PR DESCRIPTION
#### Rationale
External R scripts include a ${httpSessionId} token replacement that can be either a JSESSIONID or a temporary apiKey depending on the context the script is executed in.  The ${sessionCookieName} can either be "JSESSIONID" or "LabKeyTransformSessionId" to indicate which to use.  To reduce confusion, we are adding a new ${apiKey} token that will always include the temporary apiKey.  The ${httpSessionId} token replacement will continue to work but will print a deprecation warning when it is used.

#### TODO
* Thread warnings back to the client when an assay design is saved that uses transform script with a deprecated token replacement.
* For RReports, should we use: labkey.setDefaults(apiKey=\"${apiKey}\")
* Should we print deprecation warning when using the "LabKeyTransformSessionId" cookie for authentication

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/256
* https://github.com/LabKey/snprcEHRModules/pull/323
* https://github.com/LabKey/testAutomation/pull/525
* https://github.com/LabKey/premium/pull/211

#### Changes
- add new "apiKey" replacement when executing RReport or Assay QC/transform scripts
- warn when saving an assay design with a transform script that uses a deprecated replacement
- warn when executing a transform script with a deprecated replacement
- add a help link to error messages