### PR TITLE
Conditionalize Admin Console link in nav trail based on container

### DIFF
--- a/api/src/org/labkey/api/Constants.java
+++ b/api/src/org/labkey/api/Constants.java
@@ -49,7 +49,7 @@ public class Constants
      */
     public static String getDocumentationVersion()
     {
-        return "20.11";
+        return "21.3";
     }
 
     /**

--- a/api/src/org/labkey/api/admin/AdminUrls.java
+++ b/api/src/org/labkey/api/admin/AdminUrls.java
@@ -24,6 +24,7 @@ import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.emailTemplate.EmailTemplate;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
+import org.springframework.web.servlet.mvc.Controller;
 
 /**
  * User: jgarms
@@ -65,11 +66,13 @@ public interface AdminUrls extends UrlProvider
     ActionURL getSessionLoggingURL();
     ActionURL getTrackedAllocationsViewerURL();
 
-    void addAdminNavTrail(NavTree root, String childTitle, @Nullable ActionURL childURL);
-
     /**
-     * For actions that use the root container when accessed via the Admin Console (and therefore want a nav trail
-     * that includes it) but are also used in the context of a specific container
+     * Displays an "Admin Console" link at the start of the nav trail if invoked in the root container. Otherwise,
+     * childTitle is the start and links to the action, appropriate for actions that are invoked in the context of
+     * both the root and a specific container.
      */
-    void addAdminNavTrailIfRoot(NavTree root, String childTitle, @Nullable ActionURL childURL, @NotNull Container container);
+    void addAdminNavTrail(NavTree root, String childTitle, @NotNull Class<? extends Controller> action, @NotNull Container container);
+
+    @Deprecated // Use the other variant
+    void addAdminNavTrail(NavTree root, String childTitle, @Nullable ActionURL childURL);
 }

--- a/api/src/org/labkey/api/admin/AdminUrls.java
+++ b/api/src/org/labkey/api/admin/AdminUrls.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.admin;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.UrlProvider;
 import org.labkey.api.data.Container;
@@ -65,4 +66,10 @@ public interface AdminUrls extends UrlProvider
     ActionURL getTrackedAllocationsViewerURL();
 
     void addAdminNavTrail(NavTree root, String childTitle, @Nullable ActionURL childURL);
+
+    /**
+     * For actions that use the root container when accessed via the Admin Console (and therefore want a nav trail
+     * that includes it) but are also used in the context of a specific container
+     */
+    void addAdminNavTrailIfRoot(NavTree root, String childTitle, @Nullable ActionURL childURL, @NotNull Container container);
 }

--- a/api/src/org/labkey/api/view/FolderManagement.java
+++ b/api/src/org/labkey/api/view/FolderManagement.java
@@ -54,7 +54,7 @@ public class FolderManagement
                 if (c.isRoot())
                 {
                     TabProvider provider = TYPE_ACTION_TAB_PROVIDER.get(this).get(action.getClass());
-                    PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, provider.getText(), null);
+                    PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, provider.getText(), action.getClass(), c);
                 }
                 else
                 {
@@ -94,7 +94,7 @@ public class FolderManagement
             void addNavTrail(BaseViewAction action, NavTree root, Container c, User user)
             {
                 action.setHelpTopic(new HelpTopic("customizeLook"));
-                PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "Look and Feel Settings", null);
+                PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "Look and Feel Settings", action.getClass(), c);
             }
 
             @Override

--- a/audit/src/org/labkey/audit/AuditController.java
+++ b/audit/src/org/labkey/audit/AuditController.java
@@ -144,12 +144,7 @@ public class AuditController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             setHelpTopic(new HelpTopic("audits"));
-            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Audit Log", getURL());
-        }
-
-        public ActionURL getURL()
-        {
-            return new ActionURL(ShowAuditLogAction.class, ContainerManager.getRoot());
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Audit Log", getClass(), getContainer());
         }
     }
 

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -2183,7 +2183,7 @@ public class CoreController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             getPageConfig().setHelpTopic(new HelpTopic("configureScripting"));
-            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Views and Scripting Configuration", new ActionURL(this.getClass(), getContainer()));
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Views and Scripting Configuration", getClass(), getContainer());
         }
     }
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -621,6 +621,12 @@ public class AdminController extends SpringActionController
         }
 
         @Override
+        public void addAdminNavTrailIfRoot(NavTree root, String childTitle, @Nullable ActionURL childURL, @NotNull Container container)
+        {
+            AdminController.addAdminNavTrail(root, childTitle, childURL, container);
+        }
+
+        @Override
         public ActionURL getFileRootsURL(Container c)
         {
             return new ActionURL(FileRootsAction.class, c);

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -615,15 +615,16 @@ public class AdminController extends SpringActionController
         }
 
         @Override
-        public void addAdminNavTrail(NavTree root, String childTitle, @Nullable ActionURL childURL)
+        public void addAdminNavTrail(NavTree root, String childTitle, @NotNull Class<? extends Controller> action, @NotNull Container container)
         {
-            AdminController.addAdminNavTrail(root, childTitle, childURL, ContainerManager.getRoot());
+            AdminController.addAdminNavTrail(root, childTitle, new ActionURL(action, container), container);
         }
 
         @Override
-        public void addAdminNavTrailIfRoot(NavTree root, String childTitle, @Nullable ActionURL childURL, @NotNull Container container)
+        @Deprecated
+        public void addAdminNavTrail(NavTree root, String childTitle, @Nullable ActionURL childURL)
         {
-            AdminController.addAdminNavTrail(root, childTitle, childURL, container);
+            AdminController.addAdminNavTrail(root, childTitle, childURL, ContainerManager.getRoot());
         }
 
         @Override

--- a/core/src/org/labkey/core/admin/FileListAction.java
+++ b/core/src/org/labkey/core/admin/FileListAction.java
@@ -45,7 +45,7 @@ public class FileListAction extends SimpleViewAction
     @Override
     public void addNavTrail(NavTree root)
     {
-        PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "File List", null);
+        PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "File List", getClass(), getContainer());
     }
 }
 

--- a/core/src/org/labkey/core/admin/FilesSiteSettingsAction.java
+++ b/core/src/org/labkey/core/admin/FilesSiteSettingsAction.java
@@ -90,7 +90,7 @@ public class FilesSiteSettingsAction extends AbstractFileSiteSettingsAction<File
     @Override
     public void addNavTrail(NavTree root)
     {
-        PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "Configure File System Access", null);
+        PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "Configure File System Access", getClass(), getContainer());
     }
 
     public static class TestCase extends AbstractActionPermissionTest

--- a/core/src/org/labkey/core/admin/logger/LoggerController.java
+++ b/core/src/org/labkey/core/admin/logger/LoggerController.java
@@ -316,7 +316,7 @@ public class LoggerController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Manage Log4J Loggers", new ActionURL(getClass(), getContainer()));
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Manage Log4J Loggers", getClass(), getContainer());
         }
     }
 

--- a/core/src/org/labkey/core/admin/miniprofiler/MiniProfilerController.java
+++ b/core/src/org/labkey/core/admin/miniprofiler/MiniProfilerController.java
@@ -38,7 +38,6 @@ import org.labkey.api.security.RequiresSiteAdmin;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.URLHelper;
-import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.UnauthorizedException;
@@ -115,7 +114,7 @@ public class MiniProfilerController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Profiling Settings", new ActionURL(getClass(), getContainer()));
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Profiling Settings", getClass(), getContainer());
         }
     }
 

--- a/core/src/org/labkey/core/admin/sql/SqlScriptController.java
+++ b/core/src/org/labkey/core/admin/sql/SqlScriptController.java
@@ -316,12 +316,7 @@ public class SqlScriptController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            urlProvider(AdminUrls.class).addAdminNavTrail(root, "SQL Scripts", getURL());
-        }
-
-        public ActionURL getURL()
-        {
-            return new ActionURL(SqlScriptController.ScriptsAction.class, ContainerManager.getRoot());
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "SQL Scripts", getClass(), ContainerManager.getRoot());
         }
     }
 

--- a/core/src/org/labkey/core/analytics/AnalyticsController.java
+++ b/core/src/org/labkey/core/analytics/AnalyticsController.java
@@ -76,7 +76,7 @@ public class AnalyticsController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Analytics", null);
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Analytics", getClass(), getContainer());
         }
 
         @Override

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -2400,7 +2400,7 @@ public class LoginController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             setHelpTopic(new HelpTopic("authenticationModule"));
-            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Authentication Configuration", new ActionURL(getClass(), getContainer()));
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Authentication Configuration", getClass(), getContainer());
         }
     }
 

--- a/pipeline/src/org/labkey/pipeline/PipelineController.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineController.java
@@ -387,7 +387,7 @@ public class PipelineController extends SpringActionController
         {
             if (getContainer().isRoot())
             {
-                urlProvider(AdminUrls.class).addAdminNavTrail(root, "Data Processing Pipeline Setup", new ActionURL(getClass(), getContainer()));
+                urlProvider(AdminUrls.class).addAdminNavTrail(root, "Data Processing Pipeline Setup", getClass(), getContainer());
             }
             else
             {

--- a/pipeline/src/org/labkey/pipeline/analysis/AnalysisController.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/AnalysisController.java
@@ -608,7 +608,7 @@ public class AnalysisController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Internal List Pipelines", new ActionURL(getClass(), getContainer()));
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Internal List Pipelines", getClass(), getContainer());
         }
     }
 

--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -255,7 +255,15 @@ public class StatusController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Data Pipeline", new ActionURL(getClass(), getContainer()));
+            // This action is used both for the site-wide listing via the Admin Console and a container's list
+            if (getContainer().isRoot())
+            {
+                urlProvider(AdminUrls.class).addAdminNavTrail(root, "Data Pipeline", new ActionURL(getClass(), getContainer()));
+            }
+            else
+            {
+                root.addChild("Data Pipeline");
+            }
         }
     }
 

--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -255,15 +255,7 @@ public class StatusController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            // This action is used both for the site-wide listing via the Admin Console and a container's list
-            if (getContainer().isRoot())
-            {
-                urlProvider(AdminUrls.class).addAdminNavTrail(root, "Data Pipeline", new ActionURL(getClass(), getContainer()));
-            }
-            else
-            {
-                root.addChild("Data Pipeline");
-            }
+            urlProvider(AdminUrls.class).addAdminNavTrailIfRoot(root, "Data Pipeline", new ActionURL(getClass(), getContainer()), getContainer());
         }
     }
 

--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -255,7 +255,7 @@ public class StatusController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            urlProvider(AdminUrls.class).addAdminNavTrailIfRoot(root, "Data Pipeline", new ActionURL(getClass(), getContainer()), getContainer());
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Data Pipeline", getClass(), getContainer());
         }
     }
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -700,7 +700,7 @@ public class QueryController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            requireNonNull(urlProvider(AdminUrls.class)).addAdminNavTrail(root, "Data Source Administration ", null);
+            requireNonNull(urlProvider(AdminUrls.class)).addAdminNavTrail(root, "Data Source Administration", getClass(), getContainer());
         }
     }
 

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -381,7 +381,7 @@ public class SearchController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             setHelpTopic(new HelpTopic("searchAdmin"));
-            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Full-Text Search Configuration", new ActionURL(AdminAction.class, ContainerManager.getRoot()));
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Full-Text Search Configuration", getClass(), getContainer());
         }
     }
 

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -7559,7 +7559,7 @@ public class StudyController extends BaseStudyController
         @Override
         public void addNavTrail(NavTree root)
         {
-            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Configure Master Patient Index", new ActionURL(getClass(), getContainer()));
+            urlProvider(AdminUrls.class).addAdminNavTrail(root, "Configure Master Patient Index", getClass(), getContainer());
         }
     }
 


### PR DESCRIPTION
#### Rationale
The pipeline status action (grid view) is used both for individual containers and site-wide, as linked from the Admin Console

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1940

#### Changes
* Don't show Admin Console link when the list is viewed for a single container