### PR TITLE
Use ActionURLs instead of Strings

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -2392,7 +2392,7 @@ public class AnnouncementsController extends SpringActionController
                         // Build up a link to unsubscribe from the thread
                         ActionURL url = new ActionURL(SubscribeThreadAction.class, c);
                         url.addParameter("threadId", ann.getParent() == null ? ann.getEntityId() : ann.getParent());
-                        url.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().toString());
+                        url.addReturnURL(getViewContext().getActionURL());
                         url.addParameter("unsubscribe", true);
                         buttons.addChild("unsubscribe", url).usePost();
                     }
@@ -2431,7 +2431,7 @@ public class AnnouncementsController extends SpringActionController
                             subscribeTree.addChild("forum", getEmailPreferencesURL(c, getViewContext().getActionURL(), ann.lookupSrcIdentifer()));
                             ActionURL subscribeThreadURL = new ActionURL(SubscribeThreadAction.class, c);
                             subscribeThreadURL.addParameter("threadId", ann.getParent() == null ? ann.getEntityId() : ann.getParent());
-                            subscribeThreadURL.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().toString());
+                            subscribeThreadURL.addReturnURL(getViewContext().getActionURL());
                             subscribeTree.addChild("thread", subscribeThreadURL).usePost();
                             buttons.addChild(subscribeTree);
                         }

--- a/api/src/org/labkey/api/assay/query/RunListQueryView.java
+++ b/api/src/org/labkey/api/assay/query/RunListQueryView.java
@@ -143,8 +143,8 @@ public class RunListQueryView extends ExperimentRunListView
             if (getContainer().hasPermission(getUser(), QCAnalystPermission.class))
             {
                 ActionURL updateAction = PageFlowUtil.urlProvider(AssayUrls.class).getUpdateQCStateURL(getContainer(), schema.getProtocol())
-                        .addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().getLocalURIString());
-                NavTree updateItem = button.addMenuItem("Update state of selected rows", "#", "if (verifySelected(" + DataRegion.getJavaScriptObjectReference(getDataRegionName()) + ".form, \"" +
+                        .addReturnURL(getViewContext().getActionURL());
+                NavTree updateItem = button.addMenuItem("Update state of selected rows", "if (verifySelected(" + DataRegion.getJavaScriptObjectReference(getDataRegionName()) + ".form, \"" +
                         updateAction.getLocalURIString() + "\", \"post\", \"rows\")) " + DataRegion.getJavaScriptObjectReference(getDataRegionName()) + ".form.submit()");
                 updateItem.setId("QCState:updateSelected");
                 addButton = true;
@@ -154,7 +154,7 @@ public class RunListQueryView extends ExperimentRunListView
             if (protocolContainer.hasPermission(getUser(), AdminPermission.class))
             {
                 button.addMenuItem("Manage states", PageFlowUtil.urlProvider(CoreUrls.class).getManageQCStatesURL(protocolContainer)
-                        .addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().getLocalURIString()));
+                        .addReturnURL(getViewContext().getActionURL()));
                 addButton = true;
             }
 

--- a/api/src/org/labkey/api/data/MenuButton.java
+++ b/api/src/org/labkey/api/data/MenuButton.java
@@ -18,6 +18,7 @@ package org.labkey.api.data;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.PopupMenu;
@@ -69,20 +70,15 @@ public class MenuButton extends ActionButton
 
     public NavTree addMenuItem(String caption, ActionURL url)
     {
-        return addMenuItem(caption, url.toString());
+        return addMenuItem(caption, url, null, false);
     }
 
-    public NavTree addMenuItem(String caption, String url)
+    public NavTree addMenuItem(String caption, String onClickScript)
     {
-        return addMenuItem(caption, url, null);
+        return addMenuItem(caption, null, onClickScript, false);
     }
 
-    public NavTree addMenuItem(String caption, String url, String onClickScript)
-    {
-        return addMenuItem(caption, url, onClickScript, false);
-    }
-
-    public NavTree addMenuItem(String caption, String url, @Nullable String onClickScript, boolean checked)
+    public NavTree addMenuItem(String caption, URLHelper url, @Nullable String onClickScript, boolean checked)
     {
         return addMenuItem(caption, url, onClickScript, checked, false);
     }
@@ -92,7 +88,7 @@ public class MenuButton extends ActionButton
         return addMenuItem(caption, null, null, checked, disabled);
     }
 
-    protected NavTree addMenuItem(String caption, String url, @Nullable String onClickScript, boolean checked, boolean disabled)
+    private NavTree addMenuItem(String caption, URLHelper url, @Nullable String onClickScript, boolean checked, boolean disabled)
     {
         NavTree menuItem = new NavTree(caption, url);
         menuItem.setScript(onClickScript);

--- a/api/src/org/labkey/api/exp/ExperimentRunListView.java
+++ b/api/src/org/labkey/api/exp/ExperimentRunListView.java
@@ -187,7 +187,7 @@ public class ExperimentRunListView extends QueryView
             String javascript = view.getDataRegion().getJavascriptFormReference() + ".method = \"POST\";\n " +
                     view.getDataRegion().getJavascriptFormReference() + ".action = " + PageFlowUtil.jsString(url + "&noPost=true") + ";\n " +
                     view.getDataRegion().getJavascriptFormReference() + ".submit();";
-            addToExperimentButton.addMenuItem("Create new run group...", null, javascript);
+            addToExperimentButton.addMenuItem("Create new run group...", javascript);
 
             List<? extends ExpExperiment> experiments = ExperimentService.get().getExperiments(c, getViewContext().getUser(), true, false);
             if (experiments.size() > 0)
@@ -198,7 +198,7 @@ public class ExperimentRunListView extends QueryView
             for (ExpExperiment exp : experiments)
             {
                 ActionURL addRunUrl = PageFlowUtil.urlProvider(ExperimentUrls.class).getAddRunsToExperimentURL(getContainer(), exp);
-                addToExperimentButton.addMenuItem(exp.getName(), null, "if (verifySelected(" + view.getDataRegion().getJavascriptFormReference() + ", \"" + addRunUrl.getLocalURIString() + "\", \"post\", \"run\")) { " + view.getDataRegion().getJavascriptFormReference() + ".submit(); }");
+                addToExperimentButton.addMenuItem(exp.getName(), "if (verifySelected(" + view.getDataRegion().getJavascriptFormReference() + ", \"" + addRunUrl.getLocalURIString() + "\", \"post\", \"run\")) { " + view.getDataRegion().getJavascriptFormReference() + ".submit(); }");
             }
             bar.add(addToExperimentButton);
         }

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -425,7 +425,7 @@ public class QueryView extends WebPartView<Object>
                 for (QueryDefinition query : getSchema().getTablesAndQueries(true))
                 {
                     String name = query.getName();
-                    NavTree item = new NavTree(name, target.clone().replaceParameter(param(QueryParam.queryName), name).getLocalURIString());
+                    NavTree item = new NavTree(name, target.clone().replaceParameter(param(QueryParam.queryName), name));
                     item.setId(getDataRegionName() + ":" + label + ":" + name);
                     // Intentionally don't set the description so we can avoid having to instantiate all of the TableInfos,
                     // which can be expensive for some schemas
@@ -1492,7 +1492,7 @@ public class QueryView extends WebPartView<Object>
             {
                 if (viewItemFilter.accept(designer.getReportType(), designer.getLabel()))
                 {
-                    NavTree item = new NavTree("Create " + designer.getLabel(), designer.getDesignerURL().getLocalURIString());
+                    NavTree item = new NavTree("Create " + designer.getLabel(), designer.getDesignerURL());
                     item.setId(getBaseMenuId() + ":Reports:Create:" + designer.getLabel());
                     item.setImageSrc(designer.getIconURL());
                     item.setImageCls(designer.getIconCls());
@@ -1534,7 +1534,7 @@ public class QueryView extends WebPartView<Object>
 
             for (ReportService.DesignerInfo designer : reportDesigners)
             {
-                NavTree item = new NavTree("Create " + designer.getLabel(), designer.getDesignerURL().getLocalURIString());
+                NavTree item = new NavTree("Create " + designer.getLabel(), designer.getDesignerURL());
                 item.setId(getBaseMenuId() + ":Charts:Create" + designer.getLabel());
                 item.setImageSrc(designer.getIconURL());
                 item.setImageCls(designer.getIconCls());
@@ -1664,12 +1664,12 @@ public class QueryView extends WebPartView<Object>
             if (ignoreUserFilter())
             {
                 url.deleteParameter(param(QueryParam.ignoreFilter));
-                item = new NavTree(label, url.toString());
+                item = new NavTree(label, url);
             }
             else
             {
                 url.replaceParameter(param(QueryParam.ignoreFilter), "1");
-                item = new NavTree(label, url.toString());
+                item = new NavTree(label, url);
                 item.setSelected(true);
             }
             item.setScript("LABKEY.DataRegions['" + getDataRegionName() + "'].clearSelected({quiet: true});");
@@ -1766,7 +1766,7 @@ public class QueryView extends WebPartView<Object>
             {
                 String label = Objects.toString(view.getLabel(), "default");
 
-                item = new NavTree(label, (String) null);
+                item = new NavTree(label, (ActionURL) null);
                 item.setScript(getChangeViewScript(""));
                 item.setId(getBaseMenuId() + ":GridViews:default");
                 if ("".equals(currentView))
@@ -1776,7 +1776,7 @@ public class QueryView extends WebPartView<Object>
             {
                 String label = view.getLabel();
 
-                item = new NavTree(label, (String) null);
+                item = new NavTree(label, (ActionURL) null);
                 item.setScript(getChangeViewScript(name));
                 item.setId(getBaseMenuId() + ":GridViews:grid-" + PageFlowUtil.filter(name));
                 if (name.equals(currentView))
@@ -1882,7 +1882,7 @@ public class QueryView extends WebPartView<Object>
             for (Report report : reports)
             {
                 String reportId = report.getDescriptor().getReportId().toString();
-                NavTree item = new NavTree(report.getDescriptor().getReportName(), (String) null);
+                NavTree item = new NavTree(report.getDescriptor().getReportName(), (ActionURL) null);
                 item.setId(getBaseMenuId() + ":Reports:" + PageFlowUtil.filter(report.getDescriptor().getReportName()));
                 if (report.getDescriptor().getReportId().equals(getSettings().getReportId()))
                     item.setStrong(true);
@@ -1940,7 +1940,7 @@ public class QueryView extends WebPartView<Object>
             for (Report chart : charts)
             {
                 String chartId = chart.getDescriptor().getReportId().toString();
-                NavTree item = new NavTree(chart.getDescriptor().getReportName(), (String) null);
+                NavTree item = new NavTree(chart.getDescriptor().getReportName(), (ActionURL) null);
                 item.setImageSrc(ReportUtil.getIconUrl(getContainer(), chart));
                 item.setImageCls(ReportUtil.getIconCls(chart));
                 item.setScript(getChangeReportScript(chartId));

--- a/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
@@ -96,8 +96,7 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
         final VBox view = new VBox();
 
         // todo: pass inputParameters down from upper layers like we do for
-        // executeScript API below.  Currently they are still taken off the
-        // URL under the covers
+        // executeScript API below. Currently they are still taken off the URL under the covers
         renderReport(context, null, new Renderer<HttpView>()
         {
             @Override

--- a/api/src/org/labkey/api/view/NavTree.java
+++ b/api/src/org/labkey/api/view/NavTree.java
@@ -81,7 +81,7 @@ public class NavTree implements Collapsible
     }
 
 
-    public NavTree(String text, String href, boolean collapsed)
+    private NavTree(String text, String href, boolean collapsed)
     {
         _text = text;
         _href = href;

--- a/api/src/org/labkey/api/view/Portal.java
+++ b/api/src/org/labkey/api/view/Portal.java
@@ -1499,9 +1499,9 @@ public class Portal implements ModuleChangeListener
         return null;
     }
 
-    public static String getCustomizeURL(ViewContext context, Portal.WebPart webPart)
+    public static ActionURL getCustomizeURL(ViewContext context, Portal.WebPart webPart)
     {
-        return urlProvider().getCustomizeWebPartURL(context.getContainer(), webPart, context.getActionURL()).getLocalURIString();
+        return urlProvider().getCustomizeWebPartURL(context.getContainer(), webPart, context.getActionURL());
     }
 
 

--- a/api/src/org/labkey/api/view/TabStripView.java
+++ b/api/src/org/labkey/api/view/TabStripView.java
@@ -124,7 +124,7 @@ public abstract class TabStripView extends JspView<TabStripView>
     {
         public TabInfo(String name, String id, URLHelper url)
         {
-            super(name, url.clone().replaceParameter(TAB_PARAM, id).getLocalURIString());
+            super(name, url.clone().replaceParameter(TAB_PARAM, id));
             setId(id);
         }
     }

--- a/assay/api-src/org/labkey/api/assay/dilution/query/DilutionResultsQueryView.java
+++ b/assay/api-src/org/labkey/api/assay/dilution/query/DilutionResultsQueryView.java
@@ -113,7 +113,7 @@ public abstract class DilutionResultsQueryView extends ResultsQueryView
         rgn.addHiddenFormField("captionColumn", "");
         rgn.addHiddenFormField("chartTitle", "");
 
-        graphSelectedButton.addMenuItem("Default Graph", "#",
+        graphSelectedButton.addMenuItem("Default Graph",
                 "document.forms[" + PageFlowUtil.jsString(rgn.getFormId()) + "].action = '" + graphSelectedURL.getLocalURIString() + "';\n" +
                 "document.forms[" + PageFlowUtil.jsString(rgn.getFormId()) + "].method = 'POST';\n" +
                 "document.forms[" + PageFlowUtil.jsString(rgn.getFormId()) + "].submit(); return false;");

--- a/assay/src/org/labkey/assay/AssayListPortalView.java
+++ b/assay/src/org/labkey/assay/AssayListPortalView.java
@@ -47,7 +47,7 @@ public class AssayListPortalView extends AssayListQueryView
         if (getContainer().hasPermission(getUser(), DesignAssayPermission.class))
         {
             ActionURL insertURL = PageFlowUtil.urlProvider(AssayUrls.class).getChooseAssayTypeURL(view.getViewContext().getContainer());
-            insertURL.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().getLocalURIString());
+            insertURL.addReturnURL(getViewContext().getActionURL());
             bar.add(new ActionButton("New Assay Design", insertURL));
         }
         bar.add(new ActionButton("Manage Assays", PageFlowUtil.urlProvider(AssayUrls.class).getBeginURL(getContainer())));

--- a/assay/src/org/labkey/assay/AssayListQueryView.java
+++ b/assay/src/org/labkey/assay/AssayListQueryView.java
@@ -59,7 +59,7 @@ public class AssayListQueryView extends QueryView
         if (getContainer().hasPermission(getUser(), DesignAssayPermission.class))
         {
             ActionURL insertURL = PageFlowUtil.urlProvider(AssayUrls.class).getChooseAssayTypeURL(view.getViewContext().getContainer());
-            insertURL.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().getLocalURIString());
+            insertURL.addReturnURL(getViewContext().getActionURL());
             ActionButton insert = new ActionButton("New Assay Design", insertURL);
             insert.setActionType(ActionButton.Action.LINK);
             insert.setDisplayPermission(DesignAssayPermission.class);
@@ -89,7 +89,7 @@ public class AssayListQueryView extends QueryView
         if (getContainer().hasPermission(getUser(), DesignAssayPermission.class))
         {
             ActionURL plateURL = PageFlowUtil.urlProvider(PlateUrls.class).getPlateTemplateListURL(getContainer());
-            plateURL.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().getLocalURIString());
+            plateURL.addReturnURL(getViewContext().getActionURL());
             ActionButton insert = new ActionButton("Configure Plate Templates", plateURL);
             insert.setActionType(ActionButton.Action.LINK);
             insert.setDisplayPermission(DesignAssayPermission.class);

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -411,7 +411,7 @@ public class AssayManager implements AssayService
             if (context.getContainer().hasPermission(context.getUser(), DesignAssayPermission.class))
             {
                 ActionURL insertURL = PageFlowUtil.urlProvider(AssayUrls.class).getChooseAssayTypeURL(context.getContainer());
-                insertURL.addParameter(ActionURL.Param.returnUrl, context.getActionURL().getLocalURIString());
+                insertURL.addReturnURL(context.getActionURL());
                 menu.addChild("New Assay Design", insertURL);
             }
             menu.addChild("Manage Assays", PageFlowUtil.urlProvider(AssayUrls.class).getBeginURL(context.getContainer()));
@@ -906,7 +906,7 @@ public class AssayManager implements AssayService
     private ActionURL getAssayDataImportURL(ViewContext context)
     {
         ActionURL importURL = new ActionURL("assay", "assayDataImport", context.getContainer());
-        importURL.addParameter(ActionURL.Param.returnUrl, context.getActionURL().getLocalURIString());
+        importURL.addReturnURL(context.getActionURL());
         return importURL;
     }
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -545,7 +545,7 @@ public class AdminController extends SpringActionController
             }
             if (returnURL != null)
             {
-                url.addParameter(ActionURL.Param.returnUrl, returnURL.toString());
+                url.addReturnURL(returnURL);
             }
             return url;
         }
@@ -560,7 +560,7 @@ public class AdminController extends SpringActionController
         {
             ActionURL url = new ActionURL(MaintenanceAction.class, ContainerManager.getRoot());
             if (returnURL != null)
-                url.addParameter(ActionURL.Param.returnUrl, returnURL.toString());
+                url.addReturnURL(returnURL);
             return url;
         }
 
@@ -606,7 +606,7 @@ public class AdminController extends SpringActionController
             ActionURL result = new ActionURL(CreateFolderAction.class, c);
             if (returnURL != null)
             {
-                result.addParameter(ActionURL.Param.returnUrl, returnURL.toString());
+                result.addReturnURL(returnURL);
             }
             return result;
         }
@@ -5616,7 +5616,7 @@ public class AdminController extends SpringActionController
                         MenuButton adminButton = new MenuButton("Update user settings");
                         adminButton.setRequiresSelection(true);
                         for (ConfigTypeProvider provider : MessageConfigService.get().getConfigTypes())
-                            adminButton.addMenuItem("For " + provider.getName().toLowerCase(), null, "userSettings_"+provider.getName()+"(LABKEY.DataRegions.Users.getSelectionCount())" );
+                            adminButton.addMenuItem("For " + provider.getName().toLowerCase(), "userSettings_"+provider.getName()+"(LABKEY.DataRegions.Users.getSelectionCount())" );
 
                         bar.add(adminButton);
                         super.populateButtonBar(dataView, bar);

--- a/core/src/org/labkey/core/project/folderNav.jsp
+++ b/core/src/org/labkey/core/project/folderNav.jsp
@@ -63,10 +63,10 @@
     ActionURL startURL = c.getStartURL(getUser()); // 30975: Return to startURL due to async view context
 
     ActionURL createProjectURL = urlProvider(AdminUrls.class).getCreateProjectURL(null);
-    createProjectURL.addParameter(ActionURL.Param.returnUrl, startURL.toString());
+    createProjectURL.addReturnURL(startURL);
 
     ActionURL createFolderURL = urlProvider(AdminUrls.class).getCreateFolderURL(c, null);
-    createFolderURL.addParameter(ActionURL.Param.returnUrl, startURL.toString());
+    createFolderURL.addReturnURL(startURL);
 
     ActionURL folderManagementURL = urlProvider(AdminUrls.class).getManageFoldersURL(c);
     if (size > 1) { // Only show the nav trail if subfolders exist

--- a/experiment/src/org/labkey/experiment/DataClassWebPart.java
+++ b/experiment/src/org/labkey/experiment/DataClassWebPart.java
@@ -119,7 +119,7 @@ public class DataClassWebPart extends QueryView
         super.populateButtonBar(view, bar);
 
         ActionURL deleteURL = new ActionURL(ExperimentController.DeleteDataClassAction.class, getContainer());
-        deleteURL.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().toString());
+        deleteURL.addReturnURL(getViewContext().getActionURL());
 
         ActionButton deleteButton = new ActionButton(ExperimentController.DeleteDataClassAction.class, "Delete", ActionButton.Action.GET);
         deleteButton.setDisplayPermission(DesignDataClassPermission.class);
@@ -130,7 +130,7 @@ public class DataClassWebPart extends QueryView
         bar.add(deleteButton);
 
         ActionURL urlInsert = new ActionURL(ExperimentController.EditDataClassAction.class, getContainer());
-        urlInsert.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().toString());
+        urlInsert.addReturnURL(getViewContext().getActionURL());
         Set<String> templates = DomainTemplateGroup.getTemplatesForDomainKind(getContainer(), DataClassDomainKind.NAME);
         if (templates.size() > 0)
         {
@@ -141,7 +141,7 @@ public class DataClassWebPart extends QueryView
             insertItem.setId("NewDataClass:fromDesigner");
 
             ActionURL urlTemplate = new ActionURL(ExperimentController.CreateDataClassFromTemplateAction.class, getContainer());
-            urlTemplate.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().toString());
+            urlTemplate.addReturnURL(getViewContext().getActionURL());
             NavTree templateItem = createMenuButton.addMenuItem("Create from Template", urlTemplate);
             templateItem.setId("NewDataClass:fromTemplate");
 

--- a/experiment/src/org/labkey/experiment/SampleTypeWebPart.java
+++ b/experiment/src/org/labkey/experiment/SampleTypeWebPart.java
@@ -90,7 +90,7 @@ public class SampleTypeWebPart extends QueryView
         super.populateButtonBar(view, bar);
 
         ActionURL deleteURL = new ActionURL(ExperimentController.DeleteSampleTypesAction.class, getContainer());
-        deleteURL.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().toString());
+        deleteURL.addReturnURL(getViewContext().getActionURL());
 
         ActionButton deleteButton = new ActionButton(ExperimentController.DeleteSampleTypesAction.class, "Delete", ActionButton.Action.GET);
         deleteButton.setDisplayPermission(DesignSampleTypePermission.class);
@@ -101,7 +101,7 @@ public class SampleTypeWebPart extends QueryView
         bar.add(deleteButton);
 
         ActionURL urlInsert = new ActionURL(ExperimentController.EditSampleTypeAction.class, getContainer());
-        urlInsert.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().toString());
+        urlInsert.addReturnURL(getViewContext().getActionURL());
         ActionButton createNewButton = new ActionButton(urlInsert, "New Sample Type", ActionButton.Action.LINK);
         createNewButton.setDisplayPermission(DesignSampleTypePermission.class);
         createNewButton.setURL(urlInsert);

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -666,7 +666,7 @@ public class ExperimentController extends SpringActionController
                 {
                     ActionURL updateURL = new ActionURL(EditSampleTypeAction.class, _sampleType.getContainer());
                     updateURL.addParameter("RowId", _sampleType.getRowId());
-                    updateURL.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().toString());
+                    updateURL.addReturnURL(getViewContext().getActionURL());
                     ActionButton updateButton = new ActionButton(updateURL, "Edit Type", ActionButton.Action.LINK);
                     updateButton.setDisplayPermission(DesignSampleTypePermission.class);
                     updateButton.setPrimary(true);
@@ -674,7 +674,7 @@ public class ExperimentController extends SpringActionController
 
                     ActionURL deleteURL = new ActionURL(DeleteSampleTypesAction.class, _sampleType.getContainer());
                     deleteURL.addParameter("singleObjectRowId", _sampleType.getRowId());
-                    deleteURL.addParameter(ActionURL.Param.returnUrl, ExperimentUrlsImpl.get().getShowSampleTypeListURL(getContainer()).toString());
+                    deleteURL.addReturnURL(ExperimentUrlsImpl.get().getShowSampleTypeListURL(getContainer()));
                     ActionButton deleteButton = new ActionButton(deleteURL, "Delete Type", ActionButton.Action.LINK);
                     deleteButton.setDisplayPermission(DesignSampleTypePermission.class);
                     detailsView.getDataRegion().getButtonBar(DataRegion.MODE_DETAILS).add(deleteButton);
@@ -684,7 +684,7 @@ public class ExperimentController extends SpringActionController
                     ActionURL editURL = domainKind.urlEditDefinition(_sampleType.getDomain(), new ViewBackgroundInfo(_sampleType.getContainer(), getUser(), getViewContext().getActionURL()));
                     if (editURL != null)
                     {
-                        editURL.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().toString());
+                        editURL.addReturnURL(getViewContext().getActionURL());
                         ActionButton editTypeButton = new ActionButton(editURL, "Edit Fields");
                         editTypeButton.setDisplayPermission(UpdatePermission.class);
                         detailsView.getDataRegion().getButtonBar(DataRegion.MODE_DETAILS).add(editTypeButton);
@@ -701,7 +701,7 @@ public class ExperimentController extends SpringActionController
                     if (importURL != null)
                     {
                         importURL = importURL.clone();
-                        importURL.replaceParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().toString());
+                        importURL.addReturnURL(getViewContext().getActionURL());
                         ActionButton uploadButton = new ActionButton(importURL, "Import More Samples", ActionButton.Action.LINK);
                         uploadButton.setDisplayPermission(UpdatePermission.class);
                         detailsView.getDataRegion().getButtonBar(DataRegion.MODE_DETAILS).add(uploadButton);
@@ -988,7 +988,7 @@ public class ExperimentController extends SpringActionController
             {
                 ActionURL updateURL = new ActionURL(EditDataClassAction.class, _dataClass.getContainer());
                 updateURL.addParameter("rowId", _dataClass.getRowId());
-                updateURL.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().toString());
+                updateURL.addReturnURL(getViewContext().getActionURL());
                 ActionButton updateButton = new ActionButton(updateURL, "Edit", ActionButton.Action.LINK);
                 updateButton.setDisplayPermission(DesignDataClassPermission.class);
                 updateButton.setPrimary(true);
@@ -996,7 +996,7 @@ public class ExperimentController extends SpringActionController
 
                 ActionURL deleteURL = new ActionURL(ExperimentController.DeleteDataClassAction.class, _dataClass.getContainer());
                 deleteURL.addParameter("singleObjectRowId", _dataClass.getRowId());
-                deleteURL.addParameter(ActionURL.Param.returnUrl, ExperimentUrlsImpl.get().getDataClassListURL(getContainer()).toString());
+                deleteURL.addReturnURL(ExperimentUrlsImpl.get().getDataClassListURL(getContainer()));
                 ActionButton deleteButton = new ActionButton(deleteURL, "Delete", ActionButton.Action.LINK);
                 deleteButton.setDisplayPermission(DesignDataClassPermission.class);
                 bb.add(deleteButton);
@@ -6085,7 +6085,7 @@ public class ExperimentController extends SpringActionController
         @Override
         public ActionURL getDeleteExperimentsURL(Container container, URLHelper returnURL)
         {
-            return new ActionURL(DeleteSelectedExperimentsAction.class, container).addParameter(ActionURL.Param.returnUrl, returnURL.getLocalURIString());
+            return new ActionURL(DeleteSelectedExperimentsAction.class, container).addReturnURL(returnURL);
         }
 
         @Override
@@ -6095,7 +6095,7 @@ public class ExperimentController extends SpringActionController
             result.addParameter("singleObjectRowId", protocol.getRowId());
             if (returnURL != null)
             {
-                result.addParameter(ActionURL.Param.returnUrl, returnURL.getLocalURIString());
+                result.addReturnURL(returnURL);
             }
             return result;
         }

--- a/list/src/org/labkey/list/model/ListDefinitionImpl.java
+++ b/list/src/org/labkey/list/model/ListDefinitionImpl.java
@@ -708,8 +708,8 @@ public class ListDefinitionImpl implements ListDefinition
 
         if (returnAndCancelUrl != null)
         {
-            url.addParameter(ActionURL.Param.cancelUrl, returnAndCancelUrl.getLocalURIString());
-            url.addParameter(ActionURL.Param.returnUrl, returnAndCancelUrl.getLocalURIString());
+            url.addCancelURL(returnAndCancelUrl);
+            url.addReturnURL(returnAndCancelUrl);
         }
 
         return url;

--- a/mothership/src/org/labkey/mothership/query/ExceptionStackTraceQueryView.java
+++ b/mothership/src/org/labkey/mothership/query/ExceptionStackTraceQueryView.java
@@ -56,14 +56,14 @@ public class ExceptionStackTraceQueryView extends QueryView
                 String script = "if (verifySelected("+form+", '" + url +
                         "', 'post', 'rows')) "+form+".submit();";
 
-                assignToButton.addMenuItem(user.getDisplayName(getSchema().getUser()), null, script);
+                assignToButton.addMenuItem(user.getDisplayName(getSchema().getUser()), script);
             }
             assignToButton.addSeparator();
             ActionURL ignoreURL = new ActionURL(MothershipController.BulkUpdateAction.class, getContainer());
             ignoreURL.addParameter("ignore", true);
             String ignoreScript = "if (verifySelected("+form+", '" + ignoreURL +
                     "', 'post', 'rows')) "+form+".submit();";
-            assignToButton.addMenuItem("Ignore", null, ignoreScript);
+            assignToButton.addMenuItem("Ignore", ignoreScript);
             bar.add(assignToButton);
         }
     }

--- a/pipeline/src/org/labkey/pipeline/PipelineController.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineController.java
@@ -176,7 +176,7 @@ public class PipelineController extends SpringActionController
     {
         ActionURL url = new ActionURL(SetupAction.class, c);
         if (returnURL != null)
-            url.addParameter(ActionURL.Param.returnUrl, returnURL.toString());
+            url.addReturnURL(returnURL);
         if (rootSet)
             url.addParameter(Params.rootset, "1");
         if (overrideRoot)
@@ -1723,7 +1723,7 @@ public class PipelineController extends SpringActionController
             ActionURL url = new ActionURL(BrowseAction.class, container);
 
             if (null != returnUrl)
-                url.addParameter(ActionURL.Param.returnUrl, returnUrl.toString());
+                url.addReturnURL(returnUrl);
 
             if (path != null)
                 url.addParameter(Params.path, path);
@@ -1797,7 +1797,7 @@ public class PipelineController extends SpringActionController
                 url.addParameter("pipelineTask", pipelineId);
 
             if (returnUrl != null)
-                url.addParameter(ActionURL.Param.returnUrl, returnUrl.toString());
+                url.addReturnURL(returnUrl);
 
             return url;
         }

--- a/pipeline/src/org/labkey/pipeline/status/PipelineQueryView.java
+++ b/pipeline/src/org/labkey/pipeline/status/PipelineQueryView.java
@@ -143,7 +143,7 @@ public class PipelineQueryView extends QueryView
         if (_buttonOption == PipelineService.PipelineButtonOption.Standard)
         {
             ActionURL retryURL = new ActionURL(StatusController.RetryStatusAction.class, getContainer());
-            retryURL.addParameter(ActionURL.Param.returnUrl, _returnURL.toString());
+            retryURL.addReturnURL(_returnURL);
 
             ActionButton retryStatus = new ActionButton(retryURL, "Retry");
             retryStatus.setRequiresSelection(true);
@@ -157,7 +157,7 @@ public class PipelineQueryView extends QueryView
             if (showDeleteButton())
             {
                 ActionURL deleteURL = new ActionURL(StatusController.DeleteStatusAction.class, getContainer());
-                deleteURL.addParameter(ActionURL.Param.returnUrl, _returnURL.toString());
+                deleteURL.addReturnURL(_returnURL);
                 ActionButton deleteStatus = new ActionButton(deleteURL, "Delete");
                 deleteStatus.setIconCls("trash");
                 deleteStatus.setRequiresSelection(true);
@@ -167,7 +167,7 @@ public class PipelineQueryView extends QueryView
             }
 
             ActionURL cancelURL = new ActionURL(StatusController.CancelStatusAction.class, getContainer());
-            cancelURL.addParameter(ActionURL.Param.returnUrl, _returnURL.toString());
+            cancelURL.addReturnURL(_returnURL);
             ActionButton cancelButton = new ActionButton(cancelURL, "Cancel");
             cancelButton.setRequiresSelection(true);
             cancelButton.setActionType(ActionButton.Action.POST);
@@ -188,7 +188,7 @@ public class PipelineQueryView extends QueryView
         if (_buttonOption == PipelineService.PipelineButtonOption.Standard)
         {
             ActionURL completeURL = new ActionURL(StatusController.CompleteStatusAction.class, getContainer());
-            completeURL.addParameter(ActionURL.Param.returnUrl, _returnURL.toString());
+            completeURL.addReturnURL(_returnURL);
             ActionButton completeStatus = new ActionButton(completeURL, "Complete");
             completeStatus.setRequiresSelection(true);
             completeStatus.setActionType(ActionButton.Action.POST);

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -3844,7 +3844,7 @@ public class StudyController extends BaseStudyController
             datasetURL.setAction(DatasetAction.class);
 
             String label = _def.getLabel() != null ? _def.getLabel() : "" + _def.getDatasetId();
-            root.addChild(new NavTree(label, datasetURL.getLocalURIString()));
+            root.addChild(new NavTree(label, datasetURL));
 
             root.addChild(new NavTree("View Preferences"));
         }
@@ -5709,7 +5709,7 @@ public class StudyController extends BaseStudyController
             if (_showCustomizeLink && c.hasPermissions(getViewContext().getUser(), permissions))
             {
                 ActionURL customizeURL = new ActionURL(CustomizeParticipantViewAction.class, c);
-                customizeURL.addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().getLocalURIString());
+                customizeURL.addReturnURL(getViewContext().getActionURL());
                 customizeURL.addParameter("participantId", _currentParticipantId);
                 customizeURL.addParameter(SharedFormParameters.QCState, _encodedQcState);
                 out.print("</td><td>");
@@ -6942,7 +6942,7 @@ public class StudyController extends BaseStudyController
                             ActionURL cancelURL = new ActionURL(CancelDefineDatasetAction.class, getContainer()).addParameter("expectationDataset", form.getExpectationDataset());
 
                             redirect = new ActionURL(EditTypeAction.class, getContainer()).addParameter(DatasetDefinition.DATASETKEY, form.getExpectationDataset());
-                            redirect.addParameter(ActionURL.Param.cancelUrl.name(), cancelURL.getLocalURIString());
+                            redirect.addCancelURL(cancelURL);
                             response.put("redirectUrl", redirect.getLocalURIString());
                         }
                         else

--- a/study/src/org/labkey/study/controllers/specimen/SpecimenController.java
+++ b/study/src/org/labkey/study/controllers/specimen/SpecimenController.java
@@ -990,8 +990,8 @@ public class SpecimenController extends BaseStudyController
                 MenuButton exportMenuButton = new MenuButton("Export");
                 ActionURL exportExcelURL = context.getActionURL().clone().addParameter("export", "excel");
                 ActionURL exportTextURL = context.getActionURL().clone().addParameter("export", "tsv");
-                exportMenuButton.addMenuItem("Export all to Excel (.xls)", exportExcelURL.getLocalURIString());
-                exportMenuButton.addMenuItem("Export all to text file (.tsv)", exportTextURL.getLocalURIString());
+                exportMenuButton.addMenuItem("Export all to Excel (.xls)", exportExcelURL);
+                exportMenuButton.addMenuItem("Export all to text file (.tsv)", exportTextURL);
                 buttons.add(exportMenuButton);
                 _specimenQueryView.setShowExportButtons(false);
                 _specimenQueryView.getSettings().setAllowChooseView(false);

--- a/study/src/org/labkey/study/controllers/specimen/SpecimenUtils.java
+++ b/study/src/org/labkey/study/controllers/specimen/SpecimenUtils.java
@@ -131,20 +131,9 @@ public class SpecimenUtils
         return getSpecimenQueryView(showVials, forExport, null, viewMode, cohortFilter);
     }
 
-    private String urlFor(Class<? extends Controller> action)
+    private ActionURL urlFor(Class<? extends Controller> action)
     {
-        return urlFor(action, null);
-    }
-
-    private String urlFor(Class<? extends Controller> action, Map<Enum, String> parameters)
-    {
-        ActionURL url = new ActionURL(action, getContainer());
-        if (parameters != null)
-        {
-            for (Map.Entry<Enum, String> entry : parameters.entrySet())
-                url.addParameter(entry.getKey(), entry.getValue());
-        }
-        return url.getLocalURIString();
+        return new ActionURL(action, getContainer());
     }
 
     public static boolean isCommentsMode(Container container, SpecimenQueryView.Mode selectedMode)
@@ -196,18 +185,16 @@ public class SpecimenUtils
                 if (getViewContext().getContainer().hasPermission(getViewContext().getUser(), RequestSpecimensPermission.class))
                 {
                     final String jsRegionObject = DataRegion.getJavaScriptObjectReference(gridView.getSettings().getDataRegionName());
-                    String createRequestURL = urlFor(SpecimenController.ShowCreateSampleRequestAction.class,
-                            Collections.singletonMap(SpecimenController.CreateSampleRequestForm.PARAMS.returnUrl,
-                                    getViewContext().getActionURL().getLocalURIString()));
+                    String createRequestURL = urlFor(SpecimenController.ShowCreateSampleRequestAction.class).addReturnURL(getViewContext().getActionURL()).toString();
 
-                    requestMenuButton.addMenuItem("Create New Request", null,
+                    requestMenuButton.addMenuItem("Create New Request",
                             "if (verifySelected(" + jsRegionObject + ".form, '" + createRequestURL +
                             "', 'post', 'rows')) " + jsRegionObject + ".form.submit();");
 
                     if (getViewContext().getContainer().hasPermission(getViewContext().getUser(), ManageRequestsPermission.class) ||
                             SpecimenManager.getInstance().isSpecimenShoppingCartEnabled(getViewContext().getContainer()))
                     {
-                        requestMenuButton.addMenuItem("Add To Existing Request", null,
+                        requestMenuButton.addMenuItem("Add To Existing Request",
                                 "if (verifySelected(" + jsRegionObject + ".form, '#', " +
                                 "'get', 'rows')) { " + jsRegionObject + ".getSelected({success: function (data) { showRequestWindow(data.selected, '" + (showVials ? SpecimenApiController.VialRequestForm.IdTypes.RowId
                                 : SpecimenApiController.VialRequestForm.IdTypes.SpecimenHash) + "');}})}");
@@ -231,14 +218,14 @@ public class SpecimenUtils
             {
                 MenuButton commentsMenuButton = new MenuButton("Comments" + (manualQCEnabled ? " and QC" : ""));
                 final String jsRegionObject = DataRegion.getJavaScriptObjectReference(gridView.getSettings().getDataRegionName());
-                String setCommentsURL = urlFor(SpecimenController.UpdateCommentsAction.class);
-                NavTree setItem = commentsMenuButton.addMenuItem("Set Vial Comment " + (manualQCEnabled ? "or QC State " : "") + "for Selected", "#",
+                String setCommentsURL = urlFor(SpecimenController.UpdateCommentsAction.class).toString();
+                NavTree setItem = commentsMenuButton.addMenuItem("Set Vial Comment " + (manualQCEnabled ? "or QC State " : "") + "for Selected",
                         "if (verifySelected(" + jsRegionObject + ".form, '" + setCommentsURL +
                         "', 'post', 'rows')) " + jsRegionObject + ".form.submit(); return false;");
                 setItem.setId("Comments:Set");
 
-                String clearCommentsURL = urlFor(SpecimenController.ClearCommentsAction.class);
-                NavTree clearItem = commentsMenuButton.addMenuItem("Clear Vial Comments for Selected", "#",
+                String clearCommentsURL = urlFor(SpecimenController.ClearCommentsAction.class).toString();
+                NavTree clearItem = commentsMenuButton.addMenuItem("Clear Vial Comments for Selected",
                         "if (verifySelected(" + jsRegionObject + ".form, '" + clearCommentsURL +
                         "', 'post', 'rows') && confirm('This will permanently clear comments for all selected vials. " +
                                 (manualQCEnabled ? "Quality control states will remain unchanged. " : "" )+ "Continue?')) " +

--- a/study/src/org/labkey/study/model/ParticipantGroupManager.java
+++ b/study/src/org/labkey/study/model/ParticipantGroupManager.java
@@ -282,7 +282,7 @@ public class ParticipantGroupManager
                     if (null != filter)
                     {
                         ActionURL enrolledURL = filter.addURLParameters(study, baseURL.clone(), dataRegionName);
-                        button.addMenuItem("Enrolled", enrolledURL.toString(), null, (selected.isEmpty() && filter.equals(cohortFilter)));
+                        button.addMenuItem("Enrolled", enrolledURL, null, (selected.isEmpty() && filter.equals(cohortFilter)));
                     }
                 }
 

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -509,7 +509,7 @@ public class DatasetQueryView extends StudyQueryView
 
         for (QCStateSet set : stateSets)
         {
-            NavTree setItem = new NavTree(set.getLabel(), getViewContext().cloneActionURL().replaceParameter(BaseStudyController.SharedFormParameters.QCState, set.getFormValue()).toString());
+            NavTree setItem = new NavTree(set.getLabel(), getViewContext().cloneActionURL().replaceParameter(BaseStudyController.SharedFormParameters.QCState, set.getFormValue()));
             setItem.setId("QCState:" + set.getLabel());
             if (set.equals(currentSet))
                 setItem.setSelected(true);
@@ -525,7 +525,7 @@ public class DatasetQueryView extends StudyQueryView
                 button.addSeparator();
             }
             ActionURL updateAction = new ActionURL(StudyController.UpdateQCStateAction.class, getContainer());
-            NavTree updateItem = button.addMenuItem("Update state of selected rows", "#", "if (verifySelected(" + DataRegion.getJavaScriptObjectReference(getDataRegionName()) + ".form, \"" +
+            NavTree updateItem = button.addMenuItem("Update state of selected rows", "if (verifySelected(" + DataRegion.getJavaScriptObjectReference(getDataRegionName()) + ".form, \"" +
                     updateAction.getLocalURIString() + "\", \"post\", \"rows\")) " + DataRegion.getJavaScriptObjectReference(getDataRegionName()) + ".form.submit()");
             updateItem.setId("QCState:updateSelected");
         }
@@ -535,7 +535,7 @@ public class DatasetQueryView extends StudyQueryView
             if (!addSeparator)
                 button.addSeparator();
             button.addMenuItem("Manage states", new ActionURL(StudyController.ManageQCStatesAction.class,
-                    getContainer()).addParameter(ActionURL.Param.returnUrl, getViewContext().getActionURL().getLocalURIString()));
+                    getContainer()).addReturnURL(getViewContext().getActionURL()));
         }
         return button;
     }

--- a/study/src/org/labkey/study/query/SpecimenQueryView.java
+++ b/study/src/org/labkey/study/query/SpecimenQueryView.java
@@ -212,7 +212,7 @@ public class SpecimenQueryView extends BaseStudyQueryView
     {
         Container container = null != containerId ? ContainerManager.getForId(containerId) : ctx.getContainer();
         ActionURL historyLink = new ActionURL(SpecimenController.SampleEventsAction.class, container);
-        historyLink.addParameter(ActionURL.Param.returnUrl, ctx.getActionURL().getLocalURIString());
+        historyLink.addReturnURL(ctx.getActionURL());
         return historyLink.toString() + "&id=";
     }
 

--- a/study/src/org/labkey/study/view/createQueryReport.jsp
+++ b/study/src/org/labkey/study/view/createQueryReport.jsp
@@ -101,7 +101,7 @@
 <input type="hidden" id="redirectToReport" name="redirectToReport" value="true">
 <input type="hidden" id="redirectToDataset" name="redirectToDataset" value="-1">
 <input type="hidden" id="showWithDataset" name="showWithDataset" value="0">
-<input type="hidden" name="<%=ActionURL.Param.returnUrl%>" value="<%=h(bean.getSrcURL().getLocalURIString())%>">
+<input type="hidden" name="<%=ActionURL.Param.returnUrl%>" value="<%=h(bean.getSrcURL())%>">
 <input type="hidden" id="viewName" name="<%=QueryParam.viewName%>" value="">
 <input type="hidden" name="dataRegionName" value="<%=h(DatasetQueryView.DATAREGION)%>">
 <table>

--- a/visualization/src/org/labkey/visualization/views/chartWizard.jsp
+++ b/visualization/src/org/labkey/visualization/views/chartWizard.jsp
@@ -160,7 +160,7 @@
             var renderTo = <%=q(renderId)%>,
                     reportId = <%=q(id != null ? id.toString() : null) %>,
                     canEdit = <%=canEdit%>,
-                    editUrl = <%=q(editUrl != null ? editUrl.toString() : null) %>;
+                    editUrl = <%=q(editUrl) %>;
 
             init(reportId, renderTo, canEdit, editUrl);
         });

--- a/wiki/src/org/labkey/wiki/WikiController.java
+++ b/wiki/src/org/labkey/wiki/WikiController.java
@@ -1373,7 +1373,7 @@ public class WikiController extends SpringActionController
         public final String createdBy;
         public final Date created;
         public final String versionLink;            //base url for different versions of this page
-        public final String compareLink;            //base url for comparing to another version
+        public final ActionURL compareLink;         //base url for comparing to another version
 
         private VersionBean(Wiki wiki, WikiVersion wikiVersion, BaseWikiPermissions perms)
         {
@@ -1391,7 +1391,7 @@ public class WikiController extends SpringActionController
             createdBy = UserManager.getDisplayName(wikiVersion.getCreatedBy(), getUser());
             created = wikiVersion.getCreated();
             versionLink = getVersionURL(wiki.getName()).toString();
-            compareLink = getCompareVersionsURL(wiki.getName()).toString();
+            compareLink = getCompareVersionsURL(wiki.getName());
         }
     }
 

--- a/wiki/src/org/labkey/wiki/model/BaseWikiView.java
+++ b/wiki/src/org/labkey/wiki/model/BaseWikiView.java
@@ -275,7 +275,7 @@ public abstract class BaseWikiView extends JspView<Object>
         {
             // The wiki might not have been set yet -- so there is no content
             if (null != customizeURL)
-                setCustomize(new NavTree("", customizeURL.toString()));
+                setCustomize(new NavTree("", customizeURL));
         }
 
         return menu;

--- a/wiki/src/org/labkey/wiki/view/wikiVersion.jsp
+++ b/wiki/src/org/labkey/wiki/view/wikiVersion.jsp
@@ -21,6 +21,7 @@
 <%@ page import="org.labkey.api.security.User" %>
 <%@ page import="org.labkey.api.security.UserManager" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
+<%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.wiki.WikiController.VersionBean" %>
@@ -89,7 +90,7 @@ else
         if (versions.length > 1)
         {
             MenuButton compare = new MenuButton("Compare With ...");
-            String baseCompareLink = bean.compareLink + "&version1=" + nCurVersion;
+            ActionURL baseCompareURL = bean.compareLink.addParameter("version1", nCurVersion);
 
             for (int i = versions.length - 1; i >= 0; i--)
             {
@@ -100,7 +101,7 @@ else
                 if (n != bean.wikiVersion.getVersion())
                 {
                     // Show the author who created the version if available, or skip if that user's been deleted
-                    compare.addMenuItem((n == nLatestVersion ? "Latest Version" : "Version " + n) + (author == null ? "" : " (" + author.getDisplayName(user) + ")"), baseCompareLink + "&version2=" + n);
+                    compare.addMenuItem((n == nLatestVersion ? "Latest Version" : "Version " + n) + (author == null ? "" : " (" + author.getDisplayName(user) + ")"), baseCompareURL.replaceParameter("version2", n));
                 }
             }
 


### PR DESCRIPTION
#### Rationale
Building URLs via String manipulation is inconvenient and unreliable. This PR converts some easy cases of String-based URL handling with `ActionURL`s.

#### Related Pull Requests
* See list below

#### Changes
* Switch all uses of `MenuButton.addMenuItem()` String URL variants to variants that take an ActionURL. Eliminate all String URL method variants.
* Switch `actionUrl.addParameter(ActionURL.Param.returnUrl, currentUrl.toString())` to `actionUrl.addReturnURL(currentUrl)`.
