### PR TITLE
Issue 42168: Show queue position for jobs in the Data Pipeline webpart

### DIFF
--- a/api/src/org/labkey/api/pipeline/PipelineQueue.java
+++ b/api/src/org/labkey/api/pipeline/PipelineQueue.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.pipeline;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 
@@ -99,4 +100,8 @@ public interface PipelineQueue
      */
     @Deprecated
     PipelineJobData getJobDataInMemory(Container c);
+
+    /** @return the position of this job in the queue if it's waiting, if available */
+    @Nullable
+    Integer getQueuePosition(PipelineStatusFile statusFile);
 }

--- a/api/src/org/labkey/api/pipeline/PipelineQueue.java
+++ b/api/src/org/labkey/api/pipeline/PipelineQueue.java
@@ -16,11 +16,12 @@
 
 package org.labkey.api.pipeline;
 
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * PipelineQueues accept submissions of jobs and some of their basic management. Implementations might run all work in
@@ -101,7 +102,7 @@ public interface PipelineQueue
     @Deprecated
     PipelineJobData getJobDataInMemory(Container c);
 
-    /** @return the position of this job in the queue if it's waiting, if available */
-    @Nullable
-    Integer getQueuePosition(PipelineStatusFile statusFile);
+    /** @return the position of each job in the queue, keyed by the RowId of the status file */
+    @NotNull
+    Map<Integer, Integer> getQueuePositions();
 }

--- a/api/src/org/labkey/api/pipeline/PipelineQueue.java
+++ b/api/src/org/labkey/api/pipeline/PipelineQueue.java
@@ -102,7 +102,7 @@ public interface PipelineQueue
     @Deprecated
     PipelineJobData getJobDataInMemory(Container c);
 
-    /** @return the position of each job in the queue, keyed by the RowId of the status file */
+    /** @return the position of each job in the queue, keyed by the job's GUID of the status file */
     @NotNull
-    Map<Integer, Integer> getQueuePositions();
+    Map<String, Integer> getQueuePositions();
 }

--- a/pipeline/src/org/labkey/pipeline/api/PipelineQuerySchema.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineQuerySchema.java
@@ -41,7 +41,6 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.util.HtmlString;
-import org.labkey.pipeline.mule.EPipelineQueueImpl;
 import org.labkey.pipeline.query.TriggerConfigurationsTable;
 
 import java.util.ArrayList;
@@ -114,7 +113,7 @@ public class PipelineQuerySchema extends UserSchema
                 table.setContainerFilter(new ContainerFilter.AllFolders(getUser()));
             }
 
-            MutableColumnInfo positionCol = table.addWrapColumn("QueuePosition", table.getRealTable().getColumn("RowId"));
+            MutableColumnInfo positionCol = table.addWrapColumn("QueuePosition", table.getRealTable().getColumn("Job"));
             positionCol.setDisplayColumnFactory(QueuePositionDisplayColumn::new);
 
             table.getMutableColumn("RowId").setURL(DetailsURL.fromString(urlExp));
@@ -175,10 +174,7 @@ public class PipelineQuerySchema extends UserSchema
                 defaultCols.add(FieldKey.fromParts("Description"));
             }
             defaultCols.add(FieldKey.fromParts("Info"));
-            if (PipelineService.get().isEnterprisePipeline())
-            {
-                defaultCols.add(positionCol.getFieldKey());
-            }
+            defaultCols.add(positionCol.getFieldKey());
             table.setDefaultVisibleColumns(defaultCols);
             table.setTitleColumn("Description");
             return table;
@@ -213,7 +209,7 @@ public class PipelineQuerySchema extends UserSchema
     /** Show the position in the job queue (only available when using the JMS queue-based pipeline) */
     private static class QueuePositionDisplayColumn extends DataColumn
     {
-        private final Map<Integer, Integer> _positions;
+        private final Map<String, Integer> _positions;
 
         public QueuePositionDisplayColumn(ColumnInfo col)
         {
@@ -237,11 +233,8 @@ public class PipelineQuerySchema extends UserSchema
         public Object getValue(RenderContext ctx)
         {
             Object value = super.getValue(ctx);
-            if (value instanceof Number)
-            {
-                return _positions.get(((Number) value).intValue());
-            }
-            return null;
+            //noinspection SuspiciousMethodCalls
+            return _positions.get(value);
         }
 
         @Override

--- a/pipeline/src/org/labkey/pipeline/api/PipelineQuerySchema.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineQuerySchema.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.pipeline.api;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerDisplayColumn;
@@ -23,9 +24,11 @@ import org.labkey.api.data.ContainerForeignKey;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.module.Module;
+import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
@@ -37,10 +40,13 @@ import org.labkey.api.query.UserIdQueryForeignKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.util.HtmlString;
+import org.labkey.pipeline.mule.EPipelineQueueImpl;
 import org.labkey.pipeline.query.TriggerConfigurationsTable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -84,7 +90,7 @@ public class PipelineQuerySchema extends UserSchema
     {
         if (JOB_TABLE_NAME.equalsIgnoreCase(name))
         {
-            FilteredTable table = new FilteredTable<PipelineQuerySchema>(PipelineSchema.getInstance().getTableInfoStatusFiles(), this, cf)
+            FilteredTable<?> table = new FilteredTable<>(PipelineSchema.getInstance().getTableInfoStatusFiles(), this, cf)
             {
                 @Override
                 public FieldKey getContainerFieldKey()
@@ -107,6 +113,9 @@ public class PipelineQuerySchema extends UserSchema
             {
                 table.setContainerFilter(new ContainerFilter.AllFolders(getUser()));
             }
+
+            MutableColumnInfo positionCol = table.addWrapColumn("QueuePosition", table.getRealTable().getColumn("RowId"));
+            positionCol.setDisplayColumnFactory(QueuePositionDisplayColumn::new);
 
             table.getMutableColumn("RowId").setURL(DetailsURL.fromString(urlExp));
             table.getMutableColumn("Status").setDisplayColumnFactory(colInfo ->
@@ -166,6 +175,10 @@ public class PipelineQuerySchema extends UserSchema
                 defaultCols.add(FieldKey.fromParts("Description"));
             }
             defaultCols.add(FieldKey.fromParts("Info"));
+            if (PipelineService.get().isEnterprisePipeline())
+            {
+                defaultCols.add(positionCol.getFieldKey());
+            }
             table.setDefaultVisibleColumns(defaultCols);
             table.setTitleColumn("Description");
             return table;
@@ -197,4 +210,50 @@ public class PipelineQuerySchema extends UserSchema
         return names;
     }
 
+    /** Show the position in the job queue (only available when using the JMS queue-based pipeline) */
+    private static class QueuePositionDisplayColumn extends DataColumn
+    {
+        private final Map<Integer, Integer> _positions;
+
+        public QueuePositionDisplayColumn(ColumnInfo col)
+        {
+            super(col);
+            _positions = PipelineService.get().getPipelineQueue().getQueuePositions();
+        }
+
+        @Override
+        public boolean isSortable()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isFilterable()
+        {
+            return false;
+        }
+
+        @Override
+        public Object getValue(RenderContext ctx)
+        {
+            Object value = super.getValue(ctx);
+            if (value instanceof Number)
+            {
+                return _positions.get(((Number) value).intValue());
+            }
+            return null;
+        }
+
+        @Override
+        public Object getDisplayValue(RenderContext ctx)
+        {
+            return getValue(ctx);
+        }
+
+        @Override
+        public @NotNull HtmlString getFormattedHtml(RenderContext ctx)
+        {
+            return HtmlString.of(getDisplayValue(ctx));
+        }
+    }
 }

--- a/pipeline/src/org/labkey/pipeline/api/PipelineQueueImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineQueueImpl.java
@@ -39,6 +39,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
@@ -262,9 +263,25 @@ public class PipelineQueueImpl extends AbstractPipelineQueue
 
     @Override
     @NotNull
-    public Map<Integer, Integer> getQueuePositions()
+    public Map<String, Integer> getQueuePositions()
     {
-        return Collections.emptyMap();
+        Map<String, Integer> result = new HashMap<>();
+        synchronized (_running)
+        {
+            for (PipelineJob pipelineJob : _running)
+            {
+                result.put(pipelineJob.getJobGUID(), 1);
+            }
+        }
+        int position = _running.isEmpty() ? 0 : 1;
+        synchronized (_pending)
+        {
+            for (PipelineJob pipelineJob : _pending)
+            {
+                result.put(pipelineJob.getJobGUID(), ++position);
+            }
+        }
+        return result;
     }
 
     //

--- a/pipeline/src/org/labkey/pipeline/api/PipelineQueueImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineQueueImpl.java
@@ -17,6 +17,7 @@ package org.labkey.pipeline.api;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.data.ConnectionWrapper;
@@ -37,9 +38,11 @@ import org.labkey.api.view.ViewBackgroundInfo;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -258,9 +261,10 @@ public class PipelineQueueImpl extends AbstractPipelineQueue
     }
 
     @Override
-    public Integer getQueuePosition(PipelineStatusFile statusFile)
+    @NotNull
+    public Map<Integer, Integer> getQueuePositions()
     {
-        return null;
+        return Collections.emptyMap();
     }
 
     //

--- a/pipeline/src/org/labkey/pipeline/api/PipelineQueueImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineQueueImpl.java
@@ -257,6 +257,12 @@ public class PipelineQueueImpl extends AbstractPipelineQueue
         return ret;
     }
 
+    @Override
+    public Integer getQueuePosition(PipelineStatusFile statusFile)
+    {
+        return null;
+    }
+
     //
     // JUNIT
     //

--- a/pipeline/src/org/labkey/pipeline/mule/EPipelineQueueImpl.java
+++ b/pipeline/src/org/labkey/pipeline/mule/EPipelineQueueImpl.java
@@ -340,9 +340,9 @@ public class EPipelineQueueImpl extends AbstractPipelineQueue
 
     @Override
     @NotNull
-    public Map<Integer, Integer> getQueuePositions()
+    public Map<String, Integer> getQueuePositions()
     {
-        Map<Integer, Integer> result = new HashMap<>();
+        Map<String, Integer> result = new HashMap<>();
 
         Set<String> locations = new TreeSet<>();
         TaskPipelineRegistry registry = PipelineJobService.get();
@@ -358,7 +358,7 @@ public class EPipelineQueueImpl extends AbstractPipelineQueue
             int position = 0;
             for (PipelineStatusFileImpl sf : queuedJobs)
             {
-                result.put(sf.getRowId(), ++position);
+                result.put(sf.getJobId(), ++position);
             }
         }
         return result;

--- a/pipeline/src/org/labkey/pipeline/mule/EPipelineQueueImpl.java
+++ b/pipeline/src/org/labkey/pipeline/mule/EPipelineQueueImpl.java
@@ -18,12 +18,15 @@ package org.labkey.pipeline.mule;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineJobData;
+import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.pipeline.PipelineStatusFile;
 import org.labkey.api.pipeline.RemoteExecutionEngine;
 import org.labkey.api.pipeline.TaskFactory;
+import org.labkey.api.pipeline.TaskPipelineRegistry;
 import org.labkey.api.security.User;
 import org.labkey.api.util.JobRunner;
 import org.labkey.pipeline.api.AbstractPipelineQueue;
@@ -49,8 +52,11 @@ import javax.jms.TextMessage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Enterprise pipeline queue uses Mule to place jobs on a JMS message queue.
@@ -333,42 +339,28 @@ public class EPipelineQueueImpl extends AbstractPipelineQueue
     }
 
     @Override
-    public Integer getQueuePosition(PipelineStatusFile statusFile)
+    @NotNull
+    public Map<Integer, Integer> getQueuePositions()
     {
-        if (statusFile.getJobStore() != null)
-        {
-            try
-            {
-                // Deserialize so we can figure out the location of the current task
-                PipelineJob job = PipelineJob.deserializeJob(statusFile.getJobStore());
-                if (job != null && job.getActiveTaskFactory() != null)
-                {
-                    String location = job.getActiveTaskFactory().getExecutionLocation();
-                    if (location == null)
-                    {
-                        // Default queue if not set
-                        location = TaskFactory.WEBSERVER;
-                    }
+        Map<Integer, Integer> result = new HashMap<>();
 
-                    // Jobs come back in queued order
-                    List<PipelineStatusFileImpl> queuedJobs = PipelineStatusManager.getStatusFilesForLocation(location, true);
-                    int position = 0;
-                    for (PipelineStatusFileImpl sf : queuedJobs)
-                    {
-                        position++;
-                        if (sf.getRowId() == statusFile.getRowId())
-                        {
-                            return position;
-                        }
-                    }
-                }
-            }
-            catch (RuntimeException e)
+        Set<String> locations = new TreeSet<>();
+        TaskPipelineRegistry registry = PipelineJobService.get();
+        for (TaskFactory<?> taskFactory : registry.getTaskFactories(null))
+        {
+            locations.add(taskFactory.getExecutionLocation());
+        }
+
+        for (String location : locations)
+        {
+            // Jobs come back in queued order
+            List<PipelineStatusFileImpl> queuedJobs = PipelineStatusManager.getStatusFilesForLocation(location, true);
+            int position = 0;
+            for (PipelineStatusFileImpl sf : queuedJobs)
             {
-                // Non-fatal - probably an old serialized job that doesn't match the current Java code
-                _log.debug("Failed to deserialize job to determine position in queue", e);
+                result.put(sf.getRowId(), ++position);
             }
         }
-        return null;
+        return result;
     }
 }

--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -524,9 +524,9 @@ public class StatusController extends SpringActionController
 
             bean.modified = _statusFile.getModified();
             bean.status = StatusDetailsBean.create(getContainer(), _statusFile, 0, 0);
-            bean.queuePosition = PipelineService.get().getPipelineQueue().getQueuePosition(_statusFile);
+            bean.queuePosition = PipelineService.get().getPipelineQueue().getQueuePositions().get(_statusFile.getRowId());
 
-            return new JspView<DetailsBean>("/org/labkey/pipeline/status/details.jsp", bean, errors);
+            return new JspView<>("/org/labkey/pipeline/status/details.jsp", bean, errors);
         }
 
         @Override

--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -478,6 +478,7 @@ public class StatusController extends SpringActionController
         public ActionURL dataUrl;
         public Date modified;
         public StatusDetailsBean status;
+        public Integer queuePosition;
     }
 
     @RequiresPermission(ReadPermission.class)
@@ -523,6 +524,7 @@ public class StatusController extends SpringActionController
 
             bean.modified = _statusFile.getModified();
             bean.status = StatusDetailsBean.create(getContainer(), _statusFile, 0, 0);
+            bean.queuePosition = PipelineService.get().getPipelineQueue().getQueuePosition(_statusFile);
 
             return new JspView<DetailsBean>("/org/labkey/pipeline/status/details.jsp", bean, errors);
         }

--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -524,7 +524,7 @@ public class StatusController extends SpringActionController
 
             bean.modified = _statusFile.getModified();
             bean.status = StatusDetailsBean.create(getContainer(), _statusFile, 0, 0);
-            bean.queuePosition = PipelineService.get().getPipelineQueue().getQueuePositions().get(_statusFile.getRowId());
+            bean.queuePosition = PipelineService.get().getPipelineQueue().getQueuePositions().get(_statusFile.getJobId());
 
             return new JspView<>("/org/labkey/pipeline/status/details.jsp", bean, errors);
         }

--- a/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
@@ -161,7 +161,7 @@ public class StatusDetailsBean
                     .collect(toList());
         }
 
-        return new StatusDetailsBean(c, psf, statusFiles, statusRuns, parentStatus, splitStatus, statusLog, fetchCount, PipelineService.get().getPipelineQueue().getQueuePosition(psf));
+        return new StatusDetailsBean(c, psf, statusFiles, statusRuns, parentStatus, splitStatus, statusLog, fetchCount, PipelineService.get().getPipelineQueue().getQueuePositions().get(psf.getRowId()));
     }
 
     // Copy the file content from Path to the PrintWriter,

--- a/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
@@ -161,7 +161,7 @@ public class StatusDetailsBean
                     .collect(toList());
         }
 
-        return new StatusDetailsBean(c, psf, statusFiles, statusRuns, parentStatus, splitStatus, statusLog, fetchCount, PipelineService.get().getPipelineQueue().getQueuePositions().get(psf.getRowId()));
+        return new StatusDetailsBean(c, psf, statusFiles, statusRuns, parentStatus, splitStatus, statusLog, fetchCount, PipelineService.get().getPipelineQueue().getQueuePositions().get(psf.getJobId()));
     }
 
     // Copy the file content from Path to the PrintWriter,

--- a/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
@@ -59,14 +59,15 @@ public class StatusDetailsBean
     public final List<StatusDetailRun> runs;
     public final StatusDetailLog log;
     public final Integer fetchCount;
+    public final Integer queuePosition;
 
     // private constructor for parent/split job status
     private StatusDetailsBean(Container c, PipelineStatusFile psf)
     {
-        this(c, psf, null, null, null, null, null, null);
+        this(c, psf, null, null, null, null, null, null, null);
     }
 
-    public StatusDetailsBean(Container c, PipelineStatusFile psf, List<StatusDetailFile> files, List<StatusDetailRun> runs, StatusDetailsBean parentStatus, List<StatusDetailsBean> splitStatus, StatusDetailLog log, Integer fetchCount)
+    public StatusDetailsBean(Container c, PipelineStatusFile psf, List<StatusDetailFile> files, List<StatusDetailRun> runs, StatusDetailsBean parentStatus, List<StatusDetailsBean> splitStatus, StatusDetailLog log, Integer fetchCount, Integer queuePosition)
     {
         this.rowId = psf.getRowId();
         this.jobId = psf.getJobId();
@@ -89,6 +90,7 @@ public class StatusDetailsBean
         this.runs = runs;
         this.log = log;
         this.fetchCount = fetchCount;
+        this.queuePosition = queuePosition;
     }
 
     public static StatusDetailsBean create(Container c, PipelineStatusFile psf, long logOffset, int fetchCount)
@@ -159,7 +161,7 @@ public class StatusDetailsBean
                     .collect(toList());
         }
 
-        return new StatusDetailsBean(c, psf, statusFiles, statusRuns, parentStatus, splitStatus, statusLog, fetchCount);
+        return new StatusDetailsBean(c, psf, statusFiles, statusRuns, parentStatus, splitStatus, statusLog, fetchCount, PipelineService.get().getPipelineQueue().getQueuePosition(psf));
     }
 
     // Copy the file content from Path to the PrintWriter,

--- a/pipeline/src/org/labkey/pipeline/status/details.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/details.jsp
@@ -116,6 +116,12 @@
             <td class="lk-form-label">Info:</td>
             <td id="info"><%=h(status.info)%></td>
         </tr>
+        <% if (bean.queuePosition != null) { %>
+            <tr>
+                <td class="lk-form-label">Queue Position:</td>
+                <td id="queuePosition"><%=h(bean.queuePosition)%></td>
+            </tr>
+        <% } %>
         <tr>
             <td class="lk-form-label">Description:</td>
             <td id="description"><%=h(status.description)%></td>
@@ -258,6 +264,7 @@
     let infoEl = document.getElementById('info');
     let descriptionEl = document.getElementById('description');
     let filePathEl = document.getElementById('file-path');
+    let queuePosition = document.getElementById('queuePosition');
 
     let filesListEl = document.getElementById('files-list');
     let runsListEl = document.getElementById('runs-list');
@@ -362,7 +369,7 @@ ended very recently. --%>
         const MAX_UNCHANGED_COUNT = 3;
 
         function updateField(el, text) {
-            if (text !== null && text !== undefined)
+            if (text !== null && text !== undefined && el)
                 el.innerText = text;
         }
 
@@ -679,6 +686,7 @@ ended very recently. --%>
                         updateField(emailEl, status.email);
                         updateField(infoEl, status.info);
                         updateField(descriptionEl, status.description);
+                        updateField(queuePosition, status.queuePosition);
                         updateStatus(active, status.status, status.hadError);
                         updateRuns(status.runs);
                         updateFiles(status.files);


### PR DESCRIPTION
#### Rationale
On shared servers, users' jobs may sit in the pipeline queue for some time. We can help them understand their place in line, at least when the server is configured to use JMS.

#### Changes
* Show job queue position in pipeline details page, hooking into page refresh
* Add column to pipeline job grid too