### PR TITLE
Issue 42519: Allow submitter to insert into custom issue fields

### DIFF
--- a/issues/src/org/labkey/issue/model/IssuePage.java
+++ b/issues/src/org/labkey/issue/model/IssuePage.java
@@ -510,6 +510,7 @@ public class IssuePage implements DataRegionSelection.DataSelectionKeyForm
 
     public static boolean shouldDisplay(DomainProperty prop, Container container, User user)
     {
+        // Issue 42519 : this change in approach to check for InsertPermission before is for submitter role
         // treat anything higher than NotPHI as needing special permission
         return container.hasPermission(user, InsertPermission.class) ||
                 prop.getPHI().isExportLevelAllowed(PHI.NotPHI) && container.hasPermission(user, ReadPermission.class);

--- a/issues/src/org/labkey/issue/model/IssuePage.java
+++ b/issues/src/org/labkey/issue/model/IssuePage.java
@@ -510,9 +510,8 @@ public class IssuePage implements DataRegionSelection.DataSelectionKeyForm
 
     public static boolean shouldDisplay(DomainProperty prop, Container container, User user)
     {
-        // treat anything higher than NotPHI as needing special permission
-        Class<? extends Permission> permission = prop.getPHI().isExportLevelAllowed(PHI.NotPHI) ? ReadPermission.class : InsertPermission.class;
-        return container.hasPermission(user, permission);
+        return container.hasPermission(user, InsertPermission.class) ||
+                prop.getPHI().isExportLevelAllowed(PHI.NotPHI) && container.hasPermission(user, ReadPermission.class);
     }
 
     public HtmlString writeInput(String field, String value, int tabIndex)

--- a/issues/src/org/labkey/issue/model/IssuePage.java
+++ b/issues/src/org/labkey/issue/model/IssuePage.java
@@ -510,6 +510,7 @@ public class IssuePage implements DataRegionSelection.DataSelectionKeyForm
 
     public static boolean shouldDisplay(DomainProperty prop, Container container, User user)
     {
+        // treat anything higher than NotPHI as needing special permission
         return container.hasPermission(user, InsertPermission.class) ||
                 prop.getPHI().isExportLevelAllowed(PHI.NotPHI) && container.hasPermission(user, ReadPermission.class);
     }


### PR DESCRIPTION
#### Rationale
Previous work fixed the general insert apis to allow submitter. This fixes the actual issue of allowing submitter not able to insert into custom issue definition fields for which the prev work started.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2031

#### Changes
* update check on IssuePage
