### PR TITLE
Retry participant purge on SQL Server if it deadlocks

### DIFF
--- a/study/src/org/labkey/study/visitmanager/PurgeParticipantsTask.java
+++ b/study/src/org/labkey/study/visitmanager/PurgeParticipantsTask.java
@@ -101,6 +101,11 @@ public class PurgeParticipantsTask extends TimerTask
                                 _logger.info("Object not found exception (" + e.getMessage() + "). Requeuing another participant purge attempt.");
                                 retry = true;
                             }
+                            else if (SqlDialect.isTransactionException(e))
+                            {
+                                _logger.info("Transaction or deadlock exception (" + e.getMessage() + "). Requeuing another participant purge attempt.");
+                                retry = true;
+                            }
                             else
                             {
                                 // Unexpected problem... log it and continue on


### PR DESCRIPTION
#### Rationale
After the changes to run triggers and other validation on study archive dataset TSV import, we're getting intermittent deadlock errors on SQL Server EHR tests. We already retry the purge on a number of failure conditions, and this is another candidate.

#### Changes
* Retry background participant purge operation when we get a SQLException on a transaction deadlock