### PR TITLE
Use JDBC Driver for initial connections and stop supporting Tomcat JDBC connection pool

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1530,7 +1530,7 @@ public class DbScope
         throw new ConfigurationException("Can't connect to data source \"" + dsName + "\".", "Make sure that your LabKey Server configuration file includes the correct user name, password, url, port, etc. for your database and that the database server is running.", lastException);
     }
 
-    // Establish a data source connection that bypasses the connection pool
+    // Establish a direct data source connection that bypasses the connection pool
     private static Connection getRawConnection(DataSourceProperties props) throws ServletException, SQLException
     {
         return getRawConnection(props.getUrl(), props);
@@ -1558,7 +1558,7 @@ public class DbScope
         return driver.connect(url, info);
     }
 
-    public static void createDataBase(SqlDialect dialect, DataSourceProperties props, boolean primaryDataSource) throws ServletException
+    private static void createDataBase(SqlDialect dialect, DataSourceProperties props, boolean primaryDataSource) throws ServletException
     {
         String url = props.getUrl();
         String dbName = dialect.getDatabaseName(url);

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1088,7 +1088,7 @@ public abstract class SqlDialect
     }
 
 
-    // Trying to be DataSource implementation agnostic here.  DataSource interface doesn't provide access to any of
+    // Trying to be DataSource-implementation agnostic here. DataSource interface doesn't provide access to any of
     // these properties, but we don't want to cast to a specific implementation class, so use reflection to get them.
     public static class DataSourceProperties
     {
@@ -1144,16 +1144,7 @@ public abstract class SqlDialect
 
         public String getPassword() throws ServletException
         {
-            // Special handling for Tomcat JDBC connection pool; getPassword() returns a fixed string
-            if ("org.apache.tomcat.jdbc.pool.DataSource".equals(_ds.getClass().getName()))
-            {
-                Properties props = callGetter("getDbProperties");
-                return props.getProperty("password");
-            }
-            else
-            {
-                return getProperty("getPassword");
-            }
+            return getProperty("getPassword");
         }
 
         public Integer getMaxTotal()
@@ -1193,7 +1184,6 @@ public abstract class SqlDialect
                 return null;
             }
         }
-
     }
 
 

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -51,7 +51,6 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.dialect.DatabaseNotSupportedException;
 import org.labkey.api.data.dialect.SqlDialect;
-import org.labkey.api.data.dialect.SqlDialectManager;
 import org.labkey.api.module.ModuleUpgrader.Execution;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.resource.Resource;
@@ -84,13 +83,6 @@ import org.springframework.context.support.FileSystemXmlApplicationContext;
 import org.springframework.web.context.support.XmlWebApplicationContext;
 import org.springframework.web.servlet.mvc.Controller;
 
-import javax.naming.Binding;
-import javax.naming.Context;
-import javax.naming.InitialContext;
-import javax.naming.NameNotFoundException;
-import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
-import javax.naming.Reference;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -98,12 +90,10 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.sql.DataSource;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -122,11 +112,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
@@ -477,7 +465,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
         verifyProductionModeMatchesBuild();
 
         // Initialize data sources before initializing modules; modules will fail to initialize if the appropriate data sources aren't available
-        initializeDataSources();
+        DbScope.initializeDataSources();
 
         // Start up a thread that lets us hit a breakpoint in the debugger, even if all the real working threads are hung.
         // This lets us invoke methods in the debugger, gain easier access to statics, etc.
@@ -1088,92 +1076,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
         return _tomcatVersion;
     }
 
-    // Enumerate each jdbc DataSource in labkey.xml and tell DbScope to initialize them
-    private void initializeDataSources()
-    {
-        verifyJdbcDrivers();
-
-        _log.debug("Ensuring that all databases specified by data sources in webapp configuration xml are present");
-
-        Map<String, DataSource> dataSources = new TreeMap<>(String::compareTo);
-
-        String labkeyDsName;
-
-        try
-        {
-            // Ensure that the labkeyDataSource (or cpasDataSource, for old installations) exists in
-            // labkey.xml / cpas.xml and create the associated database if it doesn't already exist.
-            labkeyDsName = ensureDatabase(LABKEY_DATA_SOURCE, CPAS_DATA_SOURCE);
-
-            InitialContext ctx = new InitialContext();
-            Context envCtx = (Context) ctx.lookup("java:comp/env");
-            NamingEnumeration<Binding> iter = envCtx.listBindings("jdbc");
-
-            while (iter.hasMore())
-            {
-                try
-                {
-                    Binding o = iter.next();
-                    String dsName = o.getName();
-                    DataSource ds = validate((DataSource) o.getObject(), dsName);
-                    dataSources.put(dsName, ds);
-                }
-                catch (NamingException e)
-                {
-                    _log.error("DataSources are not properly configured in " + AppProps.getInstance().getWebappConfigurationFilename() + ".", e);
-                }
-            }
-        }
-        catch (Exception e)
-        {
-            throw new ConfigurationException("DataSources are not properly configured in " + AppProps.getInstance().getWebappConfigurationFilename() + ".", e);
-        }
-
-        DbScope.initializeScopes(labkeyDsName, dataSources);
-    }
-
-    // Reject data sources configured with the Tomcat JDBC connection pool, #42125
-    private DataSource validate(DataSource dataSource, String dsName) throws ServletException
-    {
-        String dataSourceClassName = dataSource.getClass().getName();
-        if (!dataSourceClassName.equals("org.apache.tomcat.dbcp.dbcp2.BasicDataSource"))
-        {
-            String message;
-            if (dataSourceClassName.equals("org.apache.tomcat.jdbc.pool.DataSource"))
-            {
-                message = "Tomcat JDBC connection pool is not supported;";
-            }
-            else
-            {
-                message = "Unknown DataSource implementation, \"" + dataSourceClassName + "\";";
-            }
-
-            throw new ServletException(message + " LabKey only supports the Commons DBCP connection pool. Please remove the \"factory\" attribute from the \"" + dsName + "\" DataSource definition.");
-        }
-
-        return dataSource;
-    }
-
-    // Verify that old JDBC drivers are not present in <tomcat>/lib -- they are now provided by the API module
-    private void verifyJdbcDrivers()
-    {
-        File lib = getTomcatLib();
-
-        if (null != lib)
-        {
-            List<String> existing = Stream.of("jtds.jar", "mysql.jar", "postgresql.jar")
-                .filter(name->new File(lib, name).exists())
-                .collect(Collectors.toList());
-
-            if (!existing.isEmpty())
-            {
-                String path = FileUtil.getAbsoluteCaseSensitiveFile(lib).getAbsolutePath();
-                throw new ConfigurationException("You must delete the following JDBC drivers from " + path + ": " + existing);
-            }
-        }
-    }
-
-    public @Nullable File getTomcatLib()
+    public static @Nullable File getTomcatLib()
     {
         String classPath = System.getProperty("java.class.path", ".");
 
@@ -1199,48 +1102,6 @@ public class ModuleLoader implements Filter, MemTrackerListener
         }
 
         return new File(tomcat, "lib");
-    }
-
-    // For each name, look for a matching data source in labkey.xml. If found, attempt a connection and
-    // create the database if it doesn't already exist, report any errors and return the name.
-    public String ensureDatabase(@NotNull String primaryName, String... alternativeNames) throws NamingException, ServletException
-    {
-        List<String> dsNames = new ArrayList<>();
-        dsNames.add(primaryName);
-        dsNames.addAll(Arrays.asList(alternativeNames));
-
-        InitialContext ctx = new InitialContext();
-        Context envCtx = (Context) ctx.lookup("java:comp/env");
-
-        DataSource dataSource = null;
-        String dsName = null;
-
-        for (String name : dsNames)
-        {
-            dsName = name;
-
-            try
-            {
-                dataSource = validate((DataSource)envCtx.lookup("jdbc/" + dsName), dsName);
-                break;
-            }
-            catch (NameNotFoundException e)
-            {
-                // Name not found is fine (for now); keep looping through alternative names
-            }
-            catch (NamingException e)
-            {
-                throw new ConfigurationException("Failed to load DataSource \"" + dsName + "\" defined in " + AppProps.getInstance().getWebappConfigurationFilename() +
-                    ". This could be caused by an attempt to use the Tomcat JDBC connection pool, which is not supported. Please remove the \"factory\" attribute from this DataSource definition.", e);
-            }
-        }
-
-        if (null == dataSource)
-            throw new ConfigurationException("You must have a DataSource named \"" + primaryName + "\" defined in " + AppProps.getInstance().getWebappConfigurationFilename() + ".");
-
-        DbScope.ensureDataBase(dsName, dataSource);
-
-        return dsName;
     }
 
 

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -1930,7 +1930,7 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
         if (paramCount > 0)
         {
             sb.append("(");
-            sb.append("?, ".repeat(paramCount));
+            sb.append(StringUtils.repeat("?", ", ", paramCount));
             sb.append(")");
         }
 


### PR DESCRIPTION
#### Rationale
[Issue 42069: Use JDBC Driver to create unpooled connections](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42069)
[Issue 42125: Remove support for Tomcat JDBC Connection Pool](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42125)

#### Changes
* Refactor initial database connections to use `Driver.connect()` instead of `DriverManager.getConnection()`. This ensures deterministic behavior.
* Remove all support for Tomcat JDBC Connection Pool. A data source configured with this factory will cause server start to fail with a clear message.
* Use `_dsProps.getUrl()` instead of stashing `DbScope._URL`
* Move most data source handling in `ModuleLoader` to `DbScope`