### PR TITLE
Issue 39822: Visit calculations are not as expected in the published child Date study

### DIFF
--- a/study/src/org/labkey/study/importer/TopLevelStudyPropertiesImporter.java
+++ b/study/src/org/labkey/study/importer/TopLevelStudyPropertiesImporter.java
@@ -117,6 +117,9 @@ public class TopLevelStudyPropertiesImporter implements InternalStudyImporter
 
             StudyManager.getInstance().updateStudy(ctx.getUser(), study);
 
+            // Issue 39822: update participant visits after importing study details like start date
+            StudyManager.getInstance().getVisitManager(study).updateParticipantVisits(ctx.getUser(), study.getDatasets());
+
             ctx.getLogger().info("Done importing " + getDescription());
         }
     }


### PR DESCRIPTION
#### Rationale
Need to recalculate participant visits after updating top level study info as they are dependent on study start date.

#### Changes
* Add updateParticipantVisits call to TopLevelStudyPropertiesImporter.process
