### PR TITLE
Issue 33004: Template.Framed appears to not be a thing

### DIFF
--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -268,9 +268,6 @@ public abstract class SpringActionController implements Controller, HasViewConte
         if (null != StringUtils.trimToNull(request.getParameter("_print")) ||
             null != StringUtils.trimToNull(request.getParameter("_print.x")))
             page.setTemplate(PageConfig.Template.Print);
-        if (null != StringUtils.trimToNull(request.getParameter("_frame")) ||
-            null != StringUtils.trimToNull(request.getParameter("_frame.x")))
-            page.setTemplate(PageConfig.Template.Framed);
         if (null != StringUtils.trimToNull(request.getParameter("_template")))
         {
             try

--- a/api/src/org/labkey/api/view/template/PageConfig.java
+++ b/api/src/org/labkey/api/view/template/PageConfig.java
@@ -62,7 +62,6 @@ public class PageConfig
         None,
         Home,
         Print,
-        Framed, // In an Iframe same as print except tries to maintain template on navigate
         Dialog,
         Wizard,
         Body,

--- a/core/src/org/labkey/core/view/template/bootstrap/ViewServiceImpl.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/ViewServiceImpl.java
@@ -67,30 +67,25 @@ public class ViewServiceImpl implements ViewService
     {
         switch (t)
         {
-            case None:
-            {
+            case None -> {
                 return null;
             }
-            case Framed:
-            case Print:
-            {
+            case Print -> {
                 return new PrintTemplate(context, body, page);
             }
-            case Dialog:
-            {
+            case Dialog -> {
                 return new DialogTemplate(context, body, page);
             }
-            case Wizard:
-            {
+            case Wizard -> {
                 return new WizardTemplate(context, body, page);
             }
-            case Body:
-            case App:
-            {
-                return new AppTemplate(context, body, page, t.equals(Template.App));
+            case App -> {
+                return new AppTemplate(context, body, page, true);
             }
-            case Home:
-            {
+            case Body -> {
+                return new AppTemplate(context, body, page, false);
+            }
+            case Home -> {
                 return new PageTemplate(context, body, page);
             }
         }


### PR DESCRIPTION
#### Rationale
Remove unused Template.Framed option, but mostly an excuse to introduce a bit of Java 14 syntax (switch expressions)