### PR TITLE
42074: Query report charting options

### DIFF
--- a/api/src/org/labkey/api/reports/report/view/renderQueryReport.jsp
+++ b/api/src/org/labkey/api/reports/report/view/renderQueryReport.jsp
@@ -84,7 +84,6 @@
                 schemaName  : <%=q(schemaName)%>,
                 queryName   : <%=q(queryName)%>,
                 viewName    : <%=(viewName != null) ? q(viewName) : null%>,
-                showReports : false,
                 frame       : 'none',
                 allowChooseQuery : false
             });


### PR DESCRIPTION
#### Rationale
The client has requested the ability to create charts from query reports by exposing the charting button on the data region. This is a simple fix, and AFAIK there wasn't a reason to exclude the button originally and has always been that way.

#### Related Issue
- https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42074

