### PR TITLE
Remove default sample type upgrade code

### DIFF
--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -279,9 +279,6 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     protected void startupAfterSpringConfig(ModuleContext moduleContext)
     {
-        // delete the default "Unspecified" SampleType TODO: move to an upgrade script in 19.2
-        SampleTypeServiceImpl.get().deleteDefaultSampleType();
-
         // TODO move to an upgrade script
         ExperimentUpgradeCode.upgradeMaterialSource(null);
 
@@ -520,7 +517,6 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
         return list;
     }
 
-
     @Override
     @NotNull
     public Set<Class> getIntegrationTests()
@@ -546,7 +542,6 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
         list.add(new JspTestCase("/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp"));
         return list;
     }
-
 
     @NotNull
     @Override
@@ -579,7 +574,6 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
         return PageFlowUtil.set(DataClassDomainKind.PROVISIONED_SCHEMA_NAME, SampleTypeDomainKind.PROVISIONED_SCHEMA_NAME);
     }
 
-
     @Override
     public void enumerateDocuments(final @NotNull SearchService.IndexTask task, final @NotNull Container c, final Date modifiedSince)
     {
@@ -608,7 +602,6 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
             task.addResourceList(dataObjects, 100, ExpDataImpl::createDocument);
         }, SearchService.PRIORITY.bulk);
     }
-
 
     @Override
     public void indexDeleted()

--- a/experiment/src/org/labkey/experiment/ExperimentRunWebPartFactory.java
+++ b/experiment/src/org/labkey/experiment/ExperimentRunWebPartFactory.java
@@ -46,7 +46,6 @@ public class ExperimentRunWebPartFactory extends BaseWebPartFactory
     public ExperimentRunWebPartFactory()
     {
         super(ExperimentModule.EXPERIMENT_RUN_WEB_PART_NAME, true, false);
-
     }
 
     private String getConfiguredRunFilterName(Portal.WebPart webPart)


### PR DESCRIPTION
#### Rationale
Earliest upgrade is now 19.1, which means the `deleteDefaultSampleType()` code that was added in 19.1 no longer needs to run. At this point, no installation (whether new or upgraded) will have a default sample type.
