### PR TITLE
Make CopyAssayToStudyTest work when specimen module is present

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/CopyAssayToStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/CopyAssayToStudyTest.java
@@ -75,7 +75,7 @@ public class CopyAssayToStudyTest extends AbstractAssayTest
     {
         setupEnvironment();
         setupPipeline(getProjectName());
-        if (_studyHelper.isSpecimenModuleActive())
+        if (_studyHelper.isSpecimenModulePresent())
         {
             SpecimenImporter importer = new SpecimenImporter(TestFileUtils.getTestTempDir(),
                     StudyHelper.SPECIMEN_ARCHIVE_A,


### PR DESCRIPTION
#### Rationale
Specimen module doesn't need to be enabled to import specimens.

#### Related Pull Requests
* #2080 

#### Changes
* Import specimens if specimen module is present
