### PR TITLE
Work around crawler complaint

### DIFF
--- a/api/src/org/labkey/api/util/UnexpectedException.java
+++ b/api/src/org/labkey/api/util/UnexpectedException.java
@@ -16,10 +16,18 @@
 
 package org.labkey.api.util;
 
+import java.lang.reflect.InvocationTargetException;
+
 public class UnexpectedException extends RuntimeException
 {
     static public void rethrow(Throwable cause)
     {
+        // This case avoids extra wrapping when bad webpart parameters cause exceptions. For example, crawler passing a
+        // bogus enrollmentTokenBatches.containerFilterName parameter.
+        if (cause instanceof InvocationTargetException && cause.getCause() instanceof RuntimeException)
+        {
+            throw (RuntimeException) cause.getCause();
+        }
         if (cause instanceof RuntimeException)
         {
             throw (RuntimeException) cause;

--- a/api/src/org/labkey/api/view/SimpleWebPartFactory.java
+++ b/api/src/org/labkey/api/view/SimpleWebPartFactory.java
@@ -22,6 +22,7 @@ import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * Serves up a static .html file that's part of a module's ./resources/views as a webpart (by virtue of having
@@ -124,7 +125,11 @@ public class SimpleWebPartFactory extends BaseWebPartFactory
         }
         catch (Exception x)
         {
-            if (x instanceof RuntimeException)
+            // Avoids rendering BadRequestException in the browser when bad parameters are used. For example, crawler
+            // passing a bogus enrollmentTokenBatches.containerFilterName parameter.
+            if (x instanceof InvocationTargetException && x.getCause() instanceof RuntimeException)
+                throw (RuntimeException)x.getCause();
+            else if (x instanceof RuntimeException)
                 throw (RuntimeException)x;
             else
                  throw new RuntimeException(x);

--- a/api/src/org/labkey/api/view/SimpleWebPartFactory.java
+++ b/api/src/org/labkey/api/view/SimpleWebPartFactory.java
@@ -22,7 +22,6 @@ import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 
 /**
  * Serves up a static .html file that's part of a module's ./resources/views as a webpart (by virtue of having
@@ -125,14 +124,8 @@ public class SimpleWebPartFactory extends BaseWebPartFactory
         }
         catch (Exception x)
         {
-            // Avoids rendering BadRequestException in the browser when bad parameters are used. For example, crawler
-            // passing a bogus enrollmentTokenBatches.containerFilterName parameter.
-            if (x instanceof InvocationTargetException && x.getCause() instanceof RuntimeException)
-                throw (RuntimeException)x.getCause();
-            else if (x instanceof RuntimeException)
-                throw (RuntimeException)x;
-            else
-                 throw new RuntimeException(x);
+            UnexpectedException.rethrow(x);
+            return null;
         }
     }
 


### PR DESCRIPTION
#### Rationale
Crawler is injecting bogus webpart parameters (e.g., enrollmentTokenBatches.containerFilterName=-->">%27>%27"</script><script>alert("8(");</script>) and objecting to the resulting stack trace rendering. 

#### Changes
* Reuse UnexpectedException.rethrow() to reduce boilerplate
* Unwrap InvocationTargetException when appropriate to allow normal exception handling to occur (for BadRequestException, e.g.)