### PR TITLE
Issue #42006: Fix numeric ParentIds not getting parsed/processed

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -242,7 +242,6 @@ public class ExpDataIterators
             boolean hasNext = super.next();
 
             // skip processing if there are errors upstream
-            //noinspection ThrowableNotThrown
             if (getErrors().hasErrors())
                 return hasNext;
 
@@ -335,7 +334,6 @@ public class ExpDataIterators
                 return false;
 
             // skip processing if there are errors upstream
-            //noinspection ThrowableNotThrown
             if (getErrors().hasErrors())
                 return true;
 
@@ -461,7 +459,6 @@ public class ExpDataIterators
             boolean hasNext = super.next();
 
             // skip processing if there are errors upstream
-            //noinspection ThrowableNotThrown
             if (getErrors().hasErrors())
                 return hasNext;
 
@@ -486,12 +483,13 @@ public class ExpDataIterators
                         }
                         else if (o instanceof Collection)
                         {
+                            //noinspection rawtypes
                             Collection<?> c = ((Collection)o);
                             parentNames = c.stream().map(String::valueOf).collect(Collectors.toSet());
                         }
                         else if (o instanceof Number)
                         {
-                            parentNames = Arrays.asList(((Number) o).toString());
+                            parentNames = Arrays.asList(o.toString());
                         }
                         else
                         {
@@ -517,7 +515,6 @@ public class ExpDataIterators
                     _parentNames.put(lsid, allParts);
             }
 
-            //noinspection ThrowableNotThrown
             if (getErrors().hasErrors())
                 return hasNext;
 
@@ -609,8 +606,7 @@ public class ExpDataIterators
                                 Map<ExpMaterial, String> parentMaterialMap = pair.first.getMaterials();
                                 Map<ExpData, String> parentDataMap = pair.first.getDatas();
 
-                                boolean merge = _isSample;
-                                UploadSamplesHelper.record(merge, runRecords,
+                                UploadSamplesHelper.record(_isSample, runRecords,
                                         parentMaterialMap, currentMaterialMap,
                                         parentDataMap, currentDataMap);
                             }
@@ -718,7 +714,7 @@ public class ExpDataIterators
     // see SimpleQueryUpdateService.convertTypes() for similar handling of FILE_LINK columns
     public static class FileLinkDataIterator extends WrapperDataIterator
     {
-        Supplier[] suppliers;
+        Supplier<?>[] suppliers;
         String[] savedFileName;
 
         FileLinkDataIterator(final DataIterator in, final DataIteratorContext context, Container c, String file_link_dir_name)
@@ -776,8 +772,7 @@ public class ExpDataIterators
         @Override
         public boolean next() throws BatchValidationException
         {
-            for (int i=0 ; i<savedFileName.length ; i++)
-                savedFileName[i] = null;
+            Arrays.fill(savedFileName, null);
             return super.next();
         }
     }
@@ -892,11 +887,10 @@ public class ExpDataIterators
 
             // Hack: add the alias and lsid values back into the input so we can process them in the chained data iterator
             DataIteratorBuilder step6 = step5;
-            DataIteratorBuilder step7 = step6;
             if (null != _indexFunction)
-                step7 = LoggingDataIterator.wrap(new ExpDataIterators.SearchIndexIteratorBuilder(step6, _indexFunction)); // may need to add this after the aliases are set
+                step6 = LoggingDataIterator.wrap(new ExpDataIterators.SearchIndexIteratorBuilder(step5, _indexFunction)); // may need to add this after the aliases are set
 
-            return LoggingDataIterator.wrap(step7.getDataIterator(context));
+            return LoggingDataIterator.wrap(step6.getDataIterator(context));
         }
 
         private Set<DomainProperty> findVocabularyProperties(Map<String, Integer> colNameMap)

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -489,6 +489,10 @@ public class ExpDataIterators
                             Collection<?> c = ((Collection)o);
                             parentNames = c.stream().map(String::valueOf).collect(Collectors.toSet());
                         }
+                        else if (o instanceof Number)
+                        {
+                            parentNames = Arrays.asList(((Number) o).toString());
+                        }
                         else
                         {
                             getErrors().addRowError(new ValidationException("Expected comma separated list or a JSONArray of parent names: " + o, _parentCols.get(parentCol)));


### PR DESCRIPTION
#### Rationale
[Error when importing Parent Alias with integer SampleID](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42006)

#### Changes
* Added block to the parentId parser to map Number values
* Cleaned up most of the lint warnings for ExpDataIterators
