### PR TITLE
Issue 42680: can't update Sample Type domain using idCols

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -278,7 +278,7 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
     // NOTE: intentionally not public in ExpSampleType interface
     public void setNameExpression(String expression)
     {
-        if (hasIdColumns() && !hasNameAsIdCol())
+        if (expression != null && hasIdColumns() && !hasNameAsIdCol())
             throw new IllegalArgumentException("Can't set both a name expression and idCols");
 
         _object.setNameExpression(expression);


### PR DESCRIPTION
#### Rationale
Don't throw an exception when setting a null name expression when the Sample Type is using idCols.