### PR TITLE
21.3 fb issue 42758

### DIFF
--- a/experiment/src/org/labkey/experiment/api/AbstractRunItemImpl.java
+++ b/experiment/src/org/labkey/experiment/api/AbstractRunItemImpl.java
@@ -44,7 +44,7 @@ public abstract class AbstractRunItemImpl<Type extends RunItem> extends ExpIdent
 {
     private ExpProtocolApplicationImpl _sourceApp;
     private List<ExpProtocolApplication> _successorAppList;
-    private List<Integer> _successorRunIdList = Collections.emptyList();
+    private List<Integer> _successorRunIdList = null;
 
     // For serialization
     protected AbstractRunItemImpl() {}

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
@@ -437,7 +437,7 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
     }
 
     /**
-     * Generate a query to get the runIds where the supplied set of ExpData's were used as inputs
+     * Generate a query to get the runIds where the supplied set of ExpData's were used as inputs or outputs
      * CONSIDER : moving this to ExperimentService on trunk
      */
     private List<? extends ExpRun> getRunsForExpData(List<ExpData> datas)


### PR DESCRIPTION
#### Rationale
Sample type and data class export can be slow even if the number of referenced samples or data is small. This is because we take all of the sample derivation runs and check to see if any of the material or data inputs/outputs match those that are selected. If the folder has a large number of derivation runs, this can be expensive since the runs need to be fully populated to do these checks.

#### Changes
Reverse the logic and use queries to determine the list of runs which are using the specified samples or datas.
