### PR TITLE
Prevent Container field by checking in DomainKind validation options.

### DIFF
--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -331,5 +331,10 @@ abstract public class DomainKind<T>  implements Handler<String>
 
         if (isUpdate && !canEditDefinition(user, domain))
             throw new UnauthorizedException("You don't have permission to edit this domain");
+
+        //Case insensitive match
+        if (updatedDomainDesign.getFieldByName("Container") != null)
+            throw new IllegalArgumentException("Property name 'Container' is a reserved name.");
+
     }
 }

--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -331,10 +331,5 @@ abstract public class DomainKind<T>  implements Handler<String>
 
         if (isUpdate && !canEditDefinition(user, domain))
             throw new UnauthorizedException("You don't have permission to edit this domain");
-
-        //Case insensitive match
-        if (updatedDomainDesign.getFieldByName("Container") != null)
-            throw new IllegalArgumentException("Property name 'Container' is a reserved name.");
-
     }
 }

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
@@ -88,8 +89,9 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
         )));
 
 
-        RESERVED_NAMES = BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet());
+        RESERVED_NAMES = new CaseInsensitiveHashSet(BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()));
         RESERVED_NAMES.addAll(Arrays.asList(ExpDataClassDataTable.Column.values()).stream().map(ExpDataClassDataTable.Column::name).collect(Collectors.toList()));
+        RESERVED_NAMES.add("Container");
 
         FOREIGN_KEYS = Collections.unmodifiableSet(Sets.newLinkedHashSet(Arrays.asList(
                 // NOTE: We join to exp.data using LSID instead of rowid for insert performance -- we will generate


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=42636

#### Changes
* Update the base DomainKind to prevent creation of a field named `Container`
