### PR TITLE
add DATETIME to _sqlTypeNameMap

### DIFF
--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -230,6 +230,10 @@ public abstract class SqlDialect
         _sqlTypeNameMap.put("VARBINARY", Types.VARBINARY);
         _sqlTypeNameMap.put("VARCHAR", Types.VARCHAR);
 
+        // Some databases call Types.TIMESTAMP "TIMESTAMP" and some call it "DATETIME"
+        // however we always want to accept "DATETIME" which can be used unambiguously in schema.xml
+        _sqlTypeNameMap.put("DATETIME", Types.TIMESTAMP);
+
         addSqlTypeNames(_sqlTypeNameMap);
     }
 


### PR DESCRIPTION
#### Rationale
Can't use TIMESTAMP in schema.xml because it is ambiguous.  So always support DATETIME as a valid name for java.sql.Types.TIMESTAMP.