### PR TITLE
Issue 42355: Perf problem during copy-to-study with many rows

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -801,13 +801,6 @@ public abstract class AbstractAssayProvider implements AssayProvider
         return result;
     }
 
-//    @Override
-//    public ExpData getDataForDataRow(Object dataRowId, ExpProtocol protocol)
-//    {
-//        Set<ExpData> datas = getDatasForDataRows(Collections.singleton(dataRowId), protocol, new ResolverCache());
-//        return datas.isEmpty() ? null : datas.iterator().next();
-//    }
-
     @Nullable
     public final ExpData getDataForDataRow(int resultRowId, ExpProtocol protocol)
     {
@@ -833,6 +826,7 @@ public abstract class AbstractAssayProvider implements AssayProvider
             {
                 return null;
             }
+            // Don't use computeIfAbsent() because it treats null values as if they weren't in the map at all
             if (cache.containsKey(key))
             {
                 return cache.get(key);

--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -133,6 +133,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * User: jeckels
@@ -757,52 +758,106 @@ public abstract class AbstractAssayProvider implements AssayProvider
     // CONSIDER: combining with .getTargetStudy()
     // UNDONE: Doesn't look at TargetStudy in Results domain yet.
     @Override
-    public Container getAssociatedStudyContainer(ExpProtocol protocol, Object dataId)
+    public Set<Container> getAssociatedStudyContainers(ExpProtocol protocol, Collection<Integer> rowIds)
     {
         Pair<ExpProtocol.AssayDomainTypes, DomainProperty> pair = findTargetStudyProperty(protocol);
         if (pair == null)
-            return null;
+            return Collections.emptySet();
 
         DomainProperty targetStudyColumn = pair.second;
 
-        ExpData data = getDataForDataRow(dataId, protocol);
-        if (data == null)
-            return null;
-        ExpRun run = data.getRun();
-        if (run == null)
-            return null;
+        ResolverCache cache = new ResolverCache();
 
-        ExpObject source;
-        switch (pair.first)
+        Set<Container> result = new HashSet<>();
+
+        for (ExpData data : getDatasForResultRows(rowIds, protocol, cache))
         {
+            Container container = null;
+            if (data.getRunId() != null)
+            {
+                ExpRun run = cache.getRun(data.getRunId());
+                if (run != null)
+                {
+                    // Ignore Results domain TargetStudy for now.
+                    // The participant resolver will find the TargetStudy on the row.
+                    ExpObject source = switch (pair.first)
+                    {
+                        case Run -> run;
+                        default -> cache.getBatch(run);
+                    };
 
-            case Run:
-                source = run;
-                break;
+                    if (source != null)
+                    {
+                        Map<String, Object> properties = OntologyManager.getProperties(source.getContainer(), source.getLSID());
+                        String targetStudyId = (String) properties.get(targetStudyColumn.getPropertyURI());
 
-            case Result:
-                // Ignore Results domain TargetStudy for now.
-                // The participant resolver will find the TargetStudy on the row.
-            case Batch:
-            default:
-                source = AssayService.get().findBatch(run);
-                break;
+                        if (targetStudyId != null)
+                            container = ContainerManager.getForId(targetStudyId);
+                    }
+                }
+            }
+            result.add(container);
         }
-
-        if (source != null)
-        {
-            Map<String, Object> properties = OntologyManager.getProperties(source.getContainer(), source.getLSID());
-            String targetStudyId = (String) properties.get(targetStudyColumn.getPropertyURI());
-
-            if (targetStudyId != null)
-                return ContainerManager.getForId(targetStudyId);
-        }
-        
-        return null;
+        return result;
     }
 
-    public abstract ExpData getDataForDataRow(Object dataRowId, ExpProtocol protocol);
+//    @Override
+//    public ExpData getDataForDataRow(Object dataRowId, ExpProtocol protocol)
+//    {
+//        Set<ExpData> datas = getDatasForDataRows(Collections.singleton(dataRowId), protocol, new ResolverCache());
+//        return datas.isEmpty() ? null : datas.iterator().next();
+//    }
 
+    @Nullable
+    public final ExpData getDataForDataRow(int resultRowId, ExpProtocol protocol)
+    {
+        Set<ExpData> matches = getDatasForResultRows(Collections.singleton(resultRowId), protocol, new ResolverCache());
+        return matches.isEmpty() ? null : matches.iterator().next();
+    }
+
+    /** Resolve result rows to their owning ExpData object. Optional method for assays that support copy-to-study */
+    public Set<ExpData> getDatasForResultRows(Collection<Integer> rowIds, ExpProtocol protocol, ResolverCache cache)
+    {
+        return Collections.emptySet();
+    }
+
+    public static class ResolverCache
+    {
+        private final Map<Integer, ExpData> _dataById = new HashMap<>();
+        private final Map<Integer, ExpRun> _runById = new HashMap<>();
+        private final Map<ExpRun, ExpExperiment> _batchByRun = new HashMap<>();
+
+        private <K, T extends ExpObject> T get(K key, Map<K, T> cache, Supplier<T> supplier)
+        {
+            if (key == null)
+            {
+                return null;
+            }
+            if (cache.containsKey(key))
+            {
+                return cache.get(key);
+            }
+            T result = supplier.get();
+            cache.put(key, result);
+            return result;
+
+        }
+
+        public ExpData getDataById(int dataId)
+        {
+            return get(dataId, _dataById, () -> ExperimentService.get().getExpData(dataId));
+        }
+
+        public ExpRun getRun(int runId)
+        {
+            return get(runId, _runById, () -> ExperimentService.get().getExpRun(runId));
+        }
+
+        public ExpExperiment getBatch(ExpRun run)
+        {
+            return get(run, _batchByRun, () -> AssayService.get().findBatch(run));
+        }
+    }
 
     @Override
     public ActionURL getImportURL(Container container, ExpProtocol protocol)

--- a/api/src/org/labkey/api/assay/AssayProvider.java
+++ b/api/src/org/labkey/api/assay/AssayProvider.java
@@ -23,13 +23,16 @@ import org.labkey.api.assay.actions.AssayRunUploadForm;
 import org.labkey.api.assay.pipeline.AssayRunAsyncContext;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Handler;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpExperiment;
+import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
+import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.IAssayDomainType;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
@@ -55,9 +58,12 @@ import org.springframework.web.servlet.mvc.Controller;
 import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * An AssayProvider is the main implementation point for participating in the overall assay framework. It provides
@@ -148,7 +154,7 @@ public interface AssayProvider extends Handler<ExpProtocol>
     @Nullable
     Pair<ExpProtocol.AssayDomainTypes, DomainProperty> findTargetStudyProperty(ExpProtocol protocol);
 
-    Container getAssociatedStudyContainer(ExpProtocol protocol, Object dataId);
+    Set<Container> getAssociatedStudyContainers(ExpProtocol protocol, Collection<Integer> rowIds);
 
     /** @return the URL used to import data when the user still needs to upload data files */
     ActionURL getImportURL(Container container, ExpProtocol protocol);

--- a/api/src/org/labkey/api/assay/actions/AssayResultDetailsAction.java
+++ b/api/src/org/labkey/api/assay/actions/AssayResultDetailsAction.java
@@ -43,7 +43,7 @@ public class AssayResultDetailsAction extends BaseAssayAction<DataDetailsForm>
 {
     private ExpProtocol _protocol;
     private ExpData _data;
-    private Object _dataRowId;
+    private int _dataRowId;
 
     @Override
     public ModelAndView getView(DataDetailsForm form, BindException errors)

--- a/api/src/org/labkey/api/assay/actions/DataDetailsForm.java
+++ b/api/src/org/labkey/api/assay/actions/DataDetailsForm.java
@@ -22,14 +22,14 @@ package org.labkey.api.assay.actions;
  */
 public class DataDetailsForm extends ProtocolIdForm
 {
-    private Object _dataRowId;
+    private int _dataRowId;
 
-    public Object getDataRowId()
+    public int getDataRowId()
     {
         return _dataRowId;
     }
 
-    public void setDataRowId(Object dataRowId)
+    public void setDataRowId(int dataRowId)
     {
         _dataRowId = dataRowId;
     }

--- a/api/src/org/labkey/api/util/DOM.java
+++ b/api/src/org/labkey/api/util/DOM.java
@@ -802,7 +802,8 @@ public class DOM
                     }
                 }
             var csrfInput = !isPost ? null : new CsrfInput(HttpView.currentContext());
-            return DOM.FORM(attrs, body, csrfInput);
+            // Put the CSRF token first to ensure it's available even if the full HTTP POST body hasn't been parsed
+            return DOM.FORM(attrs, csrfInput, body);
         }
 
         public static Renderable ERRORS(PageContext pageContext)

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -711,7 +711,8 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
             DefaultStudyDesignWriter.TestCase.class,
             ParticipantIdImportHelper.ParticipantIdTest.class,
             SampleMindedTransformTask.TestCase.class,
-            SequenceNumImportHelper.SequenceNumTest.class
+            SequenceNumImportHelper.SequenceNumTest.class,
+            StudyImpl.DateMathTestCase.class
         );
     }
 

--- a/study/src/org/labkey/study/assay/PublishStartAction.java
+++ b/study/src/org/labkey/study/assay/PublishStartAction.java
@@ -58,7 +58,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -264,19 +264,23 @@ public class PublishStartAction extends BaseAssayAction<PublishStartAction.Publi
         }
         else
         {
-            Set<Container> containers = new HashSet<>();
             boolean nullsFound = false;
             boolean insufficientPermissions = false;
-            for (Integer id : ids)
+
+            Set<Container> containers = provider.getAssociatedStudyContainers(_protocol, ids);
+            Iterator<Container> i = containers.iterator();
+            while (i.hasNext())
             {
-                Container studyContainer = provider.getAssociatedStudyContainer(_protocol, id);
-                if (studyContainer == null)
-                    nullsFound = true;
-                else
+                Container c = i.next();
+                if (c == null)
                 {
-                    if (!studyContainer.hasPermission(getUser(), InsertPermission.class))
-                        insufficientPermissions = true;
-                    containers.add(studyContainer);
+                    nullsFound = true;
+                    i.remove();
+                }
+                else if (!c.hasPermission(getUser(), InsertPermission.class))
+                {
+                    insufficientPermissions = true;
+                    i.remove();
                 }
             }
 

--- a/study/src/org/labkey/study/assay/view/publishChooseStudy.jsp
+++ b/study/src/org/labkey/study/assay/view/publishChooseStudy.jsp
@@ -34,6 +34,7 @@
 <%@ page import="org.labkey.study.model.StudyManager" %>
 <%@ page import="java.util.Iterator" %>
 <%@ page import="java.util.List" %>
+<%@ page import="org.labkey.api.util.StringUtilsLabKey" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
@@ -170,8 +171,11 @@
     <%
         if (!bean.getRunIds().isEmpty())
         {
+            String autoCopyLabel = "Auto copy data from " +
+                    StringUtilsLabKey.pluralize(bean.getRunIds().size(), "run") + " (" +
+                    StringUtilsLabKey.pluralize(bean.getIds().size(), "row") + ")";
     %>
-    <labkey:input type="checkbox" label="Auto copy the selected run(s)" id="autoCopy" forceSmallContext="true"
+    <labkey:input type="checkbox" label="<%= autoCopyLabel %>" id="autoCopy" forceSmallContext="true"
                   contextContent="Selecting this checkbox will skip the confirmation step and run the copy to study process in a pipeline job. Run data missing valid subject IDs and timepoints will be ignored."/>
     <%
         }

--- a/study/src/org/labkey/study/model/StudyImpl.java
+++ b/study/src/org/labkey/study/model/StudyImpl.java
@@ -1247,6 +1247,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
             date.add(Calendar.DAY_OF_MONTH, daysBetween);
         }
 
+        // Now iterate for one or possibly two more days until we go beyond the original date
         while (date.before(endDate))
         {
             date.add(Calendar.DAY_OF_MONTH, 1);
@@ -1270,6 +1271,33 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     public int hashCode()
     {
         return getContainer() != null ? getContainer().hashCode() : 0;
+    }
+
+    public static class DateMathTestCase extends Assert
+    {
+        @Test
+        public void testDayInterval()
+        {
+            // The behavior here is questionable - arguments that differ by one
+            // millisecond will return a difference of 1 day (plus or minus), but keeping as-is during the optimization
+            // to not increment by one day for the whole interval
+            Calendar jan1 = new GregorianCalendar();
+            jan1.setTimeInMillis(DateUtil.parseISODateTime("2020-01-01"));
+            Calendar c = new GregorianCalendar();
+            c.setTimeInMillis(jan1.getTimeInMillis());
+            assertEquals(0, daysBetween(jan1, c));
+
+            c.setTimeInMillis(jan1.getTimeInMillis() + 1);
+            assertEquals(1, daysBetween(jan1, c));
+
+            c.add(Calendar.DATE, 1);
+            assertEquals(2, daysBetween(jan1, c));
+
+            c.setTimeInMillis(jan1.getTimeInMillis() - 1);
+            assertEquals(-1, daysBetween(jan1, c));
+            c.add(Calendar.DATE, -1);
+            assertEquals(-2, daysBetween(jan1, c));
+        }
     }
 
 


### PR DESCRIPTION
#### Rationale
Users want to be able to copy large assay runs to study datasets. It's painfully slow because we are iterating on each row and doing lots of DB queries

#### Changes
* Switch AssayProvider to encourage implementations to query rows in bulk
* Cache ExpData, ExpRun, and ExpExperiment references during process as they're likely to be shared by result rows
* Give user more feedback on what's happening during confirmation page
* Optimize date math for visit calculation