### PR TITLE
Remove exception when AppPropsImpl encounters unknown config property

### DIFF
--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -657,7 +657,7 @@ class AppPropsImpl extends AbstractWriteableSettingsGroup implements AppProps
                     case X_FRAME_OPTIONS -> writeable.setXFrameOptions(prop.getValue());
                     case EXTERNAL_REDIRECT_HOSTS -> writeable.setExternalRedirectHosts(Arrays.asList(StringUtils.split(prop.getValue(), EXTERNAL_REDIRECT_HOST_DELIMITER)));
 
-                    default -> throw new IllegalArgumentException("Unsupported site settings property: " + prop.getName());
+                    default -> LOG.debug("Property '" + prop.getName() + "' does not map to an AppProp entry");
                 }
             }
             catch (URISyntaxException e)


### PR DESCRIPTION
#### Rationale
My previous commit assumed that AppPropsImpl was the only thing reading from the SiteSettings config property scope. Other code also looks for properties there, so it can't be super-strict.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2024

#### Changes
* Remove check that rejects a SiteSettings-scoped config property that's not part of AppPropsImpl