### PR TITLE
Issue 41908: ETL columns with special characters (including Benchling WH columns)

### DIFF
--- a/api/src/org/labkey/api/dataiterator/QueryDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/QueryDataIteratorBuilder.java
@@ -161,7 +161,7 @@ public class QueryDataIteratorBuilder implements DataIteratorBuilder
         try
         {
             ResultSet rs = qs.select(t, selectCols, _filter, null, _parameters, false);
-            return new ResultSetDataIterator(rs, context, selectCols);
+            return new ResultSetDataIterator(rs, context);
         }
         catch (QueryParseException x)
         {

--- a/api/src/org/labkey/api/dataiterator/QueryDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/QueryDataIteratorBuilder.java
@@ -161,7 +161,7 @@ public class QueryDataIteratorBuilder implements DataIteratorBuilder
         try
         {
             ResultSet rs = qs.select(t, selectCols, _filter, null, _parameters, false);
-            return new ResultSetDataIterator(rs, context);
+            return new ResultSetDataIterator(rs, context, selectCols);
         }
         catch (QueryParseException x)
         {

--- a/api/src/org/labkey/api/dataiterator/ResultSetDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ResultSetDataIterator.java
@@ -67,12 +67,10 @@ public class ResultSetDataIterator extends AbstractDataIterator implements Scrol
                 ColumnInfo ci = null;
                 if (rs instanceof Results)
                 {
-                    for (ColumnInfo col : ((Results) rs).getFieldMap().values())
+                    // Use field map to get size of columnInfos which is field map size + 1
+                    if (i <= ((Results) rs).getFieldMap().size())
                     {
-                        if (col.getName().equals(rsmd.getColumnName(i)) || col.getAlias().equals(rsmd.getColumnName(i)))
-                        {
-                            ci = col;
-                        }
+                        ci = ((Results) rs).getColumn(i);
                     }
                 }
                 

--- a/api/src/org/labkey/api/dataiterator/ResultSetDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ResultSetDataIterator.java
@@ -64,14 +64,19 @@ public class ResultSetDataIterator extends AbstractDataIterator implements Scrol
             _columns[0] = new BaseColumnInfo("_row", JdbcType.INTEGER);
             for (int i=1 ; i<=rsmd.getColumnCount() ; i++)
             {
+                ColumnInfo ci = null;
                 if (rs instanceof Results)
                 {
-                    _columns[i] = ((Results) rs).getColumn(i);
+                    for (ColumnInfo col : ((Results) rs).getFieldMap().values())
+                    {
+                        if (col.getName().equals(rsmd.getColumnName(i)) || col.getAlias().equals(rsmd.getColumnName(i)))
+                        {
+                            ci = col;
+                        }
+                    }
                 }
-                else
-                {
-                    _columns[i] = new BaseColumnInfo(rsmd, i);
-                }
+                
+                _columns[i] = ci == null ? new BaseColumnInfo(rsmd, i) : ci;
             }
         }
         catch (SQLException x)

--- a/api/src/org/labkey/api/dataiterator/ResultSetDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ResultSetDataIterator.java
@@ -66,10 +66,13 @@ public class ResultSetDataIterator extends AbstractDataIterator implements Scrol
             for (int i=1 ; i<=rsmd.getColumnCount() ; i++)
             {
                 ColumnInfo ci = null;
+
+                // Check if selectCols provided to pass metadata to result set column infos
                 if (null != selectCols)
                 {
                     for (ColumnInfo selectCol : selectCols)
                     {
+                        // If column name or alias matches then copy metadata
                         if (rsmd.getColumnName(i).equals(selectCol.getColumnName())
                                 || rsmd.getColumnName(i).equals(selectCol.getAlias()))
                         {


### PR DESCRIPTION
#### Rationale
ETLing columns with non-alphanumeric characters like $ in the column name, does not correctly bind the parameter values.  The StatementUtils creation uses the select column name and the ResultSetDataIterator uses only the alias, causing parameter values on a SQL statement to not be filled in correctly.  This PR uses columnInfos from Results metadata for ResultSetDataIterator columnInfos, if Results type of ResultSet passed in.  This is used in StatementDataIterator.init() to match result set values with sql statement parameters.

Verified on PG and MSSQL and ran nearly all major automated tests to ensure no issues.

#### Changes
- In ResultSetDataIterator constructor use Results columnInfos for metadata if Results type passed in for ResultSet.
