### PR TITLE
Fb study publish test fix

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
@@ -877,6 +877,10 @@ public class StudyPublishTest extends StudyPHIExportTest
                 "Full-text search settings",
                 "Missing value indicators",
                 "Notification settings",
+                "Role assignments for users and groups",
+                "Webpart properties and layout",
+                "Wikis and their attachments",
+                "Files",
                 "QC State Settings",
                 "Sample Types");
         clickButton("Next", 0);

--- a/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
@@ -877,11 +877,8 @@ public class StudyPublishTest extends StudyPHIExportTest
                 "Full-text search settings",
                 "Missing value indicators",
                 "Notification settings",
-                "Role assignments for users and groups",
-                "Webpart properties and layout",
-                "Wikis and their attachments",
-                "Files",
-                "QC State Settings");
+                "QC State Settings",
+                "Sample Types");
         clickButton("Next", 0);
 
         // Wizard page 11 : Publish Options


### PR DESCRIPTION
#### Rationale
Sample types were recently added to the list of default folder export types, we needed to update the StudyPublishTest because it tracks the expected and actual list of folder export types.