### PR TITLE
Data class and sample type import/export bugs

### DIFF
--- a/experiment/src/org/labkey/experiment/XarExporter.java
+++ b/experiment/src/org/labkey/experiment/XarExporter.java
@@ -394,6 +394,8 @@ public class XarExporter
                     dataLSID.setDataFileUrl(url);
                 }
             }
+            else
+                dataLSID.setCpasType(data.getCpasType());
         }
 
         List<Material> inputMaterial = ExperimentServiceImpl.get().getMaterialInputReferencesForApplication(application.getRowId());
@@ -440,8 +442,9 @@ public class XarExporter
             {
                 // Issue 31727: When data is imported via the API, no file is created for the data.  We want to
                 // include a file path in the export, though.  We use "Data" + rowId of the data object as the file name
-                // to ensure that the path won't collide with other output data from exported runs in the xar archive.
-                if (data.getDataFileUrl() == null && data.isFinalRunOutput())
+                // to ensure that the path won't collide with other output data from exported runs in the xar archive,
+                // but we don't want to include data classes as part of this behavior.
+                if (data.getDataFileUrl() == null && data.isFinalRunOutput() && (data.getDataClass(null) == null))
                     data.setDataFileURI(run.getFilePathRootPath().resolve("Data" + data.getRowId()).toUri());
                 DataBaseType xData = outputDataObjects.addNewData();
                 populateData(xData, data, null, run);

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -1393,11 +1393,15 @@ public class XarReader extends AbstractXarImporter
         }
         else
         {
-           // TODO: Allow creating the Data in a DataClass
             Data data = new Data();
             data.setLSID(dataLSID);
             data.setName(trimString(xbData.getName()));
             data.setCpasType(declaredType);
+            for (ExpDataClass dataClass : _loadedDataClasses)
+            {
+                if (dataClass.getLSID().equals(declaredType))
+                    data.setClassId(dataClass.getRowId());
+            }
 
             // This existing hack is that newData has the source URL, but the dest container
             // We change to set it with the source container here -- Handler must change the container along with the dataFileURL (Dave 2/15/18)

--- a/experiment/src/org/labkey/experiment/xar/AbstractXarImporter.java
+++ b/experiment/src/org/labkey/experiment/xar/AbstractXarImporter.java
@@ -24,6 +24,7 @@ import org.labkey.api.exp.XarSource;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.security.User;
 import org.labkey.experiment.api.ExpSampleTypeImpl;
@@ -49,7 +50,9 @@ public abstract class AbstractXarImporter
     {
         if (declaredType != null && !ExpData.DEFAULT_CPAS_TYPE.equals(declaredType))
         {
-            _job.getLogger().warn("Unrecognized CpasType '" + declaredType + "' loaded for Data object.");
+            // check if this is a reference to a data class
+            if (ExperimentService.get().getDataClass(declaredType) == null)
+                _job.getLogger().warn("Unrecognized CpasType '" + declaredType + "' loaded for Data object.");
         }
     }
 


### PR DESCRIPTION
#### Rationale
Fixes for a handful of issues related to sample type and data class export/import. Specifically when there were either data inputs/outputs to data classes from samples or if there were data inputs/outputs from a data class.

- [42162: Error importing Data Class with data inputs/outputs](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42162)
- [42161: Unable to import Data Classes as inputs/outputs for Sample Types](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42161)

