### PR TITLE
Fix failing publish tests

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
@@ -264,8 +264,8 @@ public class SharedStudyTest extends BaseWebDriverTest
         click(Locator.css(".studyWizardVisitList .x-grid3-hd-checker  div"));
         clickButton("Next", 0);
 
-        // Wizard page 5 : Specimens, if present
-        if (_studyHelper.isSpecimenModulePresent())
+        // Wizard page 5 : Specimens, if present & active
+        if (_studyHelper.isSpecimenModuleActive())
         {
             clickButton("Next", 0);
         }

--- a/study/test/src/org/labkey/test/tests/study/StudyDateAndContinuousTimepointTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDateAndContinuousTimepointTest.java
@@ -159,8 +159,8 @@ public class StudyDateAndContinuousTimepointTest extends BaseWebDriverTest
             clickButton("Next", 0);
         }
 
-        //specimens, if present
-        if (_studyHelper.isSpecimenModulePresent())
+        //specimens, if present & active
+        if (_studyHelper.isSpecimenModuleActive())
         {
             waitForElement(Locator.xpath("//div[@class = 'labkey-nav-page-header'][text() = 'Specimens']"));
             clickButton("Next", 0);

--- a/study/test/src/org/labkey/test/tests/study/StudyPHIExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPHIExportTest.java
@@ -84,7 +84,6 @@ public class StudyPHIExportTest extends StudyExportTest
 
         waitForText("No matching Mice");
 
-
         _ext4Helper.clickParticipantFilterGridRowText("Group 1", 0);
         waitForText("Found 10 mice of 25");
         assertElementPresent(Locator.xpath("//a[contains(@href, 'participant.view')]"), 10);
@@ -185,7 +184,7 @@ public class StudyPHIExportTest extends StudyExportTest
         clickAndWait(Locator.linkContainingText("datasets"));
     }
 
-    protected  void verifyMaskedClinics(int clinicCount)
+    protected void verifyMaskedClinics(int clinicCount)
     {
         List<String> nonClinics = new ArrayList<>();
 

--- a/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
@@ -839,8 +839,8 @@ public class StudyPublishTest extends StudyPHIExportTest
         verifyPublishWizardSelectedCheckboxes(StudyPublishWizardGrid.studyWizardVisitList, "Screening", "Grp1:F/U/Grp2:V#2", "G1: V#2/G2: V#3");
         clickButton("Next", 0);
 
-        // Wizard page 5 : Specimens, if present
-        if (_studyHelper.isSpecimenModulePresent())
+        // Wizard page 5 : Specimens, if present & active
+        if (_studyHelper.isSpecimenModuleActive())
         {
             waitForElement(Locator.xpath("//div[@class = 'labkey-nav-page-header'][text() = 'Specimens']"));
             Assert.assertTrue(Locator.checkboxByName("includeSpecimens").findElement(getDriver()).isSelected());


### PR DESCRIPTION
#### Rationale
The "Specimens" tab appears in the publish study wizard only if the specimen module is present and active in the current container. Some publish study tests are failing because they aren't checking whether the specimen module is active. 

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/644

#### Changes
* Conditionalize presence of "Specimens" tab in publish wizard on specimen module being active in the current folder
