### PR TITLE
Update @labkey/components after merge of release21.3-SNAPSHOT

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1224,9 +1224,9 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.34",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.34.tgz",
-      "integrity": "sha512-XcIn3iYbTEzGIxD0/dY5+4f019jIcEIWBiHc3KrmK/ROahwxmZ/s+tdj97p/5K0klz4zZUiMfUlYP0ajhSJjmA=="
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
     },
     "@fortawesome/fontawesome-free": {
       "version": "5.15.2",
@@ -1366,9 +1366,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.14.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.14.0.tgz",
-      "integrity": "sha1-N9VdYVYK+12T3I9RbbNaJXaGWas=",
+      "version": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.0-fb-merge-213-SNAPSHOT-v2.0.tgz",
+      "integrity": "sha1-33UKuqy3QCW/Sh1JlFLLiSueny4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1366,9 +1366,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.0-fb-merge-213-SNAPSHOT-v2.0.tgz",
-      "integrity": "sha1-33UKuqy3QCW/Sh1JlFLLiSueny4=",
+      "version": "2.15.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.2.tgz",
+      "integrity": "sha1-VHZlYc8Goao2YRaHjAxXQsQd1yU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "2.15.0-fb-merge-213-SNAPSHOT-v2.0"
+    "@labkey/components": "2.15.2"
   },
   "devDependencies": {
     "@labkey/build": "2.1.0"

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "2.14.0"
+    "@labkey/components": "2.15.0-fb-merge-213-SNAPSHOT-v2.0"
   },
   "devDependencies": {
     "@labkey/build": "2.1.0"

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1291,9 +1291,9 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.34",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.34.tgz",
-      "integrity": "sha512-XcIn3iYbTEzGIxD0/dY5+4f019jIcEIWBiHc3KrmK/ROahwxmZ/s+tdj97p/5K0klz4zZUiMfUlYP0ajhSJjmA=="
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
     },
     "@fortawesome/fontawesome-free": {
       "version": "5.15.2",
@@ -2029,9 +2029,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.14.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.14.1.tgz",
-      "integrity": "sha1-5ePvnKf8zOmG3e/X12/SA4ur07U=",
+      "version": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.0-fb-merge-213-SNAPSHOT-v2.0.tgz",
+      "integrity": "sha1-33UKuqy3QCW/Sh1JlFLLiSueny4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2029,9 +2029,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.0-fb-merge-213-SNAPSHOT-v2.0.tgz",
-      "integrity": "sha1-33UKuqy3QCW/Sh1JlFLLiSueny4=",
+      "version": "2.15.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.2.tgz",
+      "integrity": "sha1-VHZlYc8Goao2YRaHjAxXQsQd1yU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.1.8",
-    "@labkey/components": "2.14.1",
+    "@labkey/components": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.0.2"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.1.8",
-    "@labkey/components": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
+    "@labkey/components": "2.15.2",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.0.2"
   },

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1224,9 +1224,9 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.34",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.34.tgz",
-      "integrity": "sha512-XcIn3iYbTEzGIxD0/dY5+4f019jIcEIWBiHc3KrmK/ROahwxmZ/s+tdj97p/5K0klz4zZUiMfUlYP0ajhSJjmA=="
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
     },
     "@fortawesome/fontawesome-free": {
       "version": "5.15.2",
@@ -1366,9 +1366,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.14.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.14.0.tgz",
-      "integrity": "sha1-N9VdYVYK+12T3I9RbbNaJXaGWas=",
+      "version": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.0-fb-merge-213-SNAPSHOT-v2.0.tgz",
+      "integrity": "sha1-33UKuqy3QCW/Sh1JlFLLiSueny4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1366,9 +1366,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.0-fb-merge-213-SNAPSHOT-v2.0.tgz",
-      "integrity": "sha1-33UKuqy3QCW/Sh1JlFLLiSueny4=",
+      "version": "2.15.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.2.tgz",
+      "integrity": "sha1-VHZlYc8Goao2YRaHjAxXQsQd1yU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "2.15.0-fb-merge-213-SNAPSHOT-v2.0"
+    "@labkey/components": "2.15.2"
   },
   "devDependencies": {
     "@labkey/build": "2.1.0"

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "2.14.0"
+    "@labkey/components": "2.15.0-fb-merge-213-SNAPSHOT-v2.0"
   },
   "devDependencies": {
     "@labkey/build": "2.1.0"

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -1224,9 +1224,9 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.34",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.34.tgz",
-      "integrity": "sha512-XcIn3iYbTEzGIxD0/dY5+4f019jIcEIWBiHc3KrmK/ROahwxmZ/s+tdj97p/5K0klz4zZUiMfUlYP0ajhSJjmA=="
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
     },
     "@fortawesome/fontawesome-free": {
       "version": "5.15.2",
@@ -1366,9 +1366,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.14.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.14.0.tgz",
-      "integrity": "sha1-N9VdYVYK+12T3I9RbbNaJXaGWas=",
+      "version": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.0-fb-merge-213-SNAPSHOT-v2.0.tgz",
+      "integrity": "sha1-33UKuqy3QCW/Sh1JlFLLiSueny4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/issues/package-lock.json
+++ b/issues/package-lock.json
@@ -1366,9 +1366,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.0-fb-merge-213-SNAPSHOT-v2.0.tgz",
-      "integrity": "sha1-33UKuqy3QCW/Sh1JlFLLiSueny4=",
+      "version": "2.15.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.2.tgz",
+      "integrity": "sha1-VHZlYc8Goao2YRaHjAxXQsQd1yU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/issues/package.json
+++ b/issues/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/issues/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "2.15.0-fb-merge-213-SNAPSHOT-v2.0"
+    "@labkey/components": "2.15.2"
   },
   "devDependencies": {
     "@labkey/build": "2.1.0"

--- a/issues/package.json
+++ b/issues/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/issues/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "2.14.0"
+    "@labkey/components": "2.15.0-fb-merge-213-SNAPSHOT-v2.0"
   },
   "devDependencies": {
     "@labkey/build": "2.1.0"

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -1224,9 +1224,9 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.34",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.34.tgz",
-      "integrity": "sha512-XcIn3iYbTEzGIxD0/dY5+4f019jIcEIWBiHc3KrmK/ROahwxmZ/s+tdj97p/5K0klz4zZUiMfUlYP0ajhSJjmA=="
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
     },
     "@fortawesome/fontawesome-free": {
       "version": "5.15.2",
@@ -1366,9 +1366,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.14.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.14.0.tgz",
-      "integrity": "sha1-N9VdYVYK+12T3I9RbbNaJXaGWas=",
+      "version": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.0-fb-merge-213-SNAPSHOT-v2.0.tgz",
+      "integrity": "sha1-33UKuqy3QCW/Sh1JlFLLiSueny4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/list/package-lock.json
+++ b/list/package-lock.json
@@ -1366,9 +1366,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.0-fb-merge-213-SNAPSHOT-v2.0.tgz",
-      "integrity": "sha1-33UKuqy3QCW/Sh1JlFLLiSueny4=",
+      "version": "2.15.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.2.tgz",
+      "integrity": "sha1-VHZlYc8Goao2YRaHjAxXQsQd1yU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/list/package.json
+++ b/list/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/list/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "2.14.0"
+    "@labkey/components": "2.15.0-fb-merge-213-SNAPSHOT-v2.0"
   },
   "devDependencies": {
     "@labkey/build": "2.1.0"

--- a/list/package.json
+++ b/list/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/list/gen && rimraf resources/views/gen && rimraf resources/views/*.*"
   },
   "dependencies": {
-    "@labkey/components": "2.15.0-fb-merge-213-SNAPSHOT-v2.0"
+    "@labkey/components": "2.15.2"
   },
   "devDependencies": {
     "@labkey/build": "2.1.0"

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -1224,9 +1224,9 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.34",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.34.tgz",
-      "integrity": "sha512-XcIn3iYbTEzGIxD0/dY5+4f019jIcEIWBiHc3KrmK/ROahwxmZ/s+tdj97p/5K0klz4zZUiMfUlYP0ajhSJjmA=="
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
     },
     "@fortawesome/fontawesome-free": {
       "version": "5.15.2",
@@ -1366,9 +1366,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.14.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.14.0.tgz",
-      "integrity": "sha1-N9VdYVYK+12T3I9RbbNaJXaGWas=",
+      "version": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.0-fb-merge-213-SNAPSHOT-v2.0.tgz",
+      "integrity": "sha1-33UKuqy3QCW/Sh1JlFLLiSueny4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/query/package-lock.json
+++ b/query/package-lock.json
@@ -1366,9 +1366,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.0-fb-merge-213-SNAPSHOT-v2.0.tgz",
-      "integrity": "sha1-33UKuqy3QCW/Sh1JlFLLiSueny4=",
+      "version": "2.15.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.2.tgz",
+      "integrity": "sha1-VHZlYc8Goao2YRaHjAxXQsQd1yU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/query/package.json
+++ b/query/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/query/gen && rimraf resources/views/gen  && rimraf resources/views/queryMetadataEditor*"
   },
   "dependencies": {
-    "@labkey/components": "2.15.0-fb-merge-213-SNAPSHOT-v2.0"
+    "@labkey/components": "2.15.2"
   },
   "devDependencies": {
     "@labkey/build": "2.1.0"

--- a/query/package.json
+++ b/query/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/query/gen && rimraf resources/views/gen  && rimraf resources/views/queryMetadataEditor*"
   },
   "dependencies": {
-    "@labkey/components": "2.14.0"
+    "@labkey/components": "2.15.0-fb-merge-213-SNAPSHOT-v2.0"
   },
   "devDependencies": {
     "@labkey/build": "2.1.0"

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -1224,9 +1224,9 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.34",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.34.tgz",
-      "integrity": "sha512-XcIn3iYbTEzGIxD0/dY5+4f019jIcEIWBiHc3KrmK/ROahwxmZ/s+tdj97p/5K0klz4zZUiMfUlYP0ajhSJjmA=="
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
     },
     "@fortawesome/fontawesome-free": {
       "version": "5.15.2",
@@ -1366,9 +1366,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.14.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.14.0.tgz",
-      "integrity": "sha1-N9VdYVYK+12T3I9RbbNaJXaGWas=",
+      "version": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.0-fb-merge-213-SNAPSHOT-v2.0.tgz",
+      "integrity": "sha1-33UKuqy3QCW/Sh1JlFLLiSueny4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/study/package-lock.json
+++ b/study/package-lock.json
@@ -1366,9 +1366,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.15.0-fb-merge-213-SNAPSHOT-v2.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.0-fb-merge-213-SNAPSHOT-v2.0.tgz",
-      "integrity": "sha1-33UKuqy3QCW/Sh1JlFLLiSueny4=",
+      "version": "2.15.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.15.2.tgz",
+      "integrity": "sha1-VHZlYc8Goao2YRaHjAxXQsQd1yU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/study/package.json
+++ b/study/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/study/gen && rimraf resources/views/gen && rimraf resources/views/datasetDesigner*"
   },
   "dependencies": {
-    "@labkey/components": "2.14.0"
+    "@labkey/components": "2.15.0-fb-merge-213-SNAPSHOT-v2.0"
   },
   "devDependencies": {
     "@labkey/build": "2.1.0"

--- a/study/package.json
+++ b/study/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/study/gen && rimraf resources/views/gen && rimraf resources/views/datasetDesigner*"
   },
   "dependencies": {
-    "@labkey/components": "2.15.0-fb-merge-213-SNAPSHOT-v2.0"
+    "@labkey/components": "2.15.2"
   },
   "devDependencies": {
     "@labkey/build": "2.1.0"


### PR DESCRIPTION
#### Rationale
Pick up changes merged into the @labkey/components package from the release21.3-SNAPSHOT branch for the Ontology Concept Picker search and path information.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/479

#### Changes
* Update @labkey/components version
