### PR TITLE
Add support for generated Unique ID fields in Sample Types

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -40,6 +40,7 @@ import org.labkey.api.dataiterator.CachingDataIterator;
 import org.labkey.api.dataiterator.DataIteratorUtil;
 import org.labkey.api.dataiterator.DiskCachingDataIterator;
 import org.labkey.api.dataiterator.ExistingRecordDataIterator;
+import org.labkey.api.dataiterator.GenerateUniqueDataIterator;
 import org.labkey.api.dataiterator.RemoveDuplicatesDataIterator;
 import org.labkey.api.dataiterator.ResultSetDataIterator;
 import org.labkey.api.dataiterator.SimpleTranslator;
@@ -50,9 +51,11 @@ import org.labkey.api.markdown.MarkdownService;
 import org.labkey.api.module.CodeOnlyModule;
 import org.labkey.api.module.FolderTypeManager;
 import org.labkey.api.module.JavaVersion;
+import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.module.ModuleDependencySorter;
 import org.labkey.api.module.ModuleHtmlView;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.module.ModuleXml;
 import org.labkey.api.module.TomcatVersion;
 import org.labkey.api.query.AbstractQueryUpdateService;
@@ -158,6 +161,7 @@ public class ApiModule extends CodeOnlyModule
             FieldKey.TestCase.class,
             FileType.TestCase.class,
             FileUtil.TestCase.class,
+            GenerateUniqueDataIterator.TestCase.class,
             HelpTopic.TestCase.class,
             InlineInClauseGenerator.TestCase.class,
             JavaVersion.TestCase.class,
@@ -289,6 +293,8 @@ public class ApiModule extends CodeOnlyModule
         AuthenticationConfiguration.SSOAuthenticationConfiguration config = AuthenticationManager.getAutoRedirectSSOAuthConfiguration();
         if (config != null)
             json.put("AutoRedirectSSOAuthConfiguration", config.getDescription());
+
+        json.put("moduleNames", ModuleLoader.getInstance().getModules().stream().map(module -> module.getName().toLowerCase()).toArray());
         return json;
     }
 }

--- a/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
@@ -656,6 +656,12 @@ public abstract class AbstractWrappedColumnInfo implements ColumnInfo
     }
 
     @Override
+    public boolean isUniqueIdField()
+    {
+        return delegate.isUniqueIdField();
+    }
+
+    @Override
     public String getFriendlyTypeName()
     {
         return delegate.getFriendlyTypeName();

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -597,6 +597,12 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     {
         checkLocked();
         _conceptURI = conceptURI;
+        if (STORAGE_UNIQUE_ID_CONCEPT_URI.equals(conceptURI))
+        {
+            _hasDbSequence = true;
+            _shownInInsertView = false;
+            _isUserEditable = false;
+        }
     }
 
     @Override

--- a/api/src/org/labkey/api/data/ColumnRenderProperties.java
+++ b/api/src/org/labkey/api/data/ColumnRenderProperties.java
@@ -123,6 +123,8 @@ public interface ColumnRenderProperties extends ImportAliasable
 
     boolean isNumericType();
 
+    boolean isUniqueIdField();
+
     default String getFriendlyTypeName()
     {
         return getFriendlyTypeName(getJavaClass());

--- a/api/src/org/labkey/api/data/ColumnRenderPropertiesImpl.java
+++ b/api/src/org/labkey/api/data/ColumnRenderPropertiesImpl.java
@@ -47,6 +47,9 @@ import java.util.regex.Pattern;
  */
 public abstract class ColumnRenderPropertiesImpl implements MutableColumnRenderProperties
 {
+    public static final String STORAGE_UNIQUE_ID_CONCEPT_URI = "http://www.labkey.org/types#storageUniqueId";
+    public static final String STORAGE_UNIQUE_ID_SEQUENCE_PREFIX = "org.labkey.api.StorageUniqueId";
+
     protected SortDirection _sortDirection = SortDirection.ASC;
     protected String _inputType;
     protected int _inputLength = -1;
@@ -510,6 +513,12 @@ public abstract class ColumnRenderPropertiesImpl implements MutableColumnRenderP
                 col.isAutoIncrement(),
                 col.isLookup(),
                 col.isHidden());
+    }
+
+    @Override
+    public boolean isUniqueIdField()
+    {
+        return STORAGE_UNIQUE_ID_CONCEPT_URI.equals(getConceptURI());
     }
 
     public static boolean inferIsMeasure(String name, String label, boolean isNumeric, boolean isAutoIncrement, boolean isLookup, boolean isHidden)

--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -261,7 +261,7 @@ public class DataIteratorUtil
                 }
                 if (count > 1)
                 {
-                    setupError.addGlobalError("Two columns mapped to target column: " + e.getKey().toString());
+                    setupError.addGlobalError("Two columns mapped to target column " + e.getKey().toString() + ". Check the column names and import aliases for your data.");
                     break;
                 }
             }

--- a/api/src/org/labkey/api/dataiterator/GenerateUniqueDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/GenerateUniqueDataIterator.java
@@ -1,0 +1,238 @@
+package org.labkey.api.dataiterator;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.data.BaseColumnInfo;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.CoreSchema;
+import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SqlSelector;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.QueryUpdateService;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+
+public class GenerateUniqueDataIterator<V> extends WrapperDataIterator
+{
+    public static final String EXISTING_RECORD_COLUMN_NAME = "_" + GenerateUniqueDataIterator.class.getName() + "#EXISTING_RECORD_COLUMN_NAME";
+
+    final TableInfo target;
+    final ColumnInfo column;
+    final Class<V> clazz;
+    final Function<Integer,List<V>> supplier;
+    final int existingColCount;
+    final int batchSize = 50;
+
+    // NOTE: WrappedDataIterator._delegate may be a logger so keep the original dataiterator
+    final CachingDataIterator cacheIterator;
+
+    // validated unique values
+    final LinkedHashSet<V> uniqueValues = new LinkedHashSet<>();
+    V currentUniqueValue = null;
+
+    GenerateUniqueDataIterator(CachingDataIterator in, TableInfo target, ColumnInfo column, Class<V> clazz, Function<Integer,List<V>> supplier)
+    {
+        super(in);
+        // make sure we're not wrapping delegate with a logger
+        cacheIterator = in;
+
+        this.target = target;
+        this.column = column;
+        this.clazz = clazz;
+        this.supplier = supplier;
+        this.existingColCount = in.getColumnCount();
+    }
+
+    @Override
+    public int getColumnCount()
+    {
+        return _delegate.getColumnCount()+1;
+    }
+
+    @Override
+    public ColumnInfo getColumnInfo(int i)
+    {
+        if (i < existingColCount)
+            return _delegate.getColumnInfo(i);
+        return new BaseColumnInfo(EXISTING_RECORD_COLUMN_NAME, JdbcType.OTHER);
+    }
+
+    @Override
+    public Supplier<Object> getSupplier(int i)
+    {
+        if (i < existingColCount)
+            return _delegate.getSupplier(i);
+        return () -> get(i);
+    }
+
+    @Override
+    public Object get(int i)
+    {
+        if (i < existingColCount)
+            return _delegate.get(i);
+
+        if (null == currentUniqueValue)
+        {
+            var it = uniqueValues.iterator();
+            currentUniqueValue = it.next();
+            it.remove();
+        }
+        return currentUniqueValue;
+    }
+
+    @Override
+    public boolean isConstant(int i)
+    {
+        if (i < existingColCount)
+            return _delegate.isConstant(i);
+        return false;
+    }
+
+    @Override
+    public Object getConstantValue(int i)
+    {
+        if (i < existingColCount)
+            return _delegate.getConstantValue(i);
+        return null;
+    }
+
+    @Override
+    public boolean next() throws BatchValidationException
+    {
+        currentUniqueValue = null;
+        // NOTE: we have to call mark() before we call next() if we want the 'next' row to be cached
+        cacheIterator.mark();
+        boolean ret = super.next();
+        if (ret)
+            generateUniqueValues();
+        return ret;
+    }
+
+    private List<V> getValidatedList(List<V> proposedValues)
+    {
+        SQLFragment sqlf = new SQLFragment("WITH _values_ AS (\nSELECT * FROM (VALUES \n");
+        String comma = "";
+        for (V v : proposedValues)
+        {
+            sqlf.append(comma).append("(?)");
+            sqlf.add(v);
+            comma = "\n,";
+        }
+        sqlf.append("\n) AS _x (value))\n");
+
+        sqlf.append("SELECT _values_.value\n");
+        sqlf.append("FROM _values_ LEFT OUTER JOIN ").append(target.getFromSQL("_target_")).append(" ON ");
+        sqlf.append("(_values_.value").append("=(").append(column.getValueSql("_target_")).append("))\n");
+        sqlf.append("WHERE (").append(column.getValueSql("_target_")).append(") IS NULL");
+
+        return new SqlSelector(target.getSchema(), sqlf).getArrayList(clazz);
+    }
+
+    protected void generateUniqueValues() throws BatchValidationException
+    {
+        if (!uniqueValues.isEmpty())
+            return;
+
+        int count = 1;
+        for (int i=0 ; i<batchSize ; i++)
+        {
+            if (!_delegate.next())
+                break;
+            count++;
+        }
+
+        while (uniqueValues.isEmpty())
+        {
+            List<V> list = supplier.apply(count);
+            List<V> validated = getValidatedList(list);
+            uniqueValues.addAll(validated);
+        }
+        // backup to where we started so caller can iterate through them one at a time
+        cacheIterator.reset();
+        _delegate.next();
+    }
+
+    /**
+     * NOTE: the caller must set the container filter for target appropriately.
+     * e.g. for globally unique constraint the target must have containerFilter already set to ContainerFilter.EVERYTHING
+     */
+    public static <K> DataIteratorBuilder createBuilder(DataIteratorBuilder dib, TableInfo target, ColumnInfo column, Function<Integer,List<K>> supplier)
+    {
+        return context ->
+        {
+            DataIterator di = dib.getDataIterator(context);
+
+            QueryUpdateService.InsertOption option = context.getInsertOption();
+            // TODO behavior for merge/replace???
+
+            CachingDataIterator cache = new CachingDataIterator(di);
+            Class<K> clazz = column.getJdbcType().getJavaClass();
+            return new GenerateUniqueDataIterator<>(cache, target, column, clazz, supplier);
+        };
+    }
+
+
+
+    public static class TestCase extends Assert
+    {
+        private DataIterator make100Rows()
+        {
+            ArrayList<Map<String,Object>> maps = new ArrayList<>();
+            for (int i=0 ; i<100 ; i++)
+                maps.add(CaseInsensitiveHashMap.of("key",i));
+            return new ListofMapsDataIterator(Set.of("key"), maps);
+        }
+
+        AtomicInteger valueGenerator = new AtomicInteger();
+        List<Integer> supply(Integer n)
+        {
+            ArrayList<Integer> ret = new ArrayList<>(n);
+            for (int i=0 ; i<n ; i++)
+                ret.add(valueGenerator.incrementAndGet());
+            return ret;
+        }
+
+        @Test
+        public void testInsert() throws Exception
+        {
+            // get set<> of current container rowids
+            var setExisting = new TreeSet<Integer>();
+            new SqlSelector(CoreSchema.getInstance().getSchema(), "SELECT rowid from core.containers").fillSet(setExisting);
+            valueGenerator.set(setExisting.first());
+
+            // the generate unique dataiterator and make sure there are no collisions
+            TableInfo t = Objects.requireNonNull(CoreSchema.getInstance().getSchema().getTable("containers"));
+            ColumnInfo c = Objects.requireNonNull(t.getColumn("rowid"));
+            DataIterator generate = GenerateUniqueDataIterator.createBuilder(make100Rows(),t,c, this::supply).getDataIterator(new DataIteratorContext());
+
+            var value = generate.getSupplier(generate.getColumnCount());
+            var setGenerated = new TreeSet<Integer>();
+            int mn=1000000, mx=0;
+            while (generate.next())
+            {
+                Integer I = (Integer)value.get();
+                if (I < mn) mn = I;
+                if (I > mx) mx = I;
+                setGenerated.add(I);
+            }
+            // shouldn't be collisions
+            assertFalse(setGenerated.removeAll(setExisting));
+            // shouldn't be gaps either
+            for (int i=mn ; i<=mx ; i++)
+                assertTrue(setGenerated.contains(i) || setExisting.contains(i));
+        }
+    }
+}

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -77,6 +77,8 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
+import static org.labkey.api.data.ColumnRenderPropertiesImpl.STORAGE_UNIQUE_ID_SEQUENCE_PREFIX;
+
 /**
  * SimpleTranslator starts with no output columns (except row number), you must call add() method to add columns.
  *
@@ -1359,14 +1361,22 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         }
     }
 
+    public void addUniqueIdDbSequenceColumns(@Nullable Container c, @NotNull TableInfo target)
+    {
+        target.getColumns().stream().filter(ColumnInfo::isUniqueIdField).forEach(columnInfo -> {
+            addTextSequenceColumn(columnInfo, columnInfo.getDbSequenceContainer(c), STORAGE_UNIQUE_ID_SEQUENCE_PREFIX, null, 100);
+        });
+    }
+
     public void addDbSequenceColumns(@Nullable Container c, @NotNull TableInfo target)
     {
-        target.getColumns().forEach(columnInfo -> {
-            if (columnInfo.hasDbSequence())
-            {
+        target
+            .getColumns()
+            .stream()
+            .filter(columnInfo -> columnInfo.hasDbSequence() && !columnInfo.isUniqueIdField())
+            .forEach(columnInfo -> {
                 addSequenceColumn(columnInfo, columnInfo.getDbSequenceContainer(c), target.getDbSequenceName(columnInfo.getName()), null, 100);
-            }
-        });
+            });
     }
 
     /**
@@ -1448,7 +1458,13 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         return addColumn(col, seqCol);
     }
 
-    protected class SequenceColumn implements Supplier
+    public int addTextSequenceColumn(ColumnInfo col, Container sequenceContainer, String sequenceName, @Nullable Integer sequenceId, @Nullable Integer batchSize)
+    {
+        TextIdColumn textCol = new TextIdColumn(sequenceContainer, sequenceName, sequenceId, batchSize);
+        return addColumn(col, textCol);
+    }
+
+    protected static class SequenceColumn implements Supplier
     {
         // sequence settings
         private final Container seqContainer;
@@ -1467,7 +1483,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             this.batchSize = batchSize == null ? 1 : batchSize;
         }
 
-        private DbSequence getSequence()
+        protected DbSequence getSequence()
         {
             if (sequence == null)
                 sequence = DbSequenceManager.getPreallocatingSequence(seqContainer, seqName, seqId, batchSize);
@@ -1479,6 +1495,27 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         {
             DbSequence sequence = getSequence();
             return sequence.next();
+        }
+    }
+
+    public static class TextIdColumn extends SequenceColumn
+    {
+
+        public TextIdColumn(Container seqContainer, String seqName, @Nullable Integer seqId, @Nullable Integer batchSize)
+        {
+            super(seqContainer, seqName, seqId, batchSize);
+        }
+
+        public static Object getFormattedValue(long value)
+        {
+            return String.format("%09d", value);
+        }
+
+        @Override
+        public Object get()
+        {
+            DbSequence sequence = getSequence();
+            return getFormattedValue(sequence.next());
         }
     }
 

--- a/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
@@ -135,7 +135,7 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
 
         // Add translator/validator for ontology import features
         if (null != OntologyService.get())
-            dib = OntologyService.get().getConceptLookupDataIteratorBuilder(_inputBuilder, _target);
+            dib = OntologyService.get().getConceptLookupDataIteratorBuilder(dib, _target);
 
         DataIterator input = dib.getDataIterator(context);
 
@@ -208,7 +208,7 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
             if (null != to && _convertTypes)
             {
                 if (!unusedCols.containsKey(to.target.getFieldKey()))
-                    setupError.addGlobalError("Two columns mapped to target column: " + to.target.getName());
+                    setupError.addGlobalError("Two columns mapped to target column " + to.target.getName() + ". Check the column names and import aliases for your data.");
                 unusedCols.remove(to.target.getFieldKey());
                 to.indexFrom = i;
                 Integer indexMv = null==to.target.getMvColumnName() ? null : sourceColumnsMap.get(to.target.getMvColumnName().getName());

--- a/api/src/org/labkey/api/exp/property/DomainProperty.java
+++ b/api/src/org/labkey/api/exp/property/DomainProperty.java
@@ -17,6 +17,7 @@
 package org.labkey.api.exp.property;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.ColumnRenderPropertiesImpl;
 import org.labkey.api.data.ConditionalFormat;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ImportAliasable;
@@ -45,6 +46,7 @@ public interface DomainProperty extends ImportAliasable
     FacetingBehaviorType getFacetingBehavior();
     boolean isRequired();
     boolean isHidden();
+    boolean isDeleted();
     boolean isShownInInsertView();
     boolean isShownInUpdateView();
     boolean isShownInDetailsView();
@@ -136,4 +138,9 @@ public interface DomainProperty extends ImportAliasable
 
     void setDerivationDataScope(String type);
     String getDerivationDataScope();
+
+    default boolean isUniqueIdField()
+    {
+        return ColumnRenderPropertiesImpl.STORAGE_UNIQUE_ID_CONCEPT_URI.equals(this.getConceptURI());
+    }
 }

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2029,9 +2029,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.20.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.20.1.tgz",
-      "integrity": "sha1-UDvcuhQD64uELO/l5j0iawqRfRw=",
+      "version": "2.21.0-generate-unique.15",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.21.0-generate-unique.15.tgz",
+      "integrity": "sha1-vwQsUV/LNQMwf+ZR5fELnufTCC0=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.2.1",
-    "@labkey/components": "2.20.1",
+    "@labkey/components": "2.21.0-generate-unique.15",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.0.2"
   },

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -118,6 +118,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.labkey.api.data.ColumnRenderPropertiesImpl.STORAGE_UNIQUE_ID_CONCEPT_URI;
 import static org.labkey.api.exp.api.ExperimentService.MODULE_NAME;
 
 /**
@@ -472,6 +473,12 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
                 results.put("ontologyConceptImportColumnCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.propertydescriptor WHERE conceptimportcolumn IS NOT NULL").getObject(Long.class));
                 results.put("ontologyConceptLabelColumnCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.propertydescriptor WHERE conceptlabelcolumn IS NOT NULL").getObject(Long.class));
 
+                results.put("uniqueIdColumnCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.propertydescriptor WHERE concepturi = ?", STORAGE_UNIQUE_ID_CONCEPT_URI).getObject(Long.class));
+                results.put("sampleTypeWithUniqueIdCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(DISTINCT(DD.DomainURI)) FROM\n" +
+                        "     exp.PropertyDescriptor D \n" +
+                        "         JOIN exp.PropertyDomain PD ON D.propertyId = PD.propertyid\n" +
+                        "         JOIN exp.DomainDescriptor DD on PD.domainID = DD.domainId\n" +
+                        "WHERE D.conceptURI = ?", STORAGE_UNIQUE_ID_CONCEPT_URI).getObject(Long.class));
                 return results;
             });
         }

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -24,22 +24,15 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.AuditTypeEvent;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.Sets;
-import org.labkey.api.data.BaseColumnInfo;
-import org.labkey.api.data.ColumnInfo;
-import org.labkey.api.data.ConditionalFormat;
-import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.DbSchema;
-import org.labkey.api.data.DbScope;
-import org.labkey.api.data.ImportAliasable;
-import org.labkey.api.data.MVDisplayColumnFactory;
-import org.labkey.api.data.PropertyStorageSpec;
-import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.ServerPrimaryKeyLock;
-import org.labkey.api.data.SqlSelector;
-import org.labkey.api.data.Table;
-import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.*;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.DataIteratorContext;
+import org.labkey.api.dataiterator.ListofMapsDataIterator;
+import org.labkey.api.dataiterator.Pump;
+import org.labkey.api.dataiterator.SimpleTranslator;
+import org.labkey.api.dataiterator.StatementDataIterator;
 import org.labkey.api.defaults.DefaultValueService;
 import org.labkey.api.exceptions.OptimisticConflictException;
 import org.labkey.api.exp.ChangePropertyDescriptorException;
@@ -91,6 +84,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
+import java.util.stream.Collectors;
+
+import static org.labkey.api.data.ColumnRenderPropertiesImpl.STORAGE_UNIQUE_ID_SEQUENCE_PREFIX;
 
 public class DomainImpl implements Domain
 {
@@ -724,6 +720,14 @@ public class DomainImpl implements Domain
                     if (!propsAdded.isEmpty())
                     {
                         StorageProvisionerImpl.get().addProperties(this, propsAdded, allowAddBaseProperty);
+                        try
+                        {
+                            ensureUniqueIdValues(propsAdded);
+                        }
+                        catch (Exception e)
+                        {
+                            throw new ChangePropertyDescriptorException(e);
+                        }
                     }
                 }
 
@@ -768,6 +772,77 @@ public class DomainImpl implements Domain
             QueryService.get().updateLastModified();
             transaction.commit();
         }
+    }
+
+    private void ensureUniqueIdValues(List<DomainProperty> propsAdded) throws SQLException, BatchValidationException
+    {
+        SchemaTableInfo table = StorageProvisioner.get().getSchemaTableInfo(this);
+        DbScope scope = table.getSchema().getScope();
+
+        List<DomainProperty> uniqueIdProps = propsAdded.stream().filter(DomainProperty::isUniqueIdField).collect(Collectors.toList());
+        if (uniqueIdProps.isEmpty())
+            return;
+
+        List<ColumnInfo> uniqueIndexCols = new ArrayList<>();
+        table.getUniqueIndices().values().forEach(idx -> {
+            uniqueIndexCols.addAll(idx.second);
+        });
+
+        DbSequence sequence = DbSequenceManager.get(ContainerManager.getRoot(), STORAGE_UNIQUE_ID_SEQUENCE_PREFIX);
+
+        TableSelector selector = new TableSelector(table, uniqueIndexCols, null, null);
+        List<Map<String, Object>> rows = new ArrayList<>();
+        try (Results results = selector.getResults())
+        {
+            results.forEach(rowKeys -> {
+                Map<String, Object> newRow = new CaseInsensitiveHashMap<>();
+                newRow.putAll(rowKeys);
+                uniqueIdProps.forEach(prop -> newRow.put(prop.getName(), SimpleTranslator.TextIdColumn.getFormattedValue(sequence.next())));
+                rows.add(newRow);
+            });
+        }
+        DataIteratorContext ctx = new DataIteratorContext();
+        Set<String> colNames = new HashSet<>();
+        uniqueIndexCols.forEach(col -> {
+            colNames.add(col.getName());
+        });
+        uniqueIdProps.forEach(prop -> {
+            colNames.add(prop.getName());
+        });
+        ListofMapsDataIterator mapsDi = new ListofMapsDataIterator(colNames, rows);
+        mapsDi.setDebugName(table.getName() + ".ensureUniqueIds");
+        SQLFragment sql = new SQLFragment().append("UPDATE ").append(table.getSelectName()).append(" SET ");
+        String separator = "";
+        for (DomainProperty prop: uniqueIdProps)
+        {
+            sql.append(separator).append(prop.getName()).append(" = ?").add(new Parameter(prop.getName(), prop.getJdbcType()));
+            separator = ",";
+        }
+        sql.append(" WHERE ");
+        separator = "";
+        for (ColumnInfo col: uniqueIndexCols)
+        {
+            sql.append(separator).append(col.getName()).append(" = ?").add(new Parameter(col.getName(), col.getJdbcType()));
+            separator = " AND ";
+        }
+
+        DataIteratorBuilder it = context -> {
+            try
+            {
+                ParameterMapStatement stmt1 = new ParameterMapStatement(scope, sql, null);
+                return new StatementDataIterator(table.getSqlDialect(), mapsDi, ctx, stmt1);
+            }
+            catch (SQLException x)
+            {
+                throw new RuntimeSQLException(x);
+            }
+        };
+
+        Pump p = new Pump(it, ctx);
+        p.run();
+
+        if (ctx.getErrors().hasErrors())
+            throw ctx.getErrors();
     }
 
     // Return true if newSize is smaller than oldSize taking into account -1 is max size

--- a/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
@@ -154,6 +154,12 @@ public class DomainPropertyImpl implements DomainProperty
     }
 
     @Override
+    public boolean isDeleted()
+    {
+        return _deleted;
+    }
+
+    @Override
     public boolean isShownInInsertView()
     {
         return _pd.isShownInInsertView();

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -663,8 +663,15 @@ public class StorageProvisionerImpl implements StorageProvisioner
                     {
                         return super.getValueSql(tableAlias);
                     }
+
                 };
                 to.setHidden(from.isHidden());
+                if (from.isUniqueIdField())
+                {
+                    to.setUserEditable(false);
+                    to.setHasDbSequence(true);
+                    to.setShownInInsertView(false);
+                }
                 this.addColumn(to);
             }
         }
@@ -1132,7 +1139,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
             if (kind.hasPropertiesIncludeBaseProperties() && basePropertyNames.contains(p.getName().toLowerCase()))
                 continue;
 
-            if (!seenProperties.add(p.getName()))
+            if (!p.isDeleted() && !seenProperties.add(p.getName()))
             {
                 // There is more than property descriptor with this name attached to this table. This shouldn't happen, but we've seen
                 // at least one occurrence of it in a dev's db, thought to have been caused by in-flux code in 12/2013. The result would

--- a/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
@@ -40,6 +40,7 @@ import org.labkey.test.pages.query.ExecuteQueryPage;
 import org.labkey.test.pages.study.DeleteMultipleVisitsPage;
 import org.labkey.test.pages.study.ManageVisitPage;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.core.webdav.WebDavUploadHelper;
 
 import java.io.File;
 import java.io.IOException;
@@ -220,7 +221,8 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
     @Test
     public void testFailForUndefinedVisitsReload() throws IOException
     {
-        _containerHelper.createSubfolder(getProjectName(), "testFailForUndefinedVisitsReload");
+        String folderName = "testFailForUndefinedVisitsReload";
+        _containerHelper.createSubfolder(getProjectName(), folderName);
 
         // import the full archive and verify the defined visits
         importFolderArchiveWithFailureFlag(INITIAL_FOLDER_ARCHIVE, true, 1, false);
@@ -234,7 +236,7 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
         attemptStudyReloadNow("Error: Could not find file studyload.txt in the pipeline root for Study 001", true);
 
         // change pipeline root and then attempt reload again
-        setPipelineRoot(EXPLODED_FOLDER_ARCHIVE.getAbsolutePath());
+        new WebDavUploadHelper(getProjectName() + "/" + folderName).uploadDirectoryContents(EXPLODED_FOLDER_ARCHIVE);
         goToModule("Pipeline");
         clickButton("Process and Import Data");
         _fileBrowserHelper.uploadFile(EXPLODED_FOLDER_STUDYLOAD_TXT, null, null, true);
@@ -264,7 +266,7 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
 
     private void attemptStudyReloadNow(String expectedMsg, boolean failForUndefinedVisits) throws IOException
     {
-        Connection cn = createDefaultConnection(false);
+        Connection cn = createDefaultConnection();
         PostCommand reloadStudy = new PostCommand("study", "checkForReload");
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("failForUndefinedVisits", failForUndefinedVisits ? "true" : "false");


### PR DESCRIPTION
#### Rationale
For Sample Types, we want to give users the ability to add one or more LabKey-controlled UniqueID fields. The values in these fields are meant to be globally (within a given database) distinct across a server.  They are not user-editable.  

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/486
* #2131

#### Changes
* Add a new concept URI for the UniqueID field type
* Add method to SimpleTranslator that adds columns for the UniqueID fields during dataIterator insertion
* Update DomainImpl to backfill UniqueID fields with values after added to an existing domain.
* Add metrics for counting the number of UniqueID fields on a server and the number of sample types with these fields