### PR TITLE
Participant purge pipeline job

### DIFF
--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.study.query;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.BaseColumnInfo;
@@ -44,13 +46,12 @@ import org.labkey.api.study.security.StudySecurityEscalator;
 import org.labkey.study.model.DatasetDefinition;
 import org.labkey.study.model.StudyImpl;
 import org.labkey.study.model.StudyManager;
-import org.labkey.study.visitmanager.PurgeParticipantsTask;
+import org.labkey.study.visitmanager.PurgeParticipantsJob.ParticipantPurger;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -90,6 +91,8 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
         // see StudyImportContext.getTableIdMapMap()
         StudyImportMaps       // expected: Map<String,Map<Object,Object>>
     }
+
+    private static final Logger LOG = LogManager.getLogger(DatasetUpdateService.class);
 
     private final DatasetDefinition _dataset;
     private final Set<String> _potentiallyNewParticipants = new HashSet<>();
@@ -338,8 +341,8 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
 
     static class PurgeParticipantCommitTask implements Runnable
     {
-        public final Container _container;
-        public final Set<String> _potentiallyDeletedParticipants;
+        private final Container _container;
+        private final Set<String> _potentiallyDeletedParticipants;
 
         PurgeParticipantCommitTask(Container container, Set<String> potentiallyDeletedParticipants)
         {
@@ -350,10 +353,7 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
         @Override
         public void run()
         {
-            HashMap<String, Set<String>> potentiallyDeletedParticipantsMap = new HashMap<>();
-            potentiallyDeletedParticipantsMap.put(_container.getId(), _potentiallyDeletedParticipants);
-            PurgeParticipantsTask purgeParticipantsTask = new PurgeParticipantsTask(potentiallyDeletedParticipantsMap);
-            purgeParticipantsTask.run();
+            new ParticipantPurger(_container, _potentiallyDeletedParticipants, LOG::info, LOG::error).purgeParticipants();
         }
 
         @Override

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -338,21 +338,21 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
 
     static class PurgeParticipantCommitTask implements Runnable
     {
-        public Container _container;
-        public Set<String> _potentiallyDeletedParticipants = new HashSet<>();
+        public final Container _container;
+        public final Set<String> _potentiallyDeletedParticipants;
 
-        PurgeParticipantCommitTask(Container container, Set<String> potentiallyDeletedParticipants) {
+        PurgeParticipantCommitTask(Container container, Set<String> potentiallyDeletedParticipants)
+        {
             _container = container;
-            Set<String> copySet = new HashSet<>(potentiallyDeletedParticipants);
-            _potentiallyDeletedParticipants = copySet;
+            _potentiallyDeletedParticipants = new HashSet<>(potentiallyDeletedParticipants);
         }
 
         @Override
         public void run()
         {
-            HashMap<Container, Set<String>> potentiallyDeletedParticipantsMap = new HashMap<>();
-            potentiallyDeletedParticipantsMap.put(_container, _potentiallyDeletedParticipants);
-            PurgeParticipantsTask purgeParticipantsTask = new PurgeParticipantsTask(potentiallyDeletedParticipantsMap );
+            HashMap<String, Set<String>> potentiallyDeletedParticipantsMap = new HashMap<>();
+            potentiallyDeletedParticipantsMap.put(_container.getId(), _potentiallyDeletedParticipants);
+            PurgeParticipantsTask purgeParticipantsTask = new PurgeParticipantsTask(potentiallyDeletedParticipantsMap);
             purgeParticipantsTask.run();
         }
 

--- a/study/src/org/labkey/study/visitmanager/PurgeParticipantsJob.java
+++ b/study/src/org/labkey/study/visitmanager/PurgeParticipantsJob.java
@@ -129,7 +129,7 @@ public class PurgeParticipantsJob extends PipelineJob
                 }
                 catch (TableNotFoundException tnfe)
                 {
-                    // Just move on if container went away
+                    // Log and retry if container still exists
                     if (ContainerManager.exists(_container))
                     {
                         // A dataset or specimen table might have been deleted out from under us, so retry

--- a/study/src/org/labkey/study/visitmanager/PurgeParticipantsJob.java
+++ b/study/src/org/labkey/study/visitmanager/PurgeParticipantsJob.java
@@ -1,0 +1,152 @@
+package org.labkey.study.visitmanager;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.dialect.SqlDialect;
+import org.labkey.api.exceptions.TableNotFoundException;
+import org.labkey.api.pipeline.PipeRoot;
+import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.URLHelper;
+import org.labkey.api.view.ViewBackgroundInfo;
+import org.labkey.study.model.StudyImpl;
+import org.labkey.study.model.StudyManager;
+
+import java.io.File;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+public class PurgeParticipantsJob extends PipelineJob
+{
+    private final Map<String, Set<String>> _potentiallyDeletedParticipants;
+
+    @SuppressWarnings("unused")
+    @JsonCreator
+    public PurgeParticipantsJob(@JsonProperty("_potentiallyDeletedParticipants") Map<String, Set<String>> potentiallyDeletedParticipants)
+    {
+        _potentiallyDeletedParticipants = potentiallyDeletedParticipants;
+    }
+
+    PurgeParticipantsJob(ViewBackgroundInfo info, PipeRoot pipeRoot, Map<String, Set<String>> potentiallyDeletedParticipants)
+    {
+        super(null, info, pipeRoot);
+        _potentiallyDeletedParticipants = potentiallyDeletedParticipants;
+        setLogFile(new File(pipeRoot.getLogDirectory(), FileUtil.makeFileNameWithTimestamp("purge_participants", "log")));
+    }
+
+    @Override
+    public URLHelper getStatusHref()
+    {
+        return null;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Participant Purge";
+    }
+
+    @Override
+    public void run()
+    {
+        TaskStatus finalStatus = TaskStatus.complete;
+
+        try
+        {
+            while (true)
+            {
+                String containerId;
+                Set<String> potentiallyDeletedParticipants;
+
+                synchronized (_potentiallyDeletedParticipants)
+                {
+                    if (_potentiallyDeletedParticipants.isEmpty())
+                    {
+                        break; // Exit while() and set status
+                    }
+                    // Grab the first study to be purged, and exit the synchronized block quickly
+                    Iterator<Map.Entry<String, Set<String>>> i = _potentiallyDeletedParticipants.entrySet().iterator();
+                    Map.Entry<String, Set<String>> entry = i.next();
+                    i.remove();
+                    containerId = entry.getKey();
+                    potentiallyDeletedParticipants = entry.getValue();
+                }
+
+                Container container = ContainerManager.getForId(containerId);
+
+                if (null == container)
+                {
+                    info("Container not found: " + containerId);
+                    continue;
+                }
+
+                info("Starting to purge participants in " + container.getPath());
+
+                // Now, outside the synchronization, do the actual purge
+                // TODO: Seems like this code block should be moved into VisitManager and called by PurgeParticipantsMaintenanceTask as well (it has no exception handling and doesn't call updateParticipantVisitTable()
+                StudyImpl study = StudyManager.getInstance().getStudy(container);
+                if (study != null)
+                {
+                    boolean retry = false;
+                    try
+                    {
+                        int deleted = VisitManager.performParticipantPurge(study, potentiallyDeletedParticipants);
+                        if (deleted > 0)
+                        {
+                            StudyManager.getInstance().getVisitManager(study).updateParticipantVisitTable(null, null);
+                        }
+                        info("Finished purging participants in " + container.getPath());
+                    }
+                    catch (TableNotFoundException tnfe)
+                    {
+                        // Just move on if container went away
+                        if (ContainerManager.exists(container))
+                        {
+                            // A dataset or specimen table might have been deleted out from under us, so retry
+                            info(tnfe.getFullName() + " no longer exists. Requeuing another participant purge attempt.");
+                            retry = true;
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        if (ContainerManager.exists(container))
+                        {
+                            if (SqlDialect.isObjectNotFoundException(e))
+                            {
+                                info("Object not found exception (" + e.getMessage() + "). Requeuing another participant purge attempt.");
+                                retry = true;
+                            }
+                            else if (SqlDialect.isTransactionException(e))
+                            {
+                                info("Transaction or deadlock exception (" + e.getMessage() + "). Requeuing another participant purge attempt.");
+                                retry = true;
+                            }
+                            else
+                            {
+                                // Unexpected problem... log it and continue on
+                                error("Failed to purge participants for " + container.getPath(), e);
+                            }
+                        }
+                    }
+
+                    if (retry)
+                    {
+                        // throw them back on the queue
+                        VisitManager vm = StudyManager.getInstance().getVisitManager(study);
+                        vm.scheduleParticipantPurge(potentiallyDeletedParticipants);
+                    }
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            error("Failed to purge participants", e);
+            finalStatus = TaskStatus.error;
+        }
+
+        setStatus(finalStatus);
+    }
+}

--- a/study/src/org/labkey/study/visitmanager/PurgeParticipantsTask.java
+++ b/study/src/org/labkey/study/visitmanager/PurgeParticipantsTask.java
@@ -19,13 +19,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.dialect.SqlDialect;
-import org.labkey.api.exceptions.TableNotFoundException;
-import org.labkey.api.util.ExceptionUtil;
-import org.labkey.study.model.StudyImpl;
-import org.labkey.study.model.StudyManager;
+import org.labkey.api.pipeline.PipeRoot;
+import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.pipeline.PipelineService;
+import org.labkey.api.pipeline.PipelineValidationException;
+import org.labkey.api.util.ConfigurationException;
+import org.labkey.api.view.ViewBackgroundInfo;
 
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimerTask;
@@ -36,10 +36,11 @@ import java.util.TimerTask;
  */
 public class PurgeParticipantsTask extends TimerTask
 {
-    private final Map<Container, Set<String>> _potentiallyDeletedParticipants;
-    private static final Logger _logger = LogManager.getLogger(PurgeParticipantsTask.class);
+    private static final Logger LOG = LogManager.getLogger(PurgeParticipantsTask.class);
 
-    public PurgeParticipantsTask(Map<Container, Set<String>> potentiallyDeletedParticipants)
+    private final Map<String, Set<String>> _potentiallyDeletedParticipants;
+
+    public PurgeParticipantsTask(Map<String, Set<String>> potentiallyDeletedParticipants)
     {
         _potentiallyDeletedParticipants = potentiallyDeletedParticipants;
     }
@@ -47,88 +48,29 @@ public class PurgeParticipantsTask extends TimerTask
     @Override
     public void run()
     {
+        // Don't bother queueing a job if map is empty
+        if (_potentiallyDeletedParticipants.isEmpty())
+            return;
+
+        Container c = ContainerManager.getRoot();
+        ViewBackgroundInfo vbi = new ViewBackgroundInfo(c, null, null);
+        PipeRoot root = PipelineService.get().findPipelineRoot(c);
+
+        if (null == root)
+            throw new ConfigurationException("Invalid pipeline configuration at the root container");
+
+        if (!root.isValid())
+            throw new ConfigurationException("Invalid pipeline configuration at the root container: " + root.getRootPath().getPath());
+
         try
         {
-            while (true)
-            {
-                Container container;
-                Set<String> potentiallyDeletedParticipants;
-
-                synchronized (_potentiallyDeletedParticipants)
-                {
-                    if (_potentiallyDeletedParticipants.isEmpty())
-                    {
-                        return;
-                    }
-                    // Grab the first study to be purged, and exit the synchronized block quickly
-                    Iterator<Map.Entry<Container, Set<String>>> i = _potentiallyDeletedParticipants.entrySet().iterator();
-                    Map.Entry<Container, Set<String>> entry = i.next();
-                    i.remove();
-                    container = entry.getKey();
-                    potentiallyDeletedParticipants = entry.getValue();
-                }
-
-                _logger.info("Attempting to purge participants in " + container.getPath());
-
-                // Now, outside the synchronization, do the actual purge
-                // TODO: Seems like this code block should be moved into VisitManager and called by PurgeParticipantsMaintenanceTask as well (it has no exception handling and doesn't call updateParticipantVisitTable()
-                StudyImpl study = StudyManager.getInstance().getStudy(container);
-                if (study != null)
-                {
-                    boolean retry = false;
-                    try
-                    {
-                        int deleted = VisitManager.performParticipantPurge(study, potentiallyDeletedParticipants);
-                        if (deleted > 0)
-                        {
-                            StudyManager.getInstance().getVisitManager(study).updateParticipantVisitTable(null, null);
-                        }
-                    }
-                    catch (TableNotFoundException tnfe)
-                    {
-                        // Just move on if container went away
-                        if (ContainerManager.exists(container))
-                        {
-                            // A dataset or specimen table might have been deleted out from under us, so retry
-                            _logger.info(tnfe.getFullName() + " no longer exists. Requeuing another participant purge attempt.");
-                            retry = true;
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        if (ContainerManager.exists(container))
-                        {
-                            if (SqlDialect.isObjectNotFoundException(e))
-                            {
-                                _logger.info("Object not found exception (" + e.getMessage() + "). Requeuing another participant purge attempt.");
-                                retry = true;
-                            }
-                            else if (SqlDialect.isTransactionException(e))
-                            {
-                                _logger.info("Transaction or deadlock exception (" + e.getMessage() + "). Requeuing another participant purge attempt.");
-                                retry = true;
-                            }
-                            else
-                            {
-                                // Unexpected problem... log it and continue on
-                                _logger.error("Failed to purge participants for " + container.getPath(), e);
-                            }
-                        }
-                    }
-
-                    if (retry)
-                    {
-                        // throw them back on the queue
-                        VisitManager vm = StudyManager.getInstance().getVisitManager(study);
-                        vm.scheduleParticipantPurge(potentiallyDeletedParticipants);
-                    }
-                }
-            }
+            PipelineJob job = new PurgeParticipantsJob(vbi, root, _potentiallyDeletedParticipants);
+            LOG.info("Queuing PurgeParticipantsJob [thread " + Thread.currentThread().getName() + " to " + PipelineService.get().toString() + "]");
+            PipelineService.get().queueJob(job);
         }
-        catch (Exception e)
+        catch (PipelineValidationException e)
         {
-            _logger.error("Failed to purge participants", e);
-            ExceptionUtil.logExceptionToMothership(null, e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/study/src/org/labkey/study/visitmanager/VisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/VisitManager.java
@@ -584,7 +584,7 @@ public abstract class VisitManager
                 // This is the only request for this study in the queue, so copy the set of participants
                 mergedPTIDs = new HashSet<>(potentiallyDeletedParticipants);
             }
-            POTENTIALLY_DELETED_PARTICIPANTS.put(container, mergedPTIDs);
+            POTENTIALLY_DELETED_PARTICIPANTS.put(container.getId(), mergedPTIDs);
 
             if (TIMER == null)
             {
@@ -600,7 +600,7 @@ public abstract class VisitManager
     }
 
     /** Study container -> set of participants that may no longer be referenced. Set is null if we don't know specific PTIDs. */
-    private static final Map<Container, Set<String>> POTENTIALLY_DELETED_PARTICIPANTS = new HashMap<>();
+    private static final Map<String, Set<String>> POTENTIALLY_DELETED_PARTICIPANTS = new HashMap<>();
     private static Timer TIMER;
     /** Number of milliseconds to wait between batches of participant purges */
     private static final long PURGE_PARTICIPANT_INTERVAL = DateUtils.MILLIS_PER_MINUTE * 5;

--- a/study/src/org/labkey/study/visitmanager/VisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/VisitManager.java
@@ -281,7 +281,7 @@ public abstract class VisitManager
     {
         synchronized (POTENTIALLY_DELETED_PARTICIPANTS)
         {
-            POTENTIALLY_DELETED_PARTICIPANTS.remove(c);
+            POTENTIALLY_DELETED_PARTICIPANTS.remove(c.getId());
         }
     }
 
@@ -563,10 +563,10 @@ public abstract class VisitManager
                 // that are queued
                 mergedPTIDs = null;
             }
-            else if (POTENTIALLY_DELETED_PARTICIPANTS.containsKey(container))
+            else if (POTENTIALLY_DELETED_PARTICIPANTS.containsKey(container.getId()))
             {
                 // We already have a set of participants queued to be potentially purged
-                Set<String> existingPTIDs = POTENTIALLY_DELETED_PARTICIPANTS.get(container);
+                Set<String> existingPTIDs = POTENTIALLY_DELETED_PARTICIPANTS.get(container.getId());
                 if (existingPTIDs == null)
                 {
                     // The existing request is for all participants, so respect that
@@ -590,7 +590,7 @@ public abstract class VisitManager
             {
                 // This is the first request, so start the timer
                 TIMER = new Timer("Participant purge", true);
-                TimerTask task = new PurgeParticipantsTask(POTENTIALLY_DELETED_PARTICIPANTS);
+                TimerTask task = new PurgeParticipantsTask();
                 TIMER.scheduleAtFixedRate(task, PURGE_PARTICIPANT_INTERVAL, PURGE_PARTICIPANT_INTERVAL);
                 ShutdownListener listener = new ParticipantPurgeContextListener();
                 // Add a shutdown listener to stop the worker thread if the webapp is shut down
@@ -600,7 +600,7 @@ public abstract class VisitManager
     }
 
     /** Study container -> set of participants that may no longer be referenced. Set is null if we don't know specific PTIDs. */
-    private static final Map<String, Set<String>> POTENTIALLY_DELETED_PARTICIPANTS = new HashMap<>();
+    static final Map<String, Set<String>> POTENTIALLY_DELETED_PARTICIPANTS = new HashMap<>();
     private static Timer TIMER;
     /** Number of milliseconds to wait between batches of participant purges */
     private static final long PURGE_PARTICIPANT_INTERVAL = DateUtils.MILLIS_PER_MINUTE * 5;


### PR DESCRIPTION
#### Rationale
TeamCity is seeing frequent failures like `ERROR: relation "c132d1770_sia_minus_1" already exists` caused by the Participant Purge timer thread running in parallel with study import. A simple workaround for now is to run the Participant Purge handling as a pipeline job, ensuring that it will never run in parallel with another pipeline job. [Issue 42641: Intermittent table name collision when importing study archive](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42641)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2097

#### Changes
* Key the POTENTIALLY_DELETED_PARTICIPANTS map on String (containerId) instead of Container. Safer and happier serialization.
* If the map is not empty, the timer thread now queues a participant purge pipeline job instead of directly invoking this code