### PR TITLE
Issue 42864: Use case-insensitive sort for projects and subfolders webpart

### DIFF
--- a/core/src/org/labkey/core/project/projects.jsp
+++ b/core/src/org/labkey/core/project/projects.jsp
@@ -117,7 +117,7 @@
     List<Container> containers = set.stream()
         .map(ContainerManager::getForId)
         .filter(Objects::nonNull)
-        .sorted(Comparator.comparingInt(Container::getSortOrder).thenComparing(this::displayName))
+        .sorted(Comparator.comparingInt(Container::getSortOrder).thenComparing((c1, c2) -> String.CASE_INSENSITIVE_ORDER.compare(displayName(c1), displayName(c2))))
         .collect(Collectors.toList());
 
     if (containers.isEmpty())


### PR DESCRIPTION
#### Rationale
Users rarely want things sorted in a case sensitive way. Let's sort the project and subfolder webparts case insensitively. I believe we used to do this but it reverted in a refactor.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1209

#### Changes
* Use case-insensitive comparator