### PR TITLE
Issue 42712: Assay fields with OOR enabled are exported incorrectly

### DIFF
--- a/api/src/org/labkey/api/data/OutOfRangeDisplayColumn.java
+++ b/api/src/org/labkey/api/data/OutOfRangeDisplayColumn.java
@@ -22,8 +22,6 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 
-import java.io.IOException;
-import java.io.Writer;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.Map;
@@ -116,12 +114,6 @@ public class OutOfRangeDisplayColumn extends DataColumn
     public Object getDisplayValue(RenderContext ctx)
     {
         return getOORPrefix(ctx) + super.getDisplayValue(ctx);
-    }
-
-    @Override
-    public String getTsvFormattedValue(RenderContext ctx)
-    {
-        return getOORPrefix(ctx) + super.getTsvFormattedValue(ctx);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42712

#### Changes
* Remove OutOfRangeDisplayColumn.getTsvFormattedValue override since it ends up calling back though OutOfRangeDisplayColumn.getDisplayValue which handles the concatenation of the OOR indicator and numberic value
