### PR TITLE
Issue 40187: Provide admin warning when detecting at startup that database views are not in place

### DIFF
--- a/api/src/org/labkey/api/data/bigiron/AbstractClrInstallationManager.java
+++ b/api/src/org/labkey/api/data/bigiron/AbstractClrInstallationManager.java
@@ -209,7 +209,7 @@ public abstract class AbstractClrInstallationManager
         if (null != helpTopic)
             builder.append(" ").append(new HelpTopic(helpTopic).getSimpleLinkHtml("View installation instructions."));
 
-        warnings.add(builder.getHtmlString());
+        warnings.add(builder);
     }
 
     private static class ClrInstallationScriptProvider extends FileSqlScriptProvider

--- a/api/src/org/labkey/api/view/template/Warnings.java
+++ b/api/src/org/labkey/api/view/template/Warnings.java
@@ -16,6 +16,7 @@
 package org.labkey.api.view.template;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.util.HasHtmlString;
 import org.labkey.api.util.HtmlString;
 
 import java.util.List;
@@ -29,6 +30,12 @@ public interface Warnings
             public void add(HtmlString warning)
             {
                 collection.add(warning);
+            }
+
+            @Override
+            public void add(HasHtmlString warningBuilder)
+            {
+                collection.add(warningBuilder.getHtmlString());
             }
 
             @Override
@@ -46,6 +53,7 @@ public interface Warnings
     }
 
     void add(HtmlString warning);
+    void add(HasHtmlString warningBuilder);
     boolean isEmpty();
     List<HtmlString> getMessages();
 }

--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -117,7 +117,7 @@ public class CoreWarningProvider implements WarningProvider
             HtmlStringBuilder html = HtmlStringBuilder.of("The maximum amount of heap memory allocated to LabKey Server is too low (less than 2GB). LabKey recommends ");
             html.append(new HelpTopic("configWebappMemory").getSimpleLinkHtml("setting the maximum heap to at least 2 gigabytes (-Xmx2G) on test/evaluation servers and at least 4 gigabytes (-Xmx4G) on production servers"));
             html.append(".");
-            warnings.add(html.getHtmlString());
+            warnings.add(html);
         }
     }
 
@@ -191,7 +191,7 @@ public class CoreWarningProvider implements WarningProvider
                 int count = ConnectionWrapper.getActiveConnectionCount();
                 HtmlStringBuilder html = HtmlStringBuilder.of(new LinkBuilder(count + " DB connection" + (count == 1 ? "" : "s") + " in use.").href(PageFlowUtil.urlProvider(AdminUrls.class).getMemTrackerURL()).clearClasses());
                 html.append(" " + leakCount + " probable leak" + (leakCount == 1 ? "" : "s") + ".");
-                warnings.add(html.getHtmlString());
+                warnings.add(html);
             }
         }
     }
@@ -202,7 +202,7 @@ public class CoreWarningProvider implements WarningProvider
         HtmlStringBuilder html = HtmlStringBuilder.of(prefix + " ");
         html.append(new LinkBuilder(linkText).href(url).clearClasses());
         html.append(".");
-        warnings.add(html.getHtmlString());
+        warnings.add(html);
     }
 
     // Standard warning with a link to a LabKey documentation page
@@ -212,6 +212,6 @@ public class CoreWarningProvider implements WarningProvider
         HelpTopic topic = new HelpTopic(helpTopic);
         html.append(topic.getSimpleLinkHtml(helpText));
         html.append(" for more information.");
-        warnings.add(html.getHtmlString());
+        warnings.add(html);
     }
 }


### PR DESCRIPTION
#### Rationale
[Issue 40187: Provide admin warning when detecting at startup that database views are not in place](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40187)

#### Changes
* Register a `WarningProvider` that displays an admin warning if there are missing views
* Determine and stash missing views at startup and after the `RecreateViewsAction` is invoked
* Add `Warnings.add(HasHtmlString)` as a convenience