### PR TITLE
Check for null map before adding to results.

### DIFF
--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -466,7 +466,9 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         List<Map<String, Object>> result = new ArrayList<>(keys.size());
         for (Map<String, Object> k : keys)
         {
-            result.add(getMaterialMap(getMaterialRowId(k), getMaterialLsid(k), user, container, addInputs));
+            Map<String, Object> materialMap = getMaterialMap(getMaterialRowId(k), getMaterialLsid(k), user, container, addInputs);
+            if (materialMap != null)
+                result.add(materialMap);
         }
         return result;
     }


### PR DESCRIPTION
#### Rationale
No one wants a null map.  At least our tests don't like it.

#### Related Pull Requests
#1730 

#### Changes
* check for null result before adding to the list
