### PR TITLE
Issue 42147: setting run flag doesn't update all usages of the flag

### DIFF
--- a/internal/webapp/internal/flagColumn.js
+++ b/internal/webapp/internal/flagColumn.js
@@ -97,8 +97,8 @@ Ext4.define('LABKEY.internal.FlagColumn', {
                             for (var i=0; i < lsids.length; i++) {
                                 lsid = lsids[i];
                                 flagIcons = Ext4.DomQuery.select("i[flagId='" + lsid + "']");
-                                if (!Ext4.isEmpty(flagIcons)) {
-                                    el = Ext4.get(flagIcons[0]);
+                                for (var j = 0; j < flagIcons.length; j++) {
+                                    el = Ext4.get(flagIcons[j]);
                                     if (comment) {
                                         el.set({title: comment});
                                         if (this.flagDisabledCls && this.flagEnabledCls) {


### PR DESCRIPTION
#### Rationale
Update all usages of the same flag value in the grid (e.g., the Run flag in the assay results grid).

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/572
* https://github.com/LabKey/OConnorLabModules/pull/62