### PR TITLE
Issue 42468: Respect email subscription settings for message board moderators

### DIFF
--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -341,7 +341,7 @@ public class AnnouncementManager
 
         if (toList.isEmpty())
         {
-            LogManager.getLogger(AnnouncementManager.class).warn("New " + name.toLowerCase() + " requires moderator review, but no moderators are subscribed in this folder: " + c.getPath());
+            LogManager.getLogger(AnnouncementManager.class).warn("New " + name.toLowerCase() + " requires moderator review, but no moderators are subscribed to receive 'all' messages in this folder: " + c.getPath());
         }
         else
         {

--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -326,13 +326,22 @@ public class AnnouncementManager
     {
         String name = AnnouncementManager.getMessageBoardSettings(c).getConversationName();
         BulkEmailer emailer = new BulkEmailer(user);
-        List<String> toList = SecurityManager.getUsersWithPermissions(c, Collections.singleton(AdminPermission.class)).stream()
+
+        // Only admins should be part of the moderator review process, but we will still respect their email subscription
+        // preferences for this container
+        IndividualEmailPrefsSelector sel = new IndividualEmailPrefsSelector(c);
+        Set<User> subscribers = sel.getNotificationUsers(ann);
+
+        List<User> admins = SecurityManager.getUsersWithPermissions(c, Collections.singleton(AdminPermission.class));
+        admins.retainAll(subscribers);
+
+        List<String> toList = admins.stream()
             .map(User::getEmail)
             .collect(Collectors.toList());
 
         if (toList.isEmpty())
         {
-            LogManager.getLogger(AnnouncementManager.class).warn("New " + name.toLowerCase() + " requires moderator review, but no moderators are authorized in this folder: " + c.getPath());
+            LogManager.getLogger(AnnouncementManager.class).warn("New " + name.toLowerCase() + " requires moderator review, but no moderators are subscribed in this folder: " + c.getPath());
         }
         else
         {

--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -341,7 +341,8 @@ public class AnnouncementManager
 
         if (toList.isEmpty())
         {
-            LogManager.getLogger(AnnouncementManager.class).warn("New " + name.toLowerCase() + " requires moderator review, but no moderators are subscribed to receive 'all' messages in this folder: " + c.getPath());
+            LogManager.getLogger(AnnouncementManager.class).warn("New " + name.toLowerCase() + " requires moderator review, but no moderators are subscribed to receive 'Individual' notifications in this folder: " + c.getPath());
+
         }
         else
         {


### PR DESCRIPTION
#### Rationale
We introduced innovative, industry-leading moderator review workflow for message boards to reduce spam posts. It currently emails everyone who has admin access to the folder, including all site admins.

That's working OK for us on labkey.org (our primary use case) but it's causing more mail than desired on other installs

#### Changes
* Use the message board's email settings first, and then filter to exclude non-admins for receiving the moderator review.
