### PR TITLE
Fb sample type export fixes

### DIFF
--- a/api/src/org/labkey/api/exp/XarSource.java
+++ b/api/src/org/labkey/api/exp/XarSource.java
@@ -138,10 +138,14 @@ public abstract class XarSource implements Serializable
         return null;
     }
 
-    public void addData(String experimentRunLSID, ExpData data)
+    public void addData(String experimentRunLSID, ExpData data, @Nullable String additionalDataLSID)
     {
-        Map<String, ExpData> existingMap = _data.computeIfAbsent(experimentRunLSID, k -> new HashMap<>());
-        existingMap.put(data.getLSID(), data);
+        Map<String, ExpData> map = _data.computeIfAbsent(experimentRunLSID, k -> new HashMap<>());
+        map.put(data.getLSID(), data);
+        if (additionalDataLSID != null)
+        {
+            map.put(additionalDataLSID, data);
+        }
     }
 
     public void addMaterial(String experimentRunLSID, ExpMaterial material, @Nullable String additionalMaterialLSID)
@@ -164,6 +168,11 @@ public abstract class XarSource implements Serializable
             if (experimentRun == null)
             {
                 result = ExperimentService.get().getExpData(dataLSID);
+            }
+            if (result == null)
+            {
+                // Try for a non-run scoped variant
+                result = _data.computeIfAbsent(null, k -> new HashMap<>()).get(dataLSID);
             }
             if (result == null)
             {

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -353,7 +353,8 @@ public class ExpDataIterators
                         else
                         {
                             ExpData data = ExperimentService.get().getExpData(lsid);
-                            data.setComment(_user, flag);
+                            if (data != null)
+                                data.setComment(_user, flag);
                         }
                     }
                     catch (ValidationException e)

--- a/experiment/src/org/labkey/experiment/LSIDRelativizer.java
+++ b/experiment/src/org/labkey/experiment/LSIDRelativizer.java
@@ -57,8 +57,6 @@ public enum LSIDRelativizer implements SafeToRenderEnum
             {
                 ExpData data = (ExpData)o;
                 // Most DataClass data don't have a dataFileUrl, but some do -- like NucSequence imported from a genbank file
-                // UNDONE: Don't have user and fetching DataClass is expensive-ish. Maybe add data.hasDataClass() or something
-                // UNDONE: Maybe there is a better way to detect when we should use ${AutoFileLSID}?
                 if (data.getDataFileUrl() == null || data.getDataClass() != null)
                 {
                     // If we don't have a URL for this data object, we can't use AutoFileLSID. Instead,

--- a/experiment/src/org/labkey/experiment/LSIDRelativizer.java
+++ b/experiment/src/org/labkey/experiment/LSIDRelativizer.java
@@ -56,7 +56,10 @@ public enum LSIDRelativizer implements SafeToRenderEnum
             if (o instanceof ExpData)
             {
                 ExpData data = (ExpData)o;
-                if (data.getDataFileUrl() == null)
+                // Most DataClass data don't have a dataFileUrl, but some do -- like NucSequence imported from a genbank file
+                // UNDONE: Don't have user and fetching DataClass is expensive-ish. Maybe add data.hasDataClass() or something
+                // UNDONE: Maybe there is a better way to detect when we should use ${AutoFileLSID}?
+                if (data.getDataFileUrl() == null || data.getDataClass() != null)
                 {
                     // If we don't have a URL for this data object, we can't use AutoFileLSID. Instead,
                     // try the next best option
@@ -86,6 +89,9 @@ public enum LSIDRelativizer implements SafeToRenderEnum
             }
             else if ("Data".equals(prefix))
             {
+                // UNDONE: Now that "Data" prefix is used for DataClass, the AutoFileLSID is not a good default.
+                // UNDONE: Can we be more restrictive about which LSIDs this is applied to?  Maybe only if the objectId part of the LSID includes a "/" (%2F) or something?
+                // UNDONE: Maybe there is a better way to detect when we should use ${AutoFileLSID}?
                 return AutoFileLSIDReplacer.AUTO_FILE_LSID_SUBSTITUTION;
             }
             else if (suffix != null && SUFFIX_PATTERN.matcher(suffix).matches())

--- a/experiment/src/org/labkey/experiment/XarExporter.java
+++ b/experiment/src/org/labkey/experiment/XarExporter.java
@@ -146,9 +146,10 @@ public class XarExporter
     AssayProvider.XarCallbacks assayCallbacks = null;
 
 
-    public XarExporter(LSIDRelativizer lsidRelativizer, URLRewriter urlRewriter, User user)
+    public XarExporter(LSIDRelativizer.RelativizedLSIDs relativizedLSIDs, URLRewriter urlRewriter, User user)
     {
-        _relativizedLSIDs = new LSIDRelativizer.RelativizedLSIDs(lsidRelativizer);
+        // UNDONE: Is it ok to share the relativizedLSIDs across XarExporters and tsv writers?
+        _relativizedLSIDs = relativizedLSIDs;
         _urlRewriter = urlRewriter;
         _user = user;
 
@@ -156,9 +157,19 @@ public class XarExporter
         _archive = _document.addNewExperimentArchive();
     }
 
+    public XarExporter(LSIDRelativizer lsidRelativizer, URLRewriter urlRewriter, User user)
+    {
+        this(new LSIDRelativizer.RelativizedLSIDs(lsidRelativizer), urlRewriter, user);
+    }
+
     public XarExporter(LSIDRelativizer lsidRelativizer, XarExportSelection selection, User user, String xarXmlFileName, Logger log) throws ExperimentException
     {
-        this(lsidRelativizer, selection.createURLRewriter(), user);
+        this(new LSIDRelativizer.RelativizedLSIDs(lsidRelativizer), selection, user, xarXmlFileName, log);
+    }
+
+    public XarExporter(LSIDRelativizer.RelativizedLSIDs relativizedLSIDs, XarExportSelection selection, User user, String xarXmlFileName, Logger log) throws ExperimentException
+    {
+        this(relativizedLSIDs, selection.createURLRewriter(), user);
         _log = log;
 
         selection.addContent(this);
@@ -517,7 +528,7 @@ public class XarExporter
     }
 
     private String relativizeLSIDPropertyValue(String value, SimpleTypeNames.Enum type)
-    {
+    {// NOTE: this is interesting - we fixup LSID values in the xar xml
         if (type == SimpleTypeNames.STRING &&
             value != null &&
             value.indexOf("urn:lsid:") == 0)

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -70,6 +70,7 @@ import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.exp.xar.LsidUtils;
+import org.labkey.api.exp.xar.XarReaderRegistry;
 import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineService;
@@ -90,7 +91,6 @@ import org.labkey.experiment.pipeline.MoveRunsPipelineJob;
 import org.labkey.experiment.xar.AbstractXarImporter;
 import org.labkey.experiment.xar.AutoFileLSIDReplacer;
 import org.labkey.experiment.xar.XarExpander;
-import org.labkey.api.exp.xar.XarReaderRegistry;
 
 import javax.xml.namespace.QName;
 import java.io.File;
@@ -1354,12 +1354,12 @@ public class XarReader extends AbstractXarImporter
 
         String dataLSID = LsidUtils.resolveLsidFromTemplate(xbData.getAbout(), context, declaredType, new AutoFileLSIDReplacer(xbData.getDataFileUrl(), getContainer(), _xarSource));
         ExpDataImpl expData = ExperimentServiceImpl.get().getExpData(dataLSID);
-        ExpDataClass expDataClass = ExperimentService.get().getDataClass(declaredType);
+        ExpDataClassImpl expDataClass = ExperimentServiceImpl.get().getDataClass(declaredType);
         if (expData == null && expDataClass != null)
         {
             // Try resolving it by name within the data class in case we have it under a different LSID
-            ExpData data = expDataClass.getData(getContainer(), xbData.getName());
-            if (data instanceof ExpDataImpl)
+            ExpDataImpl data = expDataClass.getData(getContainer(), xbData.getName());
+            if (data != null)
             {
                 // Remember this as an alternate LSID during import
                 _xarSource.addData(null, data, dataLSID);
@@ -1367,7 +1367,7 @@ public class XarReader extends AbstractXarImporter
                 {
                     _xarSource.addData(experimentRun.getLSID(), data, dataLSID);
                 }
-                expData = (ExpDataImpl)data;
+                expData = data;
             }
         }
 

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -1474,7 +1474,7 @@ public class XarReader extends AbstractXarImporter
         }
         else
         {
-            getLog().warn("No data file found for " + expData.getName() + ", unable to import. (LSID: " + expData.getLSID() + ", path: " + expData.getDataFileUrl() + ")");
+            getLog().info("No data file found for " + expData.getName() + ". (LSID: " + expData.getLSID() + ", path: " + expData.getDataFileUrl() + ")");
         }
 
 

--- a/experiment/src/org/labkey/experiment/api/property/LookupValidator.java
+++ b/experiment/src/org/labkey/experiment/api/property/LookupValidator.java
@@ -230,9 +230,6 @@ public class LookupValidator extends DefaultPropertyValidator implements Validat
         //noinspection ConstantConditions
         assert value != null : "Shouldn't be validating a null value";
 
-        if (value != null)
-            value = ConvertHelper.convert(value, crpField.getJavaObjectClass());
-
         if (crpField instanceof PropertyDescriptor)
         {
             PropertyDescriptor field = (PropertyDescriptor) crpField;

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -44,6 +44,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.DEFAULT_DIRECTORY;
+import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.XAR_RUNS_NAME;
+import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.XAR_TYPES_NAME;
 
 public class SampleTypeAndDataClassFolderImporter implements FolderImporter
 {
@@ -70,7 +72,8 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
 
         if (xarDir != null)
         {
-            File xarFile = null;
+            File typesXarFile = null;
+            File runsXarFile = null;
             Map<String, String> sampleTypeDataFiles = new HashMap<>();
             Map<String, String> dataClassDataFiles = new HashMap<>();
             Logger log = ctx.getLogger();
@@ -81,12 +84,19 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
 
             for (String file: xarDir.list())
             {
-                if (file.toLowerCase().endsWith(".xar"))
+                if (file.equalsIgnoreCase(XAR_TYPES_NAME))
                 {
-                    if (xarFile == null)
-                        xarFile = new File(xarDir.getLocation(), file);
+                    if (typesXarFile == null)
+                        typesXarFile = new File(xarDir.getLocation(), file);
                     else
-                        log.error("More than one XAR file found in the sample type directory: ", file);
+                        log.error("More than one types XAR file found in the sample type directory: ", file);
+                }
+                else if (file.equalsIgnoreCase(XAR_RUNS_NAME))
+                {
+                    if (runsXarFile == null)
+                        runsXarFile = new File(xarDir.getLocation(), file);
+                    else
+                        log.error("More than one runs XAR file found in the sample type directory: ", file);
                 }
                 else if (file.toLowerCase().endsWith(".tsv"))
                 {
@@ -99,12 +109,12 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
 
             try (DbScope.Transaction transaction = ExperimentService.get().getSchema().getScope().ensureTransaction())
             {
-                if (xarFile != null)
+                if (typesXarFile != null)
                 {
                     File logFile = null;
                     // we don't need the log file in cases where the xarFile is a virtual file and not in the file system
-                    if (xarFile.exists())
-                        logFile = CompressedInputStreamXarSource.getLogFileFor(xarFile);
+                    if (typesXarFile.exists())
+                        logFile = CompressedInputStreamXarSource.getLogFileFor(typesXarFile);
 
                     if (job == null)
                     {
@@ -138,33 +148,53 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                             @Override
                             public String getDescription()
                             {
-                                return "Sample Type XAR Import";
+                                return "Sample Type and Data Class XAR Import";
                             }
                         };
                     }
-                    XarSource xarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(xarFile.getName()), xarFile, logFile, job);
+
+                    XarSource typesXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(typesXarFile.getName()), typesXarFile, logFile, job);
                     try
                     {
-                        xarSource.init();
+                        typesXarSource.init();
                     }
                     catch (Exception e)
                     {
-                        log.error("Failed to initialize XAR source", e);
+                        log.error("Failed to initialize types XAR source", e);
                         throw(e);
                     }
-                    log.info("Importing XAR file: " + xarFile.getName());
-                    XarReader reader = new XarReader(xarSource, job);
-                    reader.setStrictValidateExistingSampleType(false);
-                    reader.parseAndLoad(false);
+                    log.info("Importing the types XAR file: " + typesXarFile.getName());
+                    XarReader typesReader = new XarReader(typesXarSource, job);
+                    typesReader.setStrictValidateExistingSampleType(false);
+                    typesReader.parseAndLoad(false);
 
                     // process any sample type data files and data class files
-                    importTsvData(ctx, SamplesSchema.SCHEMA_NAME, reader.getSampleTypes().stream().map(Identifiable::getName).collect(Collectors.toList()),
+                    importTsvData(ctx, SamplesSchema.SCHEMA_NAME, typesReader.getSampleTypes().stream().map(Identifiable::getName).collect(Collectors.toList()),
                             sampleTypeDataFiles, xarDir);
-                    importTsvData(ctx, ExpSchema.SCHEMA_EXP_DATA.toString(), reader.getDataClasses().stream().map(Identifiable::getName).collect(Collectors.toList()),
+                    importTsvData(ctx, ExpSchema.SCHEMA_EXP_DATA.toString(), typesReader.getDataClasses().stream().map(Identifiable::getName).collect(Collectors.toList()),
                             dataClassDataFiles, xarDir);
+
+                    // handle wiring up any derivation runs
+                    if (runsXarFile != null)
+                    {
+                        XarSource runsXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(runsXarFile.getName()), runsXarFile, logFile, job);
+                        try
+                        {
+                            runsXarSource.init();
+                        }
+                        catch (Exception e)
+                        {
+                            log.error("Failed to initialize runs XAR source", e);
+                            throw(e);
+                        }
+                        log.info("Importing the runs XAR file: " + runsXarFile.getName());
+                        XarReader runsReader = new XarReader(runsXarSource, job);
+                        runsReader.setStrictValidateExistingSampleType(false);
+                        runsReader.parseAndLoad(false);
+                    }
                 }
                 else
-                    log.info("No xar file to process.");
+                    log.info("No types XAR file to process.");
 
                 transaction.commit();
                 log.info("Finished importing Sample Types and Data Classes");
@@ -204,7 +234,8 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                                     context.setAllowImportLookupByAlternateKey(true);
                                     ((AbstractQueryUpdateService)qus).setAttachmentDirectory(dir.getDir(tableName));
 
-                                    qus.loadRows(ctx.getUser(), ctx.getContainer(), loader, context, null);
+                                    int count = qus.loadRows(ctx.getUser(), ctx.getContainer(), loader, context, null);
+                                    log.info("Imported a total of " + count + " rows into : " + tableName);
                                     if (context.getErrors().hasErrors())
                                     {
                                         for (ValidationException error : context.getErrors().getRowErrors())
@@ -243,7 +274,8 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
         public int getPriority()
         {
             // make sure this importer runs after the FolderXarImporter (i.e. "Experiments and runs")
-            return 75;
+            //return 75;
+            return 65;
         }
     }
 }

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
@@ -15,6 +15,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.MultiValuedForeignKey;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.PHI;
 import org.labkey.api.data.PropertyStorageSpec;
@@ -76,8 +77,10 @@ import java.util.stream.Collectors;
 public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
 {
     public static final String DEFAULT_DIRECTORY = "sample-types";
-    public static final String XAR_FILE_NAME = "sample_types.xar";
-    private static final String XAR_XML_FILE_NAME = XAR_FILE_NAME + ".xml";
+    public static final String XAR_TYPES_NAME = "sample_types.xar";             // the file which contains the sample type and data class definitions
+    public static final String XAR_RUNS_NAME = "runs.xar";                      // the file which contains the derivation runs for sample types and data classes
+    private static final String XAR_TYPES_XML_NAME = XAR_TYPES_NAME + ".xml";
+    private static final String XAR_RUNS_XML_NAME = XAR_RUNS_NAME + ".xml";
     public static final String SAMPLE_TYPE_PREFIX = "SAMPLE_TYPE_";
     public static final String DATA_CLASS_PREFIX = "DATA_CLASS_";
     private PHI _exportPhiLevel = PHI.NotPHI;
@@ -102,11 +105,16 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
     @Override
     public void write(Container object, ImportContext<FolderDocument.Folder> ctx, VirtualFile vf) throws Exception
     {
-        XarExportSelection selection = new XarExportSelection();
+        // We will divide the sample type and data class definitions from the runs into two separate XAR files, the reason is
+        // during import we want all data to be imported via the query update service and any lineage will be wired up
+        // by the runs XAR.
+        XarExportSelection typesSelection = new XarExportSelection();
+        XarExportSelection runsSelection = new XarExportSelection();
         Set<ExpSampleType> sampleTypes = new HashSet<>();
         Set<ExpDataClass> dataClasses = new HashSet<>();
         _exportPhiLevel = ctx.getPhiLevel();
-        boolean exportXar = false;
+        boolean exportTypes = false;
+        boolean exportRuns = false;
 
         Lsid sampleTypeLsid = new Lsid(ExperimentService.get().generateLSID(ctx.getContainer(), ExpSampleType.class, "export"));
         for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(ctx.getContainer(), ctx.getUser(), true))
@@ -121,16 +129,16 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
             if (sampleTypeLsid.getNamespacePrefix().equals(lsid.getNamespacePrefix()))
             {
                 sampleTypes.add(sampleType);
-                selection.addSampleType(sampleType);
-                exportXar = true;
+                typesSelection.addSampleType(sampleType);
+                exportTypes = true;
             }
         }
 
         for (ExpDataClass dataClass : ExperimentService.get().getDataClasses(ctx.getContainer(), ctx.getUser(), false))
         {
             dataClasses.add(dataClass);
-            selection.addDataClass(dataClass);
-            exportXar = true;
+            typesSelection.addDataClass(dataClass);
+            exportTypes = true;
         }
 
         // add any sample derivation runs
@@ -147,29 +155,41 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
 
         if (!exportedRuns.isEmpty())
         {
-            selection.addRuns(exportedRuns);
-            exportXar = true;
+            runsSelection.addRuns(exportedRuns);
+            exportRuns = true;
         }
         VirtualFile xarDir = vf.getDir(DEFAULT_DIRECTORY);
 
-        if (exportXar)
+        // UNDONE: The other exporters use FOLDER_RELATIVE, but it wants to use ${AutoFileLSID} replacements for DataClass LSIDs when exporting the TSV data.. see comment in ExportLsidDataColumn
+        LSIDRelativizer.RelativizedLSIDs relativizedLSIDs = new LSIDRelativizer.RelativizedLSIDs(LSIDRelativizer.FOLDER_RELATIVE);
+        // create the XAR which contains the sample type and data class definitions
+        if (exportTypes)
         {
-            XarExporter exporter = new XarExporter(LSIDRelativizer.FOLDER_RELATIVE, selection, ctx.getUser(), XAR_XML_FILE_NAME, ctx.getLogger());
+            XarExporter exporter = new XarExporter(relativizedLSIDs, typesSelection, ctx.getUser(), XAR_TYPES_XML_NAME, ctx.getLogger());
+            try (OutputStream fOut = xarDir.getOutputStream(XAR_TYPES_NAME))
+            {
+                exporter.writeAsArchive(fOut);
+            }
+        }
 
-            try (OutputStream fOut = xarDir.getOutputStream(XAR_FILE_NAME))
+        // create the XAR which contains any derivation protocol runs
+        if (exportRuns)
+        {
+            XarExporter exporter = new XarExporter(relativizedLSIDs, runsSelection, ctx.getUser(), XAR_RUNS_XML_NAME, ctx.getLogger());
+            try (OutputStream fOut = xarDir.getOutputStream(XAR_RUNS_NAME))
             {
                 exporter.writeAsArchive(fOut);
             }
         }
 
         // write the sample type data as .tsv files
-        writeSampleTypeDataFiles(sampleTypes, ctx, xarDir);
+        writeSampleTypeDataFiles(sampleTypes, ctx, xarDir, relativizedLSIDs);
 
         // write the data class data as .tsv files
-        writeDataClassDataFiles(dataClasses, ctx, xarDir);
+        writeDataClassDataFiles(dataClasses, ctx, xarDir, relativizedLSIDs);
     }
 
-    private void writeSampleTypeDataFiles(Set<ExpSampleType> sampleTypes, ImportContext<FolderDocument.Folder> ctx, VirtualFile dir) throws Exception
+    private void writeSampleTypeDataFiles(Set<ExpSampleType> sampleTypes, ImportContext<FolderDocument.Folder> ctx, VirtualFile dir, LSIDRelativizer.RelativizedLSIDs relativizedLSIDs) throws Exception
     {
         // write out the sample rows that aren't participating in the derivation protocol
         UserSchema userSchema = QueryService.get().getUserSchema(ctx.getUser(), ctx.getContainer(), SamplesSchema.SCHEMA_NAME);
@@ -180,25 +200,11 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
                 TableInfo tinfo = userSchema.getTable(sampleType.getName());
                 if (tinfo != null)
                 {
-                    Collection<ColumnInfo> columns = getColumnsToExport(tinfo);
+                    Collection<ColumnInfo> columns = getColumnsToExport(ctx, tinfo, relativizedLSIDs);
 
                     if (!columns.isEmpty())
                     {
-                        // query to get all of the samples that were involved in a derivation protocol, we want to
-                        // omit these from the tsv since the XAR importer will currently wire up those rows
-                        SQLFragment sql = new SQLFragment("SELECT DISTINCT(materialId) FROM ").append(ExperimentService.get().getTinfoMaterialInput(), "mi")
-                                .append(" JOIN ").append(ExperimentService.get().getTinfoMaterial(), "mat")
-                                .append(" ON mi.materialId = mat.rowId")
-                                .append(" JOIN ").append(ExperimentServiceImpl.get().getSchema().getTable("Object"), "o")
-                                .append(" ON mat.objectId = o.objectId")
-                                .append(" WHERE o.ownerObjectId = ?")
-                                .add(sampleType.getObjectId());
-
-                        Collection<Integer> derivedIds = new SqlSelector(ExperimentService.get().getSchema(), sql).getCollection(Integer.class);
-                        SimpleFilter filter = new SimpleFilter();
-                        if (!derivedIds.isEmpty())
-                            filter.addCondition(FieldKey.fromParts("RowId"), derivedIds, CompareType.NOT_IN);
-                        ResultsFactory factory = ()->QueryService.get().select(tinfo, columns, filter, null);
+                        ResultsFactory factory = ()->QueryService.get().select(tinfo, columns, SimpleFilter.createContainerFilter(ctx.getContainer()), null);
                         try (TSVGridWriter tsvWriter = new TSVGridWriter(factory))
                         {
                             tsvWriter.setApplyFormats(false);
@@ -212,7 +218,7 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
         }
     }
 
-    private void writeDataClassDataFiles(Set<ExpDataClass> dataClasses, ImportContext<FolderDocument.Folder> ctx, VirtualFile dir) throws Exception
+    private void writeDataClassDataFiles(Set<ExpDataClass> dataClasses, ImportContext<FolderDocument.Folder> ctx, VirtualFile dir, LSIDRelativizer.RelativizedLSIDs relativizedLSIDs) throws Exception
     {
         // write out the sample rows that aren't participating in the derivation protocol
         UserSchema userSchema = QueryService.get().getUserSchema(ctx.getUser(), ctx.getContainer(), ExpSchema.SCHEMA_EXP_DATA);
@@ -223,23 +229,11 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
                 TableInfo tinfo = userSchema.getTable(dataClass.getName());
                 if (tinfo != null)
                 {
-                    Collection<ColumnInfo> columns = getColumnsToExport(tinfo);
+                    Collection<ColumnInfo> columns = getColumnsToExport(ctx, tinfo, relativizedLSIDs);
 
                     if (!columns.isEmpty())
                     {
-                        // query to get all of the data rows that were involved in a derivation protocol, we want to
-                        // omit these from the tsv since the XAR importer will currently wire up those rows
-                        SQLFragment sql = new SQLFragment("SELECT DISTINCT(dataId) FROM ").append(ExperimentService.get().getTinfoDataInput(), "di")
-                                .append(" JOIN ").append(ExperimentService.get().getTinfoData(), "dat")
-                                .append(" ON di.dataId = dat.rowId")
-                                .append(" WHERE dat.cpastype = ?")
-                                .add(dataClass.getLSID());
-
-                        Collection<Integer> derivedIds = new SqlSelector(ExperimentService.get().getSchema(), sql).getCollection(Integer.class);
-                        SimpleFilter filter = new SimpleFilter();
-                        if (!derivedIds.isEmpty())
-                            filter.addCondition(FieldKey.fromParts("RowId"), derivedIds, CompareType.NOT_IN);
-                        ResultsFactory factory = ()->QueryService.get().select(tinfo, columns, filter, null);
+                        ResultsFactory factory = ()->QueryService.get().select(tinfo, columns, SimpleFilter.createContainerFilter(ctx.getContainer()), null);
                         try (TSVGridWriter tsvWriter = new TSVGridWriter(factory))
                         {
                             tsvWriter.setApplyFormats(false);
@@ -280,7 +274,7 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
         return run.getDataOutputs().stream().anyMatch(data -> dataClasses.contains(data.getDataClass(null)));
     }
 
-    private Collection<ColumnInfo> getColumnsToExport(TableInfo tinfo)
+    private Collection<ColumnInfo> getColumnsToExport(ImportContext<FolderDocument.Folder> ctx, TableInfo tinfo, LSIDRelativizer.RelativizedLSIDs relativizedLSIDs)
     {
         Map<FieldKey, ColumnInfo> columns = new LinkedHashMap<>();
         Set<PropertyStorageSpec> baseProps = tinfo.getDomainKind().getBaseProperties(tinfo.getDomain());
@@ -292,8 +286,13 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
         {
             if (!isExportable(col))
                 continue;
-            if (basePropNames.contains(col.getName()) && !ExpMaterialTable.Column.Name.name().equalsIgnoreCase(col.getName()))
+
+            if (basePropNames.contains(col.getName())
+                    && !ExpMaterialTable.Column.Name.name().equalsIgnoreCase(col.getName())
+                    && !ExpMaterialTable.Column.LSID.name().equalsIgnoreCase(col.getName()))
+            {
                 continue;
+            }
 
             if (ExpMaterialTable.Column.Flag.name().equalsIgnoreCase(col.getName()))
             {
@@ -315,10 +314,28 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
 
                 columns.put(aliasCol.getFieldKey(), aliasCol);
             }
-            else if ((col.isUserEditable() && !col.isHidden() && !col.isReadOnly()) || col.isKeyField())
+            else if (col.getFk() instanceof MultiValuedForeignKey)
+            {
+                // skip multi-value columns
+                // NOTE: This assumes that we are exporting the junction table and lookup target tables.  Is that ok?
+                // NOTE: This needs to happen after the Alias column is handled since it has a MultiValuedForeignKey.
+                // CONSIDER: Alternate strategy would be to export the lookup target values?
+                ctx.getLogger().info("Skipping multi-value column: " + col.getName());
+            }
+            else if (col.isKeyField() ||
+                    ExpMaterialTable.Column.LSID.name().equalsIgnoreCase(col.getName()) ||
+                    (col.isUserEditable() && !col.isHidden() && !col.isReadOnly()))
             {
                 MutableColumnInfo wrappedCol = WrappedColumnInfo.wrap(col);
-                wrappedCol.setDisplayColumnFactory(colInfo -> new ExportDataColumn(colInfo));
+                // Relativize the LSID column or any column with LSID values (e.g. MoleculeSet.intendedMoleculeLsid)
+                if ("lsidtype".equalsIgnoreCase(col.getSqlTypeName()) || (col.getName().toLowerCase().endsWith("lsid") && col.isStringType() && col.getScale() == 300))
+                {
+                    wrappedCol.setDisplayColumnFactory(colInfo -> new ExportLsidDataColumn(colInfo, relativizedLSIDs));
+                }
+                else
+                {
+                    wrappedCol.setDisplayColumnFactory(ExportDataColumn::new);
+                }
                 columns.put(wrappedCol.getFieldKey(), wrappedCol);
 
                 // If the column is MV enabled, export the data in the indicator column as well
@@ -474,6 +491,34 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
         public Object getDisplayValue(RenderContext ctx)
         {
             return getValue(ctx);
+        }
+    }
+
+    // similar to XarExporter.relativizeLSIDPropertyValue but for columns
+    private static class ExportLsidDataColumn extends ExportDataColumn
+    {
+        private final LSIDRelativizer.RelativizedLSIDs relativizedLSIDs;
+
+        private ExportLsidDataColumn(ColumnInfo col, LSIDRelativizer.RelativizedLSIDs relativizedLSIDs)
+        {
+            super(col);
+            this.relativizedLSIDs = relativizedLSIDs;
+        }
+
+        @Override
+        public Object getValue(RenderContext ctx)
+        {
+            Object o = super.getValue(ctx);
+            if (o instanceof String)
+            {
+                String s = (String)o;
+                assert Lsid.isLsid(s);
+                // UNDONE: This always generates the ${AutoFileLSID} when using FOLDER_RELATIVE!! why do we do that!?!
+                String lsid = relativizedLSIDs.relativize(s);
+                return lsid;
+            }
+
+            return o;
         }
     }
 

--- a/experiment/src/org/labkey/experiment/xar/FolderXarImporterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarImporterFactory.java
@@ -146,6 +146,8 @@ public class FolderXarImporterFactory extends AbstractFolderImportFactory
                 }
 
                 FolderExportXarReader reader = new FolderExportXarReader(xarSource, job);
+                // TODO pass this in through the import context
+                reader.setStrictValidateExistingSampleType(false);
                 reader.parseAndLoad(false);
             }
 

--- a/experiment/src/org/labkey/experiment/xar/FolderXarImporterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarImporterFactory.java
@@ -146,8 +146,11 @@ public class FolderXarImporterFactory extends AbstractFolderImportFactory
                 }
 
                 FolderExportXarReader reader = new FolderExportXarReader(xarSource, job);
-                // TODO pass this in through the import context
-                reader.setStrictValidateExistingSampleType(false);
+                XarImportContext xarCtx = ctx.getContext(XarImportContext.class);
+                if (xarCtx != null)
+                {
+                    reader.setStrictValidateExistingSampleType(xarCtx.isStrictValidateExistingSampleType());
+                }
                 reader.parseAndLoad(false);
             }
 

--- a/experiment/src/org/labkey/experiment/xar/XarImportContext.java
+++ b/experiment/src/org/labkey/experiment/xar/XarImportContext.java
@@ -1,0 +1,18 @@
+package org.labkey.experiment.xar;
+
+import org.labkey.api.admin.FolderImportContext;
+
+public class XarImportContext extends FolderImportContext
+{
+    private boolean _strictValidateExistingSampleType = true;
+
+    public boolean isStrictValidateExistingSampleType()
+    {
+        return _strictValidateExistingSampleType;
+    }
+
+    public void setStrictValidateExistingSampleType(boolean strictValidateExistingSampleType)
+    {
+        _strictValidateExistingSampleType = strictValidateExistingSampleType;
+    }
+}


### PR DESCRIPTION
#### Rationale
In order to address some recent issues with sample type and data class export/import we have been reconsidering the roles that the XAR and query update service play. In the current design, rows that represent derivation or lineage are captured in the XAR format and all other rows are captured as TSV data. In this PR we pivot so that all rows are exported/imported as TSV, this will happen first and allows any special handling that the QUS may provide on all rows. The XAR handlers will then just be responsible for wiring up and creating derivation runs but will not be tasked with creating materials or datas.

Related issues:
- 42359: SampleTypeFolderExportImportTest.testExportImportDerivedSamples on sqlserver
- 42356: Folder import fails when there is an existing sample type of the same name
- 42161: Unable to import Data Classes as inputs/outputs for Sample Types

#### Changes
- Allow for creation of 2 XAR files, one for the sample type and data class definitions and another to represent any derivation protocol runs
- Export/import all rows via TSV
- Make `XarReader` a bit smarter about resolving existing sample types or data classes 
- Add XarImportContext to share XAR related settings between folder importers
