### PR TITLE
Issue 38722: Migrate ExcelWriter, TSVGridWriter, DataRegion, et al to use ResultsFactory or similar

### DIFF
--- a/api/src/org/labkey/api/assay/TsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/TsvDataHandler.java
@@ -41,8 +41,10 @@ import org.labkey.api.util.FileType;
 import org.labkey.api.util.FileUtil;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -175,7 +177,7 @@ public class TsvDataHandler extends AbstractAssayTsvDataHandler implements Trans
 
                             FileUtils.copyFile(tempFile, out);
                         }
-                        catch (Exception e)
+                        catch (IOException | SQLException e)
                         {
                             throw new ExperimentException("Problem creating TSV grid for run " + run.getName() + "(lsid: " + run.getLSID() + ")", e);
                         }

--- a/api/src/org/labkey/api/assay/TsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/TsvDataHandler.java
@@ -24,6 +24,7 @@ import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.Results;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
+import org.labkey.api.data.StashingResultsFactory;
 import org.labkey.api.data.TSVGridWriter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
@@ -146,12 +147,13 @@ public class TsvDataHandler extends AbstractAssayTsvDataHandler implements Trans
                         TableSelector ts = new TableSelector(dataTable, new SimpleFilter(FieldKey.fromParts("DataId"), data.getRowId()), new Sort("RowId"));
                         // Be sure to request lookup values and other renderer-required info, see issue 36746
                         ts.setForDisplay(true);
-                        Results results = ts.getResults();
-                        if (results.getSize() == 0)
-                            return;
 
-                        try
+                        try (var factory = new StashingResultsFactory(ts))
                         {
+                            Results results = factory.get();
+                            if (results.getSize() == 0)
+                                return;
+
                             File tempFile = File.createTempFile(FileUtil.getBaseName(FileUtil.getFileName(dataFile)), ".tsv");
 
                             // Figure out the subset of columns to actually export in the TSV, see issue 36746
@@ -165,7 +167,7 @@ public class TsvDataHandler extends AbstractAssayTsvDataHandler implements Trans
                                 }
                             }
 
-                            try (TSVGridWriter writer = new TSVGridWriter(results, displayColumns))
+                            try (TSVGridWriter writer = new TSVGridWriter(factory, displayColumns))
                             {
                                 writer.setColumnHeaderType(ColumnHeaderType.FieldKey);
                                 writer.write(tempFile);
@@ -182,5 +184,4 @@ public class TsvDataHandler extends AbstractAssayTsvDataHandler implements Trans
             }
         }
     }
-
 }

--- a/api/src/org/labkey/api/data/ExcelWriter.java
+++ b/api/src/org/labkey/api/data/ExcelWriter.java
@@ -823,27 +823,20 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
 
     protected void renderGrid(RenderContext ctx, Sheet sheet, List<ExcelColumn> visibleColumns) throws Exception
     {
-        assert null != _factory;
         try (Results results = _factory.get())
         {
-            renderGrid(ctx, sheet, visibleColumns, results);
-        }
-    }
+            if (null == results)
+                return;
 
-    // Note: caller closed Results
-    private void renderGrid(RenderContext ctx, Sheet sheet, List<ExcelColumn> visibleColumns, Results results) throws SQLException, MaxRowsExceededException
-    {
-        if (null == results)
-            return;
+            ResultSetRowMapFactory factory = ResultSetRowMapFactory.create(results);
+            ctx.setResults(results);
 
-        ResultSetRowMapFactory factory = ResultSetRowMapFactory.create(results);
-        ctx.setResults(results);
-
-        // Output all the rows, but don't exceed the document's maximum number of rows
-        while (results.next() && _currentRow <= _docType.getMaxRows())
-        {
-            ctx.setRow(factory.getRowMap(results));
-            renderGridRow(sheet, ctx, visibleColumns);
+            // Output all the rows, but don't exceed the document's maximum number of rows
+            while (results.next() && _currentRow <= _docType.getMaxRows())
+            {
+                ctx.setRow(factory.getRowMap(results));
+                renderGridRow(sheet, ctx, visibleColumns);
+            }
         }
     }
 

--- a/api/src/org/labkey/api/data/ExcelWriter.java
+++ b/api/src/org/labkey/api/data/ExcelWriter.java
@@ -582,12 +582,10 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
         return null;
     }
 
-
     public int getCurrentRow()
     {
         return _currentRow;
     }
-
 
     public void setCurrentRow(int currentRow) throws MaxRowsExceededException
     {
@@ -595,15 +593,13 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
         checkCurrentRow();
     }
 
-
     protected void incrementRow() throws MaxRowsExceededException
     {
         _currentRow++;
         checkCurrentRow();
     }
 
-
-    private void checkCurrentRow()  throws MaxRowsExceededException
+    private void checkCurrentRow() throws MaxRowsExceededException
     {
         if (_currentRow > _docType.getMaxRows())
             throw new MaxRowsExceededException();
@@ -821,7 +817,7 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
         }
     }
 
-    protected void renderGrid(RenderContext ctx, Sheet sheet, List<ExcelColumn> visibleColumns) throws Exception
+    protected void renderGrid(RenderContext ctx, Sheet sheet, List<ExcelColumn> visibleColumns) throws SQLException, MaxRowsExceededException, IOException
     {
         try (Results results = _factory.get())
         {

--- a/api/src/org/labkey/api/data/ExcelWriter.java
+++ b/api/src/org/labkey/api/data/ExcelWriter.java
@@ -219,14 +219,14 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
         _workbook = workbook == null ? docType.createWorkbook() : workbook;
     }
 
-    public ExcelWriter(ResultsFactory factory, List<DisplayColumn> displayColumns, ExcelDocumentType docType)
+    public ExcelWriter(@NotNull ResultsFactory factory, List<DisplayColumn> displayColumns, ExcelDocumentType docType)
     {
         this(docType);
         setResultsFactory(factory);
         addDisplayColumns(displayColumns);
     }
 
-    public ExcelWriter(ResultsFactory factory, List<DisplayColumn> displayColumns)
+    public ExcelWriter(@NotNull ResultsFactory factory, List<DisplayColumn> displayColumns)
     {
         this(factory, displayColumns, ExcelDocumentType.xls);
     }
@@ -291,7 +291,7 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
         setColumns(cols);
     }
 
-    public void setResultsFactory(ResultsFactory factory)
+    public void setResultsFactory(@NotNull ResultsFactory factory)
     {
         _factory = factory;
     }

--- a/api/src/org/labkey/api/data/ResultsFactory.java
+++ b/api/src/org/labkey/api/data/ResultsFactory.java
@@ -1,0 +1,6 @@
+package org.labkey.api.data;
+
+public interface ResultsFactory
+{
+    Results get() throws Exception;
+}

--- a/api/src/org/labkey/api/data/ResultsFactory.java
+++ b/api/src/org/labkey/api/data/ResultsFactory.java
@@ -1,6 +1,9 @@
 package org.labkey.api.data;
 
+import java.io.IOException;
+import java.sql.SQLException;
+
 public interface ResultsFactory
 {
-    Results get() throws Exception;
+    Results get() throws IOException, SQLException;
 }

--- a/api/src/org/labkey/api/data/StashingResultsFactory.java
+++ b/api/src/org/labkey/api/data/StashingResultsFactory.java
@@ -1,5 +1,6 @@
 package org.labkey.api.data;
 
+import java.io.IOException;
 import java.sql.SQLException;
 
 /**
@@ -23,7 +24,7 @@ public class StashingResultsFactory implements ResultsFactory, AutoCloseable
     }
 
     @Override
-    public Results get() throws Exception
+    public Results get() throws IOException, SQLException
     {
         if (null == _results)
             _results = _factory.get();

--- a/api/src/org/labkey/api/data/StashingResultsFactory.java
+++ b/api/src/org/labkey/api/data/StashingResultsFactory.java
@@ -2,6 +2,15 @@ package org.labkey.api.data;
 
 import java.sql.SQLException;
 
+/**
+ * <p>A {@link ResultsFactory} wrapper that stashes the {@link Results} on first reference and ensures the Results gets
+ * closed. Always use try-with-resources when creating an instance of this class.</p>
+ *
+ * <p>This class is useful for cases where code needs to inspect Results before invoking a class that takes a ResultsFactory.
+ * For example, code may want to short-circuit in the case of zero rows or use the Results metadata to configure an
+ * ExcelWriter or TSVGridWriter. Proper use of this class will ensure that the Results is closed in all cases (successful
+ * render, short-circuit, or error).</p>
+ */
 public class StashingResultsFactory implements ResultsFactory, AutoCloseable
 {
     private final ResultsFactory _factory;

--- a/api/src/org/labkey/api/data/StashingResultsFactory.java
+++ b/api/src/org/labkey/api/data/StashingResultsFactory.java
@@ -1,0 +1,31 @@
+package org.labkey.api.data;
+
+import java.sql.SQLException;
+
+public class StashingResultsFactory implements ResultsFactory, AutoCloseable
+{
+    private final ResultsFactory _factory;
+
+    private Results _results = null;
+
+    public StashingResultsFactory(ResultsFactory factory)
+    {
+        _factory = factory;
+    }
+
+    @Override
+    public Results get() throws Exception
+    {
+        if (null == _results)
+            _results = _factory.get();
+
+        return _results;
+    }
+
+    @Override
+    public void close() throws SQLException
+    {
+        if (_results != null && !_results.isClosed())
+            _results.close();
+    }
+}

--- a/api/src/org/labkey/api/data/StashingResultsFactory.java
+++ b/api/src/org/labkey/api/data/StashingResultsFactory.java
@@ -6,10 +6,10 @@ import java.sql.SQLException;
  * <p>A {@link ResultsFactory} wrapper that stashes the {@link Results} on first reference and ensures the Results gets
  * closed. Always use try-with-resources when creating an instance of this class.</p>
  *
- * <p>This class is useful for cases where code needs to inspect Results before invoking a class that takes a ResultsFactory.
- * For example, code may want to short-circuit in the case of zero rows or use the Results metadata to configure an
- * ExcelWriter or TSVGridWriter. Proper use of this class will ensure that the Results is closed in all cases (successful
- * render, short-circuit, or error).</p>
+ * <p>Use this class only if you must; most code paths shouldn't need to inspect the Results. This wrapper is useful for
+ * cases where you must inspect Results before configuring an ExcelWriter or TSVGridWriter, for example, to short-circuit
+ * in the case of zero rows or use the Results metadata to configure the writer. Proper use of this class will ensure
+ * that Results is closed in all cases (successful render, short-circuit, or error).</p>
  */
 public class StashingResultsFactory implements ResultsFactory, AutoCloseable
 {

--- a/api/src/org/labkey/api/data/TSVGridWriter.java
+++ b/api/src/org/labkey/api/data/TSVGridWriter.java
@@ -116,7 +116,7 @@ public class TSVGridWriter extends TSVColumnWriter implements ExportWriter
         {
             throw new RuntimeSQLException(ex);
         }
-        catch (Exception e)
+        catch (IOException e)
         {
             throw new RuntimeException(e);
         }

--- a/api/src/org/labkey/api/data/TableSelector.java
+++ b/api/src/org/labkey/api/data/TableSelector.java
@@ -43,7 +43,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFactory, TableSelector>
+public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFactory, TableSelector> implements ResultsFactory
 {
     public static final Set<String> ALL_COLUMNS = Collections.unmodifiableSet(Collections.emptySet());
 
@@ -295,6 +295,12 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
     public Results getResults()
     {
         return getResults(true);
+    }
+
+    @Override
+    public Results get() throws Exception
+    {
+        return getResults();
     }
 
     public Results getResults(boolean cache)

--- a/api/src/org/labkey/api/data/TableSelector.java
+++ b/api/src/org/labkey/api/data/TableSelector.java
@@ -298,7 +298,7 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
     }
 
     @Override
-    public Results get() throws Exception
+    public Results get()
     {
         return getResults();
     }

--- a/api/src/org/labkey/api/query/CrosstabExcelWriter.java
+++ b/api/src/org/labkey/api/query/CrosstabExcelWriter.java
@@ -27,6 +27,7 @@ import org.labkey.api.data.ExcelWriter;
 import org.labkey.api.data.ResultsFactory;
 import org.labkey.api.util.Pair;
 
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 /**
@@ -43,7 +44,7 @@ public class CrosstabExcelWriter extends ExcelWriter
     private int _numRowAxisCols = 0;
     private final List<Pair<CrosstabMember, List<DisplayColumn>>> _groupedByMember;
 
-    public CrosstabExcelWriter(CrosstabTableInfo table, ResultsFactory factory, List<DisplayColumn> displayColumns, int numRowAxisCols, ExcelDocumentType docType)
+    public CrosstabExcelWriter(CrosstabTableInfo table, @NotNull ResultsFactory factory, List<DisplayColumn> displayColumns, int numRowAxisCols, ExcelDocumentType docType)
     {
         super(factory, displayColumns, docType);
         _table = table;

--- a/api/src/org/labkey/api/query/CrosstabExcelWriter.java
+++ b/api/src/org/labkey/api/query/CrosstabExcelWriter.java
@@ -24,7 +24,7 @@ import org.labkey.api.data.CrosstabTableInfo;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.ExcelColumn;
 import org.labkey.api.data.ExcelWriter;
-import org.labkey.api.data.Results;
+import org.labkey.api.data.ResultsFactory;
 import org.labkey.api.util.Pair;
 
 import java.util.List;
@@ -39,13 +39,13 @@ import java.util.List;
 public class CrosstabExcelWriter extends ExcelWriter
 {
     private boolean _includeDimensionHeader = false;
-    private CrosstabTableInfo _table;
+    private final CrosstabTableInfo _table;
     private int _numRowAxisCols = 0;
-    private List<Pair<CrosstabMember, List<DisplayColumn>>> _groupedByMember;
+    private final List<Pair<CrosstabMember, List<DisplayColumn>>> _groupedByMember;
 
-    public CrosstabExcelWriter(CrosstabTableInfo table, Results rs, List<DisplayColumn> displayColumns, int numRowAxisCols, ExcelDocumentType docType)
+    public CrosstabExcelWriter(CrosstabTableInfo table, ResultsFactory factory, List<DisplayColumn> displayColumns, int numRowAxisCols, ExcelDocumentType docType)
     {
-        super(rs, displayColumns, docType);
+        super(factory, displayColumns, docType);
         _table = table;
         _numRowAxisCols = numRowAxisCols;
 

--- a/api/src/org/labkey/api/query/CrosstabView.java
+++ b/api/src/org/labkey/api/query/CrosstabView.java
@@ -24,8 +24,6 @@ import org.labkey.api.data.CrosstabTableInfo;
 import org.labkey.api.data.DataRegion;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.ExcelWriter;
-import org.labkey.api.data.Results;
-import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.util.Pair;
@@ -33,7 +31,6 @@ import org.labkey.api.view.DataView;
 import org.springframework.validation.Errors;
 
 import java.io.IOException;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -254,19 +251,10 @@ public class CrosstabView extends QueryView
 
         configureForExcelExport(docType, view, rgn);
 
-        try
-        {
-            Results results = rgn.getResults(view.getRenderContext());
+        CrosstabTableInfo table = (CrosstabTableInfo)getTable();
+        List<DisplayColumn> displayColumns = rgn.getDisplayColumns();
 
-            CrosstabTableInfo table = (CrosstabTableInfo)getTable();
-            List<DisplayColumn> displayColumns = rgn.getDisplayColumns();
-
-            return new CrosstabExcelWriter(table, results, getExportColumns(displayColumns), _numRowAxisCols, docType);
-        }
-        catch (SQLException e)
-        {
-            throw new RuntimeSQLException(e);
-        }
+        return new CrosstabExcelWriter(table, ()->rgn.getResults(view.getRenderContext()), getExportColumns(displayColumns), _numRowAxisCols, docType);
     }
 
     public boolean isMemberIncluded(CrosstabMember member)

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -2549,7 +2549,7 @@ public class QueryView extends WebPartView<Object>
     {
         List<DisplayColumn> displayColumns = getExcelTemplateDisplayColumns(fieldKeys);
 
-        return renameCols == null || renameCols.isEmpty()? new ExcelWriter(()->null, displayColumns, docType) : new AliasColumnExcelWriter(null, displayColumns, docType, renameCols);
+        return renameCols == null || renameCols.isEmpty()? new ExcelWriter(()->null, displayColumns, docType) : new AliasColumnExcelWriter(()->null, displayColumns, docType, renameCols);
     }
 
     protected RenderContext configureForExcelExport(ExcelWriter.ExcelDocumentType docType, DataView view, DataRegion rgn)

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -62,7 +62,6 @@ import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DataView;
-import org.labkey.api.view.DisplayElement;
 import org.labkey.api.view.GridView;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.JspView;
@@ -2315,7 +2314,7 @@ public class QueryView extends WebPartView<Object>
         return getTsvWriter(headerType, Collections.emptyMap());
     }
 
-    protected TSVGridWriter getTsvWriter(ColumnHeaderType headerType, @NotNull Map<String, String> renameColumn) throws IOException
+    protected TSVGridWriter getTsvWriter(ColumnHeaderType headerType, @NotNull Map<String, String> renameColumnMap) throws IOException
     {
         _exportView = true;
         DataView view = createDataView();
@@ -2324,20 +2323,12 @@ public class QueryView extends WebPartView<Object>
         rgn.setShowPagination(false);
         RenderContext rc = view.getRenderContext();
         rc.setCache(false);
-        try
-        {
-            Results results = rgn.getResults(rc);
-            TSVGridWriter tsv = new TSVGridWriter(results, getExportColumns(rgn.getDisplayColumns()), renameColumn);
-            tsv.setFilenamePrefix(getSettings().getQueryName() != null ? getSettings().getQueryName() : "query");
-            // don't step on default
-            if (null != headerType)
-                tsv.setColumnHeaderType(headerType);
-            return tsv;
-        }
-        catch (SQLException e)
-        {
-            throw new RuntimeSQLException(e);
-        }
+        TSVGridWriter tsv = new TSVGridWriter(()->rgn.getResults(rc), getExportColumns(rgn.getDisplayColumns()), renameColumnMap);
+        tsv.setFilenamePrefix(getSettings().getQueryName() != null ? getSettings().getQueryName() : "query");
+        // don't step on default
+        if (null != headerType)
+            tsv.setColumnHeaderType(headerType);
+        return tsv;
     }
 
     public Results getResults() throws SQLException, IOException
@@ -2397,35 +2388,27 @@ public class QueryView extends WebPartView<Object>
         return getExcelWriter(docType, null);
     }
 
-    public ExcelWriter getExcelWriter(ExcelWriter.ExcelDocumentType docType, Map<String, String> renameColumns) throws IOException
+    public ExcelWriter getExcelWriter(ExcelWriter.ExcelDocumentType docType, Map<String, String> renameColumnMap) throws IOException
     {
         DataView view = createDataView();
         DataRegion rgn = view.getDataRegion();
 
         RenderContext rc = configureForExcelExport(docType, view, rgn);
 
-        try
-        {
-            Results results = rgn.getResults(rc);
-            ExcelWriter ew = renameColumns == null || renameColumns.isEmpty() ? new ExcelWriter(results, getExportColumns(rgn.getDisplayColumns()), docType) : new AliasColumnExcelWriter(results, getExportColumns(rgn.getDisplayColumns()), docType, renameColumns);
-            ew.setFilenamePrefix(getSettings().getQueryName());
-            ew.setAutoSize(true);
-            return ew;
-        }
-        catch (SQLException e)
-        {
-            throw new RuntimeSQLException(e);
-        }
+        ExcelWriter ew = renameColumnMap == null || renameColumnMap.isEmpty() ? new ExcelWriter(()->rgn.getResults(rc), getExportColumns(rgn.getDisplayColumns()), docType) : new AliasColumnExcelWriter(()->rgn.getResults(rc), getExportColumns(rgn.getDisplayColumns()), docType, renameColumnMap);
+        ew.setFilenamePrefix(getSettings().getQueryName());
+        ew.setAutoSize(true);
+        return ew;
     }
 
     private static class AliasColumnExcelWriter extends ExcelWriter
     {
-        private Map<String, String> _renameColumns;
+        private final Map<String, String> _renameColumnMap;
 
-        public AliasColumnExcelWriter(Results results, List<DisplayColumn> displayColumns, ExcelDocumentType docType, Map<String, String> renameColumns)
+        public AliasColumnExcelWriter(ResultsFactory factory, List<DisplayColumn> displayColumns, ExcelDocumentType docType, Map<String, String> renameColumnMap)
         {
-            super(results, displayColumns, docType);
-            _renameColumns = renameColumns;
+            super(factory, displayColumns, docType);
+            _renameColumnMap = renameColumnMap;
         }
 
         @Override
@@ -2434,18 +2417,18 @@ public class QueryView extends WebPartView<Object>
         {
 
             super.renderColumnCaptions(sheet, visibleColumns);
-            if (_renameColumns == null || _renameColumns.isEmpty())
+            if (_renameColumnMap == null || _renameColumnMap.isEmpty())
                 return;
 
             int row = getCurrentRow() - 1;
             for (int col = 0; col < visibleColumns.size(); col++)
             {
                 String originalColName = visibleColumns.get(col).getName();
-                if (_renameColumns.containsKey(originalColName))
+                if (_renameColumnMap.containsKey(originalColName))
                 {
                     Cell cell = sheet.getRow(row).getCell(col);
                     if (cell != null)
-                        cell.setCellValue(_renameColumns.get(originalColName));
+                        cell.setCellValue(_renameColumnMap.get(originalColName));
                 }
             }
         }
@@ -2566,7 +2549,7 @@ public class QueryView extends WebPartView<Object>
     {
         List<DisplayColumn> displayColumns = getExcelTemplateDisplayColumns(fieldKeys);
 
-        return renameCols == null || renameCols.isEmpty()? new ExcelWriter(null, displayColumns, docType) : new AliasColumnExcelWriter(null, displayColumns, docType, renameCols);
+        return renameCols == null || renameCols.isEmpty()? new ExcelWriter(()->null, displayColumns, docType) : new AliasColumnExcelWriter(null, displayColumns, docType, renameCols);
     }
 
     protected RenderContext configureForExcelExport(ExcelWriter.ExcelDocumentType docType, DataView view, DataRegion rgn)
@@ -2611,7 +2594,7 @@ public class QueryView extends WebPartView<Object>
                                  boolean respectView,
                                  List<FieldKey> includeColumns,
                                  List<FieldKey> excludeColumns,
-                                 @NotNull Map<String, String> renameColumns,
+                                 @NotNull Map<String, String> renameColumnMap,
                                  @Nullable String prefix
                                  )
             throws IOException
@@ -2620,8 +2603,8 @@ public class QueryView extends WebPartView<Object>
         TableInfo table = getTable();
         if (table != null)
         {
-            try (ExcelWriter ew = templateOnly ? getExcelTemplateWriter(respectView, includeColumns, renameColumns, docType)
-                    : (renameColumns.isEmpty() ? getExcelWriter(docType) : getExcelWriter(docType, renameColumns)))
+            try (ExcelWriter ew = templateOnly ? getExcelTemplateWriter(respectView, includeColumns, renameColumnMap, docType)
+                    : (renameColumnMap.isEmpty() ? getExcelWriter(docType) : getExcelWriter(docType, renameColumnMap)))
             {
                 if (headerType == null)
                     headerType = getColumnHeaderType();
@@ -2687,22 +2670,21 @@ public class QueryView extends WebPartView<Object>
         exportToTsv(response, delim, quote, headerType, Collections.emptyMap());
     }
 
-    public void exportToTsv(final HttpServletResponse response, final TSVWriter.DELIM delim, final TSVWriter.QUOTE quote, ColumnHeaderType headerType, @NotNull Map<String, String> renameColumn) throws IOException
+    public void exportToTsv(final HttpServletResponse response, final TSVWriter.DELIM delim, final TSVWriter.QUOTE quote, ColumnHeaderType headerType, @NotNull Map<String, String> renameColumnMap) throws IOException
     {
         _exportView = true;
         TableInfo table = getTable();
 
         if (table != null)
         {
-            int rowCount = doExport(response, delim, quote, headerType, renameColumn);
+            int rowCount = doExport(response, delim, quote, headerType, renameColumnMap);
             logAuditEvent("Exported to TSV", rowCount);
         }
     }
 
-
-    private int doExport(HttpServletResponse response, final TSVWriter.DELIM delim, final TSVWriter.QUOTE quote, ColumnHeaderType headerType, @NotNull Map<String, String> renameColumn) throws IOException
+    private int doExport(HttpServletResponse response, final TSVWriter.DELIM delim, final TSVWriter.QUOTE quote, ColumnHeaderType headerType, @NotNull Map<String, String> renameColumnMap) throws IOException
     {
-        try (TSVGridWriter tsv = renameColumn.isEmpty() ? getTsvWriter(headerType) : getTsvWriter(headerType, renameColumn))
+        try (TSVGridWriter tsv = renameColumnMap.isEmpty() ? getTsvWriter(headerType) : getTsvWriter(headerType, renameColumnMap))
         {
             tsv.setDelimiterCharacter(delim);
             tsv.setQuoteCharacter(quote);

--- a/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
@@ -25,7 +25,6 @@ import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.query.QueryService.NamedParameterNotProvided;
 import org.labkey.api.query.QueryView;
-import org.labkey.api.query.ValidationException;
 import org.labkey.api.reports.ExternalScriptEngine;
 import org.labkey.api.reports.RConnectionHolder;
 import org.labkey.api.reports.Report;
@@ -225,21 +224,7 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
             {
                 runScript(context, outputSubst, createInputDataFile(context), inputParameters);
             }
-            catch (ScriptException e)
-            {
-                boolean continueOn = renderer.handleRuntimeException(e);
-
-                if (!continueOn)
-                    return null;
-            }
-            catch (ValidationException e)
-            {
-                boolean continueOn = renderer.handleRuntimeException(e);
-
-                if (!continueOn)
-                    return null;
-            }
-            catch (NamedParameterNotProvided e)
+            catch (ScriptException | NamedParameterNotProvided e)
             {
                 boolean continueOn = renderer.handleRuntimeException(e);
 

--- a/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
@@ -159,7 +159,7 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
     {
         try
         {
-            return renderReport(context, null, new Renderer<Thumbnail>()
+            return renderReport(context, null, new Renderer<>()
             {
                 @Override
                 public void handleValidationError(String error)
@@ -307,21 +307,16 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
                     boundFiles.add(file.getName());
             }
 
-            File[] additionalFiles = reportDir.listFiles(new FilenameFilter()
-            {
-                @Override
-                public boolean accept(File dir, String name)
-                {
-                    if (boundFiles.contains(name))
-                        return false;
-                    else if ("input_data.tsv".equalsIgnoreCase(name))
-                        return false;
-                    else if ("script.r".equalsIgnoreCase(name))
-                        return false;
-                    else if ("script.rout".equalsIgnoreCase(name))
-                        return false;
-                    return true;
-                }
+            File[] additionalFiles = reportDir.listFiles((dir, name) -> {
+                if (boundFiles.contains(name))
+                    return false;
+                else if ("input_data.tsv".equalsIgnoreCase(name))
+                    return false;
+                else if ("script.r".equalsIgnoreCase(name))
+                    return false;
+                else if ("script.rout".equalsIgnoreCase(name))
+                    return false;
+                return true;
             });
 
             for (File file : additionalFiles)
@@ -478,10 +473,7 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
 
                 try
                 {
-                    for (ParamReplacement param : ParamReplacementSvc.get().fromFile(new File(cacheDir, SUBSTITUTION_MAP)))
-                    {
-                        replacements.add(param);
-                    }
+                    replacements.addAll(ParamReplacementSvc.get().fromFile(new File(cacheDir, SUBSTITUTION_MAP)));
                     return !replacements.isEmpty();
                 }
                 catch (Exception e)
@@ -507,8 +499,8 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
         ActionURL cachedURL = _cachedReportURLMap.get(getDescriptor().getReportId());
         if (cachedURL != null)
         {
-            Map cur = PageFlowUtil.mapFromQueryString(getCacheURL(url).getQueryString());
-            Map prev = PageFlowUtil.mapFromQueryString(cachedURL.getQueryString());
+            Map<String, String> cur = PageFlowUtil.mapFromQueryString(getCacheURL(url).getQueryString());
+            Map<String, String> prev = PageFlowUtil.mapFromQueryString(cachedURL.getQueryString());
 
             return !cur.equals(prev);
         }
@@ -567,16 +559,7 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
     {
         if (DEFAULT_PERL_PATH == null)
         {
-            DEFAULT_PERL_PATH = getDefaultAppPath(new FilenameFilter()
-            {
-                @Override
-                public boolean accept(File dir, String name)
-                {
-                    if ("perl.exe".equalsIgnoreCase(name) || "perl".equalsIgnoreCase(name))
-                        return true;
-                    return false;
-                }
-            });
+            DEFAULT_PERL_PATH = getDefaultAppPath((dir, name) -> "perl.exe".equalsIgnoreCase(name) || "perl".equalsIgnoreCase(name));
         }
         return DEFAULT_PERL_PATH;
     }

--- a/api/src/org/labkey/api/reports/report/ScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/ScriptEngineReport.java
@@ -228,11 +228,20 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
     /*
      * Create the .tsv associated with the data grid for this report.
      */
-    public File createInputDataFile(@NotNull ViewContext context) throws Exception
+    public File createInputDataFile(@NotNull ViewContext context) throws SQLException, IOException
     {
         File resultFile = new File(getReportDir(context.getContainer().getId()), DATA_INPUT);
 
-        ResultsFactory factory = ()->generateResults(context, true);
+        ResultsFactory factory = ()-> {
+            try
+            {
+                return generateResults(context, true);
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException(e);
+            }
+        };
 
         try (StashingResultsFactory srf = new StashingResultsFactory(factory))
         {
@@ -815,7 +824,7 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
 
     protected static class TempFileCleanup extends HttpView
     {
-        private String _path;
+        private final String _path;
 
         public TempFileCleanup(String path)
         {

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -78,6 +78,7 @@ import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.settings.ConfigProperty;
 import org.labkey.api.util.ConfigurationException;
+import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
@@ -2522,8 +2523,8 @@ public class SecurityManager
                 SecurityManager.setPassword(email, password);
 
                 User user2 = AuthenticationManager.authenticate(ViewServlet.mockRequest("GET", new ActionURL(), null, null, null), rawEmail, password);
-                assertNotNull("login", user2);
-                assertEquals("login", user, user2);
+                assertNotNull(rawEmail + " failed to authenticate; check labkey.log around timestamp " + DateUtil.formatDateTime(new Date(), "HH:mm:ss,SSS") + " for the reason", user2);
+                assertEquals(user, user2);
             }
             finally
             {

--- a/assay/src/org/labkey/assay/actions/TemplateAction.java
+++ b/assay/src/org/labkey/assay/actions/TemplateAction.java
@@ -25,7 +25,6 @@ import org.labkey.api.data.DataRegion;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.ExcelWriter;
 import org.labkey.api.data.RenderContext;
-import org.labkey.api.data.Results;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -68,8 +67,7 @@ public class TemplateAction extends BaseAssayAction<ProtocolIdForm>
         ctx.setContainer(getContainer());
         ctx.setBaseFilter(filter);
 
-        Results results = dr.getResults(ctx);
-        try (ExcelWriter xl = new ExcelWriter(results, dr.getDisplayColumns(), ExcelWriter.ExcelDocumentType.xlsx))
+        try (ExcelWriter xl = new ExcelWriter(()->dr.getResults(ctx), dr.getDisplayColumns(), ExcelWriter.ExcelDocumentType.xlsx))
         {
             xl.write(getViewContext().getResponse());
         }

--- a/assay/src/org/labkey/assay/actions/TemplateAction.java
+++ b/assay/src/org/labkey/assay/actions/TemplateAction.java
@@ -39,9 +39,9 @@ import java.util.Map;
 
 /**
  * User: brittp
-* Date: Jul 26, 2007
-* Time: 7:23:37 PM
-*/
+ * Date: Jul 26, 2007
+ * Time: 7:23:37 PM
+ */
 @RequiresPermission(InsertPermission.class)
 public class TemplateAction extends BaseAssayAction<ProtocolIdForm>
 {

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -121,6 +121,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -1037,7 +1038,7 @@ public class SecurityController extends SpringActionController
             try (ExcelWriter ew = new ExcelWriter(()->rgn.getResults(ctx), rgn.getDisplayColumns())
                 {
                     @Override
-                    public void renderGrid(RenderContext ctx, Sheet sheet, List<ExcelColumn> visibleColumns) throws Exception
+                    public void renderGrid(RenderContext ctx, Sheet sheet, List<ExcelColumn> visibleColumns) throws MaxRowsExceededException, SQLException, IOException
                     {
                         for (Pair<Integer, String> memberGroup : memberGroups)
                         {

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -121,7 +121,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -1035,11 +1034,10 @@ public class SecurityController extends SpringActionController
                 filter.addCondition(FieldKey.fromParts("Active"), true);
             ctx.setBaseFilter(filter);
             rgn.prepareDisplayColumns(c);
-            try (ExcelWriter ew = new ExcelWriter(rgn.getResults(ctx), rgn.getDisplayColumns())
+            try (ExcelWriter ew = new ExcelWriter(()->rgn.getResults(ctx), rgn.getDisplayColumns())
                 {
                     @Override
-                    public void renderGrid (RenderContext ctx, Sheet sheet, List < ExcelColumn > visibleColumns) throws
-                    SQLException, MaxRowsExceededException
+                    public void renderGrid(RenderContext ctx, Sheet sheet, List<ExcelColumn> visibleColumns) throws Exception
                     {
                         for (Pair<Integer, String> memberGroup : memberGroups)
                         {

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
@@ -19,7 +19,7 @@ import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.PHI;
 import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.data.RenderContext;
-import org.labkey.api.data.Results;
+import org.labkey.api.data.ResultsFactory;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SqlSelector;
@@ -198,8 +198,8 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
                         SimpleFilter filter = new SimpleFilter();
                         if (!derivedIds.isEmpty())
                             filter.addCondition(FieldKey.fromParts("RowId"), derivedIds, CompareType.NOT_IN);
-                        Results rs = QueryService.get().select(tinfo, columns, filter, null);
-                        try (TSVGridWriter tsvWriter = new TSVGridWriter(rs))
+                        ResultsFactory factory = ()->QueryService.get().select(tinfo, columns, filter, null);
+                        try (TSVGridWriter tsvWriter = new TSVGridWriter(factory))
                         {
                             tsvWriter.setApplyFormats(false);
                             tsvWriter.setColumnHeaderType(ColumnHeaderType.FieldKey);
@@ -239,8 +239,8 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
                         SimpleFilter filter = new SimpleFilter();
                         if (!derivedIds.isEmpty())
                             filter.addCondition(FieldKey.fromParts("RowId"), derivedIds, CompareType.NOT_IN);
-                        Results rs = QueryService.get().select(tinfo, columns, filter, null);
-                        try (TSVGridWriter tsvWriter = new TSVGridWriter(rs))
+                        ResultsFactory factory = ()->QueryService.get().select(tinfo, columns, filter, null);
+                        try (TSVGridWriter tsvWriter = new TSVGridWriter(factory))
                         {
                             tsvWriter.setApplyFormats(false);
                             tsvWriter.setColumnHeaderType(ColumnHeaderType.FieldKey);

--- a/list/src/org/labkey/list/model/ListWriter.java
+++ b/list/src/org/labkey/list/model/ListWriter.java
@@ -31,7 +31,6 @@ import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PHI;
 import org.labkey.api.data.RenderContext;
-import org.labkey.api.data.Results;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.TSVGridWriter;
 import org.labkey.api.data.TableInfo;
@@ -165,10 +164,8 @@ public class ListWriter
                     // Sort the data rows by PK, #11261
                     Sort sort = ti.getPkColumnNames().size() != 1 ? null : new Sort(ti.getPkColumnNames().get(0));
 
-                    Results rs = QueryService.get().select(ti, columns, null, sort);
-
-                    // NOTE: TSVGridWriter closes PrintWriter and ResultSet
-                    try (TSVGridWriter tsvWriter = new TSVGridWriter(rs, displayColumns))
+                    // NOTE: TSVGridWriter generates and closes Results
+                    try (TSVGridWriter tsvWriter = new TSVGridWriter(()->QueryService.get().select(ti, columns, null, sort), displayColumns))
                     {
                         tsvWriter.setApplyFormats(false);
                         tsvWriter.setColumnHeaderType(ColumnHeaderType.DisplayFieldKey); // CONSIDER: Use FieldKey instead

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1657,7 +1657,7 @@ public class QueryController extends SpringActionController
         @Override
         void _export(ExportQueryForm form, QueryView view) throws Exception
         {
-            view.exportToExcel(getViewContext().getResponse(), form.getHeaderType(), ExcelWriter.ExcelDocumentType.xls, form.getRenameColumns());
+            view.exportToExcel(getViewContext().getResponse(), form.getHeaderType(), ExcelWriter.ExcelDocumentType.xls, form.getRenameColumnMap());
         }
     }
 
@@ -1668,7 +1668,7 @@ public class QueryController extends SpringActionController
         @Override
         void _export(ExportQueryForm form, QueryView view) throws Exception
         {
-            view.exportToExcel(getViewContext().getResponse(), form.getHeaderType(), ExcelWriter.ExcelDocumentType.xlsx, form.getRenameColumns());
+            view.exportToExcel(getViewContext().getResponse(), form.getHeaderType(), ExcelWriter.ExcelDocumentType.xlsx, form.getRenameColumnMap());
         }
     }
 
@@ -1787,7 +1787,7 @@ public class QueryController extends SpringActionController
                 }
                 catch (IllegalArgumentException ignored) {}
             }
-            view.exportToExcel(getViewContext().getResponse(), true, form.getHeaderType(), form.insertColumnsOnly, fileType, respectView, form.getIncludeColumns(), form.getExcludeColumns(), form.getRenameColumns(), form.getFilenamePrefix());
+            view.exportToExcel(getViewContext().getResponse(), true, form.getHeaderType(), form.insertColumnsOnly, fileType, respectView, form.getIncludeColumns(), form.getExcludeColumns(), form.getRenameColumnMap(), form.getFilenamePrefix());
         }
     }
 
@@ -1821,7 +1821,7 @@ public class QueryController extends SpringActionController
             this.excludeColumn = excludeColumn;
         }
 
-        public Map<String, String> getRenameColumns()
+        public Map<String, String> getRenameColumnMap()
         {
             if (renameColumns != null)
                 return renameColumns;
@@ -1840,7 +1840,6 @@ public class QueryController extends SpringActionController
 
             return renameColumns;
         }
-
     }
 
     @SuppressWarnings({"unused", "WeakerAccess"})
@@ -1883,7 +1882,7 @@ public class QueryController extends SpringActionController
         @Override
         void _export(ExportRowsTsvForm form, QueryView view) throws Exception
         {
-            view.exportToTsv(getViewContext().getResponse(), form.getDelim(), form.getQuote(), form.getHeaderType(), form.getRenameColumns());
+            view.exportToTsv(getViewContext().getResponse(), form.getDelim(), form.getQuote(), form.getHeaderType(), form.getRenameColumnMap());
         }
     }
 
@@ -6327,11 +6326,11 @@ public class QueryController extends SpringActionController
                 throw new NotFoundException();
 
             TableSelector selector = new TableSelector(queryExportAuditTable,
-                    PageFlowUtil.set(
-                            QueryExportAuditProvider.COLUMN_NAME_SCHEMA_NAME,
-                            QueryExportAuditProvider.COLUMN_NAME_QUERY_NAME,
-                            QueryExportAuditProvider.COLUMN_NAME_DETAILS_URL),
-                    new SimpleFilter(FieldKey.fromParts(AbstractAuditTypeProvider.COLUMN_NAME_ROW_ID), form.getRowId()), null);
+                PageFlowUtil.set(
+                    QueryExportAuditProvider.COLUMN_NAME_SCHEMA_NAME,
+                    QueryExportAuditProvider.COLUMN_NAME_QUERY_NAME,
+                    QueryExportAuditProvider.COLUMN_NAME_DETAILS_URL),
+                new SimpleFilter(FieldKey.fromParts(AbstractAuditTypeProvider.COLUMN_NAME_ROW_ID), form.getRowId()), null);
 
             Map<String, Object> result = selector.getMap();
             if (result == null)
@@ -6704,13 +6703,14 @@ public class QueryController extends SpringActionController
                     if (DatabaseTableType.TABLE.equals(table.getTableType()))
                     {
                         String tableName = table.getName();
-                        try (Results results = new TableSelector(table).getResults(false))
+                        try (var factory = new StashingResultsFactory(()->new TableSelector(table).getResults(false)))
                         {
+                            Results results = factory.get();
                             if (results.isBeforeFirst()) // only export tables with data
                             {
                                 File outputFile = new File(form.getOutputDir(), tableName + ".tsv.gz");
                                 GZIPOutputStream outputStream = new GZIPOutputStream(new BufferedOutputStream(new FileOutputStream(outputFile), 64 * 1024), 64 * 1024);
-                                try (TSVGridWriter tsv = new TSVGridWriter(results))
+                                try (TSVGridWriter tsv = new TSVGridWriter(factory))
                                 {
                                     tsv.setColumnHeaderType(ColumnHeaderType.DisplayFieldKey);
                                     tsv.setApplyFormats(false);

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -6674,7 +6674,7 @@ public class QueryController extends SpringActionController
         }
 
         @Override
-        public boolean handlePost(GenerateSchemaForm form, BindException errors) throws Exception
+        public boolean handlePost(GenerateSchemaForm form, BindException errors) throws SQLException, IOException
         {
             StringBuilder importScript = new StringBuilder();
 

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -7230,10 +7230,10 @@ public class StudyController extends BaseStudyController
                 cols.add(ti.getColumn("dateoffset"));
                 SimpleFilter filter = new SimpleFilter();
                 filter.addCondition(ti.getColumn("container"), getContainer());
-                Results rs = QueryService.get().select(ti, cols, filter, new Sort("participantid"));
+                ResultsFactory factory = ()->QueryService.get().select(ti, cols, filter, new Sort("participantid"));
 
-                // NOTE: TSVGridWriter.close() closes PrintWriter and ResultSet
-                try (TSVGridWriter writer = new TSVGridWriter(rs))
+                // NOTE: TSVGridWriter closes PrintWriter and ResultSet
+                try (TSVGridWriter writer = new TSVGridWriter(factory))
                 {
                     writer.setApplyFormats(false);
                     writer.setFilenamePrefix("ParticipantTransforms");

--- a/study/src/org/labkey/study/controllers/specimen/SpecimenUtils.java
+++ b/study/src/org/labkey/study/controllers/specimen/SpecimenUtils.java
@@ -21,25 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.attachments.Attachment;
 import org.labkey.api.attachments.AttachmentService;
-import org.labkey.api.data.ActionButton;
-import org.labkey.api.data.ButtonBarLineBreak;
-import org.labkey.api.data.ColumnInfo;
-import org.labkey.api.data.CompareType;
-import org.labkey.api.data.Container;
-import org.labkey.api.data.DataColumn;
-import org.labkey.api.data.DataRegion;
-import org.labkey.api.data.DataRegionSelection;
-import org.labkey.api.data.DisplayColumn;
-import org.labkey.api.data.ExcelWriter;
-import org.labkey.api.data.MenuButton;
-import org.labkey.api.data.ObjectFactory;
-import org.labkey.api.data.RenderContext;
-import org.labkey.api.data.Results;
-import org.labkey.api.data.SimpleDisplayColumn;
-import org.labkey.api.data.SimpleFilter;
-import org.labkey.api.data.Sort;
-import org.labkey.api.data.TSVGridWriter;
-import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.*;
 import org.labkey.api.query.CustomView;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryDefinition;
@@ -1020,23 +1002,21 @@ public class SpecimenUtils
         RenderContext ctx = new RenderContext(getViewContext());
         ctx.setContainer(specimenRequest.getContainer());
         ctx.setBaseFilter(getSpecimenListFilter(specimenRequest, srcLocation, type));
-        Results results = dr.getResults(ctx);
         List<DisplayColumn> cols = dr.getDisplayColumns();
-        TSVGridWriter tsv = new TSVGridWriter(results, cols);
+        TSVGridWriter tsv = new TSVGridWriter(()->dr.getResults(ctx), cols);
         tsv.setFilenamePrefix(getSpecimenListFileName(srcLocation, destLocation));
         return tsv;
     }
 
     public ExcelWriter getSpecimenListXlsWriter(SpecimenRequest specimenRequest, LocationImpl srcLocation,
-                                                 LocationImpl destLocation, SpecimenController.LabSpecimenListsBean.Type type) throws SQLException, IOException
+                                                 LocationImpl destLocation, SpecimenController.LabSpecimenListsBean.Type type)
     {
         DataRegion dr = createDataRegionForWriters(specimenRequest);
         RenderContext ctx = new RenderContext(getViewContext());
         ctx.setContainer(specimenRequest.getContainer());
         ctx.setBaseFilter(getSpecimenListFilter(specimenRequest, srcLocation, type));
-        Results results = dr.getResults(ctx);
         List<DisplayColumn> cols = dr.getDisplayColumns();
-        ExcelWriter xl = new ExcelWriter(results, cols);
+        ExcelWriter xl = new ExcelWriter(() -> dr.getResults(ctx), cols);
         xl.setFilenamePrefix(getSpecimenListFileName(srcLocation, destLocation));
         return xl;
     }

--- a/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
@@ -83,6 +83,7 @@ import org.labkey.study.query.StudyQuerySchema;
 import org.labkey.study.writer.DatasetDataWriter;
 import org.springframework.validation.BindException;
 
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -201,7 +202,7 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
     }
 
     @Override
-    public void createSnapshot(ViewContext context, QuerySnapshotDefinition qsDef, BindException errors) throws Exception
+    public void createSnapshot(ViewContext context, QuerySnapshotDefinition qsDef, BindException errors) throws IOException, SQLException
     {
         DbSchema schema = StudySchema.getInstance().getSchema();
 
@@ -513,7 +514,7 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
                         }
                     }
                 }
-                catch (SQLException e)
+                catch (SQLException | IOException e)
                 {
                     ViewContext context = form.getViewContext();
                     StudyServiceImpl.addDatasetAuditEvent(context.getUser(), context.getContainer(), dsDef,

--- a/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
@@ -34,6 +34,7 @@ import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.PHI;
 import org.labkey.api.data.Results;
 import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.StashingResultsFactory;
 import org.labkey.api.data.TSVGridWriter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.dataiterator.DataIteratorContext;
@@ -113,8 +114,8 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
     private static final QuerySnapshotDependencyThread DEPENDENCY_THREAD = new QuerySnapshotDependencyThread();
 
     // query snapshot dependency checkers
-    private static SnapshotDependency.Dataset _datasetDependency = new SnapshotDependency.Dataset();
-    private static SnapshotDependency.ParticipantCategoryDependency _categoryDependency = new SnapshotDependency.ParticipantCategoryDependency();
+    private static final SnapshotDependency.Dataset _datasetDependency = new SnapshotDependency.Dataset();
+    private static final SnapshotDependency.ParticipantCategoryDependency _categoryDependency = new SnapshotDependency.ParticipantCategoryDependency();
 
     static
     {
@@ -222,56 +223,54 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
                     if (null != view.getTable())
                     {
                         // TODO call updateSnapshot() instead of duplicating code
-                        Results results = getResults(context, view, qsDef, def);
-
-                        // TODO: Create class ResultSetDataLoader and use it here instead of round-tripping through a TSV StringBuilder
-                        StringBuilder sb = new StringBuilder();
-
-                        Map<FieldKey, ColumnInfo> fieldMap;
-
-                        try (TSVGridWriter tsvWriter = new TSVGridWriter(results))
+                        try (var factory = new StashingResultsFactory(()->getResults(context, view, qsDef, def)))
                         {
-                            tsvWriter.setApplyFormats(false);
-                            tsvWriter.setColumnHeaderType(ColumnHeaderType.DisplayFieldKey); // CONSIDER: Use FieldKey instead
-                            tsvWriter.write(sb);
+                            // TODO: Create class ResultSetDataLoader and use it here instead of round-tripping through a TSV StringBuilder
+                            StringBuilder sb = new StringBuilder();
+                            Map<FieldKey, ColumnInfo> fieldMap = factory.get().getFieldMap();
 
-                            fieldMap = tsvWriter.getFieldMap();
-                        }
-
-                        try (DbScope.Transaction transaction = schema.getScope().ensureTransaction())
-                        {
-                            DataIteratorContext dataIteratorContext = new DataIteratorContext();
-                            dataIteratorContext.setInsertOption(QueryUpdateService.InsertOption.IMPORT);
-                            if (study.isDataspaceStudy())
+                            try (TSVGridWriter tsvWriter = new TSVGridWriter(factory))
                             {
-                                if (!fieldMap.containsKey(new FieldKey(null, "container")))
-                                {
-                                    errors.reject(SpringActionController.ERROR_MSG, "Dataspace snapshot query must have a column called 'container'");
-                                    return;
-                                }
-                                Map<Enum, Object> config = Collections.singletonMap(QueryUpdateService.ConfigParameters.TargetMultipleContainers, Boolean.TRUE);
-                                dataIteratorContext.setConfigParameters(config);
+                                tsvWriter.setApplyFormats(false);
+                                tsvWriter.setColumnHeaderType(ColumnHeaderType.DisplayFieldKey); // CONSIDER: Use FieldKey instead
+                                tsvWriter.write(sb);
                             }
-                            StudyManager.getInstance().importDatasetData(context.getUser(), def,
+
+                            try (DbScope.Transaction transaction = schema.getScope().ensureTransaction())
+                            {
+                                DataIteratorContext dataIteratorContext = new DataIteratorContext();
+                                dataIteratorContext.setInsertOption(QueryUpdateService.InsertOption.IMPORT);
+                                if (study.isDataspaceStudy())
+                                {
+                                    if (!fieldMap.containsKey(new FieldKey(null, "container")))
+                                    {
+                                        errors.reject(SpringActionController.ERROR_MSG, "Dataspace snapshot query must have a column called 'container'");
+                                        return;
+                                    }
+                                    Map<Enum, Object> config = Collections.singletonMap(QueryUpdateService.ConfigParameters.TargetMultipleContainers, Boolean.TRUE);
+                                    dataIteratorContext.setConfigParameters(config);
+                                }
+                                StudyManager.getInstance().importDatasetData(context.getUser(), def,
                                     new TabLoader(sb, true), new CaseInsensitiveHashMap<>(),
                                     dataIteratorContext,
                                     study.isDataspaceStudy() ? DatasetDefinition.CheckForDuplicates.never : DatasetDefinition.CheckForDuplicates.sourceOnly,
                                     null, null);
 
-                            for (ValidationException e : dataIteratorContext.getErrors().getRowErrors())
-                                errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
+                                for (ValidationException e : dataIteratorContext.getErrors().getRowErrors())
+                                    errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
 
-                            if (!errors.hasErrors())
-                            {
-                                // if the source of the snapshot (query definition) is in a different
-                                // container, make sure the participants and visits for the study for the
-                                // snapshot are updated
-                                if (!queryDef.getContainer().equals(qsDef.getContainer()))
+                                if (!errors.hasErrors())
                                 {
-                                    StudyManager.getInstance().getVisitManager(study).updateParticipantVisits(context.getUser(),
+                                    // if the source of the snapshot (query definition) is in a different
+                                    // container, make sure the participants and visits for the study for the
+                                    // snapshot are updated
+                                    if (!queryDef.getContainer().equals(qsDef.getContainer()))
+                                    {
+                                        StudyManager.getInstance().getVisitManager(study).updateParticipantVisits(context.getUser(),
                                             Collections.singletonList(def));
+                                    }
+                                    transaction.commit();
                                 }
-                                transaction.commit();
                             }
                         }
                     }
@@ -380,7 +379,7 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
                 Study study = StudyManager.getInstance().getStudy(qsDef.getContainer());
                 DatasetDefinition def = StudyManager.getInstance().getDatasetDefinitionByName(study, qsDef.getName());
                 return new ActionURL(StudyController.DatasetAction.class, qsDef.getContainer()).
-                        addParameter(DatasetDefinition.DATASETKEY, def.getDatasetId());
+                    addParameter(DatasetDefinition.DATASETKEY, def.getDatasetId());
             }
         }
         return null;
@@ -452,66 +451,65 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
                             return null;
                         }
 
-                        Results results = getResults(form.getViewContext(), view, def, dsDef);
-
-                        // TODO: Create class ResultSetDataLoader and use it here instead of round-tripping through a TSV StringBuilder
-                        StringBuilder sb = new StringBuilder();
-                        Map<FieldKey,ColumnInfo> fieldMap;
-
-                        try (TSVGridWriter tsvWriter = new TSVGridWriter(results))
+                        try (var factory = new StashingResultsFactory(()->getResults(form.getViewContext(), view, def, dsDef)))
                         {
-                            tsvWriter.setApplyFormats(false);
-                            tsvWriter.setColumnHeaderType(ColumnHeaderType.DisplayFieldKey); // CONSIDER: Use FieldKey instead
-                            tsvWriter.write(sb);
+                            // TODO: Create class ResultSetDataLoader and use it here instead of round-tripping through a TSV StringBuilder
+                            StringBuilder sb = new StringBuilder();
+                            Map<FieldKey, ColumnInfo> fieldMap = factory.get().getFieldMap();
 
-                            fieldMap = tsvWriter.getFieldMap();
-                        }
-
-                        try (DbScope.Transaction transaction = schema.getScope().ensureTransaction())
-                        {
-                            int numRowsDeleted;
-                            List<String> newRows;
-
-                            numRowsDeleted = StudyManager.getInstance().purgeDataset(dsDef, null);
-
-                            DataIteratorContext dataIteratorContext = new DataIteratorContext();
-                            dataIteratorContext.setInsertOption(QueryUpdateService.InsertOption.IMPORT);
-                            if (study.isDataspaceStudy())
+                            try (TSVGridWriter tsvWriter = new TSVGridWriter(factory))
                             {
-                                if (!fieldMap.containsKey(new FieldKey(null, "container")))
-                                {
-                                    errors.reject(SpringActionController.ERROR_MSG, "Dataspace snapshot query must have a column called 'container'");
-                                    return null;
-                                }
-                                Map<Enum,Object> config = Collections.singletonMap(QueryUpdateService.ConfigParameters.TargetMultipleContainers, Boolean.TRUE);
-                                dataIteratorContext.setConfigParameters(config);
+                                tsvWriter.setApplyFormats(false);
+                                tsvWriter.setColumnHeaderType(ColumnHeaderType.DisplayFieldKey); // CONSIDER: Use FieldKey instead
+                                tsvWriter.write(sb);
                             }
-                            newRows = StudyManager.getInstance().importDatasetData(form.getViewContext().getUser(), dsDef,
-                                new TabLoader(sb, true), new CaseInsensitiveHashMap<>(),
-                                dataIteratorContext,
-                                study.isDataspaceStudy() ? DatasetDefinition.CheckForDuplicates.never : DatasetDefinition.CheckForDuplicates.sourceOnly,
-                                null, null);
 
-                            for (ValidationException error : dataIteratorContext.getErrors().getRowErrors())
-                                errors.reject(SpringActionController.ERROR_MSG, error.getMessage());
+                            try (DbScope.Transaction transaction = schema.getScope().ensureTransaction())
+                            {
+                                int numRowsDeleted;
+                                List<String> newRows;
 
-                            if (errors.hasErrors())
-                                return null;
+                                numRowsDeleted = StudyManager.getInstance().purgeDataset(dsDef, null);
 
-                            if (!suppressVisitManagerRecalc)
-                                StudyManager.getInstance().getVisitManager(study).updateParticipantVisits(form.getViewContext().getUser(), Collections.singleton(dsDef));
+                                DataIteratorContext dataIteratorContext = new DataIteratorContext();
+                                dataIteratorContext.setInsertOption(QueryUpdateService.InsertOption.IMPORT);
+                                if (study.isDataspaceStudy())
+                                {
+                                    if (!fieldMap.containsKey(new FieldKey(null, "container")))
+                                    {
+                                        errors.reject(SpringActionController.ERROR_MSG, "Dataspace snapshot query must have a column called 'container'");
+                                        return null;
+                                    }
+                                    Map<Enum, Object> config = Collections.singletonMap(QueryUpdateService.ConfigParameters.TargetMultipleContainers, Boolean.TRUE);
+                                    dataIteratorContext.setConfigParameters(config);
+                                }
+                                newRows = StudyManager.getInstance().importDatasetData(form.getViewContext().getUser(), dsDef,
+                                    new TabLoader(sb, true), new CaseInsensitiveHashMap<>(),
+                                    dataIteratorContext,
+                                    study.isDataspaceStudy() ? DatasetDefinition.CheckForDuplicates.never : DatasetDefinition.CheckForDuplicates.sourceOnly,
+                                    null, null);
 
-                            ViewContext context = form.getViewContext();
-                            StudyServiceImpl.addDatasetAuditEvent(context.getUser(), context.getContainer(), dsDef,
-                                    "Dataset snapshot was updated. " + numRowsDeleted + " rows were removed and replaced with " + newRows.size() + " rows.", null);
+                                for (ValidationException error : dataIteratorContext.getErrors().getRowErrors())
+                                    errors.reject(SpringActionController.ERROR_MSG, error.getMessage());
 
-                            def.setLastUpdated(new Date());
-                            def.save(form.getViewContext().getUser());
+                                if (errors.hasErrors())
+                                    return null;
 
-                            transaction.commit();
+                                if (!suppressVisitManagerRecalc)
+                                    StudyManager.getInstance().getVisitManager(study).updateParticipantVisits(form.getViewContext().getUser(), Collections.singleton(dsDef));
 
-                            return new ActionURL(StudyController.DatasetAction.class, form.getViewContext().getContainer()).
+                                ViewContext context = form.getViewContext();
+                                StudyServiceImpl.addDatasetAuditEvent(context.getUser(), context.getContainer(), dsDef,
+                                        "Dataset snapshot was updated. " + numRowsDeleted + " rows were removed and replaced with " + newRows.size() + " rows.", null);
+
+                                def.setLastUpdated(new Date());
+                                def.save(form.getViewContext().getUser());
+
+                                transaction.commit();
+
+                                return new ActionURL(StudyController.DatasetAction.class, form.getViewContext().getContainer()).
                                     addParameter(DatasetDefinition.DATASETKEY, dsDef.getDatasetId());
+                            }
                         }
                     }
                 }
@@ -598,10 +596,10 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
     {
         QuerySettings qs = new QuerySettings(context, QueryView.DATAREGIONNAME_DEFAULT);
         return new ActionURL(StudyController.EditSnapshotAction.class, context.getContainer()).
-                addParameter(qs.param(QueryParam.schemaName), settings.getSchemaName()).
-                addParameter("snapshotName", settings.getQueryName()).
-                addParameter(qs.param(QueryParam.queryName), settings.getQueryName()).
-                addParameter(ActionURL.Param.redirectUrl.name(), PageFlowUtil.encode(context.getActionURL().getLocalURIString()));
+            addParameter(qs.param(QueryParam.schemaName), settings.getSchemaName()).
+            addParameter("snapshotName", settings.getQueryName()).
+            addParameter(qs.param(QueryParam.queryName), settings.getQueryName()).
+            addParameter(ActionURL.Param.redirectUrl.name(), PageFlowUtil.encode(context.getActionURL().getLocalURIString()));
     }
 
     static ViewContext getViewContext(QuerySnapshotDefinition def, boolean pushViewContext)
@@ -726,8 +724,8 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
         }
     }
 
-    // Unfortunately complex generics here.  In English, the container key of the outer map is the source
-    // container where the dataset change events are generated.  The value is a map from the study that
+    // Unfortunately complex generics here. In English, the container key of the outer map is the source
+    // container where the dataset change events are generated. The value is a map from the study that
     // contains the snapshot datasets to a list of snapshots that need to be refreshed.
     private static final Map<Container, List<SnapshotDependency.SourceDataType>> _coalesceMap = new HashMap<>();
 
@@ -813,8 +811,8 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
 
     private static class DeferredUpdateHandler extends Thread
     {
-        private User _user;
-        private List<SnapshotDependency.SourceDataType> _sourceDataTypes = new ArrayList<>();
+        private final User _user;
+        private final List<SnapshotDependency.SourceDataType> _sourceDataTypes = new ArrayList<>();
 
         public DeferredUpdateHandler(User user, List<SnapshotDependency.SourceDataType> sourceDataTypes)
         {

--- a/study/src/org/labkey/study/reports/ExternalReport.java
+++ b/study/src/org/labkey/study/reports/ExternalReport.java
@@ -214,7 +214,7 @@ public class ExternalReport extends AbstractReport
                 factory = new TableSelector(mainTable);
             }
 
-            // TSVGridWriter generates and closed the Results
+            // TSVGridWriter generates and closes the Results
             try (TSVGridWriter tsv = new TSVGridWriter(factory))
             {
                 tsv.setColumnHeaderType(ColumnHeaderType.Name); // CONSIDER: Use FieldKey instead

--- a/study/src/org/labkey/study/writer/DatasetDataWriter.java
+++ b/study/src/org/labkey/study/writer/DatasetDataWriter.java
@@ -31,7 +31,7 @@ import org.labkey.api.data.IndexInfo;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PHI;
 import org.labkey.api.data.PropertyStorageSpec;
-import org.labkey.api.data.Results;
+import org.labkey.api.data.ResultsFactory;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SchemaTableInfo;
 import org.labkey.api.data.SimpleFilter;
@@ -141,8 +141,8 @@ public class DatasetDataWriter implements InternalStudyWriter
 
             if (ctx.isDataspaceProject())
                 DefaultStudyDesignWriter.createExtraForeignKeyColumns(ti, columns);
-            Results rs = QueryService.get().select(ti, columns, filter, sort, null, false);
-            writeResultsToTSV(rs, vf, def.getFileName());
+            ResultsFactory factory = ()->QueryService.get().select(ti, columns, filter, sort, null, false);
+            writeResultsToTSV(factory, vf, def.getFileName());
         }
     }
 
@@ -152,10 +152,10 @@ public class DatasetDataWriter implements InternalStudyWriter
         return false;
     }
 
-    private void writeResultsToTSV(Results rs, VirtualFile vf, String fileName) throws IOException
+    private void writeResultsToTSV(ResultsFactory factory, VirtualFile vf, String fileName) throws IOException
     {
-        // NOTE: TSVGridWriter.close() closes PrintWriter and ResultSet
-        try (TSVGridWriter tsvWriter = new TSVGridWriter(rs))
+        // NOTE: TSVGridWriter generates and closes Results
+        try (TSVGridWriter tsvWriter = new TSVGridWriter(factory))
         {
             tsvWriter.setApplyFormats(false);
             tsvWriter.setColumnHeaderType(ColumnHeaderType.DisplayFieldKey); // CONSIDER: Use FieldKey instead

--- a/study/src/org/labkey/study/writer/DefaultStudyDesignWriter.java
+++ b/study/src/org/labkey/study/writer/DefaultStudyDesignWriter.java
@@ -28,6 +28,7 @@ import org.labkey.api.data.ForeignKey;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PHI;
 import org.labkey.api.data.Results;
+import org.labkey.api.data.ResultsFactory;
 import org.labkey.api.data.TSVGridWriter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableInfoWriter;
@@ -70,8 +71,8 @@ public abstract class DefaultStudyDesignWriter
         // Write each table as a separate .tsv
         if (table != null)
         {
-            Results rs = QueryService.get().select(table, columns, null, null, null, false);
-            writeResultsToTSV(rs, vf, getFileName(table));
+            ResultsFactory factory = ()->QueryService.get().select(table, columns, null, null, null, false);
+            writeResultsToTSV(factory, vf, getFileName(table));
         }
     }
 
@@ -80,10 +81,10 @@ public abstract class DefaultStudyDesignWriter
         return tableInfo.getName().toLowerCase() + ".tsv";
     }
 
-    protected void writeResultsToTSV(Results rs, VirtualFile vf, String fileName) throws IOException
+    protected void writeResultsToTSV(ResultsFactory factory, VirtualFile vf, String fileName) throws IOException
     {
-        // NOTE: TSVGridWriter.close() closes PrintWriter and ResultSet
-        try (TSVGridWriter tsvWriter = new TSVGridWriter(rs))
+        // NOTE: TSVGridWriter generates and closes the Results
+        try (TSVGridWriter tsvWriter = new TSVGridWriter(factory))
         {
             tsvWriter.setApplyFormats(false);
             tsvWriter.setColumnHeaderType(ColumnHeaderType.DisplayFieldKey); // CONSIDER: Use FieldKey instead

--- a/study/src/org/labkey/study/writer/SpecimenWriter.java
+++ b/study/src/org/labkey/study/writer/SpecimenWriter.java
@@ -24,6 +24,7 @@ import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PHI;
+import org.labkey.api.data.ResultsFactory;
 import org.labkey.api.data.ResultsImpl;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlSelector;
@@ -41,7 +42,6 @@ import org.labkey.study.model.Vial;
 import org.labkey.study.query.StudyQuerySchema;
 
 import java.io.PrintWriter;
-import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -224,10 +224,10 @@ public class SpecimenWriter implements Writer<StudyImpl, StudyExportContext>
         sql.append("\nORDER BY se.ExternalId");
 
         // Note: must be uncached result set -- this query can be very large
-        ResultSet rs = new SqlSelector(StudySchema.getInstance().getSchema(), sql).getResultSet(false);
+        ResultsFactory factory = ()->new ResultsImpl(new SqlSelector(StudySchema.getInstance().getSchema(), sql).getResultSet(false), selectColumns);
 
-        // TSVGridWriter.close() closes the ResultSet
-        try (TSVGridWriter gridWriter = new TSVGridWriter(new ResultsImpl(rs, selectColumns), displayColumns))
+        // TSVGridWriter generates and closes the Results
+        try (TSVGridWriter gridWriter = new TSVGridWriter(factory, displayColumns))
         {
             gridWriter.write(pw);
         }

--- a/study/src/org/labkey/study/writer/StandardSpecimenWriter.java
+++ b/study/src/org/labkey/study/writer/StandardSpecimenWriter.java
@@ -19,6 +19,7 @@ import org.labkey.api.admin.ImportContext;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.ResultsFactory;
 import org.labkey.api.data.ResultsImpl;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlSelector;
@@ -31,7 +32,6 @@ import org.labkey.study.importer.SpecimenImporter.ImportableColumn;
 import org.labkey.study.xml.StudyDocument;
 
 import java.io.PrintWriter;
-import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -75,10 +75,10 @@ class StandardSpecimenWriter implements Writer<StandardSpecimenWriter.QueryInfo,
 
         SQLFragment sql = generateSql(ctx, tinfo, columns);
 
-        // TSVGridWriter.close() closes the ResultSet and PrintWriter
-        ResultSet rs = new SqlSelector(StudySchema.getInstance().getSchema(), sql).getResultSet(false);
+        // TSVGridWriter generates and closes the Results
+        ResultsFactory factory = ()->new ResultsImpl(new SqlSelector(StudySchema.getInstance().getSchema(), sql).getResultSet(false));
 
-        try (TSVGridWriter gridWriter = new TSVGridWriter(new ResultsImpl(rs), displayColumns))
+        try (TSVGridWriter gridWriter = new TSVGridWriter(factory, displayColumns))
         {
             gridWriter.write(pw);
         }


### PR DESCRIPTION
#### Rationale
`ExcelWriter` and `TSVGridWriter` are `AutoCloseable`, but they take `Results` that are produced by their callers. In some cases, both the writer and `Results` are passed around through separate code paths. This pattern makes it difficult to close these resources consistently (including error cases).

This change moves `ExcelWriter` and `TSVGridWriter` to a factory pattern. Instead of passing in `Results`, callers pass in a `ResultsFactory`. The writers generate the `Results` before rendering and close it immediately after, via try-with-resources. A `StashingResultsFactory` is provided for code paths that must inspect the `Results` before initializing the writer.

[Issue 38722: Migrate ExcelWriter, TSVGridWriter, DataRegion, et al to use ResultsFactory or similar](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=38722)
