### PR TITLE
fix for issue 42093

### DIFF
--- a/experiment/src/org/labkey/experiment/samples/SampleTypeFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeFolderImporter.java
@@ -97,6 +97,7 @@ public class SampleTypeFolderImporter implements FolderImporter
                     }
                     log.info("Importing XAR file: " + xarFile.getName());
                     XarReader reader = new XarReader(xarSource, job);
+                    reader.setStrictValidateExistingSampleType(false);
                     reader.parseAndLoad(false);
                 }
                 else
@@ -161,7 +162,7 @@ public class SampleTypeFolderImporter implements FolderImporter
         @Override
         public int getPriority()
         {
-            return DEFAULT_PRIORITY;
+            return 75;
         }
     }
 }


### PR DESCRIPTION
#### Rationale
Sample types are now handled by the sample type folder exporter and sample derivation runs are no longer part of the experiment & runs folder exporter. However, a sample type definition can get pulled into an assay run if there is a field in the assay that is a lookup to a sample type. In this scenario selecting both folder export options will cause the import to fail because the sample type definition is equivalent except for the materialLsidPrefix (due to the XarFileId guid).

#### Changes
- ensure that the sample type importer always runs after the experiment & runs importer and set strict checking to false for the sample type importer.