### PR TITLE
Adjust comment message applied to dataset detailed audit log entries

### DIFF
--- a/api/src/org/labkey/api/audit/AbstractAuditHandler.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditHandler.java
@@ -37,6 +37,17 @@ public abstract class AbstractAuditHandler implements AuditHandler
         }
     }
 
+    /**
+     * Create a detailed audit record object so it can be recorded in the audit tables
+     * @param user making change
+     * @param c container containing auditable data
+     * @param tInfo Auditable tableInfo containing auditable record
+     * @param action being performed
+     * @param userComment Comment provided by the user explaining reason for change. NOTE: This value is generally not currently supported by many audit logging domains, and may be ignored.
+     * @param row map of new data values
+     * @param existingRow map of data values
+     * @return DetailedAuditTypeEvent object describing audit record (NOTE: not committed to DB yet)
+     */
     protected abstract DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> existingRow);
 
     /**

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1680,7 +1680,7 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
             {
                 oldRecordString = DatasetAuditProvider.encodeForDataMap(c, record);
             }
-            else if (existingRecord != null)
+            else if (existingRecord != null && existingRecord.size() > 0)
             {
                 Pair<Map<String, Object>, Map<String, Object>> rowPair = AuditHandler.getOldAndNewRecordForMerge(record, existingRecord, Collections.emptySet());
                 oldRecordString = DatasetAuditProvider.encodeForDataMap(c, rowPair.first);

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1684,13 +1684,17 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
             {
                 Pair<Map<String, Object>, Map<String, Object>> rowPair = AuditHandler.getOldAndNewRecordForMerge(record, existingRecord, Collections.emptySet());
                 oldRecordString = DatasetAuditProvider.encodeForDataMap(c, rowPair.first);
-                newRecordString = DatasetAuditProvider.encodeForDataMap(c, rowPair.second);
 
                 // Check if no fields changed, if so adjust messaging
-                if (rowPair.second.size() == 0 && userCommentIsBlank)
+                if (rowPair.second.size() == 0 )
                 {
-                    auditComment = "Dataset row was processed, but no changes detected";
+                    auditComment = userCommentIsBlank ? "Dataset row was processed, but no changes detected" : userComment;
+                    // Record values that were processed
                     newRecordString = DatasetAuditProvider.encodeForDataMap(c, record);
+                }
+                else
+                {
+                    newRecordString = DatasetAuditProvider.encodeForDataMap(c, rowPair.second);
                 }
             }
             else

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1659,12 +1659,13 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
             throw new UnsupportedOperationException();
         }
 
+        /**
+         * NOTE: userComment field is not supported for this domain and will be ignored
+         */
         @Override
         protected DatasetAuditProvider.DatasetAuditEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> record, Map<String, Object> existingRecord)
         {
-            boolean userCommentIsBlank = StringUtils.trimToNull(userComment) == null;
-            String auditComment = !userCommentIsBlank ? userComment :
-                    switch (action)
+            String auditComment = switch (action)
                     {
                         case INSERT -> "A new dataset record was inserted";
                         case DELETE, TRUNCATE -> "A dataset record was deleted";
@@ -1688,7 +1689,7 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
                 // Check if no fields changed, if so adjust messaging
                 if (rowPair.second.size() == 0 )
                 {
-                    auditComment = userCommentIsBlank ? "Dataset row was processed, but no changes detected" : userComment;
+                    auditComment = "Dataset row was processed, but no changes detected";
                     // Record values that were processed
                     newRecordString = DatasetAuditProvider.encodeForDataMap(c, record);
                 }


### PR DESCRIPTION
#### Rationale
Update audit log message for merged dataset rows that contain no changes

#### Changes
* Adjust messaging for merges applied to dataset detailed audit log entries 
