### PR TITLE
sample type test fixes

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -669,7 +669,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                     // it with a "MVIndicator" suffix (no underscore)
                     var mvColumn = new AliasedColumn(this, dp.getName() + MvColumn.MV_INDICATOR_SUFFIX,
                             StorageProvisioner.getMvIndicatorColumn(dbTable, dp.getPropertyDescriptor(), "No MV column found for '" + dp.getName() + "' in sample type '" + getName() + "'"));
-                    mvColumn.setLabel(dp.getLabel() + " MV Indicator");
+                    mvColumn.setLabel(dp.getLabel() != null ? dp.getLabel() : dp.getName() + " MV Indicator");
                     mvColumn.setSqlTypeName("VARCHAR");
                     mvColumn.setPropertyURI(dp.getPropertyURI());
                     mvColumn.setNullable(true);

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeFolderImporter.java
@@ -51,7 +51,7 @@ public class SampleTypeFolderImporter implements FolderImporter
     @Override
     public String getDescription()
     {
-        return null;
+        return "Sample Types Importer";
     }
 
     @Override
@@ -63,7 +63,7 @@ public class SampleTypeFolderImporter implements FolderImporter
         {
             File xarFile = null;
             Set<String> dataFiles = new HashSet<>();
-            Logger log = job.getLogger();
+            Logger log = ctx.getLogger();
 
             log.info("Starting Sample Type import");
             for (String file: xarDir.list())
@@ -73,7 +73,7 @@ public class SampleTypeFolderImporter implements FolderImporter
                     if (xarFile == null)
                         xarFile = new File(xarDir.getLocation(), file);
                     else
-                        ctx.getLogger().error("More than one XAR file found in the sample type directory: ", file);
+                        log.error("More than one XAR file found in the sample type directory: ", file);
                 }
                 else if (file.toLowerCase().endsWith(".tsv"))
                 {
@@ -92,7 +92,7 @@ public class SampleTypeFolderImporter implements FolderImporter
                     }
                     catch (Exception e)
                     {
-                        ctx.getLogger().error("Failed to initialize XAR source", e);
+                        log.error("Failed to initialize XAR source", e);
                         throw(e);
                     }
                     log.info("Importing XAR file: " + xarFile.getName());
@@ -100,7 +100,7 @@ public class SampleTypeFolderImporter implements FolderImporter
                     reader.parseAndLoad(false);
                 }
                 else
-                    ctx.getLogger().info("No xar file to process.");
+                    log.info("No xar file to process.");
 
                 // process any sample type data files
                 UserSchema userSchema = QueryService.get().getUserSchema(ctx.getUser(), ctx.getContainer(), SamplesSchema.SCHEMA_NAME);

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeFolderWriter.java
@@ -35,6 +35,8 @@ import org.labkey.api.query.AliasedColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.study.SpecimenService;
+import org.labkey.api.study.StudyService;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.writer.VirtualFile;
 import org.labkey.experiment.LSIDRelativizer;
@@ -82,10 +84,15 @@ public class SampleTypeFolderWriter extends BaseFolderWriter
     {
         XarExportSelection selection = new XarExportSelection();
         Set<ExpSampleType> sampleTypes = new HashSet<>();
+        boolean exportXar = false;
 
         Lsid sampleTypeLsid = new Lsid(ExperimentService.get().generateLSID(ctx.getContainer(), ExpSampleType.class, "export"));
         for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(ctx.getContainer(), ctx.getUser(), true))
         {
+            // ignore the magic sample type that is used for the specimen repository, it is managed by the specimen importer
+            if (StudyService.get().getStudy(ctx.getContainer()) != null && SpecimenService.SAMPLE_TYPE_NAME.equals(sampleType.getName()))
+                continue;
+
             // filter out non sample type material sources
             Lsid lsid = new Lsid(sampleType.getLSID());
 
@@ -93,6 +100,7 @@ public class SampleTypeFolderWriter extends BaseFolderWriter
             {
                 sampleTypes.add(sampleType);
                 selection.addSampleType(sampleType);
+                exportXar = true;
             }
         }
 
@@ -107,14 +115,22 @@ public class SampleTypeFolderWriter extends BaseFolderWriter
             if (exportRun(run, sampleTypes))
                 exportedRuns.add(run);
         }
-        selection.addRuns(exportedRuns);
+
+        if (!exportedRuns.isEmpty())
+        {
+            selection.addRuns(exportedRuns);
+            exportXar = true;
+        }
         VirtualFile xarDir = vf.getDir(DEFAULT_DIRECTORY);
 
-        XarExporter exporter = new XarExporter(LSIDRelativizer.FOLDER_RELATIVE, selection, ctx.getUser(), XAR_XML_FILE_NAME, ctx.getLogger());
-
-        try (OutputStream fOut = xarDir.getOutputStream(XAR_FILE_NAME))
+        if (exportXar)
         {
-            exporter.writeAsArchive(fOut);
+            XarExporter exporter = new XarExporter(LSIDRelativizer.FOLDER_RELATIVE, selection, ctx.getUser(), XAR_XML_FILE_NAME, ctx.getLogger());
+
+            try (OutputStream fOut = xarDir.getOutputStream(XAR_FILE_NAME))
+            {
+                exporter.writeAsArchive(fOut);
+            }
         }
 
         // write out the sample rows that aren't participating in the derivation protocol


### PR DESCRIPTION
#### Rationale
Test automation exposed some bugs with the recently merged sample type folder export/import code. These changes are to address the handful of recent failures.

#### Changes
- In the virtual table don't assume the domain property label is non-null
- Folder writers are not always invoked with a pipeline job, use the logger in the export context
- Don't export the sample type that study specimens creates, this is fully managed by the specimen importer and is not meant to be used as a typical sample type
- Don't create a sample type XAR if there are not runs or sample types to serialize