### PR TITLE
Issue 38540: Refactor getUserDetailsLink to return an HtmlString

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -2247,7 +2247,7 @@ public class AnnouncementsController extends SpringActionController
                     User user = UserManager.getUser(userId);
 
                     if (null != user)
-                        return HtmlString.of(SecurityManager.getGroupList(ctx.getContainer(), user));
+                        return SecurityManager.getGroupList(ctx.getContainer(), user);
                 }
 
                 return HtmlString.EMPTY_STRING;

--- a/announcements/src/org/labkey/announcements/announcementThread.jsp
+++ b/announcements/src/org/labkey/announcements/announcementThread.jsp
@@ -81,7 +81,7 @@ else if (null == announcementModel.getApproved() && c.hasPermission(user, AdminP
 <table style="table-layout:fixed;width:100%">
 <tr>
     <td class="labkey-announcement-title labkey-force-word-break" width="33%" align=left><span><%=h(announcementModel.getTitle())%></span></td>
-    <td class="labkey-announcement-title" width="33%" align=center><%=text(AnnouncementManager.getUserDetailsLink(c, user, announcementModel.getCreatedBy(), bean.includeGroups, false))%></td>
+    <td class="labkey-announcement-title" width="33%" align=center><%=AnnouncementManager.getUserDetailsLink(c, user, announcementModel.getCreatedBy(), bean.includeGroups, false)%></td>
     <td class="labkey-announcement-title" width="33%" align="right" nowrap><%
 
 if (false && !bean.print && null != discussionSrc)
@@ -171,7 +171,7 @@ if (!announcementModel.getResponses().isEmpty())
         for (AnnouncementModel r : announcementModel.getResponses())
         {%>
             <tr class="labkey-alternate-row">
-                <td class="labkey-bordered" style="border-right: 0 none"><a name="row:<%=r.getRowId()%>"></a><%=text(AnnouncementManager.getUserDetailsLink(c, user, r.getCreatedBy(), bean.includeGroups, false) + " responded:")%></td>
+                <td class="labkey-bordered" style="border-right: 0 none"><a name="row:<%=r.getRowId()%>"></a><%=AnnouncementManager.getUserDetailsLink(c, user, r.getCreatedBy(), bean.includeGroups, false)%> responded:</td>
                 <td class="labkey-bordered" style="border-left: 0 none" align="right"><%
                 if (bean.perm.allowUpdate(r) && !bean.print)
                 {

--- a/announcements/src/org/labkey/announcements/announcementWebPartWithExpandos.jsp
+++ b/announcements/src/org/labkey/announcements/announcementWebPartWithExpandos.jsp
@@ -193,7 +193,7 @@ for (AnnouncementModel a : bean.announcementModels)
         if (a.getResponseCount() > 0)
             out.print(unsafe(" (" + a.getResponseCount() + (a.getResponseCount() == 1 ? "&nbsp;response)" : "&nbsp;responses)")));
         %></td>
-        <td width="20%" align="center" class="message-creator"><%=text(AnnouncementManager.getUserDetailsLink(c, user, a.getCreatedBy(), bean.includeGroups, false))%></td>
+        <td width="20%" align="center" class="message-creator"><%=AnnouncementManager.getUserDetailsLink(c, user, a.getCreatedBy(), bean.includeGroups, false)%></td>
         <td width="40%" align="right" nowrap><%=formatDateTime(a.getCreated())%></td>
     </tr>
     <tr><td colspan=3 class="labkey-title-area-line"></td></tr>

--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -63,6 +63,7 @@ import org.labkey.api.util.ContainerUtil;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.MailHelper;
 import org.labkey.api.util.MailHelper.BulkEmailer;
@@ -972,30 +973,30 @@ public class AnnouncementManager
         }
     }
 
-    public static String getUserDetailsLink(Container container, User currentUser, int formattedUserId, boolean includeGroups, boolean forEmail)
+    public static HtmlString getUserDetailsLink(Container container, User currentUser, int formattedUserId, boolean includeGroups, boolean forEmail)
     {
-        String result;
+        HtmlStringBuilder builder = HtmlStringBuilder.of();
 
         // Email link shows display name and not html link
         if (forEmail)
         {
-            result = PageFlowUtil.filter(UserManager.getDisplayName(formattedUserId, currentUser));
+            builder.append(UserManager.getDisplayName(formattedUserId, currentUser));
         }
         else
         {
-            result = UserManager.getUserDetailsHTMLLink(container, currentUser, formattedUserId);
+            builder.append(UserManager.getUserDetailsHTMLLink(container, currentUser, formattedUserId));
         }
 
         if (includeGroups)
         {
-            String groupList = SecurityManager.getGroupList(container, UserManager.getUser(formattedUserId));
+            HtmlString groupList = SecurityManager.getGroupList(container, UserManager.getUser(formattedUserId));
             if (groupList.length() > 0)
             {
-                result += " (" + (groupList) + ")";
+                builder.append(" (").append(groupList).append(")");
             }
         }
 
-        return result;
+        return builder.getHtmlString();
     }
 
 
@@ -1105,7 +1106,7 @@ public class AnnouncementManager
                     if (notificationBean == null)
                         return null;
 
-                    return getUserDetailsLink(c, notificationBean.recipient,  notificationBean.announcementModel.getCreatedBy(),notificationBean.includeGroups, true);
+                    return getUserDetailsLink(c, notificationBean.recipient,  notificationBean.announcementModel.getCreatedBy(),notificationBean.includeGroups, true).toString();
                 }
             });
 

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -30,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.labkey.api.action.LabKeyError;
+import org.labkey.api.action.MutatingApiAction;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.permissions.CanSeeAuditLogPermission;
@@ -152,8 +153,8 @@ public class SecurityManager
     static final String ADD_GROUP_TO_ITSELF_ERROR_MESSAGE = "Can't add a group to itself";
     static final String ADD_TO_SYSTEM_GROUP_ERROR_MESSAGE = "Can't add a group to a system group";
     static final String ADD_SYSTEM_GROUP_ERROR_MESSAGE = "Can't add a system group to another group";
-    static final String DIFFERENT_PROJECTS_ERROR_MESSAGE =  "Can't add a project group to a group in a different project";
-    static final String PROJECT_TO_SITE_ERROR_MESSAGE =  "Can't add a project group to a site group";
+    static final String DIFFERENT_PROJECTS_ERROR_MESSAGE = "Can't add a project group to a group in a different project";
+    static final String PROJECT_TO_SITE_ERROR_MESSAGE = "Can't add a project group to a site group";
     static final String CIRCULAR_GROUP_ERROR_MESSAGE = "Can't add a group that results in a circular group relation";
 
     public static final String TRANSFORM_SESSION_ID = "LabKeyTransformSessionId";  // issue 19748
@@ -844,7 +845,7 @@ public class SecurityManager
         if (provider == null)
             return defaultUrl;
 
-        ResetPasswordProvider urlProvider =  AuthenticationManager.getResetPasswordProvider(provider);
+        ResetPasswordProvider urlProvider = AuthenticationManager.getResetPasswordProvider(provider);
         if (urlProvider == null)
             return defaultUrl;
 
@@ -1757,12 +1758,12 @@ public class SecurityManager
     }
 
     // Returns comma-separated list of group names this user belongs to in this container
-    public static String getGroupList(Container c, User u)
+    public static HtmlString getGroupList(Container c, User u)
     {
         Container proj = c.getProject();
 
         if (null == proj || u == null)
-            return "";
+            return HtmlString.EMPTY_STRING;
 
         int[] groupIds = u.getGroups();
 
@@ -1789,7 +1790,7 @@ public class SecurityManager
             }
         }
 
-        return groupList.toString();
+        return HtmlString.of(groupList.toString());
     }
 
 
@@ -2729,15 +2730,15 @@ public class SecurityManager
             MultiValuedMap<String, ConfigProperty> testConfigPropertyMap = new HashSetValuedHashMap<>();
 
             // prepare test UserRole properties
-            ConfigProperty testUserRoleProp =  new ConfigProperty(TEST_USER_1_EMAIL, ",," + TEST_USER_1_ROLE_NAME + ",,", "startup", ConfigProperty.SCOPE_USER_ROLES);
+            ConfigProperty testUserRoleProp = new ConfigProperty(TEST_USER_1_EMAIL, ",," + TEST_USER_1_ROLE_NAME + ",,", "startup", ConfigProperty.SCOPE_USER_ROLES);
             testConfigPropertyMap.put(ConfigProperty.SCOPE_USER_ROLES, testUserRoleProp);
 
             // prepare test GroupRole properties
-            ConfigProperty testGroupRoleProp =  new ConfigProperty(TEST_GROUP_1_NAME, ",," + TEST_GROUP_1_ROLE_NAME + ",,", "startup", ConfigProperty.SCOPE_GROUP_ROLES);
+            ConfigProperty testGroupRoleProp = new ConfigProperty(TEST_GROUP_1_NAME, ",," + TEST_GROUP_1_ROLE_NAME + ",,", "startup", ConfigProperty.SCOPE_GROUP_ROLES);
             testConfigPropertyMap.put(ConfigProperty.SCOPE_GROUP_ROLES, testGroupRoleProp);
 
             // prepare test UserRole properties
-            ConfigProperty testUserGroupProp =  new ConfigProperty(TEST_USER_2_EMAIL, ",," + TEST_USER_2_GROUP_NAME + ",,", "startup", ConfigProperty.SCOPE_USER_GROUPS);
+            ConfigProperty testUserGroupProp = new ConfigProperty(TEST_USER_2_EMAIL, ",," + TEST_USER_2_GROUP_NAME + ",,", "startup", ConfigProperty.SCOPE_USER_GROUPS);
             testConfigPropertyMap.put(ConfigProperty.SCOPE_USER_GROUPS, testUserGroupProp);
 
             // set these test startup properties to be used by the entire server

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -52,6 +52,8 @@ import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.UserIdRenderer;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.HeartBeat;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.Link;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.Result;
@@ -1144,14 +1146,14 @@ public class UserManager
      * @param displayedUserId The user id of the url we want to navigate to
      * @return The HTML string to navigate to the displayedUserId's user details page
      */
-    public static String getUserDetailsHTMLLink(Container container, User currentUser, int displayedUserId)
+    public static HtmlString getUserDetailsHTMLLink(Container container, User currentUser, int displayedUserId)
     {
         User displayUser = getUser(displayedUserId);
 
         boolean isDeletedUser = displayUser == null;
 
         if (isDeletedUser)
-            return PageFlowUtil.filter("<" + displayedUserId + ">");
+            return HtmlString.of("<" + displayedUserId + ">");
 
         String displayName = displayUser.getDisplayName(currentUser);
         ActionURL url = getUserDetailsURL(container, currentUser, displayedUserId);
@@ -1159,11 +1161,10 @@ public class UserManager
         // currentUser has permissions to see user details of the displayed user
         if (url != null)
         {
-            return "<a class=\"labkey-link\" href=\"" + url +
-                    "\">" + PageFlowUtil.filter(displayName) + "</a>";
+            return new Link.LinkBuilder(displayName).href(url).clearClasses().getHtmlString();
         }
 
-        return PageFlowUtil.filter(displayName);
+        return HtmlString.of(displayName);
     }
 
     /**

--- a/issues/src/org/labkey/issue/view/detailView.jsp
+++ b/issues/src/org/labkey/issue/view/detailView.jsp
@@ -239,8 +239,8 @@
             <%=text(bean.renderAdditionalDetailInfo())%>
         </table></td>
         <td valign="top"><table class="lk-fields-table">
-            <tr><%=bean.renderLabel(bean.getLabel("Opened", false))%><td nowrap="true"><%=h(bean.writeDate(issue.getCreated()))%> by <%=text(UserManager.getUserDetailsHTMLLink(c, user, issue.getCreatedBy()))%></td></tr>
-            <tr><%=bean.renderLabel(bean.getLabel("Changed", false))%><td nowrap="true"><%=h(bean.writeDate(issue.getModified()))%> by <%=text(UserManager.getUserDetailsHTMLLink(c, user, issue.getModifiedBy()))%></td></tr>
+            <tr><%=bean.renderLabel(bean.getLabel("Opened", false))%><td nowrap="true"><%=h(bean.writeDate(issue.getCreated()))%> by <%=UserManager.getUserDetailsHTMLLink(c, user, issue.getCreatedBy())%></td></tr>
+            <tr><%=bean.renderLabel(bean.getLabel("Changed", false))%><td nowrap="true"><%=h(bean.writeDate(issue.getModified()))%> by <%=UserManager.getUserDetailsHTMLLink(c, user, issue.getModifiedBy())%></td></tr>
             <tr><%=bean.renderLabel(bean.getLabel("Resolved", false))%><td nowrap="true"><%=h(bean.writeDate(issue.getResolved()))%><%=text(issue.getResolvedBy() != null ? " by " + UserManager.getUserDetailsHTMLLink(c, user, issue.getResolvedBy()) : "")%></td></tr>
             <tr><%=bean.renderLabel(bean.getLabel("Resolution", false))%><td><%=h(issue.getResolution())%></td></tr><%
             if (bean.isVisible("resolution") || !"open".equals(issue.getStatus()) && null != issue.getDuplicate())
@@ -308,7 +308,7 @@ if (!issue.getComments().contains(comment))
         <table width="100%"><tr><td class="comment-created" align="left"><b>
             <%=h(bean.writeDate(comment.getCreated()))%>
         </b></td><td class="comment-created-by" align="right"><b>
-            <%=text(UserManager.getUserDetailsHTMLLink(c, user, comment.getCreatedBy()))%>
+            <%=UserManager.getUserDetailsHTMLLink(c, user, comment.getCreatedBy())%>
         </b></td></tr></table>
         <%
             if (!issue.getComments().contains(comment))


### PR DESCRIPTION
#### Rationale
Continuing to migrate HTML-generating methods to return `HtmlString` instead of `String` to provide stronger assurances that generated HTML is properly formed.
