### PR TITLE
Issue 42222: Hide Admin Console's System Properties and Environment V…

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -140,6 +140,7 @@ import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.PlatformDeveloperPermission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.permissions.SiteAdminPermission;
 import org.labkey.api.security.permissions.TroubleShooterPermission;
 import org.labkey.api.security.permissions.UploadFileBasedModulePermission;
 import org.labkey.api.security.roles.FolderAdminRole;
@@ -328,7 +329,7 @@ public class AdminController extends SpringActionController
         AdminConsole.addLink(Diagnostics, "check database", new ActionURL(DbCheckerAction.class, root), AdminOperationsPermission.class);
         AdminConsole.addLink(Diagnostics, "credits", new ActionURL(CreditsAction.class, root));
         AdminConsole.addLink(Diagnostics, "dump heap", new ActionURL(DumpHeapAction.class, root));
-        AdminConsole.addLink(Diagnostics, "environment variables", new ActionURL(EnvironmentVariablesAction.class, root));
+        AdminConsole.addLink(Diagnostics, "environment variables", new ActionURL(EnvironmentVariablesAction.class, root), SiteAdminPermission.class);
         AdminConsole.addLink(Diagnostics, "memory usage", new ActionURL(MemTrackerAction.class, root));
         AdminConsole.addLink(Diagnostics, "profiler", new ActionURL(MiniProfilerController.ManageAction.class, root), AdminPermission.class);
         AdminConsole.addLink(Diagnostics, "queries", getQueriesURL(null));
@@ -337,7 +338,7 @@ public class AdminController extends SpringActionController
         AdminConsole.addLink(Diagnostics, "site validation", new ActionURL(SiteValidationAction.class, root), AdminPermission.class);
         AdminConsole.addLink(Diagnostics, "sql scripts", new ActionURL(SqlScriptController.ScriptsAction.class, root), AdminOperationsPermission.class);
         AdminConsole.addLink(Diagnostics, "suspicious activity", new ActionURL(SuspiciousAction.class,root));
-        AdminConsole.addLink(Diagnostics, "system properties", new ActionURL(SystemPropertiesAction.class, root));
+        AdminConsole.addLink(Diagnostics, "system properties", new ActionURL(SystemPropertiesAction.class, root), SiteAdminPermission.class);
         AdminConsole.addLink(Diagnostics, "test email configuration", new ActionURL(EmailTestAction.class, root), AdminOperationsPermission.class);
         AdminConsole.addLink(Diagnostics, "view all site errors since reset", new ActionURL(ShowErrorsSinceMarkAction.class, root));
         AdminConsole.addLink(Diagnostics, "view all site errors", new ActionURL(ShowAllErrorsAction.class, root));
@@ -2872,7 +2873,7 @@ public class AdminController extends SpringActionController
         }
     }
 
-    @AdminConsoleAction(AdminOperationsPermission.class)
+    @RequiresSiteAdmin
     public class EnvironmentVariablesAction extends SimpleViewAction
     {
         @Override
@@ -2888,7 +2889,7 @@ public class AdminController extends SpringActionController
         }
     }
 
-    @AdminConsoleAction(AdminOperationsPermission.class)
+    @RequiresSiteAdmin
     public class SystemPropertiesAction extends SimpleViewAction
     {
         @Override

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10334,8 +10334,6 @@ public class AdminController extends SpringActionController
                     controller.new ShortURLAdminAction(),
                     controller.new CustomizeSiteAction(),
                     controller.new CachesAction(),
-                    controller.new EnvironmentVariablesAction(),
-                    controller.new SystemPropertiesAction(),
                     controller.new ConfigureSystemMaintenanceAction(),
                     controller.new ModulesAction()
             );
@@ -10353,7 +10351,9 @@ public class AdminController extends SpringActionController
                     controller.new SystemMaintenanceAction(),
                     new ModuleStatusAction(),
                     new NewInstallSiteSettingsAction(),
-                    new InstallCompleteAction()
+                    new InstallCompleteAction(),
+                    controller.new EnvironmentVariablesAction(),
+                    controller.new SystemPropertiesAction()
             );
         }
     }


### PR DESCRIPTION
…ariables from non-Site Admins

#### Rationale
These values may contain secrets that are being propagated through from the host OS or container. Thus, they should have the highest level of permissions

#### Changes
* Only allow Site Admins to see System Properties and Environment Variables