### PR TITLE
Switch most auto-complete URLs from String to ActionURL

### DIFF
--- a/announcements/src/org/labkey/announcements/announcementThread.jsp
+++ b/announcements/src/org/labkey/announcements/announcementThread.jsp
@@ -74,7 +74,7 @@ if (announcementModel.isSpam())
 }
 else if (null == announcementModel.getApproved() && c.hasPermission(user, AdminPermission.class))
 {
-    %><p></p><img src="<%=getWebappURL("_images/exclaim.gif")%>">&nbsp;This <%=h(settings.getConversationName().toLowerCase())%> requires moderator review.<%
+    %><p></p><img src="<%=getWebappURL("_images/exclaim.gif")%>">&nbsp;This <%=h(settings.getConversationName().toLowerCase())%> requires <%=link("moderator review", new ActionURL(AnnouncementsController.ModeratorReviewAction.class, c)).clearClasses()%>.<%
 }
 %>
 

--- a/api/src/org/labkey/api/exp/SamplePropertyHelper.java
+++ b/api/src/org/labkey/api/exp/SamplePropertyHelper.java
@@ -35,6 +35,7 @@ import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.study.SpecimenService;
+import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.InsertView;
 import org.labkey.api.view.ViewServlet;
 
@@ -128,7 +129,7 @@ public abstract class SamplePropertyHelper<ObjectType>
             for (String name : getSampleNames())
             {
                 String inputName = UploadWizardAction.getInputName(sampleProperty, name);
-                String autoCompletePrefix = null;
+                ActionURL autoCompletePrefix = null;
                 if (defaultValueContext != null)
                 {
                     // get the map of default values that corresponds to our current sample:
@@ -147,11 +148,11 @@ public abstract class SamplePropertyHelper<ObjectType>
                     if (targetStudy != null && targetStudy.hasPermission(defaultValueContext.getUser(), ReadPermission.class))
                     {
                         if (sampleProperty.getName().equals(AbstractAssayProvider.PARTICIPANTID_PROPERTY_NAME))
-                            autoCompletePrefix = SpecimenService.get().getCompletionURLBase(targetStudy, SpecimenService.CompletionType.ParticipantId);
+                            autoCompletePrefix = SpecimenService.get().getCompletionURL(targetStudy, SpecimenService.CompletionType.ParticipantId);
                         else if (sampleProperty.getName().equals(AbstractAssayProvider.SPECIMENID_PROPERTY_NAME))
-                            autoCompletePrefix = SpecimenService.get().getCompletionURLBase(targetStudy, SpecimenService.CompletionType.SpecimenGlobalUniqueId);
+                            autoCompletePrefix = SpecimenService.get().getCompletionURL(targetStudy, SpecimenService.CompletionType.SpecimenGlobalUniqueId);
                         else if (sampleProperty.getName().equals(AbstractAssayProvider.VISITID_PROPERTY_NAME))
-                            autoCompletePrefix = SpecimenService.get().getCompletionURLBase(targetStudy, SpecimenService.CompletionType.VisitId);
+                            autoCompletePrefix = SpecimenService.get().getCompletionURL(targetStudy, SpecimenService.CompletionType.VisitId);
                     }
                 }
                 var col = sampleProperty.getPropertyDescriptor().createColumnInfo(OntologyManager.getTinfoObject(), "ObjectURI", user, view.getViewContext().getContainer());
@@ -202,9 +203,9 @@ public abstract class SamplePropertyHelper<ObjectType>
 
     private class SpecimenInputColumn extends DataColumn
     {
-        private String _autoCompletePrefix;
+        private final ActionURL _autoCompletePrefix;
 
-        public SpecimenInputColumn(ColumnInfo col, String autoCompletePrefix)
+        public SpecimenInputColumn(ColumnInfo col, ActionURL autoCompletePrefix)
         {
             super(col);
             _autoCompletePrefix = autoCompletePrefix;
@@ -226,7 +227,7 @@ public abstract class SamplePropertyHelper<ObjectType>
         @Override
         protected String getAutoCompleteURLPrefix()
         {
-            return _autoCompletePrefix;
+            return _autoCompletePrefix.getLocalURIString();
         }
     }
 }

--- a/api/src/org/labkey/api/jsp/taglib/AutoCompleteTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/AutoCompleteTag.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.jsp.taglib;
 
+import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.UniqueID;
 import org.labkey.api.view.ActionURL;
@@ -31,7 +32,7 @@ public abstract class AutoCompleteTag extends SimpleTagBase
 {
     private String _name;
     private String _id;
-    private String _url;
+    private ActionURL _url;
     private String _value;
 
     public String getName()
@@ -54,19 +55,14 @@ public abstract class AutoCompleteTag extends SimpleTagBase
         _id = id;
     }
 
-    public String getUrl()
+    public ActionURL getUrl()
     {
         return _url;
     }
 
-    public void setUrl(String url)
-    {
-        _url = url;
-    }
-
     public void setUrl(ActionURL url)
     {
-        _url = url.getLocalURIString();
+        _url = url;
     }
 
     public String getValue()
@@ -85,18 +81,21 @@ public abstract class AutoCompleteTag extends SimpleTagBase
         // TODO: SafeToRenderBuilder
 
         String renderId = "auto-complete-div-" + UniqueID.getRequestScopedUID(HttpView.currentRequest());
-        StringBuilder sb = new StringBuilder();
-
-        sb.append("<script type=\"text/javascript\">");
-        sb.append("LABKEY.requiresScript('completion',function(){\n");
-        sb.append("Ext4.onReady(function(){\n" +
-            "        Ext4.create('LABKEY.element.AutoCompletionField', {\n" +
-            "            renderTo: " + PageFlowUtil.jsString(renderId) + ",\n" +
-            "            completionUrl: " + PageFlowUtil.jsString(getUrl()) + ",\n");
-        sb.append(getTagConfig());
-        sb.append("})})});\n");
-        sb.append("</script>\n");
-        sb.append("<div id=\"").append(renderId).append("\"></div>");
+        StringBuilder sb = new StringBuilder()
+            .append("<script type=\"text/javascript\">\n")
+            .append("    LABKEY.requiresScript('completion',function(){\n")
+            .append("        Ext4.onReady(function(){\n")
+            .append("            Ext4.create('LABKEY.element.AutoCompletionField', {\n")
+            .append("                renderTo: ").append(PageFlowUtil.jsString(renderId)).append(",\n")
+            .append("                completionUrl: ").append(PageFlowUtil.jsString(getUrl().getLocalURIString())).append(",\n")
+            .append(getTagConfig(StringUtils.repeat(' ', 16)))
+            .append("            })\n")
+            .append("        })\n")
+            .append("    });\n")
+            .append("</script>\n")
+            .append("<div id=\"")
+            .append(renderId)
+            .append("\"></div>");
 
         Writer out = getWriter();
 
@@ -109,12 +108,12 @@ public abstract class AutoCompleteTag extends SimpleTagBase
         return getOut();
     }
 
-    protected abstract String getTagConfig();
+    protected abstract String getTagConfig(String padding);
 
-    protected void addOptionalAttrs(StringBuilder sb)
+    protected void addOptionalAttrs(StringBuilder sb, String padding)
     {
         // optional attribute
         if (getId() != null)
-            sb.append("                id : ").append(PageFlowUtil.jsString(getId())).append(",\n");
+            sb.append(padding).append("    id           : ").append(PageFlowUtil.jsString(getId())).append(",\n");
     }
 }

--- a/api/src/org/labkey/api/jsp/taglib/AutoCompleteTextTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/AutoCompleteTextTag.java
@@ -49,29 +49,30 @@ public class AutoCompleteTextTag extends AutoCompleteTag
     // TODO: HtmlString
 
     @Override
-    protected String getTagConfig()
+    protected String getTagConfig(String padding)
     {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder()
+            .append(padding).append("tagConfig: {\n")
+            .append(padding).append("    tag          : 'input',\n")
+            .append(padding).append("    type         : 'text',\n");
 
-        sb.append("      tagConfig   : {\n" +
-            "                tag     : 'input',\n" +
-            "                type    : 'text',\n");
-        addOptionalAttrs(sb);
-        sb.append(
-            "                name    : " + PageFlowUtil.jsString(getName()) + ",\n" +
-            "                size    : " + getSize() + ",\n" +
-            "                autocomplete : 'off'\n" +
-            "            }\n");
+        addOptionalAttrs(sb, padding);
+
+        sb
+            .append(padding).append("    name         : ").append(PageFlowUtil.jsString(getName())).append(",\n")
+            .append(padding).append("    size         : ").append(getSize()).append(",\n")
+            .append(padding).append("    autocomplete : 'off'\n")
+            .append(padding).append("}\n");
 
         return sb.toString();
     }
 
     @Override
-    protected void addOptionalAttrs(StringBuilder sb)
+    protected void addOptionalAttrs(StringBuilder sb, String padding)
     {
-        super.addOptionalAttrs(sb);
+        super.addOptionalAttrs(sb, padding);
 
         if (getValue() != null)
-            sb.append("                value : ").append(PageFlowUtil.jsString(getValue())).append(",\n");
+            sb.append(padding).append("    value        : ").append(PageFlowUtil.jsString(getValue())).append(",\n");
     }
 }

--- a/api/src/org/labkey/api/jsp/taglib/AutoCompleteTextareaTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/AutoCompleteTextareaTag.java
@@ -60,33 +60,34 @@ public class AutoCompleteTextareaTag extends AutoCompleteTag
     // TODO: HtmlString
 
     @Override
-    protected String getTagConfig()
+    protected String getTagConfig(String padding)
     {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder()
+            .append(padding).append("tagConfig: {\n")
+            .append(padding).append("    tag          : 'textarea',\n");
 
-        sb.append(
-            "            tagConfig   : {\n" +
-            "                tag     : 'textarea',\n");
-        addOptionalAttrs(sb);
-        sb.append(
-            "                name    : " + PageFlowUtil.jsString(getName()) + ",\n" +
-            "                rows    : " + getRows() + ",\n" +
-            "                cols    : " + getCols() + ",\n" +
-            "                autocomplete : 'off'\n" +
-            "            }\n");
+        addOptionalAttrs(sb, padding);
+
+        sb
+            .append(padding).append("    name         : ").append(PageFlowUtil.jsString(getName())).append(",\n")
+            .append(padding).append("    rows         : ").append(getRows()).append(",\n")
+            .append(padding).append("    cols         : ").append(getCols()).append(",\n")
+            .append(padding).append("    autocomplete : 'off'\n")
+            .append(padding).append("}\n");
 
         return sb.toString();
     }
 
     @Override
-    protected void addOptionalAttrs(StringBuilder sb)
+    protected void addOptionalAttrs(StringBuilder sb, String padding)
     {
-        super.addOptionalAttrs(sb);
+        super.addOptionalAttrs(sb, padding);
 
-        sb.append("                tabIndex    : " + getTabindex() + ",\n");
+        sb.append(padding).append("    tabIndex     : ").append(getTabindex()).append(",\n");
 
         if (getValue() != null)
-            sb.append("                html : ").append(PageFlowUtil.jsString(getValue())).append(",\n");
-        sb.append("                class: \"form-control\", \n");
+            sb.append(padding).append("    html         : ").append(PageFlowUtil.jsString(getValue())).append(",\n");
+
+        sb.append(padding).append("    class        : \"form-control\", \n");
     }
 }

--- a/api/src/org/labkey/api/security/SecurityUrls.java
+++ b/api/src/org/labkey/api/security/SecurityUrls.java
@@ -41,6 +41,6 @@ public interface SecurityUrls extends UrlProvider
     ActionURL getAddUsersURL(Container container);
     ActionURL getFolderAccessURL(Container container);
     ActionURL getExternalToolsViewURL(User user, URLHelper returnURL); // Always root
-    String getCompleteUserURLPrefix(Container container);
-    String getCompleteUserReadURLPrefix(Container container);
+    ActionURL getCompleteUserURL(Container container);
+    ActionURL getCompleteUserReadURL(Container container);
 }

--- a/api/src/org/labkey/api/study/SpecimenService.java
+++ b/api/src/org/labkey/api/study/SpecimenService.java
@@ -66,7 +66,7 @@ public interface SpecimenService
 
     Set<ParticipantVisit> getSampleInfo(Container studyContainer, User user, String participantId, Double visit) throws SQLException;
 
-    String getCompletionURLBase(Container studyContainer, CompletionType type);
+    ActionURL getCompletionURL(Container studyContainer, CompletionType type);
 
     Set<Pair<String, Date>> getSampleInfo(Container studyContainer, User user, boolean truncateTime) throws SQLException;
 

--- a/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
+++ b/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
@@ -334,7 +334,7 @@ public class PublishResultsQueryView extends ResultsQueryView
         private final ColumnInfo _specimenVisitCol;
         private final ColumnInfo _specimenDateCol;
         private final ColumnInfo _targetStudyCol;
-        private Map<Integer, ParticipantVisitResolver> _resolvers = new HashMap<>();
+        private final Map<Integer, ParticipantVisitResolver> _resolvers = new HashMap<>();
 
         private Map<Object, String> _reshowVisits;
         private Map<Object, String> _reshowDates;
@@ -709,11 +709,11 @@ public class PublishResultsQueryView extends ResultsQueryView
 
     public static abstract class InputColumn extends SimpleDisplayColumn
     {
-        private static String RENDERED_REQUIRES_COMPLETION = InputColumn.class.getName() + "-requiresScript";
+        private static final String RENDERED_REQUIRES_COMPLETION = InputColumn.class.getName() + "-requiresScript";
 
         protected boolean _editable;
         protected String _formElementName;
-        private String _completionBase;
+        private final String _completionBase;
         protected final ResolverHelper _resolverHelper;
 
         public InputColumn(String caption, boolean editable, String formElementName, String completionBase, ResolverHelper resolverHelper)
@@ -821,7 +821,7 @@ public class PublishResultsQueryView extends ResultsQueryView
         protected String getCompletionBase(RenderContext ctx)
         {
             Container c = rowTargetStudy(_resolverHelper, ctx);
-            return SpecimenService.get().getCompletionURLBase(c, SpecimenService.CompletionType.ParticipantId);
+            return SpecimenService.get().getCompletionURL(c, SpecimenService.CompletionType.ParticipantId).getLocalURIString();
         }
 
         @Override
@@ -843,7 +843,7 @@ public class PublishResultsQueryView extends ResultsQueryView
         protected String getCompletionBase(RenderContext ctx)
         {
             Container c = rowTargetStudy(_resolverHelper, ctx);
-            return SpecimenService.get().getCompletionURLBase(c, SpecimenService.CompletionType.VisitId);
+            return SpecimenService.get().getCompletionURL(c, SpecimenService.CompletionType.VisitId).getLocalURIString();
         }
 
         @Override
@@ -855,7 +855,7 @@ public class PublishResultsQueryView extends ResultsQueryView
 
     private class DateDataInputColumn extends DataInputColumn
     {
-        private boolean _includeTimestamp;
+        private final boolean _includeTimestamp;
 
         public DateDataInputColumn(String completionBase, ResolverHelper resolverHelper, ColumnInfo dateCol, boolean includeTimestamp)
         {

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -366,7 +366,7 @@ public class PageFlowUtil
         return PageFlowUtil.jsString(PageFlowUtil.filter(s));
     }
 
-    static public String jsString(CharSequence cs)
+    public static String jsString(CharSequence cs)
     {
         if (cs == null)
             return "''";
@@ -375,12 +375,12 @@ public class PageFlowUtil
     }
 
     @Deprecated // usages look wrong to me -- they should just use q()?
-    static public HtmlString jsString(HtmlString hs)
+    public static HtmlString jsString(HtmlString hs)
     {
         return HtmlString.unsafe(jsString(hs.toString()));
     }
 
-    static public String jsString(String s)
+    public static String jsString(String s)
     {
         if (s == null)
             return "''";

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -230,19 +230,15 @@ public class SecurityController extends SpringActionController
         }
 
         @Override
-        public String getCompleteUserURLPrefix(Container container)
+        public ActionURL getCompleteUserURL(Container container)
         {
-            ActionURL url = new ActionURL(CompleteUserAction.class, container);
-            url.addParameter("prefix", "");
-            return url.getLocalURIString();
+            return new ActionURL(CompleteUserAction.class, container).addParameter("prefix", "");
         }
 
         @Override
-        public String getCompleteUserReadURLPrefix(Container container)
+        public ActionURL getCompleteUserReadURL(Container container)
         {
-            ActionURL url = new ActionURL(CompleteUserReadAction.class, container);
-            url.addParameter("prefix", "");
-            return url.getLocalURIString();
+            return new ActionURL(CompleteUserReadAction.class, container).addParameter("prefix", "");
         }
 
         @Override

--- a/issues/src/org/labkey/issue/view/updateView.jsp
+++ b/issues/src/org/labkey/issue/view/updateView.jsp
@@ -109,7 +109,7 @@
         issueListDef = IssueManager.getIssueListDef(issue);
 
     BindException errors = bean.getErrors();
-    String completionUrl = urlProvider(SecurityUrls.class).getCompleteUserReadURLPrefix(c);
+    ActionURL completionUrl = urlProvider(SecurityUrls.class).getCompleteUserReadURL(c);
     ActionURL cancelURL;
 
     if (bean.getReturnURL() != null)

--- a/pipeline/src/org/labkey/pipeline/emailNotificationSetup.jsp
+++ b/pipeline/src/org/labkey/pipeline/emailNotificationSetup.jsp
@@ -55,7 +55,7 @@
     HtmlString displaySuccess = h(notifyOwnerOnSuccess || !StringUtils.isEmpty(notifyUsersOnSuccess) ? "" : "none");
     HtmlString displayError = h(notifyOwnerOnError || !StringUtils.isEmpty(notifyUsersOnError) ? "" : "none");
 
-    String completeUserUrl = urlProvider(SecurityUrls.class).getCompleteUserURLPrefix(c);
+    ActionURL completeUserUrl = urlProvider(SecurityUrls.class).getCompleteUserURL(c);
 %>
 <script type="text/javascript">
 

--- a/query/src/org/labkey/query/reports/view/shareReport.jsp
+++ b/query/src/org/labkey/query/reports/view/shareReport.jsp
@@ -47,7 +47,7 @@
         Container container = getContainer();
         String reportName = report.getDescriptor().getResourceName();
         ActionURL returnUrl = bean.getReturnActionURL(bean.getDefaultUrl(container));
-        String completionUrl = urlProvider(SecurityUrls.class).getCompleteUserReadURLPrefix(container);
+        ActionURL completionUrl = urlProvider(SecurityUrls.class).getCompleteUserReadURL(container);
         ActionURL reportUrl = report.getRunReportURL(getViewContext());
 
         String messageSubject = bean.getMessageSubject() != null ? bean.getMessageSubject()

--- a/study/src/org/labkey/study/SpecimenServiceImpl.java
+++ b/study/src/org/labkey/study/SpecimenServiceImpl.java
@@ -259,14 +259,15 @@ public class SpecimenServiceImpl implements SpecimenService
     }
 
     @Override
-    public String getCompletionURLBase(Container studyContainer, SpecimenService.CompletionType type)
+    public ActionURL getCompletionURL(Container studyContainer, SpecimenService.CompletionType type)
     {
         if (studyContainer == null)
             return null;
 
         ActionURL url = new ActionURL(AutoCompleteAction.class, studyContainer);
         url.addParameter("type", type.name());
-        return url.getLocalURIString() + "&prefix=";
+        url.addParameter("prefix", "");
+        return url;
     }
 
     @Override

--- a/study/src/org/labkey/study/controllers/specimen/ShowGroupMembersAction.java
+++ b/study/src/org/labkey/study/controllers/specimen/ShowGroupMembersAction.java
@@ -272,9 +272,9 @@ public class ShowGroupMembersAction extends FormViewAction<ShowGroupMembersActio
             return _returnUrl;
         }
 
-        public String getCompleteUsersPrefix()
+        public ActionURL getCompleteUsersPrefix()
         {
-            return PageFlowUtil.urlProvider(SecurityUrls.class).getCompleteUserURLPrefix(_actor.getContainer());
+            return PageFlowUtil.urlProvider(SecurityUrls.class).getCompleteUserURL(_actor.getContainer());
         }
     }
 }

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -108,6 +108,7 @@ import org.labkey.api.util.CPUTimer;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.UnexpectedException;
+import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.study.StudySchema;
 import org.labkey.study.StudyServiceImpl;
@@ -1203,11 +1204,11 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
 
     private static class AutoCompleteDisplayColumnFactory implements DisplayColumnFactory
     {
-        private String _completionBase;
+        private final ActionURL _completionBase;
 
         public AutoCompleteDisplayColumnFactory(Container studyContainer, SpecimenService.CompletionType type)
         {
-            _completionBase = SpecimenService.get().getCompletionURLBase(studyContainer, type);
+            _completionBase = SpecimenService.get().getCompletionURL(studyContainer, type);
         }
 
         @Override
@@ -1218,7 +1219,7 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
                 @Override
                 protected String getAutoCompleteURLPrefix()
                 {
-                    return _completionBase;
+                    return _completionBase.getLocalURIString();
                 }
             };
         }

--- a/study/src/org/labkey/study/view/customizeParticipantWebPart.jsp
+++ b/study/src/org/labkey/study/view/customizeParticipantWebPart.jsp
@@ -38,7 +38,7 @@
     Container c = getContainer();
     ActionURL postUrl = bean.getCustomizePostURL(ctx);
     String participantId = bean.getPropertyMap().get(SubjectDetailsWebPartFactory.PARTICIPANT_ID_KEY);
-    String ptidCompletionBase = SpecimenService.get().getCompletionURLBase(c, SpecimenService.CompletionType.ParticipantId);
+    ActionURL ptidCompletionBase = SpecimenService.get().getCompletionURL(c, SpecimenService.CompletionType.ParticipantId);
 
     String selectedData = bean.getPropertyMap().get(SubjectDetailsWebPartFactory.DATA_TYPE_KEY);
     if (selectedData == null)

--- a/study/src/org/labkey/study/view/sendParticipantGroup.jsp
+++ b/study/src/org/labkey/study/view/sendParticipantGroup.jsp
@@ -37,7 +37,7 @@
     String subjectNounPlural = s.getSubjectNounPlural();
 
     ActionURL returnUrl = bean.getReturnActionURL(bean.getDefaultUrl(container));
-    String completionUrl = urlProvider(SecurityUrls.class).getCompleteUserReadURLPrefix(container);
+    ActionURL completionUrl = urlProvider(SecurityUrls.class).getCompleteUserReadURL(container);
     ActionURL sendGroupUrl = bean.getSendGroupUrl(container);
 
     String messageSubject = bean.getMessageSubject() != null ? bean.getMessageSubject()

--- a/study/src/org/labkey/study/view/specimen/manageNotifications.jsp
+++ b/study/src/org/labkey/study/view/specimen/manageNotifications.jsp
@@ -25,6 +25,7 @@
 <%@ page import="org.labkey.api.specimen.settings.RequestNotificationSettings.SpecimensAttachmentEnum" %>
 <%@ page import="org.labkey.api.study.StudyUrls" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
+<%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.study.controllers.specimen.SpecimenController" %>
@@ -50,7 +51,7 @@ function setElementDisplayByCheckbox(checkbox, element)
     RequestNotificationSettings bean = me.getModelBean();
     Container container = getContainer();
 
-    String completionURLPrefix = urlProvider(SecurityUrls.class).getCompleteUserURLPrefix(container);
+    ActionURL completionURLPrefix = urlProvider(SecurityUrls.class).getCompleteUserURL(container);
     boolean newRequestNotifyChecked = ("POST".equalsIgnoreCase(getViewContext().getRequest().getMethod()) ?
             bean.isNewRequestNotifyCheckbox() : StringUtils.isNotEmpty(bean.getNewRequestNotify()));
     boolean ccChecked = ("POST".equalsIgnoreCase(getViewContext().getRequest().getMethod()) ?


### PR DESCRIPTION
#### Rationale
Passing URLs as Strings is fragile and unnecessary

#### Changes
* Switch most auto-complete URLs from String to ActionURL
* Eliminate `AutoCompleteTag.java.setUrl(String)`; pass and stash ActionURL instead
* Add a link to moderator review page from message warnings (not related to the above, but still a darn good idea)