### PR TITLE
Sample Type Properties Panel Auto-Link Fix

### DIFF
--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -609,7 +609,7 @@ public class ExperimentController extends SpringActionController
                 autoLinkTargetColumn.setVisible(false);
 
                 SimpleDisplayColumn displayAutoLinkTargetColumn = new SimpleDisplayColumn();
-                displayAutoLinkTargetColumn.setCaption("Auto Link Target Container:");
+                displayAutoLinkTargetColumn.setCaption("Auto-Link Target Container:");
                 String path = autoLinkContainer.getPath();
                 displayAutoLinkTargetColumn.setDisplayHtml(path.equals("/") ? "" : path);
                 detailsView.getDataRegion().addDisplayColumn(displayAutoLinkTargetColumn);

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -602,6 +602,19 @@ public class ExperimentController extends SpringActionController
             detailsView.setTitle("Sample Type Properties");
             detailsView.getDataRegion().getButtonBar(DataRegion.MODE_DETAILS).setStyle(ButtonBar.Style.separateButtons);
 
+            Container autoLinkContainer = _sampleType.getAutoLinkTargetContainer();
+            if (null != autoLinkContainer)
+            {
+                DisplayColumn autoLinkTargetColumn = detailsView.getDataRegion().getDisplayColumn("autoLinkTargetContainer");
+                autoLinkTargetColumn.setVisible(false);
+
+                SimpleDisplayColumn displayAutoLinkTargetColumn = new SimpleDisplayColumn();
+                displayAutoLinkTargetColumn.setCaption("Auto Link Target Container:");
+                String path = autoLinkContainer.getPath();
+                displayAutoLinkTargetColumn.setDisplayHtml(path.equals("/") ? "" : path);
+                detailsView.getDataRegion().addDisplayColumn(displayAutoLinkTargetColumn);
+            }
+
             if (_sampleType.hasNameAsIdCol())
             {
                 SimpleDisplayColumn nameIdCol = new SimpleDisplayColumn();


### PR DESCRIPTION
#### Rationale
Within the 'Sample Type Properties Panel,' we want the value for 'Auto-Link Target Container' to be a folder path, consistent with the Sample Type Designer 'Auto-Link Data to Study' dropdown value, rather than a Container ID.

#### Related Pull Requests
- https://github.com/LabKey/sampleManagement/pull/527
- https://github.com/LabKey/biologics/pull/840

#### Changes
* Set `autoLinkTargetContainer` column to invisible
* Add `SimpleDisplayColumn` of relevant values for Sample Type Properties Panel
