### PR TITLE
Move pipeline jobs and tasks to specimen module

### DIFF
--- a/specimen/src/org/labkey/specimen/SpecimenModule.java
+++ b/specimen/src/org/labkey/specimen/SpecimenModule.java
@@ -17,13 +17,14 @@
 package org.labkey.specimen;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.exp.property.PropertyService;
-import org.labkey.api.module.CodeOnlyModule;
 import org.labkey.api.module.ModuleContext;
+import org.labkey.api.module.SpringModule;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.specimen.SpecimenRequestManager;
 import org.labkey.api.specimen.SpecimensPage;
@@ -62,7 +63,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-public class SpecimenModule extends CodeOnlyModule
+public class SpecimenModule extends SpringModule
 {
     public static final String NAME = "Specimen";
 
@@ -82,6 +83,18 @@ public class SpecimenModule extends CodeOnlyModule
             new SpecimenWebPartFactory(),
             new SpecimenReportWebPartFactory()
         );
+    }
+
+    @Override
+    public @Nullable Double getSchemaVersion()
+    {
+        return null;
+    }
+
+    @Override
+    public boolean hasScripts()
+    {
+        return false;
     }
 
     @Override
@@ -108,7 +121,7 @@ public class SpecimenModule extends CodeOnlyModule
     }
 
     @Override
-    public void doStartup(ModuleContext moduleContext)
+    protected void startupAfterSpringConfig(ModuleContext moduleContext)
     {
         ContainerManager.addContainerListener(SpecimenRequestManager.get());
 
@@ -143,6 +156,12 @@ public class SpecimenModule extends CodeOnlyModule
             SpecimenWriter.TestCase.class,
             SampleMindedTransformTask.TestCase.class
         );
+    }
+
+    @Override
+    public @NotNull Collection<String> getSchemaNames()
+    {
+        return Set.of();
     }
 
     @Override

--- a/specimen/src/org/labkey/specimen/SpecimenServiceImpl.java
+++ b/specimen/src/org/labkey/specimen/SpecimenServiceImpl.java
@@ -43,7 +43,6 @@ import org.labkey.api.specimen.actions.AutoCompleteAction;
 import org.labkey.api.specimen.importer.SimpleSpecimenImporter;
 import org.labkey.api.specimen.importer.SpecimenColumn;
 import org.labkey.api.specimen.model.SpecimenTablesProvider;
-import org.labkey.api.specimen.pipeline.SpecimenReloadJob;
 import org.labkey.api.study.ParticipantVisit;
 import org.labkey.api.study.SpecimenChangeListener;
 import org.labkey.api.study.SpecimenImportStrategyFactory;
@@ -55,6 +54,7 @@ import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewBackgroundInfo;
+import org.labkey.specimen.pipeline.SpecimenReloadJob;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/specimen/src/org/labkey/specimen/pipeline/FileAnalysisSpecimenTask.java
+++ b/specimen/src/org/labkey/specimen/pipeline/FileAnalysisSpecimenTask.java
@@ -1,4 +1,4 @@
-package org.labkey.api.specimen.pipeline;
+package org.labkey.specimen.pipeline;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.BooleanUtils;
@@ -9,10 +9,11 @@ import org.apache.tika.mime.MediaType;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.admin.ImportException;
 import org.labkey.api.admin.PipelineJobLoggerGetter;
-import org.labkey.api.annotations.Migrate;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.file.FileAnalysisJobSupport;
+import org.labkey.api.specimen.pipeline.AbstractSpecimenTask;
+import org.labkey.api.specimen.pipeline.AbstractSpecimenTaskFactory;
 import org.labkey.api.study.importer.SimpleStudyImportContext;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.writer.FileSystemFile;
@@ -23,7 +24,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Date;
 
-@Migrate // studyContext.xml is the only dependent
 public class FileAnalysisSpecimenTask extends AbstractSpecimenTask<FileAnalysisSpecimenTask.Factory>
 {
     public static final String MERGE_SPECIMEN = "mergeSpecimen";
@@ -44,7 +44,7 @@ public class FileAnalysisSpecimenTask extends AbstractSpecimenTask<FileAnalysisS
     }
 
     @Override
-    SimpleStudyImportContext getImportContext(PipelineJob job)
+    protected SimpleStudyImportContext getImportContext(PipelineJob job)
     {
         return new SimpleStudyImportContext(job.getUser(), job.getContainer(), null, null, new PipelineJobLoggerGetter(job), null);
     }

--- a/specimen/src/org/labkey/specimen/pipeline/SpecimenReloadJob.java
+++ b/specimen/src/org/labkey/specimen/pipeline/SpecimenReloadJob.java
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.labkey.api.specimen.pipeline;
+package org.labkey.specimen.pipeline;
 
-import org.labkey.api.annotations.Migrate;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.pipeline.TaskId;
 import org.labkey.api.pipeline.TaskPipeline;
+import org.labkey.api.specimen.pipeline.SpecimenBatch;
 import org.labkey.api.study.SpecimenTransform;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.view.ViewBackgroundInfo;
@@ -30,7 +30,6 @@ import java.io.Serializable;
 /**
  * Created by klum on 5/24/2014.
  */
-@Migrate // studyContext.xml is the only dependent
 public class SpecimenReloadJob extends SpecimenBatch implements Serializable, SpecimenReloadJobSupport
 {
     private String _transformName;

--- a/specimen/src/org/labkey/specimen/pipeline/SpecimenReloadJobSupport.java
+++ b/specimen/src/org/labkey/specimen/pipeline/SpecimenReloadJobSupport.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.labkey.api.specimen.pipeline;
+package org.labkey.specimen.pipeline;
 
-import org.labkey.api.annotations.Migrate;
+import org.labkey.api.specimen.pipeline.SpecimenJobSupport;
 import org.labkey.api.study.SpecimenTransform;
 
 import java.io.File;
@@ -23,7 +23,6 @@ import java.io.File;
 /**
  * Created by klum on 5/24/2014.
  */
-@Migrate
 public interface SpecimenReloadJobSupport extends SpecimenJobSupport
 {
     void setSpecimenArchive(File archiveFile);

--- a/specimen/src/org/labkey/specimen/pipeline/SpecimenReloadTask.java
+++ b/specimen/src/org/labkey/specimen/pipeline/SpecimenReloadTask.java
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.labkey.api.specimen.pipeline;
+package org.labkey.specimen.pipeline;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.annotations.Migrate;
 import org.labkey.api.pipeline.AbstractTaskFactory;
 import org.labkey.api.pipeline.AbstractTaskFactorySettings;
 import org.labkey.api.pipeline.PipeRoot;
@@ -36,7 +35,6 @@ import java.util.List;
 /**
  * Created by klum on 5/24/2014.
  */
-@Migrate // studyContext.xml is the only dependent
 public class SpecimenReloadTask extends PipelineJob.Task<SpecimenReloadTask.Factory>
 {
     private SpecimenReloadTask(Factory factory, PipelineJob job)

--- a/specimen/src/org/labkey/specimen/pipeline/StandaloneSpecimenTask.java
+++ b/specimen/src/org/labkey/specimen/pipeline/StandaloneSpecimenTask.java
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package org.labkey.api.specimen.pipeline;
+package org.labkey.specimen.pipeline;
 
-import org.labkey.api.annotations.Migrate;
 import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.specimen.pipeline.AbstractSpecimenTask;
+import org.labkey.api.specimen.pipeline.AbstractSpecimenTaskFactory;
 
 /*
 * User: adam
@@ -26,7 +27,6 @@ import org.labkey.api.pipeline.PipelineJob;
 */
 
 // This task is used to import specimen archives directly via the pipeline ui. SpecimenBatch is the associated pipeline job.
-@Migrate // studyContext.xml is the only dependent
 public class StandaloneSpecimenTask extends AbstractSpecimenTask<StandaloneSpecimenTask.Factory>
 {
     private StandaloneSpecimenTask(Factory factory, PipelineJob job)

--- a/specimen/webapp/WEB-INF/specimen/specimenContext.xml
+++ b/specimen/webapp/WEB-INF/specimen/specimenContext.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+    <bean id="specimenPipelineRegistry" class="org.labkey.api.pipeline.TaskPipelineRegistrar">
+        <property name="factoryImpls">
+            <list>
+                <bean class="org.labkey.api.specimen.pipeline.StandaloneSpecimenTask$Factory"/>
+                <bean class="org.labkey.api.specimen.pipeline.SpecimenReloadTask$Factory"/>
+                <bean class="org.labkey.api.specimen.pipeline.FileAnalysisSpecimenTask$Factory"/>
+            </list>
+        </property>
+
+        <property name="pipelines">
+            <list>
+                <!-- Standalone specimen import pipeline -->
+                <bean class="org.labkey.api.pipeline.TaskPipelineSettings">
+                    <constructor-arg type="java.lang.Class" value="org.labkey.api.specimen.pipeline.SpecimenBatch"/>
+                    <property name="taskProgressionSpec">
+                        <list>
+                            <bean id="standaloneSpecimenTask" class="org.labkey.api.pipeline.TaskId">
+                                <constructor-arg><value type="java.lang.Class">org.labkey.api.specimen.pipeline.StandaloneSpecimenTask</value></constructor-arg>
+                            </bean>
+                        </list>
+                    </property>
+                </bean>
+
+                <!-- Specimen reload job pipeline -->
+                <bean class="org.labkey.api.pipeline.TaskPipelineSettings">
+                    <constructor-arg type="java.lang.Class" value="org.labkey.api.specimen.pipeline.SpecimenReloadJob"/>
+                    <property name="taskProgressionSpec">
+                        <list>
+                            <bean id="importTask" class="org.labkey.api.pipeline.TaskId">
+                                <constructor-arg><value type="java.lang.Class">org.labkey.api.specimen.pipeline.SpecimenReloadTask</value></constructor-arg>
+                            </bean>
+                            <bean id="specimenReloadTask" class="org.labkey.api.pipeline.TaskId">
+                                <constructor-arg><value type="java.lang.Class">org.labkey.api.specimen.pipeline.StandaloneSpecimenTask</value></constructor-arg>
+                            </bean>
+                        </list>
+                    </property>
+                </bean>
+
+                <bean class="org.labkey.api.pipeline.file.FileAnalysisTaskPipelineSettings">
+                    <constructor-arg value="specimenImportTask"/>
+                    <property name="description" value="Imports specimen data using data file"/>
+                    <property name="protocolObjectId" value="specimen.specimenImport"/>
+                    <property name="protocolName" value="Specimen Import"/>
+                    <property name="protocolFactoryName" value="specimenImport"/>
+                    <property name="defaultDisplayState" value="hidden"/>
+                    <property name="allowForTriggerConfiguration" value="true"/>
+                    <property name="initialInputExts">
+                        <list>
+                            <ref bean="zipFileType"/>
+                            <ref bean="tsvFileType"/>
+                            <ref bean="specimensFileType"/>
+                        </list>
+                    </property>
+                    <property name="taskProgressionSpec">
+                        <list>
+                            <bean id="specimenImportTask" class="org.labkey.api.pipeline.TaskId">
+                                <constructor-arg><value type="java.lang.Class">org.labkey.api.specimen.pipeline.FileAnalysisSpecimenTask</value></constructor-arg>
+                            </bean>
+                        </list>
+                    </property>
+                    <property name="helpText" value="The selected Pipeline task can only be initiated on .zip and .tsv files."/>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="specimensFileType" class="org.labkey.api.util.FileType">
+        <constructor-arg value=".specimens"/>
+    </bean>
+    <bean id="tsvFileType" class="org.labkey.api.util.FileType">
+        <constructor-arg value=".tsv"/>
+    </bean>
+    <bean id="zipFileType" class="org.labkey.api.util.FileType">
+        <constructor-arg value=".zip"/>
+    </bean>
+</beans>

--- a/specimen/webapp/WEB-INF/specimen/specimenContext.xml
+++ b/specimen/webapp/WEB-INF/specimen/specimenContext.xml
@@ -6,9 +6,9 @@
     <bean id="specimenPipelineRegistry" class="org.labkey.api.pipeline.TaskPipelineRegistrar">
         <property name="factoryImpls">
             <list>
-                <bean class="org.labkey.api.specimen.pipeline.StandaloneSpecimenTask$Factory"/>
-                <bean class="org.labkey.api.specimen.pipeline.SpecimenReloadTask$Factory"/>
-                <bean class="org.labkey.api.specimen.pipeline.FileAnalysisSpecimenTask$Factory"/>
+                <bean class="org.labkey.specimen.pipeline.StandaloneSpecimenTask$Factory"/>
+                <bean class="org.labkey.specimen.pipeline.SpecimenReloadTask$Factory"/>
+                <bean class="org.labkey.specimen.pipeline.FileAnalysisSpecimenTask$Factory"/>
             </list>
         </property>
 
@@ -20,7 +20,7 @@
                     <property name="taskProgressionSpec">
                         <list>
                             <bean id="standaloneSpecimenTask" class="org.labkey.api.pipeline.TaskId">
-                                <constructor-arg><value type="java.lang.Class">org.labkey.api.specimen.pipeline.StandaloneSpecimenTask</value></constructor-arg>
+                                <constructor-arg><value type="java.lang.Class">org.labkey.specimen.pipeline.StandaloneSpecimenTask</value></constructor-arg>
                             </bean>
                         </list>
                     </property>
@@ -28,14 +28,14 @@
 
                 <!-- Specimen reload job pipeline -->
                 <bean class="org.labkey.api.pipeline.TaskPipelineSettings">
-                    <constructor-arg type="java.lang.Class" value="org.labkey.api.specimen.pipeline.SpecimenReloadJob"/>
+                    <constructor-arg type="java.lang.Class" value="org.labkey.specimen.pipeline.SpecimenReloadJob"/>
                     <property name="taskProgressionSpec">
                         <list>
                             <bean id="importTask" class="org.labkey.api.pipeline.TaskId">
-                                <constructor-arg><value type="java.lang.Class">org.labkey.api.specimen.pipeline.SpecimenReloadTask</value></constructor-arg>
+                                <constructor-arg><value type="java.lang.Class">org.labkey.specimen.pipeline.SpecimenReloadTask</value></constructor-arg>
                             </bean>
                             <bean id="specimenReloadTask" class="org.labkey.api.pipeline.TaskId">
-                                <constructor-arg><value type="java.lang.Class">org.labkey.api.specimen.pipeline.StandaloneSpecimenTask</value></constructor-arg>
+                                <constructor-arg><value type="java.lang.Class">org.labkey.specimen.pipeline.StandaloneSpecimenTask</value></constructor-arg>
                             </bean>
                         </list>
                     </property>
@@ -59,7 +59,7 @@
                     <property name="taskProgressionSpec">
                         <list>
                             <bean id="specimenImportTask" class="org.labkey.api.pipeline.TaskId">
-                                <constructor-arg><value type="java.lang.Class">org.labkey.api.specimen.pipeline.FileAnalysisSpecimenTask</value></constructor-arg>
+                                <constructor-arg><value type="java.lang.Class">org.labkey.specimen.pipeline.FileAnalysisSpecimenTask</value></constructor-arg>
                             </bean>
                         </list>
                     </property>

--- a/study/api-src/org/labkey/api/specimen/pipeline/AbstractSpecimenTask.java
+++ b/study/api-src/org/labkey/api/specimen/pipeline/AbstractSpecimenTask.java
@@ -84,7 +84,7 @@ public abstract class AbstractSpecimenTask<FactoryType extends AbstractSpecimenT
         return support.getSpecimenArchive();
     }
 
-    SimpleStudyImportContext getImportContext(PipelineJob job)
+    protected SimpleStudyImportContext getImportContext(PipelineJob job)
     {
         return job.getJobSupport(SpecimenJobSupport.class).getImportContext();
     }

--- a/study/api-src/org/labkey/api/specimen/pipeline/SpecimenReloadJobSupport.java
+++ b/study/api-src/org/labkey/api/specimen/pipeline/SpecimenReloadJobSupport.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.specimen.pipeline;
 
+import org.labkey.api.annotations.Migrate;
 import org.labkey.api.study.SpecimenTransform;
 
 import java.io.File;
@@ -22,6 +23,7 @@ import java.io.File;
 /**
  * Created by klum on 5/24/2014.
  */
+@Migrate
 public interface SpecimenReloadJobSupport extends SpecimenJobSupport
 {
     void setSpecimenArchive(File archiveFile);

--- a/study/src/org/labkey/study/importer/AbstractStudyPipelineJob.java
+++ b/study/src/org/labkey/study/importer/AbstractStudyPipelineJob.java
@@ -25,6 +25,7 @@ import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.portal.ProjectUrls;
 import org.labkey.api.security.User;
+import org.labkey.api.specimen.pipeline.StudyImportSpecimenTask;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
@@ -33,7 +34,6 @@ import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.writer.VirtualFile;
 import org.labkey.study.model.StudyImpl;
-import org.labkey.api.specimen.pipeline.StudyImportSpecimenTask;
 import org.labkey.study.xml.StudyDocument;
 
 import java.io.File;

--- a/study/webapp/WEB-INF/study/studyContext.xml
+++ b/study/webapp/WEB-INF/study/studyContext.xml
@@ -6,19 +6,14 @@
     <bean id="studyPipelineRegistry" class="org.labkey.api.pipeline.TaskPipelineRegistrar">
         <property name="factoryImpls">
             <list>
-                <bean class="org.labkey.study.importer.StudyImportInitialTask$Factory"/>
-                <bean class="org.labkey.study.pipeline.StudyImportDatasetTask$Factory"/>
-                <bean class="org.labkey.api.specimen.pipeline.StudyImportSpecimenTask$Factory"/>
                 <bean class="org.labkey.study.importer.StudyImportFinalTask$Factory"/>
-
-                <bean class="org.labkey.study.pipeline.StandaloneDatasetTask$Factory"/>
-                <bean class="org.labkey.api.specimen.pipeline.StandaloneSpecimenTask$Factory"/>
-
-                <bean class="org.labkey.api.specimen.pipeline.SpecimenReloadTask$Factory"/>
-                <bean class="org.labkey.study.pipeline.StudyReloadSourceTask$Factory"/>
-                <bean class="org.labkey.study.pipeline.FileAnalysisDatasetTask$Factory"/>
+                <bean class="org.labkey.study.importer.StudyImportInitialTask$Factory"/>
                 <bean class="org.labkey.study.importer.StudyReloadTask$Factory"/>
-                <bean class="org.labkey.api.specimen.pipeline.FileAnalysisSpecimenTask$Factory"/>
+                <bean class="org.labkey.study.pipeline.FileAnalysisDatasetTask$Factory"/>
+                <bean class="org.labkey.study.pipeline.StandaloneDatasetTask$Factory"/>
+                <bean class="org.labkey.study.pipeline.StudyImportDatasetTask$Factory"/>
+                <bean class="org.labkey.study.pipeline.StudyReloadSourceTask$Factory"/>
+                <bean class="org.labkey.api.specimen.pipeline.StudyImportSpecimenTask$Factory"/>
             </list>
         </property>
 
@@ -45,18 +40,6 @@
                     </property>
                 </bean>
 
-                <!-- Standalone specimen import pipeline -->
-                <bean class="org.labkey.api.pipeline.TaskPipelineSettings">
-                    <constructor-arg type="java.lang.Class" value="org.labkey.api.specimen.pipeline.SpecimenBatch"/>
-                    <property name="taskProgressionSpec">
-                        <list>
-                            <bean id="standaloneSpecimenTask" class="org.labkey.api.pipeline.TaskId">
-                                <constructor-arg><value type="java.lang.Class">org.labkey.api.specimen.pipeline.StandaloneSpecimenTask</value></constructor-arg>
-                            </bean>
-                        </list>
-                    </property>
-                </bean>
-
                 <!-- Standalone dataset import pipeline -->
                 <bean class="org.labkey.api.pipeline.TaskPipelineSettings">
                     <constructor-arg type="java.lang.Class" value="org.labkey.study.pipeline.DatasetBatch"/>
@@ -64,21 +47,6 @@
                         <list>
                             <bean id="standaloneDatasetTask" class="org.labkey.api.pipeline.TaskId">
                                 <constructor-arg><value type="java.lang.Class">org.labkey.study.pipeline.StandaloneDatasetTask</value></constructor-arg>
-                            </bean>
-                        </list>
-                    </property>
-                </bean>
-
-                <!-- Specimen reload job pipeline -->
-                <bean class="org.labkey.api.pipeline.TaskPipelineSettings">
-                    <constructor-arg type="java.lang.Class" value="org.labkey.api.specimen.pipeline.SpecimenReloadJob"/>
-                    <property name="taskProgressionSpec">
-                        <list>
-                            <bean id="importTask" class="org.labkey.api.pipeline.TaskId">
-                                <constructor-arg><value type="java.lang.Class">org.labkey.api.specimen.pipeline.SpecimenReloadTask</value></constructor-arg>
-                            </bean>
-                            <bean id="specimenReloadTask" class="org.labkey.api.pipeline.TaskId">
-                                <constructor-arg><value type="java.lang.Class">org.labkey.api.specimen.pipeline.StandaloneSpecimenTask</value></constructor-arg>
                             </bean>
                         </list>
                     </property>
@@ -158,31 +126,6 @@
                     </property>
                     <property name="helpText" value="The selected Pipeline task should only be initiated on a studyload.txt file underneath a pipeline root, and will only analyze exploded study archives. It will not accept compressed (.zip) study archives." />
                 </bean>
-
-                <bean class="org.labkey.api.pipeline.file.FileAnalysisTaskPipelineSettings">
-                    <constructor-arg value="specimenImportTask"/>
-                    <property name="description" value="Imports specimen data using data file"/>
-                    <property name="protocolObjectId" value="specimen.specimenImport"/>
-                    <property name="protocolName" value="Specimen Import"/>
-                    <property name="protocolFactoryName" value="specimenImport"/>
-                    <property name="defaultDisplayState" value="hidden"/>
-                    <property name="allowForTriggerConfiguration" value="true"/>
-                    <property name="initialInputExts">
-                        <list>
-                            <ref bean="zipFileType"/>
-                            <ref bean="tsvFileType"/>
-                            <ref bean="specimensFileType"/>
-                        </list>
-                    </property>
-                    <property name="taskProgressionSpec">
-                        <list>
-                            <bean id="specimenImportTask" class="org.labkey.api.pipeline.TaskId">
-                                <constructor-arg><value type="java.lang.Class">org.labkey.api.specimen.pipeline.FileAnalysisSpecimenTask</value></constructor-arg>
-                            </bean>
-                        </list>
-                    </property>
-                    <property name="helpText" value="The selected Pipeline task can only be initiated on .zip and .tsv files."/>
-                </bean>
             </list>
         </property>
     </bean>
@@ -199,11 +142,4 @@
     <bean id="txtFileType" class="org.labkey.api.util.FileType">
         <constructor-arg value=".txt"/>
     </bean>
-    <bean id="zipFileType" class="org.labkey.api.util.FileType">
-        <constructor-arg value=".zip"/>
-    </bean>
-    <bean id="specimensFileType" class="org.labkey.api.util.FileType">
-        <constructor-arg value=".specimens"/>
-    </bean>
-
 </beans>


### PR DESCRIPTION
#### Rationale
Haven't you noticed? We're moving specimen code from the study module to the specimen module. In this case, most of the specimen pipelines and tasks.

#### Changes
* Create specimenContext.xml and register most specimen pipelines and tasks there
* Move FileAnalysisSpecimenTask, SpecimenReloadJob, SpecimenReloadJobSupport, SpecimenReloadTask, and StandaloneSpecimenTask to specimen-main