### PR TITLE
Issue 42422: exp.data's Name column too short

### DIFF
--- a/experiment/resources/schemas/dbscripts/postgresql/exp-21.000-21.001.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-21.000-21.001.sql
@@ -1,0 +1,2 @@
+-- Most major file systems cap file lengths at 255 characters. Let's do the same
+ALTER TABLE exp.data ALTER COLUMN Name TYPE VARCHAR(255);

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-21.000-21.001.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-21.000-21.001.sql
@@ -1,0 +1,2 @@
+-- Most major file systems cap file lengths at 255 characters. Let's do the same
+ALTER TABLE exp.data ALTER COLUMN Name NVARCHAR(255);

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -138,7 +138,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     public Double getSchemaVersion()
     {
-        return 21.000;
+        return 21.001;
     }
 
     @Nullable


### PR DESCRIPTION
#### Rationale
Modern file systems on all major platforms support file names up to 255 characters. We're using the file name in the exp.data table's Name column, which is limited to 200

#### Changes
* Bump column to 255 characters to match file system limits