### PR TITLE
Issue 41675: allow updating the LSID of an existing exp.data

### DIFF
--- a/api/src/org/labkey/api/exp/IdentifiableBase.java
+++ b/api/src/org/labkey/api/exp/IdentifiableBase.java
@@ -87,7 +87,7 @@ public class IdentifiableBase implements Identifiable, Serializable
     }
 
     // allows updating objectId -- should only be used if there is an existing objectId that was updated
-    public void DANGEROUS_setObjectId(int objectId)
+    public void replaceExistingObjectId(int objectId)
     {
         if (this.objectId == null || this.objectId.equals(objectId))
             throw new IllegalStateException("only call this method if you are creating a new exp.object with a different LSID and need to update the objectId");

--- a/api/src/org/labkey/api/exp/IdentifiableBase.java
+++ b/api/src/org/labkey/api/exp/IdentifiableBase.java
@@ -86,6 +86,14 @@ public class IdentifiableBase implements Identifiable, Serializable
         this.objectId = objectId;
     }
 
+    // allows updating objectId -- should only be used if there is an existing objectId that was updated
+    public void DANGEROUS_setObjectId(int objectId)
+    {
+        if (this.objectId == null || this.objectId.equals(objectId))
+            throw new IllegalStateException("only call this method if you are creating a new exp.object with a different LSID and need to update the objectId");
+        this.objectId = objectId;
+    }
+
     @Override
     public Container getContainer()
     {

--- a/experiment/src/org/labkey/experiment/api/ExpIdentifiableBaseImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpIdentifiableBaseImpl.java
@@ -142,7 +142,7 @@ public abstract class ExpIdentifiableBaseImpl<Type extends IdentifiableBase> ext
                 {
                     assert !Objects.equals(_prevLsid, getLSID());
                     _objectId = OntologyManager.ensureObject(getContainer(), getLSID(), getParentObjectId());
-                    _object.DANGEROUS_setObjectId(_objectId);
+                    _object.replaceExistingObjectId(_objectId);
                 }
 
                 _object = Table.update(user, table, _object, getRowId());


### PR DESCRIPTION
#### Rationale
EvaluationContextTest is failing due to `insert or update on table "data" violates foreign key constraint "fk_data_lsid"` when importing the eval data folder.  The crux of the issue is that an existing exp.data is having it's LSID updated when it is imported into an assay.

In the EvaluationContentTest failure: First, we assign an LSID to the file (something like `urn:lsid:labkey.com:UploadedFile.Folder-142:<...guid...>`).  Later when the file is imported into an assay, it gets a new LSID (something like `urn:lsid:labkey.com:AssayRunTSVData.Folder-142:<...guid...>`).  This happens in `DefaultAssayRunCreator.createData()` near the "Reset its LSID so that it's the correct" comment. It looks like we also could change the ExpData LSID in `ThawListResolverType.configureRun`.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1741

#### Changes
- update LSID for existing exp.data by deleting and creating new exp.object
