### PR TITLE
Issue 42221: Database login properties are not reflected immediately

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticationConfigurationCache.java
+++ b/api/src/org/labkey/api/security/AuthenticationConfigurationCache.java
@@ -205,7 +205,7 @@ public class AuthenticationConfigurationCache
         return null;
     }
 
-    static void clear()
+    public static void clear()
     {
         CACHE.remove(CACHE_KEY);
     }

--- a/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
+++ b/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
@@ -15,18 +15,16 @@
  */
 package org.labkey.core.login;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.PropertyManager;
-import org.labkey.api.security.SaveConfigurationForm;
 import org.labkey.api.security.AuthenticationManager.AuthenticationValidator;
 import org.labkey.api.security.AuthenticationProvider.LoginFormAuthenticationProvider;
 import org.labkey.api.security.ConfigurationSettings;
 import org.labkey.api.security.LoginUrls;
 import org.labkey.api.security.PasswordExpiration;
+import org.labkey.api.security.SaveConfigurationForm;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
@@ -65,7 +63,7 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
             "Name", getName()
         );
 
-        Map<String, String> stringProperties = PropertyManager.getProperties(DATABASE_AUTHENTICATION_CATEGORY_KEY);
+        Map<String, String> stringProperties = DbLoginManager.getProperties();
 
         return Collections.singletonList(new DbLoginConfiguration(this, stringProperties, properties));
     }

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -736,8 +736,10 @@ public class LoginController extends SpringActionController
         public Object execute(Object o, BindException errors)
         {
             ApiSimpleResponse response = new ApiSimpleResponse();
-            response.put("full", DbLoginManager.getPasswordRule().getFullRuleHTML());
-            response.put("summary", DbLoginManager.getPasswordRule().getSummaryRuleHTML());
+            PasswordRule passwordRule = DbLoginManager.getPasswordRule();
+
+            response.put("full", passwordRule.getFullRuleHTML());
+            response.put("summary", passwordRule.getSummaryRuleHTML());
             return response;
         }
     }

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -130,6 +130,7 @@ import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.WebPartView;
 import org.labkey.api.view.template.PageConfig;
 import org.labkey.core.login.DbLoginConfiguration;
+import org.labkey.core.login.DbLoginManager;
 import org.labkey.core.login.LoginController;
 import org.labkey.core.query.CoreQuerySchema;
 import org.labkey.core.query.UserAuditProvider;
@@ -2000,11 +2001,7 @@ public class UserController extends SpringActionController
         {
             try
             {
-                Collection<DbLoginConfiguration> configurations = AuthenticationManager.getActiveConfigurations(DbLoginConfiguration.class);
-                if (configurations.size() != 1)
-                    throw new IllegalStateException("Expected exactly one DbAuthenticationConfiguration, but was: " + configurations.size());
-
-                DbLoginConfiguration configuration = configurations.iterator().next();
+                DbLoginConfiguration configuration = DbLoginManager.getConfiguration();
                 return configuration.getAuthenticationProvider().authenticate(configuration, email, password, returnUrlHelper).isAuthenticated();
             }
             catch (ValidEmail.InvalidEmailException e)


### PR DESCRIPTION
#### Rationale
[Issue 42221: Database login properties are not reflected immediately](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=42221)

Most authentication configurations are stored in the core.AuthenticationConfigurations table to allow multiple configurations per type, enabling/disabling, sorting, etc. The database login configuration is a special snowflake; there's always one, it can't be disabled or reordered, and its settings (complexity, expiration) continue to be stored in properties. Its setting save process neglected to clear the configuration cache, which meant database authentication didn't reflect changes until caches were cleared (e.g., server restart). This was not readily apparent, since other code paths (e.g., actions supporting the configuration UI) read the properties directly and therefore reflected the changes immediately.

#### Changes
* Clear authentication cache after setting database login properties
* For consistency, route all access to database login settings through the DbLoginConfiguration
