### PR TITLE
Issue 42666: LABKEY.WebPart typo in suppressRenderErrors config property handling

### DIFF
--- a/api/webapp/clientapi/dom/WebPart.js
+++ b/api/webapp/clientapi/dom/WebPart.js
@@ -120,7 +120,7 @@
         var _containerPath = config.containerPath;
         var _scope = config.scope || this;
         // Issue 42666 - backwards compatibility with originally supported, typo'd property name
-        var _suppressRenderErrors = config.suppressRenderErrors === undefined ? config.supressRenderErrors || config.suppressRenderErrors;
+        var _suppressRenderErrors = config.suppressRenderErrors === undefined ? config.supressRenderErrors : config.suppressRenderErrors;
         var _partUrl = config.partUrl || LABKEY.ActionURL.buildURL('project', 'getWebPart', _containerPath);
 
         //validate config

--- a/api/webapp/clientapi/dom/WebPart.js
+++ b/api/webapp/clientapi/dom/WebPart.js
@@ -119,7 +119,8 @@
         var _success = LABKEY.Utils.getOnSuccess(config);
         var _containerPath = config.containerPath;
         var _scope = config.scope || this;
-        var _suppressRenderErrors = config.supressRenderErrors;
+        // Issue 42666 - backwards compatibility with originally supported, typo'd property name
+        var _suppressRenderErrors = config.suppressRenderErrors === undefined ? config.supressRenderErrors || config.suppressRenderErrors;
         var _partUrl = config.partUrl || LABKEY.ActionURL.buildURL('project', 'getWebPart', _containerPath);
 
         //validate config


### PR DESCRIPTION
#### Rationale
We've got a typo in our handling of the suppressRenderErrors config property

#### Changes
* Look for the correctly spelled property name by default, but fall back to original typo'd value for backwards compatibility