### PR TITLE
Issue 39822: Visit calculations are not as expected in the published child Date study

### DIFF
--- a/api/gwtsrc/org/labkey/api/gwt/client/model/GWTPropertyDescriptor.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/model/GWTPropertyDescriptor.java
@@ -77,6 +77,7 @@ public class GWTPropertyDescriptor implements IsSerializable
     private StringProperty conceptLabelColumn = new StringProperty();
     private StringProperty principalConceptCode = new StringProperty();
     private StringProperty redactedText = new StringProperty();
+    private StringProperty derivationDataScope = new StringProperty();
     private BooleanProperty isPrimaryKey = new BooleanProperty(false);
     private StringProperty lockType = new StringProperty(LockedPropertyType.NotLocked.name());
 
@@ -141,6 +142,7 @@ public class GWTPropertyDescriptor implements IsSerializable
         setSourceOntology(s.getSourceOntology());
         setConceptImportColumn(s.getConceptImportColumn());
         setConceptLabelColumn(s.getConceptLabelColumn());
+        setDerivationDataScope(s.getDerivationDataScope());
 
         for (GWTPropertyValidator v : s.getPropertyValidators())
         {
@@ -538,6 +540,16 @@ public class GWTPropertyDescriptor implements IsSerializable
         this.redactedText.set(redactedText);
     }
 
+    public String getDerivationDataScope()
+    {
+        return derivationDataScope.getString();
+    }
+
+    public void setDerivationDataScope(String derivationDataScope)
+    {
+        this.derivationDataScope.set(derivationDataScope);
+    }
+
     public boolean getIsPrimaryKey()
     {
         return isPrimaryKey.booleanValue();
@@ -627,6 +639,7 @@ public class GWTPropertyDescriptor implements IsSerializable
         if (!equals(getConceptImportColumn(),that.getConceptImportColumn())) return false;
         if (!equals(getConceptLabelColumn(),that.getConceptLabelColumn())) return false;
         if (!equals(getPrincipalConceptCode(),that.getPrincipalConceptCode())) return false;
+        if (!equals(getDerivationDataScope(),that.getDerivationDataScope())) return false;
 
         if (getRedactedText() != null ? !getRedactedText().equals(that.getRedactedText()) : that.getRedactedText() != null) return false;
 
@@ -672,6 +685,7 @@ public class GWTPropertyDescriptor implements IsSerializable
         result = 31 * result + conceptLabelColumn.hashCode();
         result = 31 * result + principalConceptCode.hashCode();
         result = 31 * result + redactedText.hashCode();
+        result = 31 * result + derivationDataScope.hashCode();
 
         for (GWTPropertyValidator gwtPropertyValidator : getPropertyValidators())
         {

--- a/api/schemas/expTypes.xsd
+++ b/api/schemas/expTypes.xsd
@@ -197,6 +197,7 @@
 			<xs:element name="SourceProtocolLSID" type="string" minOccurs="0"/>
 			<xs:element name="Properties" type="exp:PropertyCollectionType" minOccurs="0"/>
 			<xs:element name="Alias" type="string" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="RootMaterialLSID" type="string" minOccurs="0" maxOccurs="1"/>
 		</xs:sequence>
 		<xs:attribute ref="rdf:about" use="required"/>
 	</xs:complexType>

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -399,6 +399,8 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
         setConceptImportColumn(col.getConceptImportColumn());
         setConceptLabelColumn(col.getConceptLabelColumn());
         setPrincipalConceptCode(col.getPrincipalConceptCode());
+
+        setDerivationDataScope(col.getDerivationDataScope());
     }
 
     /*
@@ -476,6 +478,8 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
         setConceptImportColumn(col.getConceptImportColumn());
         setConceptLabelColumn(col.getConceptLabelColumn());
         setPrincipalConceptCode(col.getPrincipalConceptCode());
+
+        setDerivationDataScope(col.getDerivationDataScope());
     }
 
 

--- a/api/src/org/labkey/api/data/ColumnRenderProperties.java
+++ b/api/src/org/labkey/api/data/ColumnRenderProperties.java
@@ -208,4 +208,9 @@ public interface ColumnRenderProperties extends ImportAliasable
     {
         return null;
     }
+
+    default String getDerivationDataScope()
+    {
+        return null;
+    }
 }

--- a/api/src/org/labkey/api/data/ColumnRenderPropertiesImpl.java
+++ b/api/src/org/labkey/api/data/ColumnRenderPropertiesImpl.java
@@ -99,6 +99,8 @@ public abstract class ColumnRenderPropertiesImpl implements MutableColumnRenderP
     protected String _conceptLabelColumn = null;
     protected String _principalConceptCode = null;
 
+    // used by exp material to distinguish aliquot vs meta fields
+    protected String _derivationDataScope = null;
 
     abstract public void checkLocked();
     private boolean _checkLocked()
@@ -165,6 +167,7 @@ public abstract class ColumnRenderPropertiesImpl implements MutableColumnRenderP
         to._principalConceptCode = _principalConceptCode;
         to._conceptImportColumn = _conceptImportColumn;
         to._conceptLabelColumn = _conceptLabelColumn;
+        to._derivationDataScope = _derivationDataScope;
     }
 
     @Override
@@ -900,4 +903,17 @@ public abstract class ColumnRenderPropertiesImpl implements MutableColumnRenderP
         assert _checkLocked();
         _principalConceptCode = code;
     }
+
+    @Override
+    public String getDerivationDataScope()
+    {
+        return _derivationDataScope;
+    }
+
+    @Override
+    public void setDerivationDataScope(String scope)
+    {
+        _derivationDataScope = scope;
+    }
+
 }

--- a/api/src/org/labkey/api/data/JsonWriter.java
+++ b/api/src/org/labkey/api/data/JsonWriter.java
@@ -160,6 +160,8 @@ public class JsonWriter
         props.put("conceptURI", cinfo == null ? null : cinfo.getConceptURI());
         props.put("rangeURI", cinfo == null ? null : cinfo.getRangeURI());
 
+        props.put("derivationDataScope", cinfo == null ? null : cinfo.getDerivationDataScope());
+
         ColumnInfo displayField = dc.getDisplayColumnInfo();
         if (displayField != null && displayField != cinfo)
         {

--- a/api/src/org/labkey/api/data/MutableColumnRenderProperties.java
+++ b/api/src/org/labkey/api/data/MutableColumnRenderProperties.java
@@ -89,4 +89,6 @@ public interface MutableColumnRenderProperties extends ColumnRenderProperties
     void setConceptLabelColumn(String name);
 
     void setPrincipalConceptCode(String code);
+
+    void setDerivationDataScope(String scope);
 }

--- a/api/src/org/labkey/api/data/WrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/WrappedColumnInfo.java
@@ -940,6 +940,12 @@ public class WrappedColumnInfo
         {
             throw new java.lang.UnsupportedOperationException();
         }
+
+        @Override
+        public void setDerivationDataScope(String scope)
+        {
+            throw new java.lang.UnsupportedOperationException();
+        }
     }
 
 

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -417,6 +417,93 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         }
     }
 
+    // For fields that use "Derivation Data Scope", such as sample type property fields,
+    // which can be either aliquot-specific or sample metadata, use a custom get to discard/retain field values based on field property.
+    protected class DerivationScopedConvertColumn extends SimpleConvertColumn
+    {
+        final int derivationDataColInd;
+        final int index;
+        final boolean isDerivation;
+        final String presentDerivationWarning;
+        final String presentNonDerivationWarning;
+
+        final SimpleConvertColumn _convertCol;
+
+        public DerivationScopedConvertColumn(int index, SimpleConvertColumn convertCol, int derivationDataColInd, boolean isDerivation, @Nullable String presentDerivationWarning, @Nullable String presentNonDerivationWarning)
+        {
+            super(convertCol.fieldName, convertCol.index, convertCol.type);
+            _convertCol = convertCol;
+            this.index = index;
+            this.derivationDataColInd = derivationDataColInd;
+            this.isDerivation = isDerivation;
+            this.presentDerivationWarning = presentDerivationWarning;
+            this.presentNonDerivationWarning = presentNonDerivationWarning;
+        }
+
+        @Override
+        protected Object convert(Object o)
+        {
+            Object thisValue =  _convertCol.convert(o);
+
+            return getDerivationData(thisValue, derivationDataColInd, isDerivation, presentDerivationWarning, presentNonDerivationWarning);
+
+        }
+    }
+
+    // For fields that use "Derivation Data Scope", such as sample type property fields,
+    // which can be either aliquot-specific or sample metadata, use a custom get to discard/retain field values based on field property.
+    protected class DerivationScopedColumn implements Supplier
+    {
+        final int derivationDataColInd;
+        final int index;
+        final boolean isDerivation;
+
+        final String presentDerivationWarning;
+        final String presentNonDerivationWarning;
+
+        public DerivationScopedColumn(int index, int derivationDataColInd, boolean isDerivation, @Nullable String presentDerivationWarning, @Nullable String presentNonDerivationWarning)
+        {
+            this.index = index;
+            this.derivationDataColInd = derivationDataColInd;
+            this.isDerivation = isDerivation;
+            this.presentDerivationWarning = presentDerivationWarning;
+            this.presentNonDerivationWarning = presentNonDerivationWarning;
+        }
+
+        @Override
+        public Object get()
+        {
+            Object thisValue =  _data.get(index);
+            return getDerivationData(thisValue, derivationDataColInd, isDerivation, presentDerivationWarning, presentNonDerivationWarning);
+        }
+    }
+
+    /**
+     * @param thisValue the original field value
+     * @param derivationDataColInd the col index for the field used to determine if a record is child or parent
+     * @param isDerivationField if this field is a child only field
+     * @param presentDerivationWarning the warning msg to log if a child field is present for a parent record
+     * @param presentNonDerivationWarning the warning msg to log if a parent field is present for a child record
+     * @return
+     */
+    private Object getDerivationData(Object thisValue, int derivationDataColInd, boolean isDerivationField, @Nullable String presentDerivationWarning, @Nullable String presentNonDerivationWarning)
+    {
+        Object derivationData = derivationDataColInd < 0 ? null : _data.get(derivationDataColInd);
+        if ((isDerivationField && derivationData != null)
+                || (!isDerivationField && derivationData == null))
+            return thisValue;
+
+        if (thisValue != null)
+        {
+            if (isDerivationField && presentDerivationWarning != null)
+                LOG.warn(presentDerivationWarning);
+            else if (!isDerivationField && presentNonDerivationWarning != null)
+                LOG.warn(presentNonDerivationWarning);
+        }
+
+        return null;
+    }
+
 
     protected class AliasColumn extends SimpleConvertColumn
     {
@@ -470,7 +557,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
 
 
 
-    private class SimpleConvertColumn implements Supplier<Object>
+    protected class SimpleConvertColumn implements Supplier<Object>
     {
         final int index;
         final JdbcType type;
@@ -1046,6 +1133,13 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
 
     public int addConvertColumn(ColumnInfo col, int fromIndex, boolean mv)
     {
+        SimpleConvertColumn c = getConvertColumn(col, fromIndex, mv);
+
+        return addColumn(col, c);
+    }
+
+    public SimpleConvertColumn getConvertColumn(ColumnInfo col, int fromIndex, boolean mv)
+    {
         SimpleConvertColumn c;
         if (mv)
             c = new MissingValueConvertColumn(col.getName(), fromIndex, col.getJdbcType());
@@ -1066,7 +1160,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             c = new MultiValueConvertColumn(c);
         }
 
-        return addColumn(col, c);
+        return c;
     }
 
     public int addConvertColumn(ColumnInfo col, int fromIndex, int mvIndex, boolean mv)

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -1571,7 +1571,7 @@ public class OntologyManager
                 "format, container, project, lookupcontainer, lookupschema, lookupquery, defaultvaluetype, hidden, " +
                 "mvenabled, importaliases, url, shownininsertview, showninupdateview, shownindetailsview, dimension, " +
                 "measure, scale, recommendedvariable, defaultscale, createdby, created, modifiedby, modified, facetingbehaviortype, " +
-                "phi, redactedText, excludefromshifting, mvindicatorstoragecolumnname, " +
+                "phi, redactedText, excludefromshifting, mvindicatorstoragecolumnname, derivationdatascope, " +
                 "sourceontology, conceptimportcolumn, conceptlabelcolumn, principalconceptcode)\n");
         sql.append("SELECT " +
                 "? as propertyuri, " +
@@ -1609,6 +1609,7 @@ public class OntologyManager
                 "? as redactedText, " +
                 "? as excludefromshifting, " +
                 "? as mvindicatorstoragecolumnname, " +
+                "? as derivationdatascope," +
                 "? as sourceontology," +
                 "? as conceptimportcolumn," +
                 "? as conceptlabelcolumn," +
@@ -1650,6 +1651,7 @@ public class OntologyManager
         sql.add(pd.getRedactedText());
         sql.add(pd.isExcludeFromShifting());
         sql.add(pd.getMvIndicatorStorageColumnName());
+        sql.add(pd.getDerivationDataScope());
         // ontology metadata
         sql.add(pd.getSourceOntology());
         sql.add(pd.getConceptImportColumn());
@@ -1713,6 +1715,9 @@ public class OntologyManager
 
         if (!Objects.equals(pdIn.getLookupQuery(), pd.getLookupQuery()))
             colDiffs.add("LookupQuery");
+
+        if (!Objects.equals(pdIn.getDerivationDataScope(), pd.getDerivationDataScope()))
+            colDiffs.add("DerivationDataScope");
 
         if (!Objects.equals(pdIn.getSourceOntology(), pd.getSourceOntology()))
             colDiffs.add("SourceOntology");
@@ -2342,14 +2347,14 @@ public class OntologyManager
             "format,container,project,lookupcontainer,lookupschema,lookupquery,defaultvaluetype,hidden," +
             "mvenabled,importaliases,url,shownininsertview,showninupdateview,shownindetailsview,measure,dimension,scale," +
             "sourceontology, conceptimportcolumn, conceptlabelcolumn, principalconceptcode," +
-            "recommendedvariable";
+            "recommendedvariable, derivationdatascope";
     static final String[] parametersArray = parameters.split(",");
     static final String insertSql;
     static final String updateSql;
 
     static
     {
-        insertSql = "INSERT INTO exp.propertydescriptor (" + parameters + ")\nVALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        insertSql = "INSERT INTO exp.propertydescriptor (" + parameters + ")\nVALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
         StringBuilder sb = new StringBuilder("UPDATE exp.propertydescriptor SET");
         String comma = " ";
         for (String p : parametersArray)
@@ -2590,7 +2595,7 @@ public class OntologyManager
             assertNotNull(getTinfoPropertyDescriptor());
             assertNotNull(ExperimentService.get().getTinfoSampleType());
 
-            assertEquals(9, getTinfoPropertyDescriptor().getColumns("PropertyId,PropertyURI,RangeURI,Name,Description,SourceOntology,ConceptImportColumn,ConceptLabelColumn,PrincipalConceptCode").size());
+            assertEquals(10, getTinfoPropertyDescriptor().getColumns("PropertyId,PropertyURI,RangeURI,Name,Description,DerivationDataScope,SourceOntology,ConceptImportColumn,ConceptLabelColumn,PrincipalConceptCode").size());
             assertEquals(4, getTinfoObject().getColumns("ObjectId,ObjectURI,Container,OwnerObjectId").size());
             assertEquals(11, getTinfoObjectPropertiesView().getColumns("ObjectId,ObjectURI,Container,OwnerObjectId,Name,PropertyURI,RangeURI,TypeTag,StringValue,DateTimeValue,FloatValue").size());
             assertEquals(10, ExperimentService.get().getTinfoSampleType().getColumns("RowId,Name,LSID,MaterialLSIDPrefix,Description,Created,CreatedBy,Modified,ModifiedBy,Container").size());

--- a/api/src/org/labkey/api/exp/api/ExpMaterial.java
+++ b/api/src/org/labkey/api/exp/api/ExpMaterial.java
@@ -40,4 +40,8 @@ public interface ExpMaterial extends ExpRunItem
     /** Override to signal that we never throw BatchValidationExceptions */
     @Override
     void save(User user);
+
+    String getRootMaterialLSID();
+
+    String getAliquotedFromLSID();
 }

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -93,6 +93,9 @@ public interface ExperimentService extends ExperimentRunTypeSource
     String SAMPLE_DERIVATION_PROTOCOL_LSID = "urn:lsid:labkey.org:Protocol:SampleDerivationProtocol";
     String SAMPLE_DERIVATION_PROTOCOL_NAME = "Sample Derivation Protocol";
 
+    String SAMPLE_ALIQUOT_PROTOCOL_LSID = "urn:lsid:labkey.org:Protocol:SampleAliquotProtocol";
+    String SAMPLE_ALIQUOT_PROTOCOL_NAME = "Sample Aliquot Protocol";
+
     int SIMPLE_PROTOCOL_FIRST_STEP_SEQUENCE = 1;
     int SIMPLE_PROTOCOL_CORE_STEP_SEQUENCE = 10;
     int SIMPLE_PROTOCOL_EXTRA_STEP_SEQUENCE = 15;
@@ -285,8 +288,8 @@ public interface ExperimentService extends ExperimentRunTypeSource
     /**
      * Get material by rowId in this, project, or shared container and within the provided sample type.
      *
-     * @param container       Sample will be found within this container, project, or shared container.
-     * @param user            Sample will only be resolved within containers that the user has ReadPermission.
+     * @param c       Sample will be found within this container, project, or shared container.
+     * @param u            Sample will only be resolved within containers that the user has ReadPermission.
      * @param rowId           The sample rowId.
      * @param sampleType      Optional sample type that the sample must live in.
      */
@@ -742,6 +745,9 @@ public interface ExperimentService extends ExperimentRunTypeSource
     void onRunDataCreated(ExpProtocol protocol, ExpRun run, Container container, User user) throws BatchValidationException;
 
     void onMaterialsCreated(List<? extends ExpMaterial> materials, Container container, User user);
+
+    // creates a non-assay backed sample aliquot protocol
+    ExpProtocol ensureSampleAliquotProtocol(User user) throws ExperimentException;
 
     // creates a non-assay backed sample derivation protocol
     ExpProtocol ensureSampleDerivationProtocol(User user) throws ExperimentException;

--- a/api/src/org/labkey/api/exp/api/ExperimentUrls.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentUrls.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.UrlProvider;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.ExperimentRunType;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.util.URLHelper;
@@ -102,4 +103,9 @@ public interface ExperimentUrls extends UrlProvider
     ActionURL getUploadXARURL(Container container);
 
     ActionURL getRepairTypeURL(Container container);
+
+    ActionURL getUpdateMaterialQueryRowAction(Container c, TableInfo table);
+
+    ActionURL getInsertMaterialQueryRowAction(Container c, TableInfo table);
+
 }

--- a/api/src/org/labkey/api/exp/api/SimpleRunRecord.java
+++ b/api/src/org/labkey/api/exp/api/SimpleRunRecord.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.exp.api;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -27,4 +28,7 @@ public interface SimpleRunRecord
     Map<ExpMaterial, String> getOutputMaterialMap();
     Map<ExpData, String> getInputDataMap();
     Map<ExpData, String> getOutputDataMap();
+
+    ExpMaterial getAliquotInput();
+    List<ExpMaterial> getAliquotOutputs();
 }

--- a/api/src/org/labkey/api/exp/property/DomainProperty.java
+++ b/api/src/org/labkey/api/exp/property/DomainProperty.java
@@ -133,4 +133,7 @@ public interface DomainProperty extends ImportAliasable
     void setConceptLabelColumn(String conceptLabelColumn);
     void setPrincipalConceptCode(String code);
     String getPrincipalConceptCode();
+
+    void setDerivationDataScope(String type);
+    String getDerivationDataScope();
 }

--- a/api/src/org/labkey/api/exp/query/ExpMaterialTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpMaterialTable.java
@@ -33,6 +33,8 @@ public interface ExpMaterialTable extends ExpTable<ExpMaterialTable.Column>, Upd
         Name,
         Description,
         LSID,
+        RootMaterialLSID,
+        AliquotedFromLSID,
         Flag,
         Run,
         SampleSet,

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -673,4 +673,11 @@ public class ExpSchema extends AbstractExpSchema
 
         return queryView;
     }
+
+    public enum DerivationDataScopeType
+    {
+        ChildOnly,
+        ParentOnly,
+        All
+    }
 }

--- a/api/src/org/labkey/api/inventory/InventoryService.java
+++ b/api/src/org/labkey/api/inventory/InventoryService.java
@@ -64,7 +64,7 @@ public interface InventoryService
     @NotNull
     List<Map<String, Object>> getSampleStorageLocationData(User user, Container container, int sampleId);
 
-    List<FieldKey> addInventoryStatusColumns(@Nullable String sampleTypeMetricUnit, ExpMaterialTable table, Container container);
+    List<FieldKey> addInventoryStatusColumns(@Nullable String sampleTypeMetricUnit, ExpMaterialTable table, Container container, User user);
 
     DataIteratorBuilder getPersistStorageItemDataIteratorBuilder(DataIteratorBuilder data, Container container, User user, String metricUnit);
 

--- a/api/src/org/labkey/api/jsp/JspBase.java
+++ b/api/src/org/labkey/api/jsp/JspBase.java
@@ -298,7 +298,8 @@ public abstract class JspBase extends JspContext implements HasViewContext
      */
     public JavaScriptFragment jsURL(@NotNull URLHelper url)
     {
-        return JavaScriptFragment.unsafe("new URL(" + q(url.getURIString()) + ")");
+        // Issue 42605: Apply path relative to current location
+        return JavaScriptFragment.unsafe("new URL(" + q(url) + ", window.location.origin)");
     }
 
 

--- a/api/src/org/labkey/api/query/excelExportOptions.jsp
+++ b/api/src/org/labkey/api/query/excelExportOptions.jsp
@@ -20,7 +20,6 @@
 <%@ page import="org.labkey.api.query.QueryView" %>
 <%@ page import="org.labkey.api.util.GUID" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
-<%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="java.util.LinkedHashMap" %>
 <%@ page import="java.util.Map" %>

--- a/api/src/org/labkey/api/query/textExportOptions.jsp
+++ b/api/src/org/labkey/api/query/textExportOptions.jsp
@@ -127,9 +127,7 @@
 
             var doTsvExport = function(isSign) {
                 var exportRegionName = <%=q(exportRegionName)%>;
-                var url = isSign ?
-                        new URL(<%=q(model.getSignTsvURL().getURIString())%>) :
-                        new URL(<%=q(model.getTsvURL().getURIString())%>);
+                var url = isSign ? <%=jsURL(model.getSignTsvURL())%> : <%=jsURL(model.getTsvURL())%>;
                 if (exportSelectedEl.is(':checked')) {
                     url.searchParams.set(exportRegionName + '.showRows', "SELECTED");
                     url.searchParams.set(exportRegionName + '.selectionKey', dr.selectionKey);

--- a/api/src/org/labkey/api/settings/AppProps.java
+++ b/api/src/org/labkey/api/settings/AppProps.java
@@ -49,6 +49,7 @@ public interface AppProps
     String EXPERIMENTAL_RESOLVE_PROPERTY_URI_COLUMNS = "resolve-property-uri-columns";
     String EXPERIMENTAL_NO_QUESTION_MARK_URL = "noQuestionMarkUrl";
     String EXPERIMENTAL_ERROR_PAGE = "errorPage";
+    String EXPERIMENTAL_SAMPLE_ALIQUOT = "sampleAliquot";
 
     String UNKNOWN_VERSION = "Unknown Release Version";
 

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -2115,6 +2115,7 @@ public class PageFlowUtil
         experimental.put(AppProps.EXPERIMENTAL_JAVASCRIPT_MOTHERSHIP, AppProps.getInstance().isExperimentalFeatureEnabled(AppProps.EXPERIMENTAL_JAVASCRIPT_MOTHERSHIP));
         experimental.put(AppProps.EXPERIMENTAL_JAVASCRIPT_SERVER, AppProps.getInstance().isExperimentalFeatureEnabled(AppProps.EXPERIMENTAL_JAVASCRIPT_SERVER));
         experimental.put(AppProps.EXPERIMENTAL_NO_GUESTS, AppProps.getInstance().isExperimentalFeatureEnabled(AppProps.EXPERIMENTAL_NO_GUESTS));
+        experimental.put(AppProps.EXPERIMENTAL_SAMPLE_ALIQUOT, AppProps.getInstance().isExperimentalFeatureEnabled(AppProps.EXPERIMENTAL_SAMPLE_ALIQUOT));
         json.put("experimental", experimental);
 
         json.put("contextPath", contextPath);

--- a/assay/src/org/labkey/assay/actions/BaseProtocolAPIAction.java
+++ b/assay/src/org/labkey/assay/actions/BaseProtocolAPIAction.java
@@ -68,8 +68,10 @@ public abstract class BaseProtocolAPIAction<FORM extends SimpleApiJsonForm> exte
             String protocolName = json.optString(ExperimentJSONConverter.PROTOCOL_NAME);
             if (ExperimentService.SAMPLE_DERIVATION_PROTOCOL_NAME.equals(protocolName))
                 protocol = ExperimentService.get().ensureSampleDerivationProtocol(getUser());
+            else if (ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_NAME.equals(protocolName))
+                protocol = ExperimentService.get().ensureSampleAliquotProtocol(getUser());
             else
-                throw new IllegalArgumentException("protocol name is only supported for :" + ExperimentService.SAMPLE_DERIVATION_PROTOCOL_NAME);
+                throw new IllegalArgumentException("protocol name is only supported for : \"" + ExperimentService.SAMPLE_DERIVATION_PROTOCOL_NAME + "\" and \"" + ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_NAME + "\"");
         }
         else
             throw new IllegalArgumentException("assayId or assayName or protocolName must be provided.");

--- a/assay/src/org/labkey/assay/view/plateMetadataFileUpload.jsp
+++ b/assay/src/org/labkey/assay/view/plateMetadataFileUpload.jsp
@@ -40,15 +40,13 @@ LABKEY.Utils.onReady(function () {
     var plateMetadataExampleEl = document.getElementById('plateMetadataExample');
 
     if (plateTemplateEl) {
-        var plateUrl = new URL(<%=q(plateUrl)%>, LABKEY.ActionURL.getBaseURL());
+        var plateUrl = <%=jsURL(plateUrl)%>;
         plateTemplateEl.addEventListener('change', function () {
             var templateLsid = plateTemplateEl.value;
             if (templateLsid)
                 plateUrl.searchParams.set('template', templateLsid);
             else
                 plateUrl.searchParams.delete('template');
-
-            console.log('updating url: ' + plateUrl.toString());
             plateMetadataExampleEl.href = plateUrl.toString();
         });
     }

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-21.001-21.002.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-21.001-21.002.sql
@@ -1,0 +1,3 @@
+ALTER TABLE exp.PropertyDescriptor ADD COLUMN DerivationDataScope VARCHAR(20) NULL;
+ALTER TABLE exp.Material ADD COLUMN RootMaterialLSID LSIDtype NULL;
+ALTER TABLE exp.Material ADD COLUMN AliquotedFromLSID LSIDtype NULL;

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-20.012-20.013.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-20.012-20.013.sql
@@ -29,3 +29,4 @@ ALTER TABLE exp.material ADD CONSTRAINT FK_Material_ObjectId
     FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
 ALTER TABLE exp.experimentrun ADD CONSTRAINT FK_ExperimentRun_ObjectId
     FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
+GO

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-21.001-21.002.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-21.001-21.002.sql
@@ -1,0 +1,4 @@
+ALTER TABLE exp.PropertyDescriptor ADD DerivationDataScope NVARCHAR(20) NULL;
+ALTER TABLE exp.Material ADD RootMaterialLSID LSIDtype NULL;
+ALTER TABLE exp.Material ADD AliquotedFromLSID LSIDtype NULL;
+GO

--- a/experiment/resources/schemas/exp.xml
+++ b/experiment/resources/schemas/exp.xml
@@ -302,6 +302,8 @@
           <description>Contains the time this material was last updated in the search index</description>
       </column>
       <column columnName="ObjectId"/>
+      <column columnName="RootMaterialLSID"/>
+      <column columnName="AliquotedFromLSID"/>
     </columns>
     <description>Contains a row per material or sample described in this folder. These correspond to physical items, such as vials or tissue blocks.</description>
   </table>
@@ -463,6 +465,7 @@
       <column columnName="ConceptImportColumn"/>
       <column columnName="ConceptLabelColumn"/>
       <column columnName="PrincipalConceptCode"/>
+      <column columnName="DerivationDataScope"/>
   </columns>
   </table>
   <table tableName="DomainDescriptor" tableDbType="TABLE">
@@ -939,6 +942,8 @@
       <column columnName="Container"/>
       <column columnName="LastIndexed"/>
       <column columnName="ObjectId"/>
+      <column columnName="RootMaterialLSID"/>
+      <column columnName="AliquotedFromLSID"/>
     </columns>
   </table>
   <table tableName="ObjectPropertiesView" tableDbType="VIEW">

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -140,7 +140,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     public Double getSchemaVersion()
     {
-        return 21.001;
+        return 21.002;
     }
 
     @Nullable
@@ -188,6 +188,9 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
 
         AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_RESOLVE_PROPERTY_URI_COLUMNS, "Resolve property URIs as columns on experiment tables",
                 "If a column is not found on an experiment table, attempt to resolve the column name as a Property URI and add it as a property column", false);
+
+        AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_SAMPLE_ALIQUOT, "Sample aliquot",
+                "Support creation of sample aliquot", false);
 
         RoleManager.registerPermission(new DesignVocabularyPermission(), true);
 

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -805,7 +805,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
             /* setup mini dataiterator pipeline to process lineage */
             DataIterator di = _toDataIterator("updateRows.lineage", ret);
-            ExpDataIterators.derive(user, container, di, false);
+            ExpDataIterators.derive(user, container, di, false, true);
 
             return ret;
         }

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -160,6 +160,18 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
     }
 
     @Override
+    public String getRootMaterialLSID()
+    {
+        return _object.getRootMaterialLSID();
+    }
+
+    @Override
+    public String getAliquotedFromLSID()
+    {
+        return _object.getAliquotedFromLSID();
+    }
+
+    @Override
     @NotNull
     public Collection<String> getAliases()
     {

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -490,7 +490,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             setSampleType(st, filter);
             addSampleTypeColumns(st, defaultCols);
             if (InventoryService.get() != null)
-                defaultCols.addAll(InventoryService.get().addInventoryStatusColumns(st.getMetricUnit(), this, getContainer()));
+                defaultCols.addAll(InventoryService.get().addInventoryStatusColumns(st.getMetricUnit(), this, getContainer(), _userSchema.getUser()));
             setName(_ss.getName());
 
             ActionURL gridUrl = new ActionURL(ExperimentController.ShowSampleTypeAction.class, getContainer());

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -5719,7 +5719,7 @@ public class ExperimentServiceImpl implements ExperimentService
             List<ExpProtocolActionImpl> actions = parentProtocol.getSteps();
             if (actions.size() != 3)
             {
-                throw new IllegalArgumentException("Protocol has the wrong number of steps for a simple protocol, it should have three");
+                throw new IllegalArgumentException("Protocol has the wrong number of steps for a simple protocol; it should have three.");
             }
             ExpProtocolActionImpl action1 = actions.get(0);
             assert action1.getActionSequence() == SIMPLE_PROTOCOL_FIRST_STEP_SEQUENCE;
@@ -5903,72 +5903,94 @@ public class ExperimentServiceImpl implements ExperimentService
         return derive(inputMaterials, Collections.emptyMap(), outputMaterials, Collections.emptyMap(), info, log);
     }
 
+    private void _prepareRun(DeriveSamplesBulkHelper helper, ExpRunImpl run, SimpleRunRecord runRecord, User user, Date date)
+    {
+        helper.addRunParams(run._object, user.getUserId());
+
+        // protocol applications
+        ExpProtocolImpl parentProtocol = run.getProtocol();
+
+        List<ExpProtocolActionImpl> actions = parentProtocol.getSteps();
+        if (actions.size() != 3)
+        {
+            throw new IllegalArgumentException("Protocol has the wrong number of steps for a simple protocol; it should have three.");
+        }
+        ExpProtocolActionImpl action1 = actions.get(0);
+        assert action1.getActionSequence() == SIMPLE_PROTOCOL_FIRST_STEP_SEQUENCE;
+        assert action1.getChildProtocol().getRowId() == parentProtocol.getRowId();
+
+        ExpProtocolActionImpl action2 = actions.get(1);
+        assert action2.getActionSequence() == SIMPLE_PROTOCOL_CORE_STEP_SEQUENCE;
+        ExpProtocol protocol2 = action2.getChildProtocol();
+
+        ExpProtocolActionImpl action3 = actions.get(2);
+        assert action3.getActionSequence() == SIMPLE_PROTOCOL_OUTPUT_STEP_SEQUENCE;
+        ExpProtocol outputProtocol = action3.getChildProtocol();
+        assert outputProtocol.getApplicationType() == ExpProtocol.ApplicationType.ExperimentRunOutput : "Expected third protocol to be of type ExperimentRunOutput but was " + outputProtocol.getApplicationType();
+
+        ExpProtocolApplicationImpl protApp1 = new ExpProtocolApplicationImpl(new ProtocolApplication());
+        ExpProtocolApplicationImpl protApp2 = new ExpProtocolApplicationImpl(new ProtocolApplication());
+        ExpProtocolApplicationImpl protApp3 = new ExpProtocolApplicationImpl(new ProtocolApplication());
+
+        helper.addProtocolApp(protApp1, date, action1, parentProtocol, run, runRecord);
+
+        helper.addProtocolApp(protApp2, date, action2, protocol2, run, runRecord);
+
+        helper.addProtocolApp(protApp3, date, action3, outputProtocol, run, runRecord);
+    }
+
     @Override
     public void deriveSamplesBulk(List<? extends SimpleRunRecord> runRecords, ViewBackgroundInfo info, Logger log) throws ExperimentException
     {
         final int MAX_RUNS_IN_BATCH = 1000;
-        int count = 0;
+        int countD = 0;
+        int countA = 0;
 
         User user = info.getUser();
         XarContext context = new XarContext("Simple Run Creation", info.getContainer(), user);
         Date date = new Date();
-        DeriveSamplesBulkHelper helper = new DeriveSamplesBulkHelper(info.getContainer(), context);
+        DeriveSamplesBulkHelper derivationHelper = new DeriveSamplesBulkHelper(info.getContainer(), context, false);
+        DeriveSamplesBulkHelper aliquotHelper = new DeriveSamplesBulkHelper(info.getContainer(), context, true);
 
         try (DbScope.Transaction transaction = ensureTransaction())
         {
             for (SimpleRunRecord runRecord : runRecords)
             {
-                count++;
-                ExpRunImpl run = createRun(runRecord.getInputMaterialMap(), runRecord.getInputDataMap(), runRecord.getOutputMaterialMap(), runRecord.getOutputDataMap(), info);
-
-                helper.addRunParams(run._object, user.getUserId());
-
-                // protocol applications
-                ExpProtocolImpl parentProtocol = run.getProtocol();
-
-                List<ExpProtocolActionImpl> actions = parentProtocol.getSteps();
-                if (actions.size() != 3)
+                if (!runRecord.getInputDataMap().isEmpty() || !runRecord.getInputMaterialMap().isEmpty())
                 {
-                    throw new IllegalArgumentException("Protocol has the wrong number of steps for a simple protocol, it should have three");
+                    countD++;
+                    ExpRunImpl run = createRun(runRecord.getInputMaterialMap(), runRecord.getInputDataMap(), runRecord.getOutputMaterialMap(), runRecord.getOutputDataMap(), info);
+                    _prepareRun(derivationHelper, run, runRecord, user, date);
+                    if ((countD % MAX_RUNS_IN_BATCH) == 0)
+                    {
+                        derivationHelper.saveBatch();
+                    }
                 }
-                ExpProtocolActionImpl action1 = actions.get(0);
-                assert action1.getActionSequence() == SIMPLE_PROTOCOL_FIRST_STEP_SEQUENCE;
-                assert action1.getChildProtocol().getRowId() == parentProtocol.getRowId();
-
-                ExpProtocolActionImpl action2 = actions.get(1);
-                assert action2.getActionSequence() == SIMPLE_PROTOCOL_CORE_STEP_SEQUENCE;
-                ExpProtocol protocol2 = action2.getChildProtocol();
-
-                ExpProtocolActionImpl action3 = actions.get(2);
-                assert action3.getActionSequence() == SIMPLE_PROTOCOL_OUTPUT_STEP_SEQUENCE;
-                ExpProtocol outputProtocol = action3.getChildProtocol();
-                assert outputProtocol.getApplicationType() == ExpProtocol.ApplicationType.ExperimentRunOutput : "Expected third protocol to be of type ExperimentRunOutput but was " + outputProtocol.getApplicationType();
-
-                ExpProtocolApplicationImpl protApp1 = new ExpProtocolApplicationImpl(new ProtocolApplication());
-                ExpProtocolApplicationImpl protApp2 = new ExpProtocolApplicationImpl(new ProtocolApplication());
-                ExpProtocolApplicationImpl protApp3 = new ExpProtocolApplicationImpl(new ProtocolApplication());
-
-                helper.addProtocolApp(protApp1, date, action1, parentProtocol, run, runRecord);
-
-                helper.addProtocolApp(protApp2, date, action2, protocol2, run, runRecord);
-
-                helper.addProtocolApp(protApp3, date, action3, outputProtocol, run, runRecord);
-
-                if ((count % MAX_RUNS_IN_BATCH) == 0)
+                if (runRecord.getAliquotInput() != null)
                 {
-                    helper.saveBatch();
+                    countA++;
+                    ExpRunImpl run = createAliquotRun(runRecord.getAliquotInput(), runRecord.getAliquotOutputs(), info);
+                    _prepareRun(aliquotHelper, run, runRecord, user, date);
+                    if ((countA % MAX_RUNS_IN_BATCH) == 0)
+                    {
+                        aliquotHelper.saveBatch();
+                    }
                 }
             }
 
             // process the rest of the list
-            if (!helper.isEmpty())
+            if (!derivationHelper.isEmpty())
             {
-                helper.saveBatch();
+                derivationHelper.saveBatch();
+            }
+            if (!aliquotHelper.isEmpty())
+            {
+                aliquotHelper.saveBatch();
             }
 
             transaction.commit();
         }
-        catch (SQLException e)
+        catch (SQLException | ValidationException e)
         {
             throw new ExperimentException(e);
         }
@@ -5978,6 +6000,7 @@ public class ExperimentServiceImpl implements ExperimentService
     {
         private Container _container;
         private XarContext _context;
+        private boolean _isAliquot;
 
         private List<List<?>> _runParams;
         private List<List<?>> _protAppParams;
@@ -5985,10 +6008,16 @@ public class ExperimentServiceImpl implements ExperimentService
         private List<List<?>> _materialInputParams;
         private List<List<?>> _dataInputParams;
 
-        public DeriveSamplesBulkHelper(Container container, XarContext context)
+        private List<List<?>> _aliquotInputParams;
+
+        private Map<String, String> _aliquotRootCache;
+
+        public DeriveSamplesBulkHelper(Container container, XarContext context, boolean isAliquot)
         {
             _container = container;
             _context = context;
+            _isAliquot = isAliquot;
+            _aliquotRootCache = new HashMap<>();
             resetState();
         }
 
@@ -5999,6 +6028,9 @@ public class ExperimentServiceImpl implements ExperimentService
             _protAppRecords = new ArrayList<>();
             _materialInputParams = new ArrayList<>();
             _dataInputParams = new ArrayList<>();
+
+            _aliquotInputParams = new ArrayList<>();
+            _aliquotRootCache = new HashMap<>();
         }
 
         public void addRunParams(ExperimentRun run, int userId)
@@ -6023,7 +6055,7 @@ public class ExperimentServiceImpl implements ExperimentService
             _protAppRecords.add(new ProtocolAppRecord(protApp, activityDate, action, protocol, run, runRecord));
         }
 
-        public void saveBatch() throws SQLException, XarFormatException
+        public void saveBatch() throws SQLException, XarFormatException, ValidationException
         {
             // insert into the experimentrun table
             Map<String, ExperimentRun> runLsidToRowId = saveExpRunsBatch(_container, _runParams);
@@ -6033,12 +6065,24 @@ public class ExperimentServiceImpl implements ExperimentService
             saveExpProtocolApplicationBatch(_protAppParams);
 
             // insert into the materialinput table
-            createMaterialInputParams(_protAppRecords, _materialInputParams);
-            saveExpMaterialInputBatch(_materialInputParams);
-            saveExpMaterialOutputs(_protAppRecords);
-            createDataInputParams(_protAppRecords, _dataInputParams);
-            saveExpDataInputBatch(_dataInputParams);
-            saveExpDataOutputs(_protAppRecords);
+
+            if (!_isAliquot)
+            {
+                createMaterialInputParams(_protAppRecords, _materialInputParams);
+                saveExpMaterialInputBatch(_materialInputParams);
+                saveExpMaterialOutputs(_protAppRecords);
+
+                createDataInputParams(_protAppRecords, _dataInputParams);
+                saveExpDataInputBatch(_dataInputParams);
+                saveExpDataOutputs(_protAppRecords);
+            }
+            else
+            {
+                createAliquotInputParams(_protAppRecords, _aliquotInputParams);
+                saveExpMaterialInputBatch(_aliquotInputParams);
+                initAliquotRootsCache(_protAppRecords);
+                saveExpMaterialAliquotOutputs(_protAppRecords);
+            }
 
             // clear the stored records
             resetState();
@@ -6048,6 +6092,26 @@ public class ExperimentServiceImpl implements ExperimentService
             {
                 syncRunEdges(er.getRowId(), er.getObjectId(), er.getLSID(), _container, false, cpasTypeToObjectId);
             }
+        }
+
+        private void initAliquotRootsCache(List<ProtocolAppRecord> protAppRecords)
+        {
+            Set<String> parentLSIDS = new HashSet<>();
+
+            for (ProtocolAppRecord rec : protAppRecords)
+            {
+                if (rec._runRecord.getAliquotInput() != null)
+                    parentLSIDS.add(rec._runRecord.getAliquotInput().getName());
+            }
+
+            TableInfo table = getTinfoMaterial();
+            SQLFragment sqlfilter = new SimpleFilter(FieldKey.fromParts("Lsid"), parentLSIDS, IN).getSQLFragment(table, "m");
+
+            new SqlSelector(table.getSchema(), new SQLFragment("SELECT Lsid, RootMaterialLSID FROM " + table + " ")
+                    .append(sqlfilter).append(" AND RootMaterialLSID IS NOT NULL")).forEach(rs ->
+            {
+                _aliquotRootCache.put(rs.getString("Lsid"), rs.getString("RootMaterialLSID"));
+            });
         }
 
         public boolean isEmpty()
@@ -6157,6 +6221,54 @@ public class ExperimentServiceImpl implements ExperimentService
             }
         }
 
+        private void createAliquotInputParams(List<ProtocolAppRecord> protAppRecords, List<List<?>> aliquotInputParams)
+        {
+            // get the protocol application rows id's
+            Map<String, Integer> protAppRowMap = new HashMap<>();
+
+            for (ProtocolAppRecord rec : protAppRecords)
+                protAppRowMap.put(rec._protApp.getLSID(), null);
+
+            TableInfo pa = getTinfoProtocolApplication();
+            SQLFragment sqlfilter = new SimpleFilter(FieldKey.fromParts("LSID"), protAppRowMap.keySet(), IN).getSQLFragment(pa, "pa");
+            new SqlSelector(pa.getSchema(), new SQLFragment("SELECT Lsid, RowId FROM " + pa + " ")
+                    .append(sqlfilter)).forEach(rs ->
+            {
+                if (protAppRowMap.containsKey(rs.getString("Lsid")))
+                    protAppRowMap.put(rs.getString("Lsid"), rs.getInt("RowId"));
+            });
+
+            for (ProtocolAppRecord rec : protAppRecords)
+            {
+                assert protAppRowMap.containsKey(rec._protApp.getLSID());
+
+                Integer rowId = protAppRowMap.get(rec._protApp.getLSID());
+                rec._protApp._object.setRowId(rowId);
+
+                // wire the input materials to the protocol inputs for actions 1&2
+                if (rec._action.getActionSequence() == SIMPLE_PROTOCOL_FIRST_STEP_SEQUENCE ||
+                        rec._action.getActionSequence() == SIMPLE_PROTOCOL_CORE_STEP_SEQUENCE)
+                {
+                    ExpMaterial parent = rec._runRecord.getAliquotInput();
+                    aliquotInputParams.add(Arrays.asList(
+                            parent.getRowId(),
+                            rowId,
+                            parent.getSampleType().getName()));
+                }
+                // wire the output materials to the protocol input for the last action
+                else if (rec._action.getActionSequence() == SIMPLE_PROTOCOL_OUTPUT_STEP_SEQUENCE)
+                {
+                    for (ExpMaterial aliquot: rec._runRecord.getAliquotOutputs())
+                    {
+                        aliquotInputParams.add(Arrays.asList(
+                                aliquot.getRowId(),
+                                rowId,
+                                aliquot.getSampleType().getName()));
+                    }
+                }
+            }
+        }
+
         private void createDataInputParams(List<ProtocolAppRecord> protAppRecords, List<List<?>> dataInputParams)
         {
             for (ProtocolAppRecord rec : protAppRecords)
@@ -6189,6 +6301,37 @@ public class ExperimentServiceImpl implements ExperimentService
             }
         }
 
+        private void saveExpMaterialAliquotOutputs(List<ProtocolAppRecord> protAppRecords) throws ValidationException
+        {
+            for (ProtocolAppRecord rec : protAppRecords)
+            {
+                if (rec._action.getActionSequence() == SIMPLE_PROTOCOL_CORE_STEP_SEQUENCE)
+                {
+                    ExpMaterial parent = rec._runRecord.getAliquotInput();
+                    boolean isParentRootMaterial = StringUtils.isEmpty(parent.getAliquotedFromLSID());
+                    for (ExpMaterial outputAliquot : rec._runRecord.getAliquotOutputs())
+                    {
+                        SQLFragment sql = new SQLFragment("UPDATE ").append(getTinfoMaterial(), "").
+                                append(" SET SourceApplicationId = ?, RunId = ?, RootMaterialLSID = ?, AliquotedFromLSID = ? WHERE RowId = ?");
+
+                        String rootMaterial = isParentRootMaterial ? parent.getLSID() : _aliquotRootCache.get(parent.getLSID());
+                        if (StringUtils.isEmpty(rootMaterial))
+                        {
+                            rootMaterial = parent.getRootMaterialLSID();
+                            if (StringUtils.isEmpty(rootMaterial))
+                                throw new ValidationException("Unable to find aliquot parent");
+                        }
+
+                        _aliquotRootCache.put(outputAliquot.getLSID(), rootMaterial); // add self's root to cache
+
+                        sql.addAll(rec._protApp.getRowId(), rec._protApp._object.getRunId(), rootMaterial, parent.getLSID(), outputAliquot.getRowId());
+                        
+                        new SqlExecutor(getTinfoMaterial().getSchema()).execute(sql);
+                    }
+                }
+            }
+        }
+        
         private void saveExpMaterialOutputs(List<ProtocolAppRecord> protAppRecords)
         {
             for (ProtocolAppRecord rec : protAppRecords)
@@ -6358,6 +6501,49 @@ public class ExperimentServiceImpl implements ExperimentService
         return run;
     }
 
+    private ExpRunImpl createAliquotRun(ExpMaterial parent, List<ExpMaterial> aliquots, ViewBackgroundInfo info) throws ExperimentException
+    {
+        PipeRoot pipeRoot = PipelineService.get().findPipelineRoot(info.getContainer());
+        if (pipeRoot == null || !pipeRoot.isValid())
+            throw new ExperimentException("The child folder, " + info.getContainer().getPath() + ", must have a valid pipeline root");
+
+        if (aliquots == null || aliquots.isEmpty())
+            throw new IllegalArgumentException("You must create at least one aliquot");
+
+        if (parent == null)
+            throw new IllegalArgumentException("You must create aliquot from a parent material or aliquot");
+
+        StringBuilder name = new StringBuilder("Create ");
+        if (aliquots.size() == 1)
+            name.append("aliquot ");
+        else
+            name.append(aliquots.size()).append(" aliquots ");
+        name.append("from ");
+        name.append(parent.getName());
+
+        ExpProtocol protocol = ensureSampleAliquotProtocol(info.getUser());
+        ExpRunImpl run = createExperimentRun(info.getContainer(), name.toString());
+        run.setProtocol(protocol);
+        run.setFilePathRoot(pipeRoot.getRootPath());
+
+        return run;
+    }
+
+    @Override
+    public ExpProtocol ensureSampleAliquotProtocol(User user) throws ExperimentException
+    {
+        ExpProtocol protocol = getExpProtocol(SAMPLE_ALIQUOT_PROTOCOL_LSID);
+        if (protocol == null)
+        {
+            ExpProtocolImpl baseProtocol = createExpProtocol(ContainerManager.getSharedContainer(), ExpProtocol.ApplicationType.ExperimentRun, SAMPLE_ALIQUOT_PROTOCOL_NAME);
+            baseProtocol.setLSID(SAMPLE_ALIQUOT_PROTOCOL_LSID);
+            baseProtocol.setMaxInputDataPerInstance(0);
+            baseProtocol.setProtocolDescription("Simple protocol for creating aliquots or subaliquots from the original sample or aliquots.");
+            return insertSimpleProtocol(baseProtocol, user);
+        }
+        return protocol;
+    }
+
     @Override
     public ExpProtocol ensureSampleDerivationProtocol(User user) throws ExperimentException
     {
@@ -6379,6 +6565,14 @@ public class ExperimentServiceImpl implements ExperimentService
             return false;
 
         return SAMPLE_DERIVATION_PROTOCOL_LSID.equals(protocol.getLSID());
+    }
+
+    public boolean isSampleAliquot(ExpProtocol protocol)
+    {
+        if (protocol == null)
+            return false;
+
+        return SAMPLE_ALIQUOT_PROTOCOL_LSID.equals(protocol.getLSID());
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/Material.java
+++ b/experiment/src/org/labkey/experiment/api/Material.java
@@ -29,9 +29,32 @@ import org.labkey.experiment.controllers.exp.ExperimentController;
  */
 public class Material extends RunItem
 {
+    private String rootMaterialLSID;
+    private String aliquotedFromLSID;
+
     public Material()
     {
         setCpasType(ExpMaterial.DEFAULT_CPAS_TYPE);
+    }
+
+    public String getRootMaterialLSID()
+    {
+        return rootMaterialLSID;
+    }
+
+    public void setRootMaterialLSID(String rootMaterialLSID)
+    {
+        this.rootMaterialLSID = rootMaterialLSID;
+    }
+
+    public String getAliquotedFromLSID()
+    {
+        return aliquotedFromLSID;
+    }
+
+    public void setAliquotedFromLSID(String aliquotedFromLSID)
+    {
+        this.aliquotedFromLSID = aliquotedFromLSID;
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -23,9 +23,11 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.Filter;
+import org.labkey.api.data.ImportAliasable;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SqlSelector;
@@ -44,6 +46,7 @@ import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.query.ExpMaterialTable;
+import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.inventory.InventoryService;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.DefaultQueryUpdateService;
@@ -59,6 +62,7 @@ import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.experiment.ExpDataIterators;
 import org.labkey.experiment.SampleTypeAuditProvider;
 import org.labkey.experiment.samples.UploadSamplesHelper;
+import org.springframework.util.StringUtils;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -68,6 +72,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.labkey.api.exp.query.ExpMaterialTable.Column.RootMaterialLSID;
+import static org.labkey.api.exp.query.ExpMaterialTable.Column.AliquotedFromLSID;
 
 /**
  *
@@ -83,7 +91,8 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
     public static final Logger LOG = LogManager.getLogger(SampleTypeUpdateServiceDI.class);
 
     public enum Options {
-        SkipDerivation
+        SkipDerivation,
+        SkipAliquot
     }
 
 
@@ -203,7 +212,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
         /* setup mini dataiterator pipeline to process lineage */
         DataIterator di = _toDataIterator("updateRows.lineage", ret);
-        ExpDataIterators.derive(user, container, di, true);
+        ExpDataIterators.derive(user, container, di, true, true);
 
         if (ret.size() > 0)
         {
@@ -231,6 +240,28 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         return new SqlSelector(getDbTable().getSchema(), sql).getMap();
     }
 
+    public Set<String> getAliquotSpecificFields()
+    {
+        Domain domain = getDomain();
+        Set<String> fields = domain.getProperties().stream()
+                .filter(dp -> ExpSchema.DerivationDataScopeType.ChildOnly.name().equalsIgnoreCase(dp.getDerivationDataScope()))
+                .map(ImportAliasable::getName)
+                .collect(Collectors.toSet());
+
+        return new CaseInsensitiveHashSet(fields);
+    }
+
+    public Set<String> getSampleMetaFields()
+    {
+        Domain domain = getDomain();
+        Set<String> fields = domain.getProperties().stream()
+                .filter(dp -> !ExpSchema.DerivationDataScopeType.ChildOnly.name().equalsIgnoreCase(dp.getDerivationDataScope()))
+                .map(ImportAliasable::getName)
+                .collect(Collectors.toSet());
+
+        return new CaseInsensitiveHashSet(fields);
+    }
+
     @Override
     protected Map<String, Object> _update(User user, Container c, Map<String, Object> row, Map<String, Object> oldRow, Object[] keys) throws SQLException, ValidationException
     {
@@ -239,20 +270,53 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         if (lsid == null)
             throw new ValidationException("lsid required to update row");
 
+        String oldAliquotedFromLSID = (String) oldRow.get(AliquotedFromLSID.name());
+        boolean isAliquot = !StringUtils.isEmpty(oldAliquotedFromLSID);
+        Set<String> aliquotFields = getAliquotSpecificFields();
+        Set<String> sampleMetaFields = getSampleMetaFields();
+
         // Replace attachment columns with filename and keep AttachmentFiles
         Map<String, Object> rowCopy = new CaseInsensitiveHashMap<>();
 
+        // remove aliquotedFrom from row, or error out
         rowCopy.putAll(row);
+        String newAliquotedFromLSID = (String) rowCopy.get(AliquotedFromLSID.name());
+        if (!StringUtils.isEmpty(newAliquotedFromLSID) && newAliquotedFromLSID.equals(oldAliquotedFromLSID))
+            throw new ValidationException("Updating aliquotedFrom is not supported");
+
+        rowCopy.remove(AliquotedFromLSID.name());
+        rowCopy.remove(RootMaterialLSID.name());
+
         Map<String, Object> ret = new CaseInsensitiveHashMap<>(super._update(user, c, rowCopy, oldRow, keys));
 
-        // update provisioned table -- note that LSID isn't the PK so we need to use the filter to update the correct row instead
+        Map<String, Object> validRowCopy = new CaseInsensitiveHashMap<>();
+        for (String updateField : rowCopy.keySet())
+        {
+            Object updateValue = rowCopy.get(updateField);
+            boolean isAliquotField = aliquotFields.contains(updateField);
+            boolean isSampleMetaField = sampleMetaFields.contains(updateField);
+
+            if (isAliquot && isSampleMetaField)
+            {
+                LOG.warn("Sample metadata update has been skipped for an aliquot");
+            }
+            else if (!isAliquot && isAliquotField)
+            {
+                LOG.warn("Aliquot-specific field update has been skipped for a sample.");
+            }
+            else
+            {
+                validRowCopy.put(updateField, updateValue);
+            }
+        }
+
         keys = new Object[]{lsid};
         TableInfo t = _sampleType.getTinfo();
         // Sample type uses FILE_LINK not FILE_ATTACHMENT, use convertTypes() to handle posted files
-        convertTypes(c, rowCopy, t, "sampleset");
-        if (t.getColumnNameSet().stream().anyMatch(rowCopy::containsKey))
+        convertTypes(c, validRowCopy, t, "sampleset");
+        if (t.getColumnNameSet().stream().anyMatch(validRowCopy::containsKey))
         {
-            ret.putAll(Table.update(user, t, rowCopy, t.getColumn("lsid"), keys, null, Level.DEBUG));
+            ret.putAll(Table.update(user, t, validRowCopy, t.getColumn("lsid"), keys, null, Level.DEBUG));
         }
 
         // update comment

--- a/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
@@ -658,6 +658,18 @@ public class DomainPropertyImpl implements DomainProperty
         return _pd.getPrincipalConceptCode();
     }
 
+    @Override
+    public void setDerivationDataScope(String scope)
+    {
+        if (!StringUtils.equals(scope, getDerivationDataScope()))
+            edit().setDerivationDataScope(scope);
+    }
+
+    @Override
+    public String getDerivationDataScope()
+    {
+        return _pd.getDerivationDataScope();
+    }
 
     @Override
     public PropertyDescriptor getPropertyDescriptor()

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -55,25 +55,7 @@ import org.labkey.api.attachments.AttachmentParent;
 import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.attachments.BaseDownloadAction;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
-import org.labkey.api.data.ActionButton;
-import org.labkey.api.data.ButtonBar;
-import org.labkey.api.data.ColumnInfo;
-import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.DataRegion;
-import org.labkey.api.data.DataRegionSelection;
-import org.labkey.api.data.DbSchema;
-import org.labkey.api.data.DbScope;
-import org.labkey.api.data.DisplayColumn;
-import org.labkey.api.data.ExcelWriter;
-import org.labkey.api.data.ShowRows;
-import org.labkey.api.data.SimpleDisplayColumn;
-import org.labkey.api.data.SimpleFilter;
-import org.labkey.api.data.SqlSelector;
-import org.labkey.api.data.TSVWriter;
-import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.TableSelector;
+import org.labkey.api.data.*;
 import org.labkey.api.exp.AbstractParameter;
 import org.labkey.api.exp.DuplicateMaterialException;
 import org.labkey.api.exp.ExperimentDataHandler;
@@ -120,6 +102,7 @@ import org.labkey.api.query.QueryAction;
 import org.labkey.api.query.QueryDefinition;
 import org.labkey.api.query.QueryException;
 import org.labkey.api.query.QueryForm;
+import org.labkey.api.query.QueryParam;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryUpdateForm;
@@ -128,6 +111,7 @@ import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.query.UserSchemaAction;
 import org.labkey.api.reader.ColumnDescriptor;
 import org.labkey.api.reader.DataLoader;
 import org.labkey.api.reader.DataLoaderFactory;
@@ -177,6 +161,7 @@ import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.RedirectException;
 import org.labkey.api.view.UnauthorizedException;
+import org.labkey.api.view.UpdateView;
 import org.labkey.api.view.VBox;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.api.view.ViewContext;
@@ -6331,6 +6316,26 @@ public class ExperimentController extends SpringActionController
         {
             return new ActionURL(TypesController.RepairAction.class, container);
         }
+
+        @Override
+        public ActionURL getUpdateMaterialQueryRowAction(Container c, TableInfo table)
+        {
+            ActionURL url = new ActionURL(UpdateMaterialQueryRowAction.class, c);
+            url.addParameter("schemaName", "samples");
+            url.addParameter(QueryView.DATAREGIONNAME_DEFAULT + "." + QueryParam.queryName, table.getName());
+
+            return url;
+        }
+
+        @Override
+        public ActionURL getInsertMaterialQueryRowAction(Container c, TableInfo table)
+        {
+            ActionURL url = new ActionURL(InsertMaterialQueryRowAction.class, c);
+            url.addParameter("schemaName", "samples");
+            url.addParameter(QueryView.DATAREGIONNAME_DEFAULT + "." + QueryParam.queryName, table.getName());
+
+            return url;
+        }
     }
 
     private static abstract class BaseResolveLsidApiAction<F extends ResolveLsidsForm> extends ReadOnlyApiAction<F>
@@ -6484,4 +6489,98 @@ public class ExperimentController extends SpringActionController
             return ret;
         }
     }
+
+    @RequiresPermission(UpdatePermission.class)
+    public static class UpdateMaterialQueryRowAction extends UserSchemaAction
+    {
+        @Override
+        public ModelAndView getView(QueryUpdateForm tableForm, boolean reshow, BindException errors)
+        {
+            ExpMaterial material = ExperimentService.get().getExpMaterial(Integer.valueOf((String) tableForm.getPkVal()));
+            boolean isAliquot = material != null && !StringUtils.isEmpty(material.getAliquotedFromLSID());
+
+            TableInfo tableInfo = tableForm.getTable();
+            Map<String, Boolean> propertyFields = new CaseInsensitiveHashMap<>();
+            for (DomainProperty dp : tableInfo.getDomain().getProperties())
+            {
+                propertyFields.put(dp.getName(), ExpSchema.DerivationDataScopeType.ChildOnly.name().equalsIgnoreCase(dp.getDerivationDataScope()));
+            }
+
+            for (var column : tableInfo.getColumns())
+            {
+                String columnName = column.getName();
+                if (propertyFields.containsKey(columnName))
+                {
+                    boolean isAliquotField = propertyFields.get(columnName);
+                    boolean show = (isAliquot && isAliquotField) || (!isAliquot && !isAliquotField);
+                    ((BaseColumnInfo)column).setUserEditable(show);
+                    ((BaseColumnInfo)column).setHidden(!show);
+                }
+            }
+
+            ButtonBar bb = createSubmitCancelButtonBar(tableForm);
+            UpdateView view = new UpdateView(tableForm, errors);
+            view.getDataRegion().setButtonBar(bb);
+            return view;
+        }
+
+        @Override
+        public boolean handlePost(QueryUpdateForm tableForm, BindException errors)
+        {
+            doInsertUpdate(tableForm, errors, false);
+            return 0 == errors.getErrorCount();
+        }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        {
+            super.addNavTrail(root);
+            root.addChild("Edit " + _form.getQueryName());
+        }
+    }
+
+    @RequiresPermission(InsertPermission.class)
+    public static class InsertMaterialQueryRowAction extends UserSchemaAction
+    {
+        @Override
+        public ModelAndView getView(QueryUpdateForm tableForm, boolean reshow, BindException errors)
+        {
+            TableInfo tableInfo = tableForm.getTable();
+            Map<String, Boolean> propertyFields = new CaseInsensitiveHashMap<>();
+            for (DomainProperty dp : tableInfo.getDomain().getProperties())
+            {
+                propertyFields.put(dp.getName(), ExpSchema.DerivationDataScopeType.ChildOnly.name().equalsIgnoreCase(dp.getDerivationDataScope()));
+            }
+
+            for (var column : tableInfo.getColumns())
+            {
+                String columnName = column.getName();
+                if (propertyFields.containsKey(columnName))
+                {
+                    boolean isAliquotField = propertyFields.get(columnName);
+                    ((BaseColumnInfo)column).setUserEditable(!isAliquotField);
+                    ((BaseColumnInfo)column).setHidden(isAliquotField);
+                }
+            }
+
+            InsertView view = new InsertView(tableForm, errors);
+            view.getDataRegion().setButtonBar(createSubmitCancelButtonBar(tableForm));
+            return view;
+        }
+
+        @Override
+        public boolean handlePost(QueryUpdateForm tableForm, BindException errors)
+        {
+            doInsertUpdate(tableForm, errors, true);
+            return 0 == errors.getErrorCount();
+        }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        {
+            super.addNavTrail(root);
+            root.addChild("Insert " + _form.getQueryName());
+        }
+    }
+
 }

--- a/experiment/src/org/labkey/experiment/controllers/exp/RunInputOutputBean.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/RunInputOutputBean.java
@@ -17,6 +17,7 @@
 package org.labkey.experiment.controllers.exp;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpMaterial;
 
@@ -30,17 +31,20 @@ public class RunInputOutputBean
 {
     private final Map<ExpMaterial, String> _materials;
     private final Map<ExpData, String> _datas;
+
+    private final ExpMaterial _aliquotParent;
     private final boolean _doUpdate;
 
-    public RunInputOutputBean(@NotNull Map<ExpMaterial, String> materials, @NotNull Map<ExpData, String> datas)
+    public RunInputOutputBean(@NotNull Map<ExpMaterial, String> materials, @NotNull Map<ExpData, String> datas, @Nullable ExpMaterial aliquotParent)
     {
-        this(materials, datas, false);
+        this(materials, datas, aliquotParent, false);
     }
 
-    public RunInputOutputBean(@NotNull Map<ExpMaterial, String> materials, @NotNull Map<ExpData, String> datas, boolean doUpdate)
+    public RunInputOutputBean(@NotNull Map<ExpMaterial, String> materials, @NotNull Map<ExpData, String> datas, @Nullable ExpMaterial aliquotParent, boolean doUpdate)
     {
         _materials = materials;
         _datas = datas;
+        _aliquotParent = aliquotParent;
         _doUpdate = doUpdate;
     }
 
@@ -60,4 +64,10 @@ public class RunInputOutputBean
     {
         return _materials.isEmpty() && _datas.isEmpty() && _doUpdate;
     }
+
+    public ExpMaterial getAliquotParent()
+    {
+        return _aliquotParent;
+    }
+
 }

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
@@ -141,9 +141,10 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
             exportTypes = true;
         }
 
-        // add any sample derivation runs
+        // add any sample derivation or aliquot runs
         List<ExpRun> runs = ExperimentService.get().getExpRuns(ctx.getContainer(), null, null).stream()
-                .filter(run -> run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID))
+                .filter(run -> run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID)
+                || run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_LSID))
                 .collect(Collectors.toList());
 
         Set<ExpRun> exportedRuns = new HashSet<>();

--- a/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
@@ -83,7 +83,8 @@ public class FolderXarWriterFactory implements FolderWriterFactory
         {
             // don't include the sample derivation runs, we now have a separate exporter explicitly for sample types
             return ExperimentService.get().getExpRuns(c, null, null).stream()
-                    .filter(run -> !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID))
+                    .filter(run -> !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID)
+                    && !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_LSID))
                     .collect(Collectors.toList());
         }
 
@@ -91,7 +92,8 @@ public class FolderXarWriterFactory implements FolderWriterFactory
         {
             // don't include the sample derivation runs, we now have a separate exporter explicitly for sample types
             return ExperimentService.get().getExpProtocols(c).stream()
-                    .filter(protocol -> !protocol.getLSID().startsWith(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_NAME))
+                    .filter(protocol -> !protocol.getLSID().startsWith(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_NAME)
+                    && !protocol.getLSID().startsWith(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_NAME))
                     .map(ExpObject::getRowId)
                     .collect(Collectors.toList());
         }

--- a/internal/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/internal/src/org/labkey/api/exp/property/DomainUtil.java
@@ -335,6 +335,7 @@ public class DomainUtil
         gwtProp.setSourceOntology(prop.getSourceOntology());
         gwtProp.setConceptImportColumn(prop.getConceptImportColumn());
         gwtProp.setConceptLabelColumn(prop.getConceptLabelColumn());
+        gwtProp.setDerivationDataScope(prop.getDerivationDataScope());
 
         List<GWTPropertyValidator> validators = new ArrayList<>();
         for (IPropertyValidator pv : prop.getValidators())

--- a/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
+++ b/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
@@ -90,6 +90,9 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
         RESERVED_NAMES = BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet());
         RESERVED_NAMES.addAll(Arrays.stream(ExpSampleTypeTable.Column.values()).map(ExpSampleTypeTable.Column::name).collect(Collectors.toList()));
         RESERVED_NAMES.add("CpasType");
+        RESERVED_NAMES.add("AliquotedFrom");
+        RESERVED_NAMES.add("AliquotedFromLSID");
+        RESERVED_NAMES.add("RootMaterialLSID");
 
         FOREIGN_KEYS = Collections.unmodifiableSet(Sets.newLinkedHashSet(Arrays.asList(
                 // NOTE: We join to exp.material using LSID instead of rowid for insert performance -- we will generate

--- a/query/src/org/labkey/query/MetadataTableJSON.java
+++ b/query/src/org/labkey/query/MetadataTableJSON.java
@@ -617,6 +617,8 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             metadataColumnJSON.setSourceOntology(columnInfo.getSourceOntology());
             metadataColumnJSON.setConceptImportColumn(columnInfo.getConceptImportColumn());
             metadataColumnJSON.setConceptLabelColumn(columnInfo.getConceptLabelColumn());
+
+            metadataColumnJSON.setDerivationDataScope(columnInfo.getDerivationDataScope());
         }
 
         List<QueryDef> queryDefs = QueryServiceImpl.get().findMetadataOverrideImpl(schema, tableName, false, false, null);

--- a/study/src/org/labkey/study/importer/TopLevelStudyPropertiesImporter.java
+++ b/study/src/org/labkey/study/importer/TopLevelStudyPropertiesImporter.java
@@ -117,6 +117,9 @@ public class TopLevelStudyPropertiesImporter implements InternalStudyImporter
 
             StudyManager.getInstance().updateStudy(ctx.getUser(), study);
 
+            // Issue 39822: update participant visits after importing study details like start date
+            StudyManager.getInstance().getVisitManager(study).updateParticipantVisits(ctx.getUser(), study.getDatasets());
+
             ctx.getLogger().info("Done importing " + getDescription());
         }
     }

--- a/study/src/org/labkey/study/view/subjects.jsp
+++ b/study/src/org/labkey/study/view/subjects.jsp
@@ -98,7 +98,7 @@
     var $h = Ext4.util.Format.htmlEncode;
     var first = true;
 
-    const _urlTemplate = new URL(<%= q(subjectUrl.getURIString())%>);
+    const _urlTemplate = <%=jsURL(subjectUrl)%>;
     const _singularNoun = <%= q(singularNoun) %>;
     const _pluralNoun = <%= q(pluralNoun) %>;
     const _divId = <%= q(divId) %>;


### PR DESCRIPTION
#### Rationale
Need to recalculate participant visits after updating top level study info as they are dependent on study start date.

#### Changes
* Add updateParticipantVisits call to TopLevelStudyPropertiesImporter.process