### PR TITLE
Product MenuSection Updates

### DIFF
--- a/core/api-src/org/labkey/api/products/MenuItem.java
+++ b/core/api-src/org/labkey/api/products/MenuItem.java
@@ -50,6 +50,11 @@ public class MenuItem
         _hasActiveJob = hasActiveJob;
     }
 
+    public MenuItem(String label, ActionURL url, Integer id, String key, Integer orderNum, String productId)
+    {
+        this(label, url == null ? null : url.toString(), id, key, orderNum, productId, false);
+    }
+
     public MenuItem(String label, String url, Integer id, String key, Integer orderNum, String productId)
     {
         this(label, url, id, key, orderNum, productId, false);

--- a/core/api-src/org/labkey/api/products/MenuSection.java
+++ b/core/api-src/org/labkey/api/products/MenuSection.java
@@ -38,9 +38,14 @@ public abstract class MenuSection
     protected ViewContext _context;
     protected String _label;
     protected Integer _itemLimit;
+    /**
+     * A unique key identifying this MenuSection.
+     * This is used by the client to match client configuration to the configuration supplied from LKS.
+     */
     protected String _key;
     private List<MenuItem> _allItems;
     private String _productId;
+    /** Used by the client to determine the first part of an app-relative URL. Defaults to the same as "key". */
     private String _sectionKey;
 
     public MenuSection(@NotNull ViewContext context, @NotNull String label, @NotNull String key, @Nullable Integer itemLimit, @Nullable String productId)

--- a/core/api-src/org/labkey/api/products/MenuSection.java
+++ b/core/api-src/org/labkey/api/products/MenuSection.java
@@ -41,12 +41,14 @@ public abstract class MenuSection
     protected String _key;
     private List<MenuItem> _allItems;
     private String _productId;
+    private String _sectionKey;
 
     public MenuSection(@NotNull ViewContext context, @NotNull String label, @NotNull String key, @Nullable Integer itemLimit, @Nullable String productId)
     {
         _context = context;
         _label = label;
         _key = key;
+        _sectionKey = key;
         _itemLimit = itemLimit;
         _productId = productId;
     }
@@ -159,5 +161,15 @@ public abstract class MenuSection
         if (label == null)
             label = tableInfo.getName();
         return splitCamelCase ? StringUtilsLabKey.splitCamelCase(label) : label;
+    }
+
+    public String getSectionKey()
+    {
+        return _sectionKey;
+    }
+
+    public void setSectionKey(String sectionKey)
+    {
+        _sectionKey = sectionKey;
     }
 }


### PR DESCRIPTION
#### Rationale
Adds support for `sectionKey` to `MenuSection` to allow for differentiating the section from the `key`.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/443
* https://github.com/LabKey/biologics/pull/787
* https://github.com/LabKey/sampleManagement/pull/479
* https://github.com/LabKey/inventory/pull/186

#### Changes
* Additional `MenuItem` constructor to support passing a key.
* Add `_sectionKey` prop to `MenuSection`.
