### PR TITLE
Add a JUnit test for the DerivationDataIterator

### DIFF
--- a/api/src/org/labkey/api/dataiterator/StringTestIterator.java
+++ b/api/src/org/labkey/api/dataiterator/StringTestIterator.java
@@ -27,14 +27,15 @@ import java.util.List;
 * Date: 2011-05-20
 * Time: 2:16 PM
 */
-class StringTestIterator extends AbstractDataIterator implements ScrollableDataIterator
+//TODO Move to JUnit test utils package?
+public class StringTestIterator extends AbstractDataIterator implements ScrollableDataIterator
 {
     final List<String> columns;
-    final List<String[]> data;
+    final List<Object[]> data;
     boolean isScrollable = false;
     int row = -1;
 
-    StringTestIterator(List<String> columns, List<String[]> data)
+    public StringTestIterator(List<String> columns, List<Object[]> data)
     {
         super(null);
         this.columns = columns;

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -520,6 +520,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
         return Set.of(
             DomainPropertyImpl.TestCase.class,
             ExpDataClassDataTestCase.class,
+            ExpDataIterators.DerivationDataIteratorBuilderTestCase.class,
             ExpDataTableImpl.TestCase.class,
             ExpSampleTypeTestCase.class,
             ExperimentServiceImpl.TestCase.class,


### PR DESCRIPTION
#### Rationale
As follow-on to [Issue #42006](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42006) wanted to add some test coverage for the ParentId parsing for the DerivationDataIterator

#### Related Pull Requests
* TBD

#### Changes
* Lightly refactored the DerivationDataIterator to make more testable
* Added JUnit testcase
* Made StringTestIterator public -- Might be better to move to TestAutomation's JUnitUtils or similar
