### PR TITLE
Issue 42452: Incessant per-request logging spam from WsRemoteEndpointImplServer.doClose()

### DIFF
--- a/core/src/org/labkey/core/notification/NotificationEndpoint.java
+++ b/core/src/org/labkey/core/notification/NotificationEndpoint.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
 
 /**
  * WebSocket endpoint for simple browser notification/alerting
@@ -54,6 +55,14 @@ public class NotificationEndpoint extends Endpoint
     private Session session;
     private int userId;
     private boolean errored;
+
+    static
+    {
+        // Issue 42452: Suppress overly verbose logging from Tomcat about WebSocket connections not closing in the ideal pattern
+        // https://bz.apache.org/bugzilla/show_bug.cgi?id=59062
+        java.util.logging.Logger logger = java.util.logging.Logger.getLogger("org.apache.tomcat.websocket.server.WsRemoteEndpointImplServer");
+        logger.setLevel(Level.WARNING);
+    }
 
     public NotificationEndpoint()
     {

--- a/core/src/org/labkey/core/notification/NotificationEndpoint.java
+++ b/core/src/org/labkey/core/notification/NotificationEndpoint.java
@@ -56,16 +56,12 @@ public class NotificationEndpoint extends Endpoint
     private int userId;
     private boolean errored;
 
-    static
+    public NotificationEndpoint()
     {
         // Issue 42452: Suppress overly verbose logging from Tomcat about WebSocket connections not closing in the ideal pattern
         // https://bz.apache.org/bugzilla/show_bug.cgi?id=59062
         java.util.logging.Logger logger = java.util.logging.Logger.getLogger("org.apache.tomcat.websocket.server.WsRemoteEndpointImplServer");
         logger.setLevel(Level.WARNING);
-    }
-
-    public NotificationEndpoint()
-    {
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Some dev machines (like mine) see lots of logging from Tomcat complaining that WebSockets aren't being closed appropriately. This is from a combination of java.util.logging and Tomcat's JULI configuration that is getting reset by some third-party library during initialization. I've failed to isolate the exact cause, but it seems like moving the logging level reset to later in the codepath has the intended result.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/62

#### Changes
* Set the log level when we're starting to wire up WebSocket code
