### PR TITLE
20.11 fb datasetqueryview

### DIFF
--- a/core/src/org/labkey/core/query/ModulesTableInfo.java
+++ b/core/src/org/labkey/core/query/ModulesTableInfo.java
@@ -27,6 +27,7 @@ import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.Table;
+import org.labkey.api.data.dialect.DialectStringHandler;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.module.ModuleLoader;
@@ -135,10 +136,21 @@ public class ModulesTableInfo extends SimpleUserSchema.SimpleTable<CoreQuerySche
         return (ModulesTableInfo) super.init();
     }
 
+    private void appendStringLiteral(DialectStringHandler h, SQLFragment sql, String sep, String s)
+    {
+        sql.append(sep);
+        s = StringUtils.trimToNull(s);
+        if (null == s)
+            sql.append("NULL");
+        else
+            sql.append(h.quoteStringLiteral(s));
+    }
+
     @NotNull
     @Override
     public SQLFragment getFromSQL(String alias)
     {
+        var h = getSqlDialect().getStringHandler();
         SQLFragment ret = new SQLFragment();
 
         // select in-memory modules
@@ -150,21 +162,20 @@ public class ModulesTableInfo extends SimpleUserSchema.SimpleTable<CoreQuerySche
         {
             cte.append(sep);
             sep = ",\n";
-            cte.append("(");
-            cte.append("?").add(module.getName());
-            cte.append(",?").add(StringUtils.trimToNull(module.getReleaseVersion()));
-            cte.append(",?").add(StringUtils.trimToNull(module.getLabel()));
-            cte.append(",?").add(StringUtils.trimToNull(module.getDescription()));
-            cte.append(",?").add(StringUtils.trimToNull(module.getUrl()));
-            cte.append(",?").add(StringUtils.trimToNull(module.getAuthor()));
-            cte.append(",?").add(StringUtils.trimToNull(module.getMaintainer()));
-            cte.append(",?").add(StringUtils.trimToNull(module.getOrganization()));
-            cte.append(",?").add(StringUtils.trimToNull(module.getOrganizationUrl()));
-            cte.append(",?").add(StringUtils.trimToNull(module.getLicense()));
-            cte.append(",?").add(StringUtils.trimToNull(module.getLicenseUrl()));
-            cte.append(",?").add(StringUtils.trimToNull(module.getVcsRevision()));
-            cte.append(",?").add(StringUtils.trimToNull(module.getVcsUrl()));
-            cte.append(",?").add(StringUtils.join(module.getModuleDependenciesAsSet(), ", "));
+            appendStringLiteral(h, cte,"(",module.getName());
+            appendStringLiteral(h, cte,",",module.getReleaseVersion());
+            appendStringLiteral(h, cte,",",module.getLabel());
+            appendStringLiteral(h, cte,",",module.getDescription());
+            appendStringLiteral(h, cte,",",module.getUrl());
+            appendStringLiteral(h, cte,",",module.getAuthor());
+            appendStringLiteral(h, cte,",",module.getMaintainer());
+            appendStringLiteral(h, cte,",",module.getOrganization());
+            appendStringLiteral(h, cte,",",module.getOrganizationUrl());
+            appendStringLiteral(h, cte,",",module.getLicense());
+            appendStringLiteral(h, cte,",",module.getLicenseUrl());
+            appendStringLiteral(h, cte,",",module.getVcsRevision());
+            appendStringLiteral(h, cte,",",module.getVcsUrl());
+            appendStringLiteral(h, cte,",",StringUtils.join(module.getModuleDependenciesAsSet(), ", "));
             cte.append(")");
         }
         cte.append(") AS T (");

--- a/study/src/org/labkey/study/controllers/ParticipantGroupController.java
+++ b/study/src/org/labkey/study/controllers/ParticipantGroupController.java
@@ -1128,6 +1128,7 @@ public class ParticipantGroupController extends BaseStudyController
         private String[] _participantIds;
         private String[] _ensureParticipantIds;
         private String[] _deleteParticipantIds;
+        private boolean _showDataRegionMessage = true;
 
         public int getRowId()
         {
@@ -1197,6 +1198,16 @@ public class ParticipantGroupController extends BaseStudyController
         public void setDeleteParticipantIds(String[] deleteParticipantIds)
         {
             _deleteParticipantIds = deleteParticipantIds;
+        }
+
+        public boolean isShowDataRegionMessage()
+        {
+            return _showDataRegionMessage;
+        }
+
+        public void setShowDataRegionMessage(boolean showDataRegionMessage)
+        {
+            _showDataRegionMessage = showDataRegionMessage;
         }
     }
 
@@ -1425,7 +1436,7 @@ public class ParticipantGroupController extends BaseStudyController
                     if (existing == null)
                         throw new NotFoundException("Could not find participant group with rowId " + form.getRowId());
 
-                    ParticipantGroupManager.getInstance().setSessionParticipantGroup(getContainer(), getUser(), getViewContext().getRequest(), existing.getRowId());
+                    ParticipantGroupManager.getInstance().setSessionParticipantGroup(getContainer(), getUser(), getViewContext().getRequest(), existing.getRowId(), form.isShowDataRegionMessage());
                     return success(existing);
                 }
                 else
@@ -1453,7 +1464,7 @@ public class ParticipantGroupController extends BaseStudyController
                         copy.setModified(copy.getModified());
                         copy.setModifiedBy(copy.getModifiedBy());
                         group = copy;
-                        ParticipantGroupManager.getInstance().setSessionParticipantGroup(getContainer(), getUser(), getViewContext().getRequest(), group);
+                        ParticipantGroupManager.getInstance().setSessionParticipantGroup(getContainer(), getUser(), getViewContext().getRequest(), group, form.isShowDataRegionMessage());
                     }
 
                     Set<String> participantIds = new HashSet<>(Arrays.asList(form.getParticipantIds() == null ? group.getParticipantIds() : form.getParticipantIds()));
@@ -1473,7 +1484,7 @@ public class ParticipantGroupController extends BaseStudyController
                     if (form.getFilters() != null)
                         group.setFilters(form.getFilters());
 
-                    group = ParticipantGroupManager.getInstance().setSessionParticipantGroup(getContainer(), getUser(), getViewContext().getRequest(), group);
+                    group = ParticipantGroupManager.getInstance().setSessionParticipantGroup(getContainer(), getUser(), getViewContext().getRequest(), group, form.isShowDataRegionMessage());
                     return success(group);
                 }
             }

--- a/study/src/org/labkey/study/model/ParticipantGroupManager.java
+++ b/study/src/org/labkey/study/model/ParticipantGroupManager.java
@@ -55,6 +55,7 @@ import org.labkey.api.study.permissions.SharedParticipantGroupPermission;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.SessionHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
@@ -659,16 +660,17 @@ public class ParticipantGroupManager
         return participantIdMap;
     }
 
-    public void setSessionParticipantGroup(Container c, User user, HttpServletRequest request, Integer groupRowId)
+    public void setSessionParticipantGroup(Container c, User user, HttpServletRequest request, Integer groupRowId, boolean showDataRegionMessage)
     {
         HttpSession session = request.getSession(true);
         if (session == null)
             return;
 
         session.setAttribute(PARTICIPANT_GROUP_SESSION_KEY + c.getRowId(), groupRowId);
+        session.setAttribute(PARTICIPANT_GROUP_SESSION_KEY + c.getRowId() + ".showMessage", showDataRegionMessage);
     }
 
-    public ParticipantGroup setSessionParticipantGroup(Container c, User user, HttpServletRequest request, ParticipantGroup group)
+    public ParticipantGroup setSessionParticipantGroup(Container c, User user, HttpServletRequest request, ParticipantGroup group, boolean showDataRegionMessage)
     {
         assert group.isSession();
         HttpSession session = request.getSession(true);
@@ -676,9 +678,16 @@ public class ParticipantGroupManager
             return null;
 
         session.setAttribute(PARTICIPANT_GROUP_SESSION_KEY + c.getRowId(), group);
+        session.setAttribute(PARTICIPANT_GROUP_SESSION_KEY + c.getRowId() + "showMessage", showDataRegionMessage);
         // don't MemTrack track this one, since it's going in session
         MemTracker.get().remove(group);
         return group;
+    }
+
+    public boolean getSessionParticipantGroupShowMessage(Container c, HttpServletRequest request)
+    {
+        Boolean b = (Boolean)SessionHelper.getAttribute(request, PARTICIPANT_GROUP_SESSION_KEY + c.getRowId() + "showMessage", false);
+        return b == Boolean.TRUE;
     }
 
     public ParticipantGroup getSessionParticipantGroup(Container c, User user, HttpServletRequest request)
@@ -703,6 +712,7 @@ public class ParticipantGroupManager
             return;
 
         session.removeAttribute(PARTICIPANT_GROUP_SESSION_KEY + c.getRowId());
+        session.removeAttribute(PARTICIPANT_GROUP_SESSION_KEY + c.getRowId() + ".showMessage");
     }
 
 

--- a/study/src/org/labkey/study/model/ParticipantGroupManager.java
+++ b/study/src/org/labkey/study/model/ParticipantGroupManager.java
@@ -678,7 +678,8 @@ public class ParticipantGroupManager
             return null;
 
         session.setAttribute(PARTICIPANT_GROUP_SESSION_KEY + c.getRowId(), group);
-        session.setAttribute(PARTICIPANT_GROUP_SESSION_KEY + c.getRowId() + "showMessage", showDataRegionMessage);
+        session.setAttribute(PARTICIPANT_GROUP_SESSION_KEY + c.getRowId() + ".showMessage", showDataRegionMessage);
+
         // don't MemTrack track this one, since it's going in session
         MemTracker.get().remove(group);
         return group;

--- a/study/src/org/labkey/study/model/ParticipantGroupManager.java
+++ b/study/src/org/labkey/study/model/ParticipantGroupManager.java
@@ -687,7 +687,8 @@ public class ParticipantGroupManager
 
     public boolean getSessionParticipantGroupShowMessage(Container c, HttpServletRequest request)
     {
-        Boolean b = (Boolean)SessionHelper.getAttribute(request, PARTICIPANT_GROUP_SESSION_KEY + c.getRowId() + "showMessage", false);
+        Boolean b = (Boolean)SessionHelper.getAttribute(request, PARTICIPANT_GROUP_SESSION_KEY + c.getRowId() + ".showMessage", false);
+
         return b == Boolean.TRUE;
     }
 

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -696,29 +696,32 @@ public class DatasetQueryView extends StudyQueryView
                 }
             }
 
-            ParticipantGroup sessionGroup = ParticipantGroupManager.getInstance().getSessionParticipantGroup(dqs.getContainer(), dqs.getUser(), ctx.getViewContext().getRequest());
-            if (sessionGroup != null)
+            if (ParticipantGroupManager.getInstance().getSessionParticipantGroupShowMessage(dqs.getContainer(), ctx.getViewContext().getRequest()))
             {
-                if (msg.length() > 0)
-                    msg.append("&nbsp;&nbsp;");
-                msg.append("<span class=\"labkey-strong\">Selected " + PageFlowUtil.filter(dqs.getStudy().getSubjectNounPlural()) + ":</span>&nbsp;");
-                msg.append(sessionGroup.getParticipantIds().length);
+                ParticipantGroup sessionGroup = ParticipantGroupManager.getInstance().getSessionParticipantGroup(dqs.getContainer(), dqs.getUser(), ctx.getViewContext().getRequest());
+                if (sessionGroup != null)
+                {
+                    if (msg.length() > 0)
+                        msg.append("&nbsp;&nbsp;");
+                    msg.append("<span class=\"labkey-strong\">Selected " + PageFlowUtil.filter(dqs.getStudy().getSubjectNounPlural()) + ":</span>&nbsp;");
+                    msg.append(sessionGroup.getParticipantIds().length);
+                }
+
+                if (msg.length() != 0)
+                {
+                    // HACK -- link to immport/studyFinder.view
+                    Module immport = ModuleLoader.getInstance().getModule("immport");
+                    Container project = ctx.getContainer().getProject();
+                    if (immport != null && project != null && project.getActiveModules().contains(immport))
+                    {
+                        ActionURL finderURL = new ActionURL("immport", "dataFinderRedirect.view", project);
+                        msg.append("&nbsp;&nbsp;").append(PageFlowUtil.button("Edit").href(finderURL.toString()));
+                    }
+                    msg.append("</div>");
+
+                    headerMessage.append(msg);
+                }
             }
-
-            if (msg.length() == 0)
-                return;
-
-            // HACK -- link to immport/studyFinder.view
-            Module immport = ModuleLoader.getInstance().getModule("immport");
-            Container project = ctx.getContainer().getProject();
-            if (immport != null && project != null && project.getActiveModules().contains(immport))
-            {
-                ActionURL finderURL = new ActionURL("immport", "dataFinderRedirect.view", project);
-                msg.append("&nbsp;&nbsp;").append(PageFlowUtil.button("Edit").href(finderURL.toString()));
-            }
-            msg.append("</div>");
-
-            headerMessage.append(msg);
         }
     }
 


### PR DESCRIPTION
#### Rationale
Provide option to not show session participant group summary in data region header.  a) because the client grid is not rendering this correctly at the moment 2) the client has a custom display for the same information.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42047