### PR TITLE
Issue 42603: Staging study roundtrip fails on stray SpecimenDetail query metadata

### DIFF
--- a/query/src/org/labkey/query/QueryWriter.java
+++ b/query/src/org/labkey/query/QueryWriter.java
@@ -75,12 +75,17 @@ public class QueryWriter extends BaseFolderWriter
 
             for (QueryDefinition query : queries)
             {
+                // sql is only present for custom queries -- metadata xml overrides of built-in tables will not have sql
+                String sql = query.getSql();
+                boolean metadata = StringUtils.isEmpty(sql);
+
+                if (metadata && !query.getSchema().getTableNames().contains(query.getName()))
+                    continue;
+
                 // issue 20662: handle query name collisions across schemas
                 String queryExportName = fileNameUniquifier.uniquify(query.getName());
 
-                // sql is only present for custom queries -- metadata xml overrides of built-in tables will not have sql
-                String sql = query.getSql();
-                if (StringUtils.isNotEmpty(sql))
+                if (!metadata)
                 {
                     try (PrintWriter pw = queriesDir.getPrintWriter(queryExportName + FILE_EXTENSION))
                     {


### PR DESCRIPTION
#### Rationale
Folder export includes query metadata overrides for tables that don't exist (e.g., because all your specimen tables disappeared when that specimen module went away). These orphaned metadata overrides are then imported and fail the query validation step. This change causes query export to skip over metadata overrides on tables that don't exist.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42603
