### PR TITLE
Issue 42496: Lingering General/GPAT terminology in UI after rename

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProvider.java
+++ b/api/src/org/labkey/api/assay/AssayProvider.java
@@ -130,6 +130,12 @@ public interface AssayProvider extends Handler<ExpProtocol>
      */
     String getName();
 
+    /** A user-facing short name for the assay provider. Typically matches the official name, but handy for renames */
+    default String getLabel()
+    {
+        return getName();
+    }
+
     /** Get the root resource name.  Usually this is the same as the AssayProvider name, but may be shorter
      * or omit special characters. */
     String getResourceName();

--- a/api/src/org/labkey/api/exp/ExperimentRunListView.java
+++ b/api/src/org/labkey/api/exp/ExperimentRunListView.java
@@ -240,7 +240,7 @@ public class ExperimentRunListView extends QueryView
                         NavTree btn;
                         if (!c.isContainerFor(ContainerType.DataType.assayData))
                         {
-                            btn = new NavTree(protocol.getName() + " (" + provider.getName() + ")");
+                            btn = new NavTree(protocol.getName() + " (" + provider.getLabel() + ")");
                             btn.setScript("Ext4.create('LABKEY.ext.ImportWizardWin', {" +
                                 "controller: '" + provider.getImportURL(c, protocol).getController() + "'," +
                                 "action: '" + provider.getImportURL(c, protocol).getAction() + "'," +
@@ -249,7 +249,7 @@ public class ExperimentRunListView extends QueryView
                         }
                         else
                         {
-                            btn = new NavTree(protocol.getName() + " (" + provider.getName() + ")", provider.getImportURL(getContainer(), protocol));
+                            btn = new NavTree(protocol.getName() + " (" + provider.getLabel() + ")", provider.getImportURL(getContainer(), protocol));
                         }
 
                         addRunsButton.addMenuItem(btn);

--- a/assay/README.md
+++ b/assay/README.md
@@ -1,7 +1,7 @@
 # LabKey Assay Module
 
 Provides services and other APIs that assay modules call to implement custom assay types. 
-Also includes implementation of the General Purpose Assay Type (GPAT).
+Also includes implementation of the Standard Assay Type.
 
 ### LabKey React pages
 

--- a/assay/api-src/org/labkey/api/assay/AssayPipelineProvider.java
+++ b/assay/api-src/org/labkey/api/assay/AssayPipelineProvider.java
@@ -99,7 +99,7 @@ public class AssayPipelineProvider extends PipelineProvider
                 ActionURL url = PageFlowUtil.urlProvider(AssayUrls.class).getImportURL(context.getContainer(), _assayProvider.getName(),
                         directory.getRelativePath(), new File[0]);
 
-                NavTree child = new NavTree("Create New " + _assayProvider.getName() + " Assay Design", url);
+                NavTree child = new NavTree("Create New " + _assayProvider.getLabel() + " Assay Design", url);
                 child.setId(id + ":Create Assay Definition");
                 root.addChild(child);
             }

--- a/assay/module.properties
+++ b/assay/module.properties
@@ -1,7 +1,7 @@
 ModuleClass: org.labkey.assay.AssayModule
-Label: Assay framework and General Purpose Assay Type (GPAT)
+Label: Assay framework and Standard Assay Type
 Description: Provides services and other APIs that assay modules call to implement custom assay types. \
-   Also includes implementation of the General Purpose Assay Type (GPAT).
+   Also includes implementation of the Standard Assay Type.
 URL: https://www.labkey.org/Documentation/wiki-page.view?name=instrumentData
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0

--- a/assay/src/org/labkey/assay/TsvAssayProvider.java
+++ b/assay/src/org/labkey/assay/TsvAssayProvider.java
@@ -168,6 +168,12 @@ public class TsvAssayProvider extends AbstractTsvAssayProvider
     }
 
     @Override
+    public String getLabel()
+    {
+        return "Standard";
+    }
+
+    @Override
     public AssaySaveHandler getSaveHandler()
     {
         AssaySaveHandler saveHandler = new TsvAssaySaveHandler();

--- a/assay/src/org/labkey/assay/TsvAssayProvider.java
+++ b/assay/src/org/labkey/assay/TsvAssayProvider.java
@@ -170,7 +170,9 @@ public class TsvAssayProvider extends AbstractTsvAssayProvider
     @Override
     public String getLabel()
     {
-        return "Standard";
+        // Hack because there are many subclasses where we want to keep showing their name in the UI, but we want to
+        // show "Standard" instead of "General" for direct uses of TsvAssayProvider
+        return getClass().equals(TsvAssayProvider.class) ? "Standard" : super.getLabel();
     }
 
     @Override

--- a/assay/src/org/labkey/assay/plate/TsvPlateTypeHandler.java
+++ b/assay/src/org/labkey/assay/plate/TsvPlateTypeHandler.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class TsvPlateTypeHandler extends AbstractPlateTypeHandler
 {
     public static final String BLANK_PLATE = "blank";
-    public static final String TYPE = "GPAT (General)";
+    public static final String TYPE = "Standard";
 
     @Override
     public String getAssayType()


### PR DESCRIPTION
#### Rationale
We've renamed General assay to be Standard assay, and there are lingering references to the old name in the UI.

Since we want this for 21.3 I'll retarget before merging but this will get some test coverage underway

#### Changes
* Introduce label for assay providers
* Use the label in a handful of UI text generating places
* Update some comments and metadata