### PR TITLE
Update a couple test expectations based on dataset security changes

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
@@ -359,7 +359,7 @@ public class SharedStudyTest extends BaseWebDriverTest
     {
         beginAt(WebTestHelper.buildURL("dataset", getProjectName(), "insert", Maps.of("datasetId", SHARED_DEMOGRAPHICS_ID)));
 
-        assertEquals("403: Error Page -- User does not have permission to edit this dataset", getDriver().getTitle());
+        assertEquals("403: Error Page -- User does not have permission to insert into this dataset", getDriver().getTitle());
         assertElementNotPresent(Locator.css("table.labkey-data-region"));
     }
 


### PR DESCRIPTION
#### Rationale
Dataset `InsertUpdateAction` now distinguishes between insert, update, and delete, and throws permission-specific error messages. Adjust `SharedStudyTest` accordingly.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/2057