### PR TITLE
Issue 42207: List items get indexed twice with different document IDs

### DIFF
--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -386,7 +386,8 @@ public class ListManager implements SearchService.DocumentProvider
 
             Runnable r = () ->
             {
-                ListDefinition list = ListDefinitionImpl.of(def);
+                //Refresh list definition -- Issue #42207 - MSSQL server returns entityId as uppercase string
+                ListDefinition list = ListService.get().getList(def.lookupContainer(), def.getListId());
                 indexList(task, list, designChange, false);
             };
 


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-update.view?issueId=42207
* We generate our entity ids as lowercase strings and set them to index. MS SQL returns them as uppercase strings, so the original ids aren't found and are reindexed. 

#### Changes
* Refresh list definition at indexing time.
