### PR TITLE
Update path for inputs to jsp compilation tasks to align with Gradle tasks

### DIFF
--- a/api/src/org/labkey/api/jsp/RecompilingJspClassLoader.java
+++ b/api/src/org/labkey/api/jsp/RecompilingJspClassLoader.java
@@ -111,7 +111,7 @@ public class RecompilingJspClassLoader extends JspClassLoader
                     _log.info("Recompiling " + relativePath);
 
                     // Copy .jsp file from source to build staging directory
-                    File stagingJsp = new File(jspJavaFileBuildDirectory.getParent() + "/webapp", relativePath);
+                    File stagingJsp = new File(jspJavaFileBuildDirectory.getParentFile().getParent()  + "/jspWebappDir/webapp", relativePath);
                     if (!stagingJsp.getParentFile().exists())
                         stagingJsp.getParentFile().mkdirs();
                     FileUtil.copyFile(sourceFile, stagingJsp);
@@ -143,7 +143,7 @@ public class RecompilingJspClassLoader extends JspClassLoader
                             return super.newTldScanner(context, namespaceAware, validate, blockExternal);
                         }
                     };
-                    jasper.setUriroot(jspJavaFileBuildDirectory.getParent() + "/webapp");
+                    jasper.setUriroot(jspJavaFileBuildDirectory.getParentFile().getParent() + "/jspWebappDir/webapp/");
                     jasper.setOutputDir(jspJavaFileBuildDirectory.getAbsolutePath());
                     jasper.setPackage("org.labkey.jsp.compiled");
                     jasper.setCompilerTargetVM("13");


### PR DESCRIPTION
#### Rationale
To be able to support build caching, the output of each Gradle tasks need to be independent of the input directories.  In release 1.21.0 of the gradle plugins, the JSP compilation and Jar tasks were marked as cacheable and the intermediate directories needed for compiling the JSPs were changed to avoid the overlap with the output directory.  These changes make the same adjustments for the RecompilingJspClassLoader.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/98

#### Changes
* Use jspWebappDir instead of jspTempDir as input to compilation task
