### PR TITLE
Issue 41814: Rearrange data iterators so audit logs appear in the proper order.

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -391,6 +391,11 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         }
     }
 
+    public ExpSampleType getSampleType()
+    {
+        return _ss;
+    }
+
     @Override
     public void setMaterials(Set<ExpMaterial> materials)
     {
@@ -790,11 +795,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                         }
                     }));
 
-            builder = LoggingDataIterator.wrap(new AliasDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser(), ExperimentService.get().getTinfoMaterialAliasMap()));
-            if (InventoryService.get() != null && ExperimentalFeatureService.get().isFeatureEnabled("experimental_freezerManagement"))
-                return LoggingDataIterator.wrap(InventoryService.get().getPersistStorageItemDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser(), _ss.getMetricUnit()));
-            else
-                return builder;
+            return LoggingDataIterator.wrap(new AliasDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser(), ExperimentService.get().getTinfoMaterialAliasMap()));
         }
         catch (IOException e)
         {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -35,6 +35,7 @@ import org.labkey.api.data.TableSelector;
 import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
+import org.labkey.api.dataiterator.LoggingDataIterator;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpDataClass;
 import org.labkey.api.exp.api.ExpMaterial;
@@ -43,6 +44,7 @@ import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.query.ExpMaterialTable;
+import org.labkey.api.inventory.InventoryService;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.DefaultQueryUpdateService;
 import org.labkey.api.query.FieldKey;
@@ -53,6 +55,7 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
+import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.experiment.ExpDataIterators;
 import org.labkey.experiment.SampleTypeAuditProvider;
 import org.labkey.experiment.samples.UploadSamplesHelper;
@@ -143,6 +146,22 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             audit(QueryService.AuditAction.INSERT);
         }
         return ret;
+    }
+
+    @Override
+    public DataIteratorBuilder createImportDIB(User user, Container container, DataIteratorBuilder data, DataIteratorContext context)
+    {
+        DataIteratorBuilder dib = super.createImportDIB(user, container, data, context);
+        if (InventoryService.get() != null && ExperimentalFeatureService.get().isFeatureEnabled("experimental_freezerManagement"))
+        {
+            ExpSampleType sampleType = ((ExpMaterialTableImpl) getQueryTable()).getSampleType();
+            UserSchema userSchema = getQueryTable().getUserSchema();
+            if (userSchema != null)
+                return LoggingDataIterator.wrap(InventoryService.get().getPersistStorageItemDataIteratorBuilder(dib, userSchema.getContainer(), userSchema.getUser(), sampleType.getMetricUnit()));
+            return dib;
+        }
+        else
+            return dib;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
When importing samples and adding them to storage via file import, the audit logs should appear in the same order as when doing these operations in two steps through the application.  Currently, because of the ordering of the data iterators, the audit logs for adding to storage are created before the ones for adding the samples.  We reorder the iterators to change the order of the audit logs.

#### Changes
* reorder data iterators
