### PR TITLE
- add JspBase.jsURL based on code review feedback

### DIFF
--- a/api/src/org/labkey/api/jsp/JspBase.java
+++ b/api/src/org/labkey/api/jsp/JspBase.java
@@ -280,6 +280,27 @@ public abstract class JspBase extends JspContext implements HasViewContext
         return PageFlowUtil.encode(str);
     }
 
+    /**
+     * Creates a JavaScript URL object for the passed in ActionURL.
+     * Returns the JavaScript fragment:<br>
+     * <br>
+     * <code>new URL(url.getURLString());</code><br>
+     * <br>
+     * Using the browser native URL object is preferred over manually constructing a url string to avoid
+     * URL encoding issues. Example usage:<br>
+     * <br>
+     * <code>
+     *     // in a script block of a JSP<br>
+     *     let url = <%=jsURL(new ActionURL(...))>;<br>
+     *     url.searchParams.set('icecream?', 'salt &amp; straw');<br>
+     *     window.location.href = url;
+     * </code>
+     */
+    public JavaScriptFragment jsURL(@NotNull URLHelper url)
+    {
+        return JavaScriptFragment.unsafe("new URL(" + q(url.getURIString()) + ")");
+    }
+
 
     private static final HtmlString CHECKED = HtmlString.of(" checked");
 


### PR DESCRIPTION
#### Rationale
With the experimental no-question-mark-url flag enabled, it isn't safe to concatenate parameters to the end of a URL.
Introduce `JspBase.jsURL()` convenience method that can be used in jsp code to create a browser URL object.

#### Related Pull Requests
- https://github.com/LabKey/MacCossLabModules/pull/96

#### Changes
- Add `JspBase.jsURL()` method