### PR TITLE
Fix DefaultQueryUpdateService update rows

### DIFF
--- a/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
@@ -497,7 +497,7 @@ public class DefaultQueryUpdateService extends AbstractQueryUpdateService
             lsid = (String)oldRow.get(objectUriCol.getName());
 
         List<PropertyDescriptor> tableProperties = new ArrayList<>();
-        if (objectUriCol != null && domain != null && domain.getProperties().isEmpty())
+        if (objectUriCol != null && domain != null && !domain.getProperties().isEmpty())
         {
             // convert "Property name"->value map into PropertyURI->value map
             Map<String, Object> newValues = new HashMap<>();


### PR DESCRIPTION
#### Rationale
In https://github.com/LabKey/platform/pull/1847, specifically [here](https://github.com/LabKey/platform/pull/1847/commits/42bcf91f5c8ec0f255d78d9d45e8549101f72637#diff-77246b52f5b0f1f809bcd43d69426bc4ceedcd4571981119a0e8a5f54b59fa15R500), the logic for configuring the rows during update in `DefaultQueryUpdateService` was accidentally inverted. This fixes a variety of tests that are failing to update rows.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1847

#### Changes
* Flip logic back to what was intended
