### PR TITLE
Issue 41891: Do not add google analytics on error pages

### DIFF
--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -885,6 +885,8 @@ public class ExceptionUtil
         try
         {
             renderer.setErrorType(errorType);
+            // Issue 41891: do not add google analytics on error pages.
+            pageConfig.setAllowTrackingScript(PageConfig.TrueFalse.False);
 
             if (HttpView.hasCurrentView())
             {


### PR DESCRIPTION
#### Rationale
This PR explicitly sets to disallow tracking scripts on error pages.