### PR TITLE
scope the plate template lookup to the protocol container

### DIFF
--- a/assay/src/org/labkey/assay/TsvAssayProvider.java
+++ b/assay/src/org/labkey/assay/TsvAssayProvider.java
@@ -341,6 +341,7 @@ public class TsvAssayProvider extends AbstractTsvAssayProvider
                     GWTPropertyDescriptor plateTemplate = new GWTPropertyDescriptor(AssayRunDomainKind.PLATE_TEMPLATE_COLUMN_NAME, PropertyType.STRING.getTypeUri());
                     plateTemplate.setLookupSchema(AssaySchema.NAME + "." + getResourceName());
                     plateTemplate.setLookupQuery(TsvProviderSchema.PLATE_TEMPLATE_TABLE);
+                    plateTemplate.setLookupContainer(protocol.getContainer().getId());
                     plateTemplate.setRequired(true);
                     plateTemplate.setShownInUpdateView(false);
 


### PR DESCRIPTION
#### Rationale
In 20.7 we implemented GPAT plate template support. One shortcoming of that implementation is that the run level lookup to the plate template is not scoped to the protocol. This is fine if protocol is defined in the current container, but if it is scoped at the shared or project level and a user tries to use it in a subfolder the plate template doesn't get populated correctly.

#### Related Pull Requests
- https://github.com/LabKey/neurimmune/pull/1
- https://github.com/LabKey/premium/pull/212