### PR TITLE
42758: Error when Snapshotting notebook

### DIFF
--- a/experiment/src/org/labkey/experiment/api/AbstractRunItemImpl.java
+++ b/experiment/src/org/labkey/experiment/api/AbstractRunItemImpl.java
@@ -44,7 +44,7 @@ public abstract class AbstractRunItemImpl<Type extends RunItem> extends ExpIdent
 {
     private ExpProtocolApplicationImpl _sourceApp;
     private List<ExpProtocolApplication> _successorAppList;
-    private List<Integer> _successorRunIdList = Collections.emptyList();
+    private List<Integer> _successorRunIdList = null;
 
     // For serialization
     protected AbstractRunItemImpl() {}


### PR DESCRIPTION
#### Rationale
This fixes an exception that a user ran into when creating a sample type folder archive:

```
java.lang.UnsupportedOperationException: null
    at java.util.AbstractList.add(AbstractList.java:153) ~[?:?]
    at java.util.AbstractList.add(AbstractList.java:111) ~[?:?]
    at org.labkey.experiment.api.AbstractRunItemImpl.addSuccessorRunId(AbstractRunItemImpl.java:97) ~[experiment-21.3-SNAPSHOT.jar:?]
    at org.labkey.experiment.api.ExperimentServiceImpl.lambda$populateRun$43(ExperimentServiceImpl.java:5346) ~[experiment-21.3-SNAPSHOT.jar:?]
    at org.labkey.api.data.BaseSelector.lambda$forEach$5(BaseSelector.java:375) ~[api-21.3-SNAPSHOT.jar:?]
```
The exception was a side effect from another bug fix : 
-https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=40512

This PR reverts part of that bug fix (which has been reopened) and has been recommended a different approach.
