### PR TITLE
Issue 42242: Don't include suggested columns in QueryDataIterator

### DIFF
--- a/api/src/org/labkey/api/dataiterator/QueryDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/QueryDataIteratorBuilder.java
@@ -134,7 +134,7 @@ public class QueryDataIteratorBuilder implements DataIteratorBuilder
 
         qd.setSql(sql);
         ArrayList<QueryException> qerrors = new ArrayList<>();
-        TableInfo t = qd.getTable(qerrors, true);
+        TableInfo t = qd.getTable((UserSchema)_schema, qerrors, true, true);
 
         Collection<ColumnInfo> selectCols = t.getColumns();
         if (null != _columns && !_columns.isEmpty())

--- a/api/src/org/labkey/api/dataiterator/QueryDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/QueryDataIteratorBuilder.java
@@ -134,6 +134,7 @@ public class QueryDataIteratorBuilder implements DataIteratorBuilder
 
         qd.setSql(sql);
         ArrayList<QueryException> qerrors = new ArrayList<>();
+        // Issue 42242: Don't include suggested columns in QueryDataIterator
         TableInfo t = qd.getTable((UserSchema)_schema, qerrors, true, true);
 
         Collection<ColumnInfo> selectCols = t.getColumns();


### PR DESCRIPTION
#### Rationale
Adding propertyURIs to suggested columns is causing duplicate column conflicts in ETLs.  This PR updates the QueryDataIteratorBuilder to use the skipSuggestedColumns when getting the source query.  I can't think of any reason we would need the suggested columns in the QueryDataIterator and testing across our test suites does not cause any failures.

#### Changes
- Update QueryDataIteratorBuilder.getDataIterator to use the skipSuggestedColumns parameter when getting the tableinfo
