### PR TITLE
Add QueryService.getOlapHierarchies()

### DIFF
--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -45,6 +45,7 @@ import org.labkey.api.module.Module;
 import org.labkey.api.query.snapshot.QuerySnapshotDefinition;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
+import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
@@ -471,20 +472,25 @@ public interface QueryService
     String warmCube(User user, Set<Container> containers, String schemaName, String configId, String cubeName);
     String cubeDataChangedAndRewarmCube(User user, Set<Container> containers, String schemaName, String configId, String cubeName);
 
+    /**
+     * Returns a minimal amount of information about the specified cube dimension's hierarchies
+     * @return A Collection of Pair objects containing each hierarchy's name and primary table
+     */
+    Collection<Pair<String, String>> getOlapHierarchies(String configId, Container c, String cubeName, String dimension);
 
     void saveNamedSet(String setName, List<String> setList);
     void deleteNamedSet(String setName);
     List<String> getNamedSet(String setName);
 
     /**
-     * Add a passthrough method to the whitelist for the primary LabKey database type. This enables modules to create
+     * Add a pass-through method to the allow list for the primary LabKey database type. This enables modules to create
      * and enable custom database functions, for example.
      */
     void registerPassthroughMethod(String name, String declaringSchemaName, JdbcType returnType, int minArguments, int maxArguments);
 
     /**
-     * Add a passthrough method to the whitelist for a particular database type. This enables modules to create
-     * and enable custom database functions, for example.
+     * Add a pass-through method to the allow list for a particular database type. This enables modules to create and
+     * enable custom database functions, for example.
      */
     void registerPassthroughMethod(String name, String declaringSchemaName, JdbcType returnType, int minArguments, int maxArguments, SqlDialect dialect);
 

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -34,7 +34,6 @@ import org.labkey.api.audit.AuditHandler;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.AuditTypeEvent;
 import org.labkey.api.audit.DetailedAuditTypeEvent;
-import org.labkey.api.audit.SampleTimelineAuditEvent;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
@@ -84,7 +83,10 @@ import org.labkey.data.xml.queryCustomView.OperatorType;
 import org.labkey.query.audit.QueryExportAuditProvider;
 import org.labkey.query.audit.QueryUpdateAuditProvider;
 import org.labkey.query.controllers.QueryController;
+import org.labkey.query.olap.OlapSchemaDescriptor;
 import org.labkey.query.olap.ServerManager;
+import org.labkey.query.olap.rolap.RolapCubeDef;
+import org.labkey.query.olap.rolap.RolapCubeDef.DimensionDef;
 import org.labkey.query.persist.CstmView;
 import org.labkey.query.persist.ExternalSchemaDef;
 import org.labkey.query.persist.LinkedSchemaDef;
@@ -2954,7 +2956,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
     }
 
 
-    private  QueryUpdateAuditProvider.QueryUpdateAuditEvent createAuditRecord(Container c, AuditConfigurable tinfo, String comment, @Nullable Map<String, Object> row)
+    private QueryUpdateAuditProvider.QueryUpdateAuditEvent createAuditRecord(Container c, AuditConfigurable tinfo, String comment, @Nullable Map<String, Object> row)
     {
         QueryUpdateAuditProvider.QueryUpdateAuditEvent event = new QueryUpdateAuditProvider.QueryUpdateAuditEvent(c.getId(), comment);
         DbScope.Transaction tx = tinfo.getSchema().getScope().getCurrentTransaction();
@@ -2978,6 +2980,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return event;
     }
 
+    @Override
     public List<DetailedAuditTypeEvent> getQueryUpdateAuditRecords(User user, Container container, long transactionAuditId)
     {
         SimpleFilter filter = new SimpleFilter();
@@ -3090,6 +3093,28 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         return result.toString();
     }
 
+    @Override
+    public Collection<Pair<String, String>> getOlapHierarchies(String configId, Container c, String cubeName, String dimension)
+    {
+        OlapSchemaDescriptor descriptor = ServerManager.getDescriptor(c, configId);
+
+        if (null == descriptor)
+            throw new IllegalArgumentException("OLAP schema descriptor not found: " + configId);
+
+        RolapCubeDef rolap = descriptor.getRolapCubeDefinitionByName(cubeName);
+
+        if (null == rolap)
+            throw new IllegalArgumentException("Unable to find cube definition for cubeName: " + cubeName);
+
+        DimensionDef def = rolap.getDimension(dimension);
+
+        if (null == def)
+            throw new IllegalArgumentException("Unable to find dimension " + dimension);
+
+        return def.getHierarchies().stream()
+            .map(h->Pair.of(h.getName(), h.getLevels().get(0).getTableName()))
+            .collect(Collectors.toList());
+    }
 
     /*
     public Set<ColumnInfo> getIncomingLookups(User user, Container c, TableInfo targetTable, Set<SchemaKey> schemaKeys)


### PR DESCRIPTION
#### Rationale
Data Finder needs a way to interrogate cube definitions, so add a basic `QueryService.getOlapHierarchies()` method to `QueryService`. This may be extended with annotations in the near future, but this is all Data Finder needs for now.

#### Related Pull Requests
* https://github.com/LabKey/dataFinder/pull/6