### PR TITLE
Hide "Restricted Reader" role. Allow guests group to participate in per-dataset security.

### DIFF
--- a/api/src/org/labkey/api/security/roles/RestrictedReaderRole.java
+++ b/api/src/org/labkey/api/security/roles/RestrictedReaderRole.java
@@ -18,26 +18,26 @@ package org.labkey.api.security.roles;
 import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.permissions.ReadSomePermission;
-import org.labkey.api.study.Dataset;
 import org.labkey.api.study.Study;
 
-/*
-* User: Dave
-* Date: Apr 30, 2009
-* Time: 6:09:41 PM
-*/
+/**
+ * Used exclusively in dataset security, as a marker in the study policy to indicate a group has per-dataset permissions.
+ * As a result, we don't directly surface this role anywhere in the product. See #42682.
+ *
+ * User: Dave
+ * Date: Apr 30, 2009
+ */
 public class RestrictedReaderRole extends AbstractRole
 {
     public RestrictedReaderRole()
     {
         super("Restricted Reader", "Restricted Readers may read some information, but not all.",
                 ReadSomePermission.class);
-        excludeGuests();
     }
 
     @Override
     public boolean isApplicable(SecurityPolicy policy, SecurableResource resource)
     {
-        return super.isApplicable(policy,resource) || resource instanceof Study;
+        return resource instanceof Study;
     }
 }


### PR DESCRIPTION
#### Rationale
The Manage Dataset Security page allows assigning EDIT ALL or READ ALL to Guests, but throws an exception if you attempt to assign Guests the PER DATASET option. [Issue 42681: The principal Guests may not be assigned the role Restricted Reader! error in study security](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=42681)

Restricted Reader role appears as an option on every folder permissions page, but doesn't do anything except cause confusion. [Issue 42682: Hide Restricted Reader](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=42682)
