### PR TITLE
Remove unused actions and flag non-existing crawler actions

### DIFF
--- a/devtools/src/org/labkey/devtools/DevtoolsModule.java
+++ b/devtools/src/org/labkey/devtools/DevtoolsModule.java
@@ -36,7 +36,7 @@ import java.util.List;
 
 public class DevtoolsModule extends CodeOnlyModule
 {
-    private static final String NAME = "DeveloperTools";
+    static final String NAME = "DeveloperTools";
 
     @Override
     public String getName()

--- a/devtools/src/org/labkey/devtools/ToolsController.java
+++ b/devtools/src/org/labkey/devtools/ToolsController.java
@@ -35,7 +35,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -410,8 +409,8 @@ public class ToolsController extends SpringActionController
                 addActionIds(actionIds, file);
             }
 
-            List<ControllerActionId> missingModules = new ArrayList<>();
-            List<ControllerActionId> missingActions = new ArrayList<>();
+            Set<ControllerActionId> missingModules = new TreeSet<>();
+            Set<ControllerActionId> missingActions = new TreeSet<>();
 
             for (ControllerActionId actionId : actionIds)
             {
@@ -437,7 +436,6 @@ public class ToolsController extends SpringActionController
 
             if (!missingModules.isEmpty())
             {
-                missingModules.sort(null);
                 builder
                     .append("The following actions could not be resolved to a module running in this deployment:")
                     .append(HtmlString.unsafe("<br><br>\n"));
@@ -447,7 +445,6 @@ public class ToolsController extends SpringActionController
 
             if (!missingActions.isEmpty())
             {
-                missingActions.sort(null);
                 builder
                     .append("The following actions do not exist:")
                     .append(HtmlString.unsafe("<br><br>\n"));
@@ -517,7 +514,7 @@ public class ToolsController extends SpringActionController
             @Override
             public String toString()
             {
-                return "/" + _controller + "/" + _action;
+                return "/" + _controller + "-" + _action;
             }
 
             @Override

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -734,32 +734,6 @@ public class StudyController extends BaseStudyController
         return newUrl.addParameters(context.getActionURL().getParameters());
     }
 
-    @RequiresPermission(AdminPermission.class)
-    public class DeleteDatasetReportAction extends SimpleViewAction
-    {
-        @Override
-        public ModelAndView getView(Object o, BindException errors)
-        {
-            String viewName = (String) getViewContext().get(DATASET_REPORT_ID_PARAMETER_NAME);
-            int datasetId = NumberUtils.toInt((String)getViewContext().get(DatasetDefinition.DATASETKEY));
-
-            if (NumberUtils.isDigits(viewName))
-            {
-                Report report = ReportService.get().getReport(getContainer(), NumberUtils.toInt(viewName));
-                if (report != null)
-                    ReportService.get().deleteReport(getViewContext(), report);
-            }
-            throw new RedirectException(new ActionURL(DatasetAction.class, getContainer()).
-                        addParameter(DatasetDefinition.DATASETKEY, datasetId));
-        }
-
-        @Override
-        public void addNavTrail(NavTree root)
-        {
-        }
-    }
-
-
     private static boolean canWrite(DatasetDefinition def, User user)
     {
         return def.canWrite(user) && def.getContainer().hasPermission(user, ReadPermission.class);

--- a/study/src/org/labkey/study/controllers/reports/ReportsController.java
+++ b/study/src/org/labkey/study/controllers/reports/ReportsController.java
@@ -39,8 +39,6 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.views.DataViewInfo;
 import org.labkey.api.data.views.DataViewService;
-import org.labkey.api.query.CustomView;
-import org.labkey.api.query.QueryDefinition;
 import org.labkey.api.query.QueryParam;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
@@ -155,39 +153,6 @@ public class ReportsController extends BaseStudyController
                 root.addChild("Manage Views", PageFlowUtil.urlProvider(ReportUrls.class).urlManageViews(getContainer()));
             else
                 root.addChild("Views");
-        }
-    }
-
-    @RequiresPermission(AdminPermission.class)
-    public class DeleteCustomQueryAction extends SimpleViewAction
-    {
-        @Override
-        public ModelAndView getView(Object o, BindException errors)
-        {
-            String viewName = getRequest().getParameter("reportView");
-            String defName = getRequest().getParameter("defName");
-            if (viewName != null && defName != null)
-            {
-                final ViewContext context = getViewContext();
-                final UserSchema schema = QueryService.get().getUserSchema(context.getUser(), context.getContainer(), "study");
-                final Study study = getStudyRedirectIfNull(context.getContainer());
-                QueryDefinition qd = QueryService.get().getQueryDef(context.getUser(), study.getContainer(), "study", defName);
-                if (qd == null)
-                    qd = schema.getQueryDefForTable(defName);
-
-                if (qd != null)
-                {
-                    CustomView view = qd.getCustomView(context.getUser(), context.getRequest(), viewName);
-                    if (view != null)
-                        view.delete(context.getUser(), context.getRequest());
-                }
-            }
-            return HttpView.redirect(PageFlowUtil.urlProvider(ReportUrls.class).urlManageViews(getContainer()));
-        }
-
-        @Override
-        public void addNavTrail(NavTree root)
-        {
         }
     }
 


### PR DESCRIPTION
#### Rationale
These two delete actions are unused and will throw if invoked (they are mutating actions that allow GET). Add a tools action that flags non-existent actions referenced by the crawler.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/537
