### PR TITLE
Fb sample type fixes

### DIFF
--- a/api/src/org/labkey/api/dataiterator/TableInsertDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/TableInsertDataIterator.java
@@ -32,6 +32,7 @@ import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.StatementUtils;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.UpdateableTableInfo;
+import org.labkey.api.exp.MvColumn;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryUpdateService.InsertOption;
@@ -112,7 +113,14 @@ public class TableInsertDataIterator extends StatementDataIterator implements Da
                     .collect(Collectors.toCollection(CaseInsensitiveHashSet::new));
             for (int i = 1; i <= di.getColumnCount(); i++) // Note DataIterator column index is 1-based
             {
-                targetOnlyColumnNames.remove(di.getColumnInfo(i).getName());
+                var col = di.getColumnInfo(i);
+                targetOnlyColumnNames.remove(col.getName());
+
+                if (col.getName().toLowerCase().endsWith(MvColumn.MV_INDICATOR_SUFFIX.toLowerCase()))
+                {
+                    String name = col.getName().substring(0, col.getName().length() - MvColumn.MV_INDICATOR_SUFFIX.length());
+                    targetOnlyColumnNames.remove(name + "_" + MvColumn.MV_INDICATOR_SUFFIX);
+                }
             }
             // ... except for the Modified and ModifiedBy columns, which should still be updated.
             targetOnlyColumnNames.removeAll(Arrays.stream(SimpleTranslator.SpecialColumn.values())

--- a/api/src/org/labkey/api/dataiterator/TableInsertDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/TableInsertDataIterator.java
@@ -42,6 +42,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -116,10 +117,12 @@ public class TableInsertDataIterator extends StatementDataIterator implements Da
                 var col = di.getColumnInfo(i);
                 targetOnlyColumnNames.remove(col.getName());
 
+                // We expose MV indicator columns in the virtual tables without the underscore before the suffix, while the provisioned column
+                // is created with and underscore separator, we need to account for this difference when the target table is the provisioned table
                 if (col.getName().toLowerCase().endsWith(MvColumn.MV_INDICATOR_SUFFIX.toLowerCase()))
                 {
-                    String name = col.getName().substring(0, col.getName().length() - MvColumn.MV_INDICATOR_SUFFIX.length());
-                    targetOnlyColumnNames.remove(name + "_" + MvColumn.MV_INDICATOR_SUFFIX);
+                    String mvIndicatorName = col.getName().toLowerCase().replace(MvColumn.MV_INDICATOR_SUFFIX.toLowerCase(), "_" + MvColumn.MV_INDICATOR_SUFFIX);
+                    targetOnlyColumnNames.remove(mvIndicatorName);
                 }
             }
             // ... except for the Modified and ModifiedBy columns, which should still be updated.


### PR DESCRIPTION
#### Rationale
In a recent change to support sample type export/import, I introduced a fix to allow sample type export/import of MV columns by exposing the MV indicator column in the virtual table in a more standard way (ExpMaterialTableImpl). This had the side effect of breaking the ability to update MV indicator values, 

It looks like in the TableInsertDataIterator we try to match up the columns with values with the target table columns and throw out columns that aren't being explicitly updated, we run into problems due to the difference in column names between the virtual and provisioned tables.

#### Changes
- add an explicit check for this case, not sure if there is a better way to do or implement this.