### PR TITLE
Don't register generic action class (SimpleAction.class) in static _classToDescriptor map

### DIFF
--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -139,25 +139,25 @@ public abstract class SpringActionController implements Controller, HasViewConte
         assert null == prev || prev == ad;
     }
 
-    @NotNull
     static ActionDescriptor getActionDescriptor(Class<? extends Controller> actionClass)
     {
-        ActionDescriptor ad = _classToDescriptor.get(actionClass);
-
-        if (null == ad)
-            throw new IllegalStateException("Action class '" + actionClass + "' has not been registered with a controller");
-
-        return ad;
+        return _classToDescriptor.get(actionClass);
     }
 
     public static String getControllerName(Class<? extends Controller> actionClass)
     {
-        return getActionDescriptor(actionClass).getControllerName();
+        var ad = getActionDescriptor(actionClass).getControllerName();
+        if (null == ad)
+            throw new IllegalStateException("Action class '" + actionClass + "' has not been registered with a controller");
+        return ad;
     }
 
     public static String getActionName(Class<? extends Controller> actionClass)
     {
-        return getActionDescriptor(actionClass).getPrimaryName();
+        var ad = getActionDescriptor(actionClass).getPrimaryName();
+        if (null == ad)
+            throw new IllegalStateException("Action class '" + actionClass + "' has not been registered with a controller");
+        return ad;
     }
 
     public static Collection<ActionDescriptor> getRegisteredActionDescriptors()
@@ -1002,7 +1002,9 @@ public abstract class SpringActionController implements Controller, HasViewConte
         @Override
         public void addTime(Controller action, long elapsedTime)
         {
-            getActionDescriptor(action.getClass()).addTime(elapsedTime);
+            ActionDescriptor ad = getActionDescriptor(action.getClass());
+            if (null != ad)
+                ad.addTime(elapsedTime);
         }
 
 

--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -139,6 +139,7 @@ public abstract class SpringActionController implements Controller, HasViewConte
         assert null == prev || prev == ad;
     }
 
+    @Nullable
     static ActionDescriptor getActionDescriptor(Class<? extends Controller> actionClass)
     {
         return _classToDescriptor.get(actionClass);
@@ -146,18 +147,18 @@ public abstract class SpringActionController implements Controller, HasViewConte
 
     public static String getControllerName(Class<? extends Controller> actionClass)
     {
-        var ad = getActionDescriptor(actionClass).getControllerName();
+        var ad = getActionDescriptor(actionClass);
         if (null == ad)
             throw new IllegalStateException("Action class '" + actionClass + "' has not been registered with a controller");
-        return ad;
+        return ad.getControllerName();
     }
 
     public static String getActionName(Class<? extends Controller> actionClass)
     {
-        var ad = getActionDescriptor(actionClass).getPrimaryName();
+        var ad = getActionDescriptor(actionClass);
         if (null == ad)
             throw new IllegalStateException("Action class '" + actionClass + "' has not been registered with a controller");
-        return ad;
+        return ad.getPrimaryName();
     }
 
     public static Collection<ActionDescriptor> getRegisteredActionDescriptors()

--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -135,7 +135,8 @@ public abstract class SpringActionController implements Controller, HasViewConte
 
     protected static void registerAction(ActionDescriptor ad)
     {
-        _classToDescriptor.put(ad.getActionClass(), ad);
+        ActionDescriptor prev = _classToDescriptor.put(ad.getActionClass(), ad);
+        assert null == prev || prev == ad;
     }
 
     @NotNull
@@ -847,7 +848,6 @@ public abstract class SpringActionController implements Controller, HasViewConte
 
             HTMLFileActionDescriptor htmlDescriptor = createFileActionDescriptor(module, actionName);
             _nameToDescriptor.put(actionName, htmlDescriptor);
-            registerAction(htmlDescriptor);
 
             return htmlDescriptor.createController(actionController);
         }
@@ -859,13 +859,13 @@ public abstract class SpringActionController implements Controller, HasViewConte
 
         protected class HTMLFileActionDescriptor extends BaseActionDescriptor
         {
-            private final Module _module;
+            private final String _moduleName;
             private final String _primaryName;
             private final List<String> _allNames;
 
             protected HTMLFileActionDescriptor(Module module, String primaryName)
             {
-                _module = module;
+                _moduleName = module.getName();
                 _primaryName = primaryName;
                 _allNames = Collections.singletonList(_primaryName);
             }
@@ -897,8 +897,11 @@ public abstract class SpringActionController implements Controller, HasViewConte
             @Override
             public Controller createController(Controller actionController)
             {
-                Path path = ModuleHtmlView.getViewPath(_module, getPrimaryName());
-                return new SimpleAction(_module, path);
+                Module m = ModuleLoader.getInstance().getModule(_moduleName);
+                if (null == m)
+                    return null;
+                Path path = ModuleHtmlView.getViewPath(m, getPrimaryName());
+                return new SimpleAction(m, path);
             }
         }
 


### PR DESCRIPTION
#### Rationale
Fix memory leak by not registering SimpleAction.class in the static variable SpringActionController._classToDescriptor
