### PR TITLE
move setStatus(complete) out of task into job

### DIFF
--- a/api/src/org/labkey/api/reports/report/RReportJob.java
+++ b/api/src/org/labkey/api/reports/report/RReportJob.java
@@ -169,6 +169,7 @@ public class RReportJob extends PipelineJob implements Serializable
         try
         {
             createPipelineTask(this, report, params).run();
+            setStatus(TaskStatus.complete, "Job finished at: " + DateUtil.nowISO());
         }
         catch (PipelineJobException x)
         {
@@ -257,7 +258,6 @@ public class RReportJob extends PipelineJob implements Serializable
                 }
 
                 processOutputs(_report, outputSubst);
-                getJob().setStatus(TaskStatus.complete, "Job finished at: " + DateUtil.nowISO());
             }
             catch (Exception e)
             {


### PR DESCRIPTION
#### Rationale
I mistakenly put a setStatus(complete) in RunRReportTask.runReport().  The call is now in  RReportJob.run()
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42521