### PR TITLE
Issue 41827: Exp schema very slow (and sometimes non-responsive) to lookup to or open the schema browser

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpFilesTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpFilesTableImpl.java
@@ -57,10 +57,10 @@ public class ExpFilesTableImpl extends ExpDataTableImpl
 
     @NotNull
     @Override
-    public SQLFragment getFromSQL(String alias)
+    public SQLFragment getFromSQL(String alias, boolean skipTransform)
     {
         _svc.ensureFileData(this);
-        return super.getFromSQL(alias);
+        return super.getFromSQL(alias, skipTransform);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpFilesTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpFilesTableImpl.java
@@ -24,6 +24,7 @@ import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.RenderContext;
+import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.query.ExpSchema;
@@ -52,7 +53,14 @@ public class ExpFilesTableImpl extends ExpDataTableImpl
     {
         super(name, schema, null);
         addCondition(new SimpleFilter(FieldKey.fromParts("DataFileUrl"), null, CompareType.NONBLANK));
+    }
+
+    @NotNull
+    @Override
+    public SQLFragment getFromSQL(String alias)
+    {
         _svc.ensureFileData(this);
+        return super.getFromSQL(alias);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
per code reviews from https://github.com/LabKey/platform/pull/2035 , we will move the expensive ensureFileData call from constructor to getFromSQL. 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* move ensureFileData to getFromSQL
