### PR TITLE
Issue 42729: Date Field doesn't come through when using the Participant Resolver

### DIFF
--- a/api/src/org/labkey/api/study/assay/ThawListFileResolver.java
+++ b/api/src/org/labkey/api/study/assay/ThawListFileResolver.java
@@ -57,6 +57,6 @@ public class ThawListFileResolver implements ParticipantVisitResolver
         {
             throw new ThawListResolverException("Can not resolve thaw list entry for specimenId: " + specimenID);
         }
-        return _childResolver.resolve(values.getSpecimenID(), values.getParticipantID(), values.getVisitID(), date, resultDomainTargetStudy);
+        return _childResolver.resolve(values.getSpecimenID(), values.getParticipantID(), values.getVisitID(), values.getDate(), resultDomainTargetStudy);
     }
 }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42729

When doing a NAb run import and using the import participant resolver option for "Sample indices, which map to values in a different data source", you can paste in a tsv data blob that maps your sample indices to the Participant ID, Specimen ID, Visit ID, and Date. The issue was that the Date value from this TSV wasn't getting stored in the DB.

#### Changes
* Fix ThawListFileResolver.resolve to get the date value from the values object as it does for SpecimenID, ParticipantID, and VisitID
