### PR TITLE
Ensure record selectors in dataset grids

### DIFF
--- a/study/api-src/org/labkey/api/specimen/query/BaseSpecimenQueryView.java
+++ b/study/api-src/org/labkey/api/specimen/query/BaseSpecimenQueryView.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.labkey.api.study.query;
+package org.labkey.api.specimen.query;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ButtonBar;
@@ -36,14 +36,14 @@ import java.util.List;
  * Date: Jan 26, 2007
  * Time: 10:03:34 AM
  */
-public abstract class BaseStudyQueryView extends QueryView
+public abstract class BaseSpecimenQueryView extends QueryView
 {
     protected final SimpleFilter _filter;
     protected final Sort _sort;
     protected @Nullable CohortFilter _cohortFilter;
     private List<DisplayElement> _buttons;
 
-    public BaseStudyQueryView(UserSchema schema, QuerySettings settings, SimpleFilter filter, Sort sort)
+    public BaseSpecimenQueryView(UserSchema schema, QuerySettings settings, SimpleFilter filter, Sort sort)
     {
         super(schema, settings);
         _filter = filter;

--- a/study/api-src/org/labkey/api/specimen/query/SpecimenEventQueryView.java
+++ b/study/api-src/org/labkey/api/specimen/query/SpecimenEventQueryView.java
@@ -25,7 +25,6 @@ import org.labkey.api.specimen.SpecimenQuerySchema;
 import org.labkey.api.specimen.Vial;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
-import org.labkey.api.study.query.BaseStudyQueryView;
 import org.labkey.api.view.ViewContext;
 
 /**
@@ -33,7 +32,7 @@ import org.labkey.api.view.ViewContext;
  * Date: Jan 26, 2007
  * Time: 10:13:50 AM
  */
-public class SpecimenEventQueryView extends BaseStudyQueryView
+public class SpecimenEventQueryView extends BaseSpecimenQueryView
 {
     protected SpecimenEventQueryView(UserSchema schema, QuerySettings settings, SimpleFilter filter, Sort sort)
     {

--- a/study/api-src/org/labkey/api/specimen/query/SpecimenQueryView.java
+++ b/study/api-src/org/labkey/api/specimen/query/SpecimenQueryView.java
@@ -58,7 +58,6 @@ import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.StudyUtils;
 import org.labkey.api.study.model.ParticipantDataset;
-import org.labkey.api.study.query.BaseStudyQueryView;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
@@ -85,7 +84,7 @@ import static java.util.Objects.requireNonNull;
  * Date: Aug 23, 2006
  * Time: 3:38:44 PM
  */
-public class SpecimenQueryView extends BaseStudyQueryView
+public class SpecimenQueryView extends BaseSpecimenQueryView
 {
     public enum Mode
     {

--- a/study/api-src/org/labkey/api/specimen/query/SpecimenRequestQueryView.java
+++ b/study/api-src/org/labkey/api/specimen/query/SpecimenRequestQueryView.java
@@ -38,7 +38,6 @@ import org.labkey.api.study.SpecimenUrls;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.StudyUtils;
-import org.labkey.api.study.query.BaseStudyQueryView;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
@@ -53,7 +52,7 @@ import java.util.Set;
  * Date: Apr 20, 2007
  * Time: 2:49:42 PM
  */
-public class SpecimenRequestQueryView extends BaseStudyQueryView
+public class SpecimenRequestQueryView extends BaseSpecimenQueryView
 {
     private NavTree[] _extraLinks;
     private boolean _allowSortAndFilter = true;

--- a/study/src/org/labkey/study/model/ParticipantGroupManager.java
+++ b/study/src/org/labkey/study/model/ParticipantGroupManager.java
@@ -345,8 +345,9 @@ public class ParticipantGroupManager
                     item = new NavTree("Create " + study.getSubjectNounSingular() + " Group");
                     button.addMenuItem(item);
 
-                    NavTree fromSeletion = item.addChild("From Selected " + study.getSubjectNounPlural());
-                    fromSeletion.setScript(createNewParticipantGroupScript(context, dataRegionName, true));
+                    NavTree fromSelection = item.addChild("From Selected " + study.getSubjectNounPlural());
+                    fromSelection.setScript(createNewParticipantGroupScript(context, dataRegionName, true));
+                    // TODO: Ideally, we'd do something like "fromSelection.setRequiresSelection(true)" here, like we can with buttons, but that's not an option
 
                     NavTree fromGrid = item.addChild("From All " + study.getSubjectNounPlural());
                     fromGrid.setScript(createNewParticipantGroupScript(context, dataRegionName, false));

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -380,6 +380,12 @@ public class DatasetQueryView extends StudyQueryView
         List<String> recordSelectorColumns = view.getDataRegion().getRecordSelectorValueColumns();
         bar.add(createExportButton(recordSelectorColumns));
 
+        // Duplicates logic from super.populateButtonBar(), but we need selectors
+        if ((recordSelectorColumns != null && !recordSelectorColumns.isEmpty()) || (getTable() != null && !getTable().getPkColumns().isEmpty()))
+        {
+            bar.setAlwaysShowRecordSelectors(true);
+        }
+
         User user = getUser();
         boolean canInsert = _dataset.canInsert(user);
         boolean canDelete = _dataset.canDelete(user);


### PR DESCRIPTION
#### Rationale
Related PR removed the "View Specimens" menu button when the specimen module isn't active. This caused the data region record selectors to disappear, even though the export panel, create participant group from selection, and show selected all need them. This PR turns the record selectors back on.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2057