### PR TITLE
Avoid JS error enabling modules in folder for dependencies hidden from list

### DIFF
--- a/core/src/org/labkey/core/admin/folderType.jsp
+++ b/core/src/org/labkey/core/admin/folderType.jsp
@@ -162,7 +162,9 @@ function updateDefaultOptions(cb)
 
                         function uncheckEl(m){
                             var el = Ext4.Element.select('input[value='+m+'][type="checkbox"]');
-                            el.elements[0].checked = false;
+                            if (el.elements.length > 0) {
+                                el.elements[0].checked = false;
+                            }
                         }
                     }
                 }, this);
@@ -177,7 +179,9 @@ function updateDefaultOptions(cb)
                 if(dependencyMap[m].indexOf(cb.value) > -1)
                 {
                     var el = Ext4.Element.select('input[value='+m+'][type="checkbox"]');
-                    el.elements[0].checked = true;
+                    if (el.elements.length > 0) {
+                        el.elements[0].checked = true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Rationale
Some modules, like Audit, get filtered out from the list of available modules in Folder->Management->Folder Type. They are considered active in the container, but can cause JS errors on the page if a module declares a direct dependency on them

#### Changes
* Check if a checkbox exists for the referenced module, and no-op if it doesn't

https://www.labkey.org/ONPRC/Support%20Tickets/issues-details.view?issueId=39943