### PR TITLE
Issue 42617: search index deleted and last indexed values reset on every module version change

### DIFF
--- a/search/src/org/labkey/search/SearchModule.java
+++ b/search/src/org/labkey/search/SearchModule.java
@@ -164,25 +164,28 @@ public class SearchModule extends DefaultModule
     @Override
     public void afterUpdate(ModuleContext moduleContext)
     {
-        // After every upgrade, delete the index and clear the last indexed time on all documents to rebuild the entire index, #35674
-        final StartupListener l = new StartupListener()
+        // After every search module upgrade, delete the index and clear the last indexed time on all documents
+        // to rebuild the entire index, #35674 & #42617
+        if (!moduleContext.isNewInstall() && moduleContext.needsUpgrade(getSchemaVersion()))
         {
-            @Override
-            public String getName()
+            ContextListener.addStartupListener(new StartupListener()
             {
-                return "Search Service: delete index";
-            }
+                @Override
+                public String getName()
+                {
+                    return "Search Service: delete index";
+                }
 
-            @Override
-            public void moduleStartupComplete(ServletContext servletContext)
-            {
-                SearchService ss = SearchService.get();
+                @Override
+                public void moduleStartupComplete(ServletContext servletContext)
+                {
+                    SearchService ss = SearchService.get();
 
-                if (null != ss)
-                    ss.deleteIndex();
-            }
-        };
-        ContextListener.addStartupListener(l);
+                    if (null != ss)
+                        ss.deleteIndex();
+                }
+            });
+        }
     }
 
     @NotNull


### PR DESCRIPTION
#### Rationale
Clearing the "last indexed" values can be very time consuming for large tables. The original intent was to delete the index and clear last indexed on every search module upgrade, but it's actually happening on every module upgrade, which can be annoying to developers. Change to search module upgrades only.
