### PR TITLE
Issue 42081: allow wildcard * in sql when joining between two tables containing the same fields

### DIFF
--- a/api/src/org/labkey/api/data/ContainerTable.java
+++ b/api/src/org/labkey/api/data/ContainerTable.java
@@ -216,6 +216,8 @@ public class ContainerTable extends FilteredTable<UserSchema>
         @Override
         protected String transformValue(Integer rawValue)
         {
+            if (rawValue == null)
+                return "";
             int rowId = rawValue.intValue();
             Container c = ContainerManager.getForRowId(rowId);
             if (c == null)

--- a/api/src/org/labkey/api/query/QueryDefinition.java
+++ b/api/src/org/labkey/api/query/QueryDefinition.java
@@ -105,7 +105,7 @@ public interface QueryDefinition
      * Use skipSuggestedColumns=TRUE to skip adding suggested/referenced columns.
      * Issue 36275: ODBC/Tableau generates select query containing columns from referenced table
      */
-    @Nullable TableInfo getTable(UserSchema schema, List<QueryException> errors, boolean includeMetadata, boolean skipSuggestedColumns, boolean allowDuplicateColumns);
+    @Nullable TableInfo getTable(UserSchema schema, List<QueryException> errors, boolean includeMetadata, boolean skipSuggestedColumns);
 
     String getSql();
     String getMetadataXml();

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -3245,7 +3245,7 @@ public class QueryView extends WebPartView<Object>
                 {
                     if (null != getContainerFilter())
                         queryDef.setContainerFilter(getContainerFilter());
-                    ti = queryDef.getTable(getSchema(), errors, true, false, false);
+                    ti = queryDef.getTable(getSchema(), errors, true, false, true);
                 }
             }
 

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -62,7 +62,6 @@ import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DataView;
-import org.labkey.api.view.DisplayElement;
 import org.labkey.api.view.GridView;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.JspView;
@@ -3245,7 +3244,7 @@ public class QueryView extends WebPartView<Object>
                 {
                     if (null != getContainerFilter())
                         queryDef.setContainerFilter(getContainerFilter());
-                    ti = queryDef.getTable(getSchema(), errors, true, false, true);
+                    ti = queryDef.getTable(getSchema(), errors, true, false);
                 }
             }
 

--- a/query/src/org/labkey/query/LinkedSchemaQueryDefinition.java
+++ b/query/src/org/labkey/query/LinkedSchemaQueryDefinition.java
@@ -40,7 +40,6 @@ import org.labkey.query.persist.QueryDef;
 import org.labkey.query.persist.QueryManager;
 import org.labkey.query.sql.Query;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -92,11 +91,11 @@ public class LinkedSchemaQueryDefinition extends QueryDefinitionImpl
     }
 
     @Override
-    public Query getQuery(@NotNull QuerySchema schema, List<QueryException> errors, Query parent, boolean includeMetadata, boolean skipSuggestedColumns, boolean allowDuplicateColumns)
+    public Query getQuery(@NotNull QuerySchema schema, List<QueryException> errors, Query parent, boolean includeMetadata, boolean skipSuggestedColumns)
     {
         // Parse/resolve the wrapped query in the context of the original source schema
         UserSchema sourceSchema = getSchema().getSourceSchema();
-        return super.getQuery(sourceSchema, errors, parent, includeMetadata, skipSuggestedColumns, allowDuplicateColumns);
+        return super.getQuery(sourceSchema, errors, parent, includeMetadata, skipSuggestedColumns);
     }
 
     @Override

--- a/query/src/org/labkey/query/QueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/QueryDefinitionImpl.java
@@ -453,7 +453,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
 
     public final Query getQuery(@NotNull QuerySchema schema, List<QueryException> errors, Query parent, boolean includeMetadata)
     {
-        return getQuery(schema, errors, parent, includeMetadata, false, false);
+        return getQuery(schema, errors, parent, includeMetadata, false, true);
     }
     /*
      * I find it very strange that only the xml errors get added to the "errors" list, while
@@ -527,7 +527,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
     @Override
     public TableInfo getTable(@NotNull UserSchema schema, @Nullable List<QueryException> errors, boolean includeMetadata)
     {
-        return getTable(schema, errors, includeMetadata, false, false);
+        return getTable(schema, errors, includeMetadata, false, true);
     }
 
     @Nullable
@@ -575,7 +575,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
     @Nullable
     public TableInfo createTable(@NotNull UserSchema schema, @Nullable List<QueryException> errors, boolean includeMetadata, @Nullable Query query)
     {
-        return createTable(schema, errors, includeMetadata, query, false, false);
+        return createTable(schema, errors, includeMetadata, query, false, true);
     }
 
     /**

--- a/query/src/org/labkey/query/QueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/QueryDefinitionImpl.java
@@ -453,20 +453,19 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
 
     public final Query getQuery(@NotNull QuerySchema schema, List<QueryException> errors, Query parent, boolean includeMetadata)
     {
-        return getQuery(schema, errors, parent, includeMetadata, false, true);
+        return getQuery(schema, errors, parent, includeMetadata, false);
     }
     /*
      * I find it very strange that only the xml errors get added to the "errors" list, while
      * the parse errors remain in the getParseErrors() list
      */
-    public Query getQuery(@NotNull QuerySchema schema, List<QueryException> errors, Query parent, boolean includeMetadata, boolean skipSuggestedColumns, boolean allowDuplicateColumns)
+    public Query getQuery(@NotNull QuerySchema schema, List<QueryException> errors, Query parent, boolean includeMetadata, boolean skipSuggestedColumns)
     {
         Query query = new Query(schema, getName(), parent);
 
         query.setDebugName(getSchemaName() + "." + getName());
         query.setContainerFilter(getContainerFilter());
         query.setMetadataTableMap(_metadataTableMap);
-        query.setAllowDuplicateColumns(allowDuplicateColumns);
         String sql = getSql();
         if (sql != null)
         {
@@ -527,12 +526,12 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
     @Override
     public TableInfo getTable(@NotNull UserSchema schema, @Nullable List<QueryException> errors, boolean includeMetadata)
     {
-        return getTable(schema, errors, includeMetadata, false, true);
+        return getTable(schema, errors, includeMetadata, false);
     }
 
     @Nullable
     @Override
-    public TableInfo getTable(@NotNull UserSchema schema, @Nullable List<QueryException> errors, boolean includeMetadata, boolean skipSuggestedColumns, boolean allowDuplicateColumns)
+    public TableInfo getTable(@NotNull UserSchema schema, @Nullable List<QueryException> errors, boolean includeMetadata, boolean skipSuggestedColumns)
     {
         // CONSIDER: define UserSchema.equals() ?
         if (schema.getSchemaPath().equals(getSchema().getSchemaPath()) &&
@@ -551,7 +550,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
                 // Occasionally called with a get, but simple table creation is not a serious vector for CSRF attacks
                 try (var ignored = SpringActionController.ignoreSqlUpdates())
                 {
-                    table = createTable(schema, errors, includeMetadata, null, skipSuggestedColumns, allowDuplicateColumns);
+                    table = createTable(schema, errors, includeMetadata, null, skipSuggestedColumns);
                 }
 
                 if (null == table)
@@ -575,14 +574,14 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
     @Nullable
     public TableInfo createTable(@NotNull UserSchema schema, @Nullable List<QueryException> errors, boolean includeMetadata, @Nullable Query query)
     {
-        return createTable(schema, errors, includeMetadata, query, false, true);
+        return createTable(schema, errors, includeMetadata, query, false);
     }
 
     /**
      * @param query a Query object to reuse, if available. Otherwise, a new one will be created behind the scenes
      */
     @Nullable
-    public TableInfo createTable(@NotNull UserSchema schema, @Nullable List<QueryException> errors, boolean includeMetadata, @Nullable Query query, boolean skipSuggestedColumns, boolean allowDuplicateColumns)
+    public TableInfo createTable(@NotNull UserSchema schema, @Nullable List<QueryException> errors, boolean includeMetadata, @Nullable Query query, boolean skipSuggestedColumns)
     {
         if (errors == null)
         {
@@ -590,7 +589,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
         }
         if (query == null)
         {
-            query = getQuery(schema, errors, null, includeMetadata, skipSuggestedColumns, allowDuplicateColumns);
+            query = getQuery(schema, errors, null, includeMetadata, skipSuggestedColumns);
         }
         TableInfo ret = query.getTableInfo();
         if (null != ret)

--- a/query/src/org/labkey/query/QueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/QueryDefinitionImpl.java
@@ -455,6 +455,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
     {
         return getQuery(schema, errors, parent, includeMetadata, false);
     }
+
     /*
      * I find it very strange that only the xml errors get added to the "errors" list, while
      * the parse errors remain in the getParseErrors() list

--- a/query/src/org/labkey/query/TableQueryDefinition.java
+++ b/query/src/org/labkey/query/TableQueryDefinition.java
@@ -40,7 +40,6 @@ import org.labkey.api.security.User;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.view.ActionURL;
-import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewContext;
 import org.labkey.query.persist.QueryDef;
 import org.labkey.query.persist.QueryManager;
@@ -180,7 +179,7 @@ public class TableQueryDefinition extends QueryDefinitionImpl
     }
 
     @Override
-    public TableInfo createTable(@NotNull UserSchema schema, @Nullable List<QueryException> errors, boolean includeMetadata, @Nullable Query query, boolean skipSuggestedColumns, boolean allowDuplicateColumns)
+    public TableInfo createTable(@NotNull UserSchema schema, @Nullable List<QueryException> errors, boolean includeMetadata, @Nullable Query query, boolean skipSuggestedColumns)
     {
         try
         {

--- a/query/src/org/labkey/query/sql/Query.java
+++ b/query/src/org/labkey/query/sql/Query.java
@@ -1097,8 +1097,8 @@ public class Query
         private static final String[] days = new String[] {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
         private static final String[] months = new String[] {"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"};
 
-        private String[][] data;
-        RowMapFactory _rowMapFactory;
+        private final String[][] data;
+        private final RowMapFactory<Object> _rowMapFactory;
 
 		// UNDONE: need some NULLS in here
         @SuppressWarnings({"UnusedAssignment"})
@@ -1109,7 +1109,7 @@ public class Query
             var m = new HashMap<String,Integer>();
             for (int i=0 ; i<COLUMNS.length ; i++)
                 m.put(COLUMNS[i],i);
-            _rowMapFactory = new RowMapFactory(new ArrayListMap.FindMap(m));
+            _rowMapFactory = new RowMapFactory<>(new ArrayListMap.FindMap<>(m));
 
             for (int i=1 ; i<=len ; i++)
             {
@@ -1121,7 +1121,7 @@ public class Query
                 row[c++] = days[i%7];
                 row[c++] = months[i%12];
                 row[c++] = DateUtil.toISO(DateUtil.parseISODateTime("2010-01-01") + ((long)i)*12*60*60*1000L);
-                row[c++] = DateUtil.formatDuration(i*1000);
+                row[c++] = DateUtil.formatDuration(((long)i)*1000);
                 row[c++] = GUID.makeGUID();
             }
             _columns = new ColumnDescriptor[COLUMNS.length];
@@ -1136,7 +1136,7 @@ public class Query
             return data;
         }
 
-        int i=1;
+        private int i=1;
 
         @Override
         @NotNull
@@ -1254,7 +1254,7 @@ public class Query
     {
         private final JdbcType _type;
         private final Object _value;
-        private final Callable _call;
+        private final Callable<Object> _call;
 
         MethodSqlTest(String sql, JdbcType type, Object value)
         {
@@ -1264,7 +1264,7 @@ public class Query
             _call = null;
         }
 
-        MethodSqlTest(String sql, JdbcType type, Callable call)
+        MethodSqlTest(String sql, JdbcType type, Callable<Object> call)
         {
             super(sql, 1, 1);
             _type = type;
@@ -1852,7 +1852,8 @@ public class Query
     @TestWhen(TestWhen.When.BVT)
     public static class QueryTestCase extends Assert
     {
-        private String hash = GUID.makeHash();
+        private final String hash = GUID.makeHash();
+
         private QuerySchema lists;
 
         @Before

--- a/query/src/org/labkey/query/sql/Query.java
+++ b/query/src/org/labkey/query/sql/Query.java
@@ -2107,7 +2107,7 @@ public class Query
             QueryDefinition query = QueryService.get().createQueryDef(user, c, SchemaKey.fromParts("lists"), GUID.makeHash());
             query.setSql(sql);
             ArrayList<QueryException> qerrors = new ArrayList<>();
-            TableInfo t = query.getTable(query.getSchema(), qerrors, false, true, true);
+            TableInfo t = query.getTable(query.getSchema(), qerrors, false, true);
 
             if (null == t)
             {

--- a/query/src/org/labkey/query/sql/QuerySelect.java
+++ b/query/src/org/labkey/query/sql/QuerySelect.java
@@ -443,7 +443,6 @@ groupByLoop:
                 column._key = new FieldKey(null,name);
             if (fieldKeys.containsKey(column._key))
             {
-                assert _query.isAllowDuplicateColumns();
                 if (_query.isAllowDuplicateColumns())
                 {
                     // Fabricate a unique name for this duplicate column

--- a/query/src/org/labkey/query/sql/QuerySelect.java
+++ b/query/src/org/labkey/query/sql/QuerySelect.java
@@ -456,6 +456,7 @@ groupByLoop:
                     }
                     while (fieldKeys.containsKey(uniqueKey));
                     column._key = uniqueKey;
+                    reportWarning("Automatically creating alias for duplicate column: " + name, column._node);
                 }
                 else
                 {

--- a/query/src/org/labkey/query/sql/QuerySelect.java
+++ b/query/src/org/labkey/query/sql/QuerySelect.java
@@ -443,6 +443,7 @@ groupByLoop:
                 column._key = new FieldKey(null,name);
             if (fieldKeys.containsKey(column._key))
             {
+                assert _query.isAllowDuplicateColumns();
                 if (_query.isAllowDuplicateColumns())
                 {
                     // Fabricate a unique name for this duplicate column


### PR DESCRIPTION
#### Rationale
We added support for duplicate column names in LabKey SQL queries when a special flag was passed to `createTable()` or `getTable()`. Client requested that this be made the default behavior. See [Issue 42081: allow wildcard * in sql when joining between two tables containing the same fields](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42081)

#### Changes
* Set the flag to true by default
* Remove parameter from `createTable()` and `getTable()`
* Add new junit cases for that test duplicate column names. Move previously failing tests that are now passing.