### PR TITLE
Fix NPE in various tests, including QuerySnapshotTest

### DIFF
--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -2136,7 +2136,7 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
      */
     public DataIteratorBuilder getInsertDataIterator(User user, DataIteratorBuilder in, DataIteratorContext context)
     {
-        return getInsertDataIterator(user, in, null, null, null, null, null, false);
+        return getInsertDataIterator(user, in, null, null, context, null, null, false);
     }
 
     /**


### PR DESCRIPTION
https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_BvtBPostgres/1229129

#### Rationale
java.lang.NullPointerException: Cannot invoke "org.labkey.api.dataiterator.DataIteratorContext.getConfigParameter(java.lang.Enum)" because "context" is null
	at org.labkey.study.model.DatasetDefinition.getInsertDataIterator(DatasetDefinition.java:2171)
	at org.labkey.study.model.DatasetDefinition.getInsertDataIterator(DatasetDefinition.java:2139)
	at org.labkey.study.query.DatasetUpdateService.createImportDIB(DatasetUpdateService.java:214)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1860

#### Changes
* Propagate DataIteratorContext variable