### PR TITLE
Add controller alias to match @labkey/api expectations

### DIFF
--- a/specimen/src/org/labkey/specimen/SpecimenModule.java
+++ b/specimen/src/org/labkey/specimen/SpecimenModule.java
@@ -101,7 +101,7 @@ public class SpecimenModule extends SpringModule
 
         AttachmentService.get().registerAttachmentType(SpecimenRequestEventType.get());
 
-        addController("specimen-api", SpecimenApiController.class, "study-samples-api");
+        addController("specimen-api", SpecimenApiController.class, "study-samples-api", "specimens-api");
 
         // Register early -- some modules don't declare a runtime dependency on specimen module, but will use the
         // service if it's available


### PR DESCRIPTION
#### Rationale
Many tests failed last night due to the new version of `@labkey/api` expecting `specimens-api` controller name instead of `specimen-api`. Add an alias to stop the carnage.

Boneheaded mistake by yours truly. Credit @labkey-matthewb for pointing out the mismatch.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/87