### PR TITLE
Fix admin settings pages' navtrails

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -299,7 +299,7 @@ public class AnnouncementsController extends SpringActionController
 
     public static ActionURL getAdminEmailURL(Container c, @Nullable URLHelper returnURL)
     {
-        ActionURL url = PageFlowUtil.urlProvider(AdminUrls.class).getNotificationsURL(c);
+        ActionURL url = urlProvider(AdminUrls.class).getNotificationsURL(c);
         if (returnURL != null)
             url.addReturnURL(returnURL);
 
@@ -1880,8 +1880,8 @@ public class AnnouncementsController extends SpringActionController
                 adminURL = c.hasPermission(user, AdminPermission.class) ? getAdminURL(c, url) : null;
                 emailPrefsURL = user.isGuest() ? null : getEmailPreferencesURL(c, url, c.getId());
                 emailManageURL = c.hasPermission(user, AdminPermission.class) ? getAdminEmailURL(c, url) : null;
-                containerEmailTemplateURL = c.hasPermission(user, AdminPermission.class) ? PageFlowUtil.urlProvider(AdminUrls.class).getCustomizeEmailURL(c, AnnouncementManager.NotificationEmailTemplate.class, url) : null;
-                siteEmailTemplateURL = user.hasSiteAdminPermission() ? PageFlowUtil.urlProvider(AdminUrls.class).getCustomizeEmailURL(ContainerManager.getRoot(), AnnouncementManager.NotificationEmailTemplate.class, url) : null;
+                containerEmailTemplateURL = c.hasPermission(user, AdminPermission.class) ? urlProvider(AdminUrls.class).getCustomizeEmailURL(c, AnnouncementManager.NotificationEmailTemplate.class, url) : null;
+                siteEmailTemplateURL = user.hasSiteAdminPermission() ? urlProvider(AdminUrls.class).getCustomizeEmailURL(ContainerManager.getRoot(), AnnouncementManager.NotificationEmailTemplate.class, url) : null;
                 insertURL = perm.allowInsert() ? getInsertURL(c, url) : null;
                 includeGroups = perm.includeGroups();
             }

--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -86,6 +86,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -244,6 +245,12 @@ public abstract class SpringActionController implements Controller, HasViewConte
     protected User getUser()
     {
         return getViewContext().getUser();
+    }
+
+    // Convenience method
+    protected static <P extends UrlProvider> P urlProvider(Class<P> inter)
+    {
+        return Objects.requireNonNull(PageFlowUtil.urlProvider(inter));
     }
 
     protected void requiresLogin()

--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -573,7 +573,7 @@ public abstract class SpringActionController implements Controller, HasViewConte
             if (null != action && action.getClass().isAnnotationPresent(AllowedBeforeInitialUserIsSet.class))
                 return null;
             else
-                return PageFlowUtil.urlProvider(LoginUrls.class).getInitialUserURL();
+                return urlProvider(LoginUrls.class).getInitialUserURL();
         }
 
         boolean upgradeRequired = ModuleLoader.getInstance().isUpgradeRequired();
@@ -621,11 +621,11 @@ public abstract class SpringActionController implements Controller, HasViewConte
                         uae.setType(UnauthorizedException.Type.sendBasicAuth);
                         throw uae;
                     }
-                    return PageFlowUtil.urlProvider(AdminUrls.class).getMaintenanceURL(returnURL);
+                    return urlProvider(AdminUrls.class).getMaintenanceURL(returnURL);
                 }
                 else if (upgradeRequired || !startupComplete)
                 {
-                    return PageFlowUtil.urlProvider(AdminUrls.class).getModuleStatusURL(returnURL);
+                    return urlProvider(AdminUrls.class).getModuleStatusURL(returnURL);
                 }
             }
         }

--- a/api/src/org/labkey/api/security/LoginUrls.java
+++ b/api/src/org/labkey/api/security/LoginUrls.java
@@ -45,6 +45,4 @@ public interface LoginUrls extends UrlProvider
     ActionURL getStopImpersonatingURL(Container c, @Nullable URLHelper returnURL);
     ActionURL getAgreeToTermsURL(Container c, URLHelper returnURL);
     ActionURL getSSORedirectURL(SSOAuthenticationConfiguration<?> configuration, URLHelper returnURL, boolean skipProfile);
-
-    void addAuthenticationNavTrail(NavTree root);
 }

--- a/api/src/org/labkey/api/settings/AdminConsole.java
+++ b/api/src/org/labkey/api/settings/AdminConsole.java
@@ -22,14 +22,15 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.view.ActionURL;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 /**
  * Manages registration for links to be shown in the Admin Console, as well as experimental features that can
@@ -60,7 +61,7 @@ public class AdminConsole
     }
 
     private static final Map<SettingsLinkType, Collection<AdminLink>> _links = new HashMap<>();
-    private static final List<ExperimentalFeatureFlag> _experimentalFlags = new ArrayList<>();
+    private static final Set<ExperimentalFeatureFlag> _experimentalFlags = new ConcurrentSkipListSet<>();
 
     static
     {
@@ -140,18 +141,12 @@ public class AdminConsole
 
     public static void addExperimentalFeatureFlag(String flag, String title, String description, boolean requiresRestart)
     {
-        synchronized (_experimentalFlags)
-        {
-            _experimentalFlags.add(new ExperimentalFeatureFlag(flag, title, description, requiresRestart));
-        }
+        _experimentalFlags.add(new ExperimentalFeatureFlag(flag, title, description, requiresRestart));
     }
 
     public static Collection<ExperimentalFeatureFlag> getExperimentalFeatureFlags()
     {
-        synchronized (_experimentalFlags)
-        {
-            return Collections.unmodifiableList(_experimentalFlags);
-        }
+        return Collections.unmodifiableSet(_experimentalFlags);
     }
 
     public static class ExperimentalFeatureFlag implements Comparable<ExperimentalFeatureFlag>
@@ -192,7 +187,7 @@ public class AdminConsole
         @Override
         public int compareTo(@NotNull ExperimentalFeatureFlag o)
         {
-            return getFlag().compareToIgnoreCase(o.getFlag());
+            return getTitle().compareToIgnoreCase(o.getTitle());
         }
 
         public boolean isEnabled()

--- a/api/src/org/labkey/api/view/FolderManagement.java
+++ b/api/src/org/labkey/api/view/FolderManagement.java
@@ -37,6 +37,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static org.labkey.api.view.Portal.urlProvider;
+
 /**
  * User: klum
  * Date: Jan 17, 2011
@@ -92,8 +94,7 @@ public class FolderManagement
             void addNavTrail(BaseViewAction action, NavTree root, Container c, User user)
             {
                 action.setHelpTopic(new HelpTopic("customizeLook"));
-                root.addChild("Admin Console", PageFlowUtil.urlProvider(AdminUrls.class).getAdminConsoleURL());
-                root.addChild("Look and Feel Settings");
+                PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "Look and Feel Settings", null);
             }
 
             @Override

--- a/api/src/org/labkey/api/view/FolderManagement.java
+++ b/api/src/org/labkey/api/view/FolderManagement.java
@@ -37,8 +37,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static org.labkey.api.view.Portal.urlProvider;
-
 /**
  * User: klum
  * Date: Jan 17, 2011
@@ -58,12 +56,14 @@ public class FolderManagement
                     TabProvider provider = TYPE_ACTION_TAB_PROVIDER.get(this).get(action.getClass());
                     PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, provider.getText(), null);
                 }
+                else
+                {
+                    if (c.isContainerTab())
+                        root.addChild(c.getParent().getName(), c.getParent().getStartURL(user));
 
-                if (c.isContainerTab())
-                    root.addChild(c.getParent().getName(), c.getParent().getStartURL(user));
-
-                root.addChild(c.getName(), c.getStartURL(user));
-                root.addChild("Folder Management");
+                    root.addChild(c.getName(), c.getStartURL(user));
+                    root.addChild("Folder Management");
+                }
             }
 
             @Override

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -16,7 +16,6 @@
 
 package org.labkey.assay;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.NotNull;
@@ -167,38 +166,38 @@ import java.util.zip.ZipOutputStream;
 public class AssayController extends SpringActionController
 {
     private static final DefaultActionResolver _resolver = new DefaultActionResolver(AssayController.class,
-            GetAssayBatchAction.class,
-            GetAssayBatchesAction.class,
-            SaveAssayBatchAction.class,
-            GetAssayRunAction.class,
-            GetAssayRunsAction.class,
-            SaveAssayRunsAction.class,
-            ImportRunApiAction.class,
-            UploadWizardAction.class,
-            TransformResultsAction.class,
-            PlateBasedUploadWizardAction.class,
-            PipelineDataCollectorRedirectAction.class,
-            DeleteAction.class,
-            DesignerAction.class,
-            ImportAction.class,
-            TsvImportAction.class,
-            TemplateAction.class,
-            AssayBatchesAction.class,
-            AssayBatchDetailsAction.class,
-            AssayRunsAction.class,
-            AssayRunDetailsAction.class,
-            AssayResultsAction.class,
-            AssayResultDetailsAction.class,
-            ReimportRedirectAction.class,
-            ShowSelectedRunsAction.class,
-            ShowSelectedDataAction.class,
-            SetDefaultValuesAssayAction.class,
-            AssayDetailRedirectAction.class,
-            SaveProtocolAction.class,
-            GetProtocolAction.class,
-            DeleteProtocolAction.class,
-            AssayPlateMetadataTemplateAction.class
-        );
+        GetAssayBatchAction.class,
+        GetAssayBatchesAction.class,
+        SaveAssayBatchAction.class,
+        GetAssayRunAction.class,
+        GetAssayRunsAction.class,
+        SaveAssayRunsAction.class,
+        ImportRunApiAction.class,
+        UploadWizardAction.class,
+        TransformResultsAction.class,
+        PlateBasedUploadWizardAction.class,
+        PipelineDataCollectorRedirectAction.class,
+        DeleteAction.class,
+        DesignerAction.class,
+        ImportAction.class,
+        TsvImportAction.class,
+        TemplateAction.class,
+        AssayBatchesAction.class,
+        AssayBatchDetailsAction.class,
+        AssayRunsAction.class,
+        AssayRunDetailsAction.class,
+        AssayResultsAction.class,
+        AssayResultDetailsAction.class,
+        ReimportRedirectAction.class,
+        ShowSelectedRunsAction.class,
+        ShowSelectedDataAction.class,
+        SetDefaultValuesAssayAction.class,
+        AssayDetailRedirectAction.class,
+        SaveProtocolAction.class,
+        GetProtocolAction.class,
+        DeleteProtocolAction.class,
+        AssayPlateMetadataTemplateAction.class
+    );
 
     public AssayController()
     {
@@ -330,7 +329,7 @@ public class AssayController extends SpringActionController
         assayProperties.put("importController", provider.getImportURL(c, protocol).getController());
         assayProperties.put("importAction", provider.getImportURL(c, protocol).getAction());
         assayProperties.put("reRunSupport", provider.getReRunSupport());
-        assayProperties.put("templateLink", PageFlowUtil.urlProvider(AssayUrls.class).getProtocolURL(c, protocol, TemplateAction.class));
+        assayProperties.put("templateLink", urlProvider(AssayUrls.class).getProtocolURL(c, protocol, TemplateAction.class));
         if (provider instanceof PlateBasedAssayProvider)
             assayProperties.put("plateTemplate", ((PlateBasedAssayProvider)provider).getPlateTemplate(c, protocol));
 
@@ -376,7 +375,7 @@ public class AssayController extends SpringActionController
     private static Map<String, Object> serializeAssayLinks(ExpProtocol protocol, AssayProvider provider, Container c, User user)
     {
         Map<String, Object> links = new HashMap<>();
-        AssayUrls urlProvider = PageFlowUtil.urlProvider(AssayUrls.class);
+        AssayUrls urlProvider = urlProvider(AssayUrls.class);
 
         links.put("batches", urlProvider.getAssayBatchesURL(c, protocol, null));
         links.put("begin", urlProvider.getProtocolURL(c, protocol, AssayBeginAction.class));
@@ -496,7 +495,7 @@ public class AssayController extends SpringActionController
 
             final Container currentContainer = getContainer();
             final User user = getUser();
-            final ProjectUrls projectUrls = PageFlowUtil.urlProvider(ProjectUrls.class);
+            final ProjectUrls projectUrls = urlProvider(ProjectUrls.class);
 
             ContainerTree tree = new ContainerTree("/", getUser(), DesignAssayPermission.class, null)
             {
@@ -507,7 +506,7 @@ public class AssayController extends SpringActionController
                     //the current container
                     ActionURL returnURL = (c.hasPermission(user, ReadPermission.class)) ? projectUrls.getStartURL(c) : projectUrls.getStartURL(currentContainer);
 
-                    ActionURL copyURL = PageFlowUtil.urlProvider(AssayUrls.class).getDesignerURL(c, _protocol, true, returnURL);
+                    ActionURL copyURL = urlProvider(AssayUrls.class).getDesignerURL(c, _protocol, true, returnURL);
                     html.append("<a href=\"");
                     html.append(copyURL.getEncodedLocalURIString());
                     html.append("\">");
@@ -515,7 +514,7 @@ public class AssayController extends SpringActionController
                     html.append("</a>");
                 }
             };
-            ActionURL copyHereURL = PageFlowUtil.urlProvider(AssayUrls.class).getDesignerURL(form.getContainer(), _protocol, true, null);
+            ActionURL copyHereURL = urlProvider(AssayUrls.class).getDesignerURL(form.getContainer(), _protocol, true, null);
             HtmlView fileTree = new HtmlView(HtmlStringBuilder.of()
                     .append(HtmlString.unsafe("<table><tr><td><b>Select destination folder:</b></td></tr>"))
                     .append(tree.getHtmlString())
@@ -542,7 +541,7 @@ public class AssayController extends SpringActionController
         @Override
         public ModelAndView getView(ProtocolIdForm form, BindException errors)
         {
-            throw new RedirectException(PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(getContainer(), form.getProtocol()));
+            throw new RedirectException(urlProvider(AssayUrls.class).getAssayRunsURL(getContainer(), form.getProtocol()));
         }
 
         @Override
@@ -1661,7 +1660,7 @@ public class AssayController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             Container c = getContainer();
-            ActionURL batchListURL = PageFlowUtil.urlProvider(AssayUrls.class).getAssayBatchesURL(c, _protocol, null);
+            ActionURL batchListURL = urlProvider(AssayUrls.class).getAssayBatchesURL(c, _protocol, null);
 
             super.addNavTrail(root);
             root.addChild(_protocol.getName() + " Batches", batchListURL);

--- a/audit/src/org/labkey/audit/AuditController.java
+++ b/audit/src/org/labkey/audit/AuditController.java
@@ -25,19 +25,11 @@ import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.audit.AbstractAuditTypeProvider;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.DetailedAuditTypeEvent;
-import org.labkey.api.audit.SampleTimelineAuditEvent;
 import org.labkey.api.audit.permissions.CanSeeAuditLogPermission;
 import org.labkey.api.audit.provider.SiteSettingsAuditProvider;
 import org.labkey.api.audit.view.AuditChangesView;
-import org.labkey.api.data.CompareType;
-import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.SimpleFilter;
-import org.labkey.api.data.TableSelector;
-import org.labkey.api.exp.api.ExperimentService;
-import org.labkey.api.query.FieldKey;
-import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryUrls;
 import org.labkey.api.query.QueryView;
@@ -55,7 +47,6 @@ import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.util.HelpTopic;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
@@ -69,14 +60,11 @@ import org.springframework.web.servlet.ModelAndView;
 
 import java.io.PrintWriter;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * User: adam
@@ -106,7 +94,7 @@ public class AuditController extends SpringActionController
             if (getContainer() != null && getContainer().isRoot())
                 return new ActionURL(ShowAuditLogAction.class, getContainer());
             else
-                return PageFlowUtil.urlProvider(QueryUrls.class).urlSchemaBrowser(getContainer(), "auditLog");
+                return urlProvider(QueryUrls.class).urlSchemaBrowser(getContainer(), "auditLog");
         }
     }
 
@@ -156,7 +144,7 @@ public class AuditController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             setHelpTopic(new HelpTopic("audits"));
-            PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "Audit Log", getURL());
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Audit Log", getURL());
         }
 
         public ActionURL getURL()
@@ -226,7 +214,7 @@ public class AuditController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            root.addChild("Admin Console", PageFlowUtil.urlProvider(AdminUrls.class).getAdminConsoleURL());
+            root.addChild("Admin Console", urlProvider(AdminUrls.class).getAdminConsoleURL());
 
             ActionURL urlLog = new ActionURL(ShowAuditLogAction.class, ContainerManager.getRoot());
             urlLog.addParameter("view", SiteSettingsAuditProvider.AUDIT_EVENT_TYPE);

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -2183,7 +2183,7 @@ public class CoreController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             getPageConfig().setHelpTopic(new HelpTopic("configureScripting"));
-            PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "Views and Scripting Configuration", new ActionURL(this.getClass(), getContainer()));
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Views and Scripting Configuration", new ActionURL(this.getClass(), getContainer()));
         }
     }
 

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -2183,8 +2183,7 @@ public class CoreController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             getPageConfig().setHelpTopic(new HelpTopic("configureScripting"));
-            root.addChild("Admin Console", PageFlowUtil.urlProvider(AdminUrls.class).getAdminConsoleURL());
-            root.addChild("Views and Scripting Configuration");
+            PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "Views and Scripting Configuration", new ActionURL(this.getClass(), getContainer()));
         }
     }
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -296,7 +296,7 @@ public class AdminController extends SpringActionController
         Container root = ContainerManager.getRoot();
 
         // Configuration
-        AdminConsole.addLink(Configuration, "authentication", PageFlowUtil.urlProvider(LoginUrls.class).getConfigureURL());
+        AdminConsole.addLink(Configuration, "authentication", urlProvider(LoginUrls.class).getConfigureURL());
         AdminConsole.addLink(Configuration, "email customization", new ActionURL(CustomizeEmailAction.class, root), AdminPermission.class);
         AdminConsole.addLink(Configuration, "experimental features", new ActionURL(ExperimentalFeaturesAction.class, root), AdminOperationsPermission.class);
         // TODO move to FileContentModule
@@ -314,11 +314,11 @@ public class AdminController extends SpringActionController
 /*
         // Management
         // note these should match (link and permissions) with SiteAdminMenu.getNavTree()
-        AdminConsole.addLink(Management, "site admins", PageFlowUtil.urlProvider(SecurityUrls.class).getManageGroupURL(root, "Administrators"), AdminOperationsPermission.class);
-        AdminConsole.addLink(Management, "site developers", PageFlowUtil.urlProvider(SecurityUrls.class).getManageGroupURL(root, "Developers"), AdminOperationsPermission.class);
-        AdminConsole.addLink(Management, "site users", PageFlowUtil.urlProvider(UserUrls.class).getSiteUsersURL(), UserManagementPermission.class);
-        AdminConsole.addLink(Management, "site groups", PageFlowUtil.urlProvider(SecurityUrls.class).getSiteGroupsURL(root, null), UserManagementPermission.class);
-        AdminConsole.addLink(Management, "site permissions", PageFlowUtil.urlProvider(SecurityUrls.class).getPermissionsURL(root), UserManagementPermission.class);
+        AdminConsole.addLink(Management, "site admins", urlProvider(SecurityUrls.class).getManageGroupURL(root, "Administrators"), AdminOperationsPermission.class);
+        AdminConsole.addLink(Management, "site developers", urlProvider(SecurityUrls.class).getManageGroupURL(root, "Developers"), AdminOperationsPermission.class);
+        AdminConsole.addLink(Management, "site users", urlProvider(UserUrls.class).getSiteUsersURL(), UserManagementPermission.class);
+        AdminConsole.addLink(Management, "site groups", urlProvider(SecurityUrls.class).getSiteGroupsURL(root, null), UserManagementPermission.class);
+        AdminConsole.addLink(Management, "site permissions", urlProvider(SecurityUrls.class).getPermissionsURL(root), UserManagementPermission.class);
 */
 
         // Diagnostics
@@ -750,9 +750,9 @@ public class AdminController extends SpringActionController
             {
                 URLHelper returnURL = form.getReturnURLHelper();
                 if (returnURL != null)
-                    loginURL = PageFlowUtil.urlProvider(LoginUrls.class).getLoginURL(ContainerManager.getRoot(), returnURL);
+                    loginURL = urlProvider(LoginUrls.class).getLoginURL(ContainerManager.getRoot(), returnURL);
                 else
-                    loginURL = PageFlowUtil.urlProvider(LoginUrls.class).getLoginURL();
+                    loginURL = urlProvider(LoginUrls.class).getLoginURL();
             }
 
             MaintenanceBean bean = new MaintenanceBean();
@@ -3036,7 +3036,7 @@ public class AdminController extends SpringActionController
             if (null != jobGuid)
                 _jobId = PipelineService.get().getJobId(getUser(), getContainer(), jobGuid);
 
-            PipelineStatusUrls urls = PageFlowUtil.urlProvider(PipelineStatusUrls.class);
+            PipelineStatusUrls urls = urlProvider(PipelineStatusUrls.class);
             _url = null != _jobId ? urls.urlDetails(getContainer(), _jobId) : urls.urlBegin(getContainer());
 
             return true;
@@ -4335,7 +4335,7 @@ public class AdminController extends SpringActionController
                         {
                             errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
                         }
-                        _successURL = PageFlowUtil.urlProvider(PipelineUrls.class).urlBrowse(container);
+                        _successURL = urlProvider(PipelineUrls.class).urlBrowse(container);
                     }
                     break;
                 }
@@ -4356,7 +4356,7 @@ public class AdminController extends SpringActionController
                     {
                         errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
                     }
-                    _successURL = PageFlowUtil.urlProvider(PipelineUrls.class).urlBrowse(container);
+                    _successURL = urlProvider(PipelineUrls.class).urlBrowse(container);
                     break;
                 }
                 case 2:
@@ -4518,7 +4518,7 @@ public class AdminController extends SpringActionController
             }
 
             // make sure we have a pipeline url provider to use for the success URL redirect
-            pipelineUrlProvider = PageFlowUtil.urlProvider(PipelineUrls.class);
+            pipelineUrlProvider = urlProvider(PipelineUrls.class);
             if (pipelineUrlProvider == null)
             {
                 errors.reject("folderImport", "Pipeline url provider does not exist.");
@@ -4921,7 +4921,7 @@ public class AdminController extends SpringActionController
 
             if (form.isWizard())
             {
-                _successURL = PageFlowUtil.urlProvider(SecurityUrls.class).getContainerURL(container);
+                _successURL = urlProvider(SecurityUrls.class).getContainerURL(container);
                 _successURL.addParameter("wizard", Boolean.TRUE.toString());
             }
             else
@@ -4936,7 +4936,6 @@ public class AdminController extends SpringActionController
             return _successURL;
         }
     }
-
 
     @SuppressWarnings("unused")
     public static class FileRootsForm extends SetupForm implements FileManagementForm
@@ -7834,7 +7833,7 @@ public class AdminController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(Object o)
         {
-            return PageFlowUtil.urlProvider(PipelineUrls.class).urlBegin(ContainerManager.getRoot());
+            return urlProvider(PipelineUrls.class).urlBegin(ContainerManager.getRoot());
         }
     }
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -399,26 +399,24 @@ public class AdminController extends SpringActionController
 
     private void addAdminNavTrail(NavTree root, String childTitle, Class<? extends Controller> action)
     {
-        addAdminNavTrail(root, childTitle, action, getContainer());
+        addAdminNavTrail(root, childTitle, null != action ? new ActionURL(action, getContainer()) : null, getContainer());
     }
 
-    private static void addAdminNavTrail(NavTree root, String childTitle, Class<? extends Controller> action, Container container)
+    private static void addAdminNavTrail(NavTree root, String childTitle, @Nullable ActionURL url, Container container)
     {
         if (container.isRoot())
-            root.addChild("Admin Console", getShowAdminURL());
+            root.addChild("Admin Console", getShowAdminURL().setFragment("links"));
 
-        if (null == action)
+        if (null == url)
             root.addChild(childTitle);
         else
-            root.addChild(childTitle, new ActionURL(action, container));
+            root.addChild(childTitle, url);
     }
-
 
     public static ActionURL getShowAdminURL()
     {
         return new ActionURL(ShowAdminAction.class, ContainerManager.getRoot());
     }
-
 
     @AdminConsoleAction
     public static class ShowAdminAction extends SimpleViewAction
@@ -619,12 +617,7 @@ public class AdminController extends SpringActionController
         @Override
         public void addAdminNavTrail(NavTree root, String childTitle, @Nullable ActionURL childURL)
         {
-            root.addChild("Admin Console", getAdminConsoleURL().setFragment("links") );
-
-            if (null != childURL)
-                root.addChild(childTitle, childURL);
-            else
-                root.addChild(childTitle);
+            AdminController.addAdminNavTrail(root, childTitle, childURL, ContainerManager.getRoot());
         }
 
         @Override
@@ -2296,7 +2289,7 @@ public class AdminController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             getPageConfig().setHelpTopic(new HelpTopic("dumpHeap"));
-            PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "Heap dump", null);
+            addAdminNavTrail(root, "Heap dump", null, getContainer());
         }
     }
 
@@ -7517,8 +7510,7 @@ public class AdminController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            root.addChild("Admin Console", new ActionURL(ShowAdminAction.class, getContainer()).getLocalURIString());
-            root.addChild("Test Email Configuration");
+            addAdminNavTrail(root, "Test Email Configuration", getClass());
         }
     }
 
@@ -8400,7 +8392,7 @@ public class AdminController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             setHelpTopic("experimental");
-            root.addChild("Experimental Features");
+            addAdminNavTrail(root, "Experimental Features", getClass());
         }
     }
 
@@ -8466,7 +8458,7 @@ public class AdminController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            root.addChild("Folder Types");
+            addAdminNavTrail(root, "Folder Types", getClass());
         }
     }
 
@@ -9061,7 +9053,7 @@ public class AdminController extends SpringActionController
 
     @AdminConsoleAction
     @RequiresPermission(AdminPermission.class)
-    public static class ShortURLAdminAction extends FormViewAction<ShortURLForm>
+    public class ShortURLAdminAction extends FormViewAction<ShortURLForm>
     {
         @Override
         public void validateCommand(ShortURLForm target, Errors errors) {}
@@ -9167,7 +9159,7 @@ public class AdminController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             setHelpTopic("shortURL");
-            root.addChild("Short URL Admin");
+            addAdminNavTrail(root, "Short URL Admin", getClass());
         }
     }
 
@@ -9555,7 +9547,7 @@ public class AdminController extends SpringActionController
     }
 
     @AdminConsoleAction()
-    public static class ExternalRedirectAdminAction extends FormViewAction<ExternalRedirectForm>
+    public class ExternalRedirectAdminAction extends FormViewAction<ExternalRedirectForm>
     {
         @Override
         public void validateCommand(ExternalRedirectForm target, Errors errors)
@@ -9682,7 +9674,7 @@ public class AdminController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             setHelpTopic("externalRedirectsURL");
-            root.addChild("External Redirect Host Admin");
+            addAdminNavTrail(root, "External Redirect Host Admin", getClass());
         }
     }
 
@@ -10309,7 +10301,7 @@ public class AdminController extends SpringActionController
                     controller.new MemTrackerAction(),
                     controller.new MemoryChartAction(),
                     controller.new FolderTypesAction(),
-                    new ShortURLAdminAction(),
+                    controller.new ShortURLAdminAction(),
                     controller.new CustomizeSiteAction(),
                     controller.new CachesAction(),
                     controller.new EnvironmentVariablesAction(),

--- a/core/src/org/labkey/core/admin/logger/LoggerController.java
+++ b/core/src/org/labkey/core/admin/logger/LoggerController.java
@@ -30,6 +30,7 @@ import org.labkey.api.action.MutatingApiAction;
 import org.labkey.api.action.ReadOnlyApiAction;
 import org.labkey.api.action.SimpleResponse;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.AdminConsoleAction;
@@ -292,13 +293,11 @@ public class LoggerController extends SpringActionController
         @Override
         public void validateCommand(Object target, Errors errors)
         {
-
         }
 
         @Override
         public ModelAndView getView(Object o, boolean reshow, BindException errors)
         {
-            getPageConfig().setTitle("Manage Log4J Loggers");
             return new JspView<>("/org/labkey/core/admin/logger/manage.jsp", null, errors);
         }
 
@@ -317,6 +316,7 @@ public class LoggerController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Manage Log4J Loggers", new ActionURL(getClass(), getContainer()));
         }
     }
 

--- a/core/src/org/labkey/core/admin/logger/manage.jsp
+++ b/core/src/org/labkey/core/admin/logger/manage.jsp
@@ -64,8 +64,6 @@
 
 </style>
 
-<h2>Log4j Loggers</h2>
-
 <input id="search" type="text" size="120">
 
 <p style='padding-left:0.75em; margin:0.5em;'>

--- a/core/src/org/labkey/core/admin/miniprofiler/MiniProfilerController.java
+++ b/core/src/org/labkey/core/admin/miniprofiler/MiniProfilerController.java
@@ -37,7 +37,6 @@ import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.RequiresSiteAdmin;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.util.MemTracker;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.JspView;
@@ -110,7 +109,7 @@ public class MiniProfilerController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(MiniProfilerSettingsForm form)
         {
-            return PageFlowUtil.urlProvider(AdminUrls.class).getAdminConsoleURL();
+            return urlProvider(AdminUrls.class).getAdminConsoleURL();
         }
 
         @Override
@@ -139,7 +138,7 @@ public class MiniProfilerController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(Object o)
         {
-            return PageFlowUtil.urlProvider(AdminUrls.class).getAdminConsoleURL();
+            return urlProvider(AdminUrls.class).getAdminConsoleURL();
         }
     }
 

--- a/core/src/org/labkey/core/admin/miniprofiler/MiniProfilerController.java
+++ b/core/src/org/labkey/core/admin/miniprofiler/MiniProfilerController.java
@@ -39,6 +39,7 @@ import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
+import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.UnauthorizedException;
@@ -115,7 +116,7 @@ public class MiniProfilerController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            root.addChild("Profiling Settings");
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Profiling Settings", new ActionURL(getClass(), getContainer()));
         }
     }
 

--- a/core/src/org/labkey/core/admin/mvIndicators.jsp
+++ b/core/src/org/labkey/core/admin/mvIndicators.jsp
@@ -18,7 +18,6 @@
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.data.MvUtil" %>
 <%@ page import="org.labkey.api.security.permissions.AdminPermission" %>
-<%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="java.util.Map" %>

--- a/core/src/org/labkey/core/admin/sql/SqlScriptController.java
+++ b/core/src/org/labkey/core/admin/sql/SqlScriptController.java
@@ -316,7 +316,7 @@ public class SqlScriptController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "SQL Scripts", getURL());
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "SQL Scripts", getURL());
         }
 
         public ActionURL getURL()

--- a/core/src/org/labkey/core/analytics/AnalyticsController.java
+++ b/core/src/org/labkey/core/analytics/AnalyticsController.java
@@ -25,7 +25,6 @@ import org.labkey.api.security.AdminConsoleAction;
 import org.labkey.api.security.permissions.AdminOperationsPermission;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.AdminConsole.SettingsLinkType;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
@@ -77,7 +76,7 @@ public class AnalyticsController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "Analytics", null);
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Analytics", null);
         }
 
         @Override
@@ -102,7 +101,7 @@ public class AnalyticsController extends SpringActionController
         @Override
         public ActionURL getSuccessURL(SettingsForm settingsForm)
         {
-            return PageFlowUtil.urlProvider(AdminUrls.class).getAdminConsoleURL();
+            return urlProvider(AdminUrls.class).getAdminConsoleURL();
         }
     }
 }

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -33,6 +33,7 @@ import org.labkey.api.action.ReturnUrlForm;
 import org.labkey.api.action.SimpleRedirectAction;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.collections.LabKeyCollectors;
 import org.labkey.api.collections.NamedObjectList;
 import org.labkey.api.data.Container;
@@ -136,7 +137,6 @@ import static org.labkey.api.security.AuthenticationManager.AUTO_CREATE_ACCOUNTS
 import static org.labkey.api.security.AuthenticationManager.AuthenticationStatus.Success;
 import static org.labkey.api.security.AuthenticationManager.SELF_REGISTRATION_KEY;
 import static org.labkey.api.security.AuthenticationManager.SELF_SERVICE_EMAIL_CHANGES_KEY;
-import static org.labkey.api.util.PageFlowUtil.urlProvider;
 
 /**
  * User: adam
@@ -171,13 +171,6 @@ public class LoginController extends SpringActionController
 
     public static class LoginUrlsImpl implements LoginUrls
     {
-        @Override
-        public void addAuthenticationNavTrail(NavTree root)
-        {
-            root.addChild("Admin Console", AdminController.getShowAdminURL());
-            root.addChild("Authentication", getConfigureURL());
-        }
-
         @Override
         public ActionURL getConfigureURL()
         {
@@ -2407,7 +2400,7 @@ public class LoginController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             setHelpTopic(new HelpTopic("authenticationModule"));
-            getUrls().addAuthenticationNavTrail(root);
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Authentication Configuration", new ActionURL(getClass(), getContainer()));
         }
     }
 

--- a/core/src/org/labkey/core/portal/ProjectController.java
+++ b/core/src/org/labkey/core/portal/ProjectController.java
@@ -105,7 +105,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-
 public class ProjectController extends SpringActionController
 {
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(ProjectController.class);
@@ -447,12 +446,12 @@ public class ProjectController extends SpringActionController
             if (path.startsWith(pipeline))
             {
                 path = pipeline.relativize(path);
-                redirect = PageFlowUtil.urlProvider(PipelineUrls.class).urlBrowse(c).addParameter("path", path.encode());
+                redirect = urlProvider(PipelineUrls.class).urlBrowse(c).addParameter("path", path.encode());
             }
             else if (path.startsWith(files))
             {
                 path = files.relativize(path);
-                redirect = PageFlowUtil.urlProvider(FileUrls.class).urlBegin(c).addParameter("path", path.encode());
+                redirect = urlProvider(FileUrls.class).urlBegin(c).addParameter("path", path.encode());
             }
             else
             {

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -1324,7 +1324,7 @@ public class SecurityController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             setHelpTopic("addUsers");
-            root.addChild("Site Users", PageFlowUtil.urlProvider(UserUrls.class).getSiteUsersURL());
+            root.addChild("Site Users", urlProvider(UserUrls.class).getSiteUsersURL());
             root.addChild("Add Users");
         }
 
@@ -1386,7 +1386,7 @@ public class SecurityController extends SpringActionController
 
                 if (HtmlString.isBlank(result) && user != null)
                 {
-                    ActionURL url = PageFlowUtil.urlProvider(UserUrls.class).getUserDetailsURL(getContainer(), user.getUserId(), returnURL);
+                    ActionURL url = urlProvider(UserUrls.class).getUserDetailsURL(getContainer(), user.getUserId(), returnURL);
                     result = HtmlString.unsafe(PageFlowUtil.filter(email) + " was already a registered system user.  Click <a href=\"" + url.getEncodedLocalURIString() + "\">here</a> to see this user's profile and history.");
                 }
                 else if (userToClone != null)

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -105,7 +105,6 @@ import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.MailHelper;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.util.TestContext;
@@ -328,7 +327,7 @@ public class UserController extends SpringActionController
 
         if (canAddUser)
         {
-            ActionButton insert = new ActionButton(PageFlowUtil.urlProvider(SecurityUrls.class).getAddUsersURL(getContainer()), "Add Users");
+            ActionButton insert = new ActionButton(urlProvider(SecurityUrls.class).getAddUsersURL(getContainer()), "Add Users");
             insert.setActionType(ActionButton.Action.LINK);
             gridButtonBar.add(insert);
         }
@@ -1094,7 +1093,7 @@ public class UserController extends SpringActionController
         @Override
         public ActionURL getSuccessURL(QueryUpdateForm form)
         {
-            return form.getReturnActionURL(PageFlowUtil.urlProvider(UserUrls.class).getUserDetailsURL(getContainer(), NumberUtils.toInt(form.getPkVal().toString()), null));
+            return form.getReturnActionURL(urlProvider(UserUrls.class).getUserDetailsURL(getContainer(), NumberUtils.toInt(form.getPkVal().toString()), null));
         }
 
         @Override
@@ -1551,7 +1550,7 @@ public class UserController extends SpringActionController
 
             if (isOwnRecord && loginExists && !isLoginAutoRedirect)
             {
-                ActionButton changePasswordButton = new ActionButton(PageFlowUtil.urlProvider(LoginUrls.class).getChangePasswordURL(c, user, getViewContext().getActionURL(), null), "Change Password");
+                ActionButton changePasswordButton = new ActionButton(urlProvider(LoginUrls.class).getChangePasswordURL(c, user, getViewContext().getActionURL(), null), "Change Password");
                 changePasswordButton.setActionType(ActionButton.Action.LINK);
                 changePasswordButton.addContextualRole(OwnerRole.class);
                 bb.add(changePasswordButton);

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -254,7 +254,7 @@ public class DavController extends SpringActionController
 
     ActionURL getLoginURL()
     {
-        return PageFlowUtil.urlProvider(LoginUrls.class).getLoginURL(getContainer(), getURL());
+        return urlProvider(LoginUrls.class).getLoginURL(getContainer(), getURL());
     }
 
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -5681,7 +5681,7 @@ public class ExperimentController extends SpringActionController
         @Override
         public ActionURL getSuccessURL(MoveRunsForm form)
         {
-            return PageFlowUtil.urlProvider(PipelineUrls.class).urlBegin(_targetContainer);
+            return urlProvider(PipelineUrls.class).urlBegin(_targetContainer);
         }
     }
 
@@ -6190,7 +6190,7 @@ public class ExperimentController extends SpringActionController
 
         public static ExperimentUrlsImpl get()
         {
-            return (ExperimentUrlsImpl) PageFlowUtil.urlProvider(ExperimentUrls.class);
+            return (ExperimentUrlsImpl) urlProvider(ExperimentUrls.class);
         }
 
         public ActionURL getDownloadGraphURL(ExpRun run, boolean detail, String focus, String focusType)

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -649,7 +649,7 @@ public class ExperimentController extends SpringActionController
 
             if (!getContainer().equals(_sampleType.getContainer()))
             {
-                ActionURL definitionURL = PageFlowUtil.urlProvider(ExperimentUrls.class).getShowSampleTypeURL(_sampleType);
+                ActionURL definitionURL = urlProvider(ExperimentUrls.class).getShowSampleTypeURL(_sampleType);
                 SimpleDisplayColumn definedInCol = new SimpleDisplayColumn("<a href=\"" +
                         PageFlowUtil.filter(definitionURL) +
                         "\">" +
@@ -1495,7 +1495,7 @@ public class ExperimentController extends SpringActionController
                     if (pipelineRoot.isUnderRoot(runRoot))
                     {
                         String path = pipelineRoot.relativePath(runRoot);
-                        tree.addChild("View Files", PageFlowUtil.urlProvider(PipelineUrls.class).urlBrowse(_experimentRun.getContainer(), null, path));
+                        tree.addChild("View Files", urlProvider(PipelineUrls.class).urlBrowse(_experimentRun.getContainer(), null, path));
                     }
                 }
             }
@@ -1853,7 +1853,7 @@ public class ExperimentController extends SpringActionController
                             }
                         }
                     }
-                    ActionURL browseURL = PageFlowUtil.urlProvider(PipelineUrls.class).urlBrowse(getContainer(), getViewContext().getActionURL(), relativePath);
+                    ActionURL browseURL = urlProvider(PipelineUrls.class).urlBrowse(getContainer(), getViewContext().getActionURL(), relativePath);
                     bb.add(new ActionButton("Browse in pipeline", browseURL));
                 }
             }
@@ -2880,7 +2880,7 @@ public class ExperimentController extends SpringActionController
             {
                 for (Dataset dataset : StudyService.get().getDatasetsForAssayRuns(runs, getUser()))
                 {
-                    ActionURL url = PageFlowUtil.urlProvider(StudyUrls.class).getDatasetURL(dataset.getContainer(), dataset.getDatasetId());
+                    ActionURL url = urlProvider(StudyUrls.class).getDatasetURL(dataset.getContainer(), dataset.getDatasetId());
                     if (dataset.canWrite(getUser()))
                     {
                         permissionDatasetRows.add(new Pair<>(dataset, url));
@@ -3131,7 +3131,7 @@ public class ExperimentController extends SpringActionController
                     }
                     for (Dataset dataset : StudyService.get().getDatasetsForAssayProtocol(protocol))
                     {
-                        Pair<SecurableResource, ActionURL> entry = new Pair<>(dataset, PageFlowUtil.urlProvider(StudyUrls.class).getDatasetURL(dataset.getContainer(), dataset.getDatasetId()));
+                        Pair<SecurableResource, ActionURL> entry = new Pair<>(dataset, urlProvider(StudyUrls.class).getDatasetURL(dataset.getContainer(), dataset.getDatasetId()));
                         if (dataset.canDeleteDefinition(getUser()))
                         {
                             deleteableDatasets.add(entry);
@@ -4631,7 +4631,7 @@ public class ExperimentController extends SpringActionController
 
             if (root == null || !root.isValid())
             {
-                ActionURL pipelineURL = PageFlowUtil.urlProvider(PipelineUrls.class).urlSetup(c);
+                ActionURL pipelineURL = urlProvider(PipelineUrls.class).urlSetup(c);
                 return new HtmlView(DOM.DIV("You must ",
                     DOM.A(DOM.at(href, pipelineURL), "configure a valid pipeline root for this folder"),
                     " before deriving samples."));

--- a/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
+++ b/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
@@ -80,7 +80,6 @@ import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.JsonUtil;
 import org.labkey.api.util.JunitUtil;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.SessionTempFileHolder;
 import org.labkey.api.util.TestContext;
@@ -130,7 +129,7 @@ public class PropertyController extends SpringActionController
 
     public static final String UNRECOGNIZED_FILE_TYPE_ERROR = "Unrecognized file type. Please upload a .xls, .xlsx, .tsv, .csv or .txt file";
 
-    private static PropertyService _propertyService = PropertyService.get();
+    private static final PropertyService _propertyService = PropertyService.get();
 
     public PropertyController()
     {
@@ -197,7 +196,7 @@ public class PropertyController extends SpringActionController
 
                 // re-fetch the domain so that we can redirect using the saved domainId
                 _domain = PropertyService.get().getDomain(getContainer(), domainURI);
-                ActionURL redirectURL = PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(getContainer(), _domain);
+                ActionURL redirectURL = urlProvider(ExperimentUrls.class).getDomainEditorURL(getContainer(), _domain);
                 URLHelper returnURL = getViewContext().getActionURL().getReturnURL();
                 if (returnURL != null)
                     redirectURL.addReturnURL(returnURL);

--- a/filecontent/src/org/labkey/filecontent/FileContentController.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentController.java
@@ -762,7 +762,7 @@ public class FileContentController extends SpringActionController
 
                     if (containsFileWebPart(c))
                     {
-                        ActionURL config = PageFlowUtil.urlProvider(AdminUrls.class).getFileRootsURL(c);
+                        ActionURL config = urlProvider(AdminUrls.class).getFileRootsURL(c);
 
                         node.put("configureURL", config.getEncodedLocalURIString());
                         node.put("browseURL", browse.getEncodedLocalURIString());

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -2202,7 +2202,7 @@ public class IssuesController extends SpringActionController
                 }
 
                 //Search for the query term instead
-                return PageFlowUtil.urlProvider(SearchUrls.class).getSearchURL(getContainer(), issueId, IssueSearchResultTemplate.NAME);
+                return urlProvider(SearchUrls.class).getSearchURL(getContainer(), issueId, IssueSearchResultTemplate.NAME);
             }
 
             ActionURL url = getViewContext().cloneActionURL();
@@ -2375,7 +2375,7 @@ public class IssuesController extends SpringActionController
         @Override
         public URLHelper getRedirectURL(SearchForm form)
         {
-            return PageFlowUtil.urlProvider(SearchUrls.class).getSearchURL(getContainer(), form.getQ(), IssueSearchResultTemplate.NAME);
+            return urlProvider(SearchUrls.class).getSearchURL(getContainer(), form.getQ(), IssueSearchResultTemplate.NAME);
         }
     }
 

--- a/pipeline/src/org/labkey/pipeline/PipelineController.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineController.java
@@ -1443,11 +1443,11 @@ public class PipelineController extends SpringActionController
             Container c = getContainer();
             if (_importContainers.size() == 1 && _importContainers.get(0).equals(c))
             {
-                return PageFlowUtil.urlProvider(PipelineStatusUrls.class).urlBegin(c);
+                return urlProvider(PipelineStatusUrls.class).urlBegin(c);
             }
             else
             {
-                ActionURL url = PageFlowUtil.urlProvider(PipelineStatusUrls.class).urlBegin(c.getProject());
+                ActionURL url = urlProvider(PipelineStatusUrls.class).urlBegin(c.getProject());
                 url.addParameter("StatusFiles.containerFilterName", ContainerFilter.Type.CurrentAndSubfolders.name());
                 return url;
             }
@@ -1703,7 +1703,7 @@ public class PipelineController extends SpringActionController
 
     public static void registerAdminConsoleLinks()
     {
-        ActionURL url = PageFlowUtil.urlProvider(PipelineUrls.class).urlSetup(ContainerManager.getRoot());
+        ActionURL url = urlProvider(PipelineUrls.class).urlSetup(ContainerManager.getRoot());
         AdminConsole.addLink(AdminConsole.SettingsLinkType.Management, "pipeline email notification", url, AdminOperationsPermission.class);
     }
 

--- a/pipeline/src/org/labkey/pipeline/PipelineController.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineController.java
@@ -35,6 +35,7 @@ import org.labkey.api.action.SimpleErrorView;
 import org.labkey.api.action.SimpleRedirectAction;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.admin.ImportException;
 import org.labkey.api.admin.ImportOptions;
 import org.labkey.api.compliance.ComplianceService;
@@ -115,7 +116,6 @@ import org.springframework.web.servlet.ModelAndView;
 
 import java.io.File;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -385,8 +385,15 @@ public class PipelineController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            root.addChild("Data Pipeline", new ActionURL(BeginAction.class, getContainer()));
-            root.addChild("Data Processing Pipeline Setup");
+            if (getContainer().isRoot())
+            {
+                urlProvider(AdminUrls.class).addAdminNavTrail(root, "Data Processing Pipeline Setup", new ActionURL(getClass(), getContainer()));
+            }
+            else
+            {
+                root.addChild("Data Pipeline", new ActionURL(BeginAction.class, getContainer()));
+                root.addChild("Data Processing Pipeline Setup");
+            }
         }
     }
 

--- a/pipeline/src/org/labkey/pipeline/analysis/AnalysisController.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/AnalysisController.java
@@ -32,6 +32,7 @@ import org.labkey.api.action.MutatingApiAction;
 import org.labkey.api.action.ReturnUrlForm;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DataRegionSelection;
@@ -592,13 +593,13 @@ public class AnalysisController extends SpringActionController
         @Override
         public ModelAndView getView(Object o, BindException errors)
         {
-            return new JspView("/org/labkey/pipeline/analysis/internalListPipelines.jsp", null, errors);
+            return new JspView<>("/org/labkey/pipeline/analysis/internalListPipelines.jsp", null, errors);
         }
 
         @Override
         public void addNavTrail(NavTree root)
         {
-            root.addChild("Internal List Pipelines");
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Internal List Pipelines", new ActionURL(getClass(), getContainer()));
         }
     }
 

--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -16,7 +16,6 @@
 
 package org.labkey.pipeline.status;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
@@ -32,6 +31,7 @@ import org.labkey.api.action.SimpleRedirectAction;
 import org.labkey.api.action.SimpleStreamAction;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
 import org.labkey.api.data.Container;
@@ -100,7 +100,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import static org.labkey.api.util.PageFlowUtil.urlProvider;
 import static org.labkey.pipeline.api.PipelineStatusManager.cancelStatus;
 import static org.labkey.pipeline.api.PipelineStatusManager.completeStatus;
 import static org.labkey.pipeline.api.PipelineStatusManager.deleteStatus;
@@ -256,13 +255,13 @@ public class StatusController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            root.addChild("Data Pipeline");
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Data Pipeline", new ActionURL(getClass(), getContainer()));
         }
     }
 
     public static class EnterprisePipelineBean
     {
-        private Set<String> _locations;
+        private final Set<String> _locations;
 
         public EnterprisePipelineBean(Set<String> locations)
         {

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -700,7 +700,7 @@ public class QueryController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            requireNonNull(PageFlowUtil.urlProvider(AdminUrls.class)).addAdminNavTrail(root, "Data Source Administration ", null);
+            requireNonNull(urlProvider(AdminUrls.class)).addAdminNavTrail(root, "Data Source Administration ", null);
         }
     }
 

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -1057,7 +1057,7 @@ public class ReportsController extends SpringActionController
         {
             if (_report != null && getContainer().hasPermission(getUser(), AdminPermission.class))
             {
-                return PageFlowUtil.urlProvider(StudyUrls.class).getManageReportPermissions(getContainer()).
+                return urlProvider(StudyUrls.class).getManageReportPermissions(getContainer()).
                         addParameter(ReportDescriptor.Prop.reportId, _report.getDescriptor().getReportId().toString());
             }
 

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -381,7 +381,7 @@ public class SearchController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             setHelpTopic(new HelpTopic("searchAdmin"));
-            PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "Full-Text Search Configuration", new ActionURL(AdminAction.class, ContainerManager.getRoot()));
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Full-Text Search Configuration", new ActionURL(AdminAction.class, ContainerManager.getRoot()));
         }
     }
 

--- a/study/src/org/labkey/study/controllers/PublishController.java
+++ b/study/src/org/labkey/study/controllers/PublishController.java
@@ -35,7 +35,6 @@ import org.labkey.api.study.assay.AssayPublishService;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.HelpTopic;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
@@ -118,7 +117,7 @@ public class PublishController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            root.addChild("Assay List", PageFlowUtil.urlProvider(AssayUrls.class).getBeginURL(getContainer()));
+            root.addChild("Assay List", urlProvider(AssayUrls.class).getBeginURL(getContainer()));
             root.addChild(_protocol.getName(), new ActionURL(AssayRunsAction.class, getContainer()).addParameter("rowId", _protocol.getRowId()));
             root.addChild("Copy-to-Study History");
         }
@@ -137,7 +136,7 @@ public class PublishController extends SpringActionController
             if (null != jobGuid)
                 jobId = PipelineService.get().getJobId(getUser(), getContainer(), jobGuid);
 
-            PipelineStatusUrls urls = PageFlowUtil.urlProvider(PipelineStatusUrls.class);
+            PipelineStatusUrls urls = urlProvider(PipelineStatusUrls.class);
             ActionURL url  = null != jobId ? urls.urlDetails(getContainer(), jobId) : urls.urlBegin(getContainer());
 
             response.put("success", true);

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -348,13 +348,13 @@ public class StudyController extends BaseStudyController
         @Override
         public ActionURL getCopyToStudyURL(Container container, ExpProtocol protocol)
         {
-            return PageFlowUtil.urlProvider(AssayUrls.class).getProtocolURL(container, protocol, PublishStartAction.class);
+            return urlProvider(AssayUrls.class).getProtocolURL(container, protocol, PublishStartAction.class);
         }
 
         @Override
         public ActionURL getCopyToStudyConfirmURL(Container container, ExpProtocol protocol)
         {
-            return PageFlowUtil.urlProvider(AssayUrls.class).getProtocolURL(container, protocol, PublishConfirmAction.class);
+            return urlProvider(AssayUrls.class).getProtocolURL(container, protocol, PublishConfirmAction.class);
         }
     }
 
@@ -3711,7 +3711,7 @@ public class StudyController extends BaseStudyController
                     _log.warn("ResetPipelineAction redirect string invalid: " + redirect);
                 }
             }
-            return PageFlowUtil.urlProvider(PipelineStatusUrls.class).urlBegin(getContainer());
+            return urlProvider(PipelineStatusUrls.class).urlBegin(getContainer());
         }
     }
 
@@ -3939,7 +3939,7 @@ public class StudyController extends BaseStudyController
                     VirtualFile datasetsDir = new FileSystemFile(f.getParentFile());
                     DatasetImportUtils.submitStudyBatch(study, datasetsDir, f.getName(), c, getUser(), getViewContext().getActionURL(), root);
                 }
-                _successUrl = PageFlowUtil.urlProvider(PipelineStatusUrls.class).urlBegin(getContainer());
+                _successUrl = urlProvider(PipelineStatusUrls.class).urlBegin(getContainer());
             }
             catch (DatasetImportUtils.DatasetLockExistsException e)
             {
@@ -3966,7 +3966,7 @@ public class StudyController extends BaseStudyController
         {
             Container c = getContainer();
             File studyFile = form.getValidatedSingleFile(c);
-            return PageFlowUtil.urlProvider(PipelineUrls.class).urlStartFolderImport(c, studyFile, true, null, false);
+            return urlProvider(PipelineUrls.class).urlStartFolderImport(c, studyFile, true, null, false);
         }
 
         @Override
@@ -4676,14 +4676,14 @@ public class StudyController extends BaseStudyController
             else if (form.getReturnUrl() != null && form.getReturnUrl().length() > 0)
                 return new ActionURL(form.getReturnUrl());
             else
-                return PageFlowUtil.urlProvider(ReportUrls.class).urlManageViews(getContainer());
+                return urlProvider(ReportUrls.class).urlManageViews(getContainer());
         }
 
         @Override
         public void addNavTrail(NavTree root)
         {
             _addManageStudy(root);
-            root.addChild("Manage Views", PageFlowUtil.urlProvider(ReportUrls.class).urlManageViews(getContainer()));
+            root.addChild("Manage Views", urlProvider(ReportUrls.class).urlManageViews(getContainer()));
             root.addChild("Customize " + StudyService.get().getSubjectNounSingular(getContainer()) + " View");
         }
     }
@@ -5695,7 +5695,7 @@ public class StudyController extends BaseStudyController
 
             if (null != _currentParticipantId && null != ss)
             {
-                ActionURL search = PageFlowUtil.urlProvider(SearchUrls.class).getSearchURL(c, "+" + ss.escapeTerm(_currentParticipantId));
+                ActionURL search = urlProvider(SearchUrls.class).getSearchURL(c, "+" + ss.escapeTerm(_currentParticipantId));
                 out.print(PageFlowUtil.textLink("Search for '" + id(_currentParticipantId, c, user) + "'", search));
                 out.print("&nbsp;");
             }
@@ -7553,13 +7553,13 @@ public class StudyController extends BaseStudyController
         @Override
         public URLHelper getSuccessURL(MasterPatientProviderSettings form)
         {
-            return PageFlowUtil.urlProvider(AdminUrls.class).getAdminConsoleURL();
+            return urlProvider(AdminUrls.class).getAdminConsoleURL();
         }
 
         @Override
         public void addNavTrail(NavTree root)
         {
-            root.addChild("Configure Master Patient Index");
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Configure Master Patient Index", new ActionURL(getClass(), getContainer()));
         }
     }
 
@@ -7693,7 +7693,7 @@ public class StudyController extends BaseStudyController
                     PipelineService.get().queueJob(job);
 
                     response.put("success", true);
-                    response.put(ActionURL.Param.returnUrl.name(), PageFlowUtil.urlProvider(PipelineUrls.class).urlBegin(getContainer()));
+                    response.put(ActionURL.Param.returnUrl.name(), urlProvider(PipelineUrls.class).urlBegin(getContainer()));
                 }
                 else
                 {

--- a/study/src/org/labkey/study/controllers/StudyDefinitionController.java
+++ b/study/src/org/labkey/study/controllers/StudyDefinitionController.java
@@ -24,7 +24,6 @@ import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.permissions.AdminPermission;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
@@ -85,7 +84,7 @@ public class StudyDefinitionController extends BaseStudyController
         public URLHelper getSuccessURL(ReturnUrlForm form)
         {
             // since the study additional properties domain is scoped to the project, use the domain.getContainer() here instead of getContainer()
-            ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getDomainEditorURL(_domain.getContainer(), _domain);
+            ActionURL url = urlProvider(ExperimentUrls.class).getDomainEditorURL(_domain.getContainer(), _domain);
             form.propagateReturnURL(url);
             return url;
         }

--- a/study/src/org/labkey/study/controllers/designer/DesignerController.java
+++ b/study/src/org/labkey/study/controllers/designer/DesignerController.java
@@ -471,7 +471,7 @@ public class DesignerController extends SpringActionController
                     Study study = StudyDesignManager.get().generateStudyFromDesign(getUser(), ContainerManager.getForId(form.getParentFolderId()),
                             form.getFolderName(), form.getBeginDate(), form.getSubjectNounSingular(), form.getSubjectNounPlural(),
                             form.getSubjectColumnName(), _info, participantMaps, getSpecimens());
-                    _successURL = PageFlowUtil.urlProvider(ProjectUrls.class).getStartURL(study.getContainer());
+                    _successURL = urlProvider(ProjectUrls.class).getStartURL(study.getContainer());
                     return true;
             }
             return false;
@@ -546,7 +546,7 @@ public class DesignerController extends SpringActionController
         //Now see if the study already exists.
         if (info.isActive())
         {
-            throw new RedirectException(PageFlowUtil.urlProvider(ProjectUrls.class).getStartURL(info.getContainer()));
+            throw new RedirectException(urlProvider(ProjectUrls.class).getStartURL(info.getContainer()));
         }
 
         //Make sure we haven't done some crazy back/forward thing

--- a/study/src/org/labkey/study/controllers/reports/ReportsController.java
+++ b/study/src/org/labkey/study/controllers/reports/ReportsController.java
@@ -115,7 +115,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-
 public class ReportsController extends BaseStudyController
 {
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(ReportsController.class);
@@ -151,7 +150,7 @@ public class ReportsController extends BaseStudyController
             if (_study == null)
                 root.addChild("No Study In Folder");
             else if (getContainer().hasPermission(getUser(), AdminPermission.class))
-                root.addChild("Manage Views", PageFlowUtil.urlProvider(ReportUrls.class).urlManageViews(getContainer()));
+                root.addChild("Manage Views", urlProvider(ReportUrls.class).urlManageViews(getContainer()));
             else
                 root.addChild("Views");
         }
@@ -295,7 +294,7 @@ public class ReportsController extends BaseStudyController
                     }
                     else
                     {
-                        _successURL = PageFlowUtil.urlProvider(ReportUrls.class).urlManageViews(getContainer());
+                        _successURL = urlProvider(ReportUrls.class).urlManageViews(getContainer());
                     }
                 }
 
@@ -1190,7 +1189,7 @@ public class ReportsController extends BaseStudyController
             addRootNavTrail(root);
 
             if (getContainer().hasPermission(getUser(), AdminPermission.class))
-                root.addChild("Manage Views", PageFlowUtil.urlProvider(ReportUrls.class).urlManageViews(getContainer()));
+                root.addChild("Manage Views", urlProvider(ReportUrls.class).urlManageViews(getContainer()));
         }
         catch (Exception e)
         {
@@ -1205,7 +1204,7 @@ public class ReportsController extends BaseStudyController
             Study study = addRootNavTrail(root);
 
             if (getContainer().hasPermission(getUser(), AdminPermission.class))
-                root.addChild("Manage Views", PageFlowUtil.urlProvider(ReportUrls.class).urlManageViews(getContainer()));
+                root.addChild("Manage Views", urlProvider(ReportUrls.class).urlManageViews(getContainer()));
 
             VisitImpl visit = null;
 
@@ -1286,7 +1285,7 @@ public class ReportsController extends BaseStudyController
                 {
                     NavTree menu = new NavTree();
                     menu.addChild("New " + StudyService.get().getSubjectNounSingular(getContainer()) + " Report", new ActionURL(this.getClass(), getContainer()));
-                    menu.addChild("Manage Views", PageFlowUtil.urlProvider(ReportUrls.class).urlManageViews(getContainer()));
+                    menu.addChild("Manage Views", urlProvider(ReportUrls.class).urlManageViews(getContainer()));
                     view.setNavMenu(menu);
                 }
                 return view;

--- a/study/src/org/labkey/study/controllers/security/SecurityController.java
+++ b/study/src/org/labkey/study/controllers/security/SecurityController.java
@@ -564,7 +564,7 @@ public class SecurityController extends SpringActionController
                 root.addChild(study.getLabel(), BaseStudyController.getStudyOverviewURL(getContainer()));
 
                 if (getContainer().hasPermission(getUser(), AdminPermission.class))
-                    root.addChild("Manage Views", PageFlowUtil.urlProvider(ReportUrls.class).urlManageViews(getContainer()).getLocalURIString());
+                    root.addChild("Manage Views", urlProvider(ReportUrls.class).urlManageViews(getContainer()).getLocalURIString());
             }
             catch (Exception e)
             {

--- a/study/src/org/labkey/study/controllers/specimen/SpecimenController.java
+++ b/study/src/org/labkey/study/controllers/specimen/SpecimenController.java
@@ -2654,7 +2654,7 @@ public class SpecimenController extends BaseStudyController
 
     private ActionURL getManageStudyURL()
     {
-        return PageFlowUtil.urlProvider(StudyUrls.class).getManageStudyURL(getContainer());
+        return urlProvider(StudyUrls.class).getManageStudyURL(getContainer());
     }
 
     public static class EmailSpecimenListForm extends IdForm
@@ -3888,11 +3888,10 @@ public class SpecimenController extends BaseStudyController
             return true;
         }
 
-
         @Override
         public ActionURL getSuccessURL(PipelineForm pipelineForm)
         {
-            return PageFlowUtil.urlProvider(PipelineStatusUrls.class).urlBegin(getContainer());
+            return urlProvider(PipelineStatusUrls.class).urlBegin(getContainer());
         }
     }
 
@@ -3931,7 +3930,7 @@ public class SpecimenController extends BaseStudyController
         @Override
         public ActionURL getSuccessURL(PipelineForm pipelineForm)
         {
-            return PageFlowUtil.urlProvider(PipelineStatusUrls.class).urlBegin(getContainer());
+            return urlProvider(PipelineStatusUrls.class).urlBegin(getContainer());
         }
     }
 


### PR DESCRIPTION
#### Rationale
Most admin console links navigate to pages that lack a nav trail, making navigation difficult. [Issue 39832: Fix admin settings pages' navtrails](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39832)

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/611

#### Changes
* Fix `addAdminNavTrail()` so navtrails appear for all admin actions
* Add and fix navtrails for other admin actions
* Alphabetize the list of experimental features by title (amazing computer science at work!)
* Add `SpringActionController.urlProvider()` convenience method