### PR TITLE
42017: Encode Data Region Messages upon writing to DOM

### DIFF
--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -181,6 +181,11 @@ public class DataRegion extends DisplayElement
     }
     private List<GroupTable> _groupTables = new ArrayList<>();
 
+    /**
+     * Messages that are displayed to the user and included in Query API responses.
+     * These messages should NOT be HTML encoded as the responsibility for encoding is left to the caller.
+     * See https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42017
+     */
     public static class Message
     {
         private String _area;

--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -181,7 +181,6 @@ public class DataRegion extends DisplayElement
     }
     private List<GroupTable> _groupTables = new ArrayList<>();
 
-    /** HTML message to show the user attached to the region. Caller is responsible for HTML encoding as needed */
     public static class Message
     {
         private String _area;
@@ -974,7 +973,7 @@ public class DataRegion extends DisplayElement
                     _errorCreatingResults = true;
                     _showPagination = false;
                     _allowHeaderLock = false;
-                    addMessage(new Message("<span class=\"labkey-error\">" + PageFlowUtil.filter(x.getMessage()) + "</span><br>", MessageType.ERROR, MessagePart.header));
+                    addMessage(new Message(x.getMessage(), MessageType.ERROR, MessagePart.header));
                 }
             }
 
@@ -1152,7 +1151,7 @@ public class DataRegion extends DisplayElement
                 if (isThemed)
                     out.write("<div class=\"alert alert-" + (isError ? "danger" : "warning") + "\">");
 
-                out.write(message.getContent());
+                out.write(PageFlowUtil.filter(message.getContent()));
 
                 if (isThemed)
                     out.write("</div>");
@@ -1277,7 +1276,7 @@ public class DataRegion extends DisplayElement
             captions.append(".");
             content.append(captions.toString());
 
-            msg = new Message(PageFlowUtil.filter(content.toString()), MessageType.WARNING, MessagePart.header);
+            msg = new Message(content.toString(), MessageType.WARNING, MessagePart.header);
         }
 
         return msg;
@@ -2561,7 +2560,7 @@ public class DataRegion extends DisplayElement
                     msg.append(" because they do not exist.");
                 }
 
-                addMessage(new Message(PageFlowUtil.filter(msg.toString()), MessageType.WARNING, "filter"));
+                addMessage(new Message(msg.toString(), MessageType.WARNING, "filter"));
             }
 
             SimpleFilter filter = getValidFilter(ctx);
@@ -2612,7 +2611,7 @@ public class DataRegion extends DisplayElement
         {
             String msg = prepareConditionalFormats(dc);
             if (msg != null)
-                addMessage(new Message(PageFlowUtil.filter(msg), MessageType.WARNING, "filter"));
+                addMessage(new Message(msg, MessageType.WARNING, "filter"));
         }
     }
 

--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -183,7 +183,8 @@ public class DataRegion extends DisplayElement
 
     /**
      * Messages that are displayed to the user and included in Query API responses.
-     * These messages should NOT be HTML encoded as the responsibility for encoding is left to the caller.
+     * These messages' content should NOT be HTML encoded as the responsibility
+     * for encoding is left to the caller.
      * See https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42017
      */
     public static class Message
@@ -209,6 +210,7 @@ public class DataRegion extends DisplayElement
             return _area;
         }
 
+        /** Caller is responsible for HTML encoding. */
         public String getContent()
         {
             return _content;

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -2107,7 +2107,8 @@ public class QueryView extends WebPartView<Object>
 
         if (_customView != null && _customView.getErrors() != null)
         {
-            rgn.addMessageSupplier(dataRegion -> _customView.getErrors().stream().map(e -> new DataRegion.Message(PageFlowUtil.filter(e), DataRegion.MessageType.ERROR, DataRegion.MessagePart.view))
+            rgn.addMessageSupplier(dataRegion -> _customView.getErrors().stream()
+                    .map(e -> new DataRegion.Message(e, DataRegion.MessageType.ERROR, DataRegion.MessagePart.view))
                     .collect(Collectors.toList()));
         }
 

--- a/api/src/org/labkey/api/query/ReportDataRegion.java
+++ b/api/src/org/labkey/api/query/ReportDataRegion.java
@@ -17,13 +17,13 @@ package org.labkey.api.query;
 
 
 import org.apache.commons.lang3.StringUtils;
+import org.json.JSONObject;
 import org.labkey.api.data.ButtonBar;
 import org.labkey.api.data.DataRegion;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.reports.Report;
 import org.labkey.api.reports.report.ReportDescriptor;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
 
@@ -76,15 +76,6 @@ public class ReportDataRegion extends DataRegion
     {
         _request = request;
         _response = response;
-
-        String name = _report.getDescriptor().getReportName();
-        String source = StringUtils.defaultIfEmpty(_report.getDescriptor().getProperty(ReportDescriptor.Prop.viewName), "default");
-
-        String msg = "<span class=\"labkey-strong\">Name:</span>&nbsp;" + PageFlowUtil.filter(name);
-        msg += "&nbsp;";
-        msg += "<span class=\"labkey-strong\" style=\"padding-left: 30px;\">Source:</span>&nbsp;" + PageFlowUtil.filter(source);
-
-        addMessage(new Message(msg, MessageType.INFO, "report"));
         super.render(ctx, request, response);
     }
 
@@ -131,5 +122,21 @@ public class ReportDataRegion extends DataRegion
     protected boolean useTableWrap()
     {
         return false;
+    }
+
+    @Override
+    protected JSONObject toJSON(RenderContext ctx)
+    {
+        var json = super.toJSON(ctx);
+        var descriptor = _report.getDescriptor();
+
+        var reportJson = new JSONObject();
+        reportJson.put("id", descriptor.getReportId().toString());
+        reportJson.put("name", descriptor.getReportName());
+        reportJson.put("source", StringUtils.defaultIfEmpty(descriptor.getProperty(ReportDescriptor.Prop.viewName), "default"));
+
+        json.put("report", reportJson);
+
+        return json;
     }
 }

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -2309,9 +2309,9 @@ if (!LABKEY.DataRegions) {
             this.addMessage({
                 html: [
                     '<span class="labkey-strong">Name:</span>',
-                    this.report.name,
+                    LABKEY.Utils.encodeHtml(this.report.name),
                     '<span class="labkey-strong" style="padding-left: 30px;">Source:</span>',
-                    this.report.source
+                    LABKEY.Utils.encodeHtml(this.report.source)
                 ].join('&nbsp;'),
                 part: 'report',
             });

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -499,6 +499,7 @@ if (!LABKEY.DataRegions) {
             _initHeaderLocking.call(this);
             _initCustomViews.call(this);
             _initPanes.call(this);
+            _initReport.call(this);
         }
         // else the user needs to call render
 
@@ -2297,6 +2298,23 @@ if (!LABKEY.DataRegions) {
                 config.cb.call(config.scope || me, me);
             });
             delete _paneCache[this.name];
+        }
+    };
+
+    /**
+     * @private
+     */
+    var _initReport = function() {
+        if (LABKEY.Utils.isObject(this.report)) {
+            this.addMessage({
+                html: [
+                    '<span class="labkey-strong">Name:</span>',
+                    this.report.name,
+                    '<span class="labkey-strong" style="padding-left: 30px;">Source:</span>',
+                    this.report.source
+                ].join('&nbsp;'),
+                part: 'report',
+            });
         }
     };
 


### PR DESCRIPTION
#### Rationale
[Issue 42017](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42017) describes how messages in our `@labkey/components` query grid are being double encoded. This is stemming from those grid's being backed by the selectRows API with the "metadata" flag turned on. When this flag is on, then we supply messages from the (server-side) Data Region in the API response.

Until now, these messages have been HTML encoded. This is not a desirable format as the targeted layout may not want the HTML generated by the server and instead may do layout based on the other properties of the message (e.g. `area` and `type`) as well.

This changes the messages generated by `DataRegion` to not be HTML encoded upon creation and leaves it up to the user of the message to encode these (if they end up displaying them in HTML). As for the Data Region, the rendering has been updated to encode the message content upon writing the Data Region DOM.

Additionally, I'll note that this still works as a fix for [Issue 35895](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=35895) which had previously been fixed by attempting to encode the messages when they're generated (what is being reversed here).

#### Changes
* Remove HTML encoding and HTML layout from Data Region messages.
* For default Data Region rendering encode the message contents as they are written to the DOM.
