### PR TITLE
Issue 41655: AuditHandler fix for NPE test failures

### DIFF
--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -108,7 +108,6 @@ public abstract class AuditHandler
                             case UPDATE:
                             {
                                 Pair<Map<String, Object>, Map<String, Object>> rowPair = AuditHandler.getOldAndNewRecordForMerge(row, updatedRow, table.getExtraDetailedUpdateAuditFields());
-                                // record modified fields
                                 Map<String, Object> originalRow = rowPair.first;
                                 Map<String, Object> modifiedRow = rowPair.second;
 
@@ -133,7 +132,7 @@ public abstract class AuditHandler
         }
     }
 
-    public static Pair<Map<String, Object>, Map<String, Object>> getOldAndNewRecordForMerge(@NotNull Map<String, Object> row, @NotNull Map<String, Object> updatedRow, @NotNull Set<String> extraFieldsToInclude)
+    public static Pair<Map<String, Object>, Map<String, Object>> getOldAndNewRecordForMerge(@NotNull Map<String, Object> row, @NotNull Map<String, Object> updatedRow, Set<String> extraFieldsToInclude)
     {
         // record modified fields
         Map<String, Object> originalRow = new HashMap<>();
@@ -141,7 +140,7 @@ public abstract class AuditHandler
 
         for (Map.Entry<String, Object> entry : row.entrySet())
         {
-            boolean isExtraAuditField = extraFieldsToInclude.contains(entry.getKey());
+            boolean isExtraAuditField = extraFieldsToInclude != null && extraFieldsToInclude.contains(entry.getKey());
             if (updatedRow.containsKey(entry.getKey()))
             {
                 Object newValue = updatedRow.get(entry.getKey());


### PR DESCRIPTION
#### Rationale
Issue [41655](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41655): Audit log parity between sample timeline and datasets, esp new vs old record values

See related PR for the actual issue fixes. This PR is to address some NPE automated test failures in premium modules.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1710

#### Changes
* Add back null check in AuditHander. getOldAndNewRecordForMerge
