### PR TITLE
Avoid writing multiple sample type definitions to the XAR XML

### DIFF
--- a/experiment/src/org/labkey/experiment/XarExporter.java
+++ b/experiment/src/org/labkey/experiment/XarExporter.java
@@ -550,11 +550,6 @@ public class XarExporter
 
     private void addSampleType(String cpasType) throws ExperimentException
     {
-        if (_sampleSetLSIDs.contains(cpasType))
-        {
-            return;
-        }
-        _sampleSetLSIDs.add(cpasType);
         ExpSampleType sampleType = SampleTypeService.get().getSampleType(cpasType);
         addSampleType(sampleType);
     }
@@ -563,10 +558,13 @@ public class XarExporter
     {
         final String PLACEHOLDER_SUFFIX = "sfx";
 
-        if (sampleType == null)
+        if (sampleType == null || _sampleSetLSIDs.contains(sampleType.getLSID()))
         {
             return;
         }
+
+        _sampleSetLSIDs.add(sampleType.getLSID());
+
         if (_archive.getSampleSets() == null)
         {
             _archive.addNewSampleSets();


### PR DESCRIPTION
#### Rationale
In this issue : https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42159 we found that sample type imports of the same sample type and tsv data files would occur multiple times. On further investigation a sample type definition could appear multiple times in the XAR XML file.

#### Changes
Move the check for seeing a sample type into a lower point in the code.