### PR TITLE
Item 8058: Domain form support for new Ontology Lookup data type and expanded row input options

### DIFF
--- a/api/gwtsrc/org/labkey/api/gwt/client/model/GWTPropertyDescriptor.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/model/GWTPropertyDescriptor.java
@@ -137,6 +137,10 @@ public class GWTPropertyDescriptor implements IsSerializable
         setIsPrimaryKey(s.getIsPrimaryKey());
         setLockType(s.getLockType());
         setTypeEditable(s.isTypeEditable());
+        setPrincipalConceptCode(s.getPrincipalConceptCode());
+        setSourceOntology(s.getSourceOntology());
+        setConceptImportColumn(s.getConceptImportColumn());
+        setConceptLabelColumn(s.getConceptLabelColumn());
 
         for (GWTPropertyValidator v : s.getPropertyValidators())
         {

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.7.tgz",
-      "integrity": "sha1-WgthZASyOFIDrfa9fnZ4CiSNOyY=",
+      "version": "0.104.1-fb-domainOntologyLookup.8",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.8.tgz",
+      "integrity": "sha1-RQyjv55Usufg+59VzMZdfykjUxw=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.8.tgz",
-      "integrity": "sha1-RQyjv55Usufg+59VzMZdfykjUxw=",
+      "version": "0.104.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.2.tgz",
+      "integrity": "sha1-PgyjZGNl1USQ23rsReXDAV6C3GE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.0-fb-domainOntologyLookup.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0-fb-domainOntologyLookup.0.tgz",
-      "integrity": "sha1-UPo8AsJzLwVoSSojYVJiD3Amtdo=",
+      "version": "0.104.1-fb-domainOntologyLookup.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.0.tgz",
+      "integrity": "sha1-+SxT/W/qlIHCIpTasz776jlHDfE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.5",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.5.tgz",
-      "integrity": "sha1-isI/bdq+fxvjaORlcB3+3rflp+E=",
+      "version": "0.104.1-fb-domainOntologyLookup.7",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.7.tgz",
+      "integrity": "sha1-WgthZASyOFIDrfa9fnZ4CiSNOyY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1194,9 +1194,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "2.6.13",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-          "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+          "version": "2.6.14",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
         }
       }
     },
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.4",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.4.tgz",
-      "integrity": "sha1-rK1+DxOqoa4C233oGnqeTlR3RWU=",
+      "version": "0.104.1-fb-domainOntologyLookup.5",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.5.tgz",
+      "integrity": "sha1-isI/bdq+fxvjaORlcB3+3rflp+E=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1083,9 +1083,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.1.tgz",
-      "integrity": "sha512-5uSG1M64+OO+DL4U12qTqHDhc1vorwH6suCSPRH+77UVYzxO5TMyziWe/nQNPcPt9Wnl5G7dIYXuZ6MBuW/dFw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz",
+      "integrity": "sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -1141,9 +1141,9 @@
       }
     },
     "@emotion/core": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.0.tgz",
-      "integrity": "sha512-b4ojBXwumJ/Zc7zie4NjE5J/snS9DxsCCjW5dQ3Yr8sX5cOSbRPOd80ba3fIWUydTZmhRvbGXdBFJxj4J24rXg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@emotion/cache": "^10.0.27",
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0.tgz",
-      "integrity": "sha1-RMjB9kVD76Zcx823jM8K/WqDaIo=",
+      "version": "0.104.0-fb-domainOntologyLookup.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0-fb-domainOntologyLookup.0.tgz",
+      "integrity": "sha1-UPo8AsJzLwVoSSojYVJiD3Amtdo=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",
@@ -1448,9 +1448,9 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "16.9.55",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.55.tgz",
-      "integrity": "sha512-6KLe6lkILeRwyyy7yG9rULKJ0sXplUsl98MGoCfpteXf9sPWFWWMknDcsvubcpaTdBuxtsLF6HDUwdApZL/xIg==",
+      "version": "16.9.56",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
+      "integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.0.tgz",
-      "integrity": "sha1-+SxT/W/qlIHCIpTasz776jlHDfE=",
+      "version": "0.104.1-fb-domainOntologyLookup.3",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.3.tgz",
+      "integrity": "sha1-aR2gHoBuzSJj9LUImEC1ZaZxZgU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.3",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.3.tgz",
-      "integrity": "sha1-aR2gHoBuzSJj9LUImEC1ZaZxZgU=",
+      "version": "0.104.1-fb-domainOntologyLookup.4",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.4.tgz",
+      "integrity": "sha1-rK1+DxOqoa4C233oGnqeTlR3RWU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.0"
+    "@labkey/components": "0.104.0-fb-domainOntologyLookup.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.3"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.4"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.5"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.7"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.4"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.5"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.8"
+    "@labkey/components": "0.104.2"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.7"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.8"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.0-fb-domainOntologyLookup.0"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.0"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.3"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2394,9 +2394,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.8.tgz",
-      "integrity": "sha1-RQyjv55Usufg+59VzMZdfykjUxw=",
+      "version": "0.104.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.2.tgz",
+      "integrity": "sha1-PgyjZGNl1USQ23rsReXDAV6C3GE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1277,9 +1277,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "2.6.13",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-          "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+          "version": "2.6.14",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
         }
       }
     },
@@ -2394,9 +2394,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.4",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.4.tgz",
-      "integrity": "sha1-rK1+DxOqoa4C233oGnqeTlR3RWU=",
+      "version": "0.104.1-fb-domainOntologyLookup.5",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.5.tgz",
+      "integrity": "sha1-isI/bdq+fxvjaORlcB3+3rflp+E=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2394,9 +2394,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.0-fb-domainOntologyLookup.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0-fb-domainOntologyLookup.0.tgz",
-      "integrity": "sha1-UPo8AsJzLwVoSSojYVJiD3Amtdo=",
+      "version": "0.104.1-fb-domainOntologyLookup.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.0.tgz",
+      "integrity": "sha1-+SxT/W/qlIHCIpTasz776jlHDfE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2394,9 +2394,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.0.tgz",
-      "integrity": "sha1-+SxT/W/qlIHCIpTasz776jlHDfE=",
+      "version": "0.104.1-fb-domainOntologyLookup.3",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.3.tgz",
+      "integrity": "sha1-aR2gHoBuzSJj9LUImEC1ZaZxZgU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1133,9 +1133,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.1.tgz",
-      "integrity": "sha512-5uSG1M64+OO+DL4U12qTqHDhc1vorwH6suCSPRH+77UVYzxO5TMyziWe/nQNPcPt9Wnl5G7dIYXuZ6MBuW/dFw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz",
+      "integrity": "sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -1224,9 +1224,9 @@
       }
     },
     "@emotion/core": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.0.tgz",
-      "integrity": "sha512-b4ojBXwumJ/Zc7zie4NjE5J/snS9DxsCCjW5dQ3Yr8sX5cOSbRPOd80ba3fIWUydTZmhRvbGXdBFJxj4J24rXg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@emotion/cache": "^10.0.27",
@@ -2394,9 +2394,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0.tgz",
-      "integrity": "sha1-RMjB9kVD76Zcx823jM8K/WqDaIo=",
+      "version": "0.104.0-fb-domainOntologyLookup.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0-fb-domainOntologyLookup.0.tgz",
+      "integrity": "sha1-UPo8AsJzLwVoSSojYVJiD3Amtdo=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2394,9 +2394,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.7.tgz",
-      "integrity": "sha1-WgthZASyOFIDrfa9fnZ4CiSNOyY=",
+      "version": "0.104.1-fb-domainOntologyLookup.8",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.8.tgz",
+      "integrity": "sha1-RQyjv55Usufg+59VzMZdfykjUxw=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2394,9 +2394,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.5",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.5.tgz",
-      "integrity": "sha1-isI/bdq+fxvjaORlcB3+3rflp+E=",
+      "version": "0.104.1-fb-domainOntologyLookup.7",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.7.tgz",
+      "integrity": "sha1-WgthZASyOFIDrfa9fnZ4CiSNOyY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2394,9 +2394,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.3",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.3.tgz",
-      "integrity": "sha1-aR2gHoBuzSJj9LUImEC1ZaZxZgU=",
+      "version": "0.104.1-fb-domainOntologyLookup.4",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.4.tgz",
+      "integrity": "sha1-rK1+DxOqoa4C233oGnqeTlR3RWU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/core/package.json
+++ b/core/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.1.1",
-    "@labkey/components": "0.104.0-fb-domainOntologyLookup.0",
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.0",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.0.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.1.1",
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.5",
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.7",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.0.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.1.1",
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.3",
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.4",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.0.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.1.1",
-    "@labkey/components": "0.104.0",
+    "@labkey/components": "0.104.0-fb-domainOntologyLookup.0",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.0.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.1.1",
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.4",
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.5",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.0.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.1.1",
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.0",
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.3",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.0.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.1.1",
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.7",
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.8",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.0.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.1.1",
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.8",
+    "@labkey/components": "0.104.2",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.0.0"
   },

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.7.tgz",
-      "integrity": "sha1-WgthZASyOFIDrfa9fnZ4CiSNOyY=",
+      "version": "0.104.1-fb-domainOntologyLookup.8",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.8.tgz",
+      "integrity": "sha1-RQyjv55Usufg+59VzMZdfykjUxw=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.8.tgz",
-      "integrity": "sha1-RQyjv55Usufg+59VzMZdfykjUxw=",
+      "version": "0.104.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.2.tgz",
+      "integrity": "sha1-PgyjZGNl1USQ23rsReXDAV6C3GE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.0-fb-domainOntologyLookup.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0-fb-domainOntologyLookup.0.tgz",
-      "integrity": "sha1-UPo8AsJzLwVoSSojYVJiD3Amtdo=",
+      "version": "0.104.1-fb-domainOntologyLookup.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.0.tgz",
+      "integrity": "sha1-+SxT/W/qlIHCIpTasz776jlHDfE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.5",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.5.tgz",
-      "integrity": "sha1-isI/bdq+fxvjaORlcB3+3rflp+E=",
+      "version": "0.104.1-fb-domainOntologyLookup.7",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.7.tgz",
+      "integrity": "sha1-WgthZASyOFIDrfa9fnZ4CiSNOyY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1194,9 +1194,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "2.6.13",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-          "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+          "version": "2.6.14",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
         }
       }
     },
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.4",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.4.tgz",
-      "integrity": "sha1-rK1+DxOqoa4C233oGnqeTlR3RWU=",
+      "version": "0.104.1-fb-domainOntologyLookup.5",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.5.tgz",
+      "integrity": "sha1-isI/bdq+fxvjaORlcB3+3rflp+E=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1083,9 +1083,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.1.tgz",
-      "integrity": "sha512-5uSG1M64+OO+DL4U12qTqHDhc1vorwH6suCSPRH+77UVYzxO5TMyziWe/nQNPcPt9Wnl5G7dIYXuZ6MBuW/dFw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz",
+      "integrity": "sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -1141,9 +1141,9 @@
       }
     },
     "@emotion/core": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.0.tgz",
-      "integrity": "sha512-b4ojBXwumJ/Zc7zie4NjE5J/snS9DxsCCjW5dQ3Yr8sX5cOSbRPOd80ba3fIWUydTZmhRvbGXdBFJxj4J24rXg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@emotion/cache": "^10.0.27",
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0.tgz",
-      "integrity": "sha1-RMjB9kVD76Zcx823jM8K/WqDaIo=",
+      "version": "0.104.0-fb-domainOntologyLookup.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0-fb-domainOntologyLookup.0.tgz",
+      "integrity": "sha1-UPo8AsJzLwVoSSojYVJiD3Amtdo=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",
@@ -1448,9 +1448,9 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "16.9.55",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.55.tgz",
-      "integrity": "sha512-6KLe6lkILeRwyyy7yG9rULKJ0sXplUsl98MGoCfpteXf9sPWFWWMknDcsvubcpaTdBuxtsLF6HDUwdApZL/xIg==",
+      "version": "16.9.56",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
+      "integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.0.tgz",
-      "integrity": "sha1-+SxT/W/qlIHCIpTasz776jlHDfE=",
+      "version": "0.104.1-fb-domainOntologyLookup.3",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.3.tgz",
+      "integrity": "sha1-aR2gHoBuzSJj9LUImEC1ZaZxZgU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.3",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.3.tgz",
-      "integrity": "sha1-aR2gHoBuzSJj9LUImEC1ZaZxZgU=",
+      "version": "0.104.1-fb-domainOntologyLookup.4",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.4.tgz",
+      "integrity": "sha1-rK1+DxOqoa4C233oGnqeTlR3RWU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.5"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.7"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.4"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.5"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.0-fb-domainOntologyLookup.0"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.3"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.4"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.0"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.3"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.7"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.8"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.8"
+    "@labkey/components": "0.104.2"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.0"
+    "@labkey/components": "0.104.0-fb-domainOntologyLookup.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/internal/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/internal/src/org/labkey/api/exp/property/DomainUtil.java
@@ -331,6 +331,10 @@ public class DomainUtil
         gwtProp.setURL(url == null ? null : url.toString());
         gwtProp.setScale(prop.getScale());
         gwtProp.setRedactedText(prop.getRedactedText());
+        gwtProp.setPrincipalConceptCode(prop.getPrincipalConceptCode());
+        gwtProp.setSourceOntology(prop.getSourceOntology());
+        gwtProp.setConceptImportColumn(prop.getConceptImportColumn());
+        gwtProp.setConceptLabelColumn(prop.getConceptLabelColumn());
 
         List<GWTPropertyValidator> validators = new ArrayList<>();
         for (IPropertyValidator pv : prop.getValidators())

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.7.tgz",
-      "integrity": "sha1-WgthZASyOFIDrfa9fnZ4CiSNOyY=",
+      "version": "0.104.1-fb-domainOntologyLookup.8",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.8.tgz",
+      "integrity": "sha1-RQyjv55Usufg+59VzMZdfykjUxw=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.8.tgz",
-      "integrity": "sha1-RQyjv55Usufg+59VzMZdfykjUxw=",
+      "version": "0.104.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.2.tgz",
+      "integrity": "sha1-PgyjZGNl1USQ23rsReXDAV6C3GE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.0-fb-domainOntologyLookup.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0-fb-domainOntologyLookup.0.tgz",
-      "integrity": "sha1-UPo8AsJzLwVoSSojYVJiD3Amtdo=",
+      "version": "0.104.1-fb-domainOntologyLookup.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.0.tgz",
+      "integrity": "sha1-+SxT/W/qlIHCIpTasz776jlHDfE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.5",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.5.tgz",
-      "integrity": "sha1-isI/bdq+fxvjaORlcB3+3rflp+E=",
+      "version": "0.104.1-fb-domainOntologyLookup.7",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.7.tgz",
+      "integrity": "sha1-WgthZASyOFIDrfa9fnZ4CiSNOyY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -1194,9 +1194,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "2.6.13",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-          "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+          "version": "2.6.14",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
         }
       }
     },
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.4",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.4.tgz",
-      "integrity": "sha1-rK1+DxOqoa4C233oGnqeTlR3RWU=",
+      "version": "0.104.1-fb-domainOntologyLookup.5",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.5.tgz",
+      "integrity": "sha1-isI/bdq+fxvjaORlcB3+3rflp+E=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -1083,9 +1083,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.1.tgz",
-      "integrity": "sha512-5uSG1M64+OO+DL4U12qTqHDhc1vorwH6suCSPRH+77UVYzxO5TMyziWe/nQNPcPt9Wnl5G7dIYXuZ6MBuW/dFw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz",
+      "integrity": "sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -1141,9 +1141,9 @@
       }
     },
     "@emotion/core": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.0.tgz",
-      "integrity": "sha512-b4ojBXwumJ/Zc7zie4NjE5J/snS9DxsCCjW5dQ3Yr8sX5cOSbRPOd80ba3fIWUydTZmhRvbGXdBFJxj4J24rXg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@emotion/cache": "^10.0.27",
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0.tgz",
-      "integrity": "sha1-RMjB9kVD76Zcx823jM8K/WqDaIo=",
+      "version": "0.104.0-fb-domainOntologyLookup.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0-fb-domainOntologyLookup.0.tgz",
+      "integrity": "sha1-UPo8AsJzLwVoSSojYVJiD3Amtdo=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",
@@ -1448,9 +1448,9 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "16.9.55",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.55.tgz",
-      "integrity": "sha512-6KLe6lkILeRwyyy7yG9rULKJ0sXplUsl98MGoCfpteXf9sPWFWWMknDcsvubcpaTdBuxtsLF6HDUwdApZL/xIg==",
+      "version": "16.9.56",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
+      "integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.0.tgz",
-      "integrity": "sha1-+SxT/W/qlIHCIpTasz776jlHDfE=",
+      "version": "0.104.1-fb-domainOntologyLookup.3",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.3.tgz",
+      "integrity": "sha1-aR2gHoBuzSJj9LUImEC1ZaZxZgU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.3",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.3.tgz",
-      "integrity": "sha1-aR2gHoBuzSJj9LUImEC1ZaZxZgU=",
+      "version": "0.104.1-fb-domainOntologyLookup.4",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.4.tgz",
+      "integrity": "sha1-rK1+DxOqoa4C233oGnqeTlR3RWU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/issues/package.json
+++ b/issues/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/issues/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.3"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.4"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/issues/package.json
+++ b/issues/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/issues/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.7"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.8"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/issues/package.json
+++ b/issues/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/issues/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.5"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.7"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/issues/package.json
+++ b/issues/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/issues/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.8"
+    "@labkey/components": "0.104.2"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/issues/package.json
+++ b/issues/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/issues/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.0"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.3"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/issues/package.json
+++ b/issues/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/issues/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.4"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.5"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/issues/package.json
+++ b/issues/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/issues/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.0"
+    "@labkey/components": "0.104.0-fb-domainOntologyLookup.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/issues/package.json
+++ b/issues/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/issues/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.0-fb-domainOntologyLookup.0"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.7.tgz",
-      "integrity": "sha1-WgthZASyOFIDrfa9fnZ4CiSNOyY=",
+      "version": "0.104.1-fb-domainOntologyLookup.8",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.8.tgz",
+      "integrity": "sha1-RQyjv55Usufg+59VzMZdfykjUxw=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.8.tgz",
-      "integrity": "sha1-RQyjv55Usufg+59VzMZdfykjUxw=",
+      "version": "0.104.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.2.tgz",
+      "integrity": "sha1-PgyjZGNl1USQ23rsReXDAV6C3GE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.5",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.5.tgz",
-      "integrity": "sha1-isI/bdq+fxvjaORlcB3+3rflp+E=",
+      "version": "0.104.1-fb-domainOntologyLookup.7",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.7.tgz",
+      "integrity": "sha1-WgthZASyOFIDrfa9fnZ4CiSNOyY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -1194,9 +1194,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "2.6.13",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-          "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+          "version": "2.6.14",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
         }
       }
     },
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.4",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.4.tgz",
-      "integrity": "sha1-rK1+DxOqoa4C233oGnqeTlR3RWU=",
+      "version": "0.104.1-fb-domainOntologyLookup.5",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.5.tgz",
+      "integrity": "sha1-isI/bdq+fxvjaORlcB3+3rflp+E=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1.tgz",
-      "integrity": "sha1-l7DEpZvzz+sShGAC6EEeCIUtmig=",
+      "version": "0.104.1-fb-domainOntologyLookup.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.0.tgz",
+      "integrity": "sha1-+SxT/W/qlIHCIpTasz776jlHDfE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -1083,9 +1083,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.1.tgz",
-      "integrity": "sha512-5uSG1M64+OO+DL4U12qTqHDhc1vorwH6suCSPRH+77UVYzxO5TMyziWe/nQNPcPt9Wnl5G7dIYXuZ6MBuW/dFw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz",
+      "integrity": "sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -1141,9 +1141,9 @@
       }
     },
     "@emotion/core": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.0.tgz",
-      "integrity": "sha512-b4ojBXwumJ/Zc7zie4NjE5J/snS9DxsCCjW5dQ3Yr8sX5cOSbRPOd80ba3fIWUydTZmhRvbGXdBFJxj4J24rXg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@emotion/cache": "^10.0.27",
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0.tgz",
-      "integrity": "sha1-RMjB9kVD76Zcx823jM8K/WqDaIo=",
+      "version": "0.104.0-fb-domainOntologyLookup.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0-fb-domainOntologyLookup.0.tgz",
+      "integrity": "sha1-UPo8AsJzLwVoSSojYVJiD3Amtdo=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",
@@ -1448,9 +1448,9 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "16.9.55",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.55.tgz",
-      "integrity": "sha512-6KLe6lkILeRwyyy7yG9rULKJ0sXplUsl98MGoCfpteXf9sPWFWWMknDcsvubcpaTdBuxtsLF6HDUwdApZL/xIg==",
+      "version": "16.9.56",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
+      "integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.0.tgz",
-      "integrity": "sha1-+SxT/W/qlIHCIpTasz776jlHDfE=",
+      "version": "0.104.1-fb-domainOntologyLookup.3",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.3.tgz",
+      "integrity": "sha1-aR2gHoBuzSJj9LUImEC1ZaZxZgU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.3",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.3.tgz",
-      "integrity": "sha1-aR2gHoBuzSJj9LUImEC1ZaZxZgU=",
+      "version": "0.104.1-fb-domainOntologyLookup.4",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.4.tgz",
+      "integrity": "sha1-rK1+DxOqoa4C233oGnqeTlR3RWU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/list/package.json
+++ b/list/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/list/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.0"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.3"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/list/package.json
+++ b/list/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/list/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.5"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.7"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/list/package.json
+++ b/list/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/list/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.7"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.8"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/list/package.json
+++ b/list/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/list/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.8"
+    "@labkey/components": "0.104.2"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/list/package.json
+++ b/list/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/list/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.0"
+    "@labkey/components": "0.104.0-fb-domainOntologyLookup.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/list/package.json
+++ b/list/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/list/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/list/package.json
+++ b/list/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/list/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.4"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.5"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/list/package.json
+++ b/list/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/list/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.3"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.4"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.7.tgz",
-      "integrity": "sha1-WgthZASyOFIDrfa9fnZ4CiSNOyY=",
+      "version": "0.104.1-fb-domainOntologyLookup.8",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.8.tgz",
+      "integrity": "sha1-RQyjv55Usufg+59VzMZdfykjUxw=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.8.tgz",
-      "integrity": "sha1-RQyjv55Usufg+59VzMZdfykjUxw=",
+      "version": "0.104.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.2.tgz",
+      "integrity": "sha1-PgyjZGNl1USQ23rsReXDAV6C3GE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.0-fb-domainOntologyLookup.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0-fb-domainOntologyLookup.0.tgz",
-      "integrity": "sha1-UPo8AsJzLwVoSSojYVJiD3Amtdo=",
+      "version": "0.104.1-fb-domainOntologyLookup.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.0.tgz",
+      "integrity": "sha1-+SxT/W/qlIHCIpTasz776jlHDfE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.5",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.5.tgz",
-      "integrity": "sha1-isI/bdq+fxvjaORlcB3+3rflp+E=",
+      "version": "0.104.1-fb-domainOntologyLookup.7",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.7.tgz",
+      "integrity": "sha1-WgthZASyOFIDrfa9fnZ4CiSNOyY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -1194,9 +1194,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "2.6.13",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-          "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+          "version": "2.6.14",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
         }
       }
     },
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.4",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.4.tgz",
-      "integrity": "sha1-rK1+DxOqoa4C233oGnqeTlR3RWU=",
+      "version": "0.104.1-fb-domainOntologyLookup.5",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.5.tgz",
+      "integrity": "sha1-isI/bdq+fxvjaORlcB3+3rflp+E=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -1083,9 +1083,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.1.tgz",
-      "integrity": "sha512-5uSG1M64+OO+DL4U12qTqHDhc1vorwH6suCSPRH+77UVYzxO5TMyziWe/nQNPcPt9Wnl5G7dIYXuZ6MBuW/dFw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz",
+      "integrity": "sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -1141,9 +1141,9 @@
       }
     },
     "@emotion/core": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.0.tgz",
-      "integrity": "sha512-b4ojBXwumJ/Zc7zie4NjE5J/snS9DxsCCjW5dQ3Yr8sX5cOSbRPOd80ba3fIWUydTZmhRvbGXdBFJxj4J24rXg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@emotion/cache": "^10.0.27",
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0.tgz",
-      "integrity": "sha1-RMjB9kVD76Zcx823jM8K/WqDaIo=",
+      "version": "0.104.0-fb-domainOntologyLookup.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0-fb-domainOntologyLookup.0.tgz",
+      "integrity": "sha1-UPo8AsJzLwVoSSojYVJiD3Amtdo=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",
@@ -1448,9 +1448,9 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "16.9.55",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.55.tgz",
-      "integrity": "sha512-6KLe6lkILeRwyyy7yG9rULKJ0sXplUsl98MGoCfpteXf9sPWFWWMknDcsvubcpaTdBuxtsLF6HDUwdApZL/xIg==",
+      "version": "16.9.56",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
+      "integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.0.tgz",
-      "integrity": "sha1-+SxT/W/qlIHCIpTasz776jlHDfE=",
+      "version": "0.104.1-fb-domainOntologyLookup.3",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.3.tgz",
+      "integrity": "sha1-aR2gHoBuzSJj9LUImEC1ZaZxZgU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.3",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.3.tgz",
-      "integrity": "sha1-aR2gHoBuzSJj9LUImEC1ZaZxZgU=",
+      "version": "0.104.1-fb-domainOntologyLookup.4",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.4.tgz",
+      "integrity": "sha1-rK1+DxOqoa4C233oGnqeTlR3RWU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/query/package.json
+++ b/query/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/query/gen && rimraf resources/views/gen  && rimraf resources/views/queryMetadataEditor*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.4"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.5"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/query/package.json
+++ b/query/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/query/gen && rimraf resources/views/gen  && rimraf resources/views/queryMetadataEditor*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.0"
+    "@labkey/components": "0.104.0-fb-domainOntologyLookup.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/query/package.json
+++ b/query/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/query/gen && rimraf resources/views/gen  && rimraf resources/views/queryMetadataEditor*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.8"
+    "@labkey/components": "0.104.2"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/query/package.json
+++ b/query/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/query/gen && rimraf resources/views/gen  && rimraf resources/views/queryMetadataEditor*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.7"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.8"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/query/package.json
+++ b/query/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/query/gen && rimraf resources/views/gen  && rimraf resources/views/queryMetadataEditor*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.3"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.4"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/query/package.json
+++ b/query/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/query/gen && rimraf resources/views/gen  && rimraf resources/views/queryMetadataEditor*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.0"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.3"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/query/package.json
+++ b/query/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/query/gen && rimraf resources/views/gen  && rimraf resources/views/queryMetadataEditor*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.0-fb-domainOntologyLookup.0"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/query/package.json
+++ b/query/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/query/gen && rimraf resources/views/gen  && rimraf resources/views/queryMetadataEditor*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.5"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.7"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/query/src/org/labkey/query/MetadataTableJSON.java
+++ b/query/src/org/labkey/query/MetadataTableJSON.java
@@ -290,7 +290,6 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             }
 
             /* NOTE: explicitly not supporting this metadata via this pathway, do not uncomment
-
             if (!StringUtils.equals(gwtColumnInfo.getPHI(), rawColumnInfo.getPHI().name()))
             {
                 xmlColumn.setPhi(PHIType.Enum.forString(gwtColumnInfo.getPHI()));
@@ -423,6 +422,16 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             if (shouldStoreValue(metadataColumnJSON.getConditionalFormats(), convertToGWT(rawColumnInfo.getConditionalFormats())))
             {
                 ConditionalFormat.convertToXML(metadataColumnJSON.getConditionalFormats(), xmlColumn);
+            }
+
+            // Set conceptURI
+            if (shouldStoreValue(metadataColumnJSON.getConceptURI(), rawColumnInfo.getConceptURI()))
+            {
+                xmlColumn.setConceptURI(metadataColumnJSON.getConceptURI());
+            }
+            else if (xmlColumn.isSetConceptURI())
+            {
+                xmlColumn.unsetConceptURI();
             }
 
             // Ontology metadata
@@ -602,7 +611,12 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
 
             List<GWTConditionalFormat> formats = convertToGWT(columnInfo.getConditionalFormats());
             metadataColumnJSON.setConditionalFormats(formats);
+
+            metadataColumnJSON.setConceptURI(columnInfo.getConceptURI());
             metadataColumnJSON.setPrincipalConceptCode(columnInfo.getPrincipalConceptCode());
+            metadataColumnJSON.setSourceOntology(columnInfo.getSourceOntology());
+            metadataColumnJSON.setConceptImportColumn(columnInfo.getConceptImportColumn());
+            metadataColumnJSON.setConceptLabelColumn(columnInfo.getConceptLabelColumn());
         }
 
         List<QueryDef> queryDefs = QueryServiceImpl.get().findMetadataOverrideImpl(schema, tableName, false, false, null);

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.7.tgz",
-      "integrity": "sha1-WgthZASyOFIDrfa9fnZ4CiSNOyY=",
+      "version": "0.104.1-fb-domainOntologyLookup.8",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.8.tgz",
+      "integrity": "sha1-RQyjv55Usufg+59VzMZdfykjUxw=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.8.tgz",
-      "integrity": "sha1-RQyjv55Usufg+59VzMZdfykjUxw=",
+      "version": "0.104.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.2.tgz",
+      "integrity": "sha1-PgyjZGNl1USQ23rsReXDAV6C3GE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.5",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.5.tgz",
-      "integrity": "sha1-isI/bdq+fxvjaORlcB3+3rflp+E=",
+      "version": "0.104.1-fb-domainOntologyLookup.7",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.7.tgz",
+      "integrity": "sha1-WgthZASyOFIDrfa9fnZ4CiSNOyY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -1194,9 +1194,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "2.6.13",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-          "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+          "version": "2.6.14",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
         }
       }
     },
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.4",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.4.tgz",
-      "integrity": "sha1-rK1+DxOqoa4C233oGnqeTlR3RWU=",
+      "version": "0.104.1-fb-domainOntologyLookup.5",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.5.tgz",
+      "integrity": "sha1-isI/bdq+fxvjaORlcB3+3rflp+E=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1.tgz",
-      "integrity": "sha1-l7DEpZvzz+sShGAC6EEeCIUtmig=",
+      "version": "0.104.1-fb-domainOntologyLookup.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.0.tgz",
+      "integrity": "sha1-+SxT/W/qlIHCIpTasz776jlHDfE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -1083,9 +1083,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.1.tgz",
-      "integrity": "sha512-5uSG1M64+OO+DL4U12qTqHDhc1vorwH6suCSPRH+77UVYzxO5TMyziWe/nQNPcPt9Wnl5G7dIYXuZ6MBuW/dFw==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz",
+      "integrity": "sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -1141,9 +1141,9 @@
       }
     },
     "@emotion/core": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.0.tgz",
-      "integrity": "sha512-b4ojBXwumJ/Zc7zie4NjE5J/snS9DxsCCjW5dQ3Yr8sX5cOSbRPOd80ba3fIWUydTZmhRvbGXdBFJxj4J24rXg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@emotion/cache": "^10.0.27",
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0.tgz",
-      "integrity": "sha1-RMjB9kVD76Zcx823jM8K/WqDaIo=",
+      "version": "0.104.0-fb-domainOntologyLookup.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.0-fb-domainOntologyLookup.0.tgz",
+      "integrity": "sha1-UPo8AsJzLwVoSSojYVJiD3Amtdo=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",
@@ -1448,9 +1448,9 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "16.9.55",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.55.tgz",
-      "integrity": "sha512-6KLe6lkILeRwyyy7yG9rULKJ0sXplUsl98MGoCfpteXf9sPWFWWMknDcsvubcpaTdBuxtsLF6HDUwdApZL/xIg==",
+      "version": "16.9.56",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
+      "integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.0.tgz",
-      "integrity": "sha1-+SxT/W/qlIHCIpTasz776jlHDfE=",
+      "version": "0.104.1-fb-domainOntologyLookup.3",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.3.tgz",
+      "integrity": "sha1-aR2gHoBuzSJj9LUImEC1ZaZxZgU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.104.1-fb-domainOntologyLookup.3",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.3.tgz",
-      "integrity": "sha1-aR2gHoBuzSJj9LUImEC1ZaZxZgU=",
+      "version": "0.104.1-fb-domainOntologyLookup.4",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.104.1-fb-domainOntologyLookup.4.tgz",
+      "integrity": "sha1-rK1+DxOqoa4C233oGnqeTlR3RWU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/study/package.json
+++ b/study/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/study/gen && rimraf resources/views/gen && rimraf resources/views/datasetDesigner*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.7"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.8"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/study/package.json
+++ b/study/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/study/gen && rimraf resources/views/gen && rimraf resources/views/datasetDesigner*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.8"
+    "@labkey/components": "0.104.2"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/study/package.json
+++ b/study/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/study/gen && rimraf resources/views/gen && rimraf resources/views/datasetDesigner*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.0"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.3"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/study/package.json
+++ b/study/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/study/gen && rimraf resources/views/gen && rimraf resources/views/datasetDesigner*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.0"
+    "@labkey/components": "0.104.0-fb-domainOntologyLookup.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/study/package.json
+++ b/study/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/study/gen && rimraf resources/views/gen && rimraf resources/views/datasetDesigner*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.5"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.7"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/study/package.json
+++ b/study/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/study/gen && rimraf resources/views/gen && rimraf resources/views/datasetDesigner*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/study/package.json
+++ b/study/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/study/gen && rimraf resources/views/gen && rimraf resources/views/datasetDesigner*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.3"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.4"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/study/package.json
+++ b/study/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/study/gen && rimraf resources/views/gen && rimraf resources/views/datasetDesigner*"
   },
   "dependencies": {
-    "@labkey/components": "0.104.1-fb-domainOntologyLookup.4"
+    "@labkey/components": "0.104.1-fb-domainOntologyLookup.5"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"


### PR DESCRIPTION
#### Rationale
Previous stories have added support for Ontology Lookup concepts to be set for a domain field via metadata XML. This story allows for some of those properties to be set in the various domain designers via a new "Ontology Lookup" data type and an expanded properties section.

Issue [41838](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=41838): Ontology Lookup data type in domain designer

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/390
* https://github.com/LabKey/testAutomation/pull/527

#### Changes
* Server side property descriptor updates for setting sourceOntology, conceptImportColumn, and conceptLabelColumn from a created / saved domain design
* Update @labkey/components package version for platform modules
