### PR TITLE
Support multiple LDAP configurations in admin messages, etc.

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticationConfiguration.java
+++ b/api/src/org/labkey/api/security/AuthenticationConfiguration.java
@@ -40,6 +40,10 @@ public interface AuthenticationConfiguration<AP extends AuthenticationProvider> 
     @NotNull AP getAuthenticationProvider();
     boolean isEnabled();
     @NotNull Map<String, Object> getCustomProperties();
+    default @Nullable String getDomain()
+    {
+        return null;
+    }
 
     /**
      * @return Map of all property names and values that are updateable and appropriate for audit logging

--- a/api/src/org/labkey/api/security/AuthenticationConfigurationCache.java
+++ b/api/src/org/labkey/api/security/AuthenticationConfigurationCache.java
@@ -220,6 +220,9 @@ public class AuthenticationConfigurationCache
         CACHE.remove(CACHE_KEY);
     }
 
+    /**
+     * Return a collection of all email domains associated with authentication configurations, not including "*" or null
+     */
     public static @NotNull Collection<String> getActiveDomains()
     {
         return CACHE.get(CACHE_KEY).getActiveDomains();

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -195,22 +195,44 @@ public class AuthenticationManager
         // Populate the general authentication properties (e.g., auto-create accounts, self registration, self-service email changes).
         ModuleLoader.getInstance().getConfigProperties(AUTHENTICATION_CATEGORY).stream()
             .filter(cp->!cp.getName().equals(PROVIDERS_KEY)) // Ignore "Authentication" -- we don't use this property anymore
-            .forEach(cp-> saveAuthSetting(null, cp.getName(), Boolean.parseBoolean(cp.getValue())));
+            .forEach(cp->saveAuthSetting(null, cp.getName(), Boolean.parseBoolean(cp.getValue())));
     }
 
     public enum Priority { High, Low }
 
-    // TODO: Replace this with a generic domain-claiming mechanism
-    private static String _ldapDomain = null;
-
-    public static @Nullable String getLdapDomain()
+    // Return a collection of all email domains associated with authentication configurations, not including "*" or null
+    public static @NotNull Collection<String> getActiveDomains()
     {
-        return _ldapDomain;
+        return AuthenticationConfigurationCache.getActiveDomains();
     }
 
-    public static void setLdapDomain(String ldapDomain)
+    public static HtmlString getStandardSendVerificationEmailsMessage()
     {
-        _ldapDomain = StringUtils.trimToNull(ldapDomain);
+        HtmlStringBuilder builder = HtmlStringBuilder.of("Send password verification emails to all new users");
+        Collection<String> activeDomains = getActiveDomains();
+
+        if (!activeDomains.isEmpty())
+        {
+            // At the moment, only LDAP configurations can be associated with a domain, so we call out LDAP below
+            builder.append(" except those with email addresses that are configured for LDAP authentication (those ending in ");
+            builder.append(
+                activeDomains.stream()
+                    .map(d->"@" + d)
+                    .collect(Collectors.joining(", "))
+            );
+
+            builder.append(")");
+        }
+
+        return builder.getHtmlString();
+    }
+
+    // Ignores domain = "*"
+    public static boolean isLdapEmail(ValidEmail email)
+    {
+        String emailAddress = email.getEmailAddress();
+        return getActiveDomains().stream()
+            .anyMatch(domain->StringUtils.endsWithIgnoreCase(emailAddress, "@" + domain));
     }
 
     public static boolean isRegistrationEnabled()
@@ -703,15 +725,15 @@ public class AuthenticationManager
 
 
     /** avoid spamming the audit log **/
-    private static Cache<String, String> authMessages = CacheManager.getCache(100, TimeUnit.MINUTES.toMillis(10), "Authentication Messages");
+    private static final Cache<String, String> AUTH_MESSAGES = CacheManager.getCache(100, TimeUnit.MINUTES.toMillis(10), "Authentication Messages");
 
     public static void addAuditEvent(@NotNull User user, HttpServletRequest request, String msg)
     {
         String key = user.getUserId() + "/" + ((null==request||null==request.getLocalAddr())?"":request.getLocalAddr());
-        String prevMessage = authMessages.get(key);
+        String prevMessage = AUTH_MESSAGES.get(key);
         if (StringUtils.equals(prevMessage, msg))
             return;
-        authMessages.put(key, msg);
+        AUTH_MESSAGES.put(key, msg);
         if (user.isGuest())
         {
             UserManager.UserAuditEvent event = new UserManager.UserAuditEvent(ContainerManager.getRoot().getId(), msg, user);

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -200,16 +200,10 @@ public class AuthenticationManager
 
     public enum Priority { High, Low }
 
-    // Return a collection of all email domains associated with authentication configurations, not including "*" or null
-    public static @NotNull Collection<String> getActiveDomains()
-    {
-        return AuthenticationConfigurationCache.getActiveDomains();
-    }
-
     public static HtmlString getStandardSendVerificationEmailsMessage()
     {
         HtmlStringBuilder builder = HtmlStringBuilder.of("Send password verification emails to all new users");
-        Collection<String> activeDomains = getActiveDomains();
+        Collection<String> activeDomains = AuthenticationConfigurationCache.getActiveDomains();
 
         if (!activeDomains.isEmpty())
         {
@@ -231,7 +225,7 @@ public class AuthenticationManager
     public static boolean isLdapEmail(ValidEmail email)
     {
         String emailAddress = email.getEmailAddress();
-        return getActiveDomains().stream()
+        return AuthenticationConfigurationCache.getActiveDomains().stream()
             .anyMatch(domain->StringUtils.endsWithIgnoreCase(emailAddress, "@" + domain));
     }
 

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -62,13 +62,11 @@ import org.labkey.api.security.impersonation.RoleImpersonationContextFactory;
 import org.labkey.api.security.impersonation.UserImpersonationContextFactory;
 import org.labkey.api.security.permissions.AddUserPermission;
 import org.labkey.api.security.permissions.AdminPermission;
-import org.labkey.api.security.permissions.ApplicationAdminPermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.SeeUserDetailsPermission;
-import org.labkey.api.security.permissions.SiteAdminPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.security.roles.EditorRole;
 import org.labkey.api.security.roles.FolderAdminRole;
@@ -395,14 +393,14 @@ public class SecurityManager
         @Override
         public void userDeletedFromSite(User user)
         {
-            // This clears the cache of security policies.  It does not remove the policies themselves.
+            // This clears the cache of security policies. It does not remove the policies themselves.
             SecurityPolicyManager.removeAll();
         }
 
         @Override
         public void userAccountDisabled(User user)
         {
-            // This clears the cache of security policies.  It does not remove the policies themselves.
+            // This clears the cache of security policies. It does not remove the policies themselves.
             SecurityPolicyManager.removeAll();
         }
 
@@ -418,7 +416,6 @@ public class SecurityManager
             // do nothing
         }
     }
-
 
     private static @Nullable Pair<String, String> getBasicCredentials(HttpServletRequest request)
     {
@@ -443,7 +440,6 @@ public class SecurityManager
         return ret;
     }
 
-
     // Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==
     private static @Nullable User authenticateBasic(HttpServletRequest request, @NotNull Pair<String, String> basicCredentials)
     {
@@ -451,7 +447,7 @@ public class SecurityManager
         {
             String rawEmail = basicCredentials.getKey();
             String password = basicCredentials.getValue();
-            if (rawEmail.toLowerCase().equals("guest"))
+            if (rawEmail.equalsIgnoreCase("guest"))
                 return User.guest;
             new ValidEmail(rawEmail);  // validate email address
 
@@ -463,12 +459,10 @@ public class SecurityManager
         }
     }
 
-
     public static boolean isBasicAuthentication(HttpServletRequest request)
     {
         return "Basic".equals(request.getAttribute(AUTHENTICATION_METHOD));
     }
-
 
     public static User getSessionUser(HttpSession session)
     {
@@ -481,7 +475,6 @@ public class SecurityManager
 
         return sessionUser;
     }
-
 
     public static Pair<User, HttpServletRequest> attemptAuthentication(HttpServletRequest request) throws UnsupportedEncodingException
     {
@@ -581,7 +574,6 @@ public class SecurityManager
         return null == u || u.isGuest() ? null : new Pair<>(u, request);
     }
 
-
     /**
      * Determine if an API key is present, checking basic auth first, then "apikey" header, and then the special "transform"
      * cookie and parameters. Return the API key if it's present; otherwise return null.
@@ -631,7 +623,6 @@ public class SecurityManager
 
         return apiKey;
     }
-
 
     public static final int SECONDS_PER_DAY = 60*60*24;
 
@@ -743,14 +734,12 @@ public class SecurityManager
         return newSession;
     }
 
-
     public static URLHelper logoutUser(HttpServletRequest request, User user, @Nullable URLHelper returnURL)
     {
         URLHelper ret = AuthenticationManager.logout(user, request, returnURL);   // Let AuthenticationProvider clean up auth-specific cookies, etc.
         SessionHelper.clearSession(request, true);
         return ret;
     }
-
 
     public static void impersonateUser(ViewContext viewContext, User impersonatedUser, ActionURL returnURL)
     {
@@ -763,13 +752,11 @@ public class SecurityManager
         impersonate(viewContext, new UserImpersonationContextFactory(project, user, impersonatedUser, returnURL));
     }
 
-
     public static void impersonateGroup(ViewContext viewContext, Group group, ActionURL returnURL)
     {
         @Nullable Container project = viewContext.getContainer().getProject();
         impersonate(viewContext, new GroupImpersonationContextFactory(project, viewContext.getUser(), group, returnURL));
     }
-
 
     public static void impersonateRoles(ViewContext viewContext, Collection<Role> newImpersonationRoles, Set<Role> currentImpersonationRoles, ActionURL returnURL)
     {
@@ -782,7 +769,6 @@ public class SecurityManager
         impersonate(viewContext, new RoleImpersonationContextFactory(project, user, newImpersonationRoles, currentImpersonationRoles, returnURL));
     }
 
-
     private static void impersonate(ViewContext viewContext, ImpersonationContextFactory factory)
     {
         // Tell the factory to start impersonating
@@ -794,7 +780,6 @@ public class SecurityManager
         session.setAttribute(IMPERSONATION_CONTEXT_FACTORY_KEY, factory);
     }
 
-
     public static void stopImpersonating(HttpServletRequest request, ImpersonationContextFactory factory)
     {
         factory.stopImpersonating(request);
@@ -804,7 +789,6 @@ public class SecurityManager
         session.removeAttribute(IMPERSONATION_CONTEXT_FACTORY_KEY);
     }
 
-
     public static void setValidators(HttpSession session, List<AuthenticationValidator> validators)
     {
         if (validators.isEmpty())
@@ -813,12 +797,10 @@ public class SecurityManager
             session.setAttribute(AUTHENTICATION_VALIDATORS_KEY, validators);
     }
 
-
     public static @Nullable List<AuthenticationValidator> getValidators(HttpSession session)
     {
         return (List<AuthenticationValidator>)session.getAttribute(AUTHENTICATION_VALIDATORS_KEY);
     }
-
 
     private static final String passwordChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     public static final int tempPasswordLength = 32;
@@ -832,7 +814,6 @@ public class SecurityManager
 
         return tempPassword.toString();
     }
-
 
     public static ActionURL createVerificationURL(Container c, ValidEmail email, String verification, @Nullable List<Pair<String, String>> extraParameters)
     {
@@ -865,13 +846,11 @@ public class SecurityManager
         return (null == getVerification(email));
     }
 
-
     public static boolean verify(ValidEmail email, String verification)
     {
         String dbVerification = getVerification(email);
         return (dbVerification != null && dbVerification.equals(verification));
     }
-
 
     public static void setVerification(ValidEmail email, @Nullable String verification) throws UserManagementException
     {
@@ -880,12 +859,10 @@ public class SecurityManager
             throw new UserManagementException(email, "Unexpected number of rows returned when setting verification: " + rows);
     }
 
-
     public static String getVerification(ValidEmail email)
     {
         return new SqlSelector(core.getSchema(), "SELECT Verification FROM " + core.getTableInfoLogins() + " WHERE Email = ?", email.getEmailAddress()).getObject(String.class);
     }
-
 
     public static class NewUserStatus
     {
@@ -906,7 +883,7 @@ public class SecurityManager
 
         public boolean isLdapEmail()
         {
-            return SecurityManager.isLdapEmail(_email);
+            return AuthenticationManager.isLdapEmail(_email);
         }
 
         public String getVerification()
@@ -1029,7 +1006,7 @@ public class SecurityManager
 
                 try
                 {
-                    Map returnMap = Table.insert(currentUser, core.getTableInfoPrincipals(), fieldsIn);
+                    Map<String, Object> returnMap = Table.insert(currentUser, core.getTableInfoPrincipals(), fieldsIn);
                     userId = (Integer) returnMap.get("UserId");
                 }
                 catch (RuntimeSQLException e)
@@ -1095,7 +1072,6 @@ public class SecurityManager
         }
     }
 
-
     private static String displayNameFromEmail(ValidEmail email, Integer userId)
     {
         String displayName;
@@ -1127,7 +1103,6 @@ public class SecurityManager
         }
         return displayName;
     }
-
 
     public static void sendEmail(Container c, User user, SecurityMessage message, String to, ActionURL verificationURL) throws ConfigurationException, MessagingException
     {
@@ -1169,7 +1144,7 @@ public class SecurityManager
         }
     }
 
-    // Create record for non-LDAP login, saving email address and hashed password.  Return verification token.
+    // Create record for non-LDAP login, saving email address and hashed password. Return verification token.
     public static String createLogin(ValidEmail email) throws UserManagementException
     {
         // Create a placeholder password hash and a separate email verification key that will get emailed to the new user
@@ -1195,7 +1170,6 @@ public class SecurityManager
         return verification;
     }
 
-
     public static void setPassword(ValidEmail email, String password) throws UserManagementException
     {
         String crypt = Crypt.BCrypt.digestWithPrefix(password);
@@ -1212,7 +1186,6 @@ public class SecurityManager
         if (1 != rows)
             throw new UserManagementException(email, "Password update statement affected " + rows + " rows.");
     }
-
 
     private static final int MAX_HISTORY = 10;
 
@@ -1234,7 +1207,6 @@ public class SecurityManager
         }
     }
 
-
     public static boolean matchesPreviousPassword(String password, User user)
     {
         List<String> history = getCryptHistory(user.getEmail());
@@ -1248,13 +1220,11 @@ public class SecurityManager
         return false;
     }
 
-
     public static Date getLastChanged(User user)
     {
         SqlSelector selector = new SqlSelector(core.getSchema(), new SQLFragment("SELECT LastChanged FROM " + core.getTableInfoLogins() + " WHERE Email=?", user.getEmail()));
         return selector.getObject(Date.class);
     }
-
 
     // Look up email in Logins table and return the corresponding password hash
     public static String getPasswordHash(ValidEmail email)
@@ -1262,14 +1232,12 @@ public class SecurityManager
         return getPasswordHash(email.getEmailAddress());
     }
 
-
     // Look up email in Logins table and return the corresponding password hash
     private static String getPasswordHash(String email)
     {
         SqlSelector selector = new SqlSelector(core.getSchema(), new SQLFragment("SELECT Crypt FROM " + core.getTableInfoLogins() + " WHERE Email = ?", email));
         return selector.getObject(String.class);
     }
-
 
     public static boolean matchPassword(String password, String hash)
     {
@@ -1285,25 +1253,21 @@ public class SecurityManager
             return Crypt.MD5.matches(password, hash);
     }
 
-
     // Used only in the case of email change... current email address might be invalid
     static boolean loginExists(String email)
     {
         return (null != getPasswordHash(email));
     }
 
-
     public static boolean loginExists(ValidEmail email)
     {
         return (null != getPasswordHash(email));
     }
 
-
     public static Group createGroup(Container c, String name)
     {
         return createGroup(c, name, PrincipalType.GROUP);
     }
-
 
     public static Group createGroup(Container c, String name, PrincipalType type)
     {
@@ -1329,7 +1293,6 @@ public class SecurityManager
         return createGroup(c, name, type, ownerId);
     }
 
-
     public static Group createGroup(Container c, String name, PrincipalType type, String ownerId)
     {
         String containerId = (null == c || c.isRoot()) ? null : c.getId();
@@ -1354,14 +1317,11 @@ public class SecurityManager
         return group;
     }
 
-
     // Case-insensitive existence check -- disallows groups that differ only by case
     private static boolean groupExists(Container c, String groupName, String ownerId)
     {
         return null != getGroupId(c, groupName, ownerId, false, true);
-
     }
-
 
     public static Group renameGroup(Group group, String newName, User currentUser)
     {
@@ -1380,14 +1340,12 @@ public class SecurityManager
         GroupCache.uncache(group.getUserId());
 
         return getGroup(getGroupId(c, newName));
-
     }
 
     public static void deleteGroup(Group group)
     {
         deleteGroup(group.getUserId());
     }
-
 
     static void deleteGroup(int groupId)
     {
@@ -1439,7 +1397,6 @@ public class SecurityManager
         SecurityPolicyManager.notifyPolicyChanges(resources);
     }
 
-
     public static void deleteGroups(Container c, @Nullable PrincipalType type)
     {
         if (!(null == type || type == PrincipalType.GROUP || type == PrincipalType.MODULE))
@@ -1487,7 +1444,6 @@ public class SecurityManager
         }
     }
 
-
     public static void deleteMember(Group group, UserPrincipal principal)
     {
         int groupId = group.getUserId();
@@ -1495,7 +1451,6 @@ public class SecurityManager
             "WHERE GroupId = ? AND UserId = ?", groupId, principal.getUserId());
         fireDeletePrincipalFromGroup(groupId, principal);
     }
-
 
     // Returns a list of errors
     public static List<String> addMembers(Group group, Collection<? extends UserPrincipal> principals)
@@ -1517,13 +1472,11 @@ public class SecurityManager
         return errors;
     }
 
-
     // Add a single user/group to a single group
     public static void addMember(Group group, UserPrincipal principal) throws InvalidGroupMembershipException
     {
         addMember(group, principal, null);
     }
-
 
     // Internal only; used by junit test
     static void addMember(Group group, UserPrincipal principal, @Nullable Runnable afterAddRunnable) throws InvalidGroupMembershipException
@@ -1539,14 +1492,13 @@ public class SecurityManager
             afterAddRunnable.run();
 
         // If we added a group then check for circular relationship... we check this above, but it's possible that
-        // another thread concurrently made a change that introduced a cycle.  If so, revert the add.
+        // another thread concurrently made a change that introduced a cycle. If so, revert the add.
         if (principal instanceof Group && hasCycle(group))
         {
             deleteMember(group, principal);
             throw new InvalidGroupMembershipException(CIRCULAR_GROUP_ERROR_MESSAGE);
         }
     }
-
 
     // Internal only; used by junit test
     static void addMemberWithoutValidation(Group group, UserPrincipal principal)
@@ -1565,7 +1517,6 @@ public class SecurityManager
 
         fireAddPrincipalToGroup(group, principal);
     }
-
 
     // True if current group relationships cycle through root. Does NOT detect all cycles in the group graph nor even
     // in the subgraph represented by root, just the ones that that link back to root itself.
@@ -1594,8 +1545,7 @@ public class SecurityManager
         return false;
     }
 
-
-    // TODO: getAddMemberError() now uses the cache (see #14383), but this is still an n^2 algorithm.  Better would be for this
+    // TODO: getAddMemberError() now uses the cache (see #14383), but this is still an n^2 algorithm. Better would be for this
     // method to validate an entire collection of candidates at once, and switch getAddMemberError() to call getValidPrincipals()
     // with a singleton.
     public static <K extends UserPrincipal> Collection<K> getValidPrincipals(Group group, Collection<K> candidates)
@@ -1611,7 +1561,6 @@ public class SecurityManager
 
         return valid;
     }
-
 
     // Return an error message if principal can't be added to the group, otherwise return null
     public static String getAddMemberError(Group group, UserPrincipal principal)
@@ -1665,7 +1614,6 @@ public class SecurityManager
         return null;
     }
 
-
     // Site groups are first (if included) followed by project groups. Each list is sorted by name (case-insensitive).
     public static @NotNull List<Group> getGroups(@Nullable Container project, boolean includeGlobalGroups)
     {
@@ -1688,7 +1636,7 @@ public class SecurityManager
         return null != principal ? principal : getGroup(id);
     }
 
-    /** This will preferentially return project users/groups.  If no principal is found at the project level and includeSiteGroups=true, it will check site groups */
+    /** This will preferentially return project users/groups. If no principal is found at the project level and includeSiteGroups=true, it will check site groups */
     @Nullable
     public static UserPrincipal getPrincipal(String name, Container container, boolean includeSiteGroups)
     {
@@ -1793,7 +1741,6 @@ public class SecurityManager
         return HtmlString.of(groupList.toString());
     }
 
-
     /** Returns the requested direct members of this group (non-recursive) */
     public static @NotNull <P extends UserPrincipal> Set<P> getGroupMembers(Group group, MemberType<P> memberType)
     {
@@ -1803,7 +1750,6 @@ public class SecurityManager
 
         return principals;
     }
-
 
     /** Returns the members of this group dictated by memberType, including those in subgroups (recursive) */
     public static @NotNull <P extends UserPrincipal> Set<P> getAllGroupMembers(Group group, MemberType<P> memberType)
@@ -1853,7 +1799,6 @@ public class SecurityManager
         return members;
     }
 
-
     private static <P extends UserPrincipal> void addMembers(Collection<P> principals, int[] ids, MemberType<P> memberType)
     {
         for (int id : ids)
@@ -1863,7 +1808,6 @@ public class SecurityManager
                 principals.add(principal);
         }
     }
-
 
     // get the list of group members that do not need to be direct members because they are a member of a member group (i.e. groups-in-groups)
     public static Map<UserPrincipal, List<UserPrincipal>> getRedundantGroupMembers(Group group)
@@ -1990,7 +1934,6 @@ public class SecurityManager
         return sb.toString();
     }    
 
-
     // TODO: Redundant with getProjectUsers() -- this approach should be more efficient for simple cases
     // TODO: Also redundant with getFolderUserids()
     // TODO: Cache this set
@@ -2002,7 +1945,6 @@ public class SecurityManager
         Selector selector = new SqlSelector(core.getSchema(), sql);
         return new HashSet<>(selector.getCollection(Integer.class));
     }
-
 
     // True fragment -- need to prepend SELECT DISTINCT() or IN () for this to be valid SQL
     public static SQLFragment getProjectUsersSQL(Container c)
@@ -2054,7 +1996,6 @@ public class SecurityManager
 
         return projectUsers;
     }
-
 
     public static Collection<Integer> getFolderUserids(Container c)
     {
@@ -2115,10 +2056,9 @@ public class SecurityManager
         return userIds;
     }
 
-
     public static List<User> getUsersWithPermissions(Container c, Set<Class<? extends Permission>> perms)
     {
-        // No cache right now, but performance seems fine.  After the user list and policy are cached, no other queries occur.
+        // No cache right now, but performance seems fine. After the user list and policy are cached, no other queries occur.
         Collection<User> allUsers = UserManager.getActiveUsers();
         List<User> users = new ArrayList<>(allUsers.size());
         SecurityPolicy policy = c.getPolicy();
@@ -2142,7 +2082,6 @@ public class SecurityManager
 
         return users;
     }
-
 
     /** Returns both users and groups, but direct members only (not recursive) */
     public static List<Pair<Integer, String>> getGroupMemberNamesAndIds(String path)
@@ -2195,7 +2134,6 @@ public class SecurityManager
         return members;
     }
 
-
     /** Returns both users and groups, but direct members only (not recursive) */
     public static String[] getGroupMemberNames(Integer groupId)
     {
@@ -2206,7 +2144,6 @@ public class SecurityManager
             names[i++] = member.getValue();
         return names;
     }
-
 
     /** Takes string such as "/test/subfolder/Users" and returns groupId */
     public static Integer getGroupId(String extraPath)
@@ -2233,13 +2170,11 @@ public class SecurityManager
         return getGroupId(c, group);
     }
 
-
     /** Takes Container (or null for root) and group name; returns groupId */
     public static Integer getGroupId(@Nullable Container c, String group)
     {
         return getGroupId(c, group, null, true);
     }
-
 
     /** Takes Container (or null for root) and group name; returns groupId */
     public static Integer getGroupId(@Nullable Container c, String group, boolean throwOnFailure)
@@ -2247,15 +2182,13 @@ public class SecurityManager
         return getGroupId(c, group, null, throwOnFailure);
     }
 
-
     public static Integer getGroupId(@Nullable Container c, String groupName, @Nullable String ownerId, boolean throwOnFailure)
     {
         return getGroupId(c, groupName, ownerId, throwOnFailure, false);
     }
 
-
     // This is temporary... in CPAS 1.5 on PostgreSQL it was possible to create two groups in the same container that differed only
-    // by case (this was not possible on SQL Server).  In CPAS 1.6 we disallow this on PostgreSQL... but we still need to be able to
+    // by case (this was not possible on SQL Server). In CPAS 1.6 we disallow this on PostgreSQL... but we still need to be able to
     // retrieve group IDs in a case-sensitive manner.
     // TODO: For CPAS 1.7: this should always be case-insensitive (we will clean up the database by renaming duplicate groups)
     private static Integer getGroupId(@Nullable Container c, String groupName, @Nullable String ownerId, boolean throwOnFailure, boolean caseInsensitive)
@@ -2295,14 +2228,6 @@ public class SecurityManager
         return groupId;
     }
 
-    // TODO: Update to iterate through all configurations
-    public static boolean isLdapEmail(ValidEmail email)
-    {
-        String ldapDomain = AuthenticationManager.getLdapDomain();
-        return AuthenticationManager.ALL_DOMAINS.equals(ldapDomain) || ldapDomain != null && email.getEmailAddress().endsWith("@" + ldapDomain.toLowerCase());
-    }
-
-
     public interface ViewFactory
     {
         HttpView createView(ViewContext context);
@@ -2318,7 +2243,6 @@ public class SecurityManager
     {
         return VIEW_FACTORIES;
     }
-
 
     public interface TermsOfUseProvider
     {
@@ -2342,7 +2266,6 @@ public class SecurityManager
     {
         return TERMS_OF_USE_PROVIDERS;
     }
-
 
     public static class TestCase extends Assert
     {
@@ -2867,13 +2790,13 @@ public class SecurityManager
 
             if (newUserStatus.isLdapEmail())
             {
-                message.append(newUser.getEmail()).append(" added as a new user to the system.  This user will be authenticated via LDAP.");
-                UserManager.addToUserHistory(newUser, newUser.getEmail() + " was added to the system.  This user will be authenticated via LDAP.");
+                message.append(newUser.getEmail()).append(" added as a new user to the system. This user will be authenticated via LDAP.");
+                UserManager.addToUserHistory(newUser, newUser.getEmail() + " was added to the system. This user will be authenticated via LDAP.");
             }
             else if (sendMail)
             {
                 message.append(email.getEmailAddress()).append(" added as a new user to the system and emailed successfully.");
-                UserManager.addToUserHistory(newUser, newUser.getEmail() + " was added to the system.  Verification email was sent successfully.");
+                UserManager.addToUserHistory(newUser, newUser.getEmail() + " was added to the system. Verification email was sent successfully.");
             }
             else
             {
@@ -2904,7 +2827,7 @@ public class SecurityManager
             User newUser = UserManager.getUser(email);
 
             if (null != newUser)
-                UserManager.addToUserHistory(newUser, newUser.getEmail() + " was added to the system.  Sending the verification email failed.");
+                UserManager.addToUserHistory(newUser, newUser.getEmail() + " was added to the system. Sending the verification email failed.");
         }
         catch (SecurityManager.UserManagementException e)
         {
@@ -2959,14 +2882,14 @@ public class SecurityManager
             try
             {
                 SecurityManager.sendRegistrationEmail(context, email, null, newUserStatus, extraParameters, registrationProviderName, true);
-                UserManager.addToUserHistory(newUser, newUser.getEmail() + " was added to the system via self-registration.  Verification email was sent successfully.");
+                UserManager.addToUserHistory(newUser, newUser.getEmail() + " was added to the system via self-registration. Verification email was sent successfully.");
             }
             catch (ConfigurationException e)
             {
                 User createdUser = UserManager.getUser(email);
 
                 if (null != createdUser)
-                    UserManager.addToUserHistory(createdUser, createdUser.getEmail() + " was added to the system via self-registration.  Sending the verification email failed.");
+                    UserManager.addToUserHistory(createdUser, createdUser.getEmail() + " was added to the system via self-registration. Sending the verification email failed.");
                 throw e;
             }
         }
@@ -3046,22 +2969,6 @@ public class SecurityManager
         SecurityPolicyManager.savePolicy(policy);
     }
 
-    public static boolean containsOnlyAdminPermissions(Container c)
-    {
-        SecurityPolicy policy = c.getPolicy();
-
-        for (RoleAssignment ra : policy.getAssignments())
-        {
-            Role role = ra.getRole();
-            Set<Class<? extends Permission>> permissions = role.getPermissions();
-            if (!(role instanceof ProjectAdminRole) && !(role instanceof FolderAdminRole)
-                && !(permissions.contains(SiteAdminPermission.class) && !permissions.contains(ApplicationAdminPermission.class)))
-                return false;
-        }
-
-        return true;
-    }
-
     public static void setInheritPermissions(Container c)
     {
         SecurityPolicyManager.deletePolicy(c);
@@ -3134,15 +3041,23 @@ public class SecurityManager
         {
             super(name);
 
-            _replacements.add(new ReplacementParam<String>("verificationURL", String.class, "Link for a user to set a password"){
+            _replacements.add(new ReplacementParam<>("verificationURL", String.class, "Link for a user to set a password")
+            {
                 @Override
-                public String getValue(Container c) {return _verificationUrl;}
+                public String getValue(Container c)
+                {
+                    return _verificationUrl;
+                }
             });
-            _replacements.add(new ReplacementParam<String>("emailAddress", String.class, "The email address of the user performing the operation"){
+            _replacements.add(new ReplacementParam<>("emailAddress", String.class, "The email address of the user performing the operation")
+            {
                 @Override
-                public String getValue(Container c) {return _originatingUser == null ? null : _originatingUser.getEmail();}
+                public String getValue(Container c)
+                {
+                    return _originatingUser == null ? null : _originatingUser.getEmail();
+                }
             });
-            _replacements.add(new ReplacementParam<String>("recipient", String.class, "The email address on the 'to:' line")
+            _replacements.add(new ReplacementParam<>("recipient", String.class, "The email address on the 'to:' line")
             {
                 @Override
                 public String getValue(Container c)
@@ -3182,12 +3097,12 @@ public class SecurityManager
                 "Welcome to the ^organizationName^ ^siteShortName^ Web Site new user registration";
         protected static final String DEFAULT_BODY =
                 "^optionalMessage^\n\n" +
-                "You now have an account on the ^organizationName^ ^siteShortName^ web site.  We are sending " +
+                "You now have an account on the ^organizationName^ ^siteShortName^ web site. We are sending " +
                 "you this message to verify your email address and to allow you to create a password that will provide secure " +
-                "access to your data on the web site.  To complete the registration process, simply click the link below or " +
-                "copy it to your browser's address bar.  You will then be asked to choose a password.\n\n" +
+                "access to your data on the web site. To complete the registration process, simply click the link below or " +
+                "copy it to your browser's address bar. You will then be asked to choose a password.\n\n" +
                 "^verificationURL^\n\n" +
-                "The ^siteShortName^ home page is ^homePageURL^.  If you have any questions don't hesitate to " +
+                "The ^siteShortName^ home page is ^homePageURL^. If you have any questions don't hesitate to " +
                 "contact the ^siteShortName^ team at ^systemEmail^.";
 
         @SuppressWarnings("UnusedDeclaration") // Constructor called via reflection
@@ -3230,7 +3145,7 @@ public class SecurityManager
         protected static final String DEFAULT_BODY =
                 "We have reset your password on the ^organizationName^ ^siteShortName^ web site. " +
                 "To sign in to the system you will need " +
-                "to specify a new password.  Click the link below or copy it to your browser's address bar.  You will then be " +
+                "to specify a new password. Click the link below or copy it to your browser's address bar. You will then be " +
                 "asked to enter a new password.\n\n" +
                 "^verificationURL^\n\n" +
                 "The ^siteShortName^ home page is ^homePageURL^.";
@@ -3272,15 +3187,12 @@ public class SecurityManager
     {
         int id = group.getUserId();
 
-        switch(id)
+        return switch (id)
         {
-            case Group.groupAdministrators:
-                return "Site Administrators";
-            case Group.groupUsers:
-                return "All Site Users";
-            default:
-                return group.getName();
-        }
+            case Group.groupAdministrators -> "Site Administrators";
+            case Group.groupUsers -> "All Site Users";
+            default -> group.getName();
+        };
     }
 
     public static boolean canSeeUserDetails(Container c, User user)
@@ -3291,7 +3203,7 @@ public class SecurityManager
     public static boolean canSeeAuditLog(User user)
     {
         //
-        // Only returns true if the user has the site permission.  If the user is an admin, then the permission
+        // Only returns true if the user has the site permission. If the user is an admin, then the permission
         // check on the current container filter will return true
         //
         return user.hasRootPermission(CanSeeAuditLogPermission.class);

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -2790,8 +2790,8 @@ public class SecurityManager
 
             if (newUserStatus.isLdapEmail())
             {
-                message.append(newUser.getEmail()).append(" added as a new user to the system. This user will be authenticated via LDAP.");
-                UserManager.addToUserHistory(newUser, newUser.getEmail() + " was added to the system. This user will be authenticated via LDAP.");
+                message.append(newUser.getEmail()).append(" added as a new user to the system and NOT emailed since this user will be authenticated via LDAP.");
+                UserManager.addToUserHistory(newUser, newUser.getEmail() + " was added to the system NOT emailed since this user will be authenticated via LDAP.");
             }
             else if (sendMail)
             {

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1810,7 +1810,7 @@ public class LoginController extends SpringActionController
             if (!SecurityManager.loginExists(email))
             {
                 if (AuthenticationManager.isLdapEmail(email))
-                    errors.reject("setPassword", "Your account will use your institution's LDAP authentication server and you do not need to set a separate password.");
+                    errors.reject("setPassword", "Your account will authenticate using LDAP and you do not need to set a separate password.");
                 else
                     errors.reject("setPassword", "This email address is not associated with an account. Make sure you've copied the entire link into your browser's address bar.");
             }

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -827,12 +827,6 @@ public class LoginController extends SpringActionController
             return Pair.of(false, "Reset Password failed: " + rawEmail + " is not a valid email address.");
         }
 
-        if (SecurityManager.isLdapEmail(email))
-        {
-            // ldap authentication users must reset through their ldap administrator
-            return Pair.of(false, "Reset Password failed: " + email + " is an LDAP email address. Please contact your LDAP administrator to reset the password for this account.");
-        }
-
         // Every case below this point should result in the same, generic message being displayed to the user to avoid revealing any details about accounts, #33907
 
         final User user = UserManager.getUser(email);
@@ -846,7 +840,7 @@ public class LoginController extends SpringActionController
         if (!SecurityManager.loginExists(email))
         {
             _log.error("Password reset attempted for an account that doesn't have a password: " + email);
-            return resetPasswordResponse(user, "You cannot reset the password for your account because it doesn't have a password. This usually means you log in via a single sign-on provider. Contact a server administrator if you have questions.", "Reset Password failed: " + email + " does not have a password");
+            return resetPasswordResponse(user, "You cannot reset the password for your account because it doesn't have a password. This usually means you log in via LDAP or single sign-on. Contact a server administrator if you have questions.", "Reset Password failed: " + email + " does not have a password");
         }
 
         if (!user.isActive())
@@ -1151,7 +1145,7 @@ public class LoginController extends SpringActionController
 
         if (null != cookies)
         {
-            // Starting in LabKey 9.1, the cookie value is URL encoded to allow for special characters like @.  See #6736.
+            // Starting in LabKey 9.1, the cookie value is URL encoded to allow for special characters like @. See #6736.
             String encodedEmail = PageFlowUtil.getCookieValue(cookies, "email", null);
 
             if (null != encodedEmail)
@@ -1687,7 +1681,7 @@ public class LoginController extends SpringActionController
         }
         catch (UserManagementException e)
         {
-            errors.reject("setPassword", "Setting password failed: " + e.getMessage() + ".  Contact the " + LookAndFeelProperties.getInstance(ContainerManager.getRoot()).getShortName() + " team.");
+            errors.reject("setPassword", "Setting password failed: " + e.getMessage() + ". Contact the " + LookAndFeelProperties.getInstance(ContainerManager.getRoot()).getShortName() + " team.");
             return null;
         }
 
@@ -1699,7 +1693,7 @@ public class LoginController extends SpringActionController
         }
         catch (UserManagementException e)
         {
-            errors.reject("setPassword", "Resetting verification failed.  Contact the " + LookAndFeelProperties.getInstance(ContainerManager.getRoot()).getShortName() + " team.");
+            errors.reject("setPassword", "Resetting verification failed. Contact the " + LookAndFeelProperties.getInstance(ContainerManager.getRoot()).getShortName() + " team.");
             return null;
         }
 
@@ -1803,7 +1797,7 @@ public class LoginController extends SpringActionController
         {
             if (user == null)
             {
-                errors.reject("setPassword", "This user doesn't exist.  Make sure you've copied the entire link into your browser's address bar.");
+                errors.reject("setPassword", "This user doesn't exist. Make sure you've copied the entire link into your browser's address bar.");
             }
             else if (!user.isActive())
             {
@@ -1815,10 +1809,10 @@ public class LoginController extends SpringActionController
         {
             if (!SecurityManager.loginExists(email))
             {
-                if (SecurityManager.isLdapEmail(email))
+                if (AuthenticationManager.isLdapEmail(email))
                     errors.reject("setPassword", "Your account will use your institution's LDAP authentication server and you do not need to set a separate password.");
                 else
-                    errors.reject("setPassword", "This email address is not associated with an account.  Make sure you've copied the entire link into your browser's address bar.");
+                    errors.reject("setPassword", "This email address is not associated with an account. Make sure you've copied the entire link into your browser's address bar.");
             }
             else if (SecurityManager.isVerified(email))
                 errors.reject("setPassword", "This email address has already been verified.");
@@ -1826,7 +1820,7 @@ public class LoginController extends SpringActionController
                 errors.reject("setPassword", "Make sure you've copied the entire link into your browser's address bar.");
             else
                 // Incorrect verification string
-                errors.reject("setPassword", "Verification failed.  Make sure you've copied the entire link into your browser's address bar.");
+                errors.reject("setPassword", "Verification failed. Make sure you've copied the entire link into your browser's address bar.");
         }
     }
 
@@ -1947,7 +1941,7 @@ public class LoginController extends SpringActionController
             }
             catch (InvalidEmailException e)
             {
-                errors.rejectValue("email", ERROR_MSG, "The string '" + PageFlowUtil.filter(form.getEmail()) + "' is not a valid email address.  Please enter an email address in this form: user@domain.tld");
+                errors.rejectValue("email", ERROR_MSG, "The string '" + PageFlowUtil.filter(form.getEmail()) + "' is not a valid email address. Please enter an email address in this form: user@domain.tld");
             }
 
             return success;

--- a/core/src/org/labkey/core/security/GroupView.java
+++ b/core/src/org/labkey/core/security/GroupView.java
@@ -17,7 +17,6 @@
 package org.labkey.core.security;
 
 import org.apache.commons.lang3.StringUtils;
-import org.labkey.api.security.AuthenticationManager;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.util.HtmlString;
@@ -46,7 +45,6 @@ public class GroupView extends JspView<GroupView.GroupBean>
         bean.members = members;
         bean.messages = messages;
         bean.isSystemGroup = systemGroup;
-        bean.ldapDomain = AuthenticationManager.getLdapDomain();
         bean.redundantMembers = redundantMembers;
     }
 
@@ -57,7 +55,6 @@ public class GroupView extends JspView<GroupView.GroupBean>
         public Collection<UserPrincipal> members;
         public List<HtmlString> messages;
         public boolean isSystemGroup;
-        public String ldapDomain;
         public Map<UserPrincipal, List<UserPrincipal>> redundantMembers;
 
         public String displayRedundancyReasonHTML(UserPrincipal principal)

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -58,6 +58,7 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.AuthenticationConfiguration.LoginFormAuthenticationConfiguration;
 import org.labkey.api.security.AuthenticationConfiguration.SSOAuthenticationConfiguration;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.*;
@@ -1789,24 +1790,27 @@ public class SecurityController extends SpringActionController
             if (!loginExists)
                 throw new NotFoundException(emailAddress + " does not seem to have a password");
 
-            // TODO: Use SecurityManager.isLdapEmail() once that method is fixed. See #42435.
-            boolean ldapConfigured = null != AuthenticationManager.getLdapDomain();
-            Collection<SSOAuthenticationConfiguration> ssoConfigs = AuthenticationManager.getActiveConfigurations(SSOAuthenticationConfiguration.class);
-
             List<String> authMethods = new LinkedList<>();
-            String ssoDetails = "";
 
-            if (ldapConfigured)
-                authMethods.add("LDAP");
+            Collection<LoginFormAuthenticationConfiguration> formConfigs = AuthenticationManager.getActiveConfigurations(LoginFormAuthenticationConfiguration.class);
+            String ldapDetails = formConfigs.stream()
+                .filter(ac->null != ac.getDomain())
+                .filter(ac->!AuthenticationManager.ALL_DOMAINS.equals(ac.getDomain()))
+                .filter(ac->StringUtils.endsWithIgnoreCase(emailAddress, "@" + ac.getDomain()))
+                .map(AuthenticationConfiguration::getDescription)
+                .collect(Collectors.joining(", "));
+            if (!ldapDetails.isBlank())
+                authMethods.add("LDAP (" + ldapDetails + ")");
 
+            Collection<SSOAuthenticationConfiguration> ssoConfigs = AuthenticationManager.getActiveConfigurations(SSOAuthenticationConfiguration.class);
             if (!ssoConfigs.isEmpty())
             {
-                authMethods.add("SSO");
-                ssoDetails = " (" +
+                authMethods.add("SSO (" +
                     ssoConfigs.stream()
                         .map(AuthenticationConfiguration::getDescription)
                         .collect(Collectors.joining(", ")) +
-                    ")";
+                    ")"
+                );
             }
 
             String guidance;
@@ -1814,7 +1818,7 @@ public class SecurityController extends SpringActionController
             if (authMethods.isEmpty())
                 guidance = "have no way to login!";
             else
-                guidance = "be able to login via " + String.join(" or ", authMethods) + ssoDetails + " only.";
+                guidance = "be able to login via " + String.join(" or ", authMethods) + " only.";
 
             return HtmlString.of("Are you sure you want to delete the current password for " + emailAddress + "? Once deleted, this user will " + guidance);
         }

--- a/core/src/org/labkey/core/security/addUsers.jsp
+++ b/core/src/org/labkey/core/security/addUsers.jsp
@@ -70,7 +70,7 @@
         {
             if (textElem.value != null && textElem.value.length > 0)
             {
-                var target = "<%=h(new UserUrlsImpl().getUserAccessURL(ContainerManager.getRoot()))%>newEmail=" + textElem.value;
+                var target = "<%=h(new UserUrlsImpl().getUserAccessURL(ContainerManager.getRoot()).addParameter("newEmail", null))%>" + textElem.value;
                 window.open(target, "permissions", "height=450,width=500,scrollbars=yes,status=yes,toolbar=no,menubar=no,location=no,resizable=yes");
             }
         }
@@ -98,28 +98,27 @@
     <table><%
             if (getErrors("form").hasErrors());
             { %>
-        <tr><td colspan="3"><labkey:errors /></td></tr><%
+        <tr><td><labkey:errors /></td></tr><%
             }
             HtmlString msg = form.getMessage();
             if (!HtmlString.isBlank(msg))
             {
-                %><tr><td colspan="3"><div class="labkey-message"><%=msg%></div></td></tr><%
+                %><tr><td><div class="labkey-message"><%=msg%></div></td></tr><%
             }
         %>
         <tr>
-            <td colspan="3">Add new users. Enter one or more email addresses, each on its own line.</td>
+            <td>Add new users. Enter one or more email addresses, each on its own line.</td>
         </tr>
         <tr>
-            <td colspan="3">
+            <td>
                 <textarea name="newUsers" id="newUsers" cols=70 rows=20></textarea><br/><br/>
             </td>
         <tr>
-            <td><input type=checkbox id="cloneUserCheck" name="cloneUserCheck" onclick="enableText();">Clone permissions from user:</td>
-            <td id="auto-completion-div"></td>
-            <td><div id=permissions><a href="#blank" style="display:none" onclick="showUserAccess();">permissions</a></div></td>
+            <td><input type=checkbox id="cloneUserCheck" name="cloneUserCheck" onclick="enableText();">Clone permissions from user:<span id="auto-completion-div"></span>
+            <span id=permissions><a href="#blank" style="display:none" onclick="showUserAccess();">permissions</a></span></td>
         </tr>
-        <tr><td colspan="3">
-            <input type=checkbox name="sendMail" id="sendMail" checked><label for="sendmail"><%=AuthenticationManager.getStandardSendVerificationEmailsMessage()%></label><br><br>
+        <tr><td>
+            <br><input type=checkbox name="sendMail" id="sendMail" checked><label for="sendmail"><%=AuthenticationManager.getStandardSendVerificationEmailsMessage()%></label><br><br>
         </td></tr>
         <tr>
             <td>

--- a/core/src/org/labkey/core/security/addUsers.jsp
+++ b/core/src/org/labkey/core/security/addUsers.jsp
@@ -119,13 +119,7 @@
             <td><div id=permissions><a href="#blank" style="display:none" onclick="showUserAccess();">permissions</a></div></td>
         </tr>
         <tr><td colspan="3">
-            <input type=checkbox name="sendMail" id="sendMail" checked><label for="sendmail">Send notification emails to all new<%
-            String LDAPDomain = AuthenticationManager.getLdapDomain();
-            if (LDAPDomain != null && LDAPDomain.length() > 0 && !AuthenticationManager.ALL_DOMAINS.equals(LDAPDomain))
-            {
-                %>, non-<%=h(LDAPDomain)%><%
-            }
-            %> users</label><br><br>
+            <input type=checkbox name="sendMail" id="sendMail" checked><label for="sendmail"><%=AuthenticationManager.getStandardSendVerificationEmailsMessage()%></label><br><br>
         </td></tr>
         <tr>
             <td>

--- a/core/src/org/labkey/core/security/group.jsp
+++ b/core/src/org/labkey/core/security/group.jsp
@@ -18,6 +18,7 @@
 <%@ page import="org.apache.commons.lang3.StringUtils" %>
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.data.ContainerManager" %>
+<%@ page import="org.labkey.api.security.AuthenticationManager" %>
 <%@ page import="org.labkey.api.security.Group" %>
 <%@ page import="org.labkey.api.security.PrincipalType" %>
 <%@ page import="org.labkey.api.security.SecurityUrls" %>
@@ -298,12 +299,7 @@ else
 <div id="add-members">
 <span style="font-weight:bold">Add New Members</span> (enter one email address or group per line):<br>
     <labkey:autoCompleteTextArea name="names" url="<%=completionUrl%>" rows="8" cols="70"/>
-    <input type="checkbox" name="sendEmail" value="true" checked>Send notification emails to all new<%
-if (null != bean.ldapDomain && bean.ldapDomain.length() != 0 && !org.labkey.api.security.AuthenticationManager.ALL_DOMAINS.equals(bean.ldapDomain))
-{
-    %>, non-<%= h(bean.ldapDomain) %><%
-}
-%> users.<br><br>
+    <input type="checkbox" name="sendEmail" value="true" checked><%=AuthenticationManager.getStandardSendVerificationEmailsMessage()%><br><br>
 <span style="font-weight:bold">Include a message</span> with the new user mail (optional):<br>
     <textarea rows="8" cols="72" name="mailPrefix"></textarea><br>
 <input type="hidden" name="group" value="<%= h(bean.groupName) %>">

--- a/study/src/org/labkey/study/controllers/specimen/ShowGroupMembersAction.java
+++ b/study/src/org/labkey/study/controllers/specimen/ShowGroupMembersAction.java
@@ -17,7 +17,6 @@ package org.labkey.study.controllers.specimen;
 
 import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.action.FormViewAction;
-import org.labkey.api.security.AuthenticationManager;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityUrls;
@@ -235,7 +234,6 @@ public class ShowGroupMembersAction extends FormViewAction<ShowGroupMembersActio
         private final SpecimenRequestActor _actor;
         private final LocationImpl _location;
         private final User[] _members;
-        private final String _ldapDomain;
         private final ActionURL _returnUrl;
 
         public GroupMembersBean(SpecimenRequestActor actor, LocationImpl location, User[] members, ActionURL returnUrl)
@@ -243,7 +241,6 @@ public class ShowGroupMembersAction extends FormViewAction<ShowGroupMembersActio
             _actor = actor;
             _location = location;
             _members = members;
-            _ldapDomain = AuthenticationManager.getLdapDomain();
             _returnUrl = returnUrl;
         }
 
@@ -260,11 +257,6 @@ public class ShowGroupMembersAction extends FormViewAction<ShowGroupMembersActio
         public LocationImpl getLocation()
         {
             return _location;
-        }
-
-        public String getLdapDomain()
-        {
-            return _ldapDomain;
         }
 
         public ActionURL getReturnUrl()

--- a/study/src/org/labkey/study/view/specimen/groupMembers.jsp
+++ b/study/src/org/labkey/study/view/specimen/groupMembers.jsp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 %>
+<%@ page import="org.labkey.api.security.AuthenticationManager" %>
 <%@ page import="org.labkey.api.security.User" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
@@ -68,14 +69,7 @@
         <labkey:autoCompleteTextArea name="names"
                                      url="<%=bean.getCompleteUsersPrefix()%>"
                                      rows="8" cols="30"/><br>
-        <input type="checkbox" name="sendEmail" value="true" checked>Send notification emails to all
-        new<%
-            if (bean.getLdapDomain() != null && bean.getLdapDomain().length() > 0 && !org.labkey.api.security.AuthenticationManager.ALL_DOMAINS.equals(bean.getLdapDomain()))
-            {
-        %>, non-<%= h(bean.getLdapDomain()) %>
-        <%
-            }
-        %> users<br><br>
+        <input type="checkbox" name="sendEmail" value="true" checked><%=AuthenticationManager.getStandardSendVerificationEmailsMessage()%><br><br>
         <input type="hidden" name="id" value="<%= bean.getActor().getRowId() %>">
 
         <%


### PR DESCRIPTION
#### Rationale
[Issue 42435: Support multiple LDAP configurations in admin workflows and messages](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42435)

#### Related Pull Requests
* https://github.com/LabKey/ldap/pull/36

#### Changes
* Collect and cache LDAP domains from all authentication configurations
* Use all the collected LDAP domains when generating admin guidance and determining LDAP email addresses