### PR TITLE
Add patchModule task in api project

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -203,15 +203,16 @@ project.tasks.register('patchModule', Jar) {
         jar.archiveExtension.set('module')
         jar.destinationDirectory = project.buildDir
         jar.outputs.cacheIf({true})
-        // include the original module file
-        jar.from(zipTree(project.tasks.module.outputs.files.singleFile))
-        // replace the ext-3.4.1 and ext-4.2.1 directories from the extjs configuration artifacts
-        jar.duplicatesStrategy(DuplicatesStrategy.INCLUDE)
+        // first include the ext-3.4.1 and ext-4.2.1 directories from the extjs configuration artifacts
         jar.into('web') {
             from configurations.extJs.collect {
                 zipTree(it)
             }
         }
+        // include the original module file ...
+        jar.from(zipTree(project.tasks.module.outputs.files.singleFile))
+        // ... but don't use the ext directories that come from that file
+        jar.duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
 }
 
 artifacts {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -121,7 +121,14 @@ configurations {
         canBeResolved = true
     }
 
-    extjs // used to pull in differently licensed versions of the extJS libraries
+    // used to declare dependencies on differently licensed versions of the extJS libraries
+    extJs
+
+    // consumable configuration to attach artifacts to
+    extJsCommercial {
+        canBeConsumed = true
+        canBeResolved = false
+    }
 }
 
 // declared separately to include the gwtsrc directory
@@ -183,12 +190,8 @@ dependencies {
     jspImplementation files(project.tasks.jar)
     jspImplementation apache, jackson, spring
 
-    extjs "com.sencha.extjs:extjs:4.2.1@zip"
-    extjs "com.sencha.extjs:extjs:3.4.1@zip"
-}
-
-artifacts {
-    apiJarFile(jar)
+    extJs "com.sencha.extjs:extjs:4.2.1:commercial@zip"
+    extJs "com.sencha.extjs:extjs:3.4.1:commercial@zip"
 }
 
 
@@ -205,8 +208,13 @@ project.tasks.register('patchModule', Jar) {
         // replace the ext-3.4.1 and ext-4.2.1 directories from the extjs configuration artifacts
         jar.duplicatesStrategy(DuplicatesStrategy.INCLUDE)
         jar.into('web') {
-            from configurations.extjs.collect {
+            from configurations.extJs.collect {
                 zipTree(it)
             }
         }
+}
+
+artifacts {
+    apiJarFile(jar)
+    extJsCommercial(project.tasks.patchModule)
 }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,4 +1,5 @@
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.GroupNames
 
 plugins {
     id 'java-library'
@@ -110,7 +111,7 @@ configurations {
         canBeResolved = true
     }
 
-    // this configuration and its artifact are declared because the default outgoing variant for the api
+    // This configuration and its artifact are declared because the default outgoing variant for the api
     // module (runtimeElements) does not include all the class files since the classes compiled from
     // the XSDs are produced in a separate classes directory.  The name is chosen to be the same as
     // the apiJarFile configuration that comes from the API Gradle plugin.  We need this jar file for
@@ -119,6 +120,8 @@ configurations {
         canBeConsumed = true
         canBeResolved = true
     }
+
+    extjs // used to pull in differently licensed versions of the extJS libraries
 }
 
 // declared separately to include the gwtsrc directory
@@ -179,8 +182,31 @@ dependencies {
 
     jspImplementation files(project.tasks.jar)
     jspImplementation apache, jackson, spring
+
+    extjs "com.sencha.extjs:extjs:4.2.1@zip"
+    extjs "com.sencha.extjs:extjs:3.4.1@zip"
 }
 
 artifacts {
     apiJarFile(jar)
+}
+
+
+project.tasks.register('patchModule', Jar) {
+    Jar jar ->
+        jar.group = GroupNames.MODULE
+        jar.description = "Patches the api module to replace ExtJS libraries with commercial versions"
+        jar.classifier("extJsCommercial")
+        jar.archiveExtension.set('module')
+        jar.destinationDirectory = project.buildDir
+        jar.outputs.cacheIf({true})
+        // include the original module file
+        jar.from(zipTree(project.tasks.module.outputs.files.singleFile))
+        // replace the ext-3.4.1 and ext-4.2.1 directories from the extjs configuration artifacts
+        jar.duplicatesStrategy(DuplicatesStrategy.INCLUDE)
+        jar.into('web') {
+            from configurations.extjs.collect {
+                zipTree(it)
+            }
+        }
 }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -120,15 +120,6 @@ configurations {
         canBeConsumed = true
         canBeResolved = true
     }
-
-    // used to declare dependencies on differently licensed versions of the extJS libraries
-    extJs
-
-    // consumable configuration to attach artifacts to
-    extJsCommercial {
-        canBeConsumed = true
-        canBeResolved = false
-    }
 }
 
 // declared separately to include the gwtsrc directory
@@ -189,33 +180,9 @@ dependencies {
 
     jspImplementation files(project.tasks.jar)
     jspImplementation apache, jackson, spring
-
-    extJs "com.sencha.extjs:extjs:4.2.1:commercial@zip"
-    extJs "com.sencha.extjs:extjs:3.4.1:commercial@zip"
 }
 
-
-project.tasks.register('patchModule', Jar) {
-    Jar jar ->
-        jar.group = GroupNames.MODULE
-        jar.description = "Patches the api module to replace ExtJS libraries with commercial versions"
-        jar.classifier("extJsCommercial")
-        jar.archiveExtension.set('module')
-        jar.destinationDirectory = project.buildDir
-        jar.outputs.cacheIf({true})
-        // first include the ext-3.4.1 and ext-4.2.1 directories from the extjs configuration artifacts
-        jar.into('web') {
-            from configurations.extJs.collect {
-                zipTree(it)
-            }
-        }
-        // include the original module file ...
-        jar.from(zipTree(project.tasks.module.outputs.files.singleFile))
-        // ... but don't use the ext directories that come from that file
-        jar.duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
-}
 
 artifacts {
     apiJarFile(jar)
-    extJsCommercial(project.tasks.patchModule)
 }


### PR DESCRIPTION
#### Rationale
Some distributions need to use a differently licensed version of the ExtJS libraries.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/114

#### Changes
* Add `patchModule` task for api module
