### PR TITLE
Restore default display for container column to show title instead of name

### DIFF
--- a/api/src/org/labkey/api/data/ContainerDisplayColumn.java
+++ b/api/src/org/labkey/api/data/ContainerDisplayColumn.java
@@ -97,7 +97,7 @@ public class ContainerDisplayColumn extends DataColumn
             else
                 return super.getDisplayValue(ctx);
         }
-        return _showPath ? c.getPath() : c.getName();
+        return _showPath ? c.getPath() : c.getTitle();
     }
 
     private String getEntityIdValue(RenderContext ctx)


### PR DESCRIPTION
#### Rationale
The work for Issue 41050 flipped the default from showing the container's title to showing the name. When the user hasn't explicitly requested the name, it's better to show the title

https://teamcity.labkey.org/project.html?projectId=LabkeyTrunk&testNameId=882197537152040170&tab=testDetails

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1807

#### Changes
* Restore previous 