### PR TITLE
Data region fixes to load Ext4 library now that it isn't always on the page

### DIFF
--- a/api/src/org/labkey/api/query/excelExportOptions.jsp
+++ b/api/src/org/labkey/api/query/excelExportOptions.jsp
@@ -169,7 +169,7 @@
                         LABKEY.requiresScript('SignSnapshotPanel.js', function() {
                             Ext4.onReady(function() {
                                 Ext4.create('LABKEY.Query.SignSnapshotPanel', {
-                                    emailInput: '<%=h(model.getEmail())%>',
+                                    emailInput: <%=q(model.getEmail())%>,
                                     params: exportParams,
                                     url: exportUrl
                                 });

--- a/api/src/org/labkey/api/query/excelExportOptions.jsp
+++ b/api/src/org/labkey/api/query/excelExportOptions.jsp
@@ -165,12 +165,14 @@
                     });
                 }
                 else {
-                    LABKEY.requiresScript(['Ext4', 'SignSnapshotPanel.js'], function() {
-                        Ext4.onReady(function() {
-                            Ext4.create('LABKEY.Query.SignSnapshotPanel', {
-                                emailInput: '<%=h(model.getEmail())%>',
-                                params: exportParams,
-                                url: exportUrl
+                    LABKEY.requiresExt4Sandbox(function() {
+                        LABKEY.requiresScript('SignSnapshotPanel.js', function() {
+                            Ext4.onReady(function() {
+                                Ext4.create('LABKEY.Query.SignSnapshotPanel', {
+                                    emailInput: '<%=h(model.getEmail())%>',
+                                    params: exportParams,
+                                    url: exportUrl
+                                });
                             });
                         });
                     });

--- a/api/src/org/labkey/api/query/textExportOptions.jsp
+++ b/api/src/org/labkey/api/query/textExportOptions.jsp
@@ -154,7 +154,7 @@
                             Ext4.onReady(function() {
                                 Ext4.create('LABKEY.Query.SignSnapshotPanel', {
                                     url: url,
-                                    emailInput: '<%=h(model.getEmail())%>'
+                                    emailInput: <%=q(model.getEmail())%>
                                 });
                             });
                         });

--- a/api/src/org/labkey/api/query/textExportOptions.jsp
+++ b/api/src/org/labkey/api/query/textExportOptions.jsp
@@ -149,11 +149,13 @@
                     window.location = url;
                 }
                 else {
-                    LABKEY.requiresScript(['Ext4', 'SignSnapshotPanel.js'], function() {
-                        Ext4.onReady(function() {
-                            Ext4.create('LABKEY.Query.SignSnapshotPanel', {
-                                url: url,
-                                emailInput: '<%=h(model.getEmail())%>'
+                    LABKEY.requiresExt4Sandbox(function() {
+                        LABKEY.requiresScript('SignSnapshotPanel.js', function() {
+                            Ext4.onReady(function() {
+                                Ext4.create('LABKEY.Query.SignSnapshotPanel', {
+                                    url: url,
+                                    emailInput: '<%=h(model.getEmail())%>'
+                                });
                             });
                         });
                     });


### PR DESCRIPTION
#### Rationale
Recent changes in platform removed the Ext4 library from automatically being loaded for every DataRegion. This means that this Ext4 usage from some other actions/buttons will need to make sure the Ext4 library is loaded lazily for this use case.

#### Previously Merged Pull Requests
* https://github.com/LabKey/platform/pull/1868
* https://github.com/LabKey/platform/pull/1874

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1875
* https://github.com/LabKey/dataintegration/pull/81
* https://github.com/LabKey/testAutomation/pull/581

#### Changes
* Load Ext4 lib before trying to load SignSnapshotPanel.js
