### PR TITLE
Item 8119: Asynchronous import for assay runs

### DIFF
--- a/api/src/org/labkey/api/assay/AssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/AssayRunCreator.java
@@ -43,6 +43,8 @@ public interface AssayRunCreator<ProviderType extends AssayProvider>
     Pair<ExpExperiment, ExpRun> saveExperimentRun(AssayRunUploadContext<ProviderType> context, @Nullable Integer batchId)
             throws ExperimentException, ValidationException;
 
+    Pair<ExpExperiment, ExpRun> saveExperimentRun(AssayRunUploadContext<ProviderType> context, @Nullable Integer batchId, boolean forceAsync)
+            throws ExperimentException, ValidationException;
     /**
      * @return the batch to which the run has been assigned
      */

--- a/api/src/org/labkey/api/assay/AssayRunUploadContext.java
+++ b/api/src/org/labkey/api/assay/AssayRunUploadContext.java
@@ -144,6 +144,16 @@ public interface AssayRunUploadContext<ProviderType extends AssayProvider> exten
 
     void uploadComplete(ExpRun run) throws ExperimentException;
 
+    default String getJobDescription()
+    {
+        return null;
+    }
+
+    default String getJobNotificationProvider()
+    {
+        return null;
+    }
+
     @Nullable
     Logger getLogger();
 
@@ -184,6 +194,8 @@ public interface AssayRunUploadContext<ProviderType extends AssayProvider> exten
         protected List<Map<String, Object>> _rawData;
         protected Map<String, AssayPlateMetadataService.MetadataLayer> _rawPlateMetadata;
         protected Map<String, File> _uploadedData;
+        protected String _jobDescription;
+        protected String _jobNotificationProvider;
 
         public Factory(
                 @NotNull ExpProtocol protocol,
@@ -315,6 +327,18 @@ public interface AssayRunUploadContext<ProviderType extends AssayProvider> exten
         public FACTORY setRawPlateMetadata(Map<String, AssayPlateMetadataService.MetadataLayer> rawPlateMetadata)
         {
             _rawPlateMetadata = rawPlateMetadata;
+            return self();
+        }
+
+        public FACTORY setJobDescription(String jobDescription)
+        {
+            _jobDescription = jobDescription;
+            return self();
+        }
+
+        public FACTORY setJobNotificationProvider(String jobNotificationProvider)
+        {
+            _jobNotificationProvider = jobNotificationProvider;
             return self();
         }
 

--- a/api/src/org/labkey/api/assay/AssayRunUploadContextImpl.java
+++ b/api/src/org/labkey/api/assay/AssayRunUploadContextImpl.java
@@ -88,6 +88,10 @@ public class AssayRunUploadContextImpl<ProviderType extends AssayProvider> imple
     // Mutable fields
     private TransformResult _transformResult;
 
+    // async fields
+    protected String _jobDescription;
+    protected String _jobNotificationProvider;
+
     private AssayRunUploadContextImpl(Factory<ProviderType> factory)
     {
         _protocol = factory._protocol;
@@ -116,6 +120,9 @@ public class AssayRunUploadContextImpl<ProviderType extends AssayProvider> imple
 
         _reRunId = factory._reRunId;
         _targetStudy = factory._targetStudy;
+
+        _jobDescription = factory._jobDescription;
+        _jobNotificationProvider = factory._jobNotificationProvider;
     }
 
     public static class Factory<ProviderType extends AssayProvider> extends AssayRunUploadContext.Factory<ProviderType, Factory<ProviderType>>
@@ -387,6 +394,18 @@ public class AssayRunUploadContextImpl<ProviderType extends AssayProvider> imple
     public void uploadComplete(ExpRun run)
     {
         // no-op
+    }
+
+    @Override
+    public String getJobDescription()
+    {
+        return _jobDescription;
+    }
+
+    @Override
+    public String getJobNotificationProvider()
+    {
+        return _jobNotificationProvider;
     }
 
     @Override

--- a/api/src/org/labkey/api/assay/pipeline/AssayRunAsyncContext.java
+++ b/api/src/org/labkey/api/assay/pipeline/AssayRunAsyncContext.java
@@ -84,6 +84,10 @@ public class AssayRunAsyncContext<ProviderType extends AssayProvider> implements
     private transient TransformResult _transformResult;
     private transient Logger _logger;
 
+    // async fields
+    protected String _jobDescription;
+    protected String _jobNotificationProvider;
+
     // For serialization
     protected AssayRunAsyncContext()
     {}
@@ -112,6 +116,9 @@ public class AssayRunAsyncContext<ProviderType extends AssayProvider> implements
         _batchPropertiesById = convertPropertiesToIds(_batchProperties);
         _runProperties = originalContext.getRunProperties();
         _runPropertiesById = convertPropertiesToIds(_runProperties);
+
+        _jobDescription = originalContext.getJobDescription();
+        _jobNotificationProvider = originalContext.getJobNotificationProvider();
     }
 
     /** Convert to a map that can be serialized - DomainProperty can't be */
@@ -382,4 +389,17 @@ public class AssayRunAsyncContext<ProviderType extends AssayProvider> implements
     {
         _logger = logger;
     }
+
+    @Override
+    public String getJobDescription()
+    {
+        return _jobDescription;
+    }
+
+    @Override
+    public String getJobNotificationProvider()
+    {
+        return _jobNotificationProvider;
+    }
+
 }

--- a/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
+++ b/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
@@ -97,6 +97,9 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
         String runFilePath;
         String moduleName;
         List<Map<String, Object>> rawData = null;
+        String jobDescription;
+        String jobNotificationProvider;
+        boolean forceAsync;
 
         // TODO: support additional input/output data/materials
         Map<Object, String> inputData = new HashMap<>();
@@ -122,6 +125,10 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
             batchId = json.optInt(AssayJSONConverter.BATCH_ID);
             name = json.optString(ExperimentJSONConverter.NAME, null);
             comments = json.optString(ExperimentJSONConverter.COMMENT, null);
+            forceAsync = json.optBoolean("forceAsync");
+            jobDescription = json.optString("jobDescription", null);
+            jobNotificationProvider = json.optString("jobNotificationProvider", null);
+
             runProperties = json.optJSONObject(ExperimentJSONConverter.PROPERTIES);
             if (runProperties != null)
                 runProperties = new CaseInsensitiveHashMap<>(runProperties);
@@ -157,6 +164,10 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
             JSONArray dataRows = form.getDataRows();
             if (dataRows != null)
                 rawData = dataRows.toMapList();
+
+            forceAsync = form.isForceAsync();
+            jobDescription = form.getJobDescription();
+            jobNotificationProvider = form.getJobNotificationProvider();
         }
 
         // Import the file at runFilePath if it is available, otherwise AssayRunUploadContextImpl.getUploadedData() will use the multi-part form POSTed file
@@ -206,7 +217,9 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
                 .setBatchProperties(batchProperties)
                 .setTargetStudy(targetStudy)
                 .setReRunId(reRunId)
-                .setLogger(LOG);
+                .setLogger(LOG)
+                .setJobDescription(jobDescription)
+                .setJobNotificationProvider(jobNotificationProvider);
 
         if (file != null && rawData != null)
             throw new ExperimentException("Either file or " + AssayJSONConverter.DATA_ROWS + " is allowed, but not both");
@@ -272,7 +285,7 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
 
         try
         {
-            Pair<ExpExperiment, ExpRun> result = provider.getRunCreator().saveExperimentRun(uploadContext, batchId);
+            Pair<ExpExperiment, ExpRun> result = provider.getRunCreator().saveExperimentRun(uploadContext, batchId, forceAsync);
             ExpRun run = result.second;
 
             ApiSimpleResponse resp = new ApiSimpleResponse();
@@ -320,6 +333,10 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
         private String _module;
         private boolean _saveDataAsFile;
         private JSONObject _plateMetadata;
+
+        private String _jobDescription;
+        private String _jobNotificationProvider;
+        private boolean _forceAsync;
 
         public JSONObject getJson()
         {
@@ -460,6 +477,37 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
         {
             _saveDataAsFile = saveDataAsFile;
         }
+
+        public String getJobDescription()
+        {
+            return _jobDescription;
+        }
+
+        public void setJobDescription(String jobDescription)
+        {
+            _jobDescription = jobDescription;
+        }
+
+        public String getJobNotificationProvider()
+        {
+            return _jobNotificationProvider;
+        }
+
+        public void setJobNotificationProvider(String jobNotificationProvider)
+        {
+            _jobNotificationProvider = jobNotificationProvider;
+        }
+
+        public boolean isForceAsync()
+        {
+            return _forceAsync;
+        }
+
+        public void setForceAsync(boolean forceAsync)
+        {
+            _forceAsync = forceAsync;
+        }
+
     }
 
 }


### PR DESCRIPTION
#### Rationale
We had previously enabled async import for samples and sources for LKSM. Assay already support async import in LKS, which is controlled by "run in background" property at assay level. To be consistent with samples and sources, whose import mechanism is determined based on file/data size, we will add a "forceAsync" param for ImportRunApi, so that assays not flagged as "run in background" can also run in async mode. Additionally, we will add hooks to assay import so that appropriate notifications can be sent to LKSM users about the job. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1854
* https://github.com/LabKey/labkey-api-js/pull/84
* https://github.com/LabKey/labkey-ui-components/pull/427
* https://github.com/LabKey/sampleManagement/pull/448
* https://github.com/LabKey/biologics/pull/763

#### Changes
* add "forceAsync" param for ImportRunApi
* allow customized "Description" for assay import
* wire up notification provider for assay import
