### PR TITLE
Issue 41897: TabLoader throws when parsing an empty file (#1732)

### DIFF
--- a/api/src/org/labkey/api/reader/BufferedReader.java
+++ b/api/src/org/labkey/api/reader/BufferedReader.java
@@ -96,7 +96,7 @@ public class BufferedReader extends Reader {
     public BufferedReader(Reader in, int size) {
         super(in);
         if (size <= 0) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Buffer size must be positive!");
         }
         this.in = in;
         buf = new char[size];

--- a/api/src/org/labkey/api/reader/TabBufferedReader.java
+++ b/api/src/org/labkey/api/reader/TabBufferedReader.java
@@ -51,12 +51,14 @@ class TabBufferedReader extends org.labkey.api.reader.BufferedReader
 
     private static int getInitialBufferSize(long exactCharacterCount)
     {
-        return (int)Math.min(exactCharacterCount, INITIAL_BUFFER_SIZE);
+        // Buffer size must always be > 0, even for empty content (exactCharacterCount == 0), Issue 41897
+        return (int)Math.min(exactCharacterCount + 1, INITIAL_BUFFER_SIZE);
     }
 
     private static int getMaxBufferSize(long exactCharacterCount)
     {
-        return (int)Math.min(exactCharacterCount, ABSOLUTE_MAX_BUFFER_SIZE);
+        // Buffer size must always be > 0, even for empty content (exactCharacterCount == 0), Issue 41897
+        return (int)Math.min(exactCharacterCount + 1, ABSOLUTE_MAX_BUFFER_SIZE);
     }
 
     /*

--- a/api/src/org/labkey/api/reader/TabLoader.java
+++ b/api/src/org/labkey/api/reader/TabLoader.java
@@ -40,6 +40,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringBufferInputStream;
+import java.io.StringReader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -807,6 +808,47 @@ public class TabLoader extends DataLoader
             csv.delete();
         }
 
+        // Test that TabLoader can handle empty and nearly empty content, Issue 41897
+        @Test
+        public void testEmptyTabLoader() throws IOException
+        {
+            testEmptyTabLoader("", 0);
+            testEmptyTabLoader("X", 1);
+            testEmptyTabLoader("X\n", 1);
+        }
+
+        private void testEmptyTabLoader(String content, int expectedColumnCount) throws IOException
+        {
+            try (TabLoader l = new TabLoader(content, true))
+            {
+                testEmptyTabLoader(l, expectedColumnCount);
+            }
+            try (Reader r = new StringReader(content); TabLoader l = new TabLoader(r, true))
+            {
+                testEmptyTabLoader(l, expectedColumnCount);
+            }
+            File tsv = _createTempFile(content, ".tsv");
+            try (TabLoader l = new TabLoader(tsv, true))
+            {
+                testEmptyTabLoader(l, expectedColumnCount);
+            }
+            try (Reader r = Readers.getReader(tsv); TabLoader l = new TabLoader(r, true))
+            {
+                testEmptyTabLoader(l, expectedColumnCount);
+            }
+            try (Reader r = Readers.getUnbufferedReader(tsv); TabLoader l = new TabLoader(r, true))
+            {
+                testEmptyTabLoader(l, expectedColumnCount);
+            }
+            assertTrue(tsv.delete());
+        }
+
+        private void testEmptyTabLoader(TabLoader l, int expectedColumnCount) throws IOException
+        {
+            List<Map<String, Object>> maps = l.load();
+            assertEquals(expectedColumnCount, l.getColumns().length);
+            assertEquals(0, maps.size());
+        }
 
         @Test
         public void testCSVFile() throws IOException


### PR DESCRIPTION
#### Rationale
Backport fix for Issue 41897: TabLoader throws when parsing an empty file (#1732)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1732
