### PR TITLE
Issue 41897: TabLoader throws when parsing an empty file

### DIFF
--- a/api/src/org/labkey/api/reader/BufferedReader.java
+++ b/api/src/org/labkey/api/reader/BufferedReader.java
@@ -96,7 +96,7 @@ public class BufferedReader extends Reader {
     public BufferedReader(Reader in, int size) {
         super(in);
         if (size <= 0) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Buffer size must be positive!");
         }
         this.in = in;
         buf = new char[size];

--- a/api/src/org/labkey/api/reader/TabBufferedReader.java
+++ b/api/src/org/labkey/api/reader/TabBufferedReader.java
@@ -51,12 +51,14 @@ class TabBufferedReader extends org.labkey.api.reader.BufferedReader
 
     private static int getInitialBufferSize(long exactCharacterCount)
     {
-        return (int)Math.min(exactCharacterCount, INITIAL_BUFFER_SIZE);
+        // Buffer size must always be > 0, even for empty content (exactCharacterCount == 0), Issue 41897
+        return (int)Math.min(exactCharacterCount + 1, INITIAL_BUFFER_SIZE);
     }
 
     private static int getMaxBufferSize(long exactCharacterCount)
     {
-        return (int)Math.min(exactCharacterCount, ABSOLUTE_MAX_BUFFER_SIZE);
+        // Buffer size must always be > 0, even for empty content (exactCharacterCount == 0), Issue 41897
+        return (int)Math.min(exactCharacterCount + 1, ABSOLUTE_MAX_BUFFER_SIZE);
     }
 
     /*


### PR DESCRIPTION
#### Rationale
[Issue 41897: TabLoader throws when parsing an empty file](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=41897)

`TabLoader` has always handled empty files. We recently (for 20.7.0) introduced an expandable buffer that allows increasing the number of rows we examine during infer fields process. The new buffer size handling code resulted in our asking BufferedReader to allocate a buffer of size zero in the case of an empty file, which is illegal and caused the constructor to throw.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1263

#### Changes
* Always pass a positive buffer size to `org.labkey.api.reader.BufferedReader`
* Add junit tests to verify empty and nearly empty cases
* Fill in a reasonable exception message
