### PR TITLE
fix doubling up on ExistingRecordDataIterator

### DIFF
--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -146,8 +146,7 @@ public class ExistingRecordDataIterator extends WrapperDataIterator
         return context ->
         {
             DataIterator di = dib.getDataIterator(context);
-            // BUG SampleTypeUpdateServiceDI needs to override createImportDIB(), so that we don't insert two ExistingRecordDataIterator
-            // assert !di.supportsGetExistingRecord();
+            assert !di.supportsGetExistingRecord();
             if (di.supportsGetExistingRecord())
                 return di;
             QueryUpdateService.InsertOption option = context.getInsertOption();

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -622,6 +622,8 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         public DataClassDataUpdateService(ExpDataClassDataTableImpl table)
         {
             super(table, table.getRealTable());
+            // Note that this class actually overrides createImportDIB(), so currently we're not looking at this flag.
+            _enableExistingRecordsDataIterator = false;
         }
 
         @Override
@@ -844,8 +846,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         public DataIteratorBuilder createImportDIB(User user, Container container, DataIteratorBuilder data, DataIteratorContext context)
         {
             StandardDataIteratorBuilder standard = StandardDataIteratorBuilder.forInsert(getQueryTable(), data, container, user, context);
-            DataIteratorBuilder existing = ExistingRecordDataIterator.createBuilder(standard, getQueryTable(), Set.of(ExpDataTable.Column.LSID.toString()));
-            DataIteratorBuilder dib = ((UpdateableTableInfo)getQueryTable()).persistRows(existing, context);
+            DataIteratorBuilder dib = ((UpdateableTableInfo)getQueryTable()).persistRows(standard, context);
             dib = AttachmentDataIterator.getAttachmentDataIteratorBuilder(getQueryTable(), dib, user, context.getInsertOption().batch ? getAttachmentDirectory() : null,
                     container, getAttachmentParentFactory(), FieldKey.fromParts(Column.LSID));
             dib = DetailedAuditLogDataIterator.getDataIteratorBuilder(getQueryTable(), dib, context.getInsertOption() == InsertOption.MERGE ? QueryService.AuditAction.MERGE : QueryService.AuditAction.INSERT, user, container);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -100,6 +100,8 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         _sampleType = sampleType;
         _schema = table.getUserSchema();
         _samplesTable = sampleType.getTinfo();
+        // we do this in ExpMaterialTableImpl.persistRows() via ExpDataIterators.PersistDataIteratorBuilder
+        _enableExistingRecordsDataIterator = false;
     }
 
     UserSchema getSchema()


### PR DESCRIPTION
#### Rationale
Fix case where we were doubling up on ExistingRecordDataIterator.  
re-enable guard assert()
