### PR TITLE
42330: Lookup when validation is turned on is not resolving correctly

### DIFF
--- a/experiment/src/org/labkey/experiment/api/property/LookupValidator.java
+++ b/experiment/src/org/labkey/experiment/api/property/LookupValidator.java
@@ -20,6 +20,7 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ColumnRenderProperties;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.ForeignKey;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.TableInfo;
@@ -228,6 +229,9 @@ public class LookupValidator extends DefaultPropertyValidator implements Validat
     {
         //noinspection ConstantConditions
         assert value != null : "Shouldn't be validating a null value";
+
+        if (value != null)
+            value = ConvertHelper.convert(value, crpField.getJavaObjectClass());
 
         if (crpField instanceof PropertyDescriptor)
         {


### PR DESCRIPTION
#### Rationale
[42330: Lookup when validation is turned on is not resolving correctly
](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42330)

Lookup validation can fail if the target table has an integer key field. Ontology based columns store values to the database as either string, float, or date in exp.objectProperty. For integer property types when validating against the lookup there will be a comparison between float and integer values unless a conversion occurs.
