### PR TITLE
Issue 42715: SQLException when deleting exp.data without a row in the table

### DIFF
--- a/api/src/org/labkey/api/data/ParameterMarkerInClauseGenerator.java
+++ b/api/src/org/labkey/api/data/ParameterMarkerInClauseGenerator.java
@@ -31,7 +31,15 @@ public class ParameterMarkerInClauseGenerator implements InClauseGenerator
     public SQLFragment appendInClauseSql(SQLFragment sql, @NotNull Collection<?> params)
     {
         sql.append(" IN (");
-        sql.append(StringUtils.repeat("?", ", ", params.size()));
+        if (params.isEmpty())
+        {
+            // Not a common scenario, but don't generate an empty in clause that's not legal SQL
+            sql.append("NULL");
+        }
+        else
+        {
+            sql.append(StringUtils.repeat("?", ", ", params.size()));
+        }
         sql.append(")");
 
         sql.addAll(params);

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4322,6 +4322,13 @@ public class ExperimentServiceImpl implements ExperimentService
             SimpleFilter rowIdFilter = new SimpleFilter().addInClause(FieldKey.fromParts("RowId"), selectedDataIds);
             List<Data> datas = new TableSelector(getTinfoData(), rowIdFilter, null).getArrayList(Data.class);
 
+            if (datas.isEmpty())
+            {
+                // Nothing to do - already deleted. Bail out. See issue 41715
+                transaction.commit();
+                return;
+            }
+
             List<String> allLsids = new ArrayList<>(datas.size());
             Map<Integer, List<String>> lsidsByClass = new LinkedHashMap<>();
 


### PR DESCRIPTION
#### Rationale
Recent changes to experiment object deletion appear to have introduce a chance for a race condition on exp.data deletion.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1741

#### Changes
* Double-check there's still something to delete before proceeding
* Avoid generating illegal SQL in clauses
