### PR TITLE
Issue 42134: Selecting view metadata on schema/IssueListDef table gives an error

### DIFF
--- a/issues/src/org/labkey/issue/query/IssuesListDefTable.java
+++ b/issues/src/org/labkey/issue/query/IssuesListDefTable.java
@@ -110,7 +110,7 @@ public class IssuesListDefTable extends FilteredTable<IssuesQuerySchema>
     private void addAllColumns()
     {
         setDescription("Contains one row for each issue list");
-        setName("Issue List Definitions");
+        setTitle("Issue List Definitions");
 
         addWrapColumn(getRealTable().getColumn(FieldKey.fromParts("RowId"))).setHidden(true);
 
@@ -239,12 +239,6 @@ public class IssuesListDefTable extends FilteredTable<IssuesQuerySchema>
     public ActionURL getImportDataURL(Container container)
     {
         return LINK_DISABLER_ACTION_URL;
-    }
-
-    @Override
-    public String getPublicName()
-    {
-        return IssuesQuerySchema.TableType.IssueListDef.name();
     }
 
     private class UpdateService extends DefaultQueryUpdateService

--- a/issues/src/org/labkey/issue/query/IssuesListDefTable.java
+++ b/issues/src/org/labkey/issue/query/IssuesListDefTable.java
@@ -241,6 +241,12 @@ public class IssuesListDefTable extends FilteredTable<IssuesQuerySchema>
         return LINK_DISABLER_ACTION_URL;
     }
 
+    @Override
+    public String getPublicName()
+    {
+        return IssuesQuerySchema.TableType.IssueListDef.name();
+    }
+
     private class UpdateService extends DefaultQueryUpdateService
     {
         public UpdateService(IssuesListDefTable table)


### PR DESCRIPTION
#### Rationale
EditMetadata link on issue list definitions table has the queryName as the label of the query which is causing the page to be not found.


#### Changes
* return the correct name for IssueListDefTable