### PR TITLE
Issue 42386: Make inventory status fields also reserved fields for sample types

### DIFF
--- a/api/src/org/labkey/api/audit/AbstractAuditHandler.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditHandler.java
@@ -170,7 +170,7 @@ public abstract class AbstractAuditHandler implements AuditHandler
 
     private void setOldAndNewMapsForUpdate(DetailedAuditTypeEvent event, Container c, Map<String, Object> row, Map<String, Object> existingRow, TableInfo table)
     {
-        Pair<Map<String, Object>, Map<String, Object>> rowPair = AuditHandler.getOldAndNewRecordForMerge(row, existingRow, table.getExtraDetailedUpdateAuditFields());
+        Pair<Map<String, Object>, Map<String, Object>> rowPair = AuditHandler.getOldAndNewRecordForMerge(row, existingRow, table.getExtraDetailedUpdateAuditFields(), table.getExcludedDetailedUpdateAuditFields());
 
         Map<String, Object> originalRow = rowPair.first;
         Map<String, Object> modifiedRow = rowPair.second;

--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -2,8 +2,6 @@ package org.labkey.api.audit;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.collections.CaseInsensitiveHashSet;
-import org.labkey.api.data.AuditConfigurable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.dataiterator.DataIterator;
@@ -16,16 +14,12 @@ import org.labkey.api.util.Pair;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-
-import static org.labkey.api.gwt.client.AuditBehaviorType.SUMMARY;
 
 
 public interface AuditHandler

--- a/api/src/org/labkey/api/inventory/InventoryService.java
+++ b/api/src/org/labkey/api/inventory/InventoryService.java
@@ -40,7 +40,7 @@ public interface InventoryService
 {
     String PRODUCT_ID = "freezerManager";
 
-    public static Set<String> INVENTORY_STATUS_COLUMN_NAMES = new CaseInsensitiveHashSet(
+    Set<String> INVENTORY_STATUS_COLUMN_NAMES = new CaseInsensitiveHashSet(
             "FreezeThawCount",
             "CheckedOutBy",
             "CheckedOut",
@@ -48,8 +48,12 @@ public interface InventoryService
             "StorageRow",
             "StorageCol",
             "StorageLocation",
+            "EnteredStorage",
+            "StorageStatus",
+            "StoredAmountDisplay",
             "StoredAmount",
-            "EnteredStorage"
+            "Units",
+            "StorageComment"
     );
 
     String EXPERIMENTAL_FM_BIOLOGICS = "experimental-freezermanager-biologics";

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
@@ -985,13 +985,11 @@ public void testDetailedAuditLog() throws Exception
     assertFalse(oldRecordMap.containsKey("lsid"));
     assertEquals("Updated", oldRecordMap.get("Measure"));
     assertEquals("2.0", oldRecordMap.get("Value"));
-    //map has (measure,value,genid), do we want genid???
-    assertEquals(3, oldRecordMap.size());
+    assertEquals(2, oldRecordMap.size());
     assertFalse(newRecordMap.containsKey("lsid"));
     assertEquals("Merged",newRecordMap.get("Measure"));
     assertEquals("3.0", newRecordMap.get("Value"));
-    //map has (measure,value,genid), do we want genid???
-    assertEquals(3, newRecordMap.size());
+    assertEquals(2, newRecordMap.size());
 
     st.delete(user);
 }

--- a/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
+++ b/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
@@ -49,6 +49,7 @@ import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTIndex;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
+import org.labkey.api.inventory.InventoryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
@@ -94,6 +95,7 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
         RESERVED_NAMES.add("AliquotedFromLSID");
         RESERVED_NAMES.add("RootMaterialLSID");
         RESERVED_NAMES.add("Container");
+        RESERVED_NAMES.addAll(InventoryService.INVENTORY_STATUS_COLUMN_NAMES);
 
         FOREIGN_KEYS = Collections.unmodifiableSet(Sets.newLinkedHashSet(Arrays.asList(
                 // NOTE: We join to exp.material using LSID instead of rowid for insert performance -- we will generate

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1683,7 +1683,7 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
             }
             else if (existingRecord != null && existingRecord.size() > 0)
             {
-                Pair<Map<String, Object>, Map<String, Object>> rowPair = AuditHandler.getOldAndNewRecordForMerge(record, existingRecord, Collections.emptySet(), tInfo.getExcludedDetailedUpdateAuditFields());
+                Pair<Map<String, Object>, Map<String, Object>> rowPair = AuditHandler.getOldAndNewRecordForMerge(record, existingRecord, Collections.emptySet(), tInfo == null? TableInfo.defaultExcludedDetailedUpdateAuditFields : tInfo.getExcludedDetailedUpdateAuditFields());
                 oldRecordString = DatasetAuditProvider.encodeForDataMap(c, rowPair.first);
 
                 // Check if no fields changed, if so adjust messaging

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1683,7 +1683,7 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
             }
             else if (existingRecord != null && existingRecord.size() > 0)
             {
-                Pair<Map<String, Object>, Map<String, Object>> rowPair = AuditHandler.getOldAndNewRecordForMerge(record, existingRecord, Collections.emptySet());
+                Pair<Map<String, Object>, Map<String, Object>> rowPair = AuditHandler.getOldAndNewRecordForMerge(record, existingRecord, Collections.emptySet(), tInfo.getExcludedDetailedUpdateAuditFields());
                 oldRecordString = DatasetAuditProvider.encodeForDataMap(c, rowPair.first);
 
                 // Check if no fields changed, if so adjust messaging


### PR DESCRIPTION
#### Rationale
When inferring fields from a file to define a sample type, we want to exclude the columns that get added for recording inventory status.  These inventory status fields should also be excluded from the detailed audit log for a sample update since changes in these fields are recorded by the detailed inventory audit log.  The refactor of detailed audit log handling lost the call to the method that would have excluded these.

#### Related Pull Requests
* #2064

#### Changes
* Call table's `getExcludedDetailedAuditFields` when setting the old and new maps for update
* Add more fields to the `INVENTORY_STATUS_COLUMN_NAMES` and add all of these to the `RESERVED_NAMES` for the SampleType domain.
