### PR TITLE
Simplify default repository settings

### DIFF
--- a/study/api-src/org/labkey/api/specimen/settings/RepositorySettings.java
+++ b/study/api-src/org/labkey/api/specimen/settings/RepositorySettings.java
@@ -59,11 +59,11 @@ public class RepositorySettings
     {
         this(container);
         String simple = map.get(KEY_SIMPLE);
-        _simple = null != simple && Boolean.parseBoolean(simple);
+        _simple = Boolean.parseBoolean(simple);
         String enableRequests = map.get(KEY_ENABLE_REQUESTS);
         _enableRequests = null == enableRequests ? !_simple : Boolean.parseBoolean(enableRequests);
         String specimenDataEditable = map.get(KEY_SPECIMENDATA_EDITABLE);
-        _specimenDataEditable = null != specimenDataEditable && Boolean.parseBoolean(specimenDataEditable);
+        _specimenDataEditable = Boolean.parseBoolean(specimenDataEditable);
 
         String firstGrouping = map.get(makeKeySpecWebPartGroup(0,0));
         if (null != firstGrouping)
@@ -188,18 +188,9 @@ public class RepositorySettings
     public static RepositorySettings getDefaultSettings(Container container)
     {
         RepositorySettings settings = new RepositorySettings(container);
-        if (null != StudyService.get().getStudy(container))
-        {
-            settings.setSimple(false);
-            settings.setEnableRequests(true);
-            settings.setSpecimenDataEditable(false);
-        }
-        else
-        {
-            settings.setSimple(true);
-            settings.setEnableRequests(false);
-            settings.setSpecimenDataEditable(false);
-        }
+        settings.setSimple(true);
+        settings.setEnableRequests(false);
+        settings.setSpecimenDataEditable(false);
         return settings;
     }
 


### PR DESCRIPTION
#### Rationale
`AdvancedImportOptionsTest.testImportToMultipleFolders` started failing because the default specimen repository settings weren't matching its expectations. The goal of this PR is to restore the previous defaults without breaking a bunch of other tests.

In more detail, study's handling of specimen repository default settings has been complicated and somewhat unpredictable. `StudyImpl` had a `getRepositorySettings()` method that ended up getting invoked by reflection by the table layer before each study was created. This method used the ensure pattern to proactively save default repository settings. The refactor to extract specimen functionality from study changed this, first removing the getter and therefore the early call, and then removing the ensure pattern; we simply return the default values until they're explicitly saved. Problem now is that the default settings actually change based on whether a study is present or not. I can't see a good reason for this, so this PR shifts to always return the same default settings.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1873
* https://github.com/LabKey/platform/pull/1894

#### Changes
* Return the same default repository values (standard repository, requests disabled) regardless of whether a study exists or not