### PR TITLE
Issue 42410: custom login through project settings

### DIFF
--- a/api/src/org/labkey/api/data/LoggingResultSetWrapper.java
+++ b/api/src/org/labkey/api/data/LoggingResultSetWrapper.java
@@ -53,19 +53,25 @@ public class LoggingResultSetWrapper extends ResultSetWrapper
     @Override
     public void close() throws SQLException
     {
-        if (!_queryLogging.isEmpty() && _queryLogging.isShouldAudit())
+        try
         {
-            SelectQueryAuditEvent selectQueryAuditEvent = _queryLogging.getSelectQueryAuditEvent();
-            SelectQueryAuditProvider selectQueryAuditProvider = _queryLogging.getSelectQueryAuditProvider();
-            boolean logEmpty = selectQueryAuditEvent.isLogEmptyResults()
-                    && (selectQueryAuditProvider == null || selectQueryAuditProvider.isLogEmptyResults());
-            if (!_dataLoggingValues.isEmpty() || logEmpty)
+            if (!_queryLogging.isEmpty() && _queryLogging.isShouldAudit())
             {
-                selectQueryAuditEvent.setDataLogging(_queryLogging, _dataLoggingValues);
-                AuditLogService.get().addEvent(_queryLogging.getUser(), selectQueryAuditEvent);
+                SelectQueryAuditEvent selectQueryAuditEvent = _queryLogging.getSelectQueryAuditEvent();
+                SelectQueryAuditProvider selectQueryAuditProvider = _queryLogging.getSelectQueryAuditProvider();
+                boolean logEmpty = selectQueryAuditEvent.isLogEmptyResults()
+                        && (selectQueryAuditProvider == null || selectQueryAuditProvider.isLogEmptyResults());
+                if (!_dataLoggingValues.isEmpty() || logEmpty)
+                {
+                    selectQueryAuditEvent.setDataLogging(_queryLogging, _dataLoggingValues);
+                    AuditLogService.get().addEvent(_queryLogging.getUser(), selectQueryAuditEvent);
+                }
             }
         }
-        super.close();
+        finally
+        {
+            super.close();
+        }
     }
 
 

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1111,7 +1111,7 @@ public class LoginController extends SpringActionController
         // regarding 'server upgrade' and 'server startup' is executed regardless of the custom login action the user specified.
         String loginController = "login";
         String loginAction = "login";
-        String customLogin = StringUtils.trimToNull(LookAndFeelProperties.getInstance(ContainerManager.getRoot()).getCustomLogin());
+        String customLogin = StringUtils.trimToNull(LookAndFeelProperties.getInstance(getContainer()).getCustomLogin());
         WebPartView view = null;
         if (null != customLogin)
         {


### PR DESCRIPTION
#### Rationale
The "Project Settings" page accepts and saves an "Alternative login page" setting on a per-project basis... which is then completely ignored. (Only the site-wide "Alternative login page" setting is respected.)

#### Changes
* Respect "Alternative login page" settings saved in the project
* Unrelated change to ensure `ResultSet`s are closed even if audit logging throws