### PR TITLE
Issue 42497: org.labkey.api.data.RuntimeSQLException: Sharenet.S330.ex.txt: Method not yet supported

### DIFF
--- a/api/src/org/labkey/api/data/JdbcMetaDataSelector.java
+++ b/api/src/org/labkey/api/data/JdbcMetaDataSelector.java
@@ -38,7 +38,7 @@ public class JdbcMetaDataSelector
     public JdbcMetaDataSelector(JdbcMetaDataLocator locator, JdbcMetaDataResultSetFactory factory)
     {
         _locator = locator;
-        _factory = factory;
+        _factory = locator.getScope().getSqlDialect().getJdbcMetaDataResultSetFactory(factory);
     }
 
     private static final int DEADLOCK_RETRIES = 5;

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -27,6 +27,7 @@ import org.labkey.api.collections.CsvSet;
 import org.labkey.api.collections.Sets;
 import org.labkey.api.data.*;
 import org.labkey.api.data.ConnectionWrapper.Closer;
+import org.labkey.api.data.JdbcMetaDataSelector.JdbcMetaDataResultSetFactory;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.AliasManager;
@@ -928,6 +929,12 @@ public abstract class SqlDialect
     public final ForeignKeyResolver getForeignKeyResolver(DbScope scope, @Nullable String schemaName, @Nullable String tableName)
     {
         return getTableResolver().getForeignKeyResolver(scope, schemaName, tableName);
+    }
+
+    // Pass-through by default. Dialects can override if they need special handling.
+    public JdbcMetaDataResultSetFactory getJdbcMetaDataResultSetFactory(JdbcMetaDataResultSetFactory jdbcMetaDataResultSetFactory)
+    {
+        return jdbcMetaDataResultSetFactory;
     }
 
     public abstract boolean canExecuteUpgradeScripts();


### PR DESCRIPTION
#### Rationale
After a refactor in July, 2020, LabKey started calling `getRow()` on SAS/SHARE JDBC metadata ResultSets, but SAS/SHARE ResultSets don't support this method. We wrap most SAS/SHARE ResultSets with a special class where we've implemented `getRow()` ourselves. The solution is to use that wrapper in the JDBC metadata case as well.

[Issue 42497: org.labkey.api.data.RuntimeSQLException: Sharenet.S330.ex.txt: Method not yet supported](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42497)
