### PR TITLE
Issue41810:  Fix links in interstitial for Specimen Importer

### DIFF
--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -6243,6 +6243,7 @@ public class StudyController extends BaseStudyController
         @Override
         public ModelAndView getView(EnabledSpecimenImportForm form, boolean reshow, BindException errors) throws Exception
         {
+            setHelpTopic(new HelpTopic("externalSpecimens"));
             return new JspView<>("/org/labkey/study/view/chooseImporter.jsp", form, errors);
         }
 

--- a/study/src/org/labkey/study/view/chooseImporter.jsp
+++ b/study/src/org/labkey/study/view/chooseImporter.jsp
@@ -14,6 +14,7 @@
 <%@ page import="org.labkey.api.util.URLHelper" %>
 <%@ page import="org.labkey.study.controllers.StudyController" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
+<%@ page import="org.labkey.api.util.HelpTopic" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 
@@ -131,10 +132,10 @@
             <h3>Specimen Import is not available with your current edition of LabKey Server.</h3>
             <hr>
             <p>Professional/Enterprise edition subscribers have the ability to import from an external specimen repository like FreezerPro or a specimen data mart.</p>
-            <p><a class="alert-link" href="" target="_blank" rel="noopener noreferrer">Learn more <i class="fa fa-external-link"></i></a></p>
+            <p><a class="alert-link" target="_blank" rel="noopener noreferrer" href="<%=h(new HelpTopic("externalSpecimens").toString())%>">Learn more <i class="fa fa-external-link"></i></a></p>
             <p>In addition to this feature, Professional/Enterprise editions of LabKey Server provide professional support and advanced functionality to help teams maximize the value of the platform.</p>
             <br>
-            <p><a class="alert-link" href="https://www.labkey.com/platform/go-premium/" target="_blank" rel="noopener noreferrer">Learn more about Professional/Enterprise editions <i class="fa fa-external-link"></i></a></p>
+            <p><a class="alert-link" href="https://www.labkey.com/products-services/labkey-server/labkey-server-editions-feature-comparison/" target="_blank" rel="noopener noreferrer">Learn more about Professional/Enterprise editions <i class="fa fa-external-link"></i></a></p>
         </div>
     <%
         }


### PR DESCRIPTION
#### Rationale
Jsp links are broken on upsell page of specimen importers.

#### Related Pull Requests
* n/a

#### Changes
* Update, for upsell page, 'Learn more' and 'Professional/Enterprise' link destinations
* Add context-sensitive help link on interstitial page
