### PR TITLE
add more logging to bootstrap property loading

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -2188,11 +2188,17 @@ public class ModuleLoader implements Filter, MemTrackerListener
             File newinstall = new File(propsDir, "newinstall");
             if (newinstall.isFile())
             {
+                _log.debug("'newinstall' file detected: " + newinstall.getAbsolutePath());
+
                 _newInstall = true;
                 if (newinstall.canWrite())
                     newinstall.delete();
                 else
                     throw new ConfigurationException("file 'newinstall'  exists, but is not writeable: " + newinstall.getAbsolutePath());
+            }
+            else
+            {
+                _log.debug("no 'newinstall' file detected");
             }
 
             File[] propFiles = propsDir.listFiles((File dir, String name) -> equalsIgnoreCase(FileUtil.getExtension(name), ("properties")));
@@ -2205,6 +2211,8 @@ public class ModuleLoader implements Filter, MemTrackerListener
 
                 for (File propFile : sortedPropFiles)
                 {
+                    _log.debug("loading propsFile: " + propFile.getAbsolutePath());
+
                     try (FileInputStream in = new FileInputStream(propFile))
                     {
                         Properties props = new Properties();
@@ -2214,6 +2222,8 @@ public class ModuleLoader implements Filter, MemTrackerListener
                         {
                             if (entry.getKey() instanceof String && entry.getValue() instanceof String)
                             {
+                                _log.trace("property '" + entry.getKey() + "' resolved to value: '" + entry.getValue() + "'");
+
                                 ConfigProperty config = createConfigProperty(entry.getKey().toString(), entry.getValue().toString());
                                 if (_configPropertyMap.containsMapping(config.getScope(), config))
                                     _configPropertyMap.removeMapping(config.getScope(), config);
@@ -2227,6 +2237,14 @@ public class ModuleLoader implements Filter, MemTrackerListener
                     }
                 }
             }
+            else
+            {
+                _log.debug("no propFiles to load");
+            }
+        }
+        else
+        {
+            _log.debug("propsDir non-existant or not a directory: " + propsDir.getAbsolutePath());
         }
 
         // load any system properties with the labkey prop prefix


### PR DESCRIPTION
#### Rationale
This pull request adds `debug` and `trace` level logging to a few parts of the bootstrap properties loading process to indicate negatives cases that previously failed silently.