### PR TITLE
Show diff in audit logs when doing a merge on import if possible

### DIFF
--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -120,20 +120,7 @@ public abstract class AuditHandler
                             }
                             case UPDATE:
                             {
-                                Pair<Map<String, Object>, Map<String, Object>> rowPair = AuditHandler.getOldAndNewRecordForMerge(row, updatedRow, table.getExtraDetailedUpdateAuditFields());
-                                Map<String, Object> originalRow = rowPair.first;
-                                Map<String, Object> modifiedRow = rowPair.second;
-
-                                // allow for adding fields that may be present in the updated row but not represented in the original row
-                                addDetailedModifiedFields(row, modifiedRow, updatedRow);
-
-                                String oldRecord = AbstractAuditTypeProvider.encodeForDataMap(c, originalRow);
-                                if (oldRecord != null)
-                                    event.setOldRecordMap(oldRecord);
-
-                                String newRecord = AbstractAuditTypeProvider.encodeForDataMap(c, modifiedRow);
-                                if (newRecord != null)
-                                    event.setNewRecordMap(newRecord);
+                                setOldAndNewMapsForUpdate(event, c, row, updatedRow, table);
                                 break;
                             }
                         }

--- a/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
+++ b/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
@@ -40,9 +40,9 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
             return _actionLabel;
         }
 
-        public static String getActionCommentDetailed(@NotNull QueryService.AuditAction action)
+        public static String getActionCommentDetailed(@NotNull QueryService.AuditAction action, boolean isUpdate)
         {
-            SampleTimelineEventType type = getTypeFromAction(action);
+            SampleTimelineEventType type = getTypeFromAction(action == QueryService.AuditAction.MERGE && isUpdate ? QueryService.AuditAction.UPDATE : action);
             return type == null ? null : type.getComment();
         }
 

--- a/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
+++ b/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
@@ -42,7 +42,12 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
 
         public static String getActionCommentDetailed(@NotNull QueryService.AuditAction action, boolean isUpdate)
         {
-            SampleTimelineEventType type = getTypeFromAction(action == QueryService.AuditAction.MERGE && isUpdate ? QueryService.AuditAction.UPDATE : action);
+
+            SampleTimelineEventType type;
+            if (action == QueryService.AuditAction.MERGE)
+                type = getTypeFromAction(isUpdate ? QueryService.AuditAction.UPDATE : QueryService.AuditAction.INSERT);
+            else
+                type = getTypeFromAction(action);
             return type == null ? null : type.getComment();
         }
 

--- a/api/src/org/labkey/api/inventory/InventoryService.java
+++ b/api/src/org/labkey/api/inventory/InventoryService.java
@@ -17,6 +17,7 @@ package org.labkey.api.inventory;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
@@ -29,6 +30,7 @@ import org.labkey.api.services.ServiceRegistry;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * User: kevink
@@ -37,6 +39,18 @@ import java.util.Map;
 public interface InventoryService
 {
     String PRODUCT_ID = "freezerManager";
+
+    public static Set<String> INVENTORY_STATUS_COLUMN_NAMES = new CaseInsensitiveHashSet(
+            "FreezeThawCount",
+            "CheckedOutBy",
+            "CheckedOut",
+            "DisplayUnit", // this is the name of the column, not the display name of "Units"
+            "StorageRow",
+            "StorageCol",
+            "StorageLocation",
+            "StoredAmount",
+            "EnteredStorage"
+    );
 
     static void setInstance(InventoryService impl)
     {

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -51,6 +51,7 @@ import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.exp.query.ExpDataTable;
 import org.labkey.api.query.AbstractQueryUpdateService;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.QueryUpdateService;
@@ -87,9 +88,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
-import static org.labkey.api.exp.api.ExperimentJSONConverter.CREATED;
-import static org.labkey.api.exp.api.ExperimentJSONConverter.CREATED_BY;
-import static org.labkey.api.exp.api.ExperimentJSONConverter.LSID;
+
 
 public class ExpDataIterators
 {
@@ -779,7 +778,7 @@ public class ExpDataIterators
         }
     }
 
-    public static final Set<String> NOT_FOR_UPDATE = Sets.newCaseInsensitiveHashSet(LSID, CREATED, CREATED_BY, "genId");
+    public static final Set<String> NOT_FOR_UPDATE = Sets.newCaseInsensitiveHashSet(ExpDataTable.Column.LSID.toString(), ExpDataTable.Column.Created.toString(), ExpDataTable.Column.CreatedBy.toString(), "genId");
 
     public static class PersistDataIteratorBuilder implements DataIteratorBuilder
     {
@@ -854,7 +853,7 @@ public class ExpDataIterators
             dontUpdate.addAll(NOT_FOR_UPDATE);
             CaseInsensitiveHashSet keyColumns = new CaseInsensitiveHashSet();
             if (isSample || !context.getInsertOption().mergeRows)
-                keyColumns.add(LSID);
+                keyColumns.add(ExpDataTable.Column.LSID.toString());
             else
             {
                 keyColumns.add("classid");

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -847,6 +847,8 @@ public class ExpDataIterators
 
             CaseInsensitiveHashSet dontUpdate = new CaseInsensitiveHashSet();
             dontUpdate.add("lsid");
+            dontUpdate.add("created");
+            dontUpdate.add("createdBy");
             CaseInsensitiveHashSet keyColumns = new CaseInsensitiveHashSet();
             if (isSample || !context.getInsertOption().mergeRows)
                 keyColumns.add("lsid");

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -87,6 +87,9 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+import static org.labkey.api.exp.api.ExperimentJSONConverter.CREATED;
+import static org.labkey.api.exp.api.ExperimentJSONConverter.CREATED_BY;
+import static org.labkey.api.exp.api.ExperimentJSONConverter.LSID;
 
 public class ExpDataIterators
 {
@@ -776,6 +779,8 @@ public class ExpDataIterators
         }
     }
 
+    public static final Set<String> NOT_FOR_UPDATE = Sets.newCaseInsensitiveHashSet(LSID, CREATED, CREATED_BY, "genId");
+
     public static class PersistDataIteratorBuilder implements DataIteratorBuilder
     {
         private final DataIteratorBuilder _in;
@@ -846,13 +851,10 @@ public class ExpDataIterators
                 step0.addColumn(AliasDataIterator.ALIASCOLUMNALIAS, colNameMap.get("alias")); // see AliasDataIteratorBuilder
 
             CaseInsensitiveHashSet dontUpdate = new CaseInsensitiveHashSet();
-            dontUpdate.add("lsid");
-            dontUpdate.add("created");
-            dontUpdate.add("createdBy");
-            dontUpdate.add("genId");
+            dontUpdate.addAll(NOT_FOR_UPDATE);
             CaseInsensitiveHashSet keyColumns = new CaseInsensitiveHashSet();
             if (isSample || !context.getInsertOption().mergeRows)
-                keyColumns.add("lsid");
+                keyColumns.add(LSID);
             else
             {
                 keyColumns.add("classid");

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -849,6 +849,7 @@ public class ExpDataIterators
             dontUpdate.add("lsid");
             dontUpdate.add("created");
             dontUpdate.add("createdBy");
+            dontUpdate.add("genId");
             CaseInsensitiveHashSet keyColumns = new CaseInsensitiveHashSet();
             if (isSample || !context.getInsertOption().mergeRows)
                 keyColumns.add("lsid");

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -160,8 +160,8 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                         try
                         {
                             SampleTypeUpdateServiceDI qus = (SampleTypeUpdateServiceDI) getUpdateService();
-                            if (qus != null) {
-
+                            if (qus != null)
+                            {
                                 List<Map<String, Object>> existingRows = qus.getRows(user, container, Collections.singletonList(Map.of("LSID", newRow.get(ExpDataTable.Column.LSID.toString()))), true);
                                 if (existingRows != null && !existingRows.isEmpty())
                                 {

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -30,12 +30,10 @@ import org.labkey.api.data.DataRegion;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.JdbcType;
-import org.labkey.api.data.MultiValuedForeignKey;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.Sort;
-import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.UnionContainerFilter;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
@@ -74,7 +72,6 @@ import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpression;
@@ -145,7 +142,9 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         // Special case sample auditing to help build a useful timeline view
         if (getUserSchema().getName().equalsIgnoreCase(SamplesSchema.SCHEMA_NAME))
         {
-            Map<String, Object> params = new CaseInsensitiveHashMap<>(parameters);
+            Map<String, Object> newRow = new CaseInsensitiveHashMap<>(parameters);
+            Map<String, Object> existingRow = null;
+            Object rowId = null;
             if (auditAction.equals(QueryService.AuditAction.MERGE))
             {
                 AuditBehaviorType sampleAuditType = auditBehavior;
@@ -156,15 +155,34 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 {
                     // material.rowid is a dbsequence column that auto increments during merge, even if rowId is not updated
                     // need to reselect rowId
-                    if (params.containsKey(LSID))
+                    if (newRow.containsKey(LSID))
                     {
-                        ExpMaterial sample = ExperimentService.get().getExpMaterial((String) params.get(LSID));
-                        if (sample != null)
-                            params.put(ROW_ID, sample.getRowId());
+                        try
+                        {
+                            QueryUpdateService qus = getUpdateService();
+                            if (qus != null) {
+                                List<Map<String, Object>> existingRows = qus.getRows(user, container, Collections.singletonList(Map.of("LSID", newRow.get(LSID))));
+                                if (existingRows != null && !existingRows.isEmpty()) {
+                                    existingRow = existingRows.get(0);
+                                    rowId = existingRow.get("RowId");
+                                }
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            ExpMaterial sample = ExperimentService.get().getExpMaterial((String) newRow.get(LSID));
+                            rowId = sample.getRowId();
+                        }
+
+                        if (rowId != null)
+                            newRow.put(ROW_ID, rowId);
                     }
                 }
             }
-            SampleTypeService.get().addAuditEvent(user, container, this, auditBehavior, userComment, auditAction, Collections.singletonList(params));
+            if (existingRow != null)
+                SampleTypeService.get().addAuditEvent(user, container, this, auditBehavior, userComment, auditAction, Collections.singletonList(existingRow), Collections.singletonList(newRow));
+            else
+                SampleTypeService.get().addAuditEvent(user, container, this, auditBehavior, userComment, auditAction, Collections.singletonList(newRow));
         }
         else
         {

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -161,14 +161,15 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                     {
                         try
                         {
-                            QueryUpdateService qus = getUpdateService();
+                            SampleTypeUpdateServiceDI qus = (SampleTypeUpdateServiceDI) getUpdateService();
                             if (qus != null) {
-                                List<Map<String, Object>> existingRows = qus.getRows(user, container, Collections.singletonList(Map.of("LSID", newRow.get(LSID))));
+                                List<Map<String, Object>> existingRows = qus.getRows(user, container, Collections.singletonList(Map.of("LSID", newRow.get(LSID))), true);
                                 if (existingRows != null && !existingRows.isEmpty()) {
                                     existingRow = existingRows.get(0);
                                     rowId = existingRow.get("RowId");
                                     existingRow.remove(CREATED); // These fields won't be updated
                                     existingRow.remove(CREATED_BY);
+                                    existingRow.remove("genId");
                                 }
                             }
                         }
@@ -183,6 +184,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                             newRow.put(ROW_ID, rowId);
                             newRow.remove(CREATED);
                             newRow.remove(CREATED_BY);
+                            newRow.remove("genId");
                         }
                     }
                 }

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -96,6 +96,7 @@ import static org.labkey.api.exp.api.ExperimentJSONConverter.CREATED;
 import static org.labkey.api.exp.api.ExperimentJSONConverter.CREATED_BY;
 import static org.labkey.api.exp.api.ExperimentJSONConverter.LSID;
 import static org.labkey.api.exp.api.ExperimentJSONConverter.ROW_ID;
+import static org.labkey.experiment.ExpDataIterators.NOT_FOR_UPDATE;
 
 public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.Column> implements ExpMaterialTable
 {
@@ -163,13 +164,12 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                         {
                             SampleTypeUpdateServiceDI qus = (SampleTypeUpdateServiceDI) getUpdateService();
                             if (qus != null) {
+
                                 List<Map<String, Object>> existingRows = qus.getRows(user, container, Collections.singletonList(Map.of("LSID", newRow.get(LSID))), true);
                                 if (existingRows != null && !existingRows.isEmpty()) {
+                                    NOT_FOR_UPDATE.forEach(name -> existingRows.get(0).remove(name));
                                     existingRow = existingRows.get(0);
-                                    rowId = existingRow.get("RowId");
-                                    existingRow.remove(CREATED); // These fields won't be updated
-                                    existingRow.remove(CREATED_BY);
-                                    existingRow.remove("genId");
+                                    rowId = existingRow.get(ROW_ID);
                                 }
                             }
                         }
@@ -182,9 +182,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                         if (rowId != null)
                         {
                             newRow.put(ROW_ID, rowId);
-                            newRow.remove(CREATED);
-                            newRow.remove(CREATED_BY);
-                            newRow.remove("genId");
+                            NOT_FOR_UPDATE.forEach(newRow::remove);
                         }
                     }
                 }

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -92,6 +92,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
+import static org.labkey.api.exp.api.ExperimentJSONConverter.CREATED;
+import static org.labkey.api.exp.api.ExperimentJSONConverter.CREATED_BY;
 import static org.labkey.api.exp.api.ExperimentJSONConverter.LSID;
 import static org.labkey.api.exp.api.ExperimentJSONConverter.ROW_ID;
 
@@ -165,6 +167,8 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                                 if (existingRows != null && !existingRows.isEmpty()) {
                                     existingRow = existingRows.get(0);
                                     rowId = existingRow.get("RowId");
+                                    existingRow.remove(CREATED); // These fields won't be updated
+                                    existingRow.remove(CREATED_BY);
                                 }
                             }
                         }
@@ -175,7 +179,11 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                         }
 
                         if (rowId != null)
+                        {
                             newRow.put(ROW_ID, rowId);
+                            newRow.remove(CREATED);
+                            newRow.remove(CREATED_BY);
+                        }
                     }
                 }
             }

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -181,6 +181,9 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                         {
                             newRow.put(ExpDataTable.Column.RowId.toString(), rowId);
                             NOT_FOR_UPDATE.forEach(newRow::remove);
+                            // We don't want the inventory columns to show up in the sample timeline audit record;
+                            // they are captured in their own audit record.
+                            InventoryService.INVENTORY_STATUS_COLUMN_NAMES.forEach(newRow::remove);
                         }
                     }
                 }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -900,9 +900,9 @@ public class SampleTypeServiceImpl extends AuditHandler implements SampleTypeSer
         return true;
     }
 
-    protected String getCommentDetailed(QueryService.AuditAction action)
+    protected String getCommentDetailed(QueryService.AuditAction action, boolean isUpdate)
     {
-        String comment = SampleTimelineAuditEvent.SampleTimelineEventType.getActionCommentDetailed(action);
+        String comment = SampleTimelineAuditEvent.SampleTimelineEventType.getActionCommentDetailed(action, isUpdate);
         return StringUtils.isEmpty(comment) ? action.getCommentDetailed() : comment;
     }
 
@@ -910,7 +910,7 @@ public class SampleTypeServiceImpl extends AuditHandler implements SampleTypeSer
     public DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> updatedRow)
     {
         // not doing anything with userComment at the moment
-        return createAuditRecord(c, getCommentDetailed(action), row, updatedRow, action);
+        return createAuditRecord(c, getCommentDetailed(action, !updatedRow.isEmpty()), row, updatedRow, action);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -457,10 +457,16 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
     public List<Map<String, Object>> getRows(User user, Container container, List<Map<String, Object>> keys)
             throws QueryUpdateServiceException
     {
+        return getRows(user, container, keys, false /*skip addInputs for insertRows*/);
+    }
+
+    public List<Map<String, Object>> getRows(User user, Container container, List<Map<String, Object>> keys, boolean addInputs)
+            throws QueryUpdateServiceException
+    {
         List<Map<String, Object>> result = new ArrayList<>(keys.size());
         for (Map<String, Object> k : keys)
         {
-            result.add(getMaterialMap(getMaterialRowId(k), getMaterialLsid(k), user, container, false/*skip addInputs for insertRows*/));
+            result.add(getMaterialMap(getMaterialRowId(k), getMaterialLsid(k), user, container, addInputs/*skip addInputs for insertRows*/));
         }
         return result;
     }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -466,7 +466,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         List<Map<String, Object>> result = new ArrayList<>(keys.size());
         for (Map<String, Object> k : keys)
         {
-            result.add(getMaterialMap(getMaterialRowId(k), getMaterialLsid(k), user, container, addInputs/*skip addInputs for insertRows*/));
+            result.add(getMaterialMap(getMaterialRowId(k), getMaterialLsid(k), user, container, addInputs));
         }
         return result;
     }


### PR DESCRIPTION
#### Rationale
When importing data, but in particular samples, and indicating that we want to merge existing records, the audit log that is created currently looks like an audit log for an insert instead of an audit log created when using an updateRows call.  We would like the audit logs and the behavior to be similar for these two types of actions when importing from a file and doing detailed audit logging, as we are for the Sample Manager application.  Since we were already querying to get an ExpMaterial in order to use the proper rowId of existing samples in our audit log, this change shouldn't affect the performance.

There was also a desire to change the audit log comment from the "Register or updated" to be "registered" or "updated" as applicable.


#### Changes
* update AuditHandler to check for the existence of oldRow and updatedRow to determine if an update-type audit log can be created
* Add 'created' and 'createdBy' to the dontUpdate columns passed to the TableInsertDataIterator from ExpDataIterators
* update comment from SampleTimelineAuditEvent.
