### PR TITLE
42141: importing file into assay after deleting the run creates duplicate exp.data

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractTempDirDataCollector.java
+++ b/api/src/org/labkey/api/assay/AbstractTempDirDataCollector.java
@@ -28,7 +28,6 @@ import org.labkey.api.util.NetworkDrive;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -92,7 +91,7 @@ public abstract class AbstractTempDirDataCollector<ContextType extends AssayRunU
     public void initDir(ContextType context) throws ExperimentException
     {
         // If upload files are specified
-        if(!context.getUploadedData().isEmpty())
+        if (!context.getUploadedData().isEmpty())
         {
             // TODO: remove this instanceof check
             if (!(context instanceof AssayRunUploadForm))
@@ -106,7 +105,7 @@ public abstract class AbstractTempDirDataCollector<ContextType extends AssayRunU
             if (NetworkDrive.exists(uploadAttemptDir))
             {
                 File[] fileList = uploadAttemptDir.listFiles();
-                if(null != fileList)
+                if (null != fileList)
                 {
                     for (File file : fileList)
                     {
@@ -123,7 +122,7 @@ public abstract class AbstractTempDirDataCollector<ContextType extends AssayRunU
                             }
                         }
 
-                        if(!save)
+                        if (!save)
                         {
                             FileUtils.deleteQuietly(file);
                         }
@@ -131,25 +130,6 @@ public abstract class AbstractTempDirDataCollector<ContextType extends AssayRunU
                 }
             }
         }
-    }
-
-    @Override
-    @Nullable
-    public File getRoot(@Nullable ExpRun run, @Nullable File data)
-    {
-        File root = null;
-
-        if(null != run)
-        {
-            root = Paths.get(run.getFilePathRoot().getParentFile().getParentFile().getParent()).toFile();
-        }
-        else if(null != data)
-        {
-            // Need to get to root in root/assaydata/uploadTemp/<tempname>/file
-            root = Paths.get(data.getParentFile().getParentFile().getParentFile().getParent()).toFile();
-        }
-
-        return root;
     }
 
     @Override
@@ -211,7 +191,7 @@ public abstract class AbstractTempDirDataCollector<ContextType extends AssayRunU
             for (File tempDirFile : tempDir.listFiles())
             {
                 File assayDirFile = getFilePath(context, run, tempDirFile);
-                if(assayDirFile != null)
+                if (assayDirFile != null)
                 {
                     String uploadName = fileToName.get(tempDirFile);
                     if (uploadName != null)

--- a/api/src/org/labkey/api/assay/AssayDataCollector.java
+++ b/api/src/org/labkey/api/assay/AssayDataCollector.java
@@ -78,8 +78,6 @@ public interface AssayDataCollector<ContextType extends AssayRunUploadContext>
 
     default void initDir(ContextType context) throws ExperimentException {}
 
-    File getRoot(@Nullable ExpRun run, @Nullable File data);
-
     /**
      * For files that already existed on the server's file system prior to import, and which have been copied
      * to a temporary directory for processing, the original path to the primary data file.

--- a/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
+++ b/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
@@ -1038,6 +1038,7 @@ public class TsvDataExchangeHandler implements DataExchangeHandler
                     {
                         File file = entry.getValue();
                         String type = entry.getKey();
+                        LOG.debug("processing transformed data file: type=" + type + ", file=" + file.getPath());
 
                         File workingDir = getWorkingDirectory(context);
                         if (workingDir == null)
@@ -1049,10 +1050,11 @@ public class TsvDataExchangeHandler implements DataExchangeHandler
                         }
                         else
                         {
-                            // Copy to the working directory
+                            // Move to the working directory
                             File tempDirCopy = new File(workingDir, file.getName());
                             if (!file.equals(tempDirCopy))
                             {
+                                LOG.debug("moving to working directory=" + tempDirCopy);
                                 FileUtils.moveFile(file, tempDirCopy);
                                 file = tempDirCopy;
                             }
@@ -1064,6 +1066,7 @@ public class TsvDataExchangeHandler implements DataExchangeHandler
                         ExpData data = ExperimentService.get().getExpDataByURL(file, context.getContainer());
                         if (data == null)
                         {
+                            LOG.debug("exp.data doesn't exist, creating new one");
                             data = DefaultAssayRunCreator.createData(context.getContainer(), file, "transformed output", new DataType(type), true);
                             data.setName(file.getName());
                         }

--- a/assay/src/org/labkey/assay/actions/PipelineDataCollectorRedirectAction.java
+++ b/assay/src/org/labkey/assay/actions/PipelineDataCollectorRedirectAction.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.assay.actions;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.labkey.api.action.LabKeyError;
 import org.labkey.api.action.SimpleErrorView;
 import org.labkey.api.action.SimpleViewAction;
@@ -50,6 +52,8 @@ import java.util.Map;
 @RequiresPermission(InsertPermission.class)
 public class PipelineDataCollectorRedirectAction extends SimpleViewAction<PipelineDataCollectorRedirectAction.UploadRedirectForm>
 {
+    private static final Logger LOG = LogManager.getLogger(PipelineDataCollectorRedirectAction.class);
+
     @Override
     public ModelAndView getView(UploadRedirectForm form, BindException errors)
     {
@@ -135,6 +139,8 @@ public class PipelineDataCollectorRedirectAction extends SimpleViewAction<Pipeli
         for (File file : files)
         {
             ExpData data = ExperimentService.get().getExpDataByURL(file, getContainer());
+            if (data != null)
+                LOG.debug("Found existing data: rowId=" + data.getRowId() + ", url=" + data.getDataFileUrl());
             if (data != null && data.getRun() != null)
             {
                 errors.addError(new LabKeyError("The file " + file.getAbsolutePath() + " has already been imported"));

--- a/pipeline/src/org/labkey/pipeline/PipelineController.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineController.java
@@ -1619,19 +1619,14 @@ public class PipelineController extends SpringActionController
             URLHelper url;
 
             PipelineService.get().saveTriggerConfig(getContainer(), getUser(), form);
-            if (form.getReturnUrl() != null)
+            if (form.getReturnActionURL() != null)
             {
-                try
-                {
-                    url = new URLHelper(form.getReturnUrl());
-                }
-                catch (URISyntaxException e)
-                {
-                    url = getContainer().getStartURL(getUser());
-                }
+                url = form.getReturnActionURL();
             }
             else
+            {
                 url = getContainer().getStartURL(getUser());
+            }
 
             response.put("success", true);
             response.put(ActionURL.Param.returnUrl.name(), url.toString());


### PR DESCRIPTION
#### Rationale
When importing a file from the filebrowser into an assay, the existing exp.data for the file isn't used.  This can happen when a file is imported into the assay a second time after the original assay run has been deleted.

During import the existing file is moved into the assay upload temp directory, a new exp.data for the new file path is created, and the file is moved the file back to the original location.  The result is two exp.data for the same file path.  This PR skips moving the file into the assay upload temp directory if the file already exists in the pipeline root so that the existing exp.data can be found during import.

#### Related Issues
* [Issue 26726](https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=26726): Transform script in assay not handling files when imported via pipeline

#### Changes
- don't copy uploaded file into assay upload temp dir if it already exists under the pipe root
- add regression test to verify the original exp.data is reused if the file is imported a second time
- remove unused `AssayDataCollector.getRoot` method
