### PR TITLE
Serialize Attachments in AnnouncementModel

### DIFF
--- a/announcements/src/org/labkey/announcements/model/AnnouncementModel.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementModel.java
@@ -183,7 +183,6 @@ public class AnnouncementModel extends Entity implements Serializable
         return UserManager.getDisplayNameOrUserId(getAssignedTo(), currentUser);
     }
 
-    @JsonIgnore // TODO: See about making Attachment serializable
     public @NotNull Collection<Attachment> getAttachments()
     {
         return AttachmentService.get().getAttachments(getAttachmentParent());

--- a/api/src/org/labkey/api/attachments/Attachment.java
+++ b/api/src/org/labkey/api/attachments/Attachment.java
@@ -16,6 +16,8 @@
 
 package org.labkey.api.attachments;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.services.ServiceRegistry;
@@ -43,6 +45,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * NOTE: Attachment is only used to list the attachments, it does not contain document data
  * and cannot be used directly to insert or update attachments.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Attachment implements Serializable
 {
     private String _parent; // entityid
@@ -275,6 +278,7 @@ public class Attachment implements Serializable
     }
 
 
+    @JsonIgnore
     public Date getLastIndexed()
     {
         return _lastIndexed;
@@ -326,6 +330,7 @@ public class Attachment implements Serializable
         _parent = parent;
     }
 
+    @JsonIgnore
     public File getFile()
     {
         return _file;


### PR DESCRIPTION
#### Rationale
This PR serializes attachments in the AnnouncementModel so users can add/remove/view attachments on ELN comments.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/835

#### Changes
* Serialize Attachments in AnnouncementModel
