### PR TITLE
support for sample type import from folder template

### DIFF
--- a/experiment/src/org/labkey/experiment/samples/SampleTypeFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeFolderImporter.java
@@ -7,10 +7,11 @@ import org.labkey.api.admin.FolderArchiveDataTypes;
 import org.labkey.api.admin.FolderImporter;
 import org.labkey.api.admin.FolderImporterFactory;
 import org.labkey.api.admin.ImportContext;
+import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.dataiterator.DataIteratorContext;
-import org.labkey.api.exp.CompressedXarSource;
+import org.labkey.api.exp.CompressedInputStreamXarSource;
 import org.labkey.api.exp.XarSource;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.query.SamplesSchema;
@@ -21,7 +22,9 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.reader.DataLoader;
+import org.labkey.api.security.User;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.URLHelper;
 import org.labkey.api.writer.VirtualFile;
 import org.labkey.experiment.XarReader;
 
@@ -85,7 +88,45 @@ public class SampleTypeFolderImporter implements FolderImporter
             {
                 if (xarFile != null)
                 {
-                    XarSource xarSource = new CompressedXarSource(xarFile, job, ctx.getContainer());
+                    File logFile = CompressedInputStreamXarSource.getLogFileFor(xarFile);
+
+                    if (job == null)
+                    {
+                        // need to fake up a job for the XarReader
+                        job = new PipelineJob()
+                        {
+                            @Override
+                            public User getUser()
+                            {
+                                return ctx.getUser();
+                            }
+
+                            @Override
+                            public Container getContainer()
+                            {
+                                return ctx.getContainer();
+                            }
+
+                            @Override
+                            public synchronized Logger getLogger()
+                            {
+                                return ctx.getLogger();
+                            }
+
+                            @Override
+                            public URLHelper getStatusHref()
+                            {
+                                return null;
+                            }
+
+                            @Override
+                            public String getDescription()
+                            {
+                                return "Sample Type XAR Import";
+                            }
+                        };
+                    }
+                    XarSource xarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(xarFile.getName()), xarFile, logFile, job);
                     try
                     {
                         xarSource.init();

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeFolderWriter.java
@@ -76,7 +76,8 @@ public class SampleTypeFolderWriter extends BaseFolderWriter
     @Override
     public boolean show(Container c)
     {
-        return !SampleTypeService.get().getSampleTypes(c, null, false).isEmpty();
+        // need to always return true so it can be used in a folder template
+        return true;
     }
 
     @Override

--- a/internal/src/org/labkey/api/exp/CompressedInputStreamXarSource.java
+++ b/internal/src/org/labkey/api/exp/CompressedInputStreamXarSource.java
@@ -1,0 +1,85 @@
+package org.labkey.api.exp;
+
+import org.apache.xmlbeans.XmlException;
+import org.fhcrc.cpas.exp.xml.ExperimentArchiveDocument;
+import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.XmlBeansUtil;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * XAR file sourced from a compressed input stream. This allows operations for either in-memory virtual file or a
+ * file on disk so it can be used for operations like study publish or import from a folder template as well
+ * as import from a zip file.
+ */
+public class CompressedInputStreamXarSource extends AbstractFileXarSource
+{
+    private final InputStream _xarInputStream;
+    private final File _logFile;
+    private String _xml;
+
+    public CompressedInputStreamXarSource(InputStream xarInputStream, File xarFile, File logFile, PipelineJob job)
+    {
+        super(job.getDescription(), job.getContainer(), job.getUser(), job);
+        _xarInputStream = xarInputStream;
+        _xmlFile = xarFile;
+        _logFile = logFile;
+    }
+
+    @Override
+    public void init() throws IOException, ExperimentException
+    {
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        try (OutputStream stream = new BufferedOutputStream(byteStream))
+        {
+            byte[] zipBytes = _xarInputStream.readAllBytes();
+
+            ByteArrayInputStream bais = new ByteArrayInputStream(zipBytes);
+            ZipInputStream zis = new ZipInputStream(bais);
+            ZipEntry entry;
+
+            while (null != (entry = zis.getNextEntry()))
+            {
+                // not interested in directories, only files
+                if (!entry.isDirectory())
+                {
+                    if (entry.getName().endsWith(".xar.xml"))
+                    {
+                        BufferedInputStream bis = new BufferedInputStream(zis);
+                        FileUtil.copyData(bis, stream);
+                    }
+                }
+                zis.closeEntry();
+            }
+        }
+        _xml = byteStream.toString(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public ExperimentArchiveDocument getDocument() throws XmlException, IOException
+    {
+        if (_xml != null)
+        {
+            return ExperimentArchiveDocument.Factory.parse(_xml, XmlBeansUtil.getDefaultParseOptions());
+        }
+        else
+            throw new RuntimeException("XML source not found.");
+    }
+
+    @Override
+    public File getLogFile() throws IOException
+    {
+        return _logFile;
+    }
+}


### PR DESCRIPTION
#### Rationale
To support importing from a folder template, importers must have the ability to process in-memory virtual files, as opposed to files on disk. The typical way this is done is to process the input stream from the virtual files.

#### Changes
Implement a CompressedInputStreamXarSource and use a ZipInputStream to expand the XAR XML so the XML bean document can be instantiated.