### PR TITLE
Issue 42176: pipeline job log scrolls to bottom

### DIFF
--- a/pipeline/src/org/labkey/pipeline/status/details.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/details.jsp
@@ -76,7 +76,8 @@
 %>
 <style type="text/css">
     #log-container {
-        height: 30em;
+        /* viewport height minus a bit for the panel header and log controls and body margin-bottom (50px) */
+        height: calc(100vh - 10em - 50px);
         overflow: auto;
     }
     td.split-job-status {
@@ -559,6 +560,8 @@
                     logDataEl = document.getElementById('log-data');
                 }
 
+                const scrolledToBottom = logContainerEl.scrollHeight - logContainerEl.scrollTop === logContainerEl.clientHeight;
+
                 if (log.success) {
                     // successfully read the status log file
                     if (log.records && log.records.length > 0) {
@@ -585,7 +588,13 @@
                     }
                 }
 
-                scrollLog(true);
+                const selection = window.getSelection();
+                const hasSelection = selection && !selection.isCollapsed;
+
+                // scroll if we are at the bottom of the scrollable pane and nothing is selected
+                if (scrolledToBottom && !hasSelection) {
+                    scrollLog(true);
+                }
             }
         }
 


### PR DESCRIPTION
#### Rationale
The pipeline status page loads new log data while the job is running.  The log display will scroll the new lines into view automatically which makes it difficult to review.  This change stops the log view from scrolling to the bottom if the user has scrolled the log view up or if there is text selection.  In addition, the job log display size is increased to show more lines.

Future possible changes: improve the layout (the details panel is too large and doesn't display much information), buttons to scroll log view to top/bottom, button to disable progressive loading.

#### Changes
- increase height of the log view
- don't scroll log to bottom if the user has scrolled up or has a selection