### PR TITLE
Fix confusion about updated row and existing row in audit logs and retrieve parents for audit logs properly

### DIFF
--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -197,10 +197,11 @@ public interface AuditHandler
 
         for (Map.Entry<String, Object> entry : row.entrySet())
         {
-            boolean isExtraAuditField = extraFieldsToInclude != null && extraFieldsToInclude.contains(entry.getKey());
-            if (!excludedFromDetailDiff.contains(entry.getKey()) && existingRow.containsKey(entry.getKey()))
+            String lcKey = entry.getKey().toLowerCase();
+            boolean isExtraAuditField = extraFieldsToInclude != null && extraFieldsToInclude.contains(lcKey);
+            if (!excludedFromDetailDiff.contains(lcKey) && existingRow.containsKey(lcKey))
             {
-                Object oldValue = existingRow.get(entry.getKey());
+                Object oldValue = existingRow.get(lcKey);
                 Object newValue = entry.getValue();
                 // compare dates using string values to allow for both Date and Timestamp types
                 if (newValue instanceof Date && oldValue != null)
@@ -210,8 +211,8 @@ public interface AuditHandler
                     String oldString = oldValue instanceof Date ? formatter.format((Date) oldValue) : oldValue.toString();
                     if (!newString.equals(oldString) || isExtraAuditField)
                     {
-                        originalRow.put(entry.getKey(), oldValue);
-                        modifiedRow.put(entry.getKey(), newValue);
+                        originalRow.put(lcKey, oldValue);
+                        modifiedRow.put(lcKey, newValue);
                     }
                 }
                 else if (newValue instanceof Number && oldValue != null)
@@ -226,29 +227,29 @@ public interface AuditHandler
                         // If values differ than include in difference maps
                         if (!newVal.equals(oldVal) || isExtraAuditField)
                         {
-                            originalRow.put(entry.getKey(), oldValue);
-                            modifiedRow.put(entry.getKey(), newValue);
+                            originalRow.put(lcKey, oldValue);
+                            modifiedRow.put(lcKey, newValue);
                         }
                     }
                     catch (ParseException e)
                     {
                         // If a parsing error occurred e.g. one value was NaN, then include values in difference maps
-                        originalRow.put(entry.getKey(), oldValue);
-                        modifiedRow.put(entry.getKey(), newValue);
+                        originalRow.put(lcKey, oldValue);
+                        modifiedRow.put(lcKey, newValue);
                     }
                 }
                 else if (!Objects.equals(oldValue, newValue) || isExtraAuditField)
                 {
-                    originalRow.put(entry.getKey(), oldValue);
-                    modifiedRow.put(entry.getKey(), newValue);
+                    originalRow.put(lcKey, oldValue);
+                    modifiedRow.put(lcKey, newValue);
                 }
             }
             else if (isExtraAuditField)
             {
                 // persist extra fields desired for audit details even if no change is made, so that extra field values is available after record is deleted
                 // for example, a display label/id is desired in audit log for the record updated.
-                originalRow.put(entry.getKey(), entry.getValue());
-                modifiedRow.put(entry.getKey(), entry.getValue());
+                originalRow.put(lcKey, entry.getValue());
+                modifiedRow.put(lcKey, entry.getValue());
             }
         }
         return new Pair<>(originalRow, modifiedRow);

--- a/api/src/org/labkey/api/exp/api/ExpLineage.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineage.java
@@ -283,7 +283,7 @@ public class ExpLineage
 
         assert parentClazz == ExpMaterial.class || parentClazz == ExpData.class;
 
-        // walk from start through edges looking for all sample children, stopping at first datas found
+        // walk from start through edges looking for all sample children, stopping at first ones found
         Set<T> parents = new HashSet<>();
         Queue<Identifiable> stack = new LinkedList<>();
         Set<Identifiable> seen = new HashSet<>();

--- a/api/src/org/labkey/api/exp/api/ExpLineage.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineage.java
@@ -308,7 +308,8 @@ public class ExpLineage
                         seen.add(parent);
                     }
                 }
-                else if (parent instanceof ExpData || parent instanceof ExpMaterial)
+                else if ((parentClazz == ExpMaterial.class && parent instanceof ExpMaterial) ||
+                         (parentClazz == ExpData.class && parent instanceof ExpData))
                 {
                     parents.add((T) parent);
                 }

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -388,6 +388,18 @@ public interface ExperimentService extends ExperimentRunTypeSource
     Set<ExpMaterial> getRelatedChildSamples(Container c, User user, ExpData start);
 
     /**
+     * Find the ExpData objects, if any, that are parents of the <code>start</code> ExpMaterial.
+     */
+    @NotNull
+    Set<ExpData> getParentDatas(Container c, User user, ExpMaterial start);
+
+    /**
+     * Find the ExpMaterial objects, if any, that are parents of the <code>start</code> ExpMaterial.
+     */
+    @NotNull
+    Set<ExpMaterial> getParentMaterials(Container c, User user, ExpMaterial start);
+
+    /**
      * Find all parent ExpData that are parents of the <code>start</code> ExpMaterial,
      * stopping at the first parent generation (no grandparents.)
      */

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -633,7 +633,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         if (errors.hasErrors())
             throw errors;
 
-        addAuditEvent(user, container, QueryService.AuditAction.UPDATE, configParameters, oldRows, result);
+        addAuditEvent(user, container, QueryService.AuditAction.UPDATE, configParameters, result, oldRows);
 
         return result;
     }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -2212,6 +2212,30 @@ public class ExperimentServiceImpl implements ExperimentService
 
     @Override
     @NotNull
+    public Set<ExpData> getParentDatas(Container c, User user, ExpMaterial start)
+    {
+        ExpLineageOptions options = new ExpLineageOptions();
+        options.setChildren(false);
+        options.setDepth(2); // 2 because of the ExpRun that will always be in between
+
+        ExpLineage lineage = getLineage(c, user, start, options);
+        return lineage.findNearestParentDatas(start);
+    }
+
+    @Override
+    @NotNull
+    public Set<ExpMaterial> getParentMaterials(Container c, User user, ExpMaterial start)
+    {
+        ExpLineageOptions options = new ExpLineageOptions();
+        options.setChildren(false);
+        options.setDepth(2); // 2 because of the ExpRun that will always be in between.
+
+        ExpLineage lineage = getLineage(c, user, start, options);
+        return lineage.findNearestParentMaterials(start);
+    }
+
+    @Override
+    @NotNull
     public Set<ExpData> getNearestParentDatas(Container c, User user, ExpMaterial start)
     {
         ExpLineageOptions options = new ExpLineageOptions();

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -907,10 +907,10 @@ public class SampleTypeServiceImpl extends AuditHandler.AbstractAuditHandler imp
     }
 
     @Override
-    public DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> updatedRow)
+    public DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> existingRow)
     {
         // not doing anything with userComment at the moment
-        return createAuditRecord(c, getCommentDetailed(action, !updatedRow.isEmpty()), row, updatedRow, action);
+        return createAuditRecord(c, getCommentDetailed(action, !existingRow.isEmpty()), row, action);
     }
 
     @Override
@@ -936,10 +936,10 @@ public class SampleTypeServiceImpl extends AuditHandler.AbstractAuditHandler imp
 
     private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable Map<String, Object> row)
     {
-        return createAuditRecord(c, comment, row, null, null);
+        return createAuditRecord(c, comment, row, null);
     }
 
-    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable Map<String, Object> row, Map<String, Object> updatedRow, @Nullable QueryService.AuditAction action)
+    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable Map<String, Object> row, @Nullable QueryService.AuditAction action)
     {
         SampleTimelineAuditEvent event = new SampleTimelineAuditEvent(c.getId(), comment);
         var tx = getExpSchema().getScope().getCurrentTransaction();
@@ -949,14 +949,11 @@ public class SampleTypeServiceImpl extends AuditHandler.AbstractAuditHandler imp
         if (c.getProject() != null)
             event.setProjectId(c.getProject().getId());
 
-        if (updatedRow != null)
-        {
-            Optional<String> parentFields = updatedRow.keySet().stream().filter((fieldKey) -> fieldKey.startsWith(ExpData.DATA_INPUT_PARENT) || fieldKey.startsWith(ExpMaterial.MATERIAL_INPUT_PARENT)).findAny();
-            event.setLineageUpdate(parentFields.isPresent());
-        }
-
         if (row != null)
         {
+            Optional<String> parentFields = row.keySet().stream().filter((fieldKey) -> fieldKey.startsWith(ExpData.DATA_INPUT_PARENT) || fieldKey.startsWith(ExpMaterial.MATERIAL_INPUT_PARENT)).findAny();
+            event.setLineageUpdate(parentFields.isPresent());
+
             String sampleTypeLsid = null;
             if (row.containsKey(CPAS_TYPE))
                 sampleTypeLsid =  String.valueOf(row.get(CPAS_TYPE));

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -398,10 +398,10 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
         ExperimentService experimentService = ExperimentService.get();
         ExpMaterial seed = rowId != null ? experimentService.getExpMaterial(rowId) : experimentService.getExpMaterial(lsid);
-        Set<ExpMaterial> parentSamples = experimentService.getNearestParentMaterials(container, user, seed);
+        Set<ExpMaterial> parentSamples = experimentService.getParentMaterials(container, user, seed);
         if (!parentSamples.isEmpty())
             addParentFields(sampleRow, parentSamples, ExpMaterial.MATERIAL_INPUT_PARENT + "/", user);
-        Set<ExpData> parentDatas = experimentService.getNearestParentDatas(container, user, seed);
+        Set<ExpData> parentDatas = experimentService.getParentDatas(container, user, seed);
         if (!parentDatas.isEmpty())
             addParentFields(sampleRow, parentDatas, ExpData.DATA_INPUT_PARENT + "/", user);
 


### PR DESCRIPTION
#### Rationale
There are three fixes here that are not entirely related but fixing one revealed the other two:
1) When retrieving the nearest parents of a particular type for a sample we were not accurately verifying the type of the parent so sample parents could show up as dataClass parents, and vice versa.
2) For our audit log purposes, we don't actually want the nearest parents (actually ancestors) of a particular type.  We want the parents and if there are none, we want to show none.  Getting the "nearest" ones can bring in, say, sources that are parents of a parent sample, and we don't want those.
3) There's a confusion caused by the use of `updatedRow` to mean `existingRow` in some cases and `originalRow` in other cases. Sometimes the parameters are in the wrong order as a result.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Check for types more precisely within findNearestParent method
* Add methods for getting parents specifically, not just the nearest ancestor
* Rename parameters and swap some orderings related to creating audit logs.
