### PR TITLE
Apparently we sometimes create events that don't have registered providers

### DIFF
--- a/audit/src/org/labkey/audit/model/LogManager.java
+++ b/audit/src/org/labkey/audit/model/LogManager.java
@@ -111,6 +111,8 @@ public class LogManager
         }
 
         AuditTypeProvider provider = AuditLogService.get().getAuditProvider(type.getEventType());
+        if (null == provider)
+            return;
         Container c = ContainerManager.getForId(type.getContainer());
         UserSchema schema = AuditLogService.getAuditLogSchema(user, c != null ? c : ContainerManager.getRoot());
         TableInfo table = null==schema ? null : schema.getTable(provider.getEventName(), false);


### PR DESCRIPTION
#### Rationale
Ignore events with no provider (same as before last merge) e.g. SelectQueryAuditEvent w/o compliance module

#### Related Pull Requests
https://github.com/LabKey/platform/pull/1962

