### PR TITLE
Remove Ext3 reference from search panel

### DIFF
--- a/internal/webapp/extWidgets/SearchPanel.js
+++ b/internal/webapp/extWidgets/SearchPanel.js
@@ -465,7 +465,7 @@ Ext4.define('LABKEY.ext4.SearchPanel', {
             }
             else if (val instanceof Date){
                 var format = item.format || 'Y-m-d';
-                val = val.format(format);
+                val = Ext4.Date.format(val, format);
             }
 
             if (!Ext4.isEmpty(val) || !filterType.isDataValueRequired()){


### PR DESCRIPTION
#### Rationale
Date.format does not work on pages with no Ext3. Use Ext4 version

#### Changes
* Use Ext4.Date
