### PR TITLE
Issue 42210: Sample update details are not showing when using an import alias

### DIFF
--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -926,7 +926,7 @@ public class SampleTypeServiceImpl extends AuditHandler implements SampleTypeSer
         // we want to include the fields that indicate parent lineage has changed.
         // Note that we don't need to check for output fields because lineage can be modified only by changing inputs not outputs
         updatedRow.forEach((fieldName, value) -> {
-            if (fieldName.startsWith(ExpData.DATA_INPUT_PARENT) || fieldName.startsWith(ExpMaterial.MATERIAL_INPUT_PARENT))
+            if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUT_PARENT.toLowerCase()) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase()))
                 if (!originalRow.containsKey(fieldName))
                 {
                     modifiedRow.put(fieldName, value);


### PR DESCRIPTION
#### Rationale
When importing using alias, the alias field, as well as the "dataInputs/XX" field is present in updatedRow. The check for input fields should be case insensitive.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* case insensitive check for input field names
