### PR TITLE
Switch 21.3's earliest upgrade version to 19.1

### DIFF
--- a/api/src/org/labkey/api/Constants.java
+++ b/api/src/org/labkey/api/Constants.java
@@ -40,7 +40,7 @@ public class Constants
      */
     public static double getEarliestUpgradeVersion()
     {
-        return 18.3;
+        return 19.1;
     }
 
     /**


### PR DESCRIPTION
#### Rationale
Java upgrade code `ExperimentUpgradeCode.materializeSampleSets()`, which runs as part of the 18.30 to 19.10 upgrade, fails on 20.11 or later, due to the exp code expecting ontology columns on `exp.PropertyDescriptor`. Therefore, the earliest upgrade version we can claim for 21.3 is 19.1.
