### PR TITLE
Fix url handling and simplify ButtonTag

### DIFF
--- a/api/src/org/labkey/api/jsp/taglib/ButtonTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/ButtonTag.java
@@ -19,16 +19,14 @@ package org.labkey.api.jsp.taglib;
 import org.labkey.api.util.Button;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
-import org.labkey.api.view.ActionURL;
 
 import java.io.IOException;
 
 public class ButtonTag extends SimpleTagBase
 {
     private String _text;
-    private String _href;
+    private URLHelper _href;
     private String _onclick;
-    private String _action;
     private String _name;
     private String _id;
     private Boolean _submit = true;
@@ -44,14 +42,9 @@ public class ButtonTag extends SimpleTagBase
             button.href(_href).onClick(_onclick);
         else
         {
-            if (_onclick != null && _action != null)
-                throw new IllegalArgumentException("onclick and action cannot both be set");
-
             String onClickScript = "";
             if (_onclick != null)
                 onClickScript = _onclick;
-            if (_action != null)
-                onClickScript = ("this.form.action='" + _action + "';this.form.method='POST';");
 
             button.submit(_submit).onClick(onClickScript).name(_name);
         }
@@ -62,15 +55,9 @@ public class ButtonTag extends SimpleTagBase
         getOut().print(button);
     }
 
-    public void setHref(String href)
-    {
-        _href = href;
-    }
-
     public void setHref(URLHelper url)
     {
-        if (null != url)
-            _href = url.toString();
+        _href = url;
     }
 
     public void setText(String text)
@@ -81,11 +68,6 @@ public class ButtonTag extends SimpleTagBase
     public void setOnclick(String onclick)
     {
         _onclick = onclick;
-    }
-
-    public void setAction(ActionURL action)
-    {
-        _action = action.toString();
     }
 
     public void setName(String name)

--- a/assay/src/org/labkey/assay/view/updateQCState.jsp
+++ b/assay/src/org/labkey/assay/view/updateQCState.jsp
@@ -157,5 +157,5 @@
     %>
     <labkey:input type="hidden" name="returnUrl" value="<%=form.getReturnUrl()%>"/>
     <labkey:button text="update" submit="false" onclick="saveState();" id="update-btn"/>
-    <labkey:button text="cancel" href="<%=form.getReturnUrl()%>" onclick="LABKEY.setSubmit(true);"/>
+    <labkey:button text="cancel" href="<%=form.getReturnActionURL()%>" onclick="LABKEY.setSubmit(true);"/>
 </labkey:form>

--- a/core/src/org/labkey/core/admin/view/filesProjectSettings.jsp
+++ b/core/src/org/labkey/core/admin/view/filesProjectSettings.jsp
@@ -23,6 +23,7 @@
 <%@ page import="org.labkey.api.security.User" %>
 <%@ page import="org.labkey.api.security.permissions.AdminOperationsPermission" %>
 <%@ page import="org.labkey.api.security.permissions.AdminPermission" %>
+<%@ page import="org.labkey.api.util.URLHelper" %>
 <%@ page import="org.labkey.api.util.UniqueID" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
@@ -75,9 +76,9 @@
     String folderSetup = getActionURL().getParameter("folderSetup");
     boolean isFolderSetup = "true".equalsIgnoreCase(folderSetup);
     String cancelButtonText = isFolderSetup ? "Next" : "Cancel";
-    String cancelButtonUrl = isFolderSetup && getActionURL().getReturnURL() != null
-            ? getActionURL().getReturnURL().toString()
-            : getContainer().getStartURL(getUser()).toString();
+    URLHelper cancelButtonUrl = isFolderSetup && getActionURL().getReturnURL() != null
+            ? getActionURL().getReturnURL()
+            : getContainer().getStartURL(getUser());
     ActionURL redirectToPipeline = urlProvider(PipelineUrls.class).urlBegin(getContainer());
     boolean isCurrentFileRootCloud = FileRootProp.cloudRoot.name().equals(bean.getFileRootOption());
     boolean isCurrentFileRootManaged = !(isCurrentFileRootCloud &&

--- a/study/src/org/labkey/study/assay/PublishStartAction.java
+++ b/study/src/org/labkey/study/assay/PublishStartAction.java
@@ -113,20 +113,20 @@ public class PublishStartAction extends BaseAssayAction<PublishStartAction.Publi
 
     public class PublishBean
     {
-        private List<Integer> _ids;
-        private AssayProvider _provider;
-        private ExpProtocol _protocol;
-        private Set<Container> _studies;
-        private boolean _nullStudies;
-        private boolean _insufficientPermissions;
-        private String _dataRegionSelectionKey;
-        private final String _returnURL;
+        private final List<Integer> _ids;
+        private final AssayProvider _provider;
+        private final ExpProtocol _protocol;
+        private final Set<Container> _studies;
+        private final boolean _nullStudies;
+        private final boolean _insufficientPermissions;
+        private final String _dataRegionSelectionKey;
+        private final ActionURL _returnURL;
         private final String _containerFilterName;
-        private List<Integer> _runIds;
+        private final List<Integer> _runIds;
 
         public PublishBean(AssayProvider provider, ExpProtocol protocol,
                            List<Integer> ids, String dataRegionSelectionKey,
-                           Set<Container> studies, boolean nullStudies, boolean insufficientPermissions, String returnURL,
+                           Set<Container> studies, boolean nullStudies, boolean insufficientPermissions, ActionURL returnURL,
                            String containerFilterName, List<Integer> runIds)
         {
             _insufficientPermissions = insufficientPermissions;
@@ -141,13 +141,13 @@ public class PublishStartAction extends BaseAssayAction<PublishStartAction.Publi
             _runIds = runIds;
         }
 
-        public String getReturnURL()
+        public ActionURL getReturnURL()
         {
             if (_returnURL != null)
             {
                 return _returnURL;
             }
-            return PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(getContainer(), getProtocol()).addParameter("clearDataRegionSelectionKey", getDataRegionSelectionKey()).toString();
+            return PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(getContainer(), getProtocol()).addParameter("clearDataRegionSelectionKey", getDataRegionSelectionKey());
         }
 
         public List<Integer> getIds()
@@ -288,7 +288,7 @@ public class PublishStartAction extends BaseAssayAction<PublishStartAction.Publi
                         containers,
                         nullsFound,
                         insufficientPermissions,
-                        publishForm.getReturnUrl(),
+                        publishForm.getReturnActionURL(),
                         publishForm.getContainerFilterName(),
                         runIds));
         }

--- a/study/src/org/labkey/study/query/SpecimenRequestQueryView.java
+++ b/study/src/org/labkey/study/query/SpecimenRequestQueryView.java
@@ -34,6 +34,7 @@ import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
 import org.labkey.study.SpecimenManager;
 import org.labkey.study.controllers.specimen.SpecimenController;
+import org.labkey.study.controllers.specimen.SpecimenController.ManageRequestAction;
 import org.labkey.study.model.SpecimenRequestStatus;
 import org.labkey.study.model.StudyImpl;
 import org.labkey.study.model.StudyManager;
@@ -57,16 +58,16 @@ public class SpecimenRequestQueryView extends BaseStudyQueryView
 
     private static class RequestOptionDisplayColumn extends SimpleDisplayColumn
     {
-        private ColumnInfo _colCreatedBy;
-        private ColumnInfo _colStatus;
+        private final ColumnInfo _colCreatedBy;
+        private final ColumnInfo _colStatus;
+        private final boolean _showOptionLinks;
+        private final NavTree[] _extraLinks;
+        private final boolean _userIsSpecimenManager;
+        private final boolean _userCanRequest;
+        private final int _userId;
+        private final boolean _cartEnabled;
 
-        private boolean _showOptionLinks;
-        private NavTree[] _extraLinks;
         private Integer _shoppingCartStatusRowId;
-        private boolean _userIsSpecimenManager;
-        private boolean _userCanRequest;
-        private int _userId;
-        private boolean _cartEnabled;
 
         public RequestOptionDisplayColumn(ViewContext context, boolean showOptionLinks, ColumnInfo colCreatedBy, ColumnInfo colStatus, NavTree... extraLinks)
         {
@@ -120,18 +121,16 @@ public class SpecimenRequestQueryView extends BaseStudyQueryView
 
                     if (statusId.intValue() == _shoppingCartStatusRowId.intValue() && canEdit)
                     {
-                        String submitLink = (new ActionURL(SpecimenController.SubmitRequestAction.class, ctx.getContainer())).toString() + "id=${requestId}";
-                        String cancelLink = (new ActionURL(SpecimenController.DeleteRequestAction.class, ctx.getContainer())).toString() + "id=${requestId}";
+                        ActionURL submitUrl = new ActionURL(SpecimenController.SubmitRequestAction.class, ctx.getContainer()).addParameter("id", "${requestId}");
+                        ActionURL cancelUrl = new ActionURL(SpecimenController.DeleteRequestAction.class, ctx.getContainer()).addParameter("id", "${requestId}");
 
-                        content.append(PageFlowUtil.button("Submit").href(submitLink)
-                            .onClick("return LABKEY.Utils.confirmAndPost('" + SpecimenController.ManageRequestBean.SUBMISSION_WARNING + "', '" + submitLink + "')")).append(" ");
-                        content.append(PageFlowUtil.button("Cancel").href(cancelLink)
-                            .onClick("return LABKEY.Utils.confirmAndPost('" + SpecimenController.ManageRequestBean.CANCELLATION_WARNING + "', '" + cancelLink + "')")).append(" ");
+                        content.append(PageFlowUtil.button("Submit").href(submitUrl).usePost(SpecimenController.ManageRequestBean.SUBMISSION_WARNING));
+                        content.append(PageFlowUtil.button("Cancel").href(cancelUrl).usePost(SpecimenController.ManageRequestBean.CANCELLATION_WARNING));
                     }
                 }
 
-                String detailsLink = (new ActionURL(SpecimenController.ManageRequestAction.class, ctx.getContainer())).toString() + "id=${requestId}";
-                content.append(PageFlowUtil.button("Details").href(detailsLink));
+                ActionURL detailsUrl = new ActionURL(ManageRequestAction.class, ctx.getContainer()).addParameter("id", "${requestId}");
+                content.append(PageFlowUtil.button("Details").href(detailsUrl));
             }
             content.append("</div>");
             setDisplayHtml(content.toString());


### PR DESCRIPTION
#### Rationale
With the "No Question Marks in URLs" experimental feature turned on, the "Specimen Requests" page buttons were all broken due to their use of String concatenation. We're fixing that specific page and making some changes to move away from String-based URL manipulation.

![image](https://user-images.githubusercontent.com/5107383/103465443-552ff380-4cf0-11eb-8ff2-cfcb23f58ce2.png)

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/281

#### Changes
* Simplify and modernize the generation of specimen requests buttons. Use `ActionURLs` and `usePost()`.
* Eliminate `ButtonTag` methods `href(String)` and `action()`.