### PR TITLE
print stacktrace to server log

### DIFF
--- a/core/src/org/labkey/core/junit/JunitController.java
+++ b/core/src/org/labkey/core/junit/JunitController.java
@@ -756,9 +756,10 @@ public class JunitController extends SpringActionController
     }
 
 
-    private static void outputStackTrace(Throwable t, PrintWriter out)
+    private static List<String> filterStackTrace(Throwable t)
     {
-        out.println(h(t.toString()));
+        List<String> lines = new ArrayList<>();
+        lines.add(t.toString());
 
         for (StackTraceElement ste : t.getStackTrace())
         {
@@ -767,7 +768,23 @@ public class JunitController extends SpringActionController
             if (line.startsWith("org.junit.internal.") || line.startsWith("sun.reflect.") || line.startsWith("java.lang.reflect."))
                 break;
 
-            out.println(PageFlowUtil.filter("\tat " + ste.toString(), true));
+            lines.add("\tat " + ste.toString());
+        }
+
+        return lines;
+    }
+
+    public static String renderTrace(Throwable t)
+    {
+        return StringUtils.join(filterStackTrace(t), "\n");
+    }
+
+    private static void outputStackTrace(Throwable t, PrintWriter out)
+    {
+        List<String> lines = filterStackTrace(t);
+        for (String line : lines)
+        {
+            out.println(PageFlowUtil.filter(line, true));
         }
     }
 

--- a/core/src/org/labkey/core/junit/JunitRunner.java
+++ b/core/src/org/labkey/core/junit/JunitRunner.java
@@ -17,13 +17,14 @@
 package org.labkey.core.junit;
 
 import junit.framework.TestCase;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.runner.Description;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;
 import org.junit.runner.Result;
 import org.junit.runner.Runner;
+import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 import org.labkey.api.util.CPUTimer;
 import org.labkey.api.util.TestContext;
@@ -100,6 +101,13 @@ public class JunitRunner
                     ArrayList<CPUTimer> timers = TestContext.get().getPerfResults();
                     testTimers.put(description, timers);
                     allTimers.addAll(timers);
+                }
+
+                @Override
+                public void testFailure(Failure failure) throws Exception
+                {
+                    Throwable t = failure.getException();
+                    LOG.error("Test failed: " + failure.getDescription() + ":\n" + JunitController.renderTrace(t));
                 }
             });
             Result result = core.run(request);


### PR DESCRIPTION
#### Rationale
Print junit test failures to the server log to get clickable stacktraces in the IntelliJ console
