### PR TITLE
Switch usages to TableInsertDataIteratorBuilder

### DIFF
--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -1573,7 +1573,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     }
 
     @Override
-    public boolean hasTriggers(Container c)
+    public boolean hasTriggers(@Nullable Container c)
     {
         return !getTriggers(c).isEmpty();
     }
@@ -1594,7 +1594,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     private Collection<Trigger> _triggers = null;
 
     @NotNull
-    protected Collection<Trigger> getTriggers(Container c)
+    protected Collection<Trigger> getTriggers(@Nullable Container c)
     {
         if (_triggers == null)
         {
@@ -1605,9 +1605,9 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
 
 
     @NotNull
-    private Collection<Trigger> loadTriggers(Container c)
+    private Collection<Trigger> loadTriggers(@Nullable Container c)
     {
-        if (_triggerFactories == null || _triggerFactories.isEmpty())
+        if (_triggerFactories.isEmpty())
             return Collections.emptyList();
 
         List<Trigger> scripts = new ArrayList<>(_triggerFactories.size());

--- a/api/src/org/labkey/api/data/SchemaTableInfo.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfo.java
@@ -960,7 +960,7 @@ public class SchemaTableInfo implements TableInfo, UpdateableTableInfo, AuditCon
     @Override
     public DataIteratorBuilder persistRows(DataIteratorBuilder data, DataIteratorContext context)
     {
-        return new TableInsertDataIteratorBuilder(data, this, null);
+        return new TableInsertDataIteratorBuilder(data, this);
     }
 
     @Override

--- a/api/src/org/labkey/api/data/Table.java
+++ b/api/src/org/labkey/api/data/Table.java
@@ -38,7 +38,7 @@ import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.Pump;
 import org.labkey.api.dataiterator.SimpleTranslator;
-import org.labkey.api.dataiterator.TableInsertDataIterator;
+import org.labkey.api.dataiterator.TableInsertDataIteratorBuilder;
 import org.labkey.api.di.DataIntegrationService;
 import org.labkey.api.exceptions.OptimisticConflictException;
 import org.labkey.api.exp.api.ExperimentService;
@@ -1684,12 +1684,8 @@ public class Table
             translate.selectAll();
             translate.addBuiltInColumns(dic, JunitUtil.getTestContainer(), TestContext.get().getUser(), testTable, false);
 
-            DataIteratorBuilder load = TableInsertDataIterator.create(
-                    translate,
-                    testTable,
-                    dic
-            );
-            new Pump(load, dic).run();
+            DataIteratorBuilder load = new TableInsertDataIteratorBuilder(translate, testTable);
+            new Pump(load.getDataIterator(dic), dic).run();
 
             assertFalse(dic.getErrors().hasErrors());
 

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -506,7 +506,7 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
     /**
      * Return true if there are trigger scripts associated with this table.
      */
-    boolean hasTriggers(Container c);
+    boolean hasTriggers(@Nullable Container c);
 
     /**
      * Return true if all trigger scripts support streaming.

--- a/api/src/org/labkey/api/data/triggers/ScriptTriggerFactory.java
+++ b/api/src/org/labkey/api/data/triggers/ScriptTriggerFactory.java
@@ -49,6 +49,7 @@ public class ScriptTriggerFactory implements TriggerFactory
     @NotNull
     public Collection<Trigger> createTrigger(@Nullable Container c, TableInfo table, Map<String, Object> extraContext)
     {
+        // Without a container this factory is unable to determine the set of active modules available.
         if (c == null)
             return Collections.emptyList();
 
@@ -63,7 +64,7 @@ public class ScriptTriggerFactory implements TriggerFactory
     }
 
     @NotNull
-    protected Collection<Trigger> createTriggerScript(Container c, TableInfo table) throws ScriptException
+    protected Collection<Trigger> createTriggerScript(@NotNull Container c, TableInfo table) throws ScriptException
     {
         ScriptService svc = ScriptService.get();
         assert svc != null;
@@ -74,7 +75,7 @@ public class ScriptTriggerFactory implements TriggerFactory
     }
 
     @NotNull
-    private Collection<Trigger> getDefaultTriggers(Container c, TableInfo table, @NotNull ScriptService svc) throws ScriptException
+    private Collection<Trigger> getDefaultTriggers(@NotNull Container c, TableInfo table, @NotNull ScriptService svc) throws ScriptException
     {
 
         final String schemaName = table.getPublicSchemaName();
@@ -116,7 +117,7 @@ public class ScriptTriggerFactory implements TriggerFactory
     }
 
     @NotNull
-    protected Collection<Trigger> checkPaths(Container c, TableInfo table, @NotNull ScriptService svc, Path path) throws ScriptException
+    protected Collection<Trigger> checkPaths(@NotNull Container c, TableInfo table, @NotNull ScriptService svc, Path path) throws ScriptException
     {
         Collection<Trigger> scripts = new LinkedHashSet<>();
 

--- a/api/src/org/labkey/api/data/triggers/ScriptTriggerFactory.java
+++ b/api/src/org/labkey/api/data/triggers/ScriptTriggerFactory.java
@@ -18,6 +18,7 @@ package org.labkey.api.data.triggers;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.module.Module;
@@ -46,8 +47,11 @@ public class ScriptTriggerFactory implements TriggerFactory
 
     @Override
     @NotNull
-    public Collection<Trigger> createTrigger(Container c, TableInfo table, Map<String, Object> extraContext)
+    public Collection<Trigger> createTrigger(@Nullable Container c, TableInfo table, Map<String, Object> extraContext)
     {
+        if (c == null)
+            return Collections.emptyList();
+
         try
         {
             return createTriggerScript(c, table);
@@ -123,7 +127,7 @@ public class ScriptTriggerFactory implements TriggerFactory
                 scripts.add(new ScriptTrigger(c, table, script));
 
         }
+
         return scripts;
     }
-
 }

--- a/api/src/org/labkey/api/data/triggers/TriggerFactory.java
+++ b/api/src/org/labkey/api/data/triggers/TriggerFactory.java
@@ -16,6 +16,7 @@
 package org.labkey.api.data.triggers;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 
@@ -29,5 +30,5 @@ import java.util.Map;
 public interface TriggerFactory
 {
     @NotNull
-    Collection<Trigger> createTrigger(Container c, TableInfo table, Map<String, Object> extraContext);
+    Collection<Trigger> createTrigger(@Nullable Container c, TableInfo table, Map<String, Object> extraContext);
 }

--- a/api/src/org/labkey/api/dataiterator/TableInsertDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/TableInsertDataIterator.java
@@ -46,11 +46,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-// TODO: convert usages to TableInsertDataIteratorBuilder and stop extending DataIteratorBuilder
 public class TableInsertDataIterator extends StatementDataIterator implements DataIteratorBuilder
 {
     private final TableInfo _table;
-    private final Container _c;
+    private final Container _container;
     private final boolean _selectIds;
     private final InsertOption _insertOption;
     private final Set<String> _skipColumnNames = new CaseInsensitiveHashSet();
@@ -61,30 +60,14 @@ public class TableInsertDataIterator extends StatementDataIterator implements Da
     private Connection _conn = null;
     private Set<DomainProperty> _adhocPropColumns = new LinkedHashSet<>();
 
-    @Deprecated // use TableInsertDataIteratorBuilder
-    public static TableInsertDataIterator create(DataIterator data, TableInfo table, DataIteratorContext context)
-    {
-        DataIteratorBuilder builder = DataIteratorBuilder.wrap(data);
-        return (TableInsertDataIterator)create(builder, table, null, context, null, null, null, null, false, null);
-    }
-
-    /** If container != null, it will be set as a constant in the insert statement */
-    @Deprecated // use TableInsertDataIteratorBuilder
-    public static TableInsertDataIterator create(DataIteratorBuilder builder, TableInfo table, @Nullable Container c, DataIteratorContext context)
-    {
-        return (TableInsertDataIterator)create(builder, table, c, context, null, null, null, null, false, null);
-    }
-
-    @Deprecated  // use TableInsertDataIteratorBuilder
-    public static DataIteratorBuilder create(DataIteratorBuilder data, TableInfo table, @Nullable Container c, DataIteratorContext context,
-                                      @Nullable Set<String> keyColumns, @Nullable Set<String> addlSkipColumns, @Nullable Set<String> dontUpdate)
-    {
-        return (TableInsertDataIterator)create(data, table, c, context, keyColumns, addlSkipColumns, dontUpdate, null, false, null);
-    }
-
-    public static DataIterator create(DataIteratorBuilder data, TableInfo table, @Nullable Container c, DataIteratorContext context,
+    /**
+     * Creates and configures a TableInsertDataIterator. DO NOT call this method directly.
+     * Instead instantiate a {@link TableInsertDataIteratorBuilder}.
+     * @param container If container != null, it will be set as a constant in the insert statement.
+     */
+    public static DataIterator create(DataIteratorBuilder data, TableInfo table, @Nullable Container container, DataIteratorContext context,
          @Nullable Set<String> keyColumns, @Nullable Set<String> addlSkipColumns, @Nullable Set<String> dontUpdate,
-         @Nullable Set<DomainProperty> vocabularyColumns , boolean commitRowsBeforeContinuing, @Nullable Map<String, String> remapSchemaColumns)
+         @Nullable Set<DomainProperty> vocabularyColumns, boolean commitRowsBeforeContinuing, @Nullable Map<String, String> remapSchemaColumns)
             //extra param @NUllable Set<PDs/Names?CIs> VOCCOls
     {
         // TODO it would be better to postpone calling data.getDataIterator() until the TableInsertDataIterator.getDataIterator() is called
@@ -135,7 +118,7 @@ public class TableInsertDataIterator extends StatementDataIterator implements Da
         {
             keyColumns.addAll(context.getAlternateKeys());
         }
-        TableInsertDataIterator ti = new TableInsertDataIterator(di, table, c, context, keyColumns, addlSkipColumns, dontUpdate);
+        TableInsertDataIterator ti = new TableInsertDataIterator(di, table, container, context, keyColumns, addlSkipColumns, dontUpdate);
         DataIterator ret = ti;
 
 
@@ -157,14 +140,14 @@ public class TableInsertDataIterator extends StatementDataIterator implements Da
     }
 
 
-    protected TableInsertDataIterator(DataIterator data, TableInfo table, Container c, DataIteratorContext context,
+    protected TableInsertDataIterator(DataIterator data, TableInfo table, @Nullable Container container, DataIteratorContext context,
                                       @Nullable Set<String> keyColumns, @Nullable Set<String> addlSkipColumns, @Nullable Set<String> dontUpdate)
     {
         super(table.getSqlDialect(), data, context);
         setDebugName(table.getName());
 
         _table = table;
-        _c = c;
+        _container = container;
         _insertOption = context.getInsertOption();
 
         if (null != addlSkipColumns)
@@ -216,7 +199,7 @@ public class TableInsertDataIterator extends StatementDataIterator implements Da
         else
         {
             boolean forInsert = _context.getInsertOption().reselectIds;
-            boolean hasTriggers = _table.hasTriggers(_c);
+            boolean hasTriggers = _table.hasTriggers(_container);
             _selectIds = forInsert || hasTriggers;
         }
 
@@ -297,7 +280,7 @@ public class TableInsertDataIterator extends StatementDataIterator implements Da
                 .selectIds(_selectIds)
                 .constants(constants)
                 .setVocabularyProperties(_adhocPropColumns);
-        stmt = utils.createStatement(_conn, _c, null);
+        stmt = utils.createStatement(_conn, _container, null);
         return stmt;
     }
 
@@ -315,7 +298,7 @@ public class TableInsertDataIterator extends StatementDataIterator implements Da
                     .updateBuiltinColumns(false)
                     .selectIds(_selectIds)
                     .constants(constants);
-        stmt = util.createStatement(_conn, _c, null);
+        stmt = util.createStatement(_conn, _container, null);
         return stmt;
     }
 
@@ -324,7 +307,7 @@ public class TableInsertDataIterator extends StatementDataIterator implements Da
     public DataIterator getDataIterator(DataIteratorContext context)
     {
         assert _context == context;
-        return LoggingDataIterator.wrap((DataIterator)this);
+        return LoggingDataIterator.wrap(this);
     }
 
 

--- a/api/src/org/labkey/api/dataiterator/TableInsertDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/TableInsertDataIteratorBuilder.java
@@ -1,5 +1,6 @@
 package org.labkey.api.dataiterator;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.property.DomainProperty;
@@ -11,7 +12,7 @@ public class TableInsertDataIteratorBuilder implements DataIteratorBuilder
 {
     final DataIteratorBuilder builder;
     final TableInfo table;
-    final Container container;     // If container != null, it will be set as a constant in the insert statement
+    final Container container;
     Set<String> keyColumns = null;
     Set<String> addlSkipColumns = null;
     Set<String> dontUpdate = null;
@@ -19,11 +20,19 @@ public class TableInsertDataIteratorBuilder implements DataIteratorBuilder
     private Set<DomainProperty> vocabularyProperties;
     Map<String, String> remapSchemaColumns = null;
 
-    public TableInsertDataIteratorBuilder(DataIteratorBuilder data, TableInfo table, Container c)
+    public TableInsertDataIteratorBuilder(DataIteratorBuilder data, TableInfo table)
+    {
+        this(data, table, null);
+    }
+
+    /**
+     * @param container If container != null, it will be set as a constant in the insert statement.
+     */
+    public TableInsertDataIteratorBuilder(DataIteratorBuilder data, TableInfo table, @Nullable Container container)
     {
         this.builder = data;
         this.table = table;
-        this.container = c;
+        this.container = container;
     }
 
     public TableInsertDataIteratorBuilder setKeyColumns(Set<String> keyColumns)

--- a/assay/api-src/org/labkey/api/assay/AssayResultTable.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultTable.java
@@ -28,7 +28,6 @@ import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.OORDisplayColumnFactory;
-import org.labkey.api.data.Parameter;
 import org.labkey.api.data.ParameterMapStatement;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
@@ -39,7 +38,7 @@ import org.labkey.api.data.UpdateableTableInfo;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
-import org.labkey.api.dataiterator.TableInsertDataIterator;
+import org.labkey.api.dataiterator.TableInsertDataIteratorBuilder;
 import org.labkey.api.exp.MvColumn;
 import org.labkey.api.exp.PropertyColumn;
 import org.labkey.api.exp.PropertyDescriptor;
@@ -548,7 +547,7 @@ public class AssayResultTable extends FilteredTable<AssayProtocolSchema> impleme
     @Override
     public DataIteratorBuilder persistRows(DataIteratorBuilder data, DataIteratorContext context)
     {
-        return TableInsertDataIterator.create(data, this, null, context);
+        return new TableInsertDataIteratorBuilder(data, this);
     }
 
     @Override

--- a/internal/src/org/labkey/api/query/SimpleUserSchema.java
+++ b/internal/src/org/labkey/api/query/SimpleUserSchema.java
@@ -35,7 +35,6 @@ import org.labkey.api.data.ForeignKey;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MultiValuedForeignKey;
 import org.labkey.api.data.MutableColumnInfo;
-import org.labkey.api.data.Parameter;
 import org.labkey.api.data.ParameterMapStatement;
 import org.labkey.api.data.SchemaTableInfo;
 import org.labkey.api.data.StatementUtils;
@@ -44,7 +43,7 @@ import org.labkey.api.data.UpdateableTableInfo;
 import org.labkey.api.data.UserSchemaCustomizer;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
-import org.labkey.api.dataiterator.TableInsertDataIterator;
+import org.labkey.api.dataiterator.TableInsertDataIteratorBuilder;
 import org.labkey.api.exp.PropertyColumn;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.property.Domain;
@@ -243,7 +242,7 @@ public class SimpleUserSchema extends UserSchema
 
         protected boolean acceptColumn(ColumnInfo col)
         {
-            if(getColumn(col.getName()) != null)
+            if (getColumn(col.getName()) != null)
             {
                 _log.warn("'" + col.getName() + "' column already exists in '" + col.getParentTable() + "' table. Duplicate column won't be displayed.");
                 return false;
@@ -547,7 +546,7 @@ public class SimpleUserSchema extends UserSchema
         @Override
         public DataIteratorBuilder persistRows(DataIteratorBuilder data, DataIteratorContext context)
         {
-            return TableInsertDataIterator.create(data, this, null, context);
+            return new TableInsertDataIteratorBuilder(data, this);
         }
 
         @Override

--- a/issues/src/org/labkey/issue/query/IssuesTable.java
+++ b/issues/src/org/labkey/issue/query/IssuesTable.java
@@ -33,7 +33,7 @@ import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.DataIteratorUtil;
 import org.labkey.api.dataiterator.LoggingDataIterator;
 import org.labkey.api.dataiterator.SimpleTranslator;
-import org.labkey.api.dataiterator.TableInsertDataIterator;
+import org.labkey.api.dataiterator.TableInsertDataIteratorBuilder;
 import org.labkey.api.dataiterator.WrapperDataIterator;
 import org.labkey.api.defaults.DefaultValueService;
 import org.labkey.api.exp.ExperimentException;
@@ -605,8 +605,8 @@ public class IssuesTable extends FilteredTable<IssuesQuerySchema> implements Upd
             step0.addColumn(issueDefCol, new SimpleTranslator.ConstantColumn(_issueDef.getRowId()));
 
             // Insert into issues.issues then the provisioned table
-            DataIteratorBuilder step2 = TableInsertDataIterator.create(DataIteratorBuilder.wrap(step0), IssuesSchema.getInstance().getTableInfoIssues(), c, context);
-            DataIteratorBuilder step3 = TableInsertDataIterator.create(step2, _issueDef.createTable(getUserSchema().getUser()), c, context);
+            var step2 = new TableInsertDataIteratorBuilder(step0, IssuesSchema.getInstance().getTableInfoIssues(), c);
+            var step3 = new TableInsertDataIteratorBuilder(step2, _issueDef.createTable(getUserSchema().getUser()), c);
 
             return LoggingDataIterator.wrap(step3.getDataIterator(context));
         }

--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -534,8 +534,8 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
     {
         // NOTE: it's a little ambiguous how to factor code between persistRows() and createImportDIB()
         data = new _DataIteratorBuilder(data, context);
-        return new TableInsertDataIteratorBuilder(data, this, null)
-                .setKeyColumns( new CaseInsensitiveHashSet(getPkColumnNames()));
+        return new TableInsertDataIteratorBuilder(data, this)
+                .setKeyColumns(new CaseInsensitiveHashSet(getPkColumnNames()));
     }
 
 

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1628,12 +1628,6 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
             // }
             StudyServiceImpl.addDatasetAuditEvent(user, DatasetDefinition.this, oldRow, parameters);
         }
-
-        @Override
-        public DataIteratorBuilder persistRows(DataIteratorBuilder data, DataIteratorContext context)
-        {
-            return new TableInsertDataIteratorBuilder(data, this, null);
-        }
     }
 
 


### PR DESCRIPTION
#### Rationale
Migrates all remaining usages of `TableInsertDataIterator.create()` to using `new TableInsertDataIteratorBuilder()`. Additionally, makes `ScriptTriggerFactory` defensive against a `null` value for the `container` provided to the builder

#### Related Pull Requests
* https://github.com/LabKey/labbook/pull/87
* https://github.com/LabKey/harvest/pull/142
* https://github.com/LabKey/commonAssays/pull/294

#### Changes
* Switch usages to use `TableInsertDataIteratorBuilder`.
* Remove previously deprecated variants of `TableInsertDataIterator.create()`.
* Removes redundant override of `persistRows` in `DatasetDefinition`.
* Annotates `TriggerFactory` to indicate `container` argument is `@Nullable`.
* Makes `ScriptTriggerFactory` defensive against a `null` container value and immediately returns an empty collection. All other variants of `TriggerFactory` were not using the container value at all.
