### PR TITLE
Some code depends on 'reselect' of audit event

### DIFF
--- a/audit/src/org/labkey/audit/AuditLogImpl.java
+++ b/audit/src/org/labkey/audit/AuditLogImpl.java
@@ -111,13 +111,19 @@ public class AuditLogImpl implements AuditLogService, StartupListener
     @Override
     public <K extends AuditTypeEvent> K addEvent(User user, K event)
     {
-        addEvents(user, List.of(event));
-        return event;
+        return _addEvents(user, List.of(event),true);
     }
 
     @Override
     public <K extends AuditTypeEvent> void addEvents(User user, List<K> events)
     {
+        _addEvents(user, events, false);
+    }
+
+    private <K extends AuditTypeEvent> K _addEvents(User user, List<K> events, boolean reselectEvent)
+    {
+        assert !reselectEvent || events.size() == 1;
+
         for (var event : events)
         {
             assert event.getContainer() != null : "Container cannot be null";
@@ -178,6 +184,8 @@ public class AuditLogImpl implements AuditLogService, StartupListener
             }
             else
             {
+                if (reselectEvent && events.size()==1)
+                    return LogManager.get().insertEvent(user, events.get(0));
                 LogManager.get().insertEvents(user, events);
             }
         }
@@ -187,6 +195,7 @@ public class AuditLogImpl implements AuditLogService, StartupListener
             AuditLogService.handleAuditFailure(user, e);
             throw e;
         }
+        return null;
     }
 
     @Override

--- a/audit/src/org/labkey/audit/model/LogManager.java
+++ b/audit/src/org/labkey/audit/model/LogManager.java
@@ -34,6 +34,7 @@ import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.StatementUtils;
+import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.PropertyDescriptor;
@@ -74,9 +75,35 @@ public class LogManager
         return AuditSchema.getInstance().getSchema();
     }
 
-    public void insertEvent(User user, AuditTypeEvent event)
+    /** There are a few places that depend on the reselect behavior. e.g. to get the rowid of the event */
+    public <K extends AuditTypeEvent> K insertEvent(User user, K type)
     {
-        insertEvents(user, List.of(event));
+        Logger auditLogger = org.apache.logging.log4j.LogManager.getLogger("org.labkey.audit.event." + type.getEventType().replaceAll(" ", ""));
+        auditLogger.info(type.getAuditLogMessage());
+
+        AuditTypeProvider provider = AuditLogService.get().getAuditProvider(type.getEventType());
+
+        if (provider != null)
+        {
+            Container c = ContainerManager.getForId(type.getContainer());
+
+            UserSchema schema = AuditLogService.getAuditLogSchema(user, c != null ? c : ContainerManager.getRoot());
+
+            if (schema != null)
+            {
+                TableInfo table = schema.getTable(provider.getEventName(), false);
+
+                if (table instanceof DefaultAuditTypeTable)
+                {
+                    // consider using etl data iterator for inserts
+                    type = validateFields(provider, type);
+                    TableInfo dbTable = ((DefaultAuditTypeTable)table).getRealTable();
+                    K ret = Table.insert(user, dbTable, type);
+                    return ret;
+                }
+            }
+        }
+        return null;
     }
 
     /** all events must be of same event type and container, for optimized code path */
@@ -106,7 +133,7 @@ public class LogManager
         {
             // do one at a time if events are not all the same
             for (var event : events)
-                insertEvents(user, List.of(event));
+                insertEvent(user, event);
             return;
         }
 


### PR DESCRIPTION
#### Rationale
Some code depends on 'reselect' of audit event (e.g. DomainProeprtyEvents)
Support backward compatible insert of one event
