### PR TITLE
Issue 41202: Allow submitter to insert rows into a dataset

### DIFF
--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -130,7 +130,12 @@ public interface Dataset<T extends Dataset> extends StudyEntity, StudyCachable<T
     /**
      * @return whether the user has permission to update the dataset
      */
-    public boolean canEdit(UserPrincipal user);
+    public boolean canUpdate(UserPrincipal user);
+
+    /**
+     * @return whether the user has permission to delete from the dataset
+     */
+    public boolean canDelete(UserPrincipal user);
 
     /**
      * @return whether the user has permission to insert rows into the dataset

--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -128,9 +128,14 @@ public interface Dataset<T extends Dataset> extends StudyEntity, StudyCachable<T
     public boolean canRead(UserPrincipal user);
 
     /**
-     * @return whether the user has permission to write to the dataset
+     * @return whether the user has permission to update the dataset
      */
-    public boolean canWrite(UserPrincipal user);
+    public boolean canEdit(UserPrincipal user);
+
+    /**
+     * @return whether the user has permission to insert rows into the dataset
+     */
+    public boolean canInsert(UserPrincipal user);
 
     /**
      * @return whether the user has permission to delete the entire dataset. Use canWrite() to check if user can delete

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -107,7 +107,6 @@ import org.labkey.api.util.GUID;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.TestContext;
-import org.labkey.api.util.URIUtil;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
@@ -3725,7 +3724,7 @@ public class ExperimentServiceImpl implements ExperimentService
 
                             for (Dataset dataset : studyService.getDatasetsForAssayRuns(Collections.singletonList(run), user))
                             {
-                                if (!dataset.canWrite(user))
+                                if (!dataset.canEdit(user))
                                 {
                                     throw new UnauthorizedException("Cannot delete rows from dataset " + dataset);
                                 }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -3724,7 +3724,7 @@ public class ExperimentServiceImpl implements ExperimentService
 
                             for (Dataset dataset : studyService.getDatasetsForAssayRuns(Collections.singletonList(run), user))
                             {
-                                if (!dataset.canEdit(user))
+                                if (!dataset.canDelete(user))
                                 {
                                     throw new UnauthorizedException("Cannot delete rows from dataset " + dataset);
                                 }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -2880,7 +2880,7 @@ public class ExperimentController extends SpringActionController
                 for (Dataset dataset : StudyService.get().getDatasetsForAssayRuns(runs, getUser()))
                 {
                     ActionURL url = urlProvider(StudyUrls.class).getDatasetURL(dataset.getContainer(), dataset.getDatasetId());
-                    if (dataset.canEdit(getUser()))
+                    if (dataset.canDelete(getUser()))
                     {
                         permissionDatasetRows.add(new Pair<>(dataset, url));
                     }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -36,7 +36,6 @@ import org.labkey.api.action.ExportAction;
 import org.labkey.api.action.FormHandlerAction;
 import org.labkey.api.action.FormViewAction;
 import org.labkey.api.action.HasViewContext;
-import org.labkey.api.action.LabKeyError;
 import org.labkey.api.action.Marshal;
 import org.labkey.api.action.Marshaller;
 import org.labkey.api.action.MutatingApiAction;
@@ -2881,7 +2880,7 @@ public class ExperimentController extends SpringActionController
                 for (Dataset dataset : StudyService.get().getDatasetsForAssayRuns(runs, getUser()))
                 {
                     ActionURL url = urlProvider(StudyUrls.class).getDatasetURL(dataset.getContainer(), dataset.getDatasetId());
-                    if (dataset.canWrite(getUser()))
+                    if (dataset.canEdit(getUser()))
                     {
                         permissionDatasetRows.add(new Pair<>(dataset, url));
                     }

--- a/study/src/org/labkey/study/controllers/InsertUpdateAction.java
+++ b/study/src/org/labkey/study/controllers/InsertUpdateAction.java
@@ -129,7 +129,7 @@ public abstract class InsertUpdateAction<Form extends DatasetController.EditData
         {
             throw new UnauthorizedException("User does not have permission to insert into this dataset");
         }
-        if (!_ds.canEdit(getUser()))
+        if (!isInsert() && !_ds.canUpdate(getUser()))
         {
             throw new UnauthorizedException("User does not have permission to edit this dataset");
         }
@@ -294,7 +294,7 @@ public abstract class InsertUpdateAction<Form extends DatasetController.EditData
         {
             throw new UnauthorizedException("User does not have permission to insert into this dataset");
         }
-        else if (!isInsert && !_ds.canEdit(user))
+        else if (!isInsert && !_ds.canUpdate(user))
         {
             throw new UnauthorizedException("User does not have permission to edit this dataset");
         }

--- a/study/src/org/labkey/study/controllers/InsertUpdateAction.java
+++ b/study/src/org/labkey/study/controllers/InsertUpdateAction.java
@@ -114,6 +114,7 @@ public abstract class InsertUpdateAction<Form extends DatasetController.EditData
     public ModelAndView getView(Form form, boolean reshow, BindException errors) throws Exception
     {
         StudyImpl study = getStudy();
+
         _ds = StudyManager.getInstance().getDatasetDefinition(getStudy(), form.getDatasetId());
         if (null == _ds)
         {
@@ -124,7 +125,11 @@ public abstract class InsertUpdateAction<Form extends DatasetController.EditData
         {
             throw new UnauthorizedException("User does not have permission to view this dataset");
         }
-        if (!_ds.canWrite(getUser()))
+        if (isInsert() && !_ds.canInsert(getUser()))
+        {
+            throw new UnauthorizedException("User does not have permission to insert into this dataset");
+        }
+        if (!_ds.canEdit(getUser()))
         {
             throw new UnauthorizedException("User does not have permission to edit this dataset");
         }
@@ -284,7 +289,12 @@ public abstract class InsertUpdateAction<Form extends DatasetController.EditData
         }
         final Container c = getContainer();
         final User user = getUser();
-        if (!_ds.canWrite(user))
+        boolean isInsert = isInsert();
+        if (isInsert && !_ds.canInsert(user))
+        {
+            throw new UnauthorizedException("User does not have permission to insert into this dataset");
+        }
+        else if (!isInsert && !_ds.canEdit(user))
         {
             throw new UnauthorizedException("User does not have permission to edit this dataset");
         }

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -738,7 +738,7 @@ public class StudyController extends BaseStudyController
 
     private static boolean canWrite(DatasetDefinition def, User user)
     {
-        return def.canEdit(user) && def.getContainer().hasPermission(user, ReadPermission.class);
+        return def.canInsert(user) && def.getContainer().hasPermission(user, ReadPermission.class);
     }
 
 
@@ -2951,7 +2951,7 @@ public class StudyController extends BaseStudyController
             if (null == dataset)
                 throw new NotFoundException();
 
-            if (!dataset.canEdit(getUser()))
+            if (!dataset.canUpdate(getUser()))
                 throw new UnauthorizedException("User does not have permission to delete rows from this dataset");
 
             // Operate on each individually for audit logging purposes, but transact the whole thing

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -738,7 +738,7 @@ public class StudyController extends BaseStudyController
 
     private static boolean canWrite(DatasetDefinition def, User user)
     {
-        return def.canWrite(user) && def.getContainer().hasPermission(user, ReadPermission.class);
+        return def.canEdit(user) && def.getContainer().hasPermission(user, ReadPermission.class);
     }
 
 
@@ -2951,7 +2951,7 @@ public class StudyController extends BaseStudyController
             if (null == dataset)
                 throw new NotFoundException();
 
-            if (!dataset.canWrite(getUser()))
+            if (!dataset.canEdit(getUser()))
                 throw new UnauthorizedException("User does not have permission to delete rows from this dataset");
 
             // Operate on each individually for audit logging purposes, but transact the whole thing

--- a/study/src/org/labkey/study/controllers/specimen/SpecimenUtils.java
+++ b/study/src/org/labkey/study/controllers/specimen/SpecimenUtils.java
@@ -266,7 +266,7 @@ public class SpecimenUtils
                 if (study.getParticipantCommentDatasetId() != null && study.getParticipantCommentDatasetId() != -1)
                 {
                     DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantCommentDatasetId());
-                    if (def != null && def.canWrite(getUser()))
+                    if (def != null && def.canEdit(getUser()))
                     {
                         if (addSep)
                         {
@@ -282,7 +282,7 @@ public class SpecimenUtils
                 if (study.getParticipantVisitCommentDatasetId() != null && study.getParticipantVisitCommentDatasetId() != -1)
                 {
                     DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantVisitCommentDatasetId());
-                    if (def != null && def.canWrite(getUser()))
+                    if (def != null && def.canEdit(getUser()))
                     {
                         if (addSep)
                         {

--- a/study/src/org/labkey/study/controllers/specimen/SpecimenUtils.java
+++ b/study/src/org/labkey/study/controllers/specimen/SpecimenUtils.java
@@ -266,7 +266,7 @@ public class SpecimenUtils
                 if (study.getParticipantCommentDatasetId() != null && study.getParticipantCommentDatasetId() != -1)
                 {
                     DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantCommentDatasetId());
-                    if (def != null && def.canEdit(getUser()))
+                    if (def != null && def.canUpdate(getUser()))
                     {
                         if (addSep)
                         {
@@ -282,7 +282,7 @@ public class SpecimenUtils
                 if (study.getParticipantVisitCommentDatasetId() != null && study.getParticipantVisitCommentDatasetId() != -1)
                 {
                     DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantVisitCommentDatasetId());
-                    if (def != null && def.canEdit(getUser()))
+                    if (def != null && def.canUpdate(getUser()))
                     {
                         if (addSep)
                         {

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -921,6 +921,10 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
                 {
                     result.addAll(RoleManager.getRole(SiteAdminRole.class).getPermissions());
                 }
+                else if (getStudy().getContainer().hasPermission(user, InsertPermission.class))
+                {
+                    result.add(InsertPermission.class);
+                }
                 else if (getStudy().getContainer().hasPermission(user, UpdatePermission.class))
                 {
                     // Basic write access grants insert/update/delete for datasets to everyone who has update permission
@@ -942,6 +946,10 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
                     {
                         result.add(UpdatePermission.class);
                         result.add(DeletePermission.class);
+                        result.add(InsertPermission.class);
+                    }
+                    else if (studyPolicy.hasPermission(user, InsertPermission.class))
+                    {
                         result.add(InsertPermission.class);
                     }
                     // A user can be part of multiple groups, which are set to both Edit All and Per Dataset permissions
@@ -975,7 +983,7 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
 
 
     @Override
-    public boolean canWrite(UserPrincipal user)
+    public boolean canEdit(UserPrincipal user)
     {
         if (getStudy().isDataspaceStudy())
             return false;
@@ -984,6 +992,18 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
         if (getContainer().hasPermission(user, AdminPermission.class))
             return true;
         return getPermissions(user).contains(UpdatePermission.class);
+    }
+
+    @Override
+    public boolean canInsert(UserPrincipal user)
+    {
+        if (getStudy().isDataspaceStudy())
+            return false;
+        if (user instanceof User && !canAccessPhi((User)user))
+            return false;
+        if (getContainer().hasPermission(user, AdminPermission.class))
+            return true;
+        return getPermissions(user).contains(InsertPermission.class);
     }
 
 

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -140,7 +140,7 @@ public class DatasetQueryView extends StudyQueryView
         _showSourceLinks = settings.isShowSourceLinks();
 
         // Only show link to edit if permission allows it
-        setShowUpdateColumn(settings.isShowEditLinks() && !isExportView() && _dataset.canWrite(getUser()));
+        setShowUpdateColumn(settings.isShowEditLinks() && !isExportView() && _dataset.canEdit(getUser()));
 
         if (form.getVisitRowId() != 0)
         {
@@ -380,7 +380,8 @@ public class DatasetQueryView extends StudyQueryView
         bar.add(createExportButton(recordSelectorColumns));
 
         User user = getUser();
-        boolean canWrite = canWrite(_dataset, user);
+        boolean canEdit = canEdit(_dataset, user);
+        boolean canInsert = canInsert(_dataset, user);
         boolean canManage = canManage(_dataset, user);
         boolean isSnapshot = QueryService.get().isQuerySnapshot(getContainer(), StudySchema.getInstance().getSchemaName(), _dataset.getName());
         boolean isAssayDataset = _dataset.isAssayData();
@@ -397,7 +398,7 @@ public class DatasetQueryView extends StudyQueryView
         {
             if (!isAssayDataset) // admins always get the import and manage buttons
             {
-                if (canWrite)
+                if (canInsert)
                 {
                     // insert menu button contain Insert New and Bulk import, or button for either option
                     ActionButton insertButton = createInsertMenuButton();
@@ -408,7 +409,7 @@ public class DatasetQueryView extends StudyQueryView
                     }
                 }
 
-                if (canWrite && _study instanceof StudyImpl)
+                if (canEdit && _study instanceof StudyImpl)
                 {
                     ActionURL deleteRowsURL = urlFor(QueryAction.deleteQueryRows);
                     if (deleteRowsURL != null)
@@ -438,7 +439,7 @@ public class DatasetQueryView extends StudyQueryView
             {
                 bar.addAll(AssayService.get().getImportButtons(protocol, getUser(), getContainer(), true));
 
-                if (user.hasRootAdminPermission() || canWrite)
+                if (user.hasRootAdminPermission() || canEdit)
                 {
                     ActionURL deleteRowsURL = new ActionURL(StudyController.DeletePublishedRowsAction.class, getContainer());
                     deleteRowsURL.addParameter("protocolId", protocol.getRowId());
@@ -538,9 +539,14 @@ public class DatasetQueryView extends StudyQueryView
         return button;
     }
 
-    private boolean canWrite(DatasetDefinition def, User user)
+    private boolean canEdit(DatasetDefinition def, User user)
     {
-        return def.canWrite(user) && def.getContainer().hasPermission(user, UpdatePermission.class);
+        return def.canEdit(user) && def.getContainer().hasPermission(user, UpdatePermission.class);
+    }
+
+    private boolean canInsert(DatasetDefinition def, User user)
+    {
+        return def.canInsert(user) && def.getContainer().hasPermission(user, InsertPermission.class);
     }
 
     private boolean canManage(DatasetDefinition def, User user)

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -140,7 +140,7 @@ public class DatasetQueryView extends StudyQueryView
         _showSourceLinks = settings.isShowSourceLinks();
 
         // Only show link to edit if permission allows it
-        setShowUpdateColumn(settings.isShowEditLinks() && !isExportView() && _dataset.canEdit(getUser()));
+        setShowUpdateColumn(settings.isShowEditLinks() && !isExportView() && _dataset.canUpdate(getUser()));
 
         if (form.getVisitRowId() != 0)
         {
@@ -541,7 +541,7 @@ public class DatasetQueryView extends StudyQueryView
 
     private boolean canEdit(DatasetDefinition def, User user)
     {
-        return def.canEdit(user) && def.getContainer().hasPermission(user, UpdatePermission.class);
+        return def.canUpdate(user) && def.getContainer().hasPermission(user, UpdatePermission.class);
     }
 
     private boolean canInsert(DatasetDefinition def, User user)

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -1126,7 +1126,7 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
         if (InsertPermission.class.isAssignableFrom(perm))
             return def.canInsert(user);
         if (UpdatePermission.class.isAssignableFrom(perm) || DeletePermission.class.isAssignableFrom(perm))
-            return def.canEdit(user);
+            return def.canUpdate(user);
         return def.getPolicy().hasPermission(user, perm);
     }
 

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -1111,7 +1111,7 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
     {
         User user = _userSchema.getUser();
         Dataset def = getDatasetDefinition();
-        if (!user.hasRootAdminPermission() && !def.canWrite(user))
+        if (!user.hasRootAdminPermission() && !def.canInsert(user))
             return null;
         return new DatasetUpdateService(this);
     }
@@ -1123,8 +1123,10 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
         Dataset def = getDatasetDefinition();
         if (ReadPermission.class.isAssignableFrom(perm))
             return def.canRead(user);
-        if (InsertPermission.class.isAssignableFrom(perm) || UpdatePermission.class.isAssignableFrom(perm) || DeletePermission.class.isAssignableFrom(perm))
-            return def.canWrite(user);
+        if (InsertPermission.class.isAssignableFrom(perm))
+            return def.canInsert(user);
+        if (UpdatePermission.class.isAssignableFrom(perm) || DeletePermission.class.isAssignableFrom(perm))
+            return def.canEdit(user);
         return def.getPolicy().hasPermission(user, perm);
     }
 

--- a/study/src/org/labkey/study/view/datasetDetails.jsp
+++ b/study/src/org/labkey/study/view/datasetDetails.jsp
@@ -121,7 +121,7 @@ if (permissions.contains(AdminPermission.class))
             .href(deleteDatasetURL)
             .usePost("Are you sure you want to delete this dataset? All related data and visitmap entries will also be deleted."));
     }
-    if (user.hasRootAdminPermission() || dataset.canEdit(user))
+    if (user.hasRootAdminPermission() || dataset.canDelete(user))
     {
         buttons.add(button("Delete All Rows").onClick("truncateTable();"));
     }

--- a/study/src/org/labkey/study/view/datasetDetails.jsp
+++ b/study/src/org/labkey/study/view/datasetDetails.jsp
@@ -121,7 +121,7 @@ if (permissions.contains(AdminPermission.class))
             .href(deleteDatasetURL)
             .usePost("Are you sure you want to delete this dataset? All related data and visitmap entries will also be deleted."));
     }
-    if (user.hasRootAdminPermission() || dataset.canWrite(user))
+    if (user.hasRootAdminPermission() || dataset.canEdit(user))
     {
         buttons.add(button("Delete All Rows").onClick("truncateTable();"));
     }

--- a/study/src/org/labkey/study/view/participantCharacteristics.jsp
+++ b/study/src/org/labkey/study/view/participantCharacteristics.jsp
@@ -141,7 +141,7 @@
             datasetRow = dataset.getDatasetRow(user, lsid);
         }
 
-        boolean editAccess = dataset.canEdit(user);
+        boolean editAccess = dataset.canInsert(user);
         if (datasetRow == null)
         {
             if (editAccess)

--- a/study/src/org/labkey/study/view/participantCharacteristics.jsp
+++ b/study/src/org/labkey/study/view/participantCharacteristics.jsp
@@ -141,7 +141,7 @@
             datasetRow = dataset.getDatasetRow(user, lsid);
         }
 
-        boolean editAccess = dataset.canWrite(user);
+        boolean editAccess = dataset.canEdit(user);
         if (datasetRow == null)
         {
             if (editAccess)

--- a/study/src/org/labkey/study/view/specimen/updateComments.jsp
+++ b/study/src/org/labkey/study/view/specimen/updateComments.jsp
@@ -158,13 +158,13 @@
         if (hasParticipantMenu)
         {
             DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantCommentDatasetId());
-            hasParticipantMenu = def != null && def.canWrite(user);
+            hasParticipantMenu = def != null && def.canEdit(user);
         }
 
         if (hasParticipantVisitMenu)
         {
             DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantVisitCommentDatasetId());
-            hasParticipantVisitMenu = def != null && def.canWrite(user);
+            hasParticipantVisitMenu = def != null && def.canEdit(user);
         }
 
         if (hasParticipantMenu || hasParticipantVisitMenu)

--- a/study/src/org/labkey/study/view/specimen/updateComments.jsp
+++ b/study/src/org/labkey/study/view/specimen/updateComments.jsp
@@ -158,13 +158,13 @@
         if (hasParticipantMenu)
         {
             DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantCommentDatasetId());
-            hasParticipantMenu = def != null && def.canEdit(user);
+            hasParticipantMenu = def != null && def.canUpdate(user);
         }
 
         if (hasParticipantVisitMenu)
         {
             DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantVisitCommentDatasetId());
-            hasParticipantVisitMenu = def != null && def.canEdit(user);
+            hasParticipantVisitMenu = def != null && def.canUpdate(user);
         }
 
         if (hasParticipantMenu || hasParticipantVisitMenu)


### PR DESCRIPTION
#### Rationale
Currently to insert rows in a data set, a user must have full Edit permissions, but the Submitter role, which grants a user only Insert permission, is designed to allow for users that provide data but are not allowed to edit it or remove it.  Here we separate out checks for insert permission from overall edit permission to make the Submitter role effective for datasets.

#### Changes
* Check for insert permissions separately from update permissions as appropriate for dataset functionality
