### PR TITLE
Support <Annotations> within cube <Hierarchy> elements

### DIFF
--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -45,7 +45,6 @@ import org.labkey.api.module.Module;
 import org.labkey.api.query.snapshot.QuerySnapshotDefinition;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
-import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
@@ -473,11 +472,18 @@ public interface QueryService
     String cubeDataChangedAndRewarmCube(User user, Set<Container> containers, String schemaName, String configId, String cubeName);
     List<String> getRolapConfigIds(Container c);
 
+    interface Hierarchy
+    {
+        String getName();
+        String getTableName();
+        Map<String, String> getAnnotations();
+    }
+
     /**
-     * Returns a minimal amount of information about the specified cube dimension's hierarchies
-     * @return A Collection of Pair objects containing each hierarchy's name and primary table
+     * Returns information about the specified cube dimension's hierarchies
+     * @return A Collection of Hierarchy objects containing basic information about each hierarchy
      */
-    Collection<Pair<String, String>> getOlapHierarchies(String configId, Container c, String cubeName, String dimension);
+    Collection<Hierarchy> getOlapHierarchies(String configId, Container c, String cubeName, String dimension);
 
     void saveNamedSet(String setName, List<String> setList);
     void deleteNamedSet(String setName);

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3103,7 +3103,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
     }
 
     @Override
-    public Collection<Pair<String, String>> getOlapHierarchies(String configId, Container c, String cubeName, String dimension)
+    public Collection<QueryService.Hierarchy> getOlapHierarchies(String configId, Container c, String cubeName, String dimension)
     {
         OlapSchemaDescriptor descriptor = ServerManager.getDescriptor(c, configId);
 
@@ -3120,9 +3120,7 @@ public class QueryServiceImpl extends AuditHandler implements QueryService
         if (null == def)
             throw new IllegalArgumentException("Unable to find dimension " + dimension);
 
-        return def.getHierarchies().stream()
-            .map(h->Pair.of(h.getName(), h.getLevels().get(0).getTableName()))
-            .collect(Collectors.toList());
+        return new ArrayList<>(def.getHierarchies());
     }
 
     /*

--- a/query/src/org/labkey/query/olap/rolap/RolapCubeDef.java
+++ b/query/src/org/labkey/query/olap/rolap/RolapCubeDef.java
@@ -25,6 +25,7 @@ import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.query.AliasManager;
 import org.labkey.api.query.DefaultSchema;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.Path;
 import org.labkey.query.olap.metadata.CachedCube;
@@ -574,7 +575,7 @@ public class RolapCubeDef
 
 
 
-    static public class HierarchyDef
+    static public class HierarchyDef implements QueryService.Hierarchy
     {
         protected RolapCubeDef cube;
         protected DimensionDef dimension;
@@ -586,7 +587,9 @@ public class RolapCubeDef
         protected JoinOrTable join;
         protected boolean hasAll;
         protected ArrayList<LevelDef> levels = new ArrayList<>();
+        protected final Map<String, String> annotations = new TreeMap<>();
 
+        @Override
         public String getName()
         {
             return name;
@@ -669,6 +672,18 @@ public class RolapCubeDef
                 factTableAliases.put(dimension.foreignKey,dimension.foreignKey);
             }
             joins.add(j);
+        }
+
+        @Override
+        public Map<String,String> getAnnotations()
+        {
+            return annotations;
+        }
+
+        @Override
+        public String getTableName()
+        {
+            return getLevels().get(0).getTableName();
         }
     }
 

--- a/query/src/org/labkey/query/olap/rolap/RolapReader.java
+++ b/query/src/org/labkey/query/olap/rolap/RolapReader.java
@@ -303,6 +303,9 @@ public class RolapReader
                 case "Join":
                     _currentHier.join = parseJoinOrTable(node);
                     break;
+                case "Annotations":
+                    parseAnnotations(node, _currentHier.annotations);
+                    break;
             }
         }
         RolapCubeDef.LevelDef lowest = _currentHier.levels.get(_currentHier.levels.size()-1);


### PR DESCRIPTION
#### Rationale
We need the ability to add annotations on cube hierarchies to move facet properties and behaviors from code into meta data

#### Related Pull Requests
* https://github.com/LabKey/dataFinder/pull/9

#### Changes
* Parse & stash `<Annotations>` inside cube `<Hierarchy>` elements
* Introduce simple `Hierarchy` interface and return it (instead of Pair) from `getOlapHierarchies()`
