### PR TITLE
Issue 42373: Fix NPE when trying to retrieve folderType from the folder XML

### DIFF
--- a/api/src/org/labkey/api/admin/FolderImportContext.java
+++ b/api/src/org/labkey/api/admin/FolderImportContext.java
@@ -152,7 +152,10 @@ public class FolderImportContext extends AbstractFolderContext
     @Override
     public AuditBehaviorType getAuditBehaviorType() throws Exception
     {
-        FolderType folderType = FolderTypeManager.get().getFolderType(this.getXml().getFolderType().getName());
+        var xmlFolderType = this.getXml().getFolderType();
+        FolderType folderType = null;
+        if (xmlFolderType != null)
+            folderType = FolderTypeManager.get().getFolderType(xmlFolderType.getName());
         return folderType == null ? null : folderType.getImportAuditBehavior();
     }
 }


### PR DESCRIPTION
#### Rationale
Not all folder imports specify a folder import apparently, so we need to protect against that.

#### Related Pull Requests
#1931

#### Changes
* Add check for Null folder type.
