### PR TITLE
fix for targetStudyTest

### DIFF
--- a/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
+++ b/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
@@ -108,6 +108,7 @@ public class PublishResultsQueryView extends QueryView
     private List<ActionButton> _buttons = null;
     private Map<ExtraColFieldKeys, FieldKey> _additionalColumns;
     private Map<String, Object> _hiddenFormFields;
+    private Set<String> _hiddenColumnCaptions;
 
     public enum ExtraColFieldKeys
     {
@@ -135,7 +136,8 @@ public class PublishResultsQueryView extends QueryView
                                    boolean mismatched,
                                    boolean includeTimestamp,
                                    Map<ExtraColFieldKeys, FieldKey> additionalColumns,
-                                   Map<String, Object> hiddenFormFields)
+                                   Map<String, Object> hiddenFormFields,
+                                   Set<String> hiddenColumnCaptions)
     {
         super(schema, settings, errors);
         _targetStudyContainer = targetStudyContainer;
@@ -153,6 +155,7 @@ public class PublishResultsQueryView extends QueryView
         _includeTimestamp = includeTimestamp;
         _additionalColumns = additionalColumns;
         _hiddenFormFields = hiddenFormFields;
+        _hiddenColumnCaptions = hiddenColumnCaptions;
 
         setViewItemFilter(ReportService.EMPTY_ITEM_LIST);
         getSettings().setMaxRows(Table.ALL_ROWS);
@@ -222,11 +225,10 @@ public class PublishResultsQueryView extends QueryView
                 dr.removeColumns(captionMatchColName);
             dr.addDisplayColumn(idx++, extra);
         }
-        Set<String> hiddenColNames = getHiddenColumnCaptions();
         for (Iterator<DisplayColumn> it = dr.getDisplayColumns().iterator(); it.hasNext();)
         {
             DisplayColumn current = it.next();
-            for (String hiddenColName : hiddenColNames)
+            for (String hiddenColName : _hiddenColumnCaptions)
             {
                 if (current.getCaption().endsWith(hiddenColName))
                 {
@@ -241,16 +243,6 @@ public class PublishResultsQueryView extends QueryView
         dr.setShowRecordSelectors(true);
         dr.setShowSelectMessage(false);
         return dr;
-    }
-
-    protected Set<String> getHiddenColumnCaptions()
-    {
-        HashSet<String> hidden = new HashSet<>(Collections.singleton("Assay Match"));
-        // unclear why this conditional logic exists, it seems to imply that we may not want to hide this column
-        // if the user had added a column in the result domain with the same caption
-        //if (_targetStudyDomainProperty != null && _targetStudyDomainProperty.first != ExpProtocol.AssayDomainTypes.Result)
-            hidden.add(AbstractAssayProvider.TARGET_STUDY_PROPERTY_CAPTION);
-        return hidden;
     }
 
     private static Date convertObjectToDate(Container container, Object dateObject)

--- a/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
+++ b/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
@@ -904,8 +904,6 @@ public class PublishResultsQueryView extends QueryView
         }
     }
 
-    Pair<ExpProtocol.AssayDomainTypes, DomainProperty> _targetStudyDomainProperty = null;
-
     protected List<DisplayColumn> getExtraColumns(Collection<ColumnInfo> selectColumns)
     {
         List<DisplayColumn> columns = new ArrayList<>();

--- a/study/src/org/labkey/study/assay/AssayPublishConfirmAction.java
+++ b/study/src/org/labkey/study/assay/AssayPublishConfirmAction.java
@@ -19,8 +19,8 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.study.StudyUrls;
 import org.labkey.api.study.TimepointType;
-import org.labkey.api.study.publish.PublishKey;
 import org.labkey.api.study.assay.AssayPublishService;
+import org.labkey.api.study.publish.PublishKey;
 import org.labkey.api.study.query.PublishResultsQueryView;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.HtmlString;
@@ -40,6 +40,7 @@ import org.springframework.web.servlet.ModelAndView;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @RequiresPermission(InsertPermission.class)
 public class AssayPublishConfirmAction extends AbstractPublishConfirmAction<AssayPublishConfirmAction.AssayPublishConfirmForm>
@@ -242,6 +243,24 @@ public class AssayPublishConfirmAction extends AbstractPublishConfirmAction<Assa
         fields.put(ActionURL.Param.returnUrl.name(), returnURL);
 
         return fields;
+    }
+
+    /**
+     * Specifies the columns in the publish results query view that should not be visible (but still be in the data view)
+     * @return
+     */
+    @Override
+    protected Set<String> getHiddenPublishResultsCaptions(AssayPublishConfirmForm form)
+    {
+        Set<String> hidden = super.getHiddenPublishResultsCaptions(form);
+
+        // unclear why this conditional logic exists, it seems to imply that we may not want to hide this column
+        // if the user had added a column in the result domain with the same caption
+        Pair<ExpProtocol.AssayDomainTypes, DomainProperty> targetStudyDomainProperty = form.getProvider().findTargetStudyProperty(_protocol);
+        if (targetStudyDomainProperty != null && targetStudyDomainProperty.first != ExpProtocol.AssayDomainTypes.Result)
+            hidden.add(AbstractAssayProvider.TARGET_STUDY_PROPERTY_CAPTION);
+
+        return hidden;
     }
 
     @Override

--- a/study/src/org/labkey/study/publish/AbstractPublishConfirmAction.java
+++ b/study/src/org/labkey/study/publish/AbstractPublishConfirmAction.java
@@ -191,6 +191,15 @@ public abstract class AbstractPublishConfirmAction<FORM extends PublishConfirmFo
      */
     protected abstract ActionURL copyToStudy(FORM form, Container targetStudy, Map<Integer, PublishKey> publishData, List<String> publishErrors);
 
+    /**
+     * Specifies the columns in the publish results query view that should not be visible (but still be in the data view)
+     * @return
+     */
+    protected Set<String> getHiddenPublishResultsCaptions(FORM form)
+    {
+        return new HashSet<>(Collections.singleton("Assay Match"));
+    }
+
     @Override
     public ModelAndView getView(FORM form, boolean reshow, BindException errors) throws Exception
     {
@@ -210,7 +219,8 @@ public abstract class AbstractPublishConfirmAction<FORM extends PublishConfirmFo
                 mismatched,
                 form.isIncludeTimestamp(),
                 getAdditionalColumns(form),
-                getHiddenFormFields(form));
+                getHiddenFormFields(form),
+                getHiddenPublishResultsCaptions(form));
 
         List<ActionButton> buttons = new ArrayList<>();
         URLHelper returnURL = form.getReturnURLHelper();


### PR DESCRIPTION
#### Rationale
The targetStudyTest was failing because the target study column did not appear in the publish confirm grid. This was a bit of code that we had questions about during the most recent refactor and had commented out the logic which hid the column only if it did not appear in the results domain.

Factored out that bit of code into the assay publish confirm action.