### PR TITLE
Handle bad events even if validateFields() is called before getAuditLogMessage()

### DIFF
--- a/api/src/org/labkey/api/data/BeanObjectFactory.java
+++ b/api/src/org/labkey/api/data/BeanObjectFactory.java
@@ -224,7 +224,9 @@ public class BeanObjectFactory<K> implements ObjectFactory<K> // implements Resu
         }
         catch (InvocationTargetException x)
         {
-            throw UnexpectedException.wrap(x.getTargetException());
+            if (null != x.getTargetException())
+                throw UnexpectedException.wrap(x.getTargetException());
+            throw UnexpectedException.wrap(x);
         }
         fixupMap(m, bean);
         return m;

--- a/api/src/org/labkey/api/data/BeanObjectFactory.java
+++ b/api/src/org/labkey/api/data/BeanObjectFactory.java
@@ -224,9 +224,7 @@ public class BeanObjectFactory<K> implements ObjectFactory<K> // implements Resu
         }
         catch (InvocationTargetException x)
         {
-            assert false : x;
-            if (x.getTargetException() instanceof RuntimeException)
-                throw (RuntimeException)x.getTargetException();
+            throw UnexpectedException.wrap(x.getTargetException());
         }
         fixupMap(m, bean);
         return m;


### PR DESCRIPTION
#### Rationale
Fixes AuditInsertionFailureTestCase

#### Related Pull Requests
https://github.com/LabKey/platform/pull/1965
https://github.com/LabKey/compliance/pull/104