### PR TITLE
Issue 40081: Fix Mothership test failing on sql server because of date coming as string "null" 

### DIFF
--- a/mothership/src/org/labkey/mothership/MothershipManager.java
+++ b/mothership/src/org/labkey/mothership/MothershipManager.java
@@ -480,7 +480,7 @@ public class MothershipManager
     {
         Map<String, String> props = getProperties(c);
         String buildDate = props.get(CURRENT_BUILD_DATE_PROP);
-        return  null == buildDate || "null".equals(buildDate) ? null : new Date(DateUtil.parseDateTime(c, buildDate));
+        return  null == buildDate ? null : new Date(DateUtil.parseISODateTime(buildDate));
     }
 
     private String getStringProperty(Container c, String name)
@@ -508,7 +508,10 @@ public class MothershipManager
 
     public void setCurrentBuildDate(Container c, Date buildDate)
     {
-        saveProperty(c, CURRENT_BUILD_DATE_PROP, String.valueOf(buildDate));
+        if (null != buildDate)
+        {
+            saveProperty(c, CURRENT_BUILD_DATE_PROP, DateUtil.formatDateTimeISO8601(buildDate));
+        }
     }
 
     public void setUpgradeMessage(Container c, String message)

--- a/mothership/src/org/labkey/mothership/MothershipManager.java
+++ b/mothership/src/org/labkey/mothership/MothershipManager.java
@@ -508,10 +508,7 @@ public class MothershipManager
 
     public void setCurrentBuildDate(Container c, Date buildDate)
     {
-        if (null != buildDate)
-        {
-            saveProperty(c, CURRENT_BUILD_DATE_PROP, DateUtil.formatDateTimeISO8601(buildDate));
-        }
+        saveProperty(c, CURRENT_BUILD_DATE_PROP, DateUtil.formatDateTimeISO8601(buildDate));
     }
 
     public void setUpgradeMessage(Container c, String message)

--- a/mothership/src/org/labkey/mothership/MothershipManager.java
+++ b/mothership/src/org/labkey/mothership/MothershipManager.java
@@ -480,7 +480,7 @@ public class MothershipManager
     {
         Map<String, String> props = getProperties(c);
         String buildDate = props.get(CURRENT_BUILD_DATE_PROP);
-        return  null == buildDate ? null : new Date(DateUtil.parseDateTime(c, buildDate));
+        return  null == buildDate || "null".equals(buildDate) ? null : new Date(DateUtil.parseDateTime(c, buildDate));
     }
 
     private String getStringProperty(Container c, String name)


### PR DESCRIPTION
#### Rationale
Check for date as "null" string on configure mothership page.
