### PR TITLE
add DATETIME to _sqlTypeNameMap - issue 42514

### DIFF
--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -230,6 +230,10 @@ public abstract class SqlDialect
         _sqlTypeNameMap.put("VARBINARY", Types.VARBINARY);
         _sqlTypeNameMap.put("VARCHAR", Types.VARCHAR);
 
+        // Some databases call Types.TIMESTAMP "TIMESTAMP" and some call it "DATETIME"
+        // however we always want to accept "DATETIME" which can be used unambiguously in schema.xml
+        _sqlTypeNameMap.put("DATETIME", Types.TIMESTAMP);
+
         addSqlTypeNames(_sqlTypeNameMap);
     }
 


### PR DESCRIPTION
#### Rationale
Backporting a fix for Issue 42514: DrawTimestamp column is of type "Other" in study.SpecimenDetail

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1805

#### Changes
* Recognize DATETIME column type
