### PR TITLE
41939: nab: delete button from nab run details page should POST

### DIFF
--- a/assay/src/org/labkey/api/assay/nab/view/runNotes.jsp
+++ b/assay/src/org/labkey/api/assay/nab/view/runNotes.jsp
@@ -77,7 +77,7 @@
                 ActionURL deleteUrl = urlProvider(NabUrls.class).urlDeleteRun(c);
                 deleteUrl.addParameter("rowId", bean.getRunId());
     %>
-    <%= button("Delete Run").href(deleteUrl).onClick("return confirm('Permanently delete this run?')") %>
+    <%= button("Delete Run").href(deleteUrl).usePost("Permanently delete this run?") %>
     <%= button("Delete and Re-Import").href(rerunURL) %>
     <%
             }


### PR DESCRIPTION
#### Rationale
Fix the mutating SQL exception by changing the action from a GET to a POST. The link to delete only occurs right after you import an assay run or if the newRun=true parameter is present.

https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=41939

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/1762