### PR TITLE
Fix path for RecompilingJspClassLoader

### DIFF
--- a/api/src/org/labkey/api/jsp/RecompilingJspClassLoader.java
+++ b/api/src/org/labkey/api/jsp/RecompilingJspClassLoader.java
@@ -111,7 +111,7 @@ public class RecompilingJspClassLoader extends JspClassLoader
                     _log.info("Recompiling " + relativePath);
 
                     // Copy .jsp file from source to build staging directory
-                    File stagingJsp = new File(jspJavaFileBuildDirectory.getParent() + "/webapp", relativePath);
+                    File stagingJsp = new File(jspJavaFileBuildDirectory.getParentFile().getParent()  + "/jspWebappDir/webapp", relativePath);
                     if (!stagingJsp.getParentFile().exists())
                         stagingJsp.getParentFile().mkdirs();
                     FileUtil.copyFile(sourceFile, stagingJsp);
@@ -143,7 +143,7 @@ public class RecompilingJspClassLoader extends JspClassLoader
                             return super.newTldScanner(context, namespaceAware, validate, blockExternal);
                         }
                     };
-                    jasper.setUriroot(jspJavaFileBuildDirectory.getParent() + "/webapp");
+                    jasper.setUriroot(jspJavaFileBuildDirectory.getParentFile().getParent() + "/jspWebappDir/webapp/");
                     jasper.setOutputDir(jspJavaFileBuildDirectory.getAbsolutePath());
                     jasper.setPackage("org.labkey.jsp.compiled");
                     jasper.setCompilerTargetVM("13");


### PR DESCRIPTION
#### Rationale
Porting the change from PR #1744 to 20.11

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1744

#### Changes
* Use jspWebappDir instead of jspTempDir as input to compilation task
