### PR TITLE
Use QueryForeignKey so that full metadata gets applied to ServerInstallation lookup

### DIFF
--- a/mothership/resources/queries/mothership/recentJsonMetricValues.query.xml
+++ b/mothership/resources/queries/mothership/recentJsonMetricValues.query.xml
@@ -10,6 +10,13 @@
                     <fkTable>ServerSessions</fkTable>
                 </fk>
             </column>
+            <column columnName="DisplayKey">
+                <fk>
+                    <fkDbSchema>mothership</fkDbSchema>
+                    <fkTable>recentJsonMetrics</fkTable>
+                    <fkDisplayColumnName useRawValue="true" />
+                </fk>
+            </column>
         </columns>
     </table>
 </tables>

--- a/mothership/resources/queries/mothership/recentJsonMetrics.query.xml
+++ b/mothership/resources/queries/mothership/recentJsonMetrics.query.xml
@@ -4,6 +4,13 @@
             <column columnName="JsonKey">
                 <isKeyField>true</isKeyField>
             </column>
+            <column columnName="Info" wrappedColumnName="JsonKey">
+                <isUnselectable>true</isUnselectable>
+                <fk>
+                    <fkDbSchema>lists</fkDbSchema>
+                    <fkTable>JsonMetricMetadata</fkTable>
+                </fk>
+            </column>
         </columns>
     </table>
 </tables>

--- a/mothership/resources/queries/mothership/recentJsonMetrics.query.xml
+++ b/mothership/resources/queries/mothership/recentJsonMetrics.query.xml
@@ -1,0 +1,9 @@
+<tables xmlns="http://labkey.org/data/xml">
+    <table tableName="recentJsonMetricValues" tableDbType="NOT_IN_DB">
+        <columns>
+            <column columnName="JsonKey">
+                <isKeyField>true</isKeyField>
+            </column>
+        </columns>
+    </table>
+</tables>

--- a/mothership/src/org/labkey/mothership/query/MothershipSchema.java
+++ b/mothership/src/org/labkey/mothership/query/MothershipSchema.java
@@ -240,6 +240,8 @@ public class MothershipSchema extends UserSchema
 
         result.getMutableColumn("Container").setFk(new ContainerForeignKey(this));
 
+        result.setTitleColumn("ServerHostName");
+
         SQLFragment firstPingSQL = new SQLFragment("(SELECT MIN(EarliestKnownTime) FROM ");
         firstPingSQL.append(MothershipManager.get().getTableInfoServerSession(), "ss");
         firstPingSQL.append(" WHERE ss.ServerInstallationId = ");


### PR DESCRIPTION
#### Rationale
On labkey.org I've configured metadata with custom calculated columns on mothership.ServerInstallation but it's not getting applied to the lookup from ServerSession because it's using LookupForeignKey

#### Changes
* Use QueryForeignKey, the preferred lookup type
* Misc code cleanup