### PR TITLE
42077: Creating a folder from a template with Sample Types generates error

### DIFF
--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -98,7 +98,10 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
             {
                 if (xarFile != null)
                 {
-                    File logFile = CompressedInputStreamXarSource.getLogFileFor(xarFile);
+                    File logFile = null;
+                    // we don't need the log file in cases where the xarFile is a virtual file and not in the file system
+                    if (xarFile.exists())
+                        logFile = CompressedInputStreamXarSource.getLogFileFor(xarFile);
 
                     if (job == null)
                     {


### PR DESCRIPTION
#### Rationale
Folder writers/importers that support importing from a folder template cannot assume that the imported archive exists in the file system. For this and other pathways such as copy to study we employ an in-memory virtual file for efficiency. We needed to be a little more defensive when processing the xarFile during sample type and data class import.

related issue:
- https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42077