### PR TITLE
Issue 42822: Merging, alternative keyed, detailed logging ETLs fail on resolving PK

### DIFF
--- a/api/src/org/labkey/api/dataiterator/CachingDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/CachingDataIterator.java
@@ -158,6 +158,17 @@ public class CachingDataIterator extends AbstractDataIterator implements Scrolla
     @Override
     public Object get(int i)
     {
+        if (_currentRowArray == null)
+        {
+            // No row available
+            if (i == 0)
+            {
+                // Use null to signal we're not on a real data row
+                return null;
+            }
+            // Otherwise, no value available to share
+            throw new IllegalStateException("No current row");
+        }
         return _currentRowArray[i];
     }
 

--- a/api/src/org/labkey/api/dataiterator/CopyConfig.java
+++ b/api/src/org/labkey/api/dataiterator/CopyConfig.java
@@ -24,6 +24,7 @@ import org.labkey.api.query.SchemaKey;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.remoteapi.query.Filter;
 
+import javax.validation.constraints.NotNull;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -433,6 +434,7 @@ public class CopyConfig
         _saveState = saveState;
     }
 
+    @NotNull
     public Set<String> getAlternateKeys()
     {
         return Collections.unmodifiableSet(_alternateKeys);

--- a/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
@@ -174,6 +174,7 @@ public class DataIteratorContext
         return _dontUpdateColumnNames;
     }
 
+    @NotNull
     public Set<String> getAlternateKeys()
     {
         return _alternateKeys;

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -358,6 +358,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
     @Override
     public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
     {
+        configureDataIteratorContext(context);
         return _importRowsUsingDIB(user, container, rows, null, context, extraScriptContext);
     }
 

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -187,13 +187,14 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         }
     }
 
-    protected DataIteratorContext getDataIteratorContext(BatchValidationException errors, InsertOption forImport, Map<Enum, Object> configParameters)
+    protected final DataIteratorContext getDataIteratorContext(BatchValidationException errors, InsertOption forImport, Map<Enum, Object> configParameters)
     {
         if (null == errors)
             errors = new BatchValidationException();
         DataIteratorContext context = new DataIteratorContext(errors);
         context.setInsertOption(forImport);
         context.setConfigParameters(configParameters);
+        configureDataIteratorContext(context);
         return context;
     }
 
@@ -201,8 +202,10 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
      *  if QUS want to use something other than PK's to select existing rows for merge it can override this method
      * Used only for generating  ExistingRecordDataIterator at the moment
      */
-    protected Set<String> getSelectKeys()
+    protected Set<String> getSelectKeys(DataIteratorContext context)
     {
+        if (!context.getAlternateKeys().isEmpty())
+            return context.getAlternateKeys();
         return null;
     }
 
@@ -216,7 +219,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         if (_enableExistingRecordsDataIterator)
         {
             // some tables need to generate PK's, so they need to add ExistingRecordDataIterator in persistRows() (after generating PK, before inserting)
-            dib = ExistingRecordDataIterator.createBuilder(dib, getQueryTable(), getSelectKeys());
+            dib = ExistingRecordDataIterator.createBuilder(dib, getQueryTable(), getSelectKeys(context));
         }
         dib = ((UpdateableTableInfo)getQueryTable()).persistRows(dib, context);
         dib = AttachmentDataIterator.getAttachmentDataIteratorBuilder(getQueryTable(), dib, user, context.getInsertOption().batch ? getAttachmentDirectory() : null, container, getAttachmentParentFactory());

--- a/api/src/org/labkey/api/query/QueryUpdateService.java
+++ b/api/src/org/labkey/api/query/QueryUpdateService.java
@@ -253,4 +253,7 @@ public interface QueryUpdateService extends HasPermission
      * implementations should use this to decide whether to do optional expensive operations upon updates.
      */
     boolean isBulkLoad();
+
+    /** Setup the data iterator for any special behavior needed for the target table */
+    default void configureDataIteratorContext(DataIteratorContext context) {}
 }

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -84,19 +84,15 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
     }
 
     @Override
-    protected DataIteratorContext getDataIteratorContext(BatchValidationException errors, InsertOption insertOption, Map<Enum, Object> configParameters)
+    public void configureDataIteratorContext(DataIteratorContext context)
     {
-        DataIteratorContext context = super.getDataIteratorContext(errors, insertOption, configParameters);
-        if (insertOption.batch)
+        if (context.getInsertOption().batch)
         {
             context.setMaxRowErrors(100);
             context.setFailFast(false);
         }
 
-        Map<Enum, Object> options = new HashMap<>();
-        options.put(ConfigParameters.TrimStringRight, Boolean.TRUE);
-        context.setConfigParameters(options);
-        return context;
+        context.putConfigParameter(ConfigParameters.TrimStringRight, Boolean.TRUE);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Improvements to how we do detailed audit logging broke an ETL scenario where we're merging based on a column that's not the target table's PK

#### Related Pull Requests
* https://github.com/LabKey/dataintegration/pull/99

#### Changes
* Propagate alternateKeys early enough that the DataIteratorContext can be configured properly for the loadRows() call
* Use alternateKeys for finding rows in ExistingRecordDataIterator
* Leverage QueryUpdateService setup for DataIteratorContext in more places
* Use loadRows() for merge ETLs instead of mergeRows()