### PR TITLE
Fail startup if Redshift JDBC driver is found in <tomcat>/lib

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -26,7 +26,6 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.cache.Cache;
-import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ConnectionWrapper.Closer;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.dialect.SqlDialect.DataSourceProperties;
@@ -72,10 +71,12 @@ import java.sql.Driver;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -1217,7 +1218,7 @@ public class DbScope
     // Enumerate each jdbc DataSource in labkey.xml and initialize them
     public static void initializeDataSources()
     {
-        verifyJdbcDrivers();
+        verifyTomcatLibJars();
 
         LOG.debug("Ensuring that all databases specified by data sources in webapp configuration xml are present");
 
@@ -1280,24 +1281,36 @@ public class DbScope
         return dataSource;
     }
 
-    // Verify that old JDBC drivers are not present in <tomcat>/lib -- they are now provided by the API, BigIron, and Redshift modules
-    private static void verifyJdbcDrivers()
+    private static final List<Predicate<String>> TOMCAT_LIB_PREDICATES = new CopyOnWriteArrayList<>();
+
+    /**
+     * Register a {@code Predicate<String>} that identifies filenames that aren't allowed in the {@code <tomcat>/lib}
+     * directory. This is used to warn administrators about old, conflicting JDBC drivers that need to be removed from
+     * Tomcat.
+     * @param predicate a {@code Predicate<String>} whose {@code test(String filename)} method returns true if filename
+     *        is not allowed in the {@code <tomcat>/lib} directory
+     */
+    public static void registerForbiddenTomcatFilenamePredicate(Predicate<String> predicate)
+    {
+        TOMCAT_LIB_PREDICATES.add(predicate);
+    }
+
+    // Verify that old JDBC drivers are not present in <tomcat>/lib -- they are now provided by the modules that manage them
+    private static void verifyTomcatLibJars()
     {
         File lib = ModuleLoader.getTomcatLib();
 
         if (null != lib)
         {
-            Set<String> drivers = CaseInsensitiveHashSet.of("jtds.jar", "mysql.jar", "postgresql.jar");
+            Predicate<String> aggregatePredicate = TOMCAT_LIB_PREDICATES.stream().reduce(x->false, Predicate::or);
             String[] existing = lib.list((dir, name) ->
-                drivers.contains(name) ||
-                StringUtils.startsWithIgnoreCase(name, "RedshiftJDBC") ||
-                StringUtils.startsWithIgnoreCase(name, "redshift-jdbc")
+                aggregatePredicate.test(name)
             );
 
             if (existing.length > 0)
             {
                 String path = FileUtil.getAbsoluteCaseSensitiveFile(lib).getAbsolutePath();
-                throw new ConfigurationException("You must delete the following JDBC drivers from " + path + ": " + Arrays.toString(existing));
+                throw new ConfigurationException("You must delete the following JAR files from " + path + ": " + Arrays.toString(existing));
             }
         }
     }

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1310,7 +1310,7 @@ public class DbScope
             if (existing.length > 0)
             {
                 String path = FileUtil.getAbsoluteCaseSensitiveFile(lib).getAbsolutePath();
-                throw new ConfigurationException("You must delete the following JAR files from " + path + ": " + Arrays.toString(existing));
+                throw new ConfigurationException("You must delete the following files from " + path + ": " + Arrays.toString(existing));
             }
         }
     }

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
@@ -22,7 +22,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.CsvSet;
+import org.labkey.api.data.DbScope;
 import org.labkey.api.data.dialect.AbstractDialectRetrievalTestCase;
 import org.labkey.api.data.dialect.DatabaseNotSupportedException;
 import org.labkey.api.data.dialect.JdbcHelperTest;
@@ -56,6 +58,12 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
     private String getProductName()
     {
         return PRODUCT_NAME;
+    }
+
+    public MicrosoftSqlServerDialectFactory()
+    {
+        // jTDS JDBC driver should not be present in <tomcat>/lib
+        DbScope.registerForbiddenTomcatFilenamePredicate(filename->filename.equalsIgnoreCase("jtds.jar"));
     }
 
     @Override

--- a/bigiron/src/org/labkey/bigiron/mysql/MySqlDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySqlDialectFactory.java
@@ -20,6 +20,7 @@ import com.mysql.cj.jdbc.AbandonedConnectionCleanupThread;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.DbScope;
 import org.labkey.api.data.dialect.DatabaseNotSupportedException;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.dialect.SqlDialectFactory;
@@ -48,6 +49,9 @@ public class MySqlDialectFactory implements SqlDialectFactory
 
     public MySqlDialectFactory()
     {
+        // MySQL JDBC driver should not be present in <tomcat>/lib
+        DbScope.registerForbiddenTomcatFilenamePredicate(filename->filename.equalsIgnoreCase("mysql.jar"));
+
         // Terminate MySQL AbandonedConnectionCleanupThread at shutdown to avoid Tomcat logging IllegalStateException, Issue 42117
         ContextListener.addShutdownListener(new ShutdownListener()
         {

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -17,13 +17,14 @@
 package org.labkey.core.dialect;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.collections.CsvSet;
+import org.labkey.api.data.DbScope;
 import org.labkey.api.data.dialect.AbstractDialectRetrievalTestCase;
 import org.labkey.api.data.dialect.DatabaseNotSupportedException;
 import org.labkey.api.data.dialect.JdbcHelperTest;
@@ -48,6 +49,12 @@ import java.util.Set;
 public class PostgreSqlDialectFactory implements SqlDialectFactory
 {
     private static final Logger _log = LogManager.getLogger(PostgreSqlDialectFactory.class);
+
+    public PostgreSqlDialectFactory()
+    {
+        // PostgreSQL JDBC driver should not be present in <tomcat>/lib
+        DbScope.registerForbiddenTomcatFilenamePredicate(filename->filename.equalsIgnoreCase("postgresql.jar"));
+    }
 
     @Override
     public @Nullable SqlDialect createFromDriverClassName(String driverClassName)


### PR DESCRIPTION
#### Rationale
We are now distributing the Redshift JDBC driver in the Redshift module and need to warn admins if a Redshift driver remains in \<tomcat>/lib, as we already do with jtds.jar, postresql.jar, and mysql.jar. [Issue 42040: Ship Redshift JDBC driver with Redshift module](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42040)

#### Related Pull Requests
* https://github.com/LabKey/redshift/pull/11