### PR TITLE
Return ExpRuns ordered by their RowId

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -118,6 +118,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     ExpRun getExpRun(String lsid);
 
+    /** @return a list of ExpRuns ordered by the RowId */
     List<? extends ExpRun> getExpRuns(Container container, @Nullable ExpProtocol parentProtocol, @Nullable ExpProtocol childProtocol);
 
     List<? extends ExpRun> getExpRunsForJobId(int jobId);

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -372,6 +372,7 @@ public class ExperimentServiceImpl implements ExperimentService
                     + " WHERE PA.ProtocolLSID = ? ) ");
             sql.add(childProtocol.getLSID());
         }
+        sql.append(" ORDER BY ER.RowId ");
         return ExpRunImpl.fromRuns(new SqlSelector(getSchema(), sql).getArrayList(ExperimentRun.class));
     }
 


### PR DESCRIPTION
#### Rationale
Runs copied as part of folder export/import should be imported in the same order in the destination folder as they were in the source folder.

#### Changes
ExperimentService.getExpRuns(Container container, @Nullable ExpProtocol parentProtocol, @Nullable ExpProtocol childProtocol) returns ExpRuns in the order of their RowId


