### PR TITLE
Issue 42288: NPE setting baseServerURL startup prop to string w/o scheme

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -1256,6 +1256,13 @@ public class ModuleLoader implements Filter, MemTrackerListener
     {
         if (null == _startupFailure)
             _startupFailure = t;
+
+        if (Boolean.valueOf(System.getProperty("terminateOnStartupFailure")))
+        {
+            // Issue 40038: Ride-or-die Mode
+            _log.fatal("Startup failure, terminating", t);
+            System.exit(1);
+        }
     }
 
     public void addModuleFailure(String moduleName, Throwable t)


### PR DESCRIPTION
#### Rationale
We want to give robust and immediate feedback on invalid startup properties. Also includes progress on Issue 40038: Ride-or-die Mode

#### Related Pull Requests
* https://github.com/LabKey/server/pull/57

#### Changes
* Use standard validation when pulling in config properties for Site Settings
* New -DterminateOnStartupFailure option to shut down immediately if the server hits a fatal error during initialization