### PR TITLE
Issue 42160: Remove check for experimental feature flag that no longer exists.

### DIFF
--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -152,7 +152,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
     public DataIteratorBuilder createImportDIB(User user, Container container, DataIteratorBuilder data, DataIteratorContext context)
     {
         DataIteratorBuilder dib = super.createImportDIB(user, container, data, context);
-        if (InventoryService.get() != null && ExperimentalFeatureService.get().isFeatureEnabled("experimental_freezerManagement"))
+        if (InventoryService.get() != null)
         {
             ExpSampleType sampleType = ((ExpMaterialTableImpl) getQueryTable()).getSampleType();
             UserSchema userSchema = getQueryTable().getUserSchema();


### PR DESCRIPTION
#### Rationale
We removed the experimental flag for FreezerManagement back in December but missed this check for the flag, which prevents addition of data into storage when doing a file import.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/425

#### Changes
* Remove reference to obsolete experimental flag.