### PR TITLE
Remove support for PostgreSQL 9.5

### DIFF
--- a/api/src/org/labkey/api/data/dialect/AbstractDialectRetrievalTestCase.java
+++ b/api/src/org/labkey/api/data/dialect/AbstractDialectRetrievalTestCase.java
@@ -51,7 +51,10 @@ public abstract class AbstractDialectRetrievalTestCase extends Assert
         int begin = (int)Math.round(beginVersion * 10);
         int end = (int)Math.round(endVersion * 10);
 
-        for (int i = begin; i < end; i++)
+        // For performance, skip by 10 when testing a large range, otherwise skip by 1
+        int increment = (end - begin > 10 ? 10 : 1);
+
+        for (int i = begin; i < end; i += increment)
         {
             int majorVersion = i / 10;
             int minorVersion = i % 10;

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -28,7 +28,9 @@ import org.labkey.api.data.Selector.ForEachBlock;
 import org.labkey.api.query.AliasManager;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.ExceptionUtil;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.StringUtilsLabKey;
+import org.labkey.api.view.template.Warnings;
 import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
 import org.springframework.jdbc.BadSqlGrammarException;
 
@@ -77,6 +79,8 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     private final Map<String, Integer> _domainScaleMap = new ConcurrentHashMap<>();
     private final AtomicBoolean _arraySortFunctionExists = new AtomicBoolean(false);
     private final InClauseGenerator _tempTableInClauseGenerator = new TempTableInClauseGenerator();
+
+    private HtmlString _adminWarning = null;
 
     protected InClauseGenerator _inClauseGenerator = null;
 
@@ -1872,5 +1876,17 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     public boolean allowAsynchronousExecute()
     {
         return true;
+    }
+
+    public void setAdminWarning(HtmlString warning)
+    {
+        _adminWarning = warning;
+    }
+
+    @Override
+    public void addAdminWarningMessages(Warnings warnings)
+    {
+        if (null != _adminWarning)
+            warnings.add(_adminWarning);
     }
 }

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
@@ -16,13 +16,12 @@
 
 package org.labkey.bigiron.mssql;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
-import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.CsvSet;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.dialect.AbstractDialectRetrievalTestCase;
@@ -183,7 +182,7 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
             badProductName("SQL Server", 1.0, 14.0, "", null);
             badProductName("sqlserver", 1.0, 14.0, "", null);
 
-            // < 10.5 should result in bad version error
+            // < 10.0 should result in bad version error
             badVersion("Microsoft SQL Server", 0.0, 10.0, null, null);
 
             String driverName = "jTDS Type 4 JDBC Driver for MS SQL Server and Sybase";

--- a/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
@@ -17,23 +17,14 @@ package org.labkey.core.dialect;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
-import org.junit.Test;
-import org.labkey.api.data.CoreSchema;
-import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.ParameterMarkerInClauseGenerator;
-import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.dialect.DialectStringHandler;
 import org.labkey.api.data.dialect.JdbcHelper;
 import org.labkey.api.data.dialect.PostgreSql91Dialect;
-import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.dialect.StandardJdbcHelper;
 import org.labkey.core.admin.sql.ScriptReorderer;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;

--- a/core/src/org/labkey/core/dialect/PostgreSql93Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql93Dialect.java
@@ -29,11 +29,11 @@ import java.util.Set;
  */
 abstract class PostgreSql93Dialect extends PostgreSql92Dialect
 {
-    public PostgreSql93Dialect()
+    protected PostgreSql93Dialect()
     {
     }
 
-    public PostgreSql93Dialect(boolean standardConformingStrings)
+    protected PostgreSql93Dialect(boolean standardConformingStrings)
     {
         super(standardConformingStrings);
     }

--- a/core/src/org/labkey/core/dialect/PostgreSql94Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql94Dialect.java
@@ -16,25 +16,23 @@
 package org.labkey.core.dialect;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.util.HtmlString;
-import org.labkey.api.view.template.Warnings;
 
 import java.util.Set;
 
 /**
+ * PostgreSQL 9.4 is no longer supported, however, we keep this class to track changes we implemented specifically for this version.
+ *
  * User: adam
  * Date: 8/5/2014
  * Time: 10:49 PM
  */
 abstract class PostgreSql94Dialect extends PostgreSql93Dialect
 {
-    private HtmlString _adminWarning = null;
-
-    public PostgreSql94Dialect()
+    protected PostgreSql94Dialect()
     {
     }
 
-    public PostgreSql94Dialect(boolean standardConformingStrings)
+    protected PostgreSql94Dialect(boolean standardConformingStrings)
     {
         super(standardConformingStrings);
     }
@@ -47,18 +45,6 @@ abstract class PostgreSql94Dialect extends PostgreSql93Dialect
         words.remove("over");
 
         return words;
-    }
-
-    public void setAdminWarning(HtmlString warning)
-    {
-        _adminWarning = warning;
-    }
-
-    @Override
-    public void addAdminWarningMessages(Warnings warnings)
-    {
-        if (null != _adminWarning)
-            warnings.add(_adminWarning);
     }
 
     @Override

--- a/core/src/org/labkey/core/dialect/PostgreSql95Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql95Dialect.java
@@ -20,15 +20,17 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Set;
 
 /**
+ * PostgreSQL 9.5 is no longer supported, however, we keep this class to track changes we implemented specifically for this version.
+ *
  * Created by adam on 7/24/2015.
  */
-public class PostgreSql95Dialect extends PostgreSql94Dialect
+abstract class PostgreSql95Dialect extends PostgreSql94Dialect
 {
-    public PostgreSql95Dialect()
+    protected PostgreSql95Dialect()
     {
     }
 
-    public PostgreSql95Dialect(boolean standardConformingStrings)
+    protected PostgreSql95Dialect(boolean standardConformingStrings)
     {
         super(standardConformingStrings);
     }

--- a/core/src/org/labkey/core/dialect/PostgreSql96Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql96Dialect.java
@@ -20,4 +20,12 @@ package org.labkey.core.dialect;
  */
 public class PostgreSql96Dialect extends PostgreSql95Dialect
 {
+    public PostgreSql96Dialect()
+    {
+    }
+
+    public PostgreSql96Dialect(boolean standardConformingStrings)
+    {
+        super(standardConformingStrings);
+    }
 }

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -25,18 +25,12 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.collections.CsvSet;
 import org.labkey.api.data.DbScope;
-import org.labkey.api.data.JdbcType;
-import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.dialect.AbstractDialectRetrievalTestCase;
 import org.labkey.api.data.dialect.DatabaseNotSupportedException;
 import org.labkey.api.data.dialect.JdbcHelperTest;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.dialect.SqlDialectFactory;
-import org.labkey.api.data.dialect.SqlDialectManager;
 import org.labkey.api.data.dialect.TestUpgradeCode;
-import org.labkey.api.query.AbstractMethodInfo;
-import org.labkey.api.query.QueryParseException;
-import org.labkey.api.query.QueryService;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.VersionNumber;
@@ -65,7 +59,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
     @Override
     public @Nullable SqlDialect createFromDriverClassName(String driverClassName)
     {
-        return "org.postgresql.Driver".equals(driverClassName) ? new PostgreSql95Dialect() : null;
+        return "org.postgresql.Driver".equals(driverClassName) ? new PostgreSql96Dialect() : null;
     }
 
     final static String PRODUCT_NAME = "PostgreSQL";
@@ -105,7 +99,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
         if (PostgreSqlVersion.POSTGRESQL_UNSUPPORTED == psv)
             throw new DatabaseNotSupportedException(PRODUCT_NAME + " version " + databaseProductVersion + " is not supported. You must upgrade your database server installation; " + RECOMMENDED);
 
-        PostgreSql95Dialect dialect = psv.getDialect();
+        PostgreSql96Dialect dialect = psv.getDialect();
 
         if (logWarnings)
         {
@@ -133,10 +127,10 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
     @Override
     public Collection<? extends SqlDialect> getDialectsToTest()
     {
-        // PostgreSQL dialects are nearly identical, so just test 9.5
+        // PostgreSQL dialects are nearly identical, so just test 9.6
         return PageFlowUtil.set(
-            new PostgreSql95Dialect(true),
-            new PostgreSql95Dialect(false)
+            new PostgreSql96Dialect(true),
+            new PostgreSql96Dialect(false)
         );
     }
 
@@ -147,14 +141,13 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
         {
             final String connectionUrl = "jdbc:postgresql:";
 
-            // < 9.4 should result in bad version number exception
-            badVersion("PostgreSQL", 0.0, 9.4, null, connectionUrl);
+            // < 9.6 should result in bad version number exception
+            badVersion("PostgreSQL", 0.0, 9.6, null, connectionUrl);
 
             // 9.7, 9.8, and 9.9 are bad as well - these versions never existed
             badVersion("PostgreSQL", 9.7, 10.0, null, connectionUrl);
 
             // Test good versions
-            good("PostgreSQL", 9.5, 9.6, "", connectionUrl, null, PostgreSql95Dialect.class);
             good("PostgreSQL", 9.6, 9.7, "", connectionUrl, null, PostgreSql96Dialect.class);
             good("PostgreSQL", 10.0, 11.0, "", connectionUrl, null, PostgreSql_10_Dialect.class);
             good("PostgreSQL", 11.0, 12.0, "", connectionUrl, null, PostgreSql_11_Dialect.class);
@@ -187,7 +180,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
                     "SELECT core.executeJaavUpgradeCode('upgradeCode');\n" +          // Misspell function name
                     "SELECT core.executeJavaUpgradeCode('upgradeCode')\n";            // No semicolon
 
-            SqlDialect dialect = new PostgreSql95Dialect();
+            SqlDialect dialect = new PostgreSql96Dialect();
             TestUpgradeCode good = new TestUpgradeCode();
             dialect.runSql(null, goodSql, good, null, null);
             assertEquals(5, good.getCounter());
@@ -208,7 +201,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
                 @Override
                 protected SqlDialect getDialect()
                 {
-                    return new PostgreSql95Dialect();
+                    return new PostgreSql96Dialect();
                 }
 
                 @NotNull

--- a/core/src/org/labkey/core/dialect/PostgreSqlInClauseTest.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlInClauseTest.java
@@ -17,19 +17,19 @@ import java.util.Arrays;
  */
 public class PostgreSqlInClauseTest extends Assert
 {
-    private PostgreSql95Dialect getDialect()
+    private PostgreSql96Dialect getDialect()
     {
         DbSchema core = CoreSchema.getInstance().getSchema();
         SqlDialect d = core.getSqlDialect();
-        if (d instanceof PostgreSql95Dialect)
-            return (PostgreSql95Dialect) d;
+        if (d instanceof PostgreSql96Dialect)
+            return (PostgreSql96Dialect) d;
         return null;
     }
 
     @Test
     public void testInClause()
     {
-        PostgreSql95Dialect d = getDialect();
+        PostgreSql96Dialect d = getDialect();
         if (null == d)
             return;
         DbSchema core = CoreSchema.getInstance().getSchema();

--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 public enum PostgreSqlVersion
 {
     POSTGRESQL_UNSUPPORTED(-1, true, false, null),
-    POSTGRESQL_95(95, true, true, PostgreSql95Dialect::new),
     POSTGRESQL_96(96, false, true, PostgreSql96Dialect::new),
     POSTGRESQL_10(100, false, true, PostgreSql_10_Dialect::new),
     POSTGRESQL_11(110, false, true, PostgreSql_11_Dialect::new),
@@ -27,9 +26,9 @@ public enum PostgreSqlVersion
     private final int _version;
     private final boolean _deprecated;
     private final boolean _tested;
-    private final Supplier<? extends PostgreSql95Dialect> _dialectFactory;
+    private final Supplier<? extends PostgreSql96Dialect> _dialectFactory;
 
-    PostgreSqlVersion(int version, boolean deprecated, boolean tested, Supplier<? extends PostgreSql95Dialect> dialectFactory)
+    PostgreSqlVersion(int version, boolean deprecated, boolean tested, Supplier<? extends PostgreSql96Dialect> dialectFactory)
     {
         _version = version;
         _deprecated = deprecated;
@@ -48,7 +47,7 @@ public enum PostgreSqlVersion
         return _tested;
     }
 
-    public PostgreSql95Dialect getDialect()
+    public PostgreSql96Dialect getDialect()
     {
         return _dialectFactory.get();
     }
@@ -83,7 +82,6 @@ public enum PostgreSqlVersion
         public void test()
         {
             // Good
-            test(95, POSTGRESQL_95);
             test(96, POSTGRESQL_96);
             test(100, POSTGRESQL_10);
             test(110, POSTGRESQL_11);
@@ -104,6 +102,7 @@ public enum PostgreSqlVersion
             test(92, POSTGRESQL_UNSUPPORTED);
             test(93, POSTGRESQL_UNSUPPORTED);
             test(94, POSTGRESQL_UNSUPPORTED);
+            test(95, POSTGRESQL_UNSUPPORTED);
             test(97, POSTGRESQL_UNSUPPORTED);
             test(98, POSTGRESQL_UNSUPPORTED);
         }


### PR DESCRIPTION
#### Rationale
PostgreSQL is now considered end-of-life (EOL) and is no longer supported; see https://www.postgresql.org/support/versioning. We deprecated PostgreSQL 9.5 in 21.3.0 and are removing it completely for 21.7.0.

Also:

- Move admin message handling to the base PostgreSQL dialect since we no longer use method overrides to convey deprecation warnings
- Speed up the `DialectRetrievalTestCases` by not testing an absurd number of invalid cases
- Correct some comments
