### PR TITLE
42605: Data Region Export to Text Redirects to Login

### DIFF
--- a/api/src/org/labkey/api/jsp/JspBase.java
+++ b/api/src/org/labkey/api/jsp/JspBase.java
@@ -298,7 +298,8 @@ public abstract class JspBase extends JspContext implements HasViewContext
      */
     public JavaScriptFragment jsURL(@NotNull URLHelper url)
     {
-        return JavaScriptFragment.unsafe("new URL(" + q(url.getURIString()) + ")");
+        // 42605: Apply path relative to current location
+        return JavaScriptFragment.unsafe("new URL(" + q(url.getLocalURIString()) + ", window.location.origin)");
     }
 
 

--- a/api/src/org/labkey/api/jsp/JspBase.java
+++ b/api/src/org/labkey/api/jsp/JspBase.java
@@ -298,8 +298,8 @@ public abstract class JspBase extends JspContext implements HasViewContext
      */
     public JavaScriptFragment jsURL(@NotNull URLHelper url)
     {
-        // 42605: Apply path relative to current location
-        return JavaScriptFragment.unsafe("new URL(" + q(url.getLocalURIString()) + ", window.location.origin)");
+        // Issue 42605: Apply path relative to current location
+        return JavaScriptFragment.unsafe("new URL(" + q(url) + ", window.location.origin)");
     }
 
 

--- a/api/src/org/labkey/api/query/excelExportOptions.jsp
+++ b/api/src/org/labkey/api/query/excelExportOptions.jsp
@@ -20,7 +20,6 @@
 <%@ page import="org.labkey.api.query.QueryView" %>
 <%@ page import="org.labkey.api.util.GUID" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
-<%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="java.util.LinkedHashMap" %>
 <%@ page import="java.util.Map" %>

--- a/api/src/org/labkey/api/query/textExportOptions.jsp
+++ b/api/src/org/labkey/api/query/textExportOptions.jsp
@@ -127,9 +127,7 @@
 
             var doTsvExport = function(isSign) {
                 var exportRegionName = <%=q(exportRegionName)%>;
-                var url = isSign ?
-                        new URL(<%=q(model.getSignTsvURL().getURIString())%>) :
-                        new URL(<%=q(model.getTsvURL().getURIString())%>);
+                var url = isSign ? <%=jsURL(model.getSignTsvURL())%> : <%=jsURL(model.getTsvURL())%>;
                 if (exportSelectedEl.is(':checked')) {
                     url.searchParams.set(exportRegionName + '.showRows', "SELECTED");
                     url.searchParams.set(exportRegionName + '.selectionKey', dr.selectionKey);
@@ -140,9 +138,6 @@
                 if (headerEl && headerEl.val()) {
                     url.searchParams.set('headerType', headerEl.val());
                 }
-
-                // 42605: Drop "base URL" and apply path relative to current location
-                url = [url.pathname, url.search].join('');
 
                 if (!isSign) {
                     dr.addMessage({

--- a/api/src/org/labkey/api/query/textExportOptions.jsp
+++ b/api/src/org/labkey/api/query/textExportOptions.jsp
@@ -141,6 +141,9 @@
                     url.searchParams.set('headerType', headerEl.val());
                 }
 
+                // 42605: Drop "base URL" and apply path relative to current location
+                url = [url.pathname, url.search].join('');
+
                 if (!isSign) {
                     dr.addMessage({
                         html: '<div class=\"labkey-message\"><strong>Text export started.</strong></div>',

--- a/assay/src/org/labkey/assay/view/plateMetadataFileUpload.jsp
+++ b/assay/src/org/labkey/assay/view/plateMetadataFileUpload.jsp
@@ -40,15 +40,13 @@ LABKEY.Utils.onReady(function () {
     var plateMetadataExampleEl = document.getElementById('plateMetadataExample');
 
     if (plateTemplateEl) {
-        var plateUrl = new URL(<%=q(plateUrl)%>, LABKEY.ActionURL.getBaseURL());
+        var plateUrl = <%=jsURL(plateUrl)%>;
         plateTemplateEl.addEventListener('change', function () {
             var templateLsid = plateTemplateEl.value;
             if (templateLsid)
                 plateUrl.searchParams.set('template', templateLsid);
             else
                 plateUrl.searchParams.delete('template');
-
-            console.log('updating url: ' + plateUrl.toString());
             plateMetadataExampleEl.href = plateUrl.toString();
         });
     }

--- a/study/src/org/labkey/study/view/subjects.jsp
+++ b/study/src/org/labkey/study/view/subjects.jsp
@@ -98,7 +98,7 @@
     var $h = Ext4.util.Format.htmlEncode;
     var first = true;
 
-    const _urlTemplate = new URL(<%= q(subjectUrl.getURIString())%>);
+    const _urlTemplate = <%=jsURL(subjectUrl)%>;
     const _singularNoun = <%= q(singularNoun) %>;
     const _pluralNoun = <%= q(pluralNoun) %>;
     const _divId = <%= q(divId) %>;


### PR DESCRIPTION
#### Rationale
This PR addresses [Issue 42605](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42605) by switching the URL generation from `new URL(absolute)` to `new URL(relative, base)` for the text export options. This utilizes the recently introduced `JspBase.jsURL()` to generate JS for a `URLHelper`.

#### Changes
* Switch `JspBase.jsURL()` to use `new URL(relative, base)` alternative constructor.
* Update all current usages of `new URL()` in platform to use `JspBase.jsURL()`.
