### PR TITLE
Improve error message when a report can't find its schema any more

### DIFF
--- a/api/src/org/labkey/api/reports/report/QueryReport.java
+++ b/api/src/org/labkey/api/reports/report/QueryReport.java
@@ -135,9 +135,9 @@ public class QueryReport extends AbstractReport
         String dataRegionName = StringUtils.defaultString(getDescriptor().getProperty(ReportDescriptor.Prop.dataRegionName), QueryView.DATAREGIONNAME_DEFAULT) + "_" + getReportId().toString();
 
         if (schemaName == null)
-            errors.addError(new LabKeyError("schema name cannot be empty"));
+            errors.addError(new LabKeyError("Schema name cannot be empty"));
         if (queryName == null)
-            errors.addError(new LabKeyError("query name cannot be empty"));
+            errors.addError(new LabKeyError("Query name cannot be empty"));
 
         UserSchema schema = getSchema(context, schemaName);
 
@@ -168,7 +168,7 @@ public class QueryReport extends AbstractReport
             return view;
         }
         else
-            errors.addError(new LabKeyError("unable to create the schema for this query configuration"));
+            errors.addError(new LabKeyError("Unable to find the '" + schemaName + "' schema for this report"));
 
         return null;
     }


### PR DESCRIPTION
#### Rationale
The previous message, "unable to create the schema for this query configuration" wasn't especially clear to users

#### Changes
* Reframe message around not finding the schema, and give the schema name that's not available.