### PR TITLE
Issue 42042: Lists with text primary key don't handle commas in key value when viewing row details 

### DIFF
--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -318,7 +318,11 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
 
     public void setPkVals(String s)
     {
-        setPkVals(s.split(","));
+        //Issue 42042: Lists with text primary key don't handle commas in key value when viewing row details
+        if (getPkNamesList().size() == 1)
+            set(getPkNamesList().get(0), s);
+        else
+            setPkVals(s.split(","));
     }
 
     public void setPkVals(String[] s)


### PR DESCRIPTION
#### Rationale
[Issue 42042](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42042): Lists with text primary key don't handle commas in key value when viewing row details.

PK value containing comma is getting split when trying to view the Details page. Ex. "Test, 123" gets split into "Test" and " 123". So when trying to view the Details for row containing PK value "Test, 123", it tries to look for the first PK value, in this case "Test" and ends up on the details page for "Test" (if row containing "Test" PK value is present) or ends up in "not found" error.

#### Changes
Return pk value when there's only one pk column/value instead of splitting with a comma delimiter.