### PR TITLE
@labkey/components package update to pull in patches for release20.11

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "1.1.1-fb-mergeFrom2011.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.1.1-fb-mergeFrom2011.2.tgz",
-      "integrity": "sha1-Y6RH6Rv23hH1PBX0Yk6ZGb8WzCg=",
+      "version": "1.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.2.0.tgz",
+      "integrity": "sha1-sMrX162PC2dawcCiCYqzoJMhkA8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.105.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.105.0.tgz",
-      "integrity": "sha1-ONfmfCdDKGHp2MLtUfw8e1qUdMQ=",
+      "version": "1.1.1-fb-mergeFrom2011.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.1.1-fb-mergeFrom2011.2.tgz",
+      "integrity": "sha1-Y6RH6Rv23hH1PBX0Yk6ZGb8WzCg=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.105.0"
+    "@labkey/components": "1.1.1-fb-mergeFrom2011.2"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "1.1.1-fb-mergeFrom2011.2"
+    "@labkey/components": "1.2.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2394,9 +2394,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.105.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.105.0.tgz",
-      "integrity": "sha1-ONfmfCdDKGHp2MLtUfw8e1qUdMQ=",
+      "version": "1.1.1-fb-mergeFrom2011.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.1.1-fb-mergeFrom2011.2.tgz",
+      "integrity": "sha1-Y6RH6Rv23hH1PBX0Yk6ZGb8WzCg=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2394,9 +2394,9 @@
       }
     },
     "@labkey/components": {
-      "version": "1.1.1-fb-mergeFrom2011.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.1.1-fb-mergeFrom2011.2.tgz",
-      "integrity": "sha1-Y6RH6Rv23hH1PBX0Yk6ZGb8WzCg=",
+      "version": "1.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.2.0.tgz",
+      "integrity": "sha1-sMrX162PC2dawcCiCYqzoJMhkA8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/core/package.json
+++ b/core/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.1.1",
-    "@labkey/components": "1.1.1-fb-mergeFrom2011.2",
+    "@labkey/components": "1.2.0",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.0.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.1.1",
-    "@labkey/components": "0.105.0",
+    "@labkey/components": "1.1.1-fb-mergeFrom2011.2",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.0.0"
   },

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "1.1.1-fb-mergeFrom2011.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.1.1-fb-mergeFrom2011.2.tgz",
-      "integrity": "sha1-Y6RH6Rv23hH1PBX0Yk6ZGb8WzCg=",
+      "version": "1.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.2.0.tgz",
+      "integrity": "sha1-sMrX162PC2dawcCiCYqzoJMhkA8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.105.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.105.0.tgz",
-      "integrity": "sha1-ONfmfCdDKGHp2MLtUfw8e1qUdMQ=",
+      "version": "1.1.1-fb-mergeFrom2011.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.1.1-fb-mergeFrom2011.2.tgz",
+      "integrity": "sha1-Y6RH6Rv23hH1PBX0Yk6ZGb8WzCg=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.105.0"
+    "@labkey/components": "1.1.1-fb-mergeFrom2011.2"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "1.1.1-fb-mergeFrom2011.2"
+    "@labkey/components": "1.2.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "1.1.1-fb-mergeFrom2011.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.1.1-fb-mergeFrom2011.2.tgz",
-      "integrity": "sha1-Y6RH6Rv23hH1PBX0Yk6ZGb8WzCg=",
+      "version": "1.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.2.0.tgz",
+      "integrity": "sha1-sMrX162PC2dawcCiCYqzoJMhkA8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.105.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.105.0.tgz",
-      "integrity": "sha1-ONfmfCdDKGHp2MLtUfw8e1qUdMQ=",
+      "version": "1.1.1-fb-mergeFrom2011.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.1.1-fb-mergeFrom2011.2.tgz",
+      "integrity": "sha1-Y6RH6Rv23hH1PBX0Yk6ZGb8WzCg=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/issues/package.json
+++ b/issues/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/issues/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "1.1.1-fb-mergeFrom2011.2"
+    "@labkey/components": "1.2.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/issues/package.json
+++ b/issues/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/issues/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.105.0"
+    "@labkey/components": "1.1.1-fb-mergeFrom2011.2"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "1.1.1-fb-mergeFrom2011.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.1.1-fb-mergeFrom2011.2.tgz",
-      "integrity": "sha1-Y6RH6Rv23hH1PBX0Yk6ZGb8WzCg=",
+      "version": "1.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.2.0.tgz",
+      "integrity": "sha1-sMrX162PC2dawcCiCYqzoJMhkA8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.105.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.105.0.tgz",
-      "integrity": "sha1-ONfmfCdDKGHp2MLtUfw8e1qUdMQ=",
+      "version": "1.1.1-fb-mergeFrom2011.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.1.1-fb-mergeFrom2011.2.tgz",
+      "integrity": "sha1-Y6RH6Rv23hH1PBX0Yk6ZGb8WzCg=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/list/package.json
+++ b/list/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/list/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "0.105.0"
+    "@labkey/components": "1.1.1-fb-mergeFrom2011.2"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/list/package.json
+++ b/list/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/list/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "1.1.1-fb-mergeFrom2011.2"
+    "@labkey/components": "1.2.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "1.1.1-fb-mergeFrom2011.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.1.1-fb-mergeFrom2011.2.tgz",
-      "integrity": "sha1-Y6RH6Rv23hH1PBX0Yk6ZGb8WzCg=",
+      "version": "1.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.2.0.tgz",
+      "integrity": "sha1-sMrX162PC2dawcCiCYqzoJMhkA8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.105.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.105.0.tgz",
-      "integrity": "sha1-ONfmfCdDKGHp2MLtUfw8e1qUdMQ=",
+      "version": "1.1.1-fb-mergeFrom2011.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.1.1-fb-mergeFrom2011.2.tgz",
+      "integrity": "sha1-Y6RH6Rv23hH1PBX0Yk6ZGb8WzCg=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/query/package.json
+++ b/query/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/query/gen && rimraf resources/views/gen  && rimraf resources/views/queryMetadataEditor*"
   },
   "dependencies": {
-    "@labkey/components": "0.105.0"
+    "@labkey/components": "1.1.1-fb-mergeFrom2011.2"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/query/package.json
+++ b/query/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/query/gen && rimraf resources/views/gen  && rimraf resources/views/queryMetadataEditor*"
   },
   "dependencies": {
-    "@labkey/components": "1.1.1-fb-mergeFrom2011.2"
+    "@labkey/components": "1.2.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "1.1.1-fb-mergeFrom2011.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.1.1-fb-mergeFrom2011.2.tgz",
-      "integrity": "sha1-Y6RH6Rv23hH1PBX0Yk6ZGb8WzCg=",
+      "version": "1.2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.2.0.tgz",
+      "integrity": "sha1-sMrX162PC2dawcCiCYqzoJMhkA8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -1356,9 +1356,9 @@
       }
     },
     "@labkey/components": {
-      "version": "0.105.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-0.105.0.tgz",
-      "integrity": "sha1-ONfmfCdDKGHp2MLtUfw8e1qUdMQ=",
+      "version": "1.1.1-fb-mergeFrom2011.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.1.1-fb-mergeFrom2011.2.tgz",
+      "integrity": "sha1-Y6RH6Rv23hH1PBX0Yk6ZGb8WzCg=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.14.0",
         "@fortawesome/fontawesome-svg-core": "1.2.30",

--- a/study/package.json
+++ b/study/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/study/gen && rimraf resources/views/gen && rimraf resources/views/datasetDesigner*"
   },
   "dependencies": {
-    "@labkey/components": "0.105.0"
+    "@labkey/components": "1.1.1-fb-mergeFrom2011.2"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"

--- a/study/package.json
+++ b/study/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/study/gen && rimraf resources/views/gen && rimraf resources/views/datasetDesigner*"
   },
   "dependencies": {
-    "@labkey/components": "1.1.1-fb-mergeFrom2011.2"
+    "@labkey/components": "1.2.0"
   },
   "devDependencies": {
     "@labkey/build": "0.4.0"


### PR DESCRIPTION
#### Rationale
Now that the release20.11 changes have been merged to develop for platform, we need to bring in the package updates for the related @labkey/components changes.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/393

#### Changes
* Issue 41460: Type conflict on infer fields
* Issue 41854: Wording updates for domain designer error dialog
* Item 8058: Domain form support for new Ontology Lookup data type and expanded row input options
