### PR TITLE
Restore creation of specimen custom columns during publish study

### DIFF
--- a/specimen/src/org/labkey/specimen/importer/SpecimenSchemaImporter.java
+++ b/specimen/src/org/labkey/specimen/importer/SpecimenSchemaImporter.java
@@ -98,7 +98,11 @@ public class SpecimenSchemaImporter implements SimpleStudyImporter
             try
             {
                 VirtualFile specimenDir = ctx.getRoot().getDir(specimens.getDir());
-                if (null != specimenDir && null != specimens.getFile())
+                // Second check fails for the publish study case, since we don't create a zipped archive inside of the
+                // MemoryVirtualFile. During specimen migration, it was convenient to move calling of this method to
+                // process(), but that meant the check started to be called (and failed) in the publish case... which
+                // meant no custom columns.
+                if (null != specimenDir) // && null != specimens.getFile())
                 {
                     XmlObject schemaXml = specimenDir.getXmlBean(SpecimenArchiveDataTypes.SCHEMA_FILENAME);
                     return (schemaXml instanceof TablesDocument);


### PR DESCRIPTION
#### Rationale
Code shuffling during the specimen module refactor caused the publish study import code path to call `containsSchemasToImport()` as the other code paths do. This method always returns false during publish study because it's expecting a specimen file, which never exists in the MemoryVirtualFile case. Schema import shouldn't care whether a specimen archive exists or not, so just remove that part of the check.