### PR TITLE
Add QueryService.getRolapConfigIds() to support data finder admin page

### DIFF
--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -471,6 +471,7 @@ public interface QueryService
     void cubeDataChanged(Set<Container> containers);
     String warmCube(User user, Set<Container> containers, String schemaName, String configId, String cubeName);
     String cubeDataChangedAndRewarmCube(User user, Set<Container> containers, String schemaName, String configId, String cubeName);
+    List<String> getRolapConfigIds(Container c);
 
     /**
      * Returns a minimal amount of information about the specified cube dimension's hierarchies

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3094,6 +3094,15 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
     }
 
     @Override
+    public List<String> getRolapConfigIds(Container c)
+    {
+        return ServerManager.getDescriptors(c).stream()
+            .filter(d->!d.usesMondrian())
+            .map(OlapSchemaDescriptor::getId)
+            .collect(Collectors.toList());
+    }
+
+    @Override
     public Collection<Pair<String, String>> getOlapHierarchies(String configId, Container c, String cubeName, String dimension)
     {
         OlapSchemaDescriptor descriptor = ServerManager.getDescriptor(c, configId);


### PR DESCRIPTION
#### Rationale
Data finder admin page needs ability to query the list of cubes for its admin page

#### Related Pull Requests
* https://github.com/LabKey/dataFinder/pull/8