### PR TITLE
Fix switched new/old rows for dataset audit logging

### DIFF
--- a/api/src/org/labkey/api/audit/AbstractAuditHandler.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditHandler.java
@@ -37,7 +37,7 @@ public abstract class AbstractAuditHandler implements AuditHandler
         }
     }
 
-    protected abstract DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> updatedRow);
+    protected abstract DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> existingRow);
 
     /**
      * Allow for adding fields that may be present in the updated row but not represented in the original row

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1679,15 +1679,16 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
             String oldRecordString = null;
             String newRecordString = null;
             Object lsid = record.get("lsid");
-            if (existingRecord != null)
-            {
-                Pair<Map<String, Object>, Map<String, Object>> rowPair = AuditHandler.getOldAndNewRecordForMerge(existingRecord, record, Collections.emptySet());
-                oldRecordString = DatasetAuditProvider.encodeForDataMap(c, rowPair.first);
-                newRecordString = DatasetAuditProvider.encodeForDataMap(c, rowPair.second);
-            }
+
             if (action==DELETE || action==TRUNCATE)
             {
                 oldRecordString = DatasetAuditProvider.encodeForDataMap(c, record);
+            }
+            else if (existingRecord != null)
+            {
+                Pair<Map<String, Object>, Map<String, Object>> rowPair = AuditHandler.getOldAndNewRecordForMerge(record, existingRecord, Collections.emptySet());
+                oldRecordString = DatasetAuditProvider.encodeForDataMap(c, rowPair.first);
+                newRecordString = DatasetAuditProvider.encodeForDataMap(c, rowPair.second);
             }
             else
             {


### PR DESCRIPTION
#### Rationale
Found an issue with the audit logging for datasets where the audit event was swapping the new/old values

#### Changes
* Changed order to match other overload and existing methods
* Fixed issue where the audit event's new row data would be set incorrectly
