### PR TITLE
Remove @Deprecated from ActionURL constructor that takes a string actionName

### DIFF
--- a/api/src/org/labkey/api/view/ActionURL.java
+++ b/api/src/org/labkey/api/view/ActionURL.java
@@ -71,9 +71,8 @@ public class ActionURL extends URLHelper implements Cloneable
 
     
     /**
-     * Old pageflow constructor
+     * Pageflow constructor, used for URLs targeting a module resource view or React entryPoint generated view
      */
-    @Deprecated
     public ActionURL(String controller, String actionName, Container container)
     {
         this(true);


### PR DESCRIPTION
#### Rationale
The ActionURL constructor that takes a string actionName param was marked as deprecated 10 years ago in favor of the usage that takes an action class. However, we still have cases where we use this constructor to build a URL to a resource module view (namely for the React entryPoint generated view case).

#### Changes
* Remove @Deprecated from ActionURL string actionName constructor
