### PR TITLE
Issue 42490: NPE When Moving a Folder via Folder Mgmt UI

### DIFF
--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -671,7 +671,12 @@ public class FileUtil
                 throw new IOException("Unable to create the directory " + dest.toString() + "!");
         }
 
-        for(File file : src.listFiles())
+        File[] children = src.listFiles();
+        if (children == null)
+        {
+            throw new IOException("Unable to get file listing for directory: " + src);
+        }
+        for (File file : children)
         {
             copyBranch(file, dest, false);
         }

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -1101,9 +1101,10 @@ public class FileContentServiceImpl implements FileContentService
                 _log.info("rename failed, attempting to copy");
 
                 //listFiles can return null, which could cause a NPE
-                if (prev.listFiles() != null)
+                File[] children = prev.listFiles();
+                if (children != null)
                 {
-                    for (File file : prev.listFiles())
+                    for (File file : children)
                         FileUtil.copyBranch(file, dest);
                 }
                 FileUtil.deleteDir(prev);


### PR DESCRIPTION
#### Rationale
File.listFiles() can return null if it fails to get a list of files. A case where the user doesn't have permission to a subdirectory is probably the most common case. We can't fully recover from this during a move, but we can at least report something better in terms of the problem

#### Changes
* Add a null check and throw an IOException with the problematic path