### PR TITLE
Issue 41459: Allow user to specify schema/query for EditableGrid in core-components.view

### DIFF
--- a/core/src/client/LabKeyUIComponentsPage/EditableGridPage.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/EditableGridPage.tsx
@@ -121,11 +121,8 @@ class EditableGridPageImpl extends PureComponent<SchemaQueryInputContext> {
         const { model } = this.props;
         const editorModelWithData  = getQueryGridModel("edit-with-data|assay/assaylist");
 
-        if (!editorModelWithData) {
-            return <LoadingSpinner/>;
-        }
+        // TODO hack to force rerender after model is loaded
         if (model && !model.isLoaded) {
-            // TODO hack to force rerender after model is loaded
             window.setTimeout(() => this.forceUpdate(), 500);
         }
 

--- a/core/src/client/LabKeyUIComponentsPage/GridPanelPage.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/GridPanelPage.tsx
@@ -1,97 +1,24 @@
-import React, { PureComponent, ChangeEvent } from 'react';
-import { Panel, Button, Grid, Row, Col } from 'react-bootstrap';
-import { GridPanelWithModel, QueryConfig, SchemaQuery } from '@labkey/components';
+import React, { PureComponent } from 'react';
+import { GridPanelWithModel } from '@labkey/components';
+import {SchemaQueryInputContext, SchemaQueryInputProvider} from "./SchemaQueryInputProvider";
 
-interface State {
-    schemaName?: string;
-    queryName?: string;
-    queryConfig?: QueryConfig;
-}
-
-class GridPanelExample extends PureComponent<{}, State> {
-    readonly state = {
-        queryName: '',
-        schemaName: '',
-        queryConfig: undefined,
-    };
-
-    onFormChange = (e: ChangeEvent<HTMLInputElement>) => {
-        const { name, value } = e.target;
-        this.setState(() => ({ [name]: value }));
-    };
-
-    applySchemaQuery = () => {
-        let { schemaName, queryName } = this.state;
-        schemaName = schemaName.trim() || undefined;
-        queryName = queryName.trim() || undefined;
-
-        if (schemaName === undefined || queryName === undefined) {
-            console.warn('Cannot have empty schemaName or queryName');
-            return;
-        }
-
-        this.setState({
-            queryConfig: {
-                id: `gpe-${schemaName}-${queryName}`,
-                schemaQuery: SchemaQuery.create(schemaName, queryName),
-            },
-        });
-    };
+class GridPanelPageImpl extends PureComponent<SchemaQueryInputContext> {
 
     render() {
-        const { queryConfig, queryName, schemaName } = this.state;
+        const { queryConfig } = this.props;
 
         return (
             <div>
-                <Grid>
-                    <Row>
-                        <Col xs={4}>
-                            <label htmlFor="schemaName">Schema</label>
-                            <input
-                                id="schemaName"
-                                name="schemaName"
-                                type="text"
-                                value={schemaName}
-                                onChange={this.onFormChange}
-                            />
-                        </Col>
-
-                        <Col xs={4}>
-                            <label htmlFor="queryName">Query</label>
-                            <input
-                                id="queryName"
-                                name="queryName"
-                                type="text"
-                                value={queryName}
-                                onChange={this.onFormChange}
-                            />
-                        </Col>
-
-                        <Col xs={4}>
-                            <Button onClick={this.applySchemaQuery}>Apply</Button>
-                        </Col>
-                    </Row>
-                </Grid>
-
-                {queryConfig === undefined && <div>Enter a Schema, Query</div>}
-
-                {queryConfig !== undefined && <GridPanelWithModel queryConfig={queryConfig} />}
+                {queryConfig &&
+                    <GridPanelWithModel
+                        title={'GridPanel'}
+                        asPanel={true}
+                        queryConfig={queryConfig}
+                    />
+                }
             </div>
         );
     }
 }
 
-export class GridPanelPage extends PureComponent {
-    render() {
-        return (
-            <Panel>
-                <Panel.Heading>
-                    GridPanel
-                </Panel.Heading>
-                <Panel.Body>
-                    <GridPanelExample />
-                </Panel.Body>
-            </Panel>
-        );
-    }
-}
+export const GridPanelPage = SchemaQueryInputProvider(GridPanelPageImpl);

--- a/core/src/client/LabKeyUIComponentsPage/LabKeyUIComponentsPage.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/LabKeyUIComponentsPage.tsx
@@ -273,9 +273,7 @@ export class App extends React.Component<any, State> {
                     <DetailPage editable={true}/>
                 }
                 {selected === 'EditableGridPanel' &&
-                    this.renderPanel('EditableGridPanel',
-                        <EditableGridPage/>
-                    )
+                    <EditableGridPage/>
                 }
                 {selected === 'EntityInsertPanel' &&
                     this.renderPanel('EntityInsertPanel',

--- a/core/src/client/LabKeyUIComponentsPage/QueryGridPage.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/QueryGridPage.tsx
@@ -2,97 +2,49 @@
  * Copyright (c) 2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React from 'react'
-import {Col, FormControl, Row, Button} from "react-bootstrap";
+import React, {PureComponent, ReactNode} from 'react'
 import {
-    SchemaQuery,
-    Alert,
     QueryGridModel,
     ManageDropdownButton,
     SelectionMenuItem,
-    getStateQueryGridModel,
     QueryGridPanel
 } from "@labkey/components";
 
-interface StateProps {
-    schemaName: string
-    queryName: string,
-    error: string,
-    model: QueryGridModel
-}
+import {SchemaQueryInputContext, SchemaQueryInputProvider} from "./SchemaQueryInputProvider";
 
-export class QueryGridPage extends React.Component<any, StateProps> {
+class QueryGridPageImpl extends PureComponent<SchemaQueryInputContext> {
 
-    constructor(props: any) {
-        super(props);
-
-        this.state = {
-            schemaName: undefined,
-            queryName: undefined,
-            error: undefined,
-            model: undefined
-        };
-    }
-
-    onSchemaNameChange = (evt) => {
-        const value = evt.target.value;
-        this.setState(() => ({schemaName: value}));
-    };
-
-    onQueryNameChange = (evt) => {
-        const value = evt.target.value;
-        this.setState(() => ({queryName: value}));
-    };
-
-    onApply = () => {
-        const { schemaName, queryName } = this.state;
-        let error;
-        let model;
-
-        if (!schemaName || !queryName) {
-            error = 'You must enter a schema/query to view the QueryGridPanel.'
+    renderButtons = (updatedModel: QueryGridModel): ReactNode => {
+        if (updatedModel) {
+            return (
+                <ManageDropdownButton id={'componentmanage'}>
+                    <SelectionMenuItem
+                        id={'componentselectionmenu'}
+                        model={updatedModel}
+                        text={'Selection Based Menu Item'}
+                        onClick={() => console.log('SelectionMenuItem click: ' + updatedModel.selectedQuantity + ' selected.')}
+                    />
+                </ManageDropdownButton>
+            )
         }
-        else {
-            model = getStateQueryGridModel('querygrid', SchemaQuery.create(schemaName, queryName), {isPaged: true});
-        }
-
-        this.setState(() => ({model, error}));
     };
 
-    render() {
-        const { error, model } = this.state;
+    render(): ReactNode {
+        const { model } = this.props;
 
         return (
             <>
-                <Row>
-                    <Col xs={4}>Schema: <FormControl name={'schemaNameField'} type="text" onChange={this.onSchemaNameChange}/></Col>
-                    <Col xs={4}>Query: <FormControl name={'queryNameField'} type="text" onChange={this.onQueryNameChange}/></Col>
-                    <Col xs={4}><Button onClick={this.onApply}>Apply</Button></Col>
-                </Row>
-                <br/>
-                {error && <Alert>{error}</Alert>}
                 {model &&
                     <QueryGridPanel
                         header={'QueryGridPanel'}
                         model={model}
-                        buttons={(updatedModel: QueryGridModel) => {
-                            if (updatedModel) {
-                                return (
-                                    <ManageDropdownButton id={'componentmanage'}>
-                                        <SelectionMenuItem
-                                            id={'componentselectionmenu'}
-                                            model={updatedModel}
-                                            text={'Selection Based Menu Item'}
-                                            onClick={() => console.log('SelectionMenuItem click: ' + updatedModel.selectedQuantity + ' selected.')}
-                                        />
-                                    </ManageDropdownButton>
-                                )
-                            }
-                        }}
+                        buttons={this.renderButtons}
                     />
                 }
             </>
         )
     }
 }
+
+export const QueryGridPage = SchemaQueryInputProvider(QueryGridPageImpl);
 

--- a/core/src/client/LabKeyUIComponentsPage/SchemaQueryInputProvider.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/SchemaQueryInputProvider.tsx
@@ -1,0 +1,75 @@
+import React, {ChangeEvent} from 'react';
+import {Col, FormControl, Row, Button} from "react-bootstrap";
+import {Alert, getStateQueryGridModel, QueryConfig, QueryGridModel, SchemaQuery} from "@labkey/components";
+
+const Context = React.createContext<SchemaQueryInputContext>(undefined);
+const SchemaQueryInputContextProvider = Context.Provider;
+
+interface Props {}
+
+interface State {
+    schemaName: string,
+    queryName: string,
+    error: string,
+    model: QueryGridModel,
+    queryConfig: QueryConfig,
+}
+
+export type SchemaQueryInputContext = State;
+
+export const SchemaQueryInputProvider = (Component: React.ComponentType) => {
+    return class SchemaQueryInputProviderImpl extends React.Component<Props, State> {
+        readonly state: State = {
+            queryName: undefined,
+            schemaName: undefined,
+            error: undefined,
+            model: undefined,
+            queryConfig: undefined,
+        };
+
+        onFormChange = (e: ChangeEvent<HTMLInputElement>) => {
+            const { name, value } = e.target;
+            this.setState(() => ({
+                ...this.state,
+                error: undefined,
+                model: undefined,
+                queryConfig: undefined,
+                [name]: value
+            }));
+        };
+
+
+        onApply = () => {
+            const { schemaName, queryName } = this.state;
+
+            let error, model, queryConfig;
+            if (!schemaName || !queryName) {
+                error = 'You must enter a schema/query to view the QueryGridPanel.'
+            }
+            else {
+                const schemaQuery = SchemaQuery.create(schemaName, queryName);
+                model = getStateQueryGridModel('components-querygridmodel', schemaQuery, {isPaged: true});
+                queryConfig = { id: `components-queryconfig-${schemaName}-${queryName}`, schemaQuery };
+            }
+
+            this.setState(() => ({model, queryConfig, error}));
+        };
+
+        render() {
+            const { error } = this.state;
+
+            return (
+                <SchemaQueryInputContextProvider value={this.state}>
+                    <Row>
+                        <Col xs={4}>Schema: <FormControl name={'schemaName'} type="text" onChange={this.onFormChange}/></Col>
+                        <Col xs={4}>Query: <FormControl name={'queryName'} type="text" onChange={this.onFormChange}/></Col>
+                        <Col xs={4}><Button onClick={this.onApply}>Apply</Button></Col>
+                    </Row>
+                    <br/>
+                    {error && <Alert>{error}</Alert>}
+                    <Component {...this.props} {...this.state}/>
+                </SchemaQueryInputContextProvider>
+            )
+        }
+    }
+};

--- a/core/src/client/LabKeyUIComponentsPage/SchemaQueryInputProvider.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/SchemaQueryInputProvider.tsx
@@ -38,7 +38,6 @@ export const SchemaQueryInputProvider = (Component: React.ComponentType) => {
             }));
         };
 
-
         onApply = () => {
             const { schemaName, queryName } = this.state;
 


### PR DESCRIPTION
#### Rationale
We have a shared components testing page in the core module. A few of the components (QueryGridPanel, GridPanel, and EditableGridPanel) would benefit from allowing the user/tester to provide a schema/query name in a consistent way so that our automated tests can setup various scenarios using tables or lists with certain field properties.

#### Changes
* factor out SchemaQueryInputProvider.tsx for use in component pages for GridPanel and QueryGridPanel
