### PR TITLE
Issue 41827: Exp schema very slow (and sometimes non-responsive) to lookup to or open the schema browser

### DIFF
--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -240,6 +240,10 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         }
     }
 
+    public void afterConstruct(boolean forSchemaTree)
+    {
+        afterConstruct();
+    }
 
     protected Map<String, ColumnInfo> constructColumnMap()
     {

--- a/api/src/org/labkey/api/query/AbstractSchema.java
+++ b/api/src/org/labkey/api/query/AbstractSchema.java
@@ -159,12 +159,12 @@ abstract public class AbstractSchema implements QuerySchema
         return _container;
     }
 
-    protected void afterConstruct(TableInfo info)
+    protected void afterConstruct(TableInfo info, boolean forSchemaTree)
     {
         if (info instanceof AbstractTableInfo)
         {
             AbstractTableInfo t = ((AbstractTableInfo)info);
-            t.afterConstruct();
+            t.afterConstruct(forSchemaTree);
         }
     }
 

--- a/api/src/org/labkey/api/query/QuerySchema.java
+++ b/api/src/org/labkey/api/query/QuerySchema.java
@@ -50,6 +50,11 @@ public interface QuerySchema extends SchemaTreeNode, ContainerUser
         return getTable(name, null);
     }
 
+    default TableInfo getTable(String name, @Nullable ContainerFilter cf, boolean isSchemaTreeAction)
+    {
+        return getTable(name, null);
+    }
+
     /** Consider using getTableWithFactory(String, ContainerFilter.Factory) instead */
     TableInfo getTable(String name, @Nullable ContainerFilter cf);
 

--- a/experiment/src/org/labkey/experiment/api/ExpFilesTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpFilesTableImpl.java
@@ -52,7 +52,15 @@ public class ExpFilesTableImpl extends ExpDataTableImpl
     {
         super(name, schema, null);
         addCondition(new SimpleFilter(FieldKey.fromParts("DataFileUrl"), null, CompareType.NONBLANK));
-        _svc.ensureFileData(this);
+    }
+
+    @Override
+    public void afterConstruct(boolean forSchemaTree)
+    {
+        super.afterConstruct();
+
+        if (!forSchemaTree)
+            _svc.ensureFileData(this);
     }
 
     @Override

--- a/query/src/org/labkey/query/controllers/GetSchemaQueryTreeAction.java
+++ b/query/src/org/labkey/query/controllers/GetSchemaQueryTreeAction.java
@@ -148,7 +148,7 @@ public class GetSchemaQueryTreeAction extends ReadOnlyApiAction<GetSchemaQueryTr
                         try
                         {
                             // Try to get the TableInfo so we can send back its description
-                            tinfo = uschema.getTable(qname);
+                            tinfo = uschema.getTable(qname, null, true);
                         }
                         catch (QueryException ignored)
                         {


### PR DESCRIPTION
#### Rationale
ensureFileData crawls all files under the current directory (every 5 minutes or when accessed) to make sure all files have a corresponding exp.data record. This could be a very expensive action if the number of files are large. In the case of browsing schema tree for exp, there is no need to sync files since only basic metadata of the table is needed. 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* skip ensureFileData for exp.files on expanding schema tree
