### PR TITLE
enable folder archive filtering of assay runs, sample and data class data

### DIFF
--- a/api/src/org/labkey/api/exp/XarExportContext.java
+++ b/api/src/org/labkey/api/exp/XarExportContext.java
@@ -1,0 +1,59 @@
+package org.labkey.api.exp;
+
+import org.labkey.api.admin.FolderExportContext;
+import org.labkey.api.admin.LoggerGetter;
+import org.labkey.api.data.Container;
+import org.labkey.api.security.User;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Folder export context that allows filtering of objects in the Xar
+ */
+public class XarExportContext extends FolderExportContext
+{
+    private Set<Integer> _includedAssayRuns = new HashSet<>();
+    private Map<Integer, Set<Integer>> _includedSamples = new HashMap<>();
+    private Map<Integer, Set<Integer>> _includedDataClasses = new HashMap<>();
+
+    public XarExportContext(User user, Container c, Set<String> dataTypes, String format, LoggerGetter logger)
+    {
+        super(user, c, dataTypes, format, logger);
+    }
+
+    public Set<Integer> getIncludedAssayRuns()
+    {
+        return _includedAssayRuns;
+    }
+
+    public void setIncludedAssayRuns(Set<Integer> includedRuns)
+    {
+        if (includedRuns != null)
+            _includedAssayRuns = includedRuns;
+    }
+
+    public Map<Integer, Set<Integer>> getIncludedSamples()
+    {
+        return _includedSamples;
+    }
+
+    public void setIncludedSamples(Map<Integer, Set<Integer>> includedSamples)
+    {
+        if (includedSamples != null)
+            _includedSamples = includedSamples;
+    }
+
+    public Map<Integer, Set<Integer>> getIncludedDataClasses()
+    {
+        return _includedDataClasses;
+    }
+
+    public void setIncludedDataClasses(Map<Integer, Set<Integer>> includedDataClasses)
+    {
+        if (includedDataClasses != null)
+            _includedDataClasses = includedDataClasses;
+    }
+}

--- a/api/src/org/labkey/api/exp/XarExportContext.java
+++ b/api/src/org/labkey/api/exp/XarExportContext.java
@@ -29,10 +29,12 @@ public class XarExportContext extends FolderExportContext
         return _includedAssayRuns;
     }
 
-    public void setIncludedAssayRuns(Set<Integer> includedRuns)
+    public void setIncludedAssayRuns(Map<Integer, Set<Integer>> includedRuns)
     {
         if (includedRuns != null)
-            _includedAssayRuns = includedRuns;
+        {
+            _includedAssayRuns = includedRuns.keySet();
+        }
     }
 
     public Map<Integer, Set<Integer>> getIncludedSamples()

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
@@ -29,6 +29,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.WrappedColumnInfo;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.PropertyType;
+import org.labkey.api.exp.XarExportContext;
 import org.labkey.api.exp.api.ExpDataClass;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExpSampleType;
@@ -84,6 +85,7 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
     public static final String SAMPLE_TYPE_PREFIX = "SAMPLE_TYPE_";
     public static final String DATA_CLASS_PREFIX = "DATA_CLASS_";
     private PHI _exportPhiLevel = PHI.NotPHI;
+    private XarExportContext _xarCtx;
 
     private SampleTypeAndDataClassFolderWriter()
     {
@@ -115,12 +117,17 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
         _exportPhiLevel = ctx.getPhiLevel();
         boolean exportTypes = false;
         boolean exportRuns = false;
+        _xarCtx = ctx.getContext(XarExportContext.class);
 
         Lsid sampleTypeLsid = new Lsid(ExperimentService.get().generateLSID(ctx.getContainer(), ExpSampleType.class, "export"));
         for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(ctx.getContainer(), ctx.getUser(), true))
         {
             // ignore the magic sample type that is used for the specimen repository, it is managed by the specimen importer
             if (StudyService.get().getStudy(ctx.getContainer()) != null && SpecimenService.SAMPLE_TYPE_NAME.equals(sampleType.getName()))
+                continue;
+
+            // ignore sample types that are filtered out
+            if (_xarCtx != null && !_xarCtx.getIncludedSamples().containsKey(sampleType.getRowId()))
                 continue;
 
             // filter out non sample type material sources
@@ -136,6 +143,10 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
 
         for (ExpDataClass dataClass : ExperimentService.get().getDataClasses(ctx.getContainer(), ctx.getUser(), false))
         {
+            // ignore data classes that are filtered out
+            if (_xarCtx != null && !_xarCtx.getIncludedDataClasses().containsKey(dataClass.getRowId()))
+                continue;
+
             dataClasses.add(dataClass);
             typesSelection.addDataClass(dataClass);
             exportTypes = true;
@@ -204,7 +215,13 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
 
                     if (!columns.isEmpty())
                     {
-                        ResultsFactory factory = ()->QueryService.get().select(tinfo, columns, SimpleFilter.createContainerFilter(ctx.getContainer()), null);
+                        SimpleFilter filter = SimpleFilter.createContainerFilter(ctx.getContainer());
+
+                        // filter only to the specific samples
+                        if (_xarCtx != null && _xarCtx.getIncludedSamples().containsKey(sampleType.getRowId()))
+                            filter.addInClause(FieldKey.fromParts("RowId"), _xarCtx.getIncludedSamples().get(sampleType.getRowId()));
+
+                        ResultsFactory factory = ()->QueryService.get().select(tinfo, columns, filter, null);
                         try (TSVGridWriter tsvWriter = new TSVGridWriter(factory))
                         {
                             tsvWriter.setApplyFormats(false);
@@ -233,7 +250,13 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
 
                     if (!columns.isEmpty())
                     {
-                        ResultsFactory factory = ()->QueryService.get().select(tinfo, columns, SimpleFilter.createContainerFilter(ctx.getContainer()), null);
+                        SimpleFilter filter = SimpleFilter.createContainerFilter(ctx.getContainer());
+
+                        // filter only to the specific samples
+                        if (_xarCtx != null && _xarCtx.getIncludedDataClasses().containsKey(dataClass.getRowId()))
+                            filter.addInClause(FieldKey.fromParts("RowId"), _xarCtx.getIncludedDataClasses().get(dataClass.getRowId()));
+
+                        ResultsFactory factory = ()->QueryService.get().select(tinfo, columns, filter, null);
                         try (TSVGridWriter tsvWriter = new TSVGridWriter(factory))
                         {
                             tsvWriter.setApplyFormats(false);

--- a/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
@@ -15,7 +15,7 @@
  */
 package org.labkey.experiment.xar;
 
-import org.labkey.api.admin.AbstractFolderContext;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.admin.BaseFolderWriter;
 import org.labkey.api.admin.FolderArchiveDataTypes;
 import org.labkey.api.admin.FolderWriter;
@@ -23,9 +23,9 @@ import org.labkey.api.admin.FolderWriterFactory;
 import org.labkey.api.admin.ImportContext;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.exp.XarExportContext;
 import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExpObject;
-import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.writer.VirtualFile;
@@ -70,7 +70,7 @@ public class FolderXarWriterFactory implements FolderWriterFactory
             Set<Container> containers = ContainerManager.getAllChildren(c);
             for(Container container: containers)
             {
-                if (getProtocols(container).size() > 0 || getRuns(container).size() > 0)
+                if (getProtocols(container).size() > 0 || getRuns(null, container).size() > 0)
                 {
                     return true;
                 }
@@ -79,11 +79,20 @@ public class FolderXarWriterFactory implements FolderWriterFactory
             return false;
         }
 
-        private List<ExpRun> getRuns(Container c)
+        private List<ExpRun> getRuns(@Nullable ImportContext<FolderDocument.Folder> ctx, Container c)
         {
+            XarExportContext xarCtx = null;
+            if (ctx != null)
+                xarCtx = ctx.getContext(XarExportContext.class);
+
             // don't include the sample derivation runs, we now have a separate exporter explicitly for sample types
+            // if an additional context has been furnished, filter out runs not included in this export
+            final XarExportContext fxarCtx = xarCtx;
             return ExperimentService.get().getExpRuns(c, null, null).stream()
-                    .filter(run -> !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID))
+                    .filter(
+                        run -> !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID)
+                            && (fxarCtx == null || fxarCtx.getIncludedAssayRuns().contains(run.getRowId()))
+                    )
                     .collect(Collectors.toList());
         }
 
@@ -114,7 +123,7 @@ public class FolderXarWriterFactory implements FolderWriterFactory
 
             selection.addProtocolIds(getProtocols(ctx.getContainer()));
 
-            selection.addRuns(getRuns(ctx.getContainer()));
+            selection.addRuns(getRuns(ctx, ctx.getContainer()));
 
             ctx.getXml().addNewXar().setDir(XAR_DIRECTORY);
             VirtualFile xarDir = vf.getDir(XAR_DIRECTORY);


### PR DESCRIPTION
#### Rationale
To support finer grained filtering of ELN Notebook snapshots (which leverage folder archives), this PR introduces a nested export context to pass filtering information between the folder writers. We also added logic for both the XarWriter and sample type and dataclass folder writers to filter the data if provided by the context.

#### Related Pull Requests
- https://github.com/LabKey/labbook/pull/97

#### Changes
- Introduce a nested context : XarExportContext that can be passed between folder writers to share information
- Filter assay runs to include only those referenced (if provided)
- Filter sample and dataclass data to only the data rows referenced (if provided)