### PR TITLE
Issue 41864: DataRegion column analytics updates to lazy load Ext4 and vis dependencies

### DIFF
--- a/api/src/org/labkey/api/view/PopupMenuView.java
+++ b/api/src/org/labkey/api/view/PopupMenuView.java
@@ -157,6 +157,8 @@ public class PopupMenuView extends HttpView<PopupMenu>
     protected static void renderTreeItem(NavTree item, String cls, Writer out) throws IOException
     {
         out.write("<li");
+        if (item.getId() != null)
+            out.write(" id=\"" + item.getId() + "\"");
         if (item.isDisabled())
             cls = cls != null ? cls + " disabled" : "disabled";
         if (cls != null)

--- a/api/src/org/labkey/api/view/PopupMenuView.java
+++ b/api/src/org/labkey/api/view/PopupMenuView.java
@@ -157,8 +157,6 @@ public class PopupMenuView extends HttpView<PopupMenu>
     protected static void renderTreeItem(NavTree item, String cls, Writer out) throws IOException
     {
         out.write("<li");
-        if (item.getId() != null)
-            out.write(" id=\"" + item.getId() + "\"");
         if (item.isDisabled())
             cls = cls != null ? cls + " disabled" : "disabled";
         if (cls != null)

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -2746,9 +2746,7 @@ if (!LABKEY.DataRegions) {
             var view = _getViewFromQueryDetails(queryDetails, viewName);
             if (view && _viewContainsColumn(view, colFieldKey)) {
                 _addAnalyticsProviderToView.call(this, view, colFieldKey, providerName, false);
-
-                var elementId = this.name + ':' + colFieldKey + ':analytics-' + providerName;
-                _updateAnalyticsProviderMenuItem(elementId, true);
+                _updateAnalyticsProviderMenuItem(this.name + ':' + colFieldKey, providerName, true);
             }
         }, null, this);
     };
@@ -2765,9 +2763,7 @@ if (!LABKEY.DataRegions) {
             var view = _getViewFromQueryDetails(queryDetails, viewName);
             if (view && _viewContainsColumn(view, colFieldKey)) {
                 _removeAnalyticsProviderFromView.call(this, view, colFieldKey, providerName, false);
-
-                var elementId = this.name + ':' + colFieldKey + ':analytics-' + providerName;
-                _updateAnalyticsProviderMenuItem(elementId, false);
+                _updateAnalyticsProviderMenuItem(this.name + ':' + colFieldKey, providerName, false);
             }
         }, null, this);
     };
@@ -2858,14 +2854,23 @@ if (!LABKEY.DataRegions) {
         }
     };
 
-    var _updateAnalyticsProviderMenuItem = function(elementId, disable) {
-        // element ids include colon which needs to be escaped in the jQuery id selector
-        var el = $('#' + elementId.replace(/:/g, '\\:'));
-        if (disable) {
-            el.addClass('disabled');
-        }
-        else {
-            el.removeClass('disabled');
+    /**
+     * Attempt to find a DataRegion analytics provider column menu item so that it can be either enabled to allow
+     * it to once again be selected after removal or disabled so that it can't be selected a second time.
+     * @param columnName the DataRegion column th element column-name attribute
+     * @param providerName the analytics provider name
+     * @param disable
+     * @private
+     */
+    var _updateAnalyticsProviderMenuItem = function(columnName, providerName, disable) {
+        var menuItemEl = $("th[column-name|='" + columnName + "']").find("a[onclick*='" + providerName + "']").parent();
+        if (menuItemEl) {
+            if (disable) {
+                menuItemEl.addClass('disabled');
+            }
+            else {
+                menuItemEl.removeClass('disabled');
+            }
         }
     };
 

--- a/query/src/org/labkey/query/analytics/SummaryStatisticsAnalyticsProvider.java
+++ b/query/src/org/labkey/query/analytics/SummaryStatisticsAnalyticsProvider.java
@@ -23,9 +23,6 @@ import org.labkey.api.query.QuerySettings;
 import org.labkey.api.stats.ColumnAnalyticsProvider;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
-import org.labkey.api.view.template.ClientDependency;
-
-import java.util.Set;
 
 public class SummaryStatisticsAnalyticsProvider extends ColumnAnalyticsProvider
 {
@@ -71,22 +68,16 @@ public class SummaryStatisticsAnalyticsProvider extends ColumnAnalyticsProvider
     public String getScript(RenderContext ctx, QuerySettings settings, ColumnInfo col)
     {
         // Consider: Base provider could wrap any getScript() result with addClientDependencies() set
-        return "LABKEY.requiresScript('query/ColumnSummaryStatistics',function(){LABKEY.ColumnSummaryStatistics.showDialogFromDataRegion(" +
+        return "LABKEY.ColumnSummaryStatistics.showDialogFromDataRegion(" +
             PageFlowUtil.jsString(ctx.getCurrentRegion().getName()) + "," +
             PageFlowUtil.jsString(col.getFieldKey().toString()) +
-        ");});";
+        ");";
     }
 
     @Override
     public boolean requiresPageReload()
     {
         return true;
-    }
-
-    @Override
-    public void addClientDependencies(Set<ClientDependency> dependencies)
-    {
-        dependencies.add(ClientDependency.fromPath("query/ColumnSummaryStatistics"));
     }
 
     @Override

--- a/query/src/org/labkey/query/analytics/SummaryStatisticsAnalyticsProvider.java
+++ b/query/src/org/labkey/query/analytics/SummaryStatisticsAnalyticsProvider.java
@@ -18,6 +18,7 @@ package org.labkey.query.analytics;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DataRegion;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.stats.ColumnAnalyticsProvider;
@@ -67,11 +68,8 @@ public class SummaryStatisticsAnalyticsProvider extends ColumnAnalyticsProvider
     @Override
     public String getScript(RenderContext ctx, QuerySettings settings, ColumnInfo col)
     {
-        // Consider: Base provider could wrap any getScript() result with addClientDependencies() set
-        return "LABKEY.ColumnSummaryStatistics.showDialogFromDataRegion(" +
-            PageFlowUtil.jsString(ctx.getCurrentRegion().getName()) + "," +
-            PageFlowUtil.jsString(col.getFieldKey().toString()) +
-        ");";
+        return DataRegion.getJavaScriptObjectReference(ctx.getCurrentRegion().getName())
+            + ".showColumnStatisticsDialog(" + PageFlowUtil.jsString(col.getFieldKey().toString()) + ");";
     }
 
     @Override

--- a/query/webapp/query/ColumnSummaryStatistics.js
+++ b/query/webapp/query/ColumnSummaryStatistics.js
@@ -4,44 +4,6 @@
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
 
-LABKEY.ColumnSummaryStatistics = new function () {
-    /**
-     * Used via SummaryStatisticsAnalyticsProvider to show a dialog of the applicable summary statistics for a column in the view.
-     * @param dataRegionName
-     * @param colFieldKey
-     */
-    var showDialogFromDataRegion = function(dataRegionName, colFieldKey) {
-        var region = LABKEY.DataRegions[dataRegionName];
-        if (region) {
-            var regionViewName = region.viewName || "",
-                column = region.getColumn(colFieldKey);
-
-            if (column) {
-                region.getColumnAnalyticsProviders(regionViewName, colFieldKey, function(colSummaryStats) {
-                    Ext4.create('LABKEY.ext4.ColumnSummaryStatisticsDialog', {
-                        queryConfig: region.getQueryConfig(),
-                        filterArray: LABKEY.Filter.getFiltersFromUrl(region.selectAllURL, 'query'), //Issue 26594
-                        containerPath: region.containerPath,
-                        column: column,
-                        initSelection: colSummaryStats,
-                        listeners: {
-                            applySelection: function(win, colSummaryStatsNames) {
-                                win.getEl().mask("Applying selection...");
-                                region.setColumnSummaryStatistics(regionViewName, colFieldKey, colSummaryStatsNames);
-                                win.close();
-                            }
-                        }
-                    }).show();
-                });
-            }
-        }
-    };
-
-    return {
-        showDialogFromDataRegion: showDialogFromDataRegion
-    };
-};
-
 Ext4.define('LABKEY.ext4.ColumnSummaryStatisticsDialog', {
     extend: 'Ext.window.Window',
 

--- a/visualization/resources/views/querySummary.view.xml
+++ b/visualization/resources/views/querySummary.view.xml
@@ -1,8 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Query Summary" frame="none">
     <dependencies>
         <dependency path="vis/vis"/>
-        <dependency path="vis/ColumnVisualizationAnalytics.js"/>
-        <dependency path="vis/ColumnVisualizationAnalytics.css"/>
+        <dependency path="vis/ColumnVisualizationAnalytics"/>
         <dependency path="query/ColumnSummaryStatistics"/>
     </dependencies>
 </view>

--- a/visualization/resources/web/vis/ColumnVisualizationAnalytics.js
+++ b/visualization/resources/web/vis/ColumnVisualizationAnalytics.js
@@ -20,34 +20,36 @@
          */
         var showMeasureFromDataRegion = function(dataRegionName, columnName, colFieldKey, analyticsProviderName)
         {
-            var region = LABKEY.DataRegions[dataRegionName];
-            if (region)
-            {
-                var plotDivId = _appendPlotDiv(region);
-
-                _queryColumnData(region, colFieldKey, function(data)
+            LABKEY.requiresVisualization(function() {
+                var region = LABKEY.DataRegions[dataRegionName];
+                if (region)
                 {
-                    var regionViewName = region.viewName || "",
-                        regionColumnNames = $.map(region.columns, function(c) { return c.name; }),
-                        dataColumnNames = $.map(data.columnModel, function(col) { return col.dataIndex; }),
-                        colIndex = regionColumnNames.indexOf(columnName);
+                    var plotDivId = _appendPlotDiv(region);
 
-                    if (dataColumnNames.indexOf(columnName) === -1)
+                    _queryColumnData(region, colFieldKey, function(data)
                     {
-                        console.warn('Could not find column "' + columnName + '" in "' + region.schemaName + '.' + region.queryName + '".');
-                        return;
-                    }
+                        var regionViewName = region.viewName || "",
+                            regionColumnNames = $.map(region.columns, function(c) { return c.name; }),
+                            dataColumnNames = $.map(data.columnModel, function(col) { return col.dataIndex; }),
+                            colIndex = regionColumnNames.indexOf(columnName);
 
-                    var plot = getColumnBoxPlot(plotDivId, data.rows, columnName, region.columns[colIndex], true);
-                    plot.render();
+                        if (dataColumnNames.indexOf(columnName) === -1)
+                        {
+                            console.warn('Could not find column "' + columnName + '" in "' + region.schemaName + '.' + region.queryName + '".');
+                            return;
+                        }
 
-                    _handleAnalyticsProvidersForCustomView(region, plotDivId, regionViewName, colFieldKey, analyticsProviderName);
-                });
-            }
-            else
-            {
-                console.warn('Could not find data region "' + dataRegionName + '" for LABKEY.ColumnVisualizationAnalytics.showMeasureFromDataRegion() call.');
-            }
+                        var plot = getColumnBoxPlot(plotDivId, data.rows, columnName, region.columns[colIndex], true);
+                        plot.render();
+
+                        _handleAnalyticsProvidersForCustomView(region, plotDivId, regionViewName, colFieldKey, analyticsProviderName);
+                    });
+                }
+                else
+                {
+                    console.warn('Could not find data region "' + dataRegionName + '" for LABKEY.ColumnVisualizationAnalytics.showMeasureFromDataRegion() call.');
+                }
+            });
         };
 
         /**
@@ -59,48 +61,50 @@
          */
         var showDimensionFromDataRegion = function(dataRegionName, columnName, colFieldKey, analyticsProviderName)
         {
-            var region = LABKEY.DataRegions[dataRegionName];
-            if (region)
-            {
-                var plotDivId = _appendPlotDiv(region);
-
-                _queryColumnData(region, colFieldKey, function (data)
+            LABKEY.requiresVisualization(function() {
+                var region = LABKEY.DataRegions[dataRegionName];
+                if (region)
                 {
-                    var regionViewName = region.viewName || "",
-                        regionColumnNames = $.map(region.columns, function(c) { return c.name; }),
-                        dataColumnNames = $.map(data.columnModel, function(col) { return col.dataIndex; }),
-                        colIndex = regionColumnNames.indexOf(columnName),
-                        plot;
+                    var plotDivId = _appendPlotDiv(region);
 
-                    if (dataColumnNames.indexOf(columnName) === -1)
+                    _queryColumnData(region, colFieldKey, function (data)
                     {
-                        console.warn('Could not find column "' + columnName + '" in "' + region.schemaName + '.' + region.queryName + '".');
-                        return;
-                    }
+                        var regionViewName = region.viewName || "",
+                            regionColumnNames = $.map(region.columns, function(c) { return c.name; }),
+                            dataColumnNames = $.map(data.columnModel, function(col) { return col.dataIndex; }),
+                            colIndex = regionColumnNames.indexOf(columnName),
+                            plot;
 
-                    if ($('#' + plotDivId).length === 0)
-                        return;
+                        if (dataColumnNames.indexOf(columnName) === -1)
+                        {
+                            console.warn('Could not find column "' + columnName + '" in "' + region.schemaName + '.' + region.queryName + '".');
+                            return;
+                        }
 
-                    if (analyticsProviderName === 'VIS_BAR')
-                    {
-                        plot = getColumnBarPlot(plotDivId, data.rows, columnName, region.columns[colIndex], true);
-                        plot.render();
-                    }
-                    else if (analyticsProviderName === 'VIS_PIE')
-                    {
-                        plot = getColumnPieChart(plotDivId, data.rows, columnName, region.columns[colIndex], true);
-                    }
+                        if ($('#' + plotDivId).length === 0)
+                            return;
 
-                    if (plot)
-                    {
-                        _handleAnalyticsProvidersForCustomView(region, plotDivId, regionViewName, colFieldKey, analyticsProviderName);
-                    }
-                });
-            }
-            else
-            {
-                console.warn('Could not find data region "' + dataRegionName + '" for LABKEY.ColumnVisualizationAnalytics.showDimensionFromDataRegion() call.');
-            }
+                        if (analyticsProviderName === 'VIS_BAR')
+                        {
+                            plot = getColumnBarPlot(plotDivId, data.rows, columnName, region.columns[colIndex], true);
+                            plot.render();
+                        }
+                        else if (analyticsProviderName === 'VIS_PIE')
+                        {
+                            plot = getColumnPieChart(plotDivId, data.rows, columnName, region.columns[colIndex], true);
+                        }
+
+                        if (plot)
+                        {
+                            _handleAnalyticsProvidersForCustomView(region, plotDivId, regionViewName, colFieldKey, analyticsProviderName);
+                        }
+                    });
+                }
+                else
+                {
+                    console.warn('Could not find data region "' + dataRegionName + '" for LABKEY.ColumnVisualizationAnalytics.showDimensionFromDataRegion() call.');
+                }
+            });
         };
 
         var getColumnBoxPlot = function(renderTo, dataArray, columnName, fieldMetadata, showMainLabel)

--- a/visualization/resources/web/vis/ColumnVisualizationAnalytics.lib.xml
+++ b/visualization/resources/web/vis/ColumnVisualizationAnalytics.lib.xml
@@ -1,0 +1,6 @@
+<libraries xmlns="http://labkey.org/clientLibrary/xml/">
+    <library compileInProductionMode="true">
+        <script path="vis/ColumnVisualizationAnalytics.css"/>
+        <script path="vis/ColumnVisualizationAnalytics.js"/>
+    </library>
+</libraries>

--- a/visualization/src/org/labkey/visualization/report/DimensionBarChartAnalyticsProvider.java
+++ b/visualization/src/org/labkey/visualization/report/DimensionBarChartAnalyticsProvider.java
@@ -89,9 +89,7 @@ public class DimensionBarChartAnalyticsProvider extends ColumnAnalyticsProvider
     @Override
     public void addClientDependencies(Set<ClientDependency> dependencies)
     {
-        dependencies.add(ClientDependency.fromPath("vis/vis"));
-        dependencies.add(ClientDependency.fromPath("vis/ColumnVisualizationAnalytics.js"));
-        dependencies.add(ClientDependency.fromPath("vis/ColumnVisualizationAnalytics.css"));
+        dependencies.add(ClientDependency.fromPath("vis/ColumnVisualizationAnalytics"));
     }
 
     @Override

--- a/visualization/src/org/labkey/visualization/report/DimensionPieChartAnalyticsProvider.java
+++ b/visualization/src/org/labkey/visualization/report/DimensionPieChartAnalyticsProvider.java
@@ -89,9 +89,7 @@ public class DimensionPieChartAnalyticsProvider extends ColumnAnalyticsProvider
     @Override
     public void addClientDependencies(Set<ClientDependency> dependencies)
     {
-        dependencies.add(ClientDependency.fromPath("vis/vis"));
-        dependencies.add(ClientDependency.fromPath("vis/ColumnVisualizationAnalytics.js"));
-        dependencies.add(ClientDependency.fromPath("vis/ColumnVisualizationAnalytics.css"));
+        dependencies.add(ClientDependency.fromPath("vis/ColumnVisualizationAnalytics"));
     }
 
     @Override

--- a/visualization/src/org/labkey/visualization/report/MeasureBoxPlotAnalyticsProvider.java
+++ b/visualization/src/org/labkey/visualization/report/MeasureBoxPlotAnalyticsProvider.java
@@ -90,9 +90,7 @@ public class MeasureBoxPlotAnalyticsProvider extends ColumnAnalyticsProvider
     @Override
     public void addClientDependencies(Set<ClientDependency> dependencies)
     {
-        dependencies.add(ClientDependency.fromPath("vis/vis"));
-        dependencies.add(ClientDependency.fromPath("vis/ColumnVisualizationAnalytics.js"));
-        dependencies.add(ClientDependency.fromPath("vis/ColumnVisualizationAnalytics.css"));
+        dependencies.add(ClientDependency.fromPath("vis/ColumnVisualizationAnalytics"));
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Issue [41864](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41864): Remove dataregion dependency on ExtJS (SummaryStatisticsAnalyticsProvider)

#### Changes
* moves LABKEY.ColumnSummaryStatistics.showDialogFromDataRegion from ColumnSummaryStatistics.js to DataRegion.js
* remove ColumnSummaryStatistics dependency and vis dependency from AnalyticsProvider classes
* fix DataRegion update to column header menu item disabled state on add/remove column visualization
* wrap ColumnVisualizationAnalytics.js functions in calls to LABKEY.requiresVisualization()
