### PR TITLE
Issue 42062: Convert *Action<Void> to *Action<Object>

### DIFF
--- a/api/src/org/labkey/api/action/BaseViewAction.java
+++ b/api/src/org/labkey/api/action/BaseViewAction.java
@@ -63,12 +63,10 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -448,29 +446,6 @@ public abstract class BaseViewAction<FORM> extends PermissionCheckableAction imp
             }
         }
         return errors;
-    }
-
-    protected Map<String,Object> _fixupPropertyMap(Map<String,Object> in)
-    {
-        Map<String,Object> out = new HashMap<>(in);
-
-        /** see TableViewForm.setTypedValues() */
-        for (Map.Entry<String,Object> entry : in.entrySet())
-        {
-            String propName = entry.getKey();
-            Object o = entry.getValue();
-
-            if (Character.isUpperCase(propName.charAt(0)))
-            {
-                out.remove(propName);
-                propName = Introspector.decapitalize(propName);
-                out.put(propName,o);
-            }
-        }
-
-        out.remove("container");
-        out.remove("user");
-        return out;
     }
 
     @Override

--- a/api/src/org/labkey/api/action/SimpleViewAction.java
+++ b/api/src/org/labkey/api/action/SimpleViewAction.java
@@ -27,9 +27,6 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
-
 /**
  * Base class for actions that want to display a single page in response to a GET, including
  * form parameters. Not intended for actions that may separately receive a POST.
@@ -81,8 +78,7 @@ public abstract class SimpleViewAction<FORM> extends BaseViewAction<FORM> implem
         return v;
     }
 
-
-    private static void validateUnicodePropertyValues(PropertyValues pvs) throws ServletException
+    private static void validateUnicodePropertyValues(PropertyValues pvs)
     {
         for (PropertyValue pv : pvs.getPropertyValues())
         {
@@ -111,7 +107,6 @@ public abstract class SimpleViewAction<FORM> extends BaseViewAction<FORM> implem
             }
         }
     }
-
 
     @Override
     protected String getCommandClassMethodName()

--- a/api/src/org/labkey/api/view/FolderManagement.java
+++ b/api/src/org/labkey/api/view/FolderManagement.java
@@ -190,7 +190,7 @@ public class FolderManagement
     /**
      * Base action class for management actions that only need to display a view (no post handling).
      */
-    private static abstract class ManagementViewAction extends SimpleViewAction<Void> implements ManagementAction
+    private static abstract class ManagementViewAction extends SimpleViewAction<Object> implements ManagementAction
     {
         @Override
         public ModelAndView handleRequest() throws Exception
@@ -201,7 +201,7 @@ public class FolderManagement
         }
 
         @Override
-        public ModelAndView getView(Void form, BindException errors) throws Exception
+        public ModelAndView getView(Object form, BindException errors) throws Exception
         {
             return wrapViewInTabStrip(this, getType(), getTabView(), errors);
         }

--- a/core/src/org/labkey/core/admin/sql/SqlScriptController.java
+++ b/core/src/org/labkey/core/admin/sql/SqlScriptController.java
@@ -885,10 +885,10 @@ public class SqlScriptController extends SpringActionController
 
 
     @RequiresPermission(AdminOperationsPermission.class)
-    public class OrphanedScriptsAction extends SimpleViewAction<Void>
+    public class OrphanedScriptsAction extends SimpleViewAction<Object>
     {
         @Override
-        public ModelAndView getView(Void form, BindException errors) throws IOException
+        public ModelAndView getView(Object form, BindException errors) throws IOException
         {
             Set<SqlScript> orphanedScripts = new TreeSet<>();
             Set<String> unclaimedFiles = new TreeSet<>();

--- a/visualization/src/org/labkey/visualization/VisualizationController.java
+++ b/visualization/src/org/labkey/visualization/VisualizationController.java
@@ -583,12 +583,12 @@ public class VisualizationController extends SpringActionController
 
 
     @RequiresSiteAdmin
-    public class TestGetDataAction extends SimpleViewAction<Void>
+    public class TestGetDataAction extends SimpleViewAction<Object>
     {
         @Override
-        public ModelAndView getView(Void noform, BindException errors)
+        public ModelAndView getView(Object noform, BindException errors)
         {
-            return new JspView("/org/labkey/visualization/test/test.jsp");
+            return new JspView<>("/org/labkey/visualization/test/test.jsp");
         }
 
         @Override
@@ -675,12 +675,12 @@ public class VisualizationController extends SpringActionController
 
 
     @RequiresSiteAdmin
-    public class cdsTestGetDataAction extends SimpleViewAction<Void>
+    public class cdsTestGetDataAction extends SimpleViewAction<Object>
     {
         @Override
-        public ModelAndView getView(Void noform, BindException errors)
+        public ModelAndView getView(Object noform, BindException errors)
         {
-            return new JspView("/org/labkey/visualization/test/test.jsp");
+            return new JspView<>("/org/labkey/visualization/test/test.jsp");
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
[Issue 42062: Convert *Action\<Void> to *Action\<Object> to work around JDK-16 restriction](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42062)

JDK-16_28 EA no longer allows us to declare actions with `<Void>` command types, so convert these to `<Object>`.