### PR TITLE
Issue41815: Switch "Single sign on" to "Single sign-on" in UI 

### DIFF
--- a/core/src/client/components/AuthConfigMasterPanel.tsx
+++ b/core/src/client/components/AuthConfigMasterPanel.tsx
@@ -74,7 +74,7 @@ class PrimaryTab extends PureComponent<PrimaryTabProps> {
 
                 <div>
                     <div className="configurations__config-section-title">
-                        <span className="bold-text"> Single Sign On Configurations </span>
+                        <span className="bold-text"> Single Sign-on Configurations </span>
                         <LabelHelpTip title="Tip">
                             <div> {SSO_TIP_TEXT} </div>
                         </LabelHelpTip>

--- a/core/src/client/components/AuthConfigMasterPanel.tsx
+++ b/core/src/client/components/AuthConfigMasterPanel.tsx
@@ -74,7 +74,7 @@ class PrimaryTab extends PureComponent<PrimaryTabProps> {
 
                 <div>
                     <div className="configurations__config-section-title">
-                        <span className="bold-text"> Single Sign-on Configurations </span>
+                        <span className="bold-text"> Single Sign-On Configurations </span>
                         <LabelHelpTip title="Tip">
                             <div> {SSO_TIP_TEXT} </div>
                         </LabelHelpTip>

--- a/core/src/client/components/__snapshots__/AuthConfigMasterPanel.spec.tsx.snap
+++ b/core/src/client/components/__snapshots__/AuthConfigMasterPanel.spec.tsx.snap
@@ -1027,7 +1027,7 @@ exports[`<AuthConfigMasterPanel/> View-only mode 1`] = `
               <span
                 className="bold-text"
               >
-                 Single Sign-on Configurations 
+                 Single Sign-On Configurations 
               </span>
               <span
                 className="label-help-target"

--- a/core/src/client/components/__snapshots__/AuthConfigMasterPanel.spec.tsx.snap
+++ b/core/src/client/components/__snapshots__/AuthConfigMasterPanel.spec.tsx.snap
@@ -1027,7 +1027,7 @@ exports[`<AuthConfigMasterPanel/> View-only mode 1`] = `
               <span
                 className="bold-text"
               >
-                 Single Sign On Configurations 
+                 Single Sign-on Configurations 
               </span>
               <span
                 className="label-help-target"


### PR DESCRIPTION
#### Rationale
Docs and product are switching to use "single sign-on". 
I'm using "Single Sign-on" since title-case is used in the relevant text, and prepositions in hyphenated words typically aren't capitalized in title-case. 


#### Related Pull Requests
* n/a

#### Changes
* Update phrasing
* Update jest snapshots
