### PR TITLE
DataRegion fix for Ext4 dependency loading related to prompt to save session view

### DIFF
--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -3327,7 +3327,9 @@ if (!LABKEY.DataRegions) {
                     return;
                 }
 
-                _saveSessionShowPrompt(this, json);
+                LABKEY.requiresExt4Sandbox(function() {
+                    _saveSessionShowPrompt(this, json);
+                }, this);
             },
             scope: region
         });

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -3327,62 +3327,60 @@ if (!LABKEY.DataRegions) {
                     return;
                 }
 
-                LABKEY.requiresExt4Sandbox(function() {
-                    _saveSessionShowPrompt(this, json);
-                }, this);
+                _saveSessionShowPrompt(this, json);
             },
             scope: region
         });
     };
 
     var _saveSessionShowPrompt = function(region, queryDetails) {
-        var config = Ext4.applyIf({
-            allowableContainerFilters: region.allowableContainerFilters,
-            targetContainers: queryDetails.targetContainers,
-            canEditSharedViews: queryDetails.canEditSharedViews,
-            canEdit: LABKEY.DataRegion.getCustomViewEditableErrors(config).length == 0,
-            success: function (win, o) {
-                var timerId = setTimeout(function() {
-                    timerId = 0;
-                    Ext4.Msg.progress("Saving...", "Saving custom view...");
-                }, 500);
-
-                var jsonData = {
-                    schemaName: region.schemaName,
-                    "query.queryName": region.queryName,
-                    "query.viewName": region.viewName,
-                    newName: o.name,
-                    inherit: o.inherit,
-                    shared: o.shared
-                };
-
-                if (o.inherit) {
-                    jsonData.containerPath = o.containerPath;
-                }
-
-                LABKEY.Ajax.request({
-                    url: LABKEY.ActionURL.buildURL('query', 'saveSessionView', region.containerPath),
-                    method: 'POST',
-                    jsonData: jsonData,
-                    callback: function() {
-                        if (timerId > 0)
-                            clearTimeout(timerId);
-                        win.close();
-                    },
-                    success: function() {
-                        region.showSuccessMessage.call(region);
-                        region.changeView.call(region, {type: 'view', viewName: o.name});
-                    },
-                    failure: function(json) {
-                        Ext4.Msg.alert('Error saving view', json.exception || json.statusText);
-                    },
-                    scope: region
-                });
-            },
-            scope: region
-        }, region.view);
-
         LABKEY.DataRegion.loadViewDesigner(function() {
+            var config = Ext4.applyIf({
+                allowableContainerFilters: region.allowableContainerFilters,
+                targetContainers: queryDetails.targetContainers,
+                canEditSharedViews: queryDetails.canEditSharedViews,
+                canEdit: LABKEY.DataRegion.getCustomViewEditableErrors(config).length == 0,
+                success: function (win, o) {
+                    var timerId = setTimeout(function() {
+                        timerId = 0;
+                        Ext4.Msg.progress("Saving...", "Saving custom view...");
+                    }, 500);
+
+                    var jsonData = {
+                        schemaName: region.schemaName,
+                        "query.queryName": region.queryName,
+                        "query.viewName": region.viewName,
+                        newName: o.name,
+                        inherit: o.inherit,
+                        shared: o.shared
+                    };
+
+                    if (o.inherit) {
+                        jsonData.containerPath = o.containerPath;
+                    }
+
+                    LABKEY.Ajax.request({
+                        url: LABKEY.ActionURL.buildURL('query', 'saveSessionView', region.containerPath),
+                        method: 'POST',
+                        jsonData: jsonData,
+                        callback: function() {
+                            if (timerId > 0)
+                                clearTimeout(timerId);
+                            win.close();
+                        },
+                        success: function() {
+                            region.showSuccessMessage.call(region);
+                            region.changeView.call(region, {type: 'view', viewName: o.name});
+                        },
+                        failure: function(json) {
+                            Ext4.Msg.alert('Error saving view', json.exception || json.statusText);
+                        },
+                        scope: region
+                    });
+                },
+                scope: region
+            }, region.view);
+
             LABKEY.internal.ViewDesigner.Designer.saveCustomizeViewPrompt(config);
         });
     };


### PR DESCRIPTION
#### Rationale
Found another case where an action in the DataRegion.js code need to explicitly request Ext4 lib before showing prompt to save the session view.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1868

#### Changes
* Move call to call to LABKEY.DataRegion.loadViewDesigner() to beginning of _saveSessionShowPrompt()
