### PR TITLE
Issue 39785: Don't return error page HTML from APIs that normally return JSON

### DIFF
--- a/api/src/org/labkey/api/action/ApiQueryResponse.java
+++ b/api/src/org/labkey/api/action/ApiQueryResponse.java
@@ -85,8 +85,6 @@ public class ApiQueryResponse implements ApiResponse
     private List<FieldKey> _columnFilter;
     private boolean _includeMetaData;
 
-    private ApiResponseWriter.Format _format = ApiResponseWriter.Format.JSON;
-
     // TODO: This is silly... switch to builder pattern, or at least a constructor that takes reasonable strategies
     public ApiQueryResponse(QueryView view, boolean schemaEditable, boolean includeLookupInfo,
                             String schemaName, String queryName, long offset, List<FieldKey> fieldKeys, boolean metaDataOnly,
@@ -230,7 +228,7 @@ public class ApiQueryResponse implements ApiResponse
     {
         // If we're going to be writing JSON back, which is tolerant of extra spaces, allow async so we
         // can monitor if the client has stopped listening. XML doesn't take kindly to leading spaces
-        _dataRegion.setAllowAsync(_format.isJson());
+        _dataRegion.setAllowAsync(ApiResponseWriter.getResponseFormat(_viewContext.getRequest(), ApiResponseWriter.Format.JSON).isJson());
         try
         {
             return _dataRegion.getResults(_ctx);
@@ -643,10 +641,5 @@ public class ApiQueryResponse implements ApiResponse
     public void setColumnFilter(List<FieldKey> columnFilter)
     {
         _columnFilter = columnFilter;
-    }
-
-    public void setFormat(ApiResponseWriter.Format format)
-    {
-        _format = format;
     }
 }

--- a/api/src/org/labkey/api/action/ApiResponseWriter.java
+++ b/api/src/org/labkey/api/action/ApiResponseWriter.java
@@ -67,9 +67,9 @@ public abstract class ApiResponseWriter implements AutoCloseable
     /**
      * @return either the response format that has already been associated with the request, or the default if it's unset
      */
-    public static Format getResponseFormat(HttpServletRequest request, ApiResponseWriter.Format defaultFormat)
+    public static Format getResponseFormat(@Nullable HttpServletRequest request, ApiResponseWriter.Format defaultFormat)
     {
-        ApiResponseWriter.Format result = (ApiResponseWriter.Format) request.getAttribute(RESPONSE_FORMAT_ATTRIBUTE);
+        ApiResponseWriter.Format result = request == null ? null : (ApiResponseWriter.Format) request.getAttribute(RESPONSE_FORMAT_ATTRIBUTE);
         return result == null ? defaultFormat : result;
     }
 

--- a/api/src/org/labkey/api/action/BaseApiAction.java
+++ b/api/src/org/labkey/api/action/BaseApiAction.java
@@ -61,6 +61,7 @@ import java.util.Map;
  */
 public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
 {
+    public static final String RESPONSE_FORMAT_PARAMETER_NAME = "respFormat";
     private final Marshaller _marshaller;
 
     private ApiResponseWriter.Format _reqFormat = null;
@@ -116,7 +117,7 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
 
     private void setResponseFormat()
     {
-        ApiResponseWriter.setResponseFormat(getViewContext().getRequest(), ApiResponseWriter.Format.getFormatByName(getViewContext().getRequest().getParameter("respFormat"), ApiResponseWriter.Format.JSON));
+        ApiResponseWriter.setResponseFormat(getViewContext().getRequest(), ApiResponseWriter.Format.getFormatByName(getViewContext().getRequest().getParameter(RESPONSE_FORMAT_PARAMETER_NAME), ApiResponseWriter.Format.JSON));
     }
 
     @Override

--- a/api/src/org/labkey/api/action/BaseApiAction.java
+++ b/api/src/org/labkey/api/action/BaseApiAction.java
@@ -64,7 +64,6 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
     private final Marshaller _marshaller;
 
     private ApiResponseWriter.Format _reqFormat = null;
-    private ApiResponseWriter.Format _respFormat = ApiResponseWriter.Format.JSON;
     private String _contentTypeOverride = null;
     private double _requestedApiVersion = -1;
     private ObjectMapper _requestObjectMapper;
@@ -128,7 +127,6 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
         throw new BadRequestException("Method Not Allowed: " + getViewContext().getRequest().getMethod(), null, HttpServletResponse.SC_METHOD_NOT_ALLOWED);
     }
 
-
     @Override
     public void setViewContext(ViewContext context)
     {
@@ -159,14 +157,7 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
             FORM form = pair.first;
             BindException errors = pair.second;
 
-            if ("xml".equalsIgnoreCase(getViewContext().getRequest().getParameter("respFormat")))
-            {
-                _respFormat = ApiResponseWriter.Format.XML;
-            }
-            else if ("json_compact".equalsIgnoreCase(getViewContext().getRequest().getParameter("respFormat")))
-            {
-                _respFormat = ApiResponseWriter.Format.JSON_COMPACT;
-            }
+            ApiResponseWriter.setResponseFormat(getViewContext().getRequest(), ApiResponseWriter.Format.getFormatByName(getViewContext().getRequest().getParameter("respFormat"), ApiResponseWriter.Format.JSON));
 
             if (form != null)
             {
@@ -565,15 +556,10 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
     protected ApiResponseWriter createResponseWriter() throws IOException
     {
         // Let the response format dictate how we write the response. Typically JSON, but not always.
-        ApiResponseWriter writer = _respFormat.createWriter(getViewContext().getResponse(), getContentTypeOverride(), getResponseObjectMapper());
+        ApiResponseWriter writer = ApiResponseWriter.getResponseFormat(getViewContext().getRequest(), ApiResponseWriter.Format.JSON).createWriter(getViewContext().getResponse(), getContentTypeOverride(), getResponseObjectMapper());
         if (_marshaller == Marshaller.Jackson)
             writer.setSerializeViaJacksonAnnotations(true);
         return writer;
-    }
-
-    public ApiResponseWriter.Format getResponseFormat()
-    {
-        return _respFormat;
     }
 
     public ApiResponseWriter.Format getRequestFormat()

--- a/api/src/org/labkey/api/action/BaseApiAction.java
+++ b/api/src/org/labkey/api/action/BaseApiAction.java
@@ -106,6 +106,20 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
     }
 
     @Override
+    public void checkPermissions() throws UnauthorizedException
+    {
+        // Set the preferred response format here so we can use it for 401s
+        setResponseFormat();
+
+        super.checkPermissions();
+    }
+
+    private void setResponseFormat()
+    {
+        ApiResponseWriter.setResponseFormat(getViewContext().getRequest(), ApiResponseWriter.Format.getFormatByName(getViewContext().getRequest().getParameter("respFormat"), ApiResponseWriter.Format.JSON));
+    }
+
+    @Override
     protected String getCommandClassMethodName()
     {
         return "execute";
@@ -114,6 +128,9 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
     @Override
     public ModelAndView handleRequest() throws Exception
     {
+        // Likely a dupe with what's been done in checkPermissions(), but ensuring that future code path variants will pass through
+        setResponseFormat();
+
         switch (getViewContext().getMethod())
         {
             case POST:
@@ -156,8 +173,6 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
 
             FORM form = pair.first;
             BindException errors = pair.second;
-
-            ApiResponseWriter.setResponseFormat(getViewContext().getRequest(), ApiResponseWriter.Format.getFormatByName(getViewContext().getRequest().getParameter("respFormat"), ApiResponseWriter.Format.JSON));
 
             if (form != null)
             {

--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -776,17 +776,6 @@ public class ExceptionUtil
         }
 
         ApiResponseWriter.Format responseFormat = ApiResponseWriter.getResponseFormat(request, null);
-        if (responseFormat == null && request.getContentType() != null)
-        {
-            if (request.getContentType().contains(ApiJsonWriter.CONTENT_TYPE_JSON))
-            {
-                responseFormat = ApiResponseWriter.Format.JSON;
-            }
-            else if (request.getContentType().contains(ApiXmlWriter.CONTENT_TYPE))
-            {
-                responseFormat = ApiResponseWriter.Format.XML;
-            }
-        }
 
         if (response.isCommitted())
         {

--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -775,8 +775,18 @@ public class ExceptionUtil
             log.error("Unhandled exception: " + message, unhandledException);
         }
 
-        boolean isJSON = request.getContentType() != null && request.getContentType().contains(ApiJsonWriter.CONTENT_TYPE_JSON);
-        boolean isXML = request.getContentType() != null && request.getContentType().contains(ApiXmlWriter.CONTENT_TYPE);
+        ApiResponseWriter.Format responseFormat = ApiResponseWriter.getResponseFormat(request, null);
+        if (responseFormat == null && request.getContentType() != null)
+        {
+            if (request.getContentType().contains(ApiJsonWriter.CONTENT_TYPE_JSON))
+            {
+                responseFormat = ApiResponseWriter.Format.JSON;
+            }
+            else if (request.getContentType().contains(ApiXmlWriter.CONTENT_TYPE))
+            {
+                responseFormat = ApiResponseWriter.Format.XML;
+            }
+        }
 
         if (response.isCommitted())
         {
@@ -800,8 +810,7 @@ public class ExceptionUtil
                 }
             }
         }
-        // TODO: Possibly respect "respFormat" parameter as found in ApiAction first?
-        else if (isJSON || isXML)
+        else if (responseFormat != null)
         {
             try
             {
@@ -821,11 +830,7 @@ public class ExceptionUtil
                 if (responseStatusMessage != null || message != null)
                     errorResponse.put("exception", StringUtils.defaultString(message,responseStatusMessage));
 
-                ApiResponseWriter writer;
-                if (isJSON)
-                    writer = ApiResponseWriter.Format.JSON.createWriter(response, null, null);
-                else
-                    writer = ApiResponseWriter.Format.XML.createWriter(response, null, null);
+                ApiResponseWriter writer = responseFormat.createWriter(response, null, null);
 
                 errorResponse.render(writer);
                 writer.close();

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2946,7 +2946,6 @@ public class QueryController extends SpringActionController
                         metaDataOnly, form.isIncludeDetailsColumn(), form.isIncludeUpdateColumn(),
                         form.isIncludeDisplayValues());
             }
-            response.setFormat(getResponseFormat());
             response.includeStyle(form.isIncludeStyle());
 
             // Issues 29515 and 32269 - force key and other non-requested columns to be sent back, but only if the client has
@@ -3170,7 +3169,6 @@ public class QueryController extends SpringActionController
                         metaDataOnly, form.isIncludeDetailsColumn(), form.isIncludeUpdateColumn(),
                         form.isIncludeDisplayValues());
             }
-            response.setFormat(getResponseFormat());
             response.includeStyle(form.isIncludeStyle());
 
             return response;


### PR DESCRIPTION
#### Rationale
API callers don't like when we send back HTML responses, because they're expecting the content to be JSON, XML, or other structured content. Thus, even when we hit error conditions, we should respond in kind.

#### Changes
* Use an HttpServletRequest attribute to remember which type of response we should send
* Centralize storage of what response format to use
* Capture preferred response as part of checking permissions to ensure we capture even 401 responses