### PR TITLE
Issue 42117: Need ShutdownListener to terminate MySQL AbandonedConnectionCleanupThread

### DIFF
--- a/bigiron/src/org/labkey/bigiron/BigIronModule.java
+++ b/bigiron/src/org/labkey/bigiron/BigIronModule.java
@@ -82,6 +82,6 @@ public class BigIronModule extends CodeOnlyModule
     @NotNull
     public Set<Class> getIntegrationTests()
     {
-        return Collections.singleton(GroupConcatInstallationManager.TestCase.class);
+        return Set.of(GroupConcatInstallationManager.TestCase.class);
     }
 }

--- a/bigiron/src/org/labkey/bigiron/mysql/MySqlDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySqlDialectFactory.java
@@ -16,12 +16,15 @@
 
 package org.labkey.bigiron.mysql;
 
+import com.mysql.cj.jdbc.AbandonedConnectionCleanupThread;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.dialect.DatabaseNotSupportedException;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.dialect.SqlDialectFactory;
+import org.labkey.api.util.ContextListener;
+import org.labkey.api.util.ShutdownListener;
 import org.labkey.api.util.VersionNumber;
 
 import java.sql.DatabaseMetaData;
@@ -41,6 +44,30 @@ public class MySqlDialectFactory implements SqlDialectFactory
     private String getProductName()
     {
         return "MySQL";
+    }
+
+    public MySqlDialectFactory()
+    {
+        // Terminate MySQL AbandonedConnectionCleanupThread at shutdown to avoid Tomcat logging IllegalStateException, Issue 42117
+        ContextListener.addShutdownListener(new ShutdownListener()
+        {
+            @Override
+            public String getName()
+            {
+                return "MySQL JDBC driver clean up";
+            }
+
+            @Override
+            public void shutdownPre()
+            {
+                AbandonedConnectionCleanupThread.uncheckedShutdown();
+            }
+
+            @Override
+            public void shutdownStarted()
+            {
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
[Issue 42117: Need ShutdownListener to terminate MySQL AbandonedConnectionCleanupThread](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42117)
