### PR TITLE
Issue 42105: Preserve order and concurrency of logevents

### DIFF
--- a/api/src/org/labkey/api/util/SessionAppender.java
+++ b/api/src/org/labkey/api/util/SessionAppender.java
@@ -69,14 +69,11 @@ public class SessionAppender extends AbstractAppender
         boolean on;
         final Map<LogEvent, String> eventIdMap = Collections.synchronizedMap(new LinkedHashMap<>()
         {
+            // Safeguard against runaway size.
             @Override
-            public String put(LogEvent key, String value)
+            protected boolean removeEldestEntry(Map.Entry<LogEvent, String> eldest)
             {
-                // Safeguard against runaway size. ConcurrentReferenceHashMap does not have removeEldestEntry so have
-                // to randomly remove an entry
-                if (size() > 1000)
-                    remove(eventIdMap.keySet().toArray()[0]);
-                return super.put(key, value);
+                return size() > 1000;
             }
         });
         int eventId=0;

--- a/api/src/org/labkey/api/util/SessionAppender.java
+++ b/api/src/org/labkey/api/util/SessionAppender.java
@@ -33,8 +33,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.WeakHashMap;
 
 /**
  * User: matthewb
@@ -67,7 +67,7 @@ public class SessionAppender extends AbstractAppender
 
         final String key;
         boolean on;
-        final Map<LogEvent, String> eventIdMap = new ConcurrentReferenceHashMap<>(16, ConcurrentReferenceHashMap.ReferenceType.WEAK)
+        final Map<LogEvent, String> eventIdMap = Collections.synchronizedMap(new LinkedHashMap<>()
         {
             @Override
             public String put(LogEvent key, String value)
@@ -78,7 +78,7 @@ public class SessionAppender extends AbstractAppender
                     remove(0);
                 return super.put(key, value);
             }
-        };
+        });
         int eventId=0;
     }
 

--- a/api/src/org/labkey/api/util/SessionAppender.java
+++ b/api/src/org/labkey/api/util/SessionAppender.java
@@ -75,7 +75,7 @@ public class SessionAppender extends AbstractAppender
                 // Safeguard against runaway size. ConcurrentReferenceHashMap does not have removeEldestEntry so have
                 // to randomly remove an entry
                 if (size() > 1000)
-                    remove(0);
+                    remove(eventIdMap.keySet().toArray()[0]);
                 return super.put(key, value);
             }
         });


### PR DESCRIPTION
#### Rationale
Change in session appender during Log4J upgrade changed the server side JS LogEvents to be stored in ConcurrentReferenceHashMap from LinkedList which destroyed the logging order. This PR fixes the problem of preserving log events while having synchronization.


