### PR TITLE
Issue 39785: JSON responses for APIs targeting invalid container

### DIFF
--- a/api/src/org/labkey/api/action/ApiResponseWriter.java
+++ b/api/src/org/labkey/api/action/ApiResponseWriter.java
@@ -289,6 +289,7 @@ public abstract class ApiResponseWriter implements AutoCloseable
         jsonObj.put("exception", e.getMessage() != null ? e.getMessage() : e.getClass().getName());
         jsonObj.put("exceptionClass", e.getClass().getName());
         jsonObj.put("stackTrace", e.getStackTrace());
+        jsonObj.put("success", status == HttpServletResponse.SC_OK);
 
         try
         {

--- a/api/src/org/labkey/api/action/BaseApiAction.java
+++ b/api/src/org/labkey/api/action/BaseApiAction.java
@@ -61,7 +61,6 @@ import java.util.Map;
  */
 public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
 {
-    public static final String RESPONSE_FORMAT_PARAMETER_NAME = "respFormat";
     private final Marshaller _marshaller;
 
     private ApiResponseWriter.Format _reqFormat = null;
@@ -107,17 +106,9 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
     }
 
     @Override
-    public void checkPermissions() throws UnauthorizedException
+    public ApiResponseWriter.Format getDefaultResponseFormat()
     {
-        // Set the preferred response format here so we can use it for 401s
-        setResponseFormat();
-
-        super.checkPermissions();
-    }
-
-    private void setResponseFormat()
-    {
-        ApiResponseWriter.setResponseFormat(getViewContext().getRequest(), ApiResponseWriter.Format.getFormatByName(getViewContext().getRequest().getParameter(RESPONSE_FORMAT_PARAMETER_NAME), ApiResponseWriter.Format.JSON));
+        return ApiResponseWriter.Format.JSON;
     }
 
     @Override
@@ -129,9 +120,6 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
     @Override
     public ModelAndView handleRequest() throws Exception
     {
-        // Likely a dupe with what's been done in checkPermissions(), but ensuring that future code path variants will pass through
-        setResponseFormat();
-
         switch (getViewContext().getMethod())
         {
             case POST:

--- a/api/src/org/labkey/api/action/PermissionCheckable.java
+++ b/api/src/org/labkey/api/action/PermissionCheckable.java
@@ -18,6 +18,8 @@ package org.labkey.api.action;
 
 import org.labkey.api.view.UnauthorizedException;
 
+import javax.annotation.Nullable;
+
 /**
  * Interface for {@link Action} classes that want to handle permission checks
  * in a way that's more complex than allowed by the standard
@@ -28,4 +30,12 @@ import org.labkey.api.view.UnauthorizedException;
 public interface PermissionCheckable
 {
     void checkPermissions() throws UnauthorizedException;
+
+    /**
+     * @return  the preferred response format. Primarily utilized so that API actions can return JSON for
+     * 401, 404, 500, and other error conditions. Null indicates no preference, which will typically result in an HTML
+     * response
+     */
+    @Nullable
+    default ApiResponseWriter.Format getDefaultResponseFormat() { return null; }
 }

--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -19,7 +19,6 @@ package org.labkey.api.action;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.admin.AdminUrls;
@@ -118,6 +117,9 @@ public abstract class SpringActionController implements Controller, HasViewConte
     public static final String ERROR_CONVERSION = "typeMismatch";
     public static final String ERROR_REQUIRED = "requiredError";
     public static final String ERROR_UNIQUE = "uniqueConstraint";
+
+    /** HTTP parameter name for clients to specify a preferred response format. See supported values in ApiResponseWriter.Format */
+    public static final String RESPONSE_FORMAT_PARAMETER_NAME = "respFormat";
 
     private static final Map<Class<? extends Controller>, ActionDescriptor> _classToDescriptor = new HashMap<>();
 
@@ -403,6 +405,16 @@ public abstract class SpringActionController implements Controller, HasViewConte
 
             PermissionCheckable checkable = (PermissionCheckable)controller;
 
+            ApiResponseWriter.Format responseFormat = ApiResponseWriter.Format.getFormatByName(request.getParameter(RESPONSE_FORMAT_PARAMETER_NAME), null);
+            if (responseFormat == null)
+            {
+                responseFormat = checkable.getDefaultResponseFormat();
+            }
+            if (responseFormat != null)
+            {
+                ApiResponseWriter.setResponseFormat(request, responseFormat);
+            }
+
             ActionURL redirectURL = getUpgradeMaintenanceRedirect(request, controller);
 
             if (null != redirectURL)
@@ -418,6 +430,7 @@ public abstract class SpringActionController implements Controller, HasViewConte
             Container c = context.getContainer();
             if (null == c)
             {
+
                 String containerPath = context.getActionURL().getExtraPath();
                 if (containerPath != null && containerPath.contains("/"))
                 {


### PR DESCRIPTION
#### Rationale
The previous change used checkPermissions() to signal an action's preferred response format. That doesn't get invoked when the URL is targeting a bogus container, so API-oriented actions replied with HTML. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1787

#### Changes
* Let actions indicate preferred response format via separate method
