### PR TITLE
Issue 42620: AliasedColumn should never be considered key field for the TableInfo

### DIFF
--- a/api/src/org/labkey/api/query/AliasedColumn.java
+++ b/api/src/org/labkey/api/query/AliasedColumn.java
@@ -38,6 +38,9 @@ public class AliasedColumn extends BaseColumnInfo
         super(key, parent);
         copyAttributesFrom(column);
 
+        // Issue 42620: alias columns should never be considered key fields
+        setKeyField(false);
+
         Map<FieldKey, FieldKey> remap = new HashMap<>();
         remap.put(column.getFieldKey(), key);
         if (parent != null && parent != column.getParentTable())


### PR DESCRIPTION
#### Rationale
Related to NAb runs grid performance issue: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42620

The fix made in the related PR for 21.3 was just to explicitly set the AliasedColumns for the given NAb case as `setKeyField(false)`. However, an AliasedColumn should never be considered a key field, so this PR sets that in the AliasedColumn constructor after it does the `copyAttributesFrom(column)` call.

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/307

#### Changes
* Call setKeyField(false) in AliasedColumn constructor after copyAttributesFrom
