### PR TITLE
Make obsolete scripts action case-insensitive

### DIFF
--- a/api/src/org/labkey/api/Constants.java
+++ b/api/src/org/labkey/api/Constants.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 /**
- * This class provides a single place to update system-wide constants used for sizing caches and other purposes.
+ * This class provides a single place to update system-wide constants that specify versions, cache sizes, and other key settings.
  *
  * Created by adam on 10/22/2016.
  */

--- a/core/src/org/labkey/core/admin/sql/SqlScriptController.java
+++ b/core/src/org/labkey/core/admin/sql/SqlScriptController.java
@@ -28,6 +28,7 @@ import org.labkey.api.action.ReadOnlyApiAction;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.admin.AdminUrls;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.CoreSchema;
@@ -902,7 +903,7 @@ public class SqlScriptController extends SpringActionController
 
                 FileSqlScriptProvider provider = new FileSqlScriptProvider(module);
                 Collection<DbSchema> schemas = provider.getSchemas();
-                Set<String> allFiles = new HashSet<>();
+                Set<String> allFiles = new CaseInsensitiveHashSet();
 
                 // If module advertises no schemas then still look in the labkey dialect directory for spurious scripts
                 if (schemas.isEmpty())

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -138,7 +138,7 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
     // standard string to use in URLs etc.
     public static final String DATASETKEY = "datasetId";
 //    static final Object MANAGED_KEY_LOCK = new Object();
-    private static Logger _log = LogManager.getLogger(DatasetDefinition.class);
+    private static final Logger _log = LogManager.getLogger(DatasetDefinition.class);
 
     private final ReentrantLock _lock = new ReentrantLock();
 


### PR DESCRIPTION
#### Rationale
SQL script runner is case-insensitive, but the "orphaned scripts" action is not... so it mistakenly flags some files as "unrecognized"
