### PR TITLE
Data region fix for "Delete All Rows" to load Ext4 library on click

### DIFF
--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -1020,7 +1020,9 @@ public class QueryView extends WebPartView<Object>
         ActionButton deleteAllRows = new ActionButton("Delete All Rows");
         deleteAllRows.setDisplayPermission(AdminPermission.class);
         deleteAllRows.setActionType(ActionButton.Action.SCRIPT);
-        deleteAllRows.setScript("Ext4.Msg.confirm('Confirm Deletion', 'Are you sure you wish to delete all rows in this " + tableNoun + "? This action cannot be undone and will result in an empty " + tableNoun + ".', function(button){" +
+        deleteAllRows.setScript(
+                "LABKEY.requiresExt4Sandbox(function() {" +
+                    "Ext4.Msg.confirm('Confirm Deletion', 'Are you sure you wish to delete all rows in this " + tableNoun + "? This action cannot be undone and will result in an empty " + tableNoun + ".', function(button){" +
                         "if (button == 'yes'){" +
                             "var waitMask = Ext4.Msg.wait('Deleting Rows...', 'Delete Rows'); " +
                             "Ext4.Ajax.request({ " +
@@ -1053,7 +1055,8 @@ public class QueryView extends WebPartView<Object>
                                 "scope : this " +
                             "});" +
                         "}" +
-                    "});"
+                    "});" +
+                "});"
         );
         return deleteAllRows;
     }


### PR DESCRIPTION
#### Rationale
See related PR which removed the Ext4 library from automatically being loaded for every DataRegion. This means that this Ext4 usage from the "Delete All Rows" button will need to make sure the Ext4 library is loaded lazily for this use case.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1868

#### Changes
* Wrap on click handler for "Delete All Rows" button in LABKEY.requiresExt4Sandbox()
