### PR TITLE
Issue 41655: Record only the fields that have changed in a detailed dataset audit log

### DIFF
--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -107,32 +107,11 @@ public abstract class AuditHandler
                             }
                             case UPDATE:
                             {
+                                Pair<Map<String, Object>, Map<String, Object>> rowPair = AuditHandler.getOldAndNewRecordForMerge(row, updatedRow, table.getExtraDetailedUpdateAuditFields());
                                 // record modified fields
-                                Map<String, Object> originalRow = new HashMap<>();
-                                Map<String, Object> modifiedRow = new HashMap<>();
+                                Map<String, Object> originalRow = rowPair.first;
+                                Map<String, Object> modifiedRow = rowPair.second;
 
-                                Set<String> extraFieldsToInclude = table.getExtraDetailedUpdateAuditFields();
-
-                                for (Map.Entry<String, Object> entry : row.entrySet())
-                                {
-                                    boolean isExtraAuditField = extraFieldsToInclude != null && extraFieldsToInclude.contains(entry.getKey());
-                                    if (updatedRow.containsKey(entry.getKey()))
-                                    {
-                                        Object newValue = updatedRow.get(entry.getKey());
-                                        if (!Objects.equals(entry.getValue(), newValue) || isExtraAuditField)
-                                        {
-                                            originalRow.put(entry.getKey(), entry.getValue());
-                                            modifiedRow.put(entry.getKey(), newValue);
-                                        }
-                                    }
-                                    else if (isExtraAuditField)
-                                    {
-                                        // persist extra fields desired for audit details even if no change is made, so that extra field values is available after record is deleted
-                                        // for example, a display label/id is desired in audit log for the record updated.
-                                        originalRow.put(entry.getKey(), entry.getValue());
-                                        modifiedRow.put(entry.getKey(), entry.getValue());
-                                    }
-                                }
                                 // allow for adding fields that may be present in the updated row but not represented in the original row
                                 addDetailedModifiedFields(row, modifiedRow, updatedRow);
 

--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -146,7 +146,8 @@ public abstract class AuditHandler
             {
                 Object newValue = updatedRow.get(entry.getKey());
                 // compare dates using string values to allow for both Date and Timestamp types
-                if (newValue instanceof Date && entry.getValue() != null) {
+                if (newValue instanceof Date && entry.getValue() != null)
+                {
                     SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
                     String newString = formatter.format((java.util.Date) newValue);
                     Object oldValue = entry.getValue();
@@ -157,8 +158,7 @@ public abstract class AuditHandler
                         modifiedRow.put(entry.getKey(), newValue);
                     }
                 }
-                else
-                    if (!Objects.equals(entry.getValue(), newValue) || isExtraAuditField)
+                else if (!Objects.equals(entry.getValue(), newValue) || isExtraAuditField)
                 {
                     originalRow.put(entry.getKey(), entry.getValue());
                     modifiedRow.put(entry.getKey(), newValue);

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -617,10 +617,10 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
     }
 
     /* fields to include in detailed UPDATE audit log, even if no change is made to field value */
-    @Nullable
+    @NotNull
     default Set<String> getExtraDetailedUpdateAuditFields()
     {
-        return null;
+        return Collections.emptySet();
     }
 
     /**

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -138,14 +138,14 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
     }
 
     @Override
-    @Nullable
+    @NotNull
     public Set<String> getExtraDetailedUpdateAuditFields()
     {
         ExpSchema.DataClassCategoryType categoryType = ExpSchema.DataClassCategoryType.fromString(_dataClass.getCategory());
         if (categoryType != null)
             return categoryType.additionalAuditFields;
 
-        return null;
+        return Collections.emptySet();
     }
 
     @Override

--- a/study/src/org/labkey/study/StudyServiceImpl.java
+++ b/study/src/org/labkey/study/StudyServiceImpl.java
@@ -326,18 +326,15 @@ public class StudyServiceImpl implements StudyService
         String oldRecordString = null;
         String newRecordString = null;
         Object lsid;
-        String participantId;
         if (oldRecord == null)
         {
             newRecordString = DatasetAuditProvider.encodeForDataMap(c, newRecord);
             lsid = newRecord.get("lsid");
-            participantId = (String) newRecord.get("participantId");
         }
         else if (newRecord == null)
         {
             oldRecordString = DatasetAuditProvider.encodeForDataMap(c, oldRecord);
             lsid = oldRecord.get("lsid");
-            participantId = (String) oldRecord.get("participantId");
         }
         else
         {
@@ -346,10 +343,8 @@ public class StudyServiceImpl implements StudyService
             oldRecordString = DatasetAuditProvider.encodeForDataMap(c, rowPair.first);
             newRecordString = DatasetAuditProvider.encodeForDataMap(c, rowPair.second);
             lsid = newRecord.get("lsid");
-            participantId = (String) newRecord.get("participantId");
         }
         event.setLsid(lsid == null ? null : lsid.toString());
-        event.setParticipantId(participantId);
 
         if (oldRecordString != null) event.setOldRecordMap(oldRecordString);
         if (newRecordString != null) event.setNewRecordMap(newRecordString);

--- a/study/src/org/labkey/study/StudyServiceImpl.java
+++ b/study/src/org/labkey/study/StudyServiceImpl.java
@@ -24,6 +24,7 @@ import org.labkey.api.admin.ImportOptions;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.AssayTableMetadata;
+import org.labkey.api.audit.AuditHandler;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.AuditTypeEvent;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
@@ -75,6 +76,7 @@ import org.labkey.api.study.StudyService;
 import org.labkey.api.study.TimepointType;
 import org.labkey.api.study.UnionTable;
 import org.labkey.api.util.GUID;
+import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DataView;
 import org.labkey.api.view.ViewBackgroundInfo;
@@ -324,23 +326,30 @@ public class StudyServiceImpl implements StudyService
         String oldRecordString = null;
         String newRecordString = null;
         Object lsid;
+        String participantId;
         if (oldRecord == null)
         {
             newRecordString = DatasetAuditProvider.encodeForDataMap(c, newRecord);
             lsid = newRecord.get("lsid");
+            participantId = (String) newRecord.get("participantId");
         }
         else if (newRecord == null)
         {
             oldRecordString = DatasetAuditProvider.encodeForDataMap(c, oldRecord);
             lsid = oldRecord.get("lsid");
+            participantId = (String) oldRecord.get("participantId");
         }
         else
         {
-            oldRecordString = DatasetAuditProvider.encodeForDataMap(c, oldRecord);
-            newRecordString = DatasetAuditProvider.encodeForDataMap(c, newRecord);
+            Pair<Map<String, Object>, Map<String, Object>> rowPair = AuditHandler.getOldAndNewRecordForMerge(oldRecord, newRecord, Collections.emptySet());
+
+            oldRecordString = DatasetAuditProvider.encodeForDataMap(c, rowPair.first);
+            newRecordString = DatasetAuditProvider.encodeForDataMap(c, rowPair.second);
             lsid = newRecord.get("lsid");
+            participantId = (String) newRecord.get("participantId");
         }
         event.setLsid(lsid == null ? null : lsid.toString());
+        event.setParticipantId(participantId);
 
         if (oldRecordString != null) event.setOldRecordMap(oldRecordString);
         if (newRecordString != null) event.setNewRecordMap(newRecordString);

--- a/study/src/org/labkey/study/dataset/DatasetAuditProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetAuditProvider.java
@@ -57,6 +57,7 @@ public class DatasetAuditProvider extends AbstractAuditTypeProvider implements A
     public static final String COLUMN_NAME_DATASET_ID = "DatasetId";
     public static final String COLUMN_NAME_HAS_DETAILS = "HasDetails";
     public static final String COLUMN_NAME_LSID = "Lsid";
+    public static final String COLUMN_NAME_PARTICIPANT_ID = "ParticipantID";
 
     static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
 
@@ -68,6 +69,7 @@ public class DatasetAuditProvider extends AbstractAuditTypeProvider implements A
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_PROJECT_ID));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_CONTAINER));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_DATASET_ID));
+        defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_PARTICIPANT_ID));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_COMMENT));
     }
 
@@ -191,6 +193,7 @@ public class DatasetAuditProvider extends AbstractAuditTypeProvider implements A
         private String _lsid;
         private String _oldRecordMap;
         private String _newRecordMap;
+        private String _participantId;
 
         public DatasetAuditEvent()
         {
@@ -230,6 +233,16 @@ public class DatasetAuditProvider extends AbstractAuditTypeProvider implements A
         public void setLsid(String lsid)
         {
             _lsid = lsid;
+        }
+
+        public String getParticipantId()
+        {
+            return _participantId;
+        }
+
+        public void setParticipantId(String participantId)
+        {
+            _participantId = participantId;
         }
 
         public String getOldRecordMap()
@@ -278,6 +291,7 @@ public class DatasetAuditProvider extends AbstractAuditTypeProvider implements A
 
             Set<PropertyDescriptor> fields = new LinkedHashSet<>();
             fields.add(createPropertyDescriptor(COLUMN_NAME_DATASET_ID, PropertyType.INTEGER));
+            fields.add(createPropertyDescriptor(COLUMN_NAME_PARTICIPANT_ID, PropertyType.STRING));
             fields.add(createPropertyDescriptor(COLUMN_NAME_HAS_DETAILS, PropertyType.BOOLEAN));
             fields.add(createPropertyDescriptor(COLUMN_NAME_LSID, PropertyType.STRING));
             fields.add(createPropertyDescriptor(OLD_RECORD_PROP_NAME, PropertyType.STRING, -1));        // varchar max

--- a/study/src/org/labkey/study/dataset/DatasetAuditProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetAuditProvider.java
@@ -57,7 +57,6 @@ public class DatasetAuditProvider extends AbstractAuditTypeProvider implements A
     public static final String COLUMN_NAME_DATASET_ID = "DatasetId";
     public static final String COLUMN_NAME_HAS_DETAILS = "HasDetails";
     public static final String COLUMN_NAME_LSID = "Lsid";
-    public static final String COLUMN_NAME_PARTICIPANT_ID = "ParticipantID";
 
     static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
 
@@ -69,7 +68,6 @@ public class DatasetAuditProvider extends AbstractAuditTypeProvider implements A
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_PROJECT_ID));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_CONTAINER));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_DATASET_ID));
-        defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_PARTICIPANT_ID));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_COMMENT));
     }
 
@@ -193,7 +191,6 @@ public class DatasetAuditProvider extends AbstractAuditTypeProvider implements A
         private String _lsid;
         private String _oldRecordMap;
         private String _newRecordMap;
-        private String _participantId;
 
         public DatasetAuditEvent()
         {
@@ -233,16 +230,6 @@ public class DatasetAuditProvider extends AbstractAuditTypeProvider implements A
         public void setLsid(String lsid)
         {
             _lsid = lsid;
-        }
-
-        public String getParticipantId()
-        {
-            return _participantId;
-        }
-
-        public void setParticipantId(String participantId)
-        {
-            _participantId = participantId;
         }
 
         public String getOldRecordMap()
@@ -291,7 +278,6 @@ public class DatasetAuditProvider extends AbstractAuditTypeProvider implements A
 
             Set<PropertyDescriptor> fields = new LinkedHashSet<>();
             fields.add(createPropertyDescriptor(COLUMN_NAME_DATASET_ID, PropertyType.INTEGER));
-            fields.add(createPropertyDescriptor(COLUMN_NAME_PARTICIPANT_ID, PropertyType.STRING));
             fields.add(createPropertyDescriptor(COLUMN_NAME_HAS_DETAILS, PropertyType.BOOLEAN));
             fields.add(createPropertyDescriptor(COLUMN_NAME_LSID, PropertyType.STRING));
             fields.add(createPropertyDescriptor(OLD_RECORD_PROP_NAME, PropertyType.STRING, -1));        // varchar max

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -2554,7 +2554,7 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
             resetCreatedColumnsSQL.add(oldData.get(DatasetDomainKind.CREATED_BY));
             resetCreatedColumnsSQL.add(newLSID);
             new SqlExecutor(getStorageTableInfo().getSchema()).execute(resetCreatedColumnsSQL);
-
+            
             StudyServiceImpl.addDatasetAuditEvent(u, this, oldData, mergeData);
 
             // Successfully updated


### PR DESCRIPTION
#### Rationale
We do not need to show all of the fields in a dataset when only some of them have changed.  Instead we capture just the fields that have changed during an update.


#### Changes
* extract method for finding the fields that have been modified into a static method in AuditHandler and use that for getting the old and new records for dataset audit events in which rows have changed.