### PR TITLE
Add only the parents of the type we're looking for

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExpLineage.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineage.java
@@ -283,7 +283,7 @@ public class ExpLineage
 
         assert parentClazz == ExpMaterial.class || parentClazz == ExpData.class;
 
-        // walk from start through edges looking for all sample children, stopping at first datas found
+        // walk from start through edges looking for all sample children, stopping at first ones found
         Set<T> parents = new HashSet<>();
         Queue<Identifiable> stack = new LinkedList<>();
         Set<Identifiable> seen = new HashSet<>();

--- a/api/src/org/labkey/api/exp/api/ExpLineage.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineage.java
@@ -308,7 +308,8 @@ public class ExpLineage
                         seen.add(parent);
                     }
                 }
-                else if (parent instanceof ExpData || parent instanceof ExpMaterial)
+                else if ((parentClazz == ExpMaterial.class && parent instanceof ExpMaterial) ||
+                         (parentClazz == ExpData.class && parent instanceof ExpData))
                 {
                     parents.add((T) parent);
                 }

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -388,6 +388,18 @@ public interface ExperimentService extends ExperimentRunTypeSource
     Set<ExpMaterial> getRelatedChildSamples(Container c, User user, ExpData start);
 
     /**
+     * Find the ExpData objects, if any, that are parents of the <code>start</code> ExpMaterial.
+     */
+    @NotNull
+    Set<ExpData> getParentDatas(Container c, User user, ExpMaterial start);
+
+    /**
+     * Find the ExpMaterial objects, if any, that are parents of the <code>start</code> ExpMaterial.
+     */
+    @NotNull
+    Set<ExpMaterial> getParentMaterials(Container c, User user, ExpMaterial start);
+
+    /**
      * Find all parent ExpData that are parents of the <code>start</code> ExpMaterial,
      * stopping at the first parent generation (no grandparents.)
      */

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -633,7 +633,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         if (errors.hasErrors())
             throw errors;
 
-        addAuditEvent(user, container, QueryService.AuditAction.UPDATE, configParameters, oldRows, result);
+        addAuditEvent(user, container, QueryService.AuditAction.UPDATE, configParameters, result, oldRows);
 
         return result;
     }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -2212,6 +2212,30 @@ public class ExperimentServiceImpl implements ExperimentService
 
     @Override
     @NotNull
+    public Set<ExpData> getParentDatas(Container c, User user, ExpMaterial start)
+    {
+        ExpLineageOptions options = new ExpLineageOptions();
+        options.setChildren(false);
+        options.setDepth(2); // 2 because of the ExpRun that will always be in between
+
+        ExpLineage lineage = getLineage(c, user, start, options);
+        return lineage.findNearestParentDatas(start);
+    }
+
+    @Override
+    @NotNull
+    public Set<ExpMaterial> getParentMaterials(Container c, User user, ExpMaterial start)
+    {
+        ExpLineageOptions options = new ExpLineageOptions();
+        options.setChildren(false);
+        options.setDepth(2); // 2 because of the ExpRun that will always be in between.
+
+        ExpLineage lineage = getLineage(c, user, start, options);
+        return lineage.findNearestParentMaterials(start);
+    }
+
+    @Override
+    @NotNull
     public Set<ExpData> getNearestParentDatas(Container c, User user, ExpMaterial start)
     {
         ExpLineageOptions options = new ExpLineageOptions();

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -907,10 +907,10 @@ public class SampleTypeServiceImpl extends AuditHandler.AbstractAuditHandler imp
     }
 
     @Override
-    public DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> updatedRow)
+    public DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> existingRow)
     {
         // not doing anything with userComment at the moment
-        return createAuditRecord(c, getCommentDetailed(action, !updatedRow.isEmpty()), row, updatedRow, action);
+        return createAuditRecord(c, getCommentDetailed(action, !existingRow.isEmpty()), row, action);
     }
 
     @Override
@@ -936,10 +936,10 @@ public class SampleTypeServiceImpl extends AuditHandler.AbstractAuditHandler imp
 
     private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable Map<String, Object> row)
     {
-        return createAuditRecord(c, comment, row, null, null);
+        return createAuditRecord(c, comment, row, null);
     }
 
-    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable Map<String, Object> row, Map<String, Object> updatedRow, @Nullable QueryService.AuditAction action)
+    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable Map<String, Object> row, @Nullable QueryService.AuditAction action)
     {
         SampleTimelineAuditEvent event = new SampleTimelineAuditEvent(c.getId(), comment);
         var tx = getExpSchema().getScope().getCurrentTransaction();
@@ -949,14 +949,11 @@ public class SampleTypeServiceImpl extends AuditHandler.AbstractAuditHandler imp
         if (c.getProject() != null)
             event.setProjectId(c.getProject().getId());
 
-        if (updatedRow != null)
-        {
-            Optional<String> parentFields = updatedRow.keySet().stream().filter((fieldKey) -> fieldKey.startsWith(ExpData.DATA_INPUT_PARENT) || fieldKey.startsWith(ExpMaterial.MATERIAL_INPUT_PARENT)).findAny();
-            event.setLineageUpdate(parentFields.isPresent());
-        }
-
         if (row != null)
         {
+            Optional<String> parentFields = row.keySet().stream().filter((fieldKey) -> fieldKey.startsWith(ExpData.DATA_INPUT_PARENT) || fieldKey.startsWith(ExpMaterial.MATERIAL_INPUT_PARENT)).findAny();
+            event.setLineageUpdate(parentFields.isPresent());
+
             String sampleTypeLsid = null;
             if (row.containsKey(CPAS_TYPE))
                 sampleTypeLsid =  String.valueOf(row.get(CPAS_TYPE));

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -398,10 +398,10 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
         ExperimentService experimentService = ExperimentService.get();
         ExpMaterial seed = rowId != null ? experimentService.getExpMaterial(rowId) : experimentService.getExpMaterial(lsid);
-        Set<ExpMaterial> parentSamples = experimentService.getNearestParentMaterials(container, user, seed);
+        Set<ExpMaterial> parentSamples = experimentService.getParentMaterials(container, user, seed);
         if (!parentSamples.isEmpty())
             addParentFields(sampleRow, parentSamples, ExpMaterial.MATERIAL_INPUT_PARENT + "/", user);
-        Set<ExpData> parentDatas = experimentService.getNearestParentDatas(container, user, seed);
+        Set<ExpData> parentDatas = experimentService.getParentDatas(container, user, seed);
         if (!parentDatas.isEmpty())
             addParentFields(sampleRow, parentDatas, ExpData.DATA_INPUT_PARENT + "/", user);
 


### PR DESCRIPTION
#### Rationale
The refactor that produced the `findNearestParents` common method inadvertently started adding parents of either ExpMaterial or ExpObject to the set of parents regarless of the `parentClazz` passed in.  This surfaces when looking at sample timeline events for samples that have had lineage changes.

We might need to consider back-porting this change (the refactor happened in 06/2020). The exposure is really only through the detailed audit logs for samples and only when there are also data classes present.

#### Related Pull Requests
* #1301

#### Changes
* Check for a matching class
