### PR TITLE
Item 7342: Add query parameters for GetUserNotificationsAction so a container, type labels and maxRows can be provided

### DIFF
--- a/api/src/org/labkey/api/admin/notification/NotificationService.java
+++ b/api/src/org/labkey/api/admin/notification/NotificationService.java
@@ -74,6 +74,12 @@ public interface NotificationService
     List<Notification> getNotificationsByType(Container container, @NotNull String type, int notifyUserId, boolean unreadOnly);
 
     /*
+     * Returns a list of notifications for a specific user based on the specified type label (e.g, 'Pipeline').
+     */
+    List<Notification> getNotificationsByTypeLabel(Container container, @NotNull String typeLabel, int notifyUserId, boolean unreadOnly);
+
+
+    /*
      * Returns a notification based on the notification's RowId.
      */
     Notification getNotification(int rowId);

--- a/api/src/org/labkey/api/admin/notification/NotificationService.java
+++ b/api/src/org/labkey/api/admin/notification/NotificationService.java
@@ -74,9 +74,9 @@ public interface NotificationService
     List<Notification> getNotificationsByType(Container container, @NotNull String type, int notifyUserId, boolean unreadOnly);
 
     /*
-     * Returns a list of notifications for a specific user based on the specified type label (e.g, 'Pipeline').
+     * Returns a list of notifications for a specific user based on the specified type labels (e.g, 'Pipeline').
      */
-    List<Notification> getNotificationsByTypeLabel(Container container, @NotNull List<String> typeLabels, int notifyUserId, boolean unreadOnly);
+    List<Notification> getNotificationsByTypeLabels(Container container, @NotNull List<String> typeLabels, int notifyUserId, boolean unreadOnly);
 
     /*
      * Returns a notification based on the notification's RowId.

--- a/api/src/org/labkey/api/admin/notification/NotificationService.java
+++ b/api/src/org/labkey/api/admin/notification/NotificationService.java
@@ -76,8 +76,7 @@ public interface NotificationService
     /*
      * Returns a list of notifications for a specific user based on the specified type label (e.g, 'Pipeline').
      */
-    List<Notification> getNotificationsByTypeLabel(Container container, @NotNull String typeLabel, int notifyUserId, boolean unreadOnly);
-
+    List<Notification> getNotificationsByTypeLabel(Container container, @NotNull List<String> typeLabels, int notifyUserId, boolean unreadOnly);
 
     /*
      * Returns a notification based on the notification's RowId.

--- a/core/src/org/labkey/core/notification/NotificationController.java
+++ b/core/src/org/labkey/core/notification/NotificationController.java
@@ -279,7 +279,7 @@ public class NotificationController extends SpringActionController
             if (form.getTypeLabels() == null || form.getTypeLabels().isEmpty())
                 notifications = service.getNotificationsByUser(container, getUser().getUserId(), false);
             else
-                notifications = service.getNotificationsByTypeLabel(container, form.getTypeLabels(), getUser().getUserId(), false);
+                notifications = service.getNotificationsByTypeLabels(container, form.getTypeLabels(), getUser().getUserId(), false);
 
             int i = 0;
             int unreadCount = 0;

--- a/core/src/org/labkey/core/notification/NotificationController.java
+++ b/core/src/org/labkey/core/notification/NotificationController.java
@@ -152,7 +152,13 @@ public class NotificationController extends SpringActionController
                 NotificationService service = NotificationService.get();
                 Container container = form.getContainer() == null ? null : ContainerManager.getForId(form.getContainer());
 
-                for (Notification notification : service.getNotificationsByUser(container, getUser().getUserId(), true))
+                List<Notification> notifications;
+                if (form.getTypeLabels() == null || form.getTypeLabels().isEmpty())
+                    notifications = service.getNotificationsByUser(container, getUser().getUserId(), true);
+                else
+                    notifications = service.getNotificationsByTypeLabels(container, form.getTypeLabels(), getUser().getUserId(), true);
+
+                for (Notification notification : notifications)
                 {
                     Container c = ContainerManager.getForId(notification.getContainer());
                     int numUpdated = NotificationService.get().markAsRead(c, getUser(), notification.getObjectId(),

--- a/core/src/org/labkey/core/notification/NotificationServiceImpl.java
+++ b/core/src/org/labkey/core/notification/NotificationServiceImpl.java
@@ -194,9 +194,13 @@ public class NotificationServiceImpl extends AbstractContainerListener implement
     }
 
     @Override
-    public List<Notification> getNotificationsByTypeLabel(Container container, @NotNull String typeLabel, int notifyUserId, boolean unreadOnly)
+    public List<Notification> getNotificationsByTypeLabel(Container container, @NotNull List<String> typeLabels, int notifyUserId, boolean unreadOnly)
     {
-        return getNotificationsByUserOrType(container, _labelTypesMap.get(typeLabel), notifyUserId, unreadOnly);
+        List<String> types = new ArrayList<>();
+        typeLabels.forEach(label -> {
+            types.addAll(_labelTypesMap.get(label));
+        });
+        return getNotificationsByUserOrType(container, types, notifyUserId, unreadOnly);
     }
 
     private List<Notification> getNotificationsByUserOrType(Container container, @Nullable List<String> types, int notifyUserId, boolean unreadOnly)

--- a/core/src/org/labkey/core/notification/NotificationServiceImpl.java
+++ b/core/src/org/labkey/core/notification/NotificationServiceImpl.java
@@ -54,6 +54,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMultipart;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -69,6 +70,7 @@ public class NotificationServiceImpl extends AbstractContainerListener implement
 {
     private final static NotificationServiceImpl INSTANCE = new NotificationServiceImpl();
     private final Map<String, String> _typeLabelMap = new ConcurrentHashMap<>();
+    private final Map<String, List<String>> _labelTypesMap = new ConcurrentHashMap<>();
     private final Map<String, String> _typeIconMap = new ConcurrentHashMap<>();
 
     public static NotificationServiceImpl getInstance()
@@ -188,17 +190,23 @@ public class NotificationServiceImpl extends AbstractContainerListener implement
     @Override
     public List<Notification> getNotificationsByType(Container container, @NotNull String type, int notifyUserId, boolean unreadOnly)
     {
-        return getNotificationsByUserOrType(container, type, notifyUserId, unreadOnly);
+        return getNotificationsByUserOrType(container, Collections.singletonList(type), notifyUserId, unreadOnly);
     }
 
-    private List<Notification> getNotificationsByUserOrType(Container container, String type, int notifyUserId, boolean unreadOnly)
+    @Override
+    public List<Notification> getNotificationsByTypeLabel(Container container, @NotNull String typeLabel, int notifyUserId, boolean unreadOnly)
+    {
+        return getNotificationsByUserOrType(container, _labelTypesMap.get(typeLabel), notifyUserId, unreadOnly);
+    }
+
+    private List<Notification> getNotificationsByUserOrType(Container container, @Nullable List<String> types, int notifyUserId, boolean unreadOnly)
     {
         SimpleFilter filter = new SimpleFilter();
         if (null != container)
             filter = SimpleFilter.createContainerFilter(container);
         filter.addCondition(FieldKey.fromParts("UserID"), notifyUserId);
-        if (type != null)
-            filter.addCondition(FieldKey.fromParts("Type"), type);
+        if (types != null)
+            filter.addCondition(FieldKey.fromParts("Type"), types, CompareType.IN);
         if (unreadOnly)
             filter.addCondition(FieldKey.fromParts("ReadOn"), null, CompareType.ISBLANK);
 
@@ -338,6 +346,9 @@ public class NotificationServiceImpl extends AbstractContainerListener implement
             _typeLabelMap.put(type, label);
         else
             throw new IllegalStateException("A label has already been registered for this type: " + type);
+        List<String> typesForLabel = _labelTypesMap.getOrDefault(label, new ArrayList<>());
+        typesForLabel.add(type);
+        _labelTypesMap.put(label, typesForLabel);
 
         if (iconCls != null)
         {

--- a/core/src/org/labkey/core/notification/NotificationServiceImpl.java
+++ b/core/src/org/labkey/core/notification/NotificationServiceImpl.java
@@ -194,7 +194,7 @@ public class NotificationServiceImpl extends AbstractContainerListener implement
     }
 
     @Override
-    public List<Notification> getNotificationsByTypeLabel(Container container, @NotNull List<String> typeLabels, int notifyUserId, boolean unreadOnly)
+    public List<Notification> getNotificationsByTypeLabels(Container container, @NotNull List<String> typeLabels, int notifyUserId, boolean unreadOnly)
     {
         List<String> types = new ArrayList<>();
         typeLabels.forEach(label -> {


### PR DESCRIPTION
#### Rationale
For displaying notifications within the Sample Management application, we want to be able to show only certain types of notifications for the current container and don't need to display all the notifications. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/412

#### Changes
* Update GetUserNotificationsAction to accept container, typeLabel and maxRows parameters
* Add method for getting notifications by type label
* Add method for marking all of a user's notifications as read without having to provide the rowIds
