### PR TITLE
Dataset security usability improvements

### DIFF
--- a/api/src/org/labkey/api/util/element/Select.java
+++ b/api/src/org/labkey/api/util/element/Select.java
@@ -185,6 +185,11 @@ public class Select extends Input
             return this;
         }
 
+        /**
+         * Add multiple options from a map
+         * @param options A Map&lt;option value, option label>
+         * @return The SelectBuilder
+         */
         public SelectBuilder addOptions(Map<?, String> options)
         {
             return addOptions(

--- a/study/src/org/labkey/study/security/datasets.jsp
+++ b/study/src/org/labkey/study/security/datasets.jsp
@@ -26,16 +26,23 @@
 <%@ page import="org.labkey.api.security.roles.Role" %>
 <%@ page import="org.labkey.api.security.roles.RoleManager" %>
 <%@ page import="org.labkey.api.study.Dataset" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
+<%@ page import="org.labkey.api.util.HtmlStringBuilder" %>
 <%@ page import="org.labkey.api.util.Pair" %>
+<%@ page import="org.labkey.api.util.element.Option.OptionBuilder" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.study.controllers.StudyController.ManageStudyAction" %>
 <%@ page import="org.labkey.study.controllers.security.SecurityController.ApplyDatasetPermissionsAction" %>
 <%@ page import="org.labkey.study.model.DatasetDefinition" %>
 <%@ page import="org.labkey.study.model.SecurityType" %>
 <%@ page import="org.labkey.study.model.StudyImpl" %>
+<%@ page import="javax.annotation.Nullable" %>
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.Comparator" %>
+<%@ page import="java.util.LinkedList" %>
 <%@ page import="java.util.List" %>
+<%@ page import="java.util.Objects" %>
 <%@ page extends="org.labkey.study.view.BaseStudyPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -50,6 +57,21 @@
     String getTooltip(Dataset ds, Group group)
     {
         return "Dataset: " + ds.getLabel() + ", " + "Group: " + groupName(group);
+    }
+
+    // Used to highlight special datasets in per-dataset permissions
+    @Nullable String getTooltip(StudyImpl study, Integer datasetId)
+    {
+        List<String> messages = new LinkedList<>();
+        if (datasetId.equals(study.getParticipantCohortDatasetId()))
+            messages.add("This is the participant/cohort dataset");
+        if (datasetId.equals(study.getParticipantAliasDatasetId()))
+            messages.add("This is the participant alias dataset");
+        if (datasetId.equals(study.getParticipantCommentDatasetId()))
+            messages.add("This is the participant comment dataset");
+        if (datasetId.equals(study.getParticipantVisitCommentDatasetId()))
+            messages.add("This is the participant/visit comment dataset");
+        return messages.isEmpty() ? null : String.join("&#013;", messages);
     }
 %>
 <%
@@ -145,6 +167,18 @@ else
     <%
             }
 %>group's access to each dataset is controlled by the drop-down list in each cell.
+<%
+    // Count the number of "special" datasets (participant/cohort, altId, comment, etc.)
+    long specialDatasetCount = study.getDatasets().stream().map(dd->getTooltip(study, dd.getDatasetId())).filter(Objects::nonNull).count();
+    if (specialDatasetCount > 0)
+    {
+%>
+<br><br>The dataset<%=h(specialDatasetCount > 1 ? "s" : "")%> highlighted in <b>bold</b> below may warrant special attention.
+For example, permissions set on the participant/cohort dataset dictate who can view and<br>filter on cohorts. Read permissions
+set on the alternate ID dataset will affect who can edit other datasets. Hover over the highlighted dataset labels for details.
+<%
+    }
+%>
 <style type="text/css">
     table.table {
         width: auto !important;
@@ -154,7 +188,7 @@ else
         padding: 5px 5px 0 5px !important;
     }
 </style>
-<labkey:form id="datasetSecurityForm" action="<%=urlFor(ApplyDatasetPermissionsAction.class)%>" method="POST">
+<labkey:form id="datasetSecurityForm" action="<%=urlFor(ApplyDatasetPermissionsAction.class)%>" onsubmit="LABKEY.setSubmit(true);" method="POST">
 <%
     if (returnUrl != null)
         out.print(generateReturnUrlFormField(returnUrl));
@@ -202,28 +236,34 @@ else
     <tr class="<%=getShadeRowClass(row++)%>"><th>&nbsp;</th><%
     for (Group g : restrictedGroups)
     {
-        %><td class="dataset-permission" data-toggle="tooltip" title='Set all values in column'><select name="<%= h(g.getName()) %>" onchange="setColumnSelections(this)">
-            <option value="" selected>&lt;set all to...&gt;</option>
-            <option value="None">None</option>
-        <%
-            for (Role role : possibleRoles)
-            {
-                // Filter out roles that can't be assigned to this user/group
-                if (!role.getExcludedPrincipals().contains(g))
-                {
-        %>            <option value="<%= h(role.getName()) %>"><%= h(role.getName()) %></option><%
-                }
-            }
+        %><td class="dataset-permission" data-toggle="tooltip" title='Set all values in column'>
+        <%=select()
+            .name(g.getName())
+            .addOption(new OptionBuilder("<set all to...>", "").selected(true))
+            .addOption("None")
+            .addOptions(
+                possibleRoles.stream()
+                    .filter(pr->!pr.getExcludedPrincipals().contains(g)) // Filter out roles that can't be assigned to this group
+                    .map(Role::getName)
+            )
+            .onChange("setColumnSelections(this); LABKEY.setDirty(true);")
+            .className(null)
         %>
-        </select></td><%
+    </td><%
     }
     %></tr><%
+
     for (Dataset ds : datasets)
     {
         SecurityPolicy dsPolicy = SecurityPolicyManager.getPolicy(ds);
 
         String inputName = "dataset." + ds.getDatasetId();
-        %><tr class="<%=getShadeRowClass(row++)%>"><td><%=h(ds.getLabel())%></td><%
+        %><tr class="<%=getShadeRowClass(row++)%>"><%
+        // Highlight "special" datasets (cohort, altid, comments, etc.) in the grid
+        String toolTip = getTooltip(study, ds.getDatasetId());
+        HtmlString toolTipHtml = null == toolTip ? HtmlString.EMPTY_STRING : unsafe(" data-toggle=\"tooltip\" title=\"" + toolTip + "\"");
+        HtmlString label = null == toolTip ? h(ds.getLabel()) : HtmlStringBuilder.of().append(unsafe("<b>")).append(ds.getLabel()).append(unsafe("</b>")).getHtmlString();
+        %><td<%=toolTipHtml%>><%=label%></td><%
 
         for (Group g : restrictedGroups)
         {
@@ -239,36 +279,34 @@ else
             boolean noPerm = !writePerm && !readPerm && assignedRole == null;
             int id = g.getUserId();
             %><td style="text-align: left;" data-toggle="tooltip" title='<%=h(getTooltip(ds, g))%>'>
-                <select name="<%=h(inputName)%>">
-                    <option value="<%=id%>_NONE"<%=selected(noPerm)%>>None</option>
-                    <% for (Role possibleRole : possibleRoles)
-                    {
-                        // Filter out roles that can't be assigned to this user/group
-                        if (!possibleRole.getExcludedPrincipals().contains(g))
-                        {
-        %>                    <option value="<%=id%>_<%= h(possibleRole.getClass().getName()) %>"<%=selected(possibleRole == assignedRole)%>><%=h(possibleRole.getName()) %></option><%
-                        }
-                    }
-                    %>
-                </select>
+                <%=select()
+                    .name(inputName)
+                    .addOption(new OptionBuilder("None", id + "_NONE").selected(noPerm))
+                    .addOptions(
+                        possibleRoles.stream()
+                            .filter(pr->!pr.getExcludedPrincipals().contains(g)) // Filter out roles that can't be assigned to this group
+                            .map(r->new OptionBuilder(r.getName(), id + "_" + r.getClass().getName()).selected(r == assignedRole))
+                    )
+                    .onChange("LABKEY.setDirty(true);")
+                    .className(null)
+                %>
               </td><%
         }
         %></tr><%
     }
     %>
     </table>
-    <table>
-        <tr>
-            <td><%= button("Save").submit(true) %></td>
-            <td><%= button("Set all to Reader").href("#").onClick("return setAllSelections('Reader');") %></td><%
-            if (study.getSecurityType() == SecurityType.ADVANCED_WRITE)
-            {
-            %>
-                <td><%= button("Set all to Editor").href("#").onClick("return setAllSelections('Editor');") %></td><%
-            }
-            %>
-            <td><%= button("Clear All").href("#").onClick("return setAllSelections('None');") %></td>
-        </tr></table>
+    <%=button("Save").submit(true)%>
+    <%=button("Set all to Reader").href("#").onClick("return setAllSelections('Reader');")%>
+    <%
+    if (study.getSecurityType() == SecurityType.ADVANCED_WRITE)
+    {
+    %>
+        <%=button("Set all to Editor").href("#").onClick("return setAllSelections('Editor');")%><%
+    }
+    %>
+    <%=button("Clear All").href("#").onClick("return setAllSelections('None');")%>
+    <%=button("Cancel").href(urlFor(ManageStudyAction.class)).onClick("LABKEY.setSubmit(true);")%>
 </labkey:form>
 
     <%
@@ -297,6 +335,7 @@ function setAllSelections(value)
             }
         }
     }
+    LABKEY.setDirty(true);
     return false;
 }
 
@@ -329,6 +368,7 @@ function setColumnSelections(select)
             }
         }
     }
+    LABKEY.setDirty(true);
     return false;
 }
 </script>

--- a/study/src/org/labkey/study/security/datasets.jsp
+++ b/study/src/org/labkey/study/security/datasets.jsp
@@ -62,15 +62,16 @@
     // Used to highlight special datasets in per-dataset permissions
     @Nullable String getTooltip(StudyImpl study, Integer datasetId)
     {
+        String participant = study.getSubjectNounSingular().toLowerCase();
         List<String> messages = new LinkedList<>();
         if (datasetId.equals(study.getParticipantCohortDatasetId()))
-            messages.add("This is the participant/cohort dataset");
+            messages.add("This is the " + participant + "/cohort dataset");
         if (datasetId.equals(study.getParticipantAliasDatasetId()))
-            messages.add("This is the participant alias dataset");
+            messages.add("This is the " + participant + " alias dataset");
         if (datasetId.equals(study.getParticipantCommentDatasetId()))
-            messages.add("This is the participant comment dataset");
+            messages.add("This is the " + participant + " comment dataset");
         if (datasetId.equals(study.getParticipantVisitCommentDatasetId()))
-            messages.add("This is the participant/visit comment dataset");
+            messages.add("This is the " + participant + "/visit comment dataset");
         return messages.isEmpty() ? null : String.join("&#013;", messages);
     }
 %>
@@ -174,7 +175,7 @@ else
     {
 %>
 <br><br>The dataset<%=h(specialDatasetCount > 1 ? "s" : "")%> highlighted in <b>bold</b> below may warrant special attention.
-For example, permissions set on the participant/cohort dataset dictate who can view and<br>filter on cohorts. Read permissions
+For example, permissions set on the <%=h(study.getSubjectNounSingular().toLowerCase())%>/cohort dataset dictate who can view and<br>filter on cohorts. Read permissions
 set on the alternate ID dataset will affect who can edit other datasets. Hover over the highlighted dataset labels for details.
 <%
     }

--- a/study/src/org/labkey/study/security/study.jsp
+++ b/study/src/org/labkey/study/security/study.jsp
@@ -25,6 +25,7 @@
 <%@ page import="org.labkey.api.util.Pair" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.study.controllers.StudyController.ManageStudyAction" %>
 <%@ page import="org.labkey.study.controllers.security.SecurityController.SaveStudyPermissionsAction" %>
 <%@ page import="org.labkey.study.model.GroupSecurityType" %>
 <%@ page import="org.labkey.study.model.SecurityType" %>
@@ -38,8 +39,8 @@
     ActionURL returnUrl = pair.second;
     boolean includeEditOption = study.getSecurityType() == SecurityType.ADVANCED_WRITE;
 %>
-Any user with READ access to this folder may view some summary data.  However, access to detail data must be explicitly granted.
-    <labkey:form id="groupUpdateForm" action="<%=urlFor(SaveStudyPermissionsAction.class)%>" method="post">
+Any user with READ access to this folder may view some summary data. However, access to detail data must be explicitly granted.
+    <labkey:form id="groupUpdateForm" action="<%=urlFor(SaveStudyPermissionsAction.class)%>" onsubmit="LABKEY.setSubmit(true);" method="post">
 <%
     if (returnUrl != null)
         out.print(generateReturnUrlFormField(returnUrl));
@@ -80,15 +81,16 @@ Any user with READ access to this folder may view some summary data.  However, a
         %><tr><td><%=h(name)%></td><%
         if (includeEditOption)
         {
-        %><th><input <%=h(warning)%> type=radio name="<%=h(inputName)%>" value="<%=h(GroupSecurityType.UPDATE_ALL.getParamName())%>"<%=checked(GroupSecurityType.UPDATE_ALL == gt)%>></th><%
+        %><th><input <%=h(warning)%> type=radio name="<%=h(inputName)%>" value="<%=h(GroupSecurityType.UPDATE_ALL.getParamName())%>"<%=checked(GroupSecurityType.UPDATE_ALL == gt)%> onchange="LABKEY.setDirty(true);"></th><%
         }
         %>
-        <th><input <%=h(warning)%> type=radio name="<%=h(inputName)%>" value="<%=h(GroupSecurityType.READ_ALL.getParamName())%>"<%=checked(GroupSecurityType.READ_ALL == gt)%>></th>
-        <th><input <%=h(warning)%> type=radio name="<%=h(inputName)%>" value="<%=h(GroupSecurityType.PER_DATASET.getParamName())%>"<%=checked(GroupSecurityType.PER_DATASET == gt)%>></th>
-        <th><input <%=h(clear)%> type=radio name="<%=h(inputName)%>" value="<%=h(GroupSecurityType.NONE.getParamName())%>"<%=checked(GroupSecurityType.NONE == gt)%>></th><%
+        <th><input <%=h(warning)%> type=radio name="<%=h(inputName)%>" value="<%=h(GroupSecurityType.READ_ALL.getParamName())%>"<%=checked(GroupSecurityType.READ_ALL == gt)%> onchange="LABKEY.setDirty(true);"></th>
+        <th><input <%=h(warning)%> type=radio name="<%=h(inputName)%>" value="<%=h(GroupSecurityType.PER_DATASET.getParamName())%>"<%=checked(GroupSecurityType.PER_DATASET == gt)%> onchange="LABKEY.setDirty(true);"></th>
+        <th><input <%=h(clear)%> type=radio name="<%=h(inputName)%>" value="<%=h(GroupSecurityType.NONE.getParamName())%>"<%=checked(GroupSecurityType.NONE == gt)%> onchange="LABKEY.setDirty(true);"></th><%
         %><td id="<%=h(inputName)%>$WARN" style="display:<%=h(!hasFolderRead && (hasReadAllPerm || hasReadSomePerm)?"inline":"none")%>;"><img src="<%=getWebappURL("_images/exclaim.gif")%>" alt="group does not have folder read permissions" title="group does not have folder read permissions"></td><%
         %></tr><%
     }
     %></table>
-    <%= button("Update").submit(true).id("groupUpdateButton") %>
+    <%=button("Update").submit(true).id("groupUpdateButton")%>
+    <%=button("Cancel").href(urlFor(ManageStudyAction.class)).onClick("LABKEY.setSubmit(true);")%>
     </labkey:form>

--- a/study/src/org/labkey/study/security/studySecurity.jsp
+++ b/study/src/org/labkey/study/security/studySecurity.jsp
@@ -17,11 +17,13 @@
 %>
 <%@ page import="org.labkey.api.security.SecurityUrls"%>
 <%@ page import="org.labkey.api.study.Study"%>
+<%@ page import="org.labkey.api.util.element.Option.OptionBuilder"%>
 <%@ page import="org.labkey.api.view.HttpView"%>
-<%@ page import="org.labkey.study.controllers.security.SecurityController.StudySecurityAction"%>
+<%@ page import="org.labkey.study.controllers.security.SecurityController.StudySecurityAction" %>
 <%@ page import="org.labkey.study.model.SecurityType" %>
 <%@ page import="org.labkey.study.model.StudyImpl" %>
 <%@ page import="org.labkey.study.model.StudyManager" %>
+<%@ page import="java.util.Arrays" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.study.view.BaseStudyPage" %>
 <%
@@ -44,28 +46,25 @@
 <%
     if (isSharedStudy)
     {
-        %><p>All datasets in a dataspace (shared) study are read-only.  To add/update data you must create a study in a sub-folder.</p><%
+        %><p>All datasets in a dataspace (shared) study are read-only. To add/update data you must create a study in a sub-folder.</p><%
     }
     else
     {
 %>
 <p>If you want to set permissions on individual datasets within the study, you must select one of the custom study security options below.</p>
 
-<labkey:form action="<%=urlFor(StudySecurityAction.class)%>" method="post" name="studySecurityForm">
+<labkey:form action="<%=urlFor(StudySecurityAction.class)%>" method="post" name="studySecurityForm" onsubmit="LABKEY.setSubmit(true);">
     <p>Study Security Type<%=helpPopup("Study Security", SecurityType.getHTMLDescription(), true, 400)%>:
-    <select name="securityString" onchange="document.getElementById('securityTypeWarning').style.display = 'block';">
-        <%
-            for (SecurityType securityType : SecurityType.values())
-            {
-                // disallow per-dataset permissions in studies with shared datasets
-                if (isInSharedStudy && securityType.isSupportsPerDatasetPermissions())
-                    continue;
-                %>
-                <option value="<%=h(securityType.name())%>"<%=selected(study.getSecurityType() == securityType)%>><%=h(securityType.getLabel())%></option>
-                <%
-            }
-        %>
-    </select>
+    <%=select()
+        .name("securityString")
+        .addOptions(
+            Arrays.stream(SecurityType.values())
+                .filter(st->!(isInSharedStudy && st.isSupportsPerDatasetPermissions()))
+                .map(st->new OptionBuilder(st.getLabel(), st.name()).selected(study.getSecurityType() == st))
+        )
+        .onChange("document.getElementById('securityTypeWarning').style.display = 'block'; LABKEY.setDirty(true);")
+        .className(null)
+    %>
     <labkey:button text="Update Type" />
         <div id="securityTypeWarning" style="display: none"><em>Changing the security type can significantly alter who can view and modify data.</em></div>
     </p>
@@ -73,3 +72,9 @@
 <%
     }
 %>
+<script type="text/javascript">
+    // With up to three different sections and three different save buttons, it would be great to provide a custom message
+    // that indicates to the user where unsaved changes exist. However, to prevent scamming, modern browsers no longer
+    // support custom messages. Best we can do is a generic warning if navigating away with unsaved changes.
+    window.onbeforeunload = LABKEY.beforeunload(LABKEY.isDirty());
+</script>

--- a/study/src/org/labkey/study/view/manageStudy.jsp
+++ b/study/src/org/labkey/study/view/manageStudy.jsp
@@ -55,7 +55,6 @@
 <%@ page import="org.labkey.study.controllers.StudyDefinitionController.EditStudyDefinitionAction" %>
 <%@ page import="org.labkey.study.controllers.StudyDesignController.ManageStudyProductsAction" %>
 <%@ page import="org.labkey.study.controllers.security.SecurityController.BeginAction" %>
-<%@ page import="org.labkey.study.controllers.specimen.SpecimenController.ManageSpecimenCommentsAction" %>
 <%@ page import="org.labkey.study.model.ParticipantCategoryImpl" %>
 <%@ page import="org.labkey.study.model.ParticipantGroupManager" %>
 <%@ page import="org.labkey.study.model.StudyImpl" %>
@@ -249,11 +248,6 @@
                         <td class="lk-study-prop-label">Quality Control States</td>
                         <td class="lk-study-prop-desc">Manage QC states for datasets in this study</td>
                         <td><%=link("Manage Dataset QC States", ManageQCStatesAction.class) %></td>
-                    </tr>
-                    <tr>
-                        <td class="lk-study-prop-label">Comments</td>
-                        <td class="lk-study-prop-desc">Manage <%= h(subjectNounSingle.toLowerCase()) %> and  <%= h(subjectNounSingle.toLowerCase()) %>/visit comments</td>
-                        <td><%= link("Manage Comments", ManageSpecimenCommentsAction.class) %></td>
                     </tr>
                     <tr>
                         <td class="lk-study-prop-label">Study Products</td>

--- a/study/src/org/labkey/study/view/specimen/manageSpecimens.jsp
+++ b/study/src/org/labkey/study/view/specimen/manageSpecimens.jsp
@@ -36,6 +36,7 @@
 <%@ page import="org.labkey.study.controllers.specimen.SpecimenController.ManageDisplaySettingsAction" %>
 <%@ page import="org.labkey.study.controllers.specimen.SpecimenController.ManageNotificationsAction" %>
 <%@ page import="org.labkey.study.controllers.specimen.SpecimenController.ManageRequestInputsAction" %>
+<%@ page import="org.labkey.study.controllers.specimen.SpecimenController.ManageSpecimenCommentsAction" %>
 <%@ page import="org.labkey.study.controllers.specimen.SpecimenController.ManageSpecimenWebPartAction" %>
 <%@ page import="org.labkey.study.controllers.specimen.SpecimenController.ManageStatusesAction" %>
 <%@ page import="org.labkey.study.controllers.specimen.SpecimenController.ShowManageRepositorySettingsAction" %>
@@ -48,6 +49,7 @@
     Container c = getContainer();
     StudyImpl study = StudyManager.getInstance().getStudy(c);
     User user = getUser();
+    String subjectNounSingle = study.getSubjectNounSingular().toLowerCase();
 
     if (c.hasPermission(user, AdminPermission.class))
     {
@@ -111,6 +113,11 @@
                         <td class="lk-study-prop-label">Display and Behavior</td>
                         <td class="lk-study-prop-desc">Manage warnings, comments, and workflow</td>
                         <td><%= link("Manage Display and Behavior", ManageDisplaySettingsAction.class) %></td>
+                    </tr>
+                    <tr>
+                        <td class="lk-study-prop-label">Comments</td>
+                        <td class="lk-study-prop-desc">Manage <%=h(subjectNounSingle)%> and <%=h(subjectNounSingle)%>/visit comments</td>
+                        <td><%= link("Manage Comments", ManageSpecimenCommentsAction.class) %></td>
                     </tr>
                     <tr>
                         <td class="lk-study-prop-label">Specimen Web Part</td>


### PR DESCRIPTION
#### Rationale
We fixed a number of issues with dataset security for 21.3; as we're implementing and testing these changes, we might as well address some usability concerns with the "Manage Dataset Security" page:

- [Issue 42670: When setting dataset group security would be helpful to warn about cohorts, aliases or other dependent datasets](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42670)
- [Issue 42667: Some UI/Usability Issues with Dataset Security Page](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42667)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2057

#### Changes to "Manage Data Security" page
* Highlight datasets that might warrant special attention, such as the cohort and alternate ID datasets
* Dirty handling - warn when navigating away with unsaved changes
* Cancel buttons and fix wonky button spacing