### PR TITLE
Create separate notification type for folder imports

### DIFF
--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -1809,6 +1809,11 @@ abstract public class PipelineJob extends Job implements Serializable
         return null;
     }
 
+    protected String getNotificationType(PipelineJob.TaskStatus status)
+    {
+        return status.getNotificationType();
+    }
+
     public static String serializeJob(PipelineJob job)
     {
         return serializeJob(job, true);

--- a/api/src/org/labkey/api/pipeline/PipelineJobNotificationProvider.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJobNotificationProvider.java
@@ -93,7 +93,7 @@ public interface PipelineJobNotificationProvider
             User user = job.getUser();
             PipelineJob.TaskStatus status = job.getActiveTaskStatus();
 
-            Notification n = new Notification(job.getJobGUID(), status.getNotificationType(), user);
+            Notification n = new Notification(job.getJobGUID(), job.getNotificationType(status), user);
             if (StringUtils.isEmpty(msgContent))
             {
                 String description = StringUtils.defaultString(job.getDescription(), job.toString());

--- a/pipeline/src/org/labkey/pipeline/PipelineModule.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineModule.java
@@ -72,6 +72,7 @@ import org.labkey.pipeline.api.PipelineStatusManager;
 import org.labkey.pipeline.api.ScriptTaskFactory;
 import org.labkey.pipeline.api.properties.ApplicationPropertiesSiteSettings;
 import org.labkey.pipeline.cluster.ClusterStartup;
+import org.labkey.pipeline.importer.FolderImportJob;
 import org.labkey.pipeline.importer.FolderImportProvider;
 import org.labkey.pipeline.mule.EPipelineContextListener;
 import org.labkey.pipeline.mule.EPipelineQueueImpl;
@@ -133,6 +134,9 @@ public class PipelineModule extends SpringModule implements ContainerManager.Con
         NotificationService.get().registerNotificationType(PipelineJob.TaskStatus.complete.getNotificationType(), "Pipeline", "fa-check-circle");
         NotificationService.get().registerNotificationType(PipelineJob.TaskStatus.cancelled.getNotificationType(), "Pipeline", "fa-ban");
         NotificationService.get().registerNotificationType(PipelineJob.TaskStatus.error.getNotificationType(), "Pipeline", "fa-exclamation-triangle");
+        NotificationService.get().registerNotificationType(FolderImportJob.IMPORT_COMPLETED_NOTIFICATION, "Folder Import", "fa-check-circle");
+        NotificationService.get().registerNotificationType(FolderImportJob.IMPORT_CANCELLED_NOTIFICATION, "Folder Import", "fa-ban");
+        NotificationService.get().registerNotificationType(FolderImportJob.IMPORT_ERROR_NOTIFICATION, "Folder Import", "fa-exclamation-triangle");
 
         PipelineQuerySchema.register(this);
 

--- a/pipeline/src/org/labkey/pipeline/importer/FolderImportJob.java
+++ b/pipeline/src/org/labkey/pipeline/importer/FolderImportJob.java
@@ -47,6 +47,10 @@ public class FolderImportJob extends PipelineJob implements FolderJobSupport
 {
     private static final Logger LOG = LogManager.getLogger(FolderImportJob.class);
 
+    public static final String IMPORT_COMPLETED_NOTIFICATION = FolderImportJob.class.getName() + "." + PipelineJob.TaskStatus.complete.name();
+    public static final String IMPORT_CANCELLED_NOTIFICATION = FolderImportJob.class.getName() + "." + PipelineJob.TaskStatus.cancelled.name();
+    public static final String IMPORT_ERROR_NOTIFICATION = FolderImportJob.class.getName() + "." + PipelineJob.TaskStatus.error.name();
+
     private final FolderImportContext _ctx;
     private final VirtualFile _root;
     private final String _originalFilename;
@@ -110,5 +114,17 @@ public class FolderImportJob extends PipelineJob implements FolderJobSupport
     public String getDescription()
     {
         return "Folder import";
+    }
+
+    @Override
+    protected String getNotificationType(PipelineJob.TaskStatus status)
+    {
+        return switch (status)
+                {
+                    case complete -> IMPORT_COMPLETED_NOTIFICATION;
+                    case error -> IMPORT_ERROR_NOTIFICATION;
+                    case cancelled -> IMPORT_CANCELLED_NOTIFICATION;
+                    default -> status.getNotificationType();
+                };
     }
 }


### PR DESCRIPTION
#### Rationale
A folder import is just a pipeline job, and if subscribing to pipeline job notifications, we'll show folder imports in that set.  These imports are less functionally interesting than, say, background imports of assay data and we don't want to surface them in the LKSM application.  We add a new type of notification that applications can subscribe to or not, as appropriate.

#### Changes
* Register new notification types for folder import activities
