### PR TITLE
41693: survey datetime field not rendering properly

### DIFF
--- a/survey/webapp/survey/DateTimeField.js
+++ b/survey/webapp/survey/DateTimeField.js
@@ -290,7 +290,7 @@ Ext4.define('Ext.ux.form.field.DateTime', {
         var formats = [];
         if (format)
             formats.push(format);
-        formats = formats.concat(DATEFORMATS);
+        formats = formats.concat(LABKEY.Utils.getDateAltFormats().split('|'));
 
         var val;
         for (var i=0; i < formats.length && !val; ++i) {


### PR DESCRIPTION

#### Rationale
The custom survey component which should render both a date and time portion is throwing a javascript error after you save a value and attempt to reshow the survey. 

#### Related Issue
- [41693](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41693)

#### Changes
It's unclear when this was broken but we were relying on a variable : DATEFORMATS which is no longer defined. The solution is to replace with the standard alternate date formats returned by LABKEY.Utils.getDateAltFormats. I will also add a test team backlog item to get some automation coverage for this component.
