### PR TITLE
Issue 41768: Add alias column to exp.data

### DIFF
--- a/api/src/org/labkey/api/exp/query/ExpDataTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpDataTable.java
@@ -44,6 +44,7 @@ public interface ExpDataTable extends ExpTable<ExpDataTable.Column>
         ModifiedBy,
         Folder,
         Flag,
+        Alias,
         DownloadLink,
         ContentLink,
         ViewFileLink,

--- a/experiment/src/org/labkey/experiment/api/AliasDisplayColumnFactory.java
+++ b/experiment/src/org/labkey/experiment/api/AliasDisplayColumnFactory.java
@@ -1,0 +1,49 @@
+package org.labkey.experiment.api;
+
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.MultiValuedDisplayColumn;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.exp.api.ExperimentService;
+
+import java.util.Collections;
+import java.util.List;
+
+class AliasDisplayColumnFactory implements DisplayColumnFactory
+{
+    @Override
+    public DisplayColumn createRenderer(ColumnInfo colInfo)
+    {
+        DataColumn dataColumn = new DataColumn(colInfo);
+        dataColumn.setInputType("text");
+
+        return new MultiValuedDisplayColumn(dataColumn, true)
+        {
+            @Override
+            public Object getInputValue(RenderContext ctx)
+            {
+                Object value = super.getInputValue(ctx);
+                StringBuilder sb = new StringBuilder();
+                if (value instanceof List)
+                {
+                    String delim = "";
+                    for (Object item : (List) value)
+                    {
+                        if (item != null)
+                        {
+                            String name = new TableSelector(ExperimentService.get().getTinfoAlias(), Collections.singleton("Name")).getObject(item, String.class);
+
+                            sb.append(delim);
+                            sb.append(name);
+                            delim = ",";
+                        }
+                    }
+                }
+                return sb.toString();
+            }
+        };
+    }
+}

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -224,23 +224,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 return c;
             }
             case Alias:
-                var aliasCol = wrapColumn("Alias", getRealTable().getColumn("LSID"));
-                aliasCol.setDescription("Contains the list of aliases for this data object");
-                aliasCol.setFk(new MultiValuedForeignKey(new LookupForeignKey("LSID")
-                {
-                    @Override
-                    public TableInfo getLookupTableInfo()
-                    {
-                        return ExperimentService.get().getTinfoDataAliasMap();
-                    }
-                }, "Alias"));
-                aliasCol.setCalculated(false);
-                aliasCol.setNullable(true);
-                aliasCol.setRequired(false);
-                aliasCol.setDisplayColumnFactory(new AliasDisplayColumnFactory());
-                aliasCol.setConceptURI("http://www.labkey.org/exp/xml#alias");
-                aliasCol.setPropertyURI("http://www.labkey.org/exp/xml#alias");
-                return aliasCol;
+                return createAliasColumn(alias, ExperimentService.get()::getTinfoDataAliasMap);
 
             case Inputs:
                 return createLineageColumn(this, alias, true);
@@ -814,42 +798,6 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                     }
                 }
             }
-        }
-    }
-
-    static class AliasDisplayColumnFactory implements DisplayColumnFactory
-    {
-        @Override
-        public DisplayColumn createRenderer(ColumnInfo colInfo)
-        {
-            DataColumn dataColumn = new DataColumn(colInfo);
-            dataColumn.setInputType("text");
-
-            return new MultiValuedDisplayColumn(dataColumn, true)
-            {
-                @Override
-                public Object getInputValue(RenderContext ctx)
-                {
-                    Object value =  super.getInputValue(ctx);
-                    StringBuilder sb = new StringBuilder();
-                    if (value instanceof List)
-                    {
-                        String delim = "";
-                        for (Object item : (List)value)
-                        {
-                            if (item != null)
-                            {
-                                String name = new TableSelector(ExperimentService.get().getTinfoAlias(), Collections.singleton("Name")).getObject(item, String.class);
-
-                                sb.append(delim);
-                                sb.append(name);
-                                delim = ",";
-                            }
-                        }
-                    }
-                    return sb.toString();
-                }
-            };
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.java
@@ -57,6 +57,7 @@ import org.labkey.api.exp.property.DomainTemplateGroup;
 import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.exp.property.Lookup;
 import org.labkey.api.exp.property.PropertyService;
+import org.labkey.api.exp.query.ExpDataTable;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTIndex;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
@@ -69,11 +70,17 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.reader.MapLoader;
+import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.ConceptURIProperties;
 import org.labkey.api.test.TestWhen;
 import org.labkey.api.util.TestContext;
+import org.labkey.remoteapi.ApiKeyCredentialsProvider;
+import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.query.Filter;
+import org.labkey.remoteapi.query.SelectRowsCommand;
+import org.labkey.remoteapi.query.SelectRowsResponse;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -84,11 +91,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * User: kevink
@@ -334,7 +343,10 @@ public class ExpDataClassDataTestCase extends ExpProvisionedTableTestHelper
         int count = table.getUpdateService().loadRows(user, c, mapLoader, new DataIteratorContext(), null);
         assertEquals(2, count);
         assertEquals(2, dataClass.getDatas().size());
-        verifyAliases(new ArrayList<>(Arrays.asList("a", "b", "c")));
+
+        int rowId = new TableSelector(table, Set.of("rowId"), new SimpleFilter("aa", 50).addCondition("bb", "zz"), null).getObject(Integer.class);
+
+        verifyAliases(table, rowId, Set.of("a", "b", "c"));
     }
 
     private void testDeleteExpData(ExpDataClassImpl dataClass, User user, int expectedCount)
@@ -374,23 +386,76 @@ public class ExpDataClassDataTestCase extends ExpProvisionedTableTestHelper
         Map<String, Object> row = new CaseInsensitiveHashMap<>();
         row.put("aa", 20);
         row.put("bb", "bye");
-        row.put("alias", "aa");
+        row.put("alias", "aa,bb");
         rows.add(row);
 
+        int insertedRowId = -1;
         try (DbScope.Transaction tx = table.getSchema().getScope().beginTransaction())
         {
             List<Map<String, Object>> ret = insertRows(c, rows, table.getName());
-            verifyAliases(new ArrayList<>(Arrays.asList("aa")));
+            insertedRowId = (Integer)ret.get(0).get("rowId");
             tx.commit();
         }
+
+        verifyAliases(table, insertedRowId, Set.of("aa","bb"));
     }
 
-    private void verifyAliases(Collection<String> aliasNames)
+    private void verifyAliases(TableInfo table, int expDataRowId, Set<String> expectedAliases) throws Exception
     {
-        for (String name : aliasNames)
+        for (String name : expectedAliases)
         {
             assertEquals(new TableSelector(ExperimentService.get().getTinfoAlias(),
                     new SimpleFilter(FieldKey.fromParts("name"), name), null).getRowCount(), 1);
+        }
+
+        ExpData data = ExperimentService.get().getExpData(expDataRowId);
+        Collection<String> actualAliases = data.getAliases();
+        assertEquals(new HashSet<>(actualAliases), expectedAliases);
+
+        verifyAliasesViaSelectRows("exp", "Data", expDataRowId, expectedAliases);
+        verifyAliasesViaSelectRows("exp.data", table.getPublicName(), expDataRowId, expectedAliases);
+    }
+
+    private void verifyAliasesViaSelectRows(String schemaName, String queryName, int expDataRowId, Set<String> expectedAliases)
+            throws Exception
+    {
+        String apiKey = SecurityManager.beginTransformSession(TestContext.get().getUser());
+        try
+        {
+            String baseURL = AppProps.getInstance().getBaseServerUrl() + AppProps.getInstance().getContextPath();
+            Connection conn = new Connection(baseURL, new ApiKeyCredentialsProvider(apiKey));
+            SelectRowsCommand cmd = new SelectRowsCommand(schemaName, queryName);
+            cmd.setRequiredVersion(17.1);
+            cmd.setColumns(List.of("RowId", "Name", ExpDataTable.Column.Alias.name()));
+            cmd.setFilters(List.of(new Filter("rowId", expDataRowId, Filter.Operator.EQUAL)));
+            SelectRowsResponse resp = cmd.execute(conn, c.getPath());
+
+            assertEquals(1, resp.getRowCount().intValue());
+            Map<String, Object> row0 = resp.getRows().get(0);
+            Map<String, Object> row0data = (Map<String, Object>)row0.get("data");
+            // expected 17.1 format for the row's data:
+            // {
+            //    "RowId": {
+            //        "value": 88080, "url": "..."
+            //    },
+            //    "Name": {
+            //        "value": "JUNIT-5-50", "url": "..."
+            //    },
+            //    "Alias": [{
+            //        "displayValue": "a", "value": 4
+            //    },{
+            //        "displayValue": "c", "value": 6
+            //    },{
+            //        "displayValue": "b", "value": 989
+            //    }]
+            //}
+            List<Map<String, Object>> row0aliases = (List<Map<String, Object>>)row0data.get(ExpDataTable.Column.Alias.name());
+            Set<String> aliases = row0aliases.stream().map(m -> (String)m.get("displayValue")).collect(Collectors.toSet());
+            assertEquals(aliases, expectedAliases);
+        }
+        finally
+        {
+            SecurityManager.endTransformSession(apiKey);
         }
     }
 
@@ -447,9 +512,9 @@ public class ExpDataClassDataTestCase extends ExpProvisionedTableTestHelper
         assertEquals("testingFromTemplate", t.getTableName());
 
         DomainKind kind = domain.getDomainKind();
-        Assert.assertTrue(kind instanceof DataClassDomainKind);
+        assertTrue(kind instanceof DataClassDomainKind);
         Set<String> mandatory = kind.getMandatoryPropertyNames(domain);
-        Assert.assertTrue("Expected template to set 'aa' as mandatory: " + mandatory, mandatory.contains("aa"));
+        assertTrue("Expected template to set 'aa' as mandatory: " + mandatory, mandatory.contains("aa"));
 
         ExpDataClassImpl dataClass = (ExpDataClassImpl)ExperimentService.get().getDataClass(c, domainName);
         Assert.assertNotNull(dataClass);
@@ -597,7 +662,7 @@ public class ExpDataClassDataTestCase extends ExpProvisionedTableTestHelper
         ExpData data = ExperimentServiceImpl.get().getExpData(dataClass, "TODO-1");
 
         Collection<String> aliases = data.getAliases();
-        Assert.assertTrue("Expected aliases to contain 'xsd' and 'domain templates', got: " + aliases, aliases.containsAll(Arrays.asList("xsd", "domain templates")));
+        assertTrue("Expected aliases to contain 'xsd' and 'domain templates', got: " + aliases, aliases.containsAll(Arrays.asList("xsd", "domain templates")));
     }
 
 
@@ -707,10 +772,10 @@ public class ExpDataClassDataTestCase extends ExpProvisionedTableTestHelper
             // sqlserver only error
             String msg = ex.getMessage();
             String expected = "Error creating index over 'aa, bb'";
-            Assert.assertTrue("Expected \"" + expected + "\", got \"" + msg + "\"", msg.contains(expected));
+            assertTrue("Expected \"" + expected + "\", got \"" + msg + "\"", msg.contains(expected));
 
             expected = "Index over large columns currently only supported for a single string column";
-            Assert.assertTrue("Expected \"" + expected + "\", got \"" + msg + "\"", msg.contains(expected));
+            assertTrue("Expected \"" + expected + "\", got \"" + msg + "\"", msg.contains(expected));
         }
     }
 
@@ -766,12 +831,12 @@ public class ExpDataClassDataTestCase extends ExpProvisionedTableTestHelper
             if (sqlServer)
             {
                 // Check error message from trigger script is propagated up on SqlServer
-                Assert.assertTrue("Expected error to start with '" + SqlDialect.CUSTOM_UNIQUE_ERROR_MESSAGE + "', got '" + e.getMessage() + "'",
+                assertTrue("Expected error to start with '" + SqlDialect.CUSTOM_UNIQUE_ERROR_MESSAGE + "', got '" + e.getMessage() + "'",
                         e.getMessage().startsWith(SqlDialect.CUSTOM_UNIQUE_ERROR_MESSAGE));
             }
             Throwable t = e.getLastRowError().getGlobalError(0).getCause();
-            Assert.assertTrue("Expected a SQLException", t instanceof SQLException);
-            Assert.assertTrue("Expected a constraint violation", RuntimeSQLException.isConstraintException((SQLException)t));
+            assertTrue("Expected a SQLException", t instanceof SQLException);
+            assertTrue("Expected a constraint violation", RuntimeSQLException.isConstraintException((SQLException)t));
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
@@ -54,6 +54,7 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.PropertyService;
+import org.labkey.api.exp.query.ExpDataClassDataTable;
 import org.labkey.api.exp.query.ExpDataTable;
 import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.exp.query.SamplesSchema;
@@ -120,6 +121,8 @@ public class ExpDataTableImpl extends ExpRunItemTableImpl<ExpDataTable.Column> i
         addColumn(Column.RowId).setHidden(true);
         addColumn(Column.Name);
         addColumn(Column.Description);
+        var aliasCol = addColumn(Column.Alias);
+        aliasCol.setHidden(true);
         addColumn(Column.DataClass);
         ExpSchema schema = getExpSchema();
         addColumn(Column.Run).setFk(schema.getRunIdForeignKey(getContainerFilter()));
@@ -331,6 +334,8 @@ public class ExpDataTableImpl extends ExpRunItemTableImpl<ExpDataTable.Column> i
                 return runId;
             case Flag:
                 return createFlagColumn(alias);
+            case Alias:
+                return createAliasColumn(alias, ExperimentService.get()::getTinfoDataAliasMap);
             case DownloadLink:
             {
                 var result = wrapColumn(alias, _rootTable.getColumn("RowId"));

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -297,28 +297,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             case ModifiedBy:
                 return createUserColumn(alias, _rootTable.getColumn("ModifiedBy"));
             case Alias:
-                var aliasCol = wrapColumn("Alias", getRealTable().getColumn("LSID"));
-                aliasCol.setDescription("Contains the list of aliases for this data object");
-                aliasCol.setFk(new MultiValuedForeignKey(new LookupForeignKey("LSID") {
-                    @Override
-                    public TableInfo getLookupTableInfo()
-                    {
-                        return ExperimentService.get().getTinfoMaterialAliasMap();
-                    }
-                    }, "Alias")
-                {
-                    @Override
-                    public boolean isMultiSelectInput()
-                    {
-                        return false;
-                    }
-                });
-                aliasCol.setCalculated(false);
-                aliasCol.setNullable(true);
-                aliasCol.setRequired(false);
-                aliasCol.setDisplayColumnFactory(new ExpDataClassDataTableImpl.AliasDisplayColumnFactory());
-
-                return aliasCol;
+                return createAliasColumn(alias, ExperimentService.get()::getTinfoMaterialAliasMap);
 
             case Inputs:
                 return createLineageColumn(this, alias, true);


### PR DESCRIPTION
#### Rationale
Expose the alias column on exp.Data query table which is useful when querying across DataClass types.  Backport #1712 to 20.11 branch

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1712