### PR TITLE
Rename "study-samples" controller to "specimen"

### DIFF
--- a/api/src/org/labkey/api/study/assay/SpecimenForeignKey.java
+++ b/api/src/org/labkey/api/study/assay/SpecimenForeignKey.java
@@ -280,9 +280,9 @@ public class SpecimenForeignKey extends LookupForeignKey
 
         DetailsURL detailsURL;
         if (targetStudy != null)
-            detailsURL = DetailsURL.fromString("study-samples/sampleEventsRedirect.view?id=${" + parent.getFieldKey() + "}&targetStudy=" + targetStudy.getId() );
+            detailsURL = DetailsURL.fromString("specimen-specimenEventsRedirect.view?id=${" + parent.getFieldKey() + "}&targetStudy=" + targetStudy.getId() );
         else
-            detailsURL = DetailsURL.fromString("study-samples/sampleEventsRedirect.view?id=${" + parent.getFieldKey() + "}&targetStudy=${" + targetStudyFK + "}");
+            detailsURL = DetailsURL.fromString("specimen-specimenEventsRedirect.view?id=${" + parent.getFieldKey() + "}&targetStudy=${" + targetStudyFK + "}");
         return detailsURL;
     }
 

--- a/study/api-src/org/labkey/api/specimen/SpecimensPage.java
+++ b/study/api-src/org/labkey/api/specimen/SpecimensPage.java
@@ -29,7 +29,7 @@ public class SpecimensPage extends FolderTab.PortalPage
     public boolean isSelectedPage(ViewContext viewContext)
     {
         return super.isSelectedPage(viewContext) ||
-                "study-samples".equals(viewContext.getActionURL().getController());
+                "specimen".equals(viewContext.getActionURL().getController());
     }
 
     @Override

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -250,7 +250,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
         addController("study-shared", SharedStudyController.class);
 
         // @Migrate
-        addController("study-samples", SpecimenController.class);
+        addController("specimen", SpecimenController.class, "study-samples");
 
         ServiceRegistry.get().registerService(StudyService.class, StudyServiceImpl.INSTANCE);
         DefaultSchema.registerProvider(StudyQuerySchema.SCHEMA_NAME, new StudySchemaProvider(this));

--- a/study/src/org/labkey/study/view/specimen/configRequestabilityRules.jsp
+++ b/study/src/org/labkey/study/view/specimen/configRequestabilityRules.jsp
@@ -424,7 +424,7 @@
 
         Ext.Msg.wait("Saving...");
         Ext.Ajax.request({
-            url : LABKEY.ActionURL.buildURL("study-samples", "updateRequestabilityRules"),
+            url : LABKEY.ActionURL.buildURL("specimen", "updateRequestabilityRules"),
             method : 'POST',
             success: saveComplete,
             failure: LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.displayAjaxErrorResponse, this, true),

--- a/study/src/org/labkey/study/view/specimen/manageSpecimenWebPart.jsp
+++ b/study/src/org/labkey/study/view/specimen/manageSpecimenWebPart.jsp
@@ -211,7 +211,7 @@
                 var data = {grouping1 : [grouping1.items.items[0].getValue(), grouping1.items.items[1].getValue(), grouping1.items.items[2].getValue()],
                             grouping2 : [grouping2.items.items[0].getValue(), grouping2.items.items[1].getValue(), grouping2.items.items[2].getValue()]};
                 Ext4.Ajax.request({
-                    url : (LABKEY.ActionURL.buildURL('study-samples', 'saveSpecimenWebPartSettings')),
+                    url : (LABKEY.ActionURL.buildURL('specimen', 'saveSpecimenWebPartSettings')),
                     method : 'POST',
                     success: function(){
                         window.location = LABKEY.ActionURL.buildURL("study", 'manageStudy.view', null, null);

--- a/study/src/org/labkey/study/view/specimen/webPart.jsp
+++ b/study/src/org/labkey/study/view/specimen/webPart.jsp
@@ -91,7 +91,7 @@
         {
             var html = '<i>No specimens found.</i>';
             <% if (isAdmin && !c.isDataspace()) {%>
-                var importUrl = LABKEY.ActionURL.buildURL('study-samples', 'showUploadSpecimens', LABKEY.ActionURL.getContainer());
+                var importUrl = LABKEY.ActionURL.buildURL('specimen', 'showUploadSpecimens', LABKEY.ActionURL.getContainer());
                 html += '<p><a href="' + importUrl + '">Import Specimens</a></p>';
             <% } %>
             document.getElementById(names.content).innerHTML = html;

--- a/study/webapp/study/SpecimenSearchPanel.js
+++ b/study/webapp/study/SpecimenSearchPanel.js
@@ -380,7 +380,7 @@ Ext4.define('LABKEY.ext.SampleSearchPanel', {
         if (form.down('#searchPanel'))
             Ext4.apply(params, form.down('#searchPanel').getParams(dataRegionName));
 
-        window.location = LABKEY.ActionURL.buildURL('study-samples', 'samples', null, params);
+        window.location = LABKEY.ActionURL.buildURL('specimen', 'specimens', null, params);
     },
 
     optimizeFilter: function(op, values, field){

--- a/study/webapp/study/sampleRequest.js
+++ b/study/webapp/study/sampleRequest.js
@@ -104,7 +104,7 @@ function submitRequest()
         {
             if (button == 'yes')
             {
-                document.location = LABKEY.ActionURL.buildURL("study-samples", "submitRequest",
+                document.location = LABKEY.ActionURL.buildURL("specimen", "submitRequest",
                         LABKEY.ActionURL.getContainer(), { id: getSelectedRequestId()});
             }
         });
@@ -131,7 +131,7 @@ function cancelRequest()
 
 function showRequestDetails()
 {
-    document.location = LABKEY.ActionURL.buildURL("study-samples", "manageRequest",
+    document.location = LABKEY.ActionURL.buildURL("specimen", "manageRequest",
             LABKEY.ActionURL.getContainer(), { id: getSelectedRequestId()});
 }
 


### PR DESCRIPTION
#### Rationale
The study specimen functionality references "specimens" at times and "samples" at other times. To reduce confusion, we're moving to "specimens" exclusively, reserving "samples" to refer to sample types.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/619

#### Changes
* Rename "study-samples" controller to "specimen", while keeping old name as an alias
* Update product and test references to new controller name
* Fix AssayApi crawler failure: correct SpecimenForeignKey hard-coded action name "sampleEventsRedirect" -> "specimenEventsRedirect"
