### PR TITLE
Adding detailed audit logging for the Merge option for importing datasets

### DIFF
--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -419,7 +419,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
             AuditBehaviorType behaviorType = (_target != null) ? _target.getAuditBehavior(getAuditBehaviorType()) : getAuditBehaviorType();
             if (behaviorType != null && behaviorType != AuditBehaviorType.NONE)
                 auditEvent = createTransactionAuditEvent(getContainer(), QueryService.AuditAction.INSERT);
-            int rowCount = importData(loader, file, originalName, ve, getAuditBehaviorType(), auditEvent);
+            int rowCount = importData(loader, file, originalName, ve, behaviorType, auditEvent);
 
             if (ve.hasErrors())
                 throw ve;

--- a/study/src/org/labkey/study/assay/AssayPublishManager.java
+++ b/study/src/org/labkey/study/assay/AssayPublishManager.java
@@ -56,6 +56,7 @@ import org.labkey.api.exp.api.ProvenanceService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.PropertyService;
+import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.qc.QCState;
@@ -826,7 +827,7 @@ public class AssayPublishManager implements AssayPublishService
      * Return an array of LSIDs from the newly created dataset entries,
      * along with the upload log.
      */
-    public Pair<List<String>, UploadLog> importDatasetTSV(User user, StudyImpl study, DatasetDefinition dsd, DataLoader dl, boolean importLookupByAlternateKey, FileStream fileIn, String originalFileName, Map<String, String> columnMap, BatchValidationException errors)
+    public Pair<List<String>, UploadLog> importDatasetTSV(User user, StudyImpl study, DatasetDefinition dsd, DataLoader dl, boolean importLookupByAlternateKey, FileStream fileIn, String originalFileName, Map<String, String> columnMap, BatchValidationException errors, QueryUpdateService.InsertOption insertOption, @Nullable AuditBehaviorType auditBehaviorType)
     {
         DbScope scope = StudySchema.getInstance().getScope();
 
@@ -845,7 +846,7 @@ public class AssayPublishManager implements AssayPublishService
                 if (defaultQCStateId != null)
                     defaultQCState = QCStateManager.getInstance().getQCStateForRowId(study.getContainer(), defaultQCStateId.intValue());
                 lsids = StudyManager.getInstance().importDatasetData(user, dsd, dl, columnMap, errors, DatasetDefinition.CheckForDuplicates.sourceOnly,
-                        defaultQCState, QueryUpdateService.InsertOption.IMPORT, null, null, importLookupByAlternateKey);
+                        defaultQCState, insertOption, null, null, importLookupByAlternateKey, auditBehaviorType);
                 if (!errors.hasErrors())
                     transaction.commit();
             }

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -2541,11 +2541,12 @@ public class StudyController extends BaseStudyController
                 return new HtmlView("Error", HtmlString.of("Cannot insert dataset data in this folder.  Use a sub-study to import data."));
 
             if (_def.getTypeURI() == null)
-            throw new NotFoundException("Dataset is not yet defined.");
+                throw new NotFoundException("Dataset is not yet defined.");
 
             if (null == PipelineService.get().findPipelineRoot(getContainer()))
                 return new RequirePipelineView(_study, true, errors);
 
+            setShowImportOptions(true);
             return getDefaultImportView(form, errors);
         }
 
@@ -2569,8 +2570,7 @@ public class StudyController extends BaseStudyController
                 columnMap.put(_form.getSequenceNum(), column);
             }
 
-            Pair<List<String>, UploadLog> result;
-            result = AssayPublishManager.getInstance().importDatasetTSV(getUser(), _study, _def, dl, _importLookupByAlternateKey, file, originalName, columnMap, errors);
+            Pair<List<String>, UploadLog> result = AssayPublishManager.getInstance().importDatasetTSV(getUser(), _study, _def, dl, _importLookupByAlternateKey, file, originalName, columnMap, errors, _form.getInsertOption(), auditBehaviorType);
 
             if (!result.getKey().isEmpty())
             {
@@ -5769,6 +5769,7 @@ public class StudyController extends BaseStudyController
         private String _participantId;
         private String _sequenceNum;
         private String _name;
+        private QueryUpdateService.InsertOption _insertOption = QueryUpdateService.InsertOption.IMPORT;
 
         public int getDatasetId()
         {
@@ -5838,6 +5839,16 @@ public class StudyController extends BaseStudyController
         public void setName(String name)
         {
             _name = name;
+        }
+
+        public QueryUpdateService.InsertOption getInsertOption()
+        {
+            return _insertOption;
+        }
+
+        public void setInsertOption(QueryUpdateService.InsertOption insertOption)
+        {
+            _insertOption = insertOption;
         }
     }
 

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -41,6 +41,7 @@ import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.DataIteratorUtil;
+import org.labkey.api.dataiterator.DetailedAuditLogDataIterator;
 import org.labkey.api.dataiterator.Pump;
 import org.labkey.api.dataiterator.StandardDataIteratorBuilder;
 import org.labkey.api.exp.ChangePropertyDescriptorException;
@@ -62,6 +63,7 @@ import org.labkey.api.exp.property.DomainKind;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.Lookup;
 import org.labkey.api.exp.property.PropertyService;
+import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.qc.QCState;
 import org.labkey.api.qc.QCStateManager;
 import org.labkey.api.query.AliasedColumn;
@@ -71,6 +73,8 @@ import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.PdLookupForeignKey;
+import org.labkey.api.query.QueryService;
+import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.SimpleValidationError;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reports.model.ViewCategory;
@@ -1586,6 +1590,34 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
         {
             return _maxContainedPhi;
         }
+
+        @Override
+        public void addAuditEvent(User user, Container container, AuditBehaviorType auditBehavior, @Nullable String userComment, QueryService.AuditAction auditAction, List<Map<String, Object>>[] params)
+        {
+            List<Map<String, Object>> rows = params[0];
+            List<Map<String, Object>> updatedRows = params.length > 1 ? params[1] : Collections.emptyList();
+
+            for (int i=0; i < rows.size(); i++)
+            {
+                Map<String, Object> row = rows.get(i);
+                Map<String, Object> updatedRow = updatedRows.isEmpty() ? Collections.emptyMap() : updatedRows.get(i);
+
+                StudyServiceImpl.addDatasetAuditEvent(user, DatasetDefinition.this, row, updatedRow);
+            }
+        }
+
+        @Override
+        public void addAuditEvent(User user, Container container, AuditBehaviorType auditBehavior, @Nullable String userComment, QueryService.AuditAction auditAction, Map<String, Object> parameters)
+        {
+            Map<String,Object> oldRow = null;
+            if (auditAction == QueryService.AuditAction.MERGE)
+            {
+                //REVIEW: I'm guessing this is a terrible idea for multiple reasons, but seems to work...
+                String lsid = String.valueOf(parameters.get("lsid"));
+                oldRow = DatasetDefinition.this.getDatasetRow(user, lsid);
+            }
+            StudyServiceImpl.addDatasetAuditEvent(user, DatasetDefinition.this, oldRow, parameters);
+        }
     }
 
 
@@ -2108,8 +2140,12 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
         b.setKeyList(lsids);
 
         Container target = getDataSharingEnum() == DataSharing.NONE ? getContainer() : getDefinitionContainer();
-        StandardDataIteratorBuilder etl = StandardDataIteratorBuilder.forInsert(table, b, target, user, context);
-        return ((UpdateableTableInfo)table).persistRows(etl, context);
+        DataIteratorBuilder dib = StandardDataIteratorBuilder.forInsert(table, b, target, user, context);
+
+        if (context.getConfigParameter(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior) == AuditBehaviorType.DETAILED)
+            dib = DetailedAuditLogDataIterator.getDataIteratorBuilder(this.getTableInfo(user, false), dib, context.getInsertOption() == QueryUpdateService.InsertOption.MERGE ? QueryService.AuditAction.MERGE : QueryService.AuditAction.INSERT, user, target);
+
+        return ((UpdateableTableInfo)table).persistRows(dib, context);
     }
 
 

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -48,6 +48,7 @@ import org.labkey.api.dataiterator.BeanDataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.DataIteratorUtil;
+import org.labkey.api.dataiterator.DetailedAuditLogDataIterator;
 import org.labkey.api.dataiterator.ListofMapsDataIterator;
 import org.labkey.api.dataiterator.Pump;
 import org.labkey.api.dataiterator.StandardDataIteratorBuilder;
@@ -73,6 +74,7 @@ import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.IPropertyValidator;
 import org.labkey.api.exp.property.PropertyService;
+import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.gwt.client.model.PropertyValidatorType;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleHtmlView;
@@ -3642,19 +3644,22 @@ public class StudyManager
 
     public List<String> importDatasetData(User user, DatasetDefinition def, DataLoader loader, Map<String, String> columnMap,
                                           BatchValidationException errors, DatasetDefinition.CheckForDuplicates checkDuplicates,
-                                          QCState defaultQCState, QueryUpdateService.InsertOption insertOption, StudyImportContext studyImportContext, Logger logger, boolean importLookupByAlternateKey)
+                                          QCState defaultQCState, QueryUpdateService.InsertOption insertOption, StudyImportContext studyImportContext, Logger logger, boolean importLookupByAlternateKey, @Nullable AuditBehaviorType auditBehaviorType)
             throws IOException
     {
         parseData(user, def, loader, columnMap);
         DataIteratorContext context = new DataIteratorContext(errors);
         context.setInsertOption(insertOption);
         context.setAllowImportLookupByAlternateKey(importLookupByAlternateKey);
+        Map<Enum, Object> options = new HashMap<>();
+        options.put(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior, auditBehaviorType);
+
         if (logger != null)
         {
-            Map<Enum, Object> options = new HashMap<>();
             options.put(QueryUpdateService.ConfigParameters.Logger, logger);
-            context.setConfigParameters(options);
         }
+
+        context.setConfigParameters(options);
         return def.importDatasetData(user, loader, context, checkDuplicates, defaultQCState, studyImportContext, logger, false);
     }
 
@@ -5417,7 +5422,7 @@ public class StudyManager
             StudyManager.getInstance().importDatasetData(
                     _context.getUser(),
                     (DatasetDefinition) def, dl, columnMap,
-                    errors, DatasetDefinition.CheckForDuplicates.sourceAndDestination, null, QueryUpdateService.InsertOption.IMPORT, null, logger, false);
+                    errors, DatasetDefinition.CheckForDuplicates.sourceAndDestination, null, QueryUpdateService.InsertOption.IMPORT, null, logger, false, null);
 
             if (expectedErrors == null)
             {

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -1242,4 +1242,5 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
             }
         }
         return cols;
-    }}
+    }
+}


### PR DESCRIPTION
#### Rationale
Spec: https://docs.google.com/document/d/110fl8qRIk1o9lEgFq8RKFWNW5vo_cYCiWkE1doFq214/
Add detailed audit logging for merging bulk imports for datasets

#### Changes
* Added a DetailedAuditLogDataIterator to the DI queue
* Added DatasetSchemaTable.addAuditEvent override methods
