### PR TITLE
Pipeline log display not showing some logs on ERROR

### DIFF
--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -95,6 +95,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -476,6 +477,7 @@ public class StatusController extends SpringActionController
         public ActionURL showListUrl;
         public ActionURL showFolderUrl;
         public ActionURL dataUrl;
+        public Date modified;
         public StatusDetailsBean status;
     }
 
@@ -520,6 +522,7 @@ public class StatusController extends SpringActionController
             if (_statusFile.getJobStore() != null && (getUser().hasRootAdminPermission() || c.hasPermission(getUser(), UpdatePermission.class)))
                 bean.retryUrl = urlRetry(_statusFile);
 
+            bean.modified = _statusFile.getModified();
             bean.status = StatusDetailsBean.create(getContainer(), _statusFile, 0, 0);
 
             return new JspView<DetailsBean>("/org/labkey/pipeline/status/details.jsp", bean, errors);

--- a/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
@@ -11,7 +11,6 @@ import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.pipeline.PipelineStatusFile;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.FileUtil;
-import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.view.ActionURL;
 import org.labkey.pipeline.api.PipelineStatusFileImpl;
 import org.labkey.pipeline.api.PipelineStatusManager;

--- a/pipeline/src/org/labkey/pipeline/status/details.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/details.jsp
@@ -26,6 +26,7 @@
 <%@ page import="java.time.LocalDateTime" %>
 <%@ page import="org.labkey.api.settings.FolderSettingsCache" %>
 <%@ page import="java.time.format.DateTimeFormatter" %>
+<%@ page import="java.util.Date" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -39,6 +40,7 @@
     ActionURL showListURL = bean.showListUrl;
     ActionURL showFolderURL = bean.showFolderUrl;
     ActionURL showDataURL = bean.dataUrl;
+    Date modified = bean.modified;
 %>
 <%!
     // keep in sync with JavaScript logTextClass function
@@ -349,10 +351,10 @@
 <%-- fetch updates if the job is active, there was an error reading the log file on first render, or the job has
 ended very recently. --%>
 <%
-    LocalDateTime modifiedTime = LocalDateTime.parse(status.modified,
-            DateTimeFormatter.ofPattern(FolderSettingsCache.getDefaultDateTimeFormat(getContainer())));
-    if (status.active || status.log == null || !status.log.success
-        || (Duration.between(LocalDateTime.now(), modifiedTime).toMinutes() < 1)) { %>
+    long diffTime = new Date().getTime() - modified.getTime();
+    long diffMin = diffTime / (60 * 1000);
+
+    if (status.active || status.log == null || !status.log.success || diffMin < 1) { %>
 <script type="application/javascript">
     (function () {
 

--- a/pipeline/src/org/labkey/pipeline/status/details.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/details.jsp
@@ -16,16 +16,11 @@
  */
 %>
 <%@ page import="org.labkey.api.pipeline.PipelineJob.TaskStatus" %>
-<%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.pipeline.status.LogFileParser" %>
 <%@ page import="org.labkey.pipeline.status.StatusController" %>
 <%@ page import="org.labkey.pipeline.status.StatusDetailsBean" %>
 <%@ page import="java.util.Map" %>
-<%@ page import="java.time.Duration" %>
-<%@ page import="java.time.LocalDateTime" %>
-<%@ page import="org.labkey.api.settings.FolderSettingsCache" %>
-<%@ page import="java.time.format.DateTimeFormatter" %>
 <%@ page import="java.util.Date" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>

--- a/pipeline/src/org/labkey/pipeline/status/details.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/details.jsp
@@ -22,6 +22,10 @@
 <%@ page import="org.labkey.pipeline.status.StatusController" %>
 <%@ page import="org.labkey.pipeline.status.StatusDetailsBean" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="java.time.Duration" %>
+<%@ page import="java.time.LocalDateTime" %>
+<%@ page import="org.labkey.api.settings.FolderSettingsCache" %>
+<%@ page import="java.time.format.DateTimeFormatter" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -342,8 +346,13 @@
     scrollLog(false);
 </script>
 
-<%-- fetch updates if the job is active or there was an error reading the log file on first render. --%>
-<% if (status.active || status.log == null || !status.log.success) { %>
+<%-- fetch updates if the job is active, there was an error reading the log file on first render, or the job has
+ended very recently. --%>
+<%
+    LocalDateTime modifiedTime = LocalDateTime.parse(status.modified,
+            DateTimeFormatter.ofPattern(FolderSettingsCache.getDefaultDateTimeFormat(getContainer())));
+    if (status.active || status.log == null || !status.log.success
+        || (Duration.between(LocalDateTime.now(), modifiedTime).toMinutes() < 1)) { %>
 <script type="application/javascript">
     (function () {
 
@@ -352,7 +361,7 @@
         let fetchCount = 0;
 
         let offsetUnchangedCount = 0;
-        const MAX_UNCHANGED_COUNT = 4;
+        const MAX_UNCHANGED_COUNT = 3;
 
         function updateField(el, text) {
             if (text !== null && text !== undefined)

--- a/pipeline/src/org/labkey/pipeline/status/details.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/details.jsp
@@ -352,7 +352,7 @@
         let fetchCount = 0;
 
         let offsetUnchangedCount = 0;
-        const MAX_UNCHANGED_COUNT = 3;
+        const MAX_UNCHANGED_COUNT = 4;
 
         function updateField(el, text) {
             if (text !== null && text !== undefined)


### PR DESCRIPTION
#### Rationale
The pipeline log display is checking the log file right after executing the job.  There is a race condition between displaying the error and the logger writing the logs to file (caught with intermittent failures on TC).  This PR adds a time check to start the log rechecking process if the job has completed in the last minute.

#### Changes
- Add a check if the pipeline job modified time is within one minute of the current time.  If so, go into the pipeline log updating code.
