### PR TITLE
Add one missing JSONB function to the list

### DIFF
--- a/query/src/org/labkey/query/sql/Method.java
+++ b/query/src/org/labkey/query/sql/Method.java
@@ -1505,6 +1505,7 @@ public abstract class Method
         addJsonPassthroughMethod("strip_nulls", JdbcType.OTHER, 1, 1);
 
         postgresMethods.put("jsonb_set", new PassthroughMethod("jsonb_set", JdbcType.OTHER, 3, 4));
+        postgresMethods.put("jsonb_insert", new PassthroughMethod("jsonb_set", JdbcType.OTHER, 3, 4));
         postgresMethods.put("jsonb_pretty", new PassthroughMethod("jsonb_pretty", JdbcType.VARCHAR, 1, 1));
     }
 


### PR DESCRIPTION
#### Rationale
In prepping the docs for the new JSON passthroughs, I noticed that Postgres 9.6+ added a new function

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1996

#### Changes
* Add jsonb_insert to our list
