### PR TITLE
Issue 41202: Allow submitter to insert rows into a dataset

### DIFF
--- a/api/src/org/labkey/api/security/roles/AuthorRole.java
+++ b/api/src/org/labkey/api/security/roles/AuthorRole.java
@@ -22,27 +22,28 @@ import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.ReadSomePermission;
+import org.labkey.api.study.Dataset;
 
 /*
-* User: Dave
-* Date: Apr 27, 2009
-* Time: 1:22:12 PM
-*/
+ * User: Dave
+ * Date: Apr 27, 2009
+ */
 public class AuthorRole extends AbstractRole
 {
     public AuthorRole()
     {
         super("Author", "Authors may read and add information in some cases, but may update and delete only information they added. Supported for only " +
                         "Message Boards. See the online documentation for details.",
-                ReadPermission.class,
-                ReadSomePermission.class,
-                InsertPermission.class,
-                ShareReportPermission.class);
+            ReadPermission.class,
+            ReadSomePermission.class,
+            InsertPermission.class,
+            ShareReportPermission.class
+        );
     }
 
     @Override
     public boolean isApplicable(SecurityPolicy policy, SecurableResource resource)
     {
-        return super.isApplicable(policy,resource) || resource instanceof PipeRoot;
+        return super.isApplicable(policy,resource) || resource instanceof PipeRoot || resource instanceof Dataset;
     }
 }

--- a/api/src/org/labkey/api/security/roles/NoPermissionsRole.java
+++ b/api/src/org/labkey/api/security/roles/NoPermissionsRole.java
@@ -17,6 +17,7 @@ package org.labkey.api.security.roles;
 
 import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityPolicy;
+import org.labkey.api.study.Dataset;
 
 import java.util.Collections;
 
@@ -35,6 +36,7 @@ public class NoPermissionsRole extends AbstractContextualRole
     @Override
     public boolean isApplicable(SecurityPolicy policy, SecurableResource resource)
     {
-        return true;
+        // Don't show on dataset security page
+        return !(resource instanceof Dataset);
     }
 }

--- a/api/src/org/labkey/api/security/roles/RestrictedReaderRole.java
+++ b/api/src/org/labkey/api/security/roles/RestrictedReaderRole.java
@@ -38,6 +38,6 @@ public class RestrictedReaderRole extends AbstractRole
     @Override
     public boolean isApplicable(SecurityPolicy policy, SecurableResource resource)
     {
-        return super.isApplicable(policy,resource) || resource instanceof Study || resource instanceof Dataset;
+        return super.isApplicable(policy,resource) || resource instanceof Study;
     }
 }

--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -130,7 +130,12 @@ public interface Dataset<T extends Dataset> extends StudyEntity, StudyCachable<T
     /**
      * @return whether the user has permission to update the dataset
      */
-    public boolean canEdit(UserPrincipal user);
+    public boolean canUpdate(UserPrincipal user);
+
+    /**
+     * @return whether the user has permission to delete from the dataset
+     */
+    public boolean canDelete(UserPrincipal user);
 
     /**
      * @return whether the user has permission to insert rows into the dataset

--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -128,9 +128,14 @@ public interface Dataset<T extends Dataset> extends StudyEntity, StudyCachable<T
     public boolean canRead(UserPrincipal user);
 
     /**
-     * @return whether the user has permission to write to the dataset
+     * @return whether the user has permission to update the dataset
      */
-    public boolean canWrite(UserPrincipal user);
+    public boolean canEdit(UserPrincipal user);
+
+    /**
+     * @return whether the user has permission to insert rows into the dataset
+     */
+    public boolean canInsert(UserPrincipal user);
 
     /**
      * @return whether the user has permission to delete the entire dataset. Use canWrite() to check if user can delete

--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -122,6 +122,8 @@ public interface Dataset<T extends Dataset> extends StudyEntity, StudyCachable<T
 
     void save(User user) throws SQLException;
 
+    boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm);
+
     /**
      * @return whether the user has permission to read rows from this dataset
      */

--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -127,37 +127,37 @@ public interface Dataset<T extends Dataset> extends StudyEntity, StudyCachable<T
     /**
      * @return whether the user has permission to read rows from this dataset
      */
-    public boolean canRead(UserPrincipal user);
+    boolean canRead(UserPrincipal user);
 
     /**
      * @return whether the user has permission to update the dataset
      */
-    public boolean canUpdate(UserPrincipal user);
+    boolean canUpdate(UserPrincipal user);
 
     /**
      * @return whether the user has permission to delete from the dataset
      */
-    public boolean canDelete(UserPrincipal user);
+    boolean canDelete(UserPrincipal user);
 
     /**
      * @return whether the user has permission to insert rows into the dataset
      */
-    public boolean canInsert(UserPrincipal user);
+    boolean canInsert(UserPrincipal user);
 
     /**
      * @return whether the user has permission to delete the entire dataset. Use canWrite() to check if user can delete
      * rows from the dataset.
      */
-    public boolean canDeleteDefinition(UserPrincipal user);
+    boolean canDeleteDefinition(UserPrincipal user);
 
     /**
      * Does the user have admin permissions for this dataset
      * @param user
      * @return
      */
-    public boolean canUpdateDefinition(User user);
+    boolean canUpdateDefinition(User user);
 
-    public Set<Class<? extends Permission>> getPermissions(UserPrincipal user);
+    Set<Class<? extends Permission>> getPermissions(UserPrincipal user);
 
     KeyType getKeyType();
 
@@ -200,7 +200,7 @@ public interface Dataset<T extends Dataset> extends StudyEntity, StudyCachable<T
      * @param lsid The row LSID
      * @return A map of the dataset row columns, null if no record found
      */
-    public Map<String, Object> getDatasetRow(User u, String lsid);
+    Map<String, Object> getDatasetRow(User u, String lsid);
 
     /**
      * Fetches a set of rows from a dataset given a collection of LSIDs
@@ -208,19 +208,18 @@ public interface Dataset<T extends Dataset> extends StudyEntity, StudyCachable<T
      * @param lsids The row LSIDs
      * @return An array of maps of the dataset row columns
      */
-    @NotNull
-    public List<Map<String, Object>> getDatasetRows(User u, Collection<String> lsids);
+    @NotNull List<Map<String, Object>> getDatasetRows(User u, Collection<String> lsids);
 
     /**
      * Deletes the specified rows from the dataset.
      * @param u user performing the delete
      * @param lsids keys of the dataset rows
      */
-    public void deleteDatasetRows(User u, Collection<String> lsids);
+    void deleteDatasetRows(User u, Collection<String> lsids);
 
     // constants for dataset types
-    public static final String TYPE_STANDARD = "Standard";
-    public static final String TYPE_PLACEHOLDER = "Placeholder";
+    String TYPE_STANDARD = "Standard";
+    String TYPE_PLACEHOLDER = "Placeholder";
 
     enum KeyType
     {
@@ -245,10 +244,10 @@ public interface Dataset<T extends Dataset> extends StudyEntity, StudyCachable<T
         // Don't rename enums without updating the values in the database too
         None(""), RowId("rowid", "true"), GUID("entityid", "guid");
 
-        private String _serializationName;
-        private String[] _serializationAliases;
+        private final String _serializationName;
+        private final String[] _serializationAliases;
 
-        private KeyManagementType(String serializationName, String... serializationAliases)
+        KeyManagementType(String serializationName, String... serializationAliases)
         {
             _serializationName = serializationName;
             _serializationAliases = serializationAliases;

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -456,7 +456,7 @@ public class SecurityApiActions
     @RequiresPermission(ReadPermission.class)
     public static class GetRolesAction extends ReadOnlyApiAction
     {
-        private Set<Permission> _allPermissions = new HashSet<>();
+        private final Set<Permission> _allPermissions = new HashSet<>();
 
         @Override
         public ApiResponse execute(Object o, BindException errors)

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -107,7 +107,6 @@ import org.labkey.api.util.GUID;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.TestContext;
-import org.labkey.api.util.URIUtil;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
@@ -3725,7 +3724,7 @@ public class ExperimentServiceImpl implements ExperimentService
 
                             for (Dataset dataset : studyService.getDatasetsForAssayRuns(Collections.singletonList(run), user))
                             {
-                                if (!dataset.canWrite(user))
+                                if (!dataset.canEdit(user))
                                 {
                                     throw new UnauthorizedException("Cannot delete rows from dataset " + dataset);
                                 }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -3724,7 +3724,7 @@ public class ExperimentServiceImpl implements ExperimentService
 
                             for (Dataset dataset : studyService.getDatasetsForAssayRuns(Collections.singletonList(run), user))
                             {
-                                if (!dataset.canEdit(user))
+                                if (!dataset.canDelete(user))
                                 {
                                     throw new UnauthorizedException("Cannot delete rows from dataset " + dataset);
                                 }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -2880,7 +2880,7 @@ public class ExperimentController extends SpringActionController
                 for (Dataset dataset : StudyService.get().getDatasetsForAssayRuns(runs, getUser()))
                 {
                     ActionURL url = urlProvider(StudyUrls.class).getDatasetURL(dataset.getContainer(), dataset.getDatasetId());
-                    if (dataset.canEdit(getUser()))
+                    if (dataset.canDelete(getUser()))
                     {
                         permissionDatasetRows.add(new Pair<>(dataset, url));
                     }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -36,7 +36,6 @@ import org.labkey.api.action.ExportAction;
 import org.labkey.api.action.FormHandlerAction;
 import org.labkey.api.action.FormViewAction;
 import org.labkey.api.action.HasViewContext;
-import org.labkey.api.action.LabKeyError;
 import org.labkey.api.action.Marshal;
 import org.labkey.api.action.Marshaller;
 import org.labkey.api.action.MutatingApiAction;
@@ -2881,7 +2880,7 @@ public class ExperimentController extends SpringActionController
                 for (Dataset dataset : StudyService.get().getDatasetsForAssayRuns(runs, getUser()))
                 {
                     ActionURL url = urlProvider(StudyUrls.class).getDatasetURL(dataset.getContainer(), dataset.getDatasetId());
-                    if (dataset.canWrite(getUser()))
+                    if (dataset.canEdit(getUser()))
                     {
                         permissionDatasetRows.add(new Pair<>(dataset, url));
                     }

--- a/study/src/org/labkey/study/controllers/InsertUpdateAction.java
+++ b/study/src/org/labkey/study/controllers/InsertUpdateAction.java
@@ -129,7 +129,7 @@ public abstract class InsertUpdateAction<Form extends DatasetController.EditData
         {
             throw new UnauthorizedException("User does not have permission to insert into this dataset");
         }
-        if (!_ds.canEdit(getUser()))
+        if (!isInsert() && !_ds.canUpdate(getUser()))
         {
             throw new UnauthorizedException("User does not have permission to edit this dataset");
         }
@@ -294,7 +294,7 @@ public abstract class InsertUpdateAction<Form extends DatasetController.EditData
         {
             throw new UnauthorizedException("User does not have permission to insert into this dataset");
         }
-        else if (!isInsert && !_ds.canEdit(user))
+        else if (!isInsert && !_ds.canUpdate(user))
         {
             throw new UnauthorizedException("User does not have permission to edit this dataset");
         }

--- a/study/src/org/labkey/study/controllers/InsertUpdateAction.java
+++ b/study/src/org/labkey/study/controllers/InsertUpdateAction.java
@@ -289,12 +289,11 @@ public abstract class InsertUpdateAction<Form extends DatasetController.EditData
         }
         final Container c = getContainer();
         final User user = getUser();
-        boolean isInsert = isInsert();
-        if (isInsert && !_ds.canInsert(user))
+        if (isInsert() && !_ds.canInsert(user))
         {
             throw new UnauthorizedException("User does not have permission to insert into this dataset");
         }
-        else if (!isInsert && !_ds.canUpdate(user))
+        if (!isInsert() && !_ds.canUpdate(user))
         {
             throw new UnauthorizedException("User does not have permission to edit this dataset");
         }

--- a/study/src/org/labkey/study/controllers/InsertUpdateAction.java
+++ b/study/src/org/labkey/study/controllers/InsertUpdateAction.java
@@ -114,6 +114,7 @@ public abstract class InsertUpdateAction<Form extends DatasetController.EditData
     public ModelAndView getView(Form form, boolean reshow, BindException errors) throws Exception
     {
         StudyImpl study = getStudy();
+
         _ds = StudyManager.getInstance().getDatasetDefinition(getStudy(), form.getDatasetId());
         if (null == _ds)
         {
@@ -124,7 +125,11 @@ public abstract class InsertUpdateAction<Form extends DatasetController.EditData
         {
             throw new UnauthorizedException("User does not have permission to view this dataset");
         }
-        if (!_ds.canWrite(getUser()))
+        if (isInsert() && !_ds.canInsert(getUser()))
+        {
+            throw new UnauthorizedException("User does not have permission to insert into this dataset");
+        }
+        if (!_ds.canEdit(getUser()))
         {
             throw new UnauthorizedException("User does not have permission to edit this dataset");
         }
@@ -284,7 +289,12 @@ public abstract class InsertUpdateAction<Form extends DatasetController.EditData
         }
         final Container c = getContainer();
         final User user = getUser();
-        if (!_ds.canWrite(user))
+        boolean isInsert = isInsert();
+        if (isInsert && !_ds.canInsert(user))
+        {
+            throw new UnauthorizedException("User does not have permission to insert into this dataset");
+        }
+        else if (!isInsert && !_ds.canEdit(user))
         {
             throw new UnauthorizedException("User does not have permission to edit this dataset");
         }

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -736,12 +736,6 @@ public class StudyController extends BaseStudyController
         return newUrl.addParameters(context.getActionURL().getParameters());
     }
 
-    private static boolean canWrite(DatasetDefinition def, User user)
-    {
-        return def.canInsert(user) && def.getContainer().hasPermission(user, ReadPermission.class);
-    }
-
-
     @RequiresPermission(ReadPermission.class)
     public class DatasetAction extends QueryViewAction<DatasetFilterForm, QueryView>
     {
@@ -2493,7 +2487,7 @@ public class StudyController extends BaseStudyController
         @Override
         protected void validatePermission(User user, BindException errors)
         {
-            if (canWrite(_def, user))
+            if (_def.canInsert(user))
                 return;
             throw new UnauthorizedException("Can't update dataset: " + _def.getName());
         }

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -2934,7 +2934,8 @@ public class StudyController extends BaseStudyController
         }
     }
 
-    @RequiresPermission(DeletePermission.class)
+    // Dataset.canDelete() permissions check is below. This accommodates dataset security, where user might not have delete permission in the folder.
+    @RequiresPermission(ReadPermission.class)
     public class DeleteDatasetRowsAction extends FormHandlerAction<DeleteDatasetRowsForm>
     {
         @Override
@@ -2951,7 +2952,7 @@ public class StudyController extends BaseStudyController
             if (null == dataset)
                 throw new NotFoundException();
 
-            if (!dataset.canUpdate(getUser()))
+            if (!dataset.canDelete(getUser()))
                 throw new UnauthorizedException("User does not have permission to delete rows from this dataset");
 
             // Operate on each individually for audit logging purposes, but transact the whole thing

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -738,7 +738,7 @@ public class StudyController extends BaseStudyController
 
     private static boolean canWrite(DatasetDefinition def, User user)
     {
-        return def.canEdit(user) && def.getContainer().hasPermission(user, ReadPermission.class);
+        return def.canInsert(user) && def.getContainer().hasPermission(user, ReadPermission.class);
     }
 
 
@@ -2951,7 +2951,7 @@ public class StudyController extends BaseStudyController
             if (null == dataset)
                 throw new NotFoundException();
 
-            if (!dataset.canEdit(getUser()))
+            if (!dataset.canUpdate(getUser()))
                 throw new UnauthorizedException("User does not have permission to delete rows from this dataset");
 
             // Operate on each individually for audit logging purposes, but transact the whole thing

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -738,7 +738,7 @@ public class StudyController extends BaseStudyController
 
     private static boolean canWrite(DatasetDefinition def, User user)
     {
-        return def.canWrite(user) && def.getContainer().hasPermission(user, ReadPermission.class);
+        return def.canEdit(user) && def.getContainer().hasPermission(user, ReadPermission.class);
     }
 
 
@@ -2951,7 +2951,7 @@ public class StudyController extends BaseStudyController
             if (null == dataset)
                 throw new NotFoundException();
 
-            if (!dataset.canWrite(getUser()))
+            if (!dataset.canEdit(getUser()))
                 throw new UnauthorizedException("User does not have permission to delete rows from this dataset");
 
             // Operate on each individually for audit logging purposes, but transact the whole thing

--- a/study/src/org/labkey/study/controllers/specimen/SpecimenUtils.java
+++ b/study/src/org/labkey/study/controllers/specimen/SpecimenUtils.java
@@ -266,7 +266,7 @@ public class SpecimenUtils
                 if (study.getParticipantCommentDatasetId() != null && study.getParticipantCommentDatasetId() != -1)
                 {
                     DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantCommentDatasetId());
-                    if (def != null && def.canWrite(getUser()))
+                    if (def != null && def.canEdit(getUser()))
                     {
                         if (addSep)
                         {
@@ -282,7 +282,7 @@ public class SpecimenUtils
                 if (study.getParticipantVisitCommentDatasetId() != null && study.getParticipantVisitCommentDatasetId() != -1)
                 {
                     DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantVisitCommentDatasetId());
-                    if (def != null && def.canWrite(getUser()))
+                    if (def != null && def.canEdit(getUser()))
                     {
                         if (addSep)
                         {

--- a/study/src/org/labkey/study/controllers/specimen/SpecimenUtils.java
+++ b/study/src/org/labkey/study/controllers/specimen/SpecimenUtils.java
@@ -266,7 +266,7 @@ public class SpecimenUtils
                 if (study.getParticipantCommentDatasetId() != null && study.getParticipantCommentDatasetId() != -1)
                 {
                     DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantCommentDatasetId());
-                    if (def != null && def.canEdit(getUser()))
+                    if (def != null && def.canUpdate(getUser()))
                     {
                         if (addSep)
                         {
@@ -282,7 +282,7 @@ public class SpecimenUtils
                 if (study.getParticipantVisitCommentDatasetId() != null && study.getParticipantVisitCommentDatasetId() != -1)
                 {
                     DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantVisitCommentDatasetId());
-                    if (def != null && def.canEdit(getUser()))
+                    if (def != null && def.canUpdate(getUser()))
                     {
                         if (addSep)
                         {

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -930,7 +930,7 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
                 if (studyPolicy.hasPermission(user, ReadSomePermission.class))
                 {
                     // Advanced write grants dataset permissions based on the policy stored directly on the dataset
-                    result.addAll(SecurityPolicyManager.getPolicy(this).getPermissions(user));
+                    copyEditPerms(SecurityPolicyManager.getPolicy(this), user, result);
                 }
             }
         }

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -921,6 +921,10 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
                 {
                     result.addAll(RoleManager.getRole(SiteAdminRole.class).getPermissions());
                 }
+                else if (getStudy().getContainer().hasPermission(user, InsertPermission.class))
+                {
+                    result.add(InsertPermission.class);
+                }
                 else if (getStudy().getContainer().hasPermission(user, UpdatePermission.class))
                 {
                     // Basic write access grants insert/update/delete for datasets to everyone who has update permission
@@ -942,6 +946,10 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
                     {
                         result.add(UpdatePermission.class);
                         result.add(DeletePermission.class);
+                        result.add(InsertPermission.class);
+                    }
+                    else if (studyPolicy.hasPermission(user, InsertPermission.class))
+                    {
                         result.add(InsertPermission.class);
                     }
                     // A user can be part of multiple groups, which are set to both Edit All and Per Dataset permissions
@@ -975,7 +983,7 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
 
 
     @Override
-    public boolean canWrite(UserPrincipal user)
+    public boolean canEdit(UserPrincipal user)
     {
         if (getStudy().isDataspaceStudy())
             return false;
@@ -984,6 +992,18 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
         if (getContainer().hasPermission(user, AdminPermission.class))
             return true;
         return getPermissions(user).contains(UpdatePermission.class);
+    }
+
+    @Override
+    public boolean canInsert(UserPrincipal user)
+    {
+        if (getStudy().isDataspaceStudy())
+            return false;
+        if (user instanceof User && !canAccessPhi((User)user))
+            return false;
+        if (getContainer().hasPermission(user, AdminPermission.class))
+            return true;
+        return getPermissions(user).contains(InsertPermission.class);
     }
 
 

--- a/study/src/org/labkey/study/model/SecurityType.java
+++ b/study/src/org/labkey/study/model/SecurityType.java
@@ -23,14 +23,14 @@ package org.labkey.study.model;
 public enum SecurityType
 {
     /**
-     * Basic security: only admins can add dataset data.
+     * Basic security: only admins can add, edit, and delete dataset data
      */
     BASIC_READ("Basic security with read-only datasets",
             "Uses the security settings of the containing folder for dataset security. " +
-            "Only administrators can import or delete dataset data.", false),
+            "Only administrators can import, edit, and delete dataset data.", false),
 
     /**
-     * Anyone with update permissions can add and update dataset data
+     * Anyone with update permissions can add, edit, and delete dataset data
      */
     BASIC_WRITE("Basic security with editable datasets",
             "Uses the security settings of the containing folder for dataset security, allowing " +
@@ -41,7 +41,7 @@ public enum SecurityType
      */
     ADVANCED_READ("Custom security with read-only datasets",
             "Allows the configuration of security on individual datasets. " +
-            "Only administrators can import, edit, or delete dataset data. Not supported in shared studies.", true),
+            "Only administrators can import, edit, and delete dataset data. Not supported in shared studies.", true),
 
     /**
      * Per-dataset security, read and write

--- a/study/src/org/labkey/study/model/SecurityType.java
+++ b/study/src/org/labkey/study/model/SecurityType.java
@@ -33,22 +33,22 @@ public enum SecurityType
      * Anyone with update permissions can add and update dataset data
      */
     BASIC_WRITE("Basic security with editable datasets",
-            "Identical to Basic Read-Only Security, except that individuals with UPDATE permission " +
-            "can edit, update, and delete data from datasets.", false),
+            "Uses the security settings of the containing folder for dataset security, allowing " +
+            "non-administrators to import, edit, and delete dataset data based on their folder-assigned roles.", false),
 
     /**
      * Per-dataset security, read-only
      */
     ADVANCED_READ("Custom security with read-only datasets",
             "Allows the configuration of security on individual datasets. " +
-            "Only administrators can import or delete dataset data.  Not supported in shared studies.", true),
+            "Only administrators can import, edit, or delete dataset data. Not supported in shared studies.", true),
 
     /**
      * Per-dataset security, read and write
      */
     ADVANCED_WRITE("Custom security with editable datasets",
-            "Identical to Advanced Read-Only Security, except that datasets can be individually " +
-            "set to allow updates as well.  Not supported in shared studies.", true);
+            "Allows the configuration of security on individual datasets, including the ability for " +
+            "non-administrators to import, edit, and delete dataset data. Not supported in shared studies.", true);
 
     private final String label;
 

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -140,7 +140,7 @@ public class DatasetQueryView extends StudyQueryView
         _showSourceLinks = settings.isShowSourceLinks();
 
         // Only show link to edit if permission allows it
-        setShowUpdateColumn(settings.isShowEditLinks() && !isExportView() && _dataset.canWrite(getUser()));
+        setShowUpdateColumn(settings.isShowEditLinks() && !isExportView() && _dataset.canEdit(getUser()));
 
         if (form.getVisitRowId() != 0)
         {
@@ -380,7 +380,8 @@ public class DatasetQueryView extends StudyQueryView
         bar.add(createExportButton(recordSelectorColumns));
 
         User user = getUser();
-        boolean canWrite = canWrite(_dataset, user);
+        boolean canEdit = canEdit(_dataset, user);
+        boolean canInsert = canInsert(_dataset, user);
         boolean canManage = canManage(_dataset, user);
         boolean isSnapshot = QueryService.get().isQuerySnapshot(getContainer(), StudySchema.getInstance().getSchemaName(), _dataset.getName());
         boolean isAssayDataset = _dataset.isAssayData();
@@ -397,7 +398,7 @@ public class DatasetQueryView extends StudyQueryView
         {
             if (!isAssayDataset) // admins always get the import and manage buttons
             {
-                if (canWrite)
+                if (canInsert)
                 {
                     // insert menu button contain Insert New and Bulk import, or button for either option
                     ActionButton insertButton = createInsertMenuButton();
@@ -408,7 +409,7 @@ public class DatasetQueryView extends StudyQueryView
                     }
                 }
 
-                if (canWrite && _study instanceof StudyImpl)
+                if (canEdit && _study instanceof StudyImpl)
                 {
                     ActionURL deleteRowsURL = urlFor(QueryAction.deleteQueryRows);
                     if (deleteRowsURL != null)
@@ -438,7 +439,7 @@ public class DatasetQueryView extends StudyQueryView
             {
                 bar.addAll(AssayService.get().getImportButtons(protocol, getUser(), getContainer(), true));
 
-                if (user.hasRootAdminPermission() || canWrite)
+                if (user.hasRootAdminPermission() || canEdit)
                 {
                     ActionURL deleteRowsURL = new ActionURL(StudyController.DeletePublishedRowsAction.class, getContainer());
                     deleteRowsURL.addParameter("protocolId", protocol.getRowId());
@@ -538,9 +539,14 @@ public class DatasetQueryView extends StudyQueryView
         return button;
     }
 
-    private boolean canWrite(DatasetDefinition def, User user)
+    private boolean canEdit(DatasetDefinition def, User user)
     {
-        return def.canWrite(user) && def.getContainer().hasPermission(user, UpdatePermission.class);
+        return def.canEdit(user) && def.getContainer().hasPermission(user, UpdatePermission.class);
+    }
+
+    private boolean canInsert(DatasetDefinition def, User user)
+    {
+        return def.canInsert(user) && def.getContainer().hasPermission(user, InsertPermission.class);
     }
 
     private boolean canManage(DatasetDefinition def, User user)

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -140,7 +140,7 @@ public class DatasetQueryView extends StudyQueryView
         _showSourceLinks = settings.isShowSourceLinks();
 
         // Only show link to edit if permission allows it
-        setShowUpdateColumn(settings.isShowEditLinks() && !isExportView() && _dataset.canEdit(getUser()));
+        setShowUpdateColumn(settings.isShowEditLinks() && !isExportView() && _dataset.canUpdate(getUser()));
 
         if (form.getVisitRowId() != 0)
         {
@@ -541,7 +541,7 @@ public class DatasetQueryView extends StudyQueryView
 
     private boolean canEdit(DatasetDefinition def, User user)
     {
-        return def.canEdit(user) && def.getContainer().hasPermission(user, UpdatePermission.class);
+        return def.canUpdate(user) && def.getContainer().hasPermission(user, UpdatePermission.class);
     }
 
     private boolean canInsert(DatasetDefinition def, User user)

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -61,6 +61,7 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.QCAnalystPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.specimen.SpecimenManager;
 import org.labkey.api.study.CohortFilter;
 import org.labkey.api.study.DataspaceContainerFilter;
 import org.labkey.api.study.TimepointType;
@@ -457,12 +458,15 @@ public class DatasetQueryView extends StudyQueryView
         if (QCStateManager.getInstance().showQCStates(getContainer()))
             bar.add(createQCStateButton(_qcStateSet));
 
-        ActionURL viewSpecimensURL = new ActionURL(SpecimenController.SelectedSpecimensAction.class, getContainer());
-        ActionButton viewSpecimens = new ActionButton(viewSpecimensURL, "View Specimens");
-        viewSpecimens.setRequiresSelection(true);
-        viewSpecimens.setActionType(ActionButton.Action.POST);
-        viewSpecimens.setDisplayPermission(ReadPermission.class);
-        bar.add(viewSpecimens);
+        if (SpecimenManager.get().isSpecimenModuleActive(getContainer()))
+        {
+            ActionURL viewSpecimensURL = new ActionURL(SpecimenController.SelectedSpecimensAction.class, getContainer());
+            ActionButton viewSpecimens = new ActionButton(viewSpecimensURL, "View Specimens");
+            viewSpecimens.setRequiresSelection(true);
+            viewSpecimens.setActionType(ActionButton.Action.POST);
+            viewSpecimens.setDisplayPermission(ReadPermission.class);
+            bar.add(viewSpecimens);
+        }
 
         if (isAssayDataset)
         {

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -1126,7 +1126,7 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
         if (InsertPermission.class.isAssignableFrom(perm))
             return def.canInsert(user);
         if (UpdatePermission.class.isAssignableFrom(perm) || DeletePermission.class.isAssignableFrom(perm))
-            return def.canEdit(user);
+            return def.canUpdate(user);
         return def.getPolicy().hasPermission(user, perm);
     }
 

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -67,11 +67,7 @@ import org.labkey.api.query.UserIdQueryForeignKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
-import org.labkey.api.security.permissions.DeletePermission;
-import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.DatasetTable;
 import org.labkey.api.study.DataspaceContainerFilter;
@@ -1120,14 +1116,7 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
         // OK to edit these in Dataspace project and in any folder
-        Dataset def = getDatasetDefinition();
-        if (ReadPermission.class.isAssignableFrom(perm))
-            return def.canRead(user);
-        if (InsertPermission.class.isAssignableFrom(perm))
-            return def.canInsert(user);
-        if (UpdatePermission.class.isAssignableFrom(perm) || DeletePermission.class.isAssignableFrom(perm))
-            return def.canUpdate(user);
-        return def.getPolicy().hasPermission(user, perm);
+        return getDatasetDefinition().hasPermission(user, perm);
     }
 
     @Override

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -1111,7 +1111,7 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
     {
         User user = _userSchema.getUser();
         Dataset def = getDatasetDefinition();
-        if (!user.hasRootAdminPermission() && !def.canWrite(user))
+        if (!user.hasRootAdminPermission() && !def.canInsert(user))
             return null;
         return new DatasetUpdateService(this);
     }
@@ -1123,8 +1123,10 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
         Dataset def = getDatasetDefinition();
         if (ReadPermission.class.isAssignableFrom(perm))
             return def.canRead(user);
-        if (InsertPermission.class.isAssignableFrom(perm) || UpdatePermission.class.isAssignableFrom(perm) || DeletePermission.class.isAssignableFrom(perm))
-            return def.canWrite(user);
+        if (InsertPermission.class.isAssignableFrom(perm))
+            return def.canInsert(user);
+        if (UpdatePermission.class.isAssignableFrom(perm) || DeletePermission.class.isAssignableFrom(perm))
+            return def.canEdit(user);
         return def.getPolicy().hasPermission(user, perm);
     }
 

--- a/study/src/org/labkey/study/view/datasetDetails.jsp
+++ b/study/src/org/labkey/study/view/datasetDetails.jsp
@@ -121,7 +121,7 @@ if (permissions.contains(AdminPermission.class))
             .href(deleteDatasetURL)
             .usePost("Are you sure you want to delete this dataset? All related data and visitmap entries will also be deleted."));
     }
-    if (user.hasRootAdminPermission() || dataset.canEdit(user))
+    if (user.hasRootAdminPermission() || dataset.canDelete(user))
     {
         buttons.add(button("Delete All Rows").onClick("truncateTable();"));
     }

--- a/study/src/org/labkey/study/view/datasetDetails.jsp
+++ b/study/src/org/labkey/study/view/datasetDetails.jsp
@@ -121,7 +121,7 @@ if (permissions.contains(AdminPermission.class))
             .href(deleteDatasetURL)
             .usePost("Are you sure you want to delete this dataset? All related data and visitmap entries will also be deleted."));
     }
-    if (user.hasRootAdminPermission() || dataset.canWrite(user))
+    if (user.hasRootAdminPermission() || dataset.canEdit(user))
     {
         buttons.add(button("Delete All Rows").onClick("truncateTable();"));
     }

--- a/study/src/org/labkey/study/view/manageStudy.jsp
+++ b/study/src/org/labkey/study/view/manageStudy.jsp
@@ -38,7 +38,6 @@
 <%@ page import="org.labkey.api.study.model.ParticipantGroup" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
-<%@ page import="org.labkey.study.controllers.BaseStudyController.StudyJspView" %>
 <%@ page import="org.labkey.study.controllers.CohortController.ManageCohortsAction" %>
 <%@ page import="org.labkey.study.controllers.StudyController.ConfigureMasterPatientSettingsAction" %>
 <%@ page import="org.labkey.study.controllers.StudyController.DeleteStudyAction" %>
@@ -63,10 +62,10 @@
 <%@ page import="org.labkey.study.model.StudyImpl" %>
 <%@ page import="org.labkey.study.model.StudyManager" %>
 <%@ page import="org.labkey.study.model.StudySnapshot" %>
+<%@ page import="org.labkey.study.view.specimen.ManageSpecimenView" %>
 <%@ page import="java.util.Collection" %>
 <%@ page import="java.util.LinkedList" %>
 <%@ page import="java.util.List" %>
-<%@ page import="org.labkey.study.view.specimen.ManageSpecimenView" %>
 <%@ page extends="org.labkey.study.view.BaseStudyPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -245,12 +244,12 @@
                     </tr>
                     <tr>
                         <td class="lk-study-prop-label">Security</td>
-                        <td class="lk-study-prop-desc">Manage access to study datasets and samples</td>
+                        <td class="lk-study-prop-desc">Manage access to study datasets</td>
                         <td><%= link("Manage Security", BeginAction.class) %></td>
                     </tr>
                     <tr>
                         <td class="lk-study-prop-label">Reports/Views</td>
-                        <td class="lk-study-prop-desc">Manage views for this Study</td>
+                        <td class="lk-study-prop-desc">Manage views for this study</td>
                         <td><%=link("Manage Views", urlProvider(ReportUrls.class).urlManageViews(c)) %></td>
                     </tr>
                     <tr>

--- a/study/src/org/labkey/study/view/participantCharacteristics.jsp
+++ b/study/src/org/labkey/study/view/participantCharacteristics.jsp
@@ -141,7 +141,7 @@
             datasetRow = dataset.getDatasetRow(user, lsid);
         }
 
-        boolean editAccess = dataset.canEdit(user);
+        boolean editAccess = dataset.canInsert(user);
         if (datasetRow == null)
         {
             if (editAccess)

--- a/study/src/org/labkey/study/view/participantCharacteristics.jsp
+++ b/study/src/org/labkey/study/view/participantCharacteristics.jsp
@@ -141,7 +141,7 @@
             datasetRow = dataset.getDatasetRow(user, lsid);
         }
 
-        boolean editAccess = dataset.canWrite(user);
+        boolean editAccess = dataset.canEdit(user);
         if (datasetRow == null)
         {
             if (editAccess)

--- a/study/src/org/labkey/study/view/participantCharacteristics.jsp
+++ b/study/src/org/labkey/study/view/participantCharacteristics.jsp
@@ -141,10 +141,9 @@
             datasetRow = dataset.getDatasetRow(user, lsid);
         }
 
-        boolean editAccess = dataset.canInsert(user);
         if (datasetRow == null)
         {
-            if (editAccess)
+            if (dataset.canInsert(user))
             {
                 ActionURL addAction = new ActionURL(DatasetController.InsertAction.class, getContainer());
                 addAction.addParameter("datasetId", datasetId);
@@ -159,7 +158,7 @@
             continue;
         }
 
-        if (editAccess)
+        if (dataset.canUpdate(user))
         {
     %>
     <tr class="labkey-alternate-row" style="<%=text(expanded ? "" : "display:none")%>">

--- a/study/src/org/labkey/study/view/specimen/updateComments.jsp
+++ b/study/src/org/labkey/study/view/specimen/updateComments.jsp
@@ -158,13 +158,13 @@
         if (hasParticipantMenu)
         {
             DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantCommentDatasetId());
-            hasParticipantMenu = def != null && def.canWrite(user);
+            hasParticipantMenu = def != null && def.canEdit(user);
         }
 
         if (hasParticipantVisitMenu)
         {
             DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantVisitCommentDatasetId());
-            hasParticipantVisitMenu = def != null && def.canWrite(user);
+            hasParticipantVisitMenu = def != null && def.canEdit(user);
         }
 
         if (hasParticipantMenu || hasParticipantVisitMenu)

--- a/study/src/org/labkey/study/view/specimen/updateComments.jsp
+++ b/study/src/org/labkey/study/view/specimen/updateComments.jsp
@@ -158,13 +158,13 @@
         if (hasParticipantMenu)
         {
             DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantCommentDatasetId());
-            hasParticipantMenu = def != null && def.canEdit(user);
+            hasParticipantMenu = def != null && def.canUpdate(user);
         }
 
         if (hasParticipantVisitMenu)
         {
             DatasetDefinition def = StudyManager.getInstance().getDatasetDefinition(study, study.getParticipantVisitCommentDatasetId());
-            hasParticipantVisitMenu = def != null && def.canEdit(user);
+            hasParticipantVisitMenu = def != null && def.canUpdate(user);
         }
 
         if (hasParticipantMenu || hasParticipantVisitMenu)

--- a/study/test/src/org/labkey/test/tests/study/StudySecurityTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudySecurityTest.java
@@ -60,8 +60,8 @@ public class StudySecurityTest extends StudyBaseTest
 
     protected enum PerDatasetPerm
     {
-        Read,
-        Edit
+        Reader,
+        Editor
     }
 
     @Override
@@ -123,7 +123,7 @@ public class StudySecurityTest extends StudyBaseTest
         //move editors to per-dataset and grant edit only one of the datasets
         String[] edit = new String[]{"Types"};
         String[] noEdit = new String[]{"DEM-1: Demographics"};
-        adjustGroupDatasetPerms(GROUP_EDITORS, GroupSetting.perDataset, edit, PerDatasetPerm.Edit);
+        adjustGroupDatasetPerms(GROUP_EDITORS, GroupSetting.perDataset, edit, PerDatasetPerm.Editor);
         verifyPerms(EDITOR, edit, noEdit, edit, noEdit, false);
 
         //reset to general edit
@@ -231,8 +231,8 @@ public class StudySecurityTest extends StudyBaseTest
         clickButton("Update");
 
         //grant limited rights to read a couple of datasets
-        selectOptionByText(Locator.name("dataset.1"), "Read");
-        selectOptionByText(Locator.name("dataset.2"), "Read");
+        selectOptionByText(Locator.name("dataset.1"), "Reader");
+        selectOptionByText(Locator.name("dataset.2"), "Reader");
         clickButton("Save");
 
         clickFolder(getFolderName());


### PR DESCRIPTION
#### Rationale
In editable dataset modes, dataset editing currently requires Admin or Editor role. This means Authors and Submitters, who can insert into other tables, are not allowed to insert into datasets. Here we replace a single `canWrite()` method, that checks for update, with separate `canInsert()`, `canUpdate()`, and `canDelete()` methods. We also fix a variety of associated inconsistencies (dataset button bars not respecting dataset security, incorrect action permissions) and unnecessarily complex permission checks. All code paths should now delegate to `DatasetDefinition.hasPermission()`.

This also updates the per-dataset drop-downs to remove unnecessary roles ("No Permissions", "Restricted Reader"), add "Author", switch to standard "Reader" and "Editor" terminology, and add a sensible sort.

#### Dataset Security Rules
For the record, these are the rules we now follow:

Regardless of security type:

- Admins in the current folder can always import, insert, update, and delete rows in every dataset
- All dataset access requires folder read permission, at a minimum

Additional rules for each security type:

- Basic security with read-only datasets
  - Users with folder read permissions can read all datasets. Editors, Authors, etc. have no ability to edit datasets (edit is restricted to Admins)
- Basic security with editable datasets
  - Dataset permissions respect folder permissions. Editors can insert, update, delete, and read; Authors can insert and read; etc. (previously, only update was checked and implied insert/delete)
- Custom security with read-only datasets
  - Users assigned to groups designated as "READ ALL" can read all datasets
  - Users assigned to groups granted "PER DATASET" access can read only the datasets marked as "Read" for that group
- Custom security with editable datasets
  - Read permissions are handled as above (Custom security with read-only datasets)
  - Users assigned to groups designated as "EDIT ALL" are granted full Editor rights in all datasets. Under this type, users' permissions may be "escalated" beyond their folder permissions; for example, a user with only Reader role will become an Editor in all datasets.
  - Users assigned to groups granted "PER DATASET" access are granted full Editor rights in the datasets marked as "Edit" for that group. Again, users' permissions may be escalated beyond their folder permissions.