### PR TITLE
Issue 41675: deleting exp.object 

### DIFF
--- a/api/src/org/labkey/api/assay/TsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/TsvDataHandler.java
@@ -20,7 +20,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.labkey.api.data.ColumnHeaderType;
 import org.labkey.api.data.ColumnInfo;
-import org.labkey.api.data.Container;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.Results;
 import org.labkey.api.data.SimpleFilter;
@@ -30,7 +29,6 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
-import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.api.DataType;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -185,10 +183,4 @@ public class TsvDataHandler extends AbstractAssayTsvDataHandler implements Trans
         }
     }
 
-    @Override
-    public void deleteData(ExpData data, Container container, User user)
-    {
-        // clean up plate metadata values if any
-        OntologyManager.deleteOntologyObject(data.getLSID(), container, true);
-    }
 }

--- a/api/src/org/labkey/api/assay/pipeline/AssayUploadPipelineJob.java
+++ b/api/src/org/labkey/api/assay/pipeline/AssayUploadPipelineJob.java
@@ -26,6 +26,7 @@ import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
@@ -136,6 +137,8 @@ public class AssayUploadPipelineJob<ProviderType extends AssayProvider> extends 
             // Create the basic run
             _run = AssayService.get().createExperimentRun(_context.getName(), getContainer(), _context.getProtocol(), _primaryFile);
             _run.setComments(_context.getComments());
+            // remember which job created the run so we can show this run on the job details page
+            _run.setJobId(PipelineService.get().getJobId(getUser(), getContainer(), getJobGUID()));
 
             // Find a batch for the run
             ExpExperiment batch = ExperimentService.get().getExpExperiment(_batchId);

--- a/api/src/org/labkey/api/exp/ExperimentDataHandler.java
+++ b/api/src/org/labkey/api/exp/ExperimentDataHandler.java
@@ -83,7 +83,9 @@ public interface ExperimentDataHandler extends Handler<ExpData>
     void beforeDeleteData(List<ExpData> datas, User user) throws ExperimentException;
 
     /**
-     * Completely delete all database rows attached to this data object.
+     * Completely delete all database rows attached to this data object but not the ExpData itself.
+     * When an experiment run is deleted, the ExpData is detached from the run since they usually represent an uploaded file.
+     * Some run types (e.g., Flow and TargetedMS) will also delete the ExpData.
      */
     void deleteData(ExpData data, Container container, User user);
 

--- a/api/src/org/labkey/api/exp/OntologyObject.java
+++ b/api/src/org/labkey/api/exp/OntologyObject.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.exp;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 
 /**
@@ -25,8 +26,8 @@ import org.labkey.api.data.Container;
 public class OntologyObject
 {
     private int objectId;
-    private Container container;
-    private String objectURI;
+    private @NotNull Container container;
+    private @NotNull String objectURI;
     private Integer ownerObjectId;
 
     public int getObjectId()
@@ -39,22 +40,22 @@ public class OntologyObject
         this.objectId = objectId;
     }
 
-    public Container getContainer()
+    public @NotNull Container getContainer()
     {
         return container;
     }
 
-    public void setContainer(Container container)
+    public void setContainer(@NotNull Container container)
     {
         this.container = container;
     }
 
-    public String getObjectURI()
+    public @NotNull String getObjectURI()
     {
         return objectURI;
     }
 
-    public void setObjectURI(String objectURI)
+    public void setObjectURI(@NotNull String objectURI)
     {
         this.objectURI = objectURI;
     }

--- a/assay/api-src/org/labkey/api/assay/dilution/DilutionDataHandler.java
+++ b/assay/api-src/org/labkey/api/assay/dilution/DilutionDataHandler.java
@@ -643,7 +643,8 @@ public abstract class DilutionDataHandler extends AbstractExperimentDataHandler
     @Override
     public void deleteData(ExpData data, Container container, User user)
     {
-        OntologyManager.deleteOntologyObject(data.getLSID(), container, true);
+        // delete owned objects and the object's properties, but leave the exp.object
+        OntologyManager.deleteOntologyObjects(container, true, true, false, data.getObjectId());
     }
 
     public String getPropertyName(String prefix, int cutoff, StatsService.CurveFitType type)

--- a/assay/src/org/labkey/assay/AssayIntegrationTestCase.java
+++ b/assay/src/org/labkey/assay/AssayIntegrationTestCase.java
@@ -1,0 +1,213 @@
+package org.labkey.assay;
+
+import com.google.common.base.Charsets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.labkey.api.assay.AssayDataCollector;
+import org.labkey.api.assay.AssayDomainService;
+import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.assay.AssayRunCreator;
+import org.labkey.api.assay.AssayRunUploadContext;
+import org.labkey.api.assay.AssayService;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.PropertyStorageSpec;
+import org.labkey.api.exp.OntologyManager;
+import org.labkey.api.exp.OntologyObject;
+import org.labkey.api.exp.PropertyDescriptor;
+import org.labkey.api.exp.api.ExpData;
+import org.labkey.api.exp.api.ExpExperiment;
+import org.labkey.api.exp.api.ExpMaterial;
+import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.api.ExpRun;
+import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.exp.property.PropertyService;
+import org.labkey.api.exp.query.ExpSchema;
+import org.labkey.api.files.FileContentService;
+import org.labkey.api.files.FilesAdminOptions;
+import org.labkey.api.gwt.client.assay.model.GWTProtocol;
+import org.labkey.api.gwt.client.model.GWTDomain;
+import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
+import org.labkey.api.pipeline.PipelineService;
+import org.labkey.api.security.User;
+import org.labkey.api.util.JunitUtil;
+import org.labkey.api.util.Pair;
+import org.labkey.api.util.TestContext;
+import org.labkey.api.view.ViewBackgroundInfo;
+import org.labkey.api.view.ViewContext;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+public class AssayIntegrationTestCase
+{
+    public static final Logger LOG = LogManager.getLogger(AssayIntegrationTestCase.class);
+
+    Container c;
+
+    @Before
+    public void setUp()
+    {
+        JunitUtil.deleteTestContainer();
+        c = JunitUtil.getTestContainer();
+    }
+
+    // Issue 41675: ERROR: insert or update on table "edge" violates foreign key constraint "fk_edge_to_object"
+    // - imports a file into an assay
+    // - sets some file properties
+    // - deletes the assay run
+    // - verifies the exp.data is detatched from the run, but the properties haven't been deleted
+    // - re-imports the same file again
+    @Test
+    public void testIssue41675() throws Exception
+    {
+        final User user = TestContext.get().getUser();
+        final String ASSAY_NAME = "MyAssay";
+        final var info = new ViewBackgroundInfo(c, user, null);
+        final var context = new ViewContext(info);
+        final var pipeRoot = PipelineService.get().findPipelineRoot(info.getContainer());
+
+
+        // create a custom file property
+        FileContentService fileSvc = FileContentService.get();
+        PropertyDescriptor someStuffProp = null;
+        if (fileSvc != null)
+        {
+            String domainUri = fileSvc.getDomainURI(c, FilesAdminOptions.fileConfig.useCustom);
+            Domain domain = PropertyService.get().createDomain(c, domainUri, "FileProps");
+            domain.addProperty(new PropertyStorageSpec("SomeStuff", JdbcType.VARCHAR));
+            domain.save(user);
+
+            DomainProperty dp = domain.getPropertyByName("SomeStuff");
+            someStuffProp = dp.getPropertyDescriptor();
+        }
+
+        // create assay design
+        AssayDomainService assayDomainService = new AssayDomainServiceImpl(context);
+        GWTProtocol assayTemplate = assayDomainService.getAssayTemplate("General");
+        assayTemplate.setName(ASSAY_NAME);
+        List<GWTDomain<GWTPropertyDescriptor>> domains = assayTemplate.getDomains();
+
+        // clear the batch domain fields
+        GWTDomain<GWTPropertyDescriptor> batchDomain = domains.stream().filter(d -> "Batch Fields".equals(d.getName())).findFirst().orElseThrow();
+        batchDomain.getFields().clear();
+
+        // clear the batch domain fields
+        GWTDomain<GWTPropertyDescriptor> runDomain = domains.stream().filter(d -> "Run Fields".equals(d.getName())).findFirst().orElseThrow();
+        runDomain.getFields().clear();
+
+        // clear the result domain fields and add a sample lookup
+        GWTDomain<GWTPropertyDescriptor> resultDomain = domains.stream().filter(d -> "Data Fields".equals(d.getName())).findFirst().orElseThrow();
+        resultDomain.getFields().clear();
+        GWTPropertyDescriptor sampleLookup = new GWTPropertyDescriptor("SampleLookup", "int");
+        sampleLookup.setLookupSchema(ExpSchema.SCHEMA_NAME);
+        sampleLookup.setLookupQuery(ExpSchema.TableType.Materials.name());
+        resultDomain.getFields().add(sampleLookup);
+
+        // create the assay
+        GWTProtocol savedAssayDesign = assayDomainService.saveChanges(assayTemplate, true);
+        ExpProtocol assayProtocol = ExperimentService.get().getExpProtocol(savedAssayDesign.getProtocolId());
+        AssayProvider provider = AssayService.get().getProvider(assayProtocol);
+
+        // create a sample that will be used as an input to the run
+        final String materialName = "TestMaterial";
+        final String materialLsid = ExperimentService.get().generateLSID(c, ExpMaterial.class, "TestMaterial");
+        ExpMaterial material = ExperimentService.get().createExpMaterial(c, materialLsid, materialName);
+        material.save(user);
+
+        // create a file in the pipeline root to import
+        var file = File.createTempFile(getClass().getSimpleName(), ".tsv", pipeRoot.getRootPath());
+        Files.writeString(file.toPath(), "SampleLookup\n" + materialName + "\n", Charsets.UTF_8);
+
+        // create an upload context that imports the file
+        AssayRunUploadContext uploadContext = provider.createRunUploadFactory(assayProtocol, user, c)
+                .setName("New Run")
+                .setUploadedData(Map.of(AssayDataCollector.PRIMARY_FILE, file))
+                .create();
+
+        // create a new run
+        AssayRunCreator runCreator = provider.getRunCreator();
+        Pair<ExpExperiment, ExpRun> pair = runCreator.saveExperimentRun(uploadContext, null);
+        ExpRun run = pair.second;
+
+        // verify the exp.data is attached to the run
+        assertEquals(1, run.getDataOutputs().size());
+        final ExpData originalOutputData = run.getDataOutputs().get(0);
+        assertEquals(file.getName(), originalOutputData.getName());
+
+        final int dataRowId = originalOutputData.getRowId();
+        final String dataLsid = originalOutputData.getLSID();
+        final Integer dataOID = originalOutputData.getObjectId();
+        final OntologyObject oo1 = OntologyManager.getOntologyObject(originalOutputData.getObjectId());
+        assertNotNull(oo1);
+
+        // set some properties that will be verified later
+        originalOutputData.setComment(user, "hello world");
+        if (someStuffProp != null)
+            originalOutputData.setProperty(user, someStuffProp, "SomeData");
+
+        // verify lineage
+        var parents = ExperimentService.get().getParents(c, user, originalOutputData);
+        assertThat(parents.second, CoreMatchers.hasItem(material));
+
+        // delete the run
+        run.delete(user);
+
+        // verify the exp.data, exp.object, and the properties were not deleted
+        ExpData data2 = ExperimentService.get().getExpData(dataRowId);
+        assertNotNull(data2);
+        assertEquals(dataLsid, data2.getLSID());
+        assertEquals(dataOID, data2.getObjectId());
+        assertEquals("hello world", data2.getComment());
+        if (someStuffProp != null)
+            assertEquals("SomeData", data2.getProperty(someStuffProp));
+
+        assertNull(data2.getRunId());
+        parents = ExperimentService.get().getParents(c, user, data2);
+        assertThat(parents.second, CoreMatchers.not(CoreMatchers.hasItem(material)));
+
+        OntologyObject oo2 = OntologyManager.getOntologyObject(data2.getObjectId());
+        assertNotNull(oo2);
+        assertEquals(oo1.getObjectId(), oo2.getObjectId());
+        assertEquals(oo1.getObjectURI(), oo2.getObjectURI());
+        assertEquals(oo1.getContainer(), oo2.getContainer());
+        assertEquals(oo1.getOwnerObjectId(), oo2.getOwnerObjectId());
+
+        // import the same file again
+        uploadContext = provider.createRunUploadFactory(assayProtocol, user, c)
+                .setName("New Run2")
+                .setUploadedData(Map.of(AssayDataCollector.PRIMARY_FILE, file))
+                .create();
+
+        // create a new run
+        runCreator = provider.getRunCreator();
+        pair = runCreator.saveExperimentRun(uploadContext, null);
+        ExpRun run2 = pair.second;
+
+        // verify the exp.data and exp.object again
+        ExpData data3 = ExperimentService.get().getExpData(dataRowId);
+        assertNotNull(data3);
+        assertEquals(dataLsid, data3.getLSID());
+        assertEquals(dataOID, data3.getObjectId());
+        assertEquals("hello world", data3.getComment());
+        if (someStuffProp != null)
+            assertEquals("SomeData", data3.getProperty(someStuffProp));
+
+        assertEquals(run2.getRowId(), data3.getRunId().intValue());
+        parents = ExperimentService.get().getParents(c, user, data3);
+        assertThat(parents.second, CoreMatchers.hasItem(material));
+
+    }
+}

--- a/assay/src/org/labkey/assay/AssayIntegrationTestCase.java
+++ b/assay/src/org/labkey/assay/AssayIntegrationTestCase.java
@@ -104,7 +104,7 @@ public class AssayIntegrationTestCase
         GWTDomain<GWTPropertyDescriptor> batchDomain = domains.stream().filter(d -> "Batch Fields".equals(d.getName())).findFirst().orElseThrow();
         batchDomain.getFields().clear();
 
-        // clear the batch domain fields
+        // clear the run domain fields
         GWTDomain<GWTPropertyDescriptor> runDomain = domains.stream().filter(d -> "Run Fields".equals(d.getName())).findFirst().orElseThrow();
         runDomain.getFields().clear();
 

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -252,7 +252,8 @@ public class AssayModule extends SpringModule
     public @NotNull Set<Class> getIntegrationTests()
     {
         return Set.of(
-            ModuleAssayCache.TestCase.class
+            ModuleAssayCache.TestCase.class,
+            AssayIntegrationTestCase.class
         );
     }
 

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-20.012-20.013.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-20.012-20.013.sql
@@ -1,0 +1,31 @@
+-- create exp.object for exp.data without one
+INSERT INTO exp.object (objecturi, container)
+SELECT D.lsid as objecturi, D.container as container
+FROM exp.data D LEFT OUTER JOIN exp.object O ON D.lsid = O.objecturi
+WHERE O.objecturi IS NULL;
+
+-- fixup exp.data.objectid to be consistent with the lsid of the exp.object
+UPDATE exp.data
+SET objectid = (SELECT O.objectid FROM exp.object O WHERE O.objecturi = lsid)
+WHERE rowid IN (
+    SELECT rowid
+    FROM exp.data D
+    LEFT OUTER JOIN exp.object O ON D.lsid = O.objecturi
+    WHERE D.objectid != O.objectid
+);
+
+-- add constraints for lsid -> exp.object
+ALTER TABLE exp.data ADD CONSTRAINT FK_Data_Lsid
+    FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
+ALTER TABLE exp.material ADD CONSTRAINT FK_Material_Lsid
+    FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
+ALTER TABLE exp.experimentrun ADD CONSTRAINT FK_ExperimentRun_Lsid
+    FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
+
+-- add constraints for objectid -> exp.object
+ALTER TABLE exp.data ADD CONSTRAINT FK_Data_ObjectId
+    FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
+ALTER TABLE exp.material ADD CONSTRAINT FK_Material_ObjectId
+    FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
+ALTER TABLE exp.experimentrun ADD CONSTRAINT FK_ExperimentRun_ObjectId
+    FOREIGN KEY (objectid) REFERENCES exp.object (objectid);

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-20.012-20.013.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-20.012-20.013.sql
@@ -1,0 +1,31 @@
+-- create exp.object for exp.data without one
+INSERT INTO exp.object (objecturi, container)
+SELECT D.lsid as objecturi, D.container as container
+FROM exp.data D LEFT OUTER JOIN exp.object O ON D.lsid = O.objecturi
+WHERE O.objecturi IS NULL;
+
+-- fixup exp.data.objectid to be consistent with the lsid of the exp.object
+UPDATE exp.data
+SET objectid = (SELECT O.objectid FROM exp.object O WHERE O.objecturi = lsid)
+WHERE rowid IN (
+    SELECT rowid
+    FROM exp.data D
+    LEFT OUTER JOIN exp.object O ON D.lsid = O.objecturi
+    WHERE D.objectid != O.objectid
+);
+
+-- add constraints for lsid -> exp.object
+ALTER TABLE exp.data ADD CONSTRAINT FK_Data_Lsid
+    FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
+ALTER TABLE exp.material ADD CONSTRAINT FK_Material_Lsid
+    FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
+ALTER TABLE exp.experimentrun ADD CONSTRAINT FK_ExperimentRun_Lsid
+    FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
+
+-- add constraints for objectid -> exp.object
+ALTER TABLE exp.data ADD CONSTRAINT FK_Data_ObjectId
+    FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
+ALTER TABLE exp.material ADD CONSTRAINT FK_Material_ObjectId
+    FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
+ALTER TABLE exp.experimentrun ADD CONSTRAINT FK_ExperimentRun_ObjectId
+    FOREIGN KEY (objectid) REFERENCES exp.object (objectid);

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -134,7 +134,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     public Double getSchemaVersion()
     {
-        return 20.012;
+        return 20.013;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -2965,6 +2965,13 @@ public class ExperimentServiceImpl implements ExperimentService
                 else
                     toDataLsids.add(row);
             });
+            if (LOG.isDebugEnabled())
+            {
+                if (!fromDataLsids.isEmpty())
+                    LOG.debug("  fromDataLsids:\n  " + StringUtils.join(fromDataLsids, "\n  "));
+                if (!toDataLsids.isEmpty())
+                    LOG.debug("  toDataLsids:\n  " + StringUtils.join(toDataLsids, "\n  "));
+            }
 
             SQLFragment materials = new SQLFragment()
                     .append("SELECT m.Container, m.LSID, m.CpasType, m.ObjectId, pa.CpasType AS pa_cpas_type FROM exp.material m\n")
@@ -3002,8 +3009,8 @@ public class ExperimentServiceImpl implements ExperimentService
                 removeEdgesForRun(runId);
 
             int edgeCount = fromDataLsids.size() + fromMaterialLsids.size() + toDataLsids.size() + toMaterialLsids.size() + provenanceStartingInputs.size() + provenanceFinalOutputs.size();
-            LOG.debug(String.format("  edge counts: input data=%d, input materials=%d, output data=%d, output materials=%d, total=%d",
-                    fromDataLsids.size(), fromMaterialLsids.size(), toDataLsids.size(), toMaterialLsids.size(), edgeCount));
+            LOG.debug(String.format("  edge counts: input data=%d, input materials=%d, output data=%d, output materials=%d, input prov=%d, output prov=%d, total=%d",
+                    fromDataLsids.size(), fromMaterialLsids.size(), toDataLsids.size(), toMaterialLsids.size(), provenanceStartingInputs.size(), provenanceFinalOutputs.size(), edgeCount));
 
             if (edgeCount > 0)
             {
@@ -3234,9 +3241,6 @@ public class ExperimentServiceImpl implements ExperimentService
 
         run.deleteProtocolApplications(datasToDelete, user);
 
-        //delete run properties and all children
-        OntologyManager.deleteOntologyObject(run.getLSID(), run.getContainer(), true);
-
         SQLFragment sql = new SQLFragment("DELETE FROM exp.RunList WHERE ExperimentRunId = ?;\n");
         sql.add(run.getRowId());
         sql.append("UPDATE exp.ExperimentRun SET ReplacedByRunId = NULL WHERE ReplacedByRunId = ?;\n");
@@ -3247,6 +3251,9 @@ public class ExperimentServiceImpl implements ExperimentService
         sql.add(run.getRowId());
 
         new SqlExecutor(getExpSchema()).execute(sql);
+
+        // delete run properties and all children
+        OntologyManager.deleteOntologyObject(run.getLSID(), run.getContainer(), true);
 
         ExpProtocolImpl protocol = run.getProtocol();
         if (protocol == null)
@@ -4039,14 +4046,6 @@ public class ExperimentServiceImpl implements ExperimentService
                 executor.execute(deleteEdgeSql);
             }
 
-            // delete exp.objects
-            try (Timing ignored = MiniProfiler.step("exp.object"))
-            {
-                SQLFragment lsidFragFrag = new SQLFragment("SELECT o.ObjectUri FROM ").append(getTinfoObject(), "o").append(" WHERE o.ObjectURI ");
-                lsidFragFrag.append(lsidInFrag);
-                OntologyManager.deleteOntologyObjects(getSchema(), lsidFragFrag, container, false);
-            }
-
             // Delete MaterialInput exp.object and properties
             try (Timing ignored = MiniProfiler.step("MI exp.object"))
             {
@@ -4087,6 +4086,14 @@ public class ExperimentServiceImpl implements ExperimentService
                 SQLFragment materialSQL = new SQLFragment("DELETE FROM exp.Material WHERE RowId ");
                 materialSQL.append(rowIdInFrag);
                 executor.execute(materialSQL);
+            }
+
+            // delete exp.objects
+            try (Timing ignored = MiniProfiler.step("exp.object"))
+            {
+                SQLFragment lsidFragFrag = new SQLFragment("SELECT o.ObjectUri FROM ").append(getTinfoObject(), "o").append(" WHERE o.ObjectURI ");
+                lsidFragFrag.append(lsidInFrag);
+                OntologyManager.deleteOntologyObjects(getSchema(), lsidFragFrag, container, false);
             }
 
             // On successful commit, start task to remove items from search index
@@ -4286,6 +4293,7 @@ public class ExperimentServiceImpl implements ExperimentService
             SimpleFilter rowIdFilter = new SimpleFilter().addInClause(FieldKey.fromParts("RowId"), selectedDataIds);
             List<Data> datas = new TableSelector(getTinfoData(), rowIdFilter, null).getArrayList(Data.class);
 
+            List<String> allLsids = new ArrayList<>(datas.size());
             Map<Integer, List<String>> lsidsByClass = new LinkedHashMap<>();
 
             for (Data data : datas)
@@ -4316,13 +4324,12 @@ public class ExperimentServiceImpl implements ExperimentService
                     .append("DELETE FROM ").append(String.valueOf(getTinfoEdge())).append(" WHERE toObjectId = (select objectid from exp.object where objecturi = ?);").add(data.getLSID());
                 new SqlExecutor(getExpSchema()).execute(deleteSql);
 
-                OntologyManager.deleteOntologyObjects(container, data.getLSID());
-
                 if (data.getClassId() != null)
                 {
                     List<String> byClass = lsidsByClass.computeIfAbsent(data.getClassId(), k -> new ArrayList<>(10));
                     byClass.add(data.getLSID());
                 }
+                allLsids.add(data.getLSID());
             }
 
             SqlDialect dialect = getExpSchema().getSqlDialect();
@@ -4361,6 +4368,11 @@ public class ExperimentServiceImpl implements ExperimentService
             SQLFragment dataSQL = new SQLFragment("DELETE FROM ").append(getTinfoData()).append(" WHERE RowId ");
             dialect.appendInClauseSql(dataSQL, selectedDataIds);
             executor.execute(dataSQL);
+
+            // generate in clause for the Material LSIDs
+            SQLFragment lsidInFrag = new SQLFragment("SELECT o.ObjectUri FROM ").append(getTinfoObject(), "o").append(" WHERE o.ObjectURI ");
+            dialect.appendInClauseSql(lsidInFrag, allLsids);
+            OntologyManager.deleteOntologyObjects(getSchema(), lsidInFrag, container, false);
 
             afterDeleteData(user, container, expDatas);
 


### PR DESCRIPTION
#### Rationale
As a part of fixing Issue 37518, we added `objectId` column to the `exp.data`, `exp.material`, and `exp.experimentrun` tables and created an `exp.object` when a new row was inserted.  When deleting an experiment run, the `exp.data` is detached from the run and ExperimentDataHandler.deleteData() is called to clean up any data handler specific stuff.  The underlying issue is that the `exp.object` for the `exp.data` row was deleted.  When the `exp.data` file was used to import into another run, we created a new `exp.object` for the same `exp.data` and ended up getting out of sync with the `objectId`.

The issue only repros if the first assay run is imported from a file in the pipeline root that was not uploaded via WebDAV.

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/263
* https://github.com/LabKey/platform/pull/249

#### Related Issues
* [Issue 37518](https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=37518): deadlock when concurrently inserting samples with lineage

#### Changes
- associate assay import background job with the resulting run
- add FK from exp.data, exp.material, exp.experimentrun to exp.object by LSID and objectId
- don't delete exp.object in assay ExperimentDataHandler subclasses; it will be cleaned up when the exp.data is deleted
- added AssayIntegrationTestCase.java regression test
