### PR TITLE
Issue 41050: ContainerDisplayColumn shows wrong container name in queries

### DIFF
--- a/api/src/org/labkey/api/data/ContainerDisplayColumn.java
+++ b/api/src/org/labkey/api/data/ContainerDisplayColumn.java
@@ -239,7 +239,7 @@ public class ContainerDisplayColumn extends DataColumn
                     assertEquals("Incorrect json value for ContainerId column", row.getJSONObject("ContainerId/Name").getString("value"), project.getName());
 
                     assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ProjectId/Parent/Name").getString("value"));
-                    assertEquals("Incorrect json value for ContainerId column", row.getJSONObject("ProjectId/Parent/Name").getString("displayValue"), "");
+                    assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ProjectId/Parent/Name").getString("displayValue"));
 
                 }
                 else if (comment.contains(subFolder1.getName() + " was created"))
@@ -267,10 +267,10 @@ public class ContainerDisplayColumn extends DataColumn
                     assertEquals("Incorrect json value for ContainerId column", "<deleted>", row.getJSONObject("ContainerId").getString("displayValue"));
 
                     assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ContainerId/Name").getString("value"));
-                    assertEquals("Incorrect json value for ContainerId column", "", row.getJSONObject("ContainerId/Name").getString("displayValue"));
+                    assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ContainerId/Name").getString("displayValue"));
 
                     assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ProjectId/Parent/Name").getString("value"));
-                    assertEquals("Incorrect json value for ContainerId column", "", row.getJSONObject("ProjectId/Parent/Name").getString("displayValue"));
+                    assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ProjectId/Parent/Name").getString("displayValue"));
                 }
                 else if (comment.contains(subFolder2.getName() + " was deleted"))
                 {
@@ -282,10 +282,10 @@ public class ContainerDisplayColumn extends DataColumn
                     assertEquals("Incorrect json value for ContainerId column", "<deleted>", row.getJSONObject("ContainerId").getString("displayValue"));
 
                     assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ContainerId/Name").getString("value"));
-                    assertEquals("Incorrect json value for ContainerId column", "", row.getJSONObject("ContainerId/Name").getString("displayValue"));
+                    assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ContainerId/Name").getString("displayValue"));
 
                     assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ProjectId/Parent/Name").getString("value"));
-                    assertEquals("Incorrect json value for ContainerId column", "", row.getJSONObject("ProjectId/Parent/Name").getString("displayValue"));
+                    assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ProjectId/Parent/Name").getString("displayValue"));
                 }
                 else
                 {

--- a/api/src/org/labkey/api/data/ContainerDisplayColumn.java
+++ b/api/src/org/labkey/api/data/ContainerDisplayColumn.java
@@ -107,16 +107,6 @@ public class ContainerDisplayColumn extends DataColumn
 
     private Container getContainer(RenderContext ctx)
     {
-        // Issue 41050 - use URL's container context when possible to resolve the referenced container
-        if (getURLExpression() instanceof DetailsURL)
-        {
-            ContainerContext containerContext = ((DetailsURL) getURLExpression()).getContainerContext();
-            if (containerContext != null)
-            {
-                return containerContext.getContainer(ctx);
-            }
-        }
-
         String id = getEntityIdValue(ctx);
         return id == null ? null : ContainerManager.getForId(id);
     }

--- a/api/src/org/labkey/api/data/ContainerTable.java
+++ b/api/src/org/labkey/api/data/ContainerTable.java
@@ -104,7 +104,6 @@ public class ContainerTable extends FilteredTable<UserSchema>
         this.addColumn(col);
 
         var name = getMutableColumn("Name");
-        name.setDisplayColumnFactory(colInfo -> new ContainerDisplayColumn(colInfo, false));
         name.setURL(detailsURL);
         name.setReadOnly(true); // CONSIDER: allow renames via QueryUpdateService api
 
@@ -130,7 +129,7 @@ public class ContainerTable extends FilteredTable<UserSchema>
         folderDisplayColumn.setReadOnly(true);
         setTitleColumn(folderDisplayColumn.getName());
 
-        final var folderPathCol = this.wrapColumn("Path", getRealTable().getColumn("Name"));
+        final var folderPathCol = this.wrapColumn("Path", getRealTable().getColumn("EntityId"));
         folderPathCol.setReadOnly(true);
         folderPathCol.setDisplayColumnFactory(colInfo -> new ContainerDisplayColumn(colInfo, true));
         addColumn(folderPathCol);

--- a/study/src/org/labkey/study/query/StudySnapshotTable.java
+++ b/study/src/org/labkey/study/query/StudySnapshotTable.java
@@ -83,7 +83,7 @@ public class StudySnapshotTable extends FilteredTable<StudyQuerySchema>
             @Override
             public DisplayColumn createRenderer(ColumnInfo colInfo)
             {
-                return new ContainerDisplayColumn(colInfo, false, true){
+                return new ContainerDisplayColumn(colInfo, false){
                     @Override
                     public String renderURL(RenderContext ctx)
                     {


### PR DESCRIPTION
#### Rationale
ContainerDisplayColumn does its best to resolve the full container path and name. It wasn't working well in some custom queries

#### Changes
* Use ContainerContext which is smarter about finding the right EntityId