### PR TITLE
Move specimen import to its own pipeline provider

### DIFF
--- a/study/api-src/org/labkey/api/specimen/pipeline/AbstractSpecimenTask.java
+++ b/study/api-src/org/labkey/api/specimen/pipeline/AbstractSpecimenTask.java
@@ -109,6 +109,11 @@ public abstract class AbstractSpecimenTask<FactoryType extends AbstractSpecimenT
     public static void doImport(@Nullable File inputFile, PipelineJob job, SimpleStudyImportContext ctx, boolean merge,
                                 boolean syncParticipantVisit, ImportHelper importHelper) throws PipelineJobException
     {
+        if (SpecimenService.get() == null)
+        {
+            return;
+        }
+
         // do nothing if we've specified data types and specimen is not one of them
         if (!ctx.isDataTypeSelected(StudyImportSpecimenTask.getType()))
             return;

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -164,6 +164,7 @@ import org.labkey.study.model.TestDatasetDomainKind;
 import org.labkey.study.model.TreatmentManager;
 import org.labkey.study.model.VisitDatasetDomainKind;
 import org.labkey.study.model.VisitImpl;
+import org.labkey.study.pipeline.SpecimenPipeline;
 import org.labkey.study.pipeline.StudyPipeline;
 import org.labkey.study.qc.StudyQCImportExportHelper;
 import org.labkey.study.qc.StudyQCStateHandler;
@@ -375,6 +376,8 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
     protected void startupAfterSpringConfig(ModuleContext moduleContext)
     {
         PipelineService.get().registerPipelineProvider(new StudyPipeline(this));
+        // TODO: Move to specimen module
+        PipelineService.get().registerPipelineProvider(new SpecimenPipeline(this));
         PipelineService.get().registerPipelineProvider(new StudyImportProvider(this));
 
         // This is in the First group because when a container is deleted,

--- a/study/src/org/labkey/study/pipeline/SpecimenPipeline.java
+++ b/study/src/org/labkey/study/pipeline/SpecimenPipeline.java
@@ -1,0 +1,59 @@
+package org.labkey.study.pipeline;
+
+import org.labkey.api.module.Module;
+import org.labkey.api.pipeline.PipeRoot;
+import org.labkey.api.pipeline.PipelineDirectory;
+import org.labkey.api.pipeline.PipelineProvider;
+import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.specimen.pipeline.SpecimenBatch;
+import org.labkey.api.study.SpecimenService;
+import org.labkey.api.study.SpecimenTransform;
+import org.labkey.api.study.StudyService;
+import org.labkey.api.view.ViewContext;
+import org.labkey.study.controllers.specimen.SpecimenController;
+
+import java.io.File;
+
+public class SpecimenPipeline extends PipelineProvider
+{
+    public SpecimenPipeline(Module owningModule)
+    {
+        super("Specimen", owningModule);
+    }
+
+
+    @Override
+    public void updateFileProperties(final ViewContext context, PipeRoot pr, PipelineDirectory directory, boolean includeAll)
+    {
+        if (SpecimenService.get() == null ||
+            !context.getContainer().hasPermission(context.getUser(), InsertPermission.class) ||
+            context.getContainer().isDataspace() || // Cannot import specimens into Dataspace container
+            StudyService.get().getStudy(context.getContainer()) == null)
+        {
+            return;
+        }
+
+        File[] files = directory.listFiles(new FileEntryFilter()
+        {
+            @Override
+            public boolean accept(File f)
+            {
+                if (SpecimenBatch.ARCHIVE_FILE_TYPE.isType(f))
+                    return true;
+                else
+                {
+                    for (SpecimenTransform transform : SpecimenService.get().getSpecimenTransforms(context.getContainer()))
+                    {
+                        if (transform.getFileType().isType(f))
+                            return true;
+                    }
+                }
+                return false;
+            }
+        });
+
+        String actionId = createActionId(SpecimenController.ImportSpecimenData.class, "Import Specimen Data");
+        addAction(actionId, SpecimenController.ImportSpecimenData.class, "Import Specimen Data", directory, files, true, false, includeAll);
+    }
+
+}

--- a/study/src/org/labkey/study/pipeline/StudyPipeline.java
+++ b/study/src/org/labkey/study/pipeline/StudyPipeline.java
@@ -56,7 +56,7 @@ public class StudyPipeline extends PipelineProvider
             return;
 
         if (context.getContainer().isDataspace())
-            return;         // Cannot import specimens into Dataspace container
+            return;
 
         Study study = StudyManager.getInstance().getStudy(context.getContainer());
 

--- a/study/src/org/labkey/study/pipeline/StudyPipeline.java
+++ b/study/src/org/labkey/study/pipeline/StudyPipeline.java
@@ -22,16 +22,12 @@ import org.labkey.api.pipeline.PipelineAction;
 import org.labkey.api.pipeline.PipelineDirectory;
 import org.labkey.api.pipeline.PipelineProvider;
 import org.labkey.api.security.permissions.InsertPermission;
-import org.labkey.api.specimen.pipeline.SpecimenBatch;
-import org.labkey.api.study.SpecimenService;
-import org.labkey.api.study.SpecimenTransform;
 import org.labkey.api.study.Study;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
 import org.labkey.study.controllers.StudyController;
-import org.labkey.study.controllers.specimen.SpecimenController;
 import org.labkey.study.model.StudyManager;
 
 import java.io.File;
@@ -76,28 +72,6 @@ public class StudyPipeline extends PipelineProvider
         });
 
         handleDatasetFiles(context, study, directory, files, includeAll);
-
-        files = directory.listFiles(new FileEntryFilter()
-        {
-            @Override
-            public boolean accept(File f)
-            {
-                if (SpecimenBatch.ARCHIVE_FILE_TYPE.isType(f))
-                    return true;
-                else
-                {
-                    for (SpecimenTransform transform : SpecimenService.get().getSpecimenTransforms(context.getContainer()))
-                    {
-                        if (transform.getFileType().isType(f))
-                            return true;
-                    }
-                }
-                return false;
-            }
-        });
-
-        String actionId = createActionId(SpecimenController.ImportSpecimenData.class, "Import Specimen Data");
-        addAction(actionId, SpecimenController.ImportSpecimenData.class, "Import Specimen Data", directory, files, true, false, includeAll);
     }
 
 

--- a/study/test/src/org/labkey/test/tests/study/StudyManualTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyManualTest.java
@@ -57,7 +57,10 @@ public abstract class StudyManualTest extends StudyTest
         setFormElement(Locator.name("subjectNounPlural"), "Mice");
         setFormElement(Locator.name("subjectColumnName"), "MouseId");
         clickButton("Create Study");
-        _studyHelper.setupAdvancedRepositoryType();
+        if (_studyHelper.isSpecimenModuleActive())
+        {
+            _studyHelper.setupAdvancedRepositoryType();
+        }
 
         // change study label
         clickAndWait(Locator.linkWithText("Change Study Properties"));

--- a/study/test/src/org/labkey/test/tests/study/StudyPHIExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPHIExportTest.java
@@ -161,21 +161,24 @@ public class StudyPHIExportTest extends StudyExportTest
         importAlteredStudy();
         waitForPipelineJobsToComplete(3, "Study reimport", false);
 
-        Map reimportedFirstMouseStats = getFirstMouseStats();
+        Map<String, String> reimportedFirstMouseStats = getFirstMouseStats();
         verifyStatsMatch(alteredFirstMouseStats, reimportedFirstMouseStats);
 
         log("Verify second export and clinic masking");
 
-        startSpecimenImport(4, StudyHelper.SPECIMEN_ARCHIVE_A);
-        waitForPipelineJobsToComplete(4, "Specimen import", false);
-        exportStudy(true, false, FieldDefinition.PhiSelectType.NotPHI, true, true, true, null);
+        if (_studyHelper.isSpecimenModuleActive())
+        {
+            startSpecimenImport(4, StudyHelper.SPECIMEN_ARCHIVE_A);
+            waitForSpecimenImport();
+            exportStudy(true, false, FieldDefinition.PhiSelectType.NotPHI, true, true, true, null);
 
-        clickFolder(getFolderName());
-        deleteStudy();
-        importAlteredStudy();
-        waitForPipelineJobsToComplete(5, "Study reimport with specimens", false);
+            clickFolder(getFolderName());
+            deleteStudy();
+            importAlteredStudy();
+            waitForPipelineJobsToComplete(5, "Study reimport with specimens", false);
 
-        verifyMaskedClinics(8);
+            verifyMaskedClinics(8);
+        }
     }
 
     private void goToDatasets()


### PR DESCRIPTION
#### Rationale
We are unable to import anything via the pipeline if the study module is installed without the specimen module. We shouldn't add the "Import Specimen Data" pipeline action if the specimen module isn't present.

#### Changes
* Move specimen import to its own pipeline provider
* Update study tests to be less reliant on specimen module
