### PR TITLE
Issue 42519: fix insert api for Submitter role

### DIFF
--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -148,15 +148,8 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
     public List<Map<String, Object>> getRows(User user, Container container, List<Map<String, Object>> keys)
             throws InvalidKeyException, QueryUpdateServiceException, SQLException
     {
-        try
-        {
-            if (!hasPermission(user, ReadPermission.class))
-                throw new UnauthorizedException("You do not have permission to read data from this table.");
-        }
-        catch (UnauthorizedException e)
-        {
+        if (!hasPermission(user, ReadPermission.class))
             return keys;
-        }
 
         List<Map<String, Object>> result = new ArrayList<>();
         for (Map<String, Object> rowKeys : keys)

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -77,6 +77,7 @@ import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.reader.TabLoader;
 import org.labkey.api.security.User;
+import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
@@ -136,7 +137,8 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         return _queryTable;
     }
 
-    protected boolean hasPermission(User user, Class<? extends Permission> acl)
+    @Override
+    public boolean hasPermission(@NotNull UserPrincipal user, Class<? extends Permission> acl)
     {
         return getQueryTable().hasPermission(user, acl);
     }
@@ -149,7 +151,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
             throws InvalidKeyException, QueryUpdateServiceException, SQLException
     {
         if (!hasPermission(user, ReadPermission.class))
-            return keys;
+            throw new UnauthorizedException("You do not have permission to read data from this table.");
 
         List<Map<String, Object>> result = new ArrayList<>();
         for (Map<String, Object> rowKeys : keys)

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -148,8 +148,15 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
     public List<Map<String, Object>> getRows(User user, Container container, List<Map<String, Object>> keys)
             throws InvalidKeyException, QueryUpdateServiceException, SQLException
     {
-        if (!hasPermission(user, ReadPermission.class))
-            throw new UnauthorizedException("You do not have permission to read data from this table.");
+        try
+        {
+            if (!hasPermission(user, ReadPermission.class))
+                throw new UnauthorizedException("You do not have permission to read data from this table.");
+        }
+        catch (UnauthorizedException e)
+        {
+            return keys;
+        }
 
         List<Map<String, Object>> result = new ArrayList<>();
         for (Map<String, Object> rowKeys : keys)

--- a/api/src/org/labkey/api/query/CacheClearingQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/CacheClearingQueryUpdateService.java
@@ -20,6 +20,8 @@ import org.labkey.api.data.Container;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.security.User;
+import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.Permission;
 
 import java.sql.SQLException;
 import java.util.List;
@@ -119,5 +121,11 @@ public abstract class CacheClearingQueryUpdateService implements QueryUpdateServ
     public boolean isBulkLoad()
     {
         return _service.isBulkLoad();
+    }
+
+    @Override
+    public boolean hasPermission(UserPrincipal user, Class<? extends Permission> acl)
+    {
+        return _service.hasPermission(user, acl);
     }
 }

--- a/api/src/org/labkey/api/query/QueryUpdateService.java
+++ b/api/src/org/labkey/api/query/QueryUpdateService.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
+import org.labkey.api.security.HasPermission;
 import org.labkey.api.security.User;
 
 import java.sql.SQLException;
@@ -41,7 +42,7 @@ import java.util.Map;
  * User: Dave
  * Date: Jun 9, 2008
  */
-public interface QueryUpdateService
+public interface QueryUpdateService extends HasPermission
 {
     enum InsertOption
     {

--- a/api/src/org/labkey/api/security/permissions/AbstractActionPermissionTest.java
+++ b/api/src/org/labkey/api/security/permissions/AbstractActionPermissionTest.java
@@ -162,7 +162,7 @@ public abstract class AbstractActionPermissionTest extends Assert
         return users;
     }
 
-    public void assertForReadPermission(User user, boolean skipNoPermissionCheck, PermissionCheckableAction... actions)
+    public void assertForReadPermission(User user, boolean submitterAllowed, PermissionCheckableAction... actions)
     {
         for (PermissionCheckableAction action : actions)
         {
@@ -178,7 +178,7 @@ public abstract class AbstractActionPermissionTest extends Assert
                     _users.get(APPLICATION_ADMIN_EMAIL), _users.get(SITE_ADMIN_EMAIL)
             );
 
-            if (!skipNoPermissionCheck)
+            if (!submitterAllowed)
             {
                 assertNoPermission(_c, action,
                         _users.get(SUBMITTER_EMAIL)

--- a/api/src/org/labkey/api/security/permissions/AbstractActionPermissionTest.java
+++ b/api/src/org/labkey/api/security/permissions/AbstractActionPermissionTest.java
@@ -162,6 +162,11 @@ public abstract class AbstractActionPermissionTest extends Assert
         return users;
     }
 
+    public void assertForReadPermission(User user, PermissionCheckableAction... actions)
+    {
+        assertForReadPermission(user, false, actions);
+    }
+
     public void assertForReadPermission(User user, boolean submitterAllowed, PermissionCheckableAction... actions)
     {
         for (PermissionCheckableAction action : actions)

--- a/api/src/org/labkey/api/security/permissions/AbstractActionPermissionTest.java
+++ b/api/src/org/labkey/api/security/permissions/AbstractActionPermissionTest.java
@@ -162,7 +162,7 @@ public abstract class AbstractActionPermissionTest extends Assert
         return users;
     }
 
-    public void assertForReadPermission(User user, PermissionCheckableAction... actions)
+    public void assertForReadPermission(User user, boolean skipNoPermissionCheck, PermissionCheckableAction... actions)
     {
         for (PermissionCheckableAction action : actions)
         {
@@ -178,9 +178,12 @@ public abstract class AbstractActionPermissionTest extends Assert
                     _users.get(APPLICATION_ADMIN_EMAIL), _users.get(SITE_ADMIN_EMAIL)
             );
 
-            assertNoPermission(_c, action,
-                    _users.get(SUBMITTER_EMAIL)
-            );
+            if (!skipNoPermissionCheck)
+            {
+                assertNoPermission(_c, action,
+                        _users.get(SUBMITTER_EMAIL)
+                );
+            }
         }
     }
 

--- a/api/src/org/labkey/api/security/permissions/AbstractActionPermissionTest.java
+++ b/api/src/org/labkey/api/security/permissions/AbstractActionPermissionTest.java
@@ -184,6 +184,10 @@ public abstract class AbstractActionPermissionTest extends Assert
                         _users.get(SUBMITTER_EMAIL)
                 );
             }
+            else
+            {
+                assertPermission(_c, action, _users.get(SUBMITTER_EMAIL));
+            }
         }
     }
 

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -2402,7 +2402,7 @@ public class CoreController extends SpringActionController
             CoreController controller = new CoreController();
 
             // @RequiresPermission(ReadPermission.class)
-            assertForReadPermission(user,
+            assertForReadPermission(user, false,
                 controller.new ProjectsAction(),
                 controller.new DownloadFileLinkAction(),
                 controller.new GetExtContainerTreeAction(),

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10256,7 +10256,7 @@ public class AdminController extends SpringActionController
             AdminController controller = new AdminController();
 
             // @RequiresPermission(ReadPermission.class)
-            assertForReadPermission(user,
+            assertForReadPermission(user, false,
                     new GetModulesAction(),
                     new GetFolderTabsAction(),
                     controller.new ClearDeletedTabFoldersAction()

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -2228,7 +2228,7 @@ public class SecurityApiActions
             assertTrue(user.hasSiteAdminPermission());
 
             // @RequiresPermission(ReadPermission.class)
-            assertForReadPermission(user,
+            assertForReadPermission(user, false,
                 new GetUserPermsAction(),
                 new GetGroupsForCurrentUserAction(),
                 new GetRolesAction(),

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -2033,7 +2033,7 @@ public class SecurityController extends SpringActionController
             SecurityController controller = new SecurityController();
 
             // @RequiresPermission(ReadPermission.class)
-            assertForReadPermission(user,
+            assertForReadPermission(user, false,
                 controller.new CompleteUserReadAction()
             );
 

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -3010,7 +3010,7 @@ public class UserController extends SpringActionController
             UserController controller = new UserController();
 
             // @RequiresPermission(ReadPermission.class)
-            assertForReadPermission(user,
+            assertForReadPermission(user, false,
                 controller.new BeginAction(),
                 controller.new GetUsersAction(),
                 controller.new GetUsersWithPermissionsAction()

--- a/core/src/org/labkey/core/workbook/WorkbooksTableInfo.java
+++ b/core/src/org/labkey/core/workbook/WorkbooksTableInfo.java
@@ -180,7 +180,7 @@ public class WorkbooksTableInfo extends ContainerTable implements UpdateableTabl
         }
 
         @Override
-        protected boolean hasPermission(User user, Class<? extends Permission> acl)
+        public boolean hasPermission(@NotNull UserPrincipal user, Class<? extends Permission> acl)
         {
             return getQueryTable().hasPermission(user, acl);
         }

--- a/filecontent/src/org/labkey/filecontent/FileContentController.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentController.java
@@ -1585,7 +1585,7 @@ public class FileContentController extends SpringActionController
             FileContentController controller = new FileContentController();
 
             // @RequiresPermission(ReadPermission.class)
-            assertForReadPermission(user,
+            assertForReadPermission(user, false,
                 controller.new SendFileAction(),
                 controller.new FrameAction(),
                 controller.new BeginAction(),

--- a/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
+++ b/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
@@ -49,6 +49,7 @@ import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
+import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.util.FileUtil;
@@ -268,7 +269,7 @@ public class FileQueryUpdateService extends AbstractQueryUpdateService
     }
 
     @Override
-    protected boolean hasPermission(User user, Class<? extends Permission> acl)
+    public boolean hasPermission(@NotNull UserPrincipal user, Class<? extends Permission> acl)
     {
         return _container.hasPermission(user, acl);
     }

--- a/pipeline/src/org/labkey/pipeline/PipelineController.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineController.java
@@ -1861,7 +1861,7 @@ public class PipelineController extends SpringActionController
             PipelineController controller = new PipelineController();
 
             // @RequiresPermission(ReadPermission.class)
-            assertForReadPermission(user,
+            assertForReadPermission(user, false,
                 controller.new BeginAction(),
                 controller.new BrowseAction(),
                 controller.new ActionsAction(),

--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -1197,7 +1197,7 @@ public class StatusController extends SpringActionController
             StatusController controller = new StatusController();
 
             // @RequiresPermission(ReadPermission.class)
-            assertForReadPermission(user,
+            assertForReadPermission(user, false,
                 controller.new BeginAction(),
                 controller.new ShowListAction(),
                 controller.new ShowListRegionAction(),

--- a/query/src/org/labkey/query/controllers/OlapController.java
+++ b/query/src/org/labkey/query/controllers/OlapController.java
@@ -1592,7 +1592,7 @@ public class OlapController extends SpringActionController
             OlapController controller = new OlapController();
 
             // @RequiresPermission(ReadPermission.class)
-            assertForReadPermission(user,
+            assertForReadPermission(user, false,
                 controller.new GetCubeDefinitionAction(),
                 new TestMdxAction(),
                 new TestJsonAction(),

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -35,35 +35,7 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.labkey.api.action.Action;
-import org.labkey.api.action.ActionType;
-import org.labkey.api.action.ApiJsonWriter;
-import org.labkey.api.action.ApiQueryResponse;
-import org.labkey.api.action.ApiResponse;
-import org.labkey.api.action.ApiResponseWriter;
-import org.labkey.api.action.ApiSimpleResponse;
-import org.labkey.api.action.ApiUsageException;
-import org.labkey.api.action.ApiVersion;
-import org.labkey.api.action.ConfirmAction;
-import org.labkey.api.action.ExportAction;
-import org.labkey.api.action.ExportException;
-import org.labkey.api.action.ExtendedApiQueryResponse;
-import org.labkey.api.action.FormHandlerAction;
-import org.labkey.api.action.FormViewAction;
-import org.labkey.api.action.HasBindParameters;
-import org.labkey.api.action.LabKeyError;
-import org.labkey.api.action.Marshal;
-import org.labkey.api.action.Marshaller;
-import org.labkey.api.action.MutatingApiAction;
-import org.labkey.api.action.NullSafeBindException;
-import org.labkey.api.action.ReadOnlyApiAction;
-import org.labkey.api.action.ReportingApiQueryResponse;
-import org.labkey.api.action.ReturnUrlForm;
-import org.labkey.api.action.SimpleApiJsonForm;
-import org.labkey.api.action.SimpleErrorView;
-import org.labkey.api.action.SimpleRedirectAction;
-import org.labkey.api.action.SimpleViewAction;
-import org.labkey.api.action.SpringActionController;
+import org.labkey.api.action.*;
 import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.audit.AbstractAuditTypeProvider;
 import org.labkey.api.audit.TransactionAuditProvider;
@@ -98,6 +70,7 @@ import org.labkey.api.security.RequiresLogin;
 import org.labkey.api.security.RequiresNoPermission;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.User;
+import org.labkey.api.security.UserManager;
 import org.labkey.api.security.permissions.AbstractActionPermissionTest;
 import org.labkey.api.security.permissions.AdminOperationsPermission;
 import org.labkey.api.security.permissions.AdminPermission;
@@ -7014,7 +6987,7 @@ public class QueryController extends SpringActionController
             QueryController controller = new QueryController();
 
             // @RequiresPermission(ReadPermission.class)
-            assertForReadPermission(user,
+            assertForReadPermission(user, false,
                 new BrowseAction(),
                 new BeginAction(),
                 controller.new SchemaAction(),
@@ -7037,7 +7010,6 @@ public class QueryController extends SpringActionController
                 controller.new ImportAction(),
                 new ExportSqlAction(),
                 new UpdateRowsAction(),
-                new InsertRowsAction(),
                 new ImportRowsAction(),
                 new DeleteRowsAction(),
                 new TableInfoAction(),
@@ -7053,6 +7025,8 @@ public class QueryController extends SpringActionController
                 new SaveNamedSetAction(),
                 new DeleteNamedSetAction()
             );
+
+            assertForReadPermission(user, true, new InsertRowsAction());
 
             // @RequiresPermission(DeletePermission.class)
             assertForUpdateOrDeletePermission(user,

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -3977,7 +3977,7 @@ public class QueryController extends SpringActionController
         }
     }
 
-    @RequiresPermission(ReadPermission.class) //will check below
+    @RequiresNoPermission //will check below
     @ApiVersion(8.3)
     public static class InsertRowsAction extends BaseSaveRowsAction
     {

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -7026,6 +7026,8 @@ public class QueryController extends SpringActionController
                 new DeleteNamedSetAction()
             );
 
+
+            // submitter should be allowed for InsertRows
             assertForReadPermission(user, true, new InsertRowsAction());
 
             // @RequiresPermission(DeletePermission.class)

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -38,6 +38,7 @@ import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.SimpleValidationError;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
+import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.security.StudySecurityEscalator;
@@ -110,7 +111,7 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
     }
 
     @Override
-    protected boolean hasPermission(User user, Class<? extends Permission> acl)
+    public boolean hasPermission(@NotNull UserPrincipal user, Class<? extends Permission> acl)
     {
         if (StudySecurityEscalator.isEscalated()) {
             return true;


### PR DESCRIPTION
#### Rationale
Submitter role claims that the users may submit new information, but may not read or change anything. When a submitter (not reader) tries to insert information through Query.insertRows, the user is not successful because of ReadPermission check. This change allows the user to insert into a folder when the user is only submitter and not reader.

#### Related Pull Requests
* https://github.com/LabKey/premium/pull/230
* https://github.com/LabKey/gel/pull/4
* https://github.com/LabKey/cloud/pull/83
* https://github.com/LabKey/fileTransfer/pull/30

