### PR TITLE
Issue 41868: Use session key for R report 'apikey' substitution value

### DIFF
--- a/api/src/org/labkey/api/assay/AssayRunUploadContext.java
+++ b/api/src/org/labkey/api/assay/AssayRunUploadContext.java
@@ -28,6 +28,7 @@ import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.qc.TransformResult;
 import org.labkey.api.security.User;
 import org.labkey.api.view.ActionURL;
+import org.labkey.api.view.HasHttpRequest;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.writer.ContainerUser;
 
@@ -49,7 +50,7 @@ import static java.util.Collections.emptyMap;
  * User: brittp
  * Date: Jul 11, 2007
 */
-public interface AssayRunUploadContext<ProviderType extends AssayProvider> extends ContainerUser
+public interface AssayRunUploadContext<ProviderType extends AssayProvider> extends ContainerUser, HasHttpRequest
 {
     @NotNull
     ExpProtocol getProtocol();

--- a/api/src/org/labkey/api/assay/DefaultDataTransformer.java
+++ b/api/src/org/labkey/api/assay/DefaultDataTransformer.java
@@ -38,6 +38,7 @@ import org.labkey.api.util.CSRFUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
+import org.labkey.api.view.ViewServlet;
 
 import javax.script.Bindings;
 import javax.script.ScriptContext;
@@ -117,7 +118,7 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
                     FileUtil.deleteDirectoryContents(scriptDir);
 
                     // issue 19748: need alternative to JSESSIONID for pipeline job transform script usage (i.e., TransformSession)
-                    try (TransformSession session = SecurityManager.createTransformSession(context.getUser()))
+                    try (TransformSession session = SecurityManager.createTransformSession(context))
                     {
                         Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
                         String script = sb.toString();

--- a/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
@@ -356,7 +356,7 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
     protected Object runScript(ScriptEngine engine, ViewContext context, List<ParamReplacement> outputSubst, File inputDataTsv, Map<String, Object> inputParameters) throws ScriptException
     {
         RConnectionHolder rh = null;
-        try (TransformSession session = SecurityManager.createTransformSession(context.getUser()))
+        try (TransformSession session = SecurityManager.createTransformSession(context))
         {
             Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
             bindings.put(ExternalScriptEngine.WORKING_DIRECTORY, getReportDir(context.getContainer().getId()).getAbsolutePath());

--- a/api/src/org/labkey/api/view/HasHttpRequest.java
+++ b/api/src/org/labkey/api/view/HasHttpRequest.java
@@ -1,0 +1,11 @@
+package org.labkey.api.view;
+
+import org.jetbrains.annotations.Nullable;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface HasHttpRequest
+{
+    @Nullable
+    HttpServletRequest getRequest();
+}

--- a/api/src/org/labkey/api/view/ViewContext.java
+++ b/api/src/org/labkey/api/view/ViewContext.java
@@ -17,6 +17,7 @@ package org.labkey.api.view;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.HasPermission;
@@ -58,7 +59,7 @@ import java.util.Set;
  * User: matthewb
  * Date: Mar 20, 2005
  */
-public class ViewContext implements MessageSource, ContainerContext, ContainerUser, ApplicationContextAware, HasPermission
+public class ViewContext implements MessageSource, ContainerContext, ContainerUser, ApplicationContextAware, HasPermission, HasHttpRequest
 {
     private ApplicationContext _applicationContext;
     private HttpServletRequest _request;
@@ -211,6 +212,10 @@ public class ViewContext implements MessageSource, ContainerContext, ContainerUs
 
     // ===========================================
 
+    /**
+     * @return null if we're operating in a background thread, divorced from an in-process HTTP request
+     */
+    @Nullable
     public HttpServletRequest getRequest()
     {
         return _request;

--- a/core/src/org/labkey/core/view/configReportsAndScripts.jsp
+++ b/core/src/org/labkey/core/view/configReportsAndScripts.jsp
@@ -877,20 +877,24 @@
 
     function handleFailure(resp, opt) {
         var jsonResp = Ext4.decode(resp.responseText);
-        if (jsonResp && jsonResp.errors)
-        {
+        if (jsonResp) {
             var errorHTML = '';
-            for (var p in jsonResp.errors)
-            {
-                if (jsonResp.errors.hasOwnProperty(p))
-                {
-                    errorHTML += jsonResp.errors[p] + '\n';
+            if (jsonResp.errors) {
+                for (let i = 0; i < jsonResp.errors.length; i++) {
+                    let error = jsonResp.errors[i];
+                    if (error.msg) {
+                        errorHTML += error.msg + '\n';
+                    }
                 }
+            }
+            else if (jsonResp.exception) {
+                errorHTML = jsonResp.exception;
             }
             Ext4.Msg.alert('Error', errorHTML);
         }
-        else
+        else {
             LABKEY.Utils.displayAjaxErrorResponse(resp, opt);
+        }
     }
 
     Ext4.onReady(function()

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.java
@@ -421,7 +421,7 @@ public class ExpDataClassDataTestCase extends ExpProvisionedTableTestHelper
     private void verifyAliasesViaSelectRows(String schemaName, String queryName, int expDataRowId, Set<String> expectedAliases)
             throws Exception
     {
-        try (var session = SecurityManager.createTransformSession(TestContext.get().getUser()))
+        try (var session = SecurityManager.createTransformSession(TestContext.get().getRequest(), TestContext.get().getRequest().getSession()))
         {
             String baseURL = AppProps.getInstance().getBaseServerUrl() + AppProps.getInstance().getContextPath();
             Connection conn = new Connection(baseURL, new ApiKeyCredentialsProvider(session.getApiKey()));


### PR DESCRIPTION
#### Rationale
Use a session apikey when running external scripts.  RReports and assays can be configured to run in a background job.  In this case, the script will use a database apikey.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/546
* https://github.com/LabKey/commonAssays/pull/266

#### Changes
* Introduce a HasHttpRequest interface so the either ViewContext or AssayRunUploadContext can be in createTransformSession
