### PR TITLE
Fix error rendering on trying to delete passwords for bogus users

### DIFF
--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -1635,11 +1635,11 @@ public class SecurityController extends SpringActionController
                 // don't let non-site admin delete/reset password of site admin
                 User formUser = UserManager.getUser(email);
                 if (formUser != null && !getUser().hasSiteAdminPermission() && formUser.hasSiteAdminPermission())
-                    errors.reject("Permission denied: not authorized to " + getVerb() + " password for a Site Admin user.");
+                    errors.reject(ERROR_MSG, "Permission denied: not authorized to " + getVerb() + " password for a Site Admin user.");
             }
             catch (InvalidEmailException e)
             {
-                errors.reject(" failed: invalid email address.");
+                errors.reject(ERROR_MSG, getVerb() + " failed: invalid email address.");
             }
         }
 


### PR DESCRIPTION
#### Rationale
Our new delete password action attempts to handle invalid email addresses. But that handled error condition turns into an unhandled error rendering error

#### Changes
* Pass through a placeholder errorCode to keep Spring happy

https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailySqlserverb/1355396