### PR TITLE
Delete specimens that may have been left by a previous test

### DIFF
--- a/study/test/src/org/labkey/test/tests/search/SearchTest.java
+++ b/study/test/src/org/labkey/test/tests/search/SearchTest.java
@@ -135,6 +135,7 @@ public abstract class SearchTest extends StudyBaseTest
         Set<String> projects = new HashSet<>();
         projects.addAll(getSearchResultsProjects("Owlbear")); // List
         projects.addAll(getSearchResultsProjects("Urinalysis")); // Study
+        projects.addAll(getSearchResultsProjects("999320016")); // Specimens
         projects.addAll(getSearchResultsProjects(WIKI_NAME)); // Wiki
         projects.addAll(getSearchResultsProjects(ISSUE_TITLE)); // Issues
         projects.addAll(getSearchResultsProjects("acyclic")); // Files


### PR DESCRIPTION
#### Rationale
If a test using the same specimens as the search test (e.g. `SpecimenTest`) fails before it, there might be items left over that conflict with SearchTest's expectations.

#### Changes
* Delete project leftover from tests that import the same specimens used by the search tests
