### PR TITLE
Fix auto-complete NPEs

### DIFF
--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -46,6 +46,7 @@ import org.labkey.api.util.element.Option;
 import org.labkey.api.util.element.Option.OptionBuilder;
 import org.labkey.api.util.element.Select;
 import org.labkey.api.util.element.TextArea;
+import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.template.ClientDependency;
 
@@ -819,7 +820,7 @@ public class DataColumn extends DisplayColumn
             renderHiddenFormInput(ctx, out, formFieldName, value);
     }
 
-    protected void renderAutoCompleteFormInput(RenderContext ctx, Writer out, String formFieldName, Object value, String strVal, boolean disabledInput, String autoCompleteURLPrefix)
+    protected void renderAutoCompleteFormInput(RenderContext ctx, Writer out, String formFieldName, Object value, String strVal, boolean disabledInput, @NotNull ActionURL autoCompleteURLPrefix)
             throws IOException
     {
         String renderId = "auto-complete-div-" + UniqueID.getRequestScopedUID(HttpView.currentRequest());
@@ -829,9 +830,9 @@ public class DataColumn extends DisplayColumn
         sb.append("Ext4.onReady(function(){\n" +
                 "        Ext4.create('LABKEY.element.AutoCompletionField', {\n" +
                 "            renderTo        : " + PageFlowUtil.jsString(renderId) + ",\n" +
-                "            completionUrl   : " + PageFlowUtil.jsString(getAutoCompleteURLPrefix()) + ",\n" +
+                "            completionUrl   : " + PageFlowUtil.jsString(autoCompleteURLPrefix) + ",\n" +
                 "            sharedStore     : true,\n" +
-                "            sharedStoreId   : " + PageFlowUtil.jsString(getAutoCompleteURLPrefix()) + ",\n" +
+                "            sharedStoreId   : " + PageFlowUtil.jsString(autoCompleteURLPrefix) + ",\n" +
                 "            tagConfig   : {\n" +
                 "                tag     : 'input',\n" +
                 "                type    : 'text',\n" +
@@ -847,7 +848,7 @@ public class DataColumn extends DisplayColumn
         out.write(sb.toString());
     }
 
-    protected String getAutoCompleteURLPrefix()
+    protected @Nullable ActionURL getAutoCompleteURLPrefix()
     {
         return null;
     }

--- a/api/src/org/labkey/api/exp/SamplePropertyHelper.java
+++ b/api/src/org/labkey/api/exp/SamplePropertyHelper.java
@@ -201,7 +201,7 @@ public abstract class SamplePropertyHelper<ObjectType>
         return result;
     }
 
-    private class SpecimenInputColumn extends DataColumn
+    private static class SpecimenInputColumn extends DataColumn
     {
         private final ActionURL _autoCompletePrefix;
 
@@ -225,9 +225,9 @@ public abstract class SamplePropertyHelper<ObjectType>
         }
 
         @Override
-        protected String getAutoCompleteURLPrefix()
+        protected ActionURL getAutoCompleteURLPrefix()
         {
-            return _autoCompletePrefix.getLocalURIString();
+            return _autoCompletePrefix;
         }
     }
 }

--- a/api/src/org/labkey/api/study/query/DataInputColumn.java
+++ b/api/src/org/labkey/api/study/query/DataInputColumn.java
@@ -15,8 +15,10 @@
  */
 package org.labkey.api.study.query;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.RenderContext;
+import org.labkey.api.view.ActionURL;
 
 /**
 * User: jeckels
@@ -26,7 +28,7 @@ public abstract class DataInputColumn extends PublishResultsQueryView.InputColum
 {
     protected final ColumnInfo _requiredColumn;
 
-    public DataInputColumn(String caption, String formElementName, boolean editable, String completionBase, PublishResultsQueryView.ResolverHelper resolverHelper,
+    public DataInputColumn(String caption, String formElementName, boolean editable, @Nullable ActionURL completionBase, PublishResultsQueryView.ResolverHelper resolverHelper,
                            ColumnInfo requiredColumn)
     {
         super(caption, editable, formElementName, completionBase, resolverHelper);

--- a/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
+++ b/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
@@ -66,8 +66,8 @@ import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.UniqueID;
+import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DataView;
-import org.labkey.api.view.HttpView;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -713,10 +713,10 @@ public class PublishResultsQueryView extends ResultsQueryView
 
         protected boolean _editable;
         protected String _formElementName;
-        private final String _completionBase;
+        private final ActionURL _completionBase;
         protected final ResolverHelper _resolverHelper;
 
-        public InputColumn(String caption, boolean editable, String formElementName, String completionBase, ResolverHelper resolverHelper)
+        public InputColumn(String caption, boolean editable, String formElementName, @Nullable ActionURL completionBase, ResolverHelper resolverHelper)
         {
             _editable = editable;
             _formElementName = formElementName;
@@ -733,7 +733,7 @@ public class PublishResultsQueryView extends ResultsQueryView
                 _resolverHelper.addQueryColumns(set);
         }
 
-        protected String getCompletionBase(RenderContext ctx)
+        protected @Nullable ActionURL getCompletionBase(RenderContext ctx)
         {
             return _completionBase;
         }
@@ -743,7 +743,7 @@ public class PublishResultsQueryView extends ResultsQueryView
         {
             if (_editable)
             {
-                String completionBase = getCompletionBase(ctx);
+                ActionURL completionBase = getCompletionBase(ctx);
                 if (completionBase != null)
                 {
                     if (ctx.get(RENDERED_REQUIRES_COMPLETION) == null)
@@ -769,8 +769,8 @@ public class PublishResultsQueryView extends ResultsQueryView
                         ctx.put(RENDERED_REQUIRES_COMPLETION, true);
                     }
 
-                    String inputId = "input-tag-" + UniqueID.getRequestScopedUID(HttpView.currentRequest());
-                    String completionId = "auto-complete-div-" + UniqueID.getRequestScopedUID(HttpView.currentRequest());
+                    String inputId = "input-tag-" + UniqueID.getRequestScopedUID(ctx.getRequest());
+                    String completionId = "auto-complete-div-" + UniqueID.getRequestScopedUID(ctx.getRequest());
                     String value = PageFlowUtil.filter(getValue(ctx));
 
                     StringBuilder sb = new StringBuilder();
@@ -818,10 +818,10 @@ public class PublishResultsQueryView extends ResultsQueryView
         }
 
         @Override
-        protected String getCompletionBase(RenderContext ctx)
+        protected ActionURL getCompletionBase(RenderContext ctx)
         {
             Container c = rowTargetStudy(_resolverHelper, ctx);
-            return SpecimenService.get().getCompletionURL(c, SpecimenService.CompletionType.ParticipantId).getLocalURIString();
+            return SpecimenService.get().getCompletionURL(c, SpecimenService.CompletionType.ParticipantId);
         }
 
         @Override
@@ -840,10 +840,10 @@ public class PublishResultsQueryView extends ResultsQueryView
         }
 
         @Override
-        protected String getCompletionBase(RenderContext ctx)
+        protected ActionURL getCompletionBase(RenderContext ctx)
         {
             Container c = rowTargetStudy(_resolverHelper, ctx);
-            return SpecimenService.get().getCompletionURL(c, SpecimenService.CompletionType.VisitId).getLocalURIString();
+            return SpecimenService.get().getCompletionURL(c, SpecimenService.CompletionType.VisitId);
         }
 
         @Override
@@ -853,11 +853,11 @@ public class PublishResultsQueryView extends ResultsQueryView
         }
     }
 
-    private class DateDataInputColumn extends DataInputColumn
+    private static class DateDataInputColumn extends DataInputColumn
     {
         private final boolean _includeTimestamp;
 
-        public DateDataInputColumn(String completionBase, ResolverHelper resolverHelper, ColumnInfo dateCol, boolean includeTimestamp)
+        public DateDataInputColumn(@Nullable ActionURL completionBase, ResolverHelper resolverHelper, ColumnInfo dateCol, boolean includeTimestamp)
         {
             super(AbstractAssayProvider.DATE_PROPERTY_CAPTION, "date",
                     true, completionBase, resolverHelper, dateCol);

--- a/api/src/org/labkey/api/study/query/RunDataLinkDisplayColumn.java
+++ b/api/src/org/labkey/api/study/query/RunDataLinkDisplayColumn.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.study.query;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.actions.AssayDetailRedirectAction;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.RenderContext;
@@ -35,7 +36,7 @@ public class RunDataLinkDisplayColumn extends DataInputColumn
     private final ColumnInfo _runIdCol;
     private final ColumnInfo _objectIdCol;
 
-    public RunDataLinkDisplayColumn(String completionBase, PublishResultsQueryView.ResolverHelper resolverHelper, ColumnInfo runIdCol, ColumnInfo objectIdCol)
+    public RunDataLinkDisplayColumn(@Nullable ActionURL completionBase, PublishResultsQueryView.ResolverHelper resolverHelper, ColumnInfo runIdCol, ColumnInfo objectIdCol)
     {
         super("Originating Run", "objectId", false, completionBase, resolverHelper, objectIdCol);
         _runIdCol = runIdCol;

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -380,6 +380,11 @@ public class PageFlowUtil
         return HtmlString.unsafe(jsString(hs.toString()));
     }
 
+    public static String jsString(ActionURL url)
+    {
+        return jsString(url.getLocalURIString());
+    }
+
     public static String jsString(String s)
     {
         if (s == null)

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1217,9 +1217,9 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
             return new DataColumn(colInfo)
             {
                 @Override
-                protected String getAutoCompleteURLPrefix()
+                protected ActionURL getAutoCompleteURLPrefix()
                 {
-                    return _completionBase.getLocalURIString();
+                    return _completionBase;
                 }
             };
         }


### PR DESCRIPTION
#### Rationale
The previous PR's migration of auto-complete URL handling from String toward ActionURL introduced NPE opportunities since the final rendering was still String-based, causing tests to fail. Those NPEs are fixed by pushing ActionURLs all the way to render time, which completes the migration. "Auto-completion completion", if you will. (And even if you won't.)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1953

#### Changesg
* Push ActionURL through to DataColumn and publish study rendering of auto-complete elements
* Mark `completionBase` parameters as `@Nullable` throughout
* While we're at it, don't grab the current request from thread local when you have a RenderContext in hand