### PR TITLE
Deprecate PostgreSQL 9.5

### DIFF
--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -72,7 +72,7 @@ import java.util.stream.Collectors;
 // track changes we've implemented for each version over time.
 public abstract class PostgreSql91Dialect extends SqlDialect
 {
-    protected static final int TEMPTABLE_GENERATOR_MINSIZE = 1000;
+    public static final int TEMPTABLE_GENERATOR_MINSIZE = 1000;
 
     private final Map<String, Integer> _domainScaleMap = new ConcurrentHashMap<>();
     private final AtomicBoolean _arraySortFunctionExists = new AtomicBoolean(false);

--- a/api/src/org/labkey/api/module/JavaVersion.java
+++ b/api/src/org/labkey/api/module/JavaVersion.java
@@ -79,7 +79,7 @@ public enum JavaVersion
         JavaVersion jv = get(version);
 
         if (JAVA_UNSUPPORTED == jv)
-            throw new ConfigurationException("Unsupported Java runtime version: " + getJavaVersionDescription() + ". LabKey Server requires Java 13 or Java 14. We recommend installing " + getRecommendedJavaVersion() + ".");
+            throw new ConfigurationException("Unsupported Java runtime version: " + getJavaVersionDescription() + ". We recommend installing " + getRecommendedJavaVersion() + ".");
 
         return jv;
     }

--- a/assay/src/org/labkey/assay/view/AssayGWTView.java
+++ b/assay/src/org/labkey/assay/view/AssayGWTView.java
@@ -36,20 +36,15 @@ public class AssayGWTView extends GWTView
 
     public AssayGWTView(Class<? extends EntryPoint> clss, Map<String, String> properties)
     {
-        this(clss.getName(), properties);
-    }
-
-    public AssayGWTView(String clss, Map<String, String> properties)
-    {
         super("gwt.AssayApplication", properties);
         for (AssayApplication.GWTModule m : AssayApplication.GWTModule.values())
         {
-            if (m.className.equals(clss))
+            if (m.className.equals(clss.getName()))
             {
                 getModelBean().getProperties().put("GWTModule", m.getClass().getSimpleName());
                 return;
             }
         }
-        throw new IllegalArgumentException(clss);
+        throw new IllegalArgumentException(clss.getName());
     }
 }

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -99,7 +99,6 @@ import org.labkey.api.security.roles.PlatformDeveloperRole;
 import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
-import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.ConfigProperty;
@@ -183,8 +182,8 @@ import org.labkey.core.admin.writer.SecurityGroupWriterFactory;
 import org.labkey.core.analytics.AnalyticsController;
 import org.labkey.core.analytics.AnalyticsServiceImpl;
 import org.labkey.core.attachment.AttachmentServiceImpl;
-import org.labkey.core.dialect.PostgreSql92Dialect;
 import org.labkey.core.dialect.PostgreSqlDialectFactory;
+import org.labkey.core.dialect.PostgreSqlInClauseTest;
 import org.labkey.core.dialect.PostgreSqlVersion;
 import org.labkey.core.junit.JunitController;
 import org.labkey.core.login.DbLoginAuthenticationProvider;
@@ -1079,7 +1078,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             ModulePropertiesTestCase.class,
             NotificationServiceImpl.TestCase.class,
             PortalJUnitTest.class,
-            PostgreSql92Dialect.TestCase.class,
+            PostgreSqlInClauseTest.class,
             ProductRegistry.TestCase.class,
             RadeoxRenderer.RadeoxRenderTest.class,
             SchemaXMLTestCase.class,

--- a/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
@@ -48,7 +48,7 @@ import java.util.regex.Pattern;
  * Date: 5/21/12
  * Time: 8:52 AM
  */
-public abstract class PostgreSql92Dialect extends PostgreSql91Dialect
+abstract class PostgreSql92Dialect extends PostgreSql91Dialect
 {
     protected PostgreSql92Dialect()
     {
@@ -126,49 +126,4 @@ public abstract class PostgreSql92Dialect extends PostgreSql91Dialect
         _inClauseGenerator = getJdbcVersion(scope) >= 4 ? new ArrayParameterInClauseGenerator(scope) : new ParameterMarkerInClauseGenerator();
     }
 
-    /*
-     TestCase migrated from PostgreSql91Dialect when that class promoted to api.
-     */
-    public static class TestCase extends Assert
-    {
-        PostgreSql92Dialect getDialect()
-        {
-            DbSchema core = CoreSchema.getInstance().getSchema();
-            SqlDialect d = core.getSqlDialect();
-            if (d instanceof PostgreSql92Dialect)
-                return (PostgreSql92Dialect)d;
-            return null;
-        }
-
-        @Test
-        public void testInClause()
-        {
-            PostgreSql92Dialect d = getDialect();
-            if (null == d)
-                return;
-            DbSchema core = CoreSchema.getInstance().getSchema();
-
-            SQLFragment shortSql = new SQLFragment("SELECT COUNT(*) FROM core.usersdata WHERE userid ");
-            d.appendInClauseSql(shortSql, Arrays.asList(1, 2, 3));
-            assertEquals(1, new SqlSelector(core, shortSql).getRowCount());
-
-            ArrayList<Object> l = new ArrayList<>();
-            for (int i=1 ; i<=TEMPTABLE_GENERATOR_MINSIZE+1 ; i++)
-                l.add(i);
-            SQLFragment longSql = new SQLFragment("SELECT COUNT(*) FROM core.usersdata WHERE userid ");
-            d.appendInClauseSql(longSql, l);
-            assertEquals(1, new SqlSelector(core, longSql).getRowCount());
-
-            SQLFragment shortSqlStr = new SQLFragment("SELECT COUNT(*) FROM core.usersdata WHERE displayname ");
-            d.appendInClauseSql(shortSqlStr, Arrays.asList("1", "2", "3"));
-            assertEquals(1, new SqlSelector(core, shortSqlStr).getRowCount());
-
-            l = new ArrayList<>();
-            for (int i=1 ; i<=TEMPTABLE_GENERATOR_MINSIZE+1 ; i++)
-                l.add(String.valueOf(i));
-            SQLFragment longSqlStr = new SQLFragment("SELECT COUNT(*) FROM core.usersdata WHERE displayname ");
-            d.appendInClauseSql(longSqlStr, l);
-            assertEquals(1, new SqlSelector(core, longSqlStr).getRowCount());
-        }
-    }
 }

--- a/core/src/org/labkey/core/dialect/PostgreSql93Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql93Dialect.java
@@ -27,7 +27,7 @@ import java.util.Set;
  * Date: Jun 14, 2013
  * Time: 8:50:00 AM
  */
-public abstract class PostgreSql93Dialect extends PostgreSql92Dialect
+abstract class PostgreSql93Dialect extends PostgreSql92Dialect
 {
     public PostgreSql93Dialect()
     {

--- a/core/src/org/labkey/core/dialect/PostgreSql94Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql94Dialect.java
@@ -26,7 +26,7 @@ import java.util.Set;
  * Date: 8/5/2014
  * Time: 10:49 PM
  */
-public abstract class PostgreSql94Dialect extends PostgreSql93Dialect
+abstract class PostgreSql94Dialect extends PostgreSql93Dialect
 {
     private HtmlString _adminWarning = null;
 

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -92,7 +92,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
         if (PostgreSqlVersion.POSTGRESQL_UNSUPPORTED == psv)
             throw new DatabaseNotSupportedException(PRODUCT_NAME + " version " + databaseProductVersion + " is not supported. You must upgrade your database server installation; " + RECOMMENDED);
 
-        PostgreSql94Dialect dialect = psv.getDialect();
+        PostgreSql95Dialect dialect = psv.getDialect();
 
         if (logWarnings)
         {

--- a/core/src/org/labkey/core/dialect/PostgreSqlInClauseTest.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlInClauseTest.java
@@ -1,0 +1,59 @@
+package org.labkey.core.dialect;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.labkey.api.data.CoreSchema;
+import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SqlSelector;
+import org.labkey.api.data.dialect.PostgreSql91Dialect;
+import org.labkey.api.data.dialect.SqlDialect;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/*
+ TestCase migrated from PostgreSql91Dialect when that class promoted to api.
+ */
+public class PostgreSqlInClauseTest extends Assert
+{
+    private PostgreSql95Dialect getDialect()
+    {
+        DbSchema core = CoreSchema.getInstance().getSchema();
+        SqlDialect d = core.getSqlDialect();
+        if (d instanceof PostgreSql95Dialect)
+            return (PostgreSql95Dialect) d;
+        return null;
+    }
+
+    @Test
+    public void testInClause()
+    {
+        PostgreSql95Dialect d = getDialect();
+        if (null == d)
+            return;
+        DbSchema core = CoreSchema.getInstance().getSchema();
+
+        SQLFragment shortSql = new SQLFragment("SELECT COUNT(*) FROM core.usersdata WHERE userid ");
+        d.appendInClauseSql(shortSql, Arrays.asList(1, 2, 3));
+        assertEquals(1, new SqlSelector(core, shortSql).getRowCount());
+
+        ArrayList<Object> l = new ArrayList<>();
+        for (int i = 1; i <= PostgreSql91Dialect.TEMPTABLE_GENERATOR_MINSIZE + 1; i++)
+            l.add(i);
+        SQLFragment longSql = new SQLFragment("SELECT COUNT(*) FROM core.usersdata WHERE userid ");
+        d.appendInClauseSql(longSql, l);
+        assertEquals(1, new SqlSelector(core, longSql).getRowCount());
+
+        SQLFragment shortSqlStr = new SQLFragment("SELECT COUNT(*) FROM core.usersdata WHERE displayname ");
+        d.appendInClauseSql(shortSqlStr, Arrays.asList("1", "2", "3"));
+        assertEquals(1, new SqlSelector(core, shortSqlStr).getRowCount());
+
+        l = new ArrayList<>();
+        for (int i = 1; i <= PostgreSql91Dialect.TEMPTABLE_GENERATOR_MINSIZE + 1; i++)
+            l.add(String.valueOf(i));
+        SQLFragment longSqlStr = new SQLFragment("SELECT COUNT(*) FROM core.usersdata WHERE displayname ");
+        d.appendInClauseSql(longSqlStr, l);
+        assertEquals(1, new SqlSelector(core, longSqlStr).getRowCount());
+    }
+}

--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 public enum PostgreSqlVersion
 {
     POSTGRESQL_UNSUPPORTED(-1, true, false, null),
-    POSTGRESQL_95(95, false, true, PostgreSql95Dialect::new),
+    POSTGRESQL_95(95, true, true, PostgreSql95Dialect::new),
     POSTGRESQL_96(96, false, true, PostgreSql96Dialect::new),
     POSTGRESQL_10(100, false, true, PostgreSql_10_Dialect::new),
     POSTGRESQL_11(110, false, true, PostgreSql_11_Dialect::new),
@@ -27,9 +27,9 @@ public enum PostgreSqlVersion
     private final int _version;
     private final boolean _deprecated;
     private final boolean _tested;
-    private final Supplier<? extends PostgreSql94Dialect> _dialectFactory;
+    private final Supplier<? extends PostgreSql95Dialect> _dialectFactory;
 
-    PostgreSqlVersion(int version, boolean deprecated, boolean tested, Supplier<? extends PostgreSql94Dialect> dialectFactory)
+    PostgreSqlVersion(int version, boolean deprecated, boolean tested, Supplier<? extends PostgreSql95Dialect> dialectFactory)
     {
         _version = version;
         _deprecated = deprecated;
@@ -48,7 +48,7 @@ public enum PostgreSqlVersion
         return _tested;
     }
 
-    public PostgreSql94Dialect getDialect()
+    public PostgreSql95Dialect getDialect()
     {
         return _dialectFactory.get();
     }

--- a/study/src/org/labkey/study/view/StudyGWTView.java
+++ b/study/src/org/labkey/study/view/StudyGWTView.java
@@ -30,20 +30,15 @@ public class StudyGWTView extends GWTView
 {
     public StudyGWTView(Class<? extends EntryPoint> clss, Map<String, String> properties)
     {
-        this(clss.getName(), properties);
-    }
-
-    public StudyGWTView(String clss, Map<String, String> properties)
-    {
         super("gwt.StudyApplication", properties);
         for (StudyApplication.GWTModule m : StudyApplication.GWTModule.values())
         {
-            if (m.className.equals(clss))
+            if (m.className.equals(clss.getName()))
             {
                 getModelBean().getProperties().put("GWTModule", m.getClass().getSimpleName());
                 return;
             }
         }
-        throw new IllegalArgumentException(clss);
+        throw new IllegalArgumentException(clss.getName());
     }
 }


### PR DESCRIPTION
#### Rationale
PostgreSQL 9.5 will reach end-of-life on [February 11, 2021](https://www.postgresql.org/support/versioning/), before the LabKey Server 21.3 release. Since 9.5 will no longer be supported, we will deprecate it in 21.3 (allowing its use for this version, but warning administrators to upgrade ASAP).

#### Changes
* Deprecate PostgreSQL 9.5
* Eliminate most references and reduce visibility of unsupported versions
* Correct inaccurate "java version requirement" message by removing it
