### PR TITLE
automated test fixes

### DIFF
--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -70,29 +70,37 @@ public interface Dataset<T extends Dataset> extends StudyEntity, StudyCachable<T
                     @Override
                     public @Nullable ExpObject resolvePublishSource(Integer publishSourceId)
                     {
-                        return ExperimentService.get().getExpProtocol(publishSourceId);
+                        if (publishSourceId != null)
+                            return ExperimentService.get().getExpProtocol(publishSourceId);
+                        return null;
                     }
 
                     @Override
                     public String getLabel(Integer publishSourceId)
                     {
-                        ExpProtocol protocol = ExperimentService.get().getExpProtocol(publishSourceId);
-                        if (protocol != null)
-                            return protocol.getName();
+                        if (publishSourceId != null)
+                        {
+                            ExpProtocol protocol = ExperimentService.get().getExpProtocol(publishSourceId);
+                            if (protocol != null)
+                                return protocol.getName();
+                        }
                         return "";
                     }
 
                     @Override
                     public @Nullable ActionButton getSourceButton(Integer publishSourceId, ContainerFilter cf)
                     {
-                        ExpProtocol protocol = (ExpProtocol)resolvePublishSource(publishSourceId);
-                        if (protocol != null)
+                        if (publishSourceId != null)
                         {
-                            ActionURL url = PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(
-                                    protocol.getContainer(),
-                                    protocol,
-                                    cf);
-                            return new ActionButton("View Source Assay", url);
+                            ExpProtocol protocol = (ExpProtocol)resolvePublishSource(publishSourceId);
+                            if (protocol != null)
+                            {
+                                ActionURL url = PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(
+                                        protocol.getContainer(),
+                                        protocol,
+                                        cf);
+                                return new ActionButton("View Source Assay", url);
+                            }
                         }
                         return null;
                     }
@@ -100,12 +108,15 @@ public interface Dataset<T extends Dataset> extends StudyEntity, StudyCachable<T
                     @Override
                     public boolean hasUsefulDetailsPage(Integer publishSourceId)
                     {
-                        ExpProtocol protocol = (ExpProtocol)resolvePublishSource(publishSourceId);
-                        if (protocol != null)
+                        if (publishSourceId != null)
                         {
-                            AssayProvider provider = AssayService.get().getProvider(protocol);
-                            if (provider != null)
-                                return provider.hasUsefulDetailsPage();
+                            ExpProtocol protocol = (ExpProtocol)resolvePublishSource(publishSourceId);
+                            if (protocol != null)
+                            {
+                                AssayProvider provider = AssayService.get().getProvider(protocol);
+                                if (provider != null)
+                                    return provider.hasUsefulDetailsPage();
+                            }
                         }
                         return false;
                     }

--- a/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
@@ -187,7 +187,7 @@ public class StudySimpleExportTest extends StudyBaseTest
         new ManageStudyPage(getDriver())
                 .manageDatasetQCStates()
                 .setDefaultPipelineQCState("First QC State")
-                .setDefaultAssayQCState("Second QC State")
+                .setDefaultPublishDataQCState("Second QC State")
                 .setDefaultDirectEntryQCState("Third QC State")
                 .setDefaultVisibility("Public data")
                 .clickSave();
@@ -224,7 +224,7 @@ public class StudySimpleExportTest extends StudyBaseTest
         assertFalse("don't expect 3rd row to be public", thirdRow.getPublicData());
 
         assertEquals("First QC State", statesPage.getDefaultPipelineQCState());
-        assertEquals("Second QC State", statesPage.getDefaultAssayQCState());
+        assertEquals("Second QC State", statesPage.getDefaultPublishDataQCState());
         assertEquals("Third QC State", statesPage.getDefaultDirectEntryQCState());
         assertEquals("Public data", statesPage.getDefaultVisibility());
 


### PR DESCRIPTION
#### Rationale
Some of the study design tests were failing because they pass in a null protocol for the publish source ID. Updating the code to be a bit more defensive.

The StudySimpleExportTest also needed to be updated to reflect the change in QC state UI.