### PR TITLE
Address MUTATING SQL exception when retrieving specimen repository settings

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1414,7 +1414,7 @@ public class DbScope
                     }
                     addScope(dsName, dataSources.get(dsName), dsPropertiesBean);
                 }
-                catch (Exception e)
+                catch (Throwable e)
                 {
                     // Server can't start up if it can't connect to the labkey data source
                     if (dsName.equals(labkeyDsName))

--- a/study/api-src/org/labkey/api/specimen/settings/SettingsManager.java
+++ b/study/api-src/org/labkey/api/specimen/settings/SettingsManager.java
@@ -88,16 +88,8 @@ public class SettingsManager
 
     public RepositorySettings getRepositorySettings(Container container)
     {
-        Map<String,String> settingsMap = PropertyManager.getProperties(UserManager.getGuestUser(),
-                container, "SpecimenRepositorySettings");
-        if (settingsMap.isEmpty())
-        {
-            RepositorySettings defaults = RepositorySettings.getDefaultSettings(container);
-            saveRepositorySettings(container, defaults);
-            return defaults;
-        }
-        else
-            return new RepositorySettings(container, settingsMap);
+        Map<String,String> settingsMap = PropertyManager.getProperties(UserManager.getGuestUser(), container, "SpecimenRepositorySettings");
+        return settingsMap.isEmpty() ? RepositorySettings.getDefaultSettings(container) : new RepositorySettings(container, settingsMap);
     }
 
     public void saveRepositorySettings(Container container, RepositorySettings settings)


### PR DESCRIPTION
#### Rationale
`getRepositorySettings()` has always used the "ensure" pattern; it proactively saves the default settings if they haven't been saved previously. This can fail when a GET action attempts to retrieve the settings, since our mutating SQL check objects to the save. Solution is to simply return the default settings if they're not set. I'm sure my refactor uncovered this problem, though this is old code.

Separate, unrelated change in `DbScope` is to allow the server to start up if initializing an external data source throws a `Thowable`, which has always been our intent. Pointed out by [this Redshift issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42040), which has been fixed, but might as well improve this for the future.