### PR TITLE
42238: Issues API doesn't support closing an issue and assigning to guest

### DIFF
--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -869,7 +869,10 @@ public class IssuesController extends SpringActionController
                 CustomColumnConfiguration ccc = new CustomColumnConfigurationImpl(getContainer(), getUser(), issueListDef);
                 IssueValidation.validateRequiredFields(issueListDef, ccc, issuesForm, getUser(), errors);
                 IssueValidation.validateNotifyList(issuesForm, errors);
-                IssueValidation.validateAssignedTo(issuesForm, getContainer(), errors);
+                // don't validate the assigned to field if we are in the process
+                // of closing it
+                if (action != IssuesApiForm.action.close)
+                    IssueValidation.validateAssignedTo(issuesForm, getContainer(), errors);
                 IssueValidation.validateStringFields(issuesForm, ccc, errors);
                 IssueValidation.validateComments(issuesForm, errors);
             }

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -870,9 +870,11 @@ public class IssuesController extends SpringActionController
                 IssueValidation.validateRequiredFields(issueListDef, ccc, issuesForm, getUser(), errors);
                 IssueValidation.validateNotifyList(issuesForm, errors);
                 // don't validate the assigned to field if we are in the process
-                // of closing it
-                if (action != IssuesApiForm.action.close)
+                // of closing it and we are assigning it to the guest user (otherwise validate)
+                if (action != IssuesApiForm.action.close || UserManager.getGuestUser().getUserId() != issuesForm.getBean().getAssignedTo())
+                {
                     IssueValidation.validateAssignedTo(issuesForm, getContainer(), errors);
+                }
                 IssueValidation.validateStringFields(issuesForm, ccc, errors);
                 IssueValidation.validateComments(issuesForm, errors);
             }


### PR DESCRIPTION
#### Rationale
This is a fix for this [issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42238). The problem was we needed to conditionalize the validation of the assigned user when we are closing an issue. The same conditional logic is present in the non-API code path.

