### PR TITLE
Delete password button & action

### DIFF
--- a/api/src/org/apache/commons/validator/routines/CustomTLDEnabler.java
+++ b/api/src/org/apache/commons/validator/routines/CustomTLDEnabler.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 /**
  * Adds non-standard TLDs to allowable values for Apache Commons Validator. See issue 25041.
  * Needed because {@see DomainValidator.updateTLDOverride} is public, but its ArrayType argument is package-protected.
+ * TODO: Looks like this issue was fixed in Validator 1.5.1. See https://issues.apache.org/jira/browse/VALIDATOR-386
  * Created by: jeckels
  * Date: 1/16/16
  */

--- a/api/src/org/labkey/api/module/CodeOnlyModule.java
+++ b/api/src/org/labkey/api/module/CodeOnlyModule.java
@@ -27,7 +27,7 @@ import java.util.Set;
 /**
  * Bit of a misnomer, but I couldn't think of a better name. These modules provide code and resources, but don't manage
  * any schemas, don't run SQL scripts, and don't need to do anything at upgrade time. This simplifies the implementation
- * of such modules and eases module bumps at release time.
+ * of such modules.
  *
  * Perhaps this should implement Module instead of extending DefaultModule.
  *

--- a/api/src/org/labkey/api/module/JavaVersion.java
+++ b/api/src/org/labkey/api/module/JavaVersion.java
@@ -113,6 +113,17 @@ public enum JavaVersion
         @Test
         public void test()
         {
+            // Bad
+            test(5, JAVA_UNSUPPORTED);
+            test(6, JAVA_UNSUPPORTED);
+            test(7, JAVA_UNSUPPORTED);
+            test(8, JAVA_UNSUPPORTED);
+            test(9, JAVA_UNSUPPORTED);
+            test(10, JAVA_UNSUPPORTED);
+            test(11, JAVA_UNSUPPORTED);
+            test(12, JAVA_UNSUPPORTED);
+            test(13, JAVA_UNSUPPORTED);
+
             // Good
             test(14, JAVA_14);
             test(15, JAVA_15);
@@ -122,17 +133,6 @@ public enum JavaVersion
             // Future
             test(18, JAVA_FUTURE);
             test(19, JAVA_FUTURE);
-
-            // Bad
-            test(13, JAVA_UNSUPPORTED);
-            test(12, JAVA_UNSUPPORTED);
-            test(11, JAVA_UNSUPPORTED);
-            test(10, JAVA_UNSUPPORTED);
-            test(9, JAVA_UNSUPPORTED);
-            test(8, JAVA_UNSUPPORTED);
-            test(7, JAVA_UNSUPPORTED);
-            test(6, JAVA_UNSUPPORTED);
-            test(5, JAVA_UNSUPPORTED);
         }
 
         private void test(int version, JavaVersion expectedVersion)

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -201,9 +201,9 @@ public class AuthenticationManager
     public enum Priority { High, Low }
 
     // TODO: Replace this with a generic domain-claiming mechanism
-    public static String _ldapDomain = null;
+    private static String _ldapDomain = null;
 
-    public static String getLdapDomain()
+    public static @Nullable String getLdapDomain()
     {
         return _ldapDomain;
     }

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -3361,6 +3361,13 @@ public class SecurityManager
         }
     }
 
+    // We let admins delete passwords (i.e., entries in the logins table), see #42691
+    public static void adminDeletePassword(ValidEmail email, User user)
+    {
+        new SqlExecutor(CoreSchema.getInstance().getScope()).execute("DELETE FROM " + CoreSchema.getInstance().getTableInfoLogins() + " WHERE Email = ?", email.getEmailAddress());
+        UserManager.addToUserHistory(UserManager.getUser(email), user.getEmail() + " deleted the password.");
+    }
+
     public static void populateUserGroupsWithStartupProps()
     {
         // assign users to groups using values read from startup configuration as appropriate for prop modifier and isBootstrap flag

--- a/api/src/org/labkey/api/security/roles/RoleManager.java
+++ b/api/src/org/labkey/api/security/roles/RoleManager.java
@@ -113,7 +113,7 @@ public class RoleManager
         registerRole(new SubmitterRole());
         registerRole(new NoPermissionsRole());
         registerRole(new OwnerRole());
-        registerRole(new TroubleshooterRole());
+        registerRole(new TroubleshooterRole(), false);
         registerRole(new SeeUserAndGroupDetailsRole());
         registerRole(new CanSeeAuditLogRole());
         registerRole(new SharedViewEditorRole());

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -60,6 +60,7 @@ import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.*;
+import org.labkey.api.security.ValidEmail.InvalidEmailException;
 import org.labkey.api.security.permissions.AbstractActionPermissionTest;
 import org.labkey.api.security.permissions.AddUserPermission;
 import org.labkey.api.security.permissions.AdminOperationsPermission;
@@ -348,7 +349,7 @@ public class SecurityController extends SpringActionController
     }
 
     @RequiresNoPermission
-    public class BeginAction extends SimpleRedirectAction
+    public class BeginAction extends SimpleRedirectAction<Object>
     {
         @Override
         public URLHelper getRedirectURL(Object o)
@@ -362,7 +363,7 @@ public class SecurityController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetMaxPhiLevelAction extends ReadOnlyApiAction
+    public class GetMaxPhiLevelAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public Object execute(Object o, BindException errors) throws Exception
@@ -402,7 +403,7 @@ public class SecurityController extends SpringActionController
     }
 
 
-    public class FolderPermissionsView extends JspView<FolderPermissionsView>
+    public static class FolderPermissionsView extends JspView<FolderPermissionsView>
     {
         public final String resource;
         public final ActionURL doneURL;
@@ -524,7 +525,6 @@ public class SecurityController extends SpringActionController
         {
             return new ActionURL(PermissionsAction.class, getContainer());
         }
-
     }
 
     public static class PermissionsForm extends ReturnUrlForm
@@ -593,14 +593,10 @@ public class SecurityController extends SpringActionController
             return confirmed;
         }
 
+        @SuppressWarnings("unused")
         public void setConfirmed(boolean confirmed)
         {
             this.confirmed = confirmed;
-        }
-
-        public void setNames(String names)
-        {
-            this.names = names;
         }
 
         public String getNames()
@@ -608,11 +604,18 @@ public class SecurityController extends SpringActionController
             return this.names;
         }
 
+        @SuppressWarnings("unused")
+        public void setNames(String names)
+        {
+            this.names = names;
+        }
+
         public String[] getDelete()
         {
             return delete;
         }
 
+        @SuppressWarnings("unused")
         public void setDelete(String[] delete)
         {
             this.delete = delete;
@@ -623,6 +626,7 @@ public class SecurityController extends SpringActionController
             return sendEmail;
         }
 
+        @SuppressWarnings("unused")
         public void setSendEmail(boolean sendEmail)
         {
             this.sendEmail = sendEmail;
@@ -633,6 +637,7 @@ public class SecurityController extends SpringActionController
             return mailPrefix;
         }
 
+        @SuppressWarnings("unused")
         public void setMailPrefix(String messagePrefix)
         {
             this.mailPrefix = messagePrefix;
@@ -1240,9 +1245,11 @@ public class SecurityController extends SpringActionController
         private String newUsers;
         private String _cloneUser;
         private boolean _skipProfile;
-        private HtmlStringBuilder _message = HtmlStringBuilder.of("");
         private String _provider = null;
 
+        private final HtmlStringBuilder _message = HtmlStringBuilder.of("");
+
+        @SuppressWarnings("unused")
         public void setProvider(String provider)
         {
             _provider = provider;
@@ -1253,6 +1260,7 @@ public class SecurityController extends SpringActionController
             return _provider;
         }
 
+        @SuppressWarnings("unused")
         public void setNewUsers(String newUsers)
         {
             this.newUsers = newUsers;
@@ -1263,6 +1271,7 @@ public class SecurityController extends SpringActionController
             return this.newUsers;
         }
 
+        @SuppressWarnings("unused")
         public void setSendMail(boolean sendMail)
         {
             this.sendMail = sendMail;
@@ -1273,17 +1282,20 @@ public class SecurityController extends SpringActionController
             return this.sendMail;
         }
 
+        @SuppressWarnings("unused")
         public void setCloneUser(String cloneUser){_cloneUser = cloneUser;}
+
         public String getCloneUser(){return _cloneUser;}
+
+        @SuppressWarnings("unused")
+        public void setSkipProfile(boolean skipProfile)
+        {
+            _skipProfile = skipProfile;
+        }
 
         public boolean isSkipProfile()
         {
             return _skipProfile;
-        }
-
-        public void setSkipProfile(boolean skipProfile)
-        {
-            _skipProfile = skipProfile;
         }
 
         public void addMessage(String message)
@@ -1345,7 +1357,7 @@ public class SecurityController extends SpringActionController
                     if (userToClone == null)
                         errors.addError(new FormattedError("Failed to clone user permissions " + PageFlowUtil.filter(emailToClone) + ": User email does not exist in the system"));
                 }
-                catch (ValidEmail.InvalidEmailException e)
+                catch (InvalidEmailException e)
                 {
                     errors.addError(new FormattedError("Failed to clone user permissions " + PageFlowUtil.filter(cloneUser.trim()) + ": Invalid email address"));
                 }
@@ -1523,7 +1535,7 @@ public class SecurityController extends SpringActionController
                     SecurityManager.renderEmail(getContainer(), getUser(), message, email.getEmailAddress(), verificationURL, out);
                 }
             }
-            catch (ValidEmail.InvalidEmailException e)
+            catch (InvalidEmailException e)
             {
                 out.write("Invalid email address: " + PageFlowUtil.filter(rawEmail));
             }
@@ -1559,12 +1571,12 @@ public class SecurityController extends SpringActionController
                         throw new UnauthorizedException();
                     }
                 }
-                catch (ValidEmail.InvalidEmailException e)
+                catch (InvalidEmailException e)
                 {
                     throw new NotFoundException("Invalid email address: " + form.getEmail());
                 }
             }
-                return SecurityManager.getRegistrationMessage(form.getMailPrefix(), false);
+            return SecurityManager.getRegistrationMessage(form.getMailPrefix(), false);
         }
     }
 
@@ -1581,35 +1593,84 @@ public class SecurityController extends SpringActionController
 
 
     /**
-     * Invalidate existing password and send new password link
+     * Base class for admin password actions
      */
-    @RequiresPermission(UpdateUserPermission.class)
-    public class AdminResetPasswordAction extends ConfirmAction<EmailForm>
+    private abstract static class AdminPasswordAction extends ConfirmAction<EmailForm>
     {
+        abstract String getTitle();
+        abstract String getVerb();
+        abstract HtmlString getConfirmationMessage(boolean loginExists, String emailAddress);
+
         @Override
         public ModelAndView getConfirmView(EmailForm emailForm, BindException errors)
         {
-            setTitle("Confirm Password Reset");
+            setTitle(getTitle());
 
-            String message;
             boolean loginExists = false;
 
             try
             {
                 loginExists = SecurityManager.loginExists(new ValidEmail(emailForm.getEmail()));
             }
-            catch (ValidEmail.InvalidEmailException e)
+            catch (InvalidEmailException e)
             {
                 // Allow display and edit of users with invalid email addresses so they can be fixed, #12276.
             }
 
+            return new HtmlView(getConfirmationMessage(loginExists, emailForm.getEmail()));
+        }
 
-            if (loginExists)
-                message = "You are about to clear the user's current password, send the user a reset password email, and force the user to pick a new password to access the site.";
-            else
-                message = "You are about to send the user a reset password email, letting the user pick a password to access the site.";
+        @Override
+        public void validateCommand(EmailForm form, Errors errors)
+        {
+            String rawEmail = form.getEmail();
 
-            return new HtmlView(message);
+            try
+            {
+                ValidEmail email = new ValidEmail(rawEmail);
+
+                // don't let non-site admin delete/reset password of site admin
+                User formUser = UserManager.getUser(email);
+                if (formUser != null && !getUser().hasSiteAdminPermission() && formUser.hasSiteAdminPermission())
+                    errors.reject("Permission denied: not authorized to " + getVerb() + " password for a Site Admin user.");
+            }
+            catch (InvalidEmailException e)
+            {
+                errors.reject(" failed: invalid email address.");
+            }
+        }
+
+        @Override
+        public @NotNull URLHelper getSuccessURL(EmailForm emailForm)
+        {
+            return emailForm.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL());
+        }
+    }
+
+    /**
+     * Invalidate existing password and send new password link
+     */
+    @RequiresPermission(UpdateUserPermission.class)
+    public class AdminResetPasswordAction extends AdminPasswordAction
+    {
+        @Override
+        String getTitle()
+        {
+            return "Confirm Password Reset";
+        }
+
+        @Override
+        String getVerb()
+        {
+            return "reset";
+        }
+
+        @Override
+        HtmlString getConfirmationMessage(boolean loginExists, String emailAddress)
+        {
+            return HtmlString.of(loginExists ?
+                "You are about to clear the user's current password, send the user a reset password email, and force the user to pick a new password to access the site." :
+                "You are about to send the user a reset password email, letting the user pick a password to access the site.");
         }
 
         private boolean _loginExists;
@@ -1623,7 +1684,7 @@ public class SecurityController extends SpringActionController
                 _loginExists = SecurityManager.loginExists(email);
                 SecurityManager.adminRotatePassword(email, errors, getContainer(), getUser(), getMailHelpText(form.getEmail()));
             }
-            catch (ValidEmail.InvalidEmailException e)
+            catch (InvalidEmailException e)
             {
                 //Should be caught in validation
                 errors.addError(new LabKeyError(new Exception("Invalid email address." + e.getMessage(), e)));
@@ -1633,47 +1694,22 @@ public class SecurityController extends SpringActionController
         }
 
         @Override
-        public void validateCommand(EmailForm form, Errors errors)
-        {
-            String rawEmail = form.getEmail();
-
-            try
-            {
-                ValidEmail email = new ValidEmail(rawEmail);
-
-                // don't let non-site admin reset password of site admin
-                User formUser = UserManager.getUser(email);
-                if (formUser != null && !getUser().hasSiteAdminPermission() && formUser.hasSiteAdminPermission())
-                    errors.reject("Permission denied: not authorized to reset password for a Site Admin user.");
-
-            }
-            catch (ValidEmail.InvalidEmailException e)
-            {
-                errors.reject(" failed: invalid email address.");
-            }
-        }
-
-        @Override
         public ModelAndView getSuccessView(EmailForm form)
         {
             ActionURL actionURL = new ActionURL(ShowResetEmailAction.class, getContainer()).addParameter("email", form.getEmail());
 
-            String page = String.format("<p>%1$s: Password %2$s.</p><p>Email sent. Click <a href=\"%3$s\" target=\"_blank\">here</a> to see the email.</p>%4$s",
-                    PageFlowUtil.filter(form.getEmail()),
-                    _loginExists ? "reset" : "created",
-                    actionURL.getLocalURIString(),
-                    PageFlowUtil.button("Done").href(form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL()))
+            String page = String.format(
+                "<p>%1$s: Password %2$s.</p><p>Email sent. Click <a href=\"%3$s\" target=\"_blank\">here</a> to see the email.</p>%4$s",
+                PageFlowUtil.filter(form.getEmail()),
+                _loginExists ? "reset" : "created",
+                actionURL.getLocalURIString(),
+                PageFlowUtil.button("Done").href(form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL()))
             );
 
             getPageConfig().setTemplate(PageConfig.Template.Dialog);
             setTitle("Password Reset Success");
-            return new HtmlView(page);
-        }
 
-        @Override
-        public @NotNull URLHelper getSuccessURL(EmailForm emailForm)
-        {
-            return emailForm.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL());
+            return new HtmlView(page);
         }
 
         @Override
@@ -1681,11 +1717,12 @@ public class SecurityController extends SpringActionController
         {
             String errorMessage = PageFlowUtil.filter(getErrorMessage(errors));
 
-            String page = String.format("<p>%1$s: Password %2$s.</p><p>%3$s</p>%4$s",
-                    PageFlowUtil.filter(form.getEmail()),
-                    _loginExists ? "reset" : "created",
-                    errorMessage,
-                    PageFlowUtil.button("Done").href(form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL()))
+            String page = String.format(
+                "<p>%1$s: Password %2$s.</p><p>%3$s</p>%4$s",
+                PageFlowUtil.filter(form.getEmail()),
+                _loginExists ? "reset" : "created",
+                errorMessage,
+                PageFlowUtil.button("Done").href(form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL()))
             );
 
             getPageConfig().setTemplate(PageConfig.Template.Dialog);
@@ -1725,6 +1762,52 @@ public class SecurityController extends SpringActionController
         }
     }
 
+    /**
+     * Delete existing password
+     */
+    @RequiresPermission(UpdateUserPermission.class)
+    public class AdminDeletePasswordAction extends AdminPasswordAction
+    {
+        @Override
+        String getTitle()
+        {
+            return "Delete Password";
+        }
+
+        @Override
+        String getVerb()
+        {
+            return "delete";
+        }
+
+        @Override
+        HtmlString getConfirmationMessage(boolean loginExists, String emailAddress)
+        {
+            if (!loginExists)
+                throw new NotFoundException(emailAddress + " does not seem to have a password");
+
+            // TODO: Additional checks and guidance here -- Is LDAP configured for this user? Is SSO configured at all?
+
+            return HtmlString.of("Are you sure you want to delete the current password for " + emailAddress + "? Once deleted, this user will be able to login via LDAP or SSO only.");
+        }
+
+        @Override
+        public boolean handlePost(EmailForm form, BindException errors) throws Exception
+        {
+            try
+            {
+                ValidEmail email = new ValidEmail(form.getEmail());
+                SecurityManager.adminDeletePassword(email, getUser());
+            }
+            catch (InvalidEmailException e)
+            {
+                //Should be caught in validation
+                errors.addError(new LabKeyError(new Exception("Invalid email address." + e.getMessage(), e)));
+            }
+
+            return !errors.hasErrors();
+        }
+    }
 
     public static class GroupDiagramViewFactory implements SecurityManager.ViewFactory
     {
@@ -1799,8 +1882,9 @@ public class SecurityController extends SpringActionController
 
     private static class GroupDiagramForm
     {
-        boolean _hideUnconnected = false;
+        private boolean _hideUnconnected = false;
 
+        @SuppressWarnings("unused")
         public void setHideUnconnected(boolean hideUnconnected)
         {
             _hideUnconnected = hideUnconnected;

--- a/query/src/org/labkey/query/controllers/OlapController.java
+++ b/query/src/org/labkey/query/controllers/OlapController.java
@@ -1329,7 +1329,7 @@ public class OlapController extends SpringActionController
         return contextNames;
     }
 
-    @RequiresPermission(TroubleShooterPermission.class)
+    @RequiresPermission(AdminPermission.class)
     public class ListAppsAction extends ReadOnlyApiAction<Object>
     {
         @Override


### PR DESCRIPTION
#### Rationale
LabKey gives admins the ability to create and reset database passwords, but no way to delete them. This is inconsistent and can be inconvenient. See [Issue 42691: Add option to delete a user's password](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42691)

#### Changes
* Give site admins a "Delete Password" button and action, sharing code with admin reset/create password action
* Provide guidance to administrators about the ramifications of deleting a password
* Fix some code warnings