### PR TITLE
Backport changes to File Root Settings to 21.3

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -5121,7 +5121,8 @@ public class AdminController extends SpringActionController
 
     /**
      * This standalone file root management action can be used on folder types that do not support
-     * the normal 'Manage Folder' UI.
+     * the normal 'Manage Folder' UI. Not currently linked in the UI, but available for direct URL
+     * navigation when a workbook needs it.
      */
     @RequiresPermission(AdminPermission.class)
     public class ManageFileRootAction extends FormViewAction<FileRootsForm>

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -5119,6 +5119,52 @@ public class AdminController extends SpringActionController
         }
     }
 
+    /**
+     * This standalone file root management action can be used on folder types that do not support
+     * the normal 'Manage Folder' UI.
+     */
+    @RequiresPermission(AdminPermission.class)
+    public class ManageFileRootAction extends FormViewAction<FileRootsForm>
+    {
+        @Override
+        public ModelAndView getView(FileRootsForm form, boolean reShow, BindException errors)
+        {
+            JspView view = getFileRootsView(form, errors, getReshow());
+            getPageConfig().setTitle("Manage File Root");
+            return view;
+        }
+
+        @Override
+        public void validateCommand(FileRootsForm form, Errors errors)
+        {
+            validateCloudFileRoot(form, getContainer(), errors);
+        }
+
+        @Override
+        public boolean handlePost(FileRootsForm form, BindException errors) throws Exception
+        {
+            return handleFileRootsPost(form, errors);
+        }
+
+        @Override
+        public ActionURL getSuccessURL(FileRootsForm form)
+        {
+            ActionURL url = getContainer().getStartURL(getUser());
+
+            if (getViewContext().getActionURL().getReturnURL() != null)
+            {
+                url.addReturnURL(getViewContext().getActionURL().getReturnURL());
+            }
+
+            return url;
+        }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        {
+        }
+    }
+
     @RequiresPermission(AdminPermission.class)
     public class FileRootsAction extends FolderManagementViewPostAction<FileRootsForm>
     {

--- a/core/src/org/labkey/core/admin/view/filesProjectSettings.jsp
+++ b/core/src/org/labkey/core/admin/view/filesProjectSettings.jsp
@@ -111,13 +111,13 @@
                         <td><input <%=h(canChangeFileSettings ? "" : " disabled ")%>
                                 type="radio" name="fileRootOption" id="optionDisable" value="<%=FileRootProp.disable%>"
                                 <%=checked(FileRootProp.disable.name().equals(bean.getFileRootOption()))%>
-                                onclick="updateSelection(true);">
+                                onclick="updateSelection(<%=h(!FileRootProp.disable.name().equals(bean.getFileRootOption()))%>);">
                             Disable file sharing for this <%=h(getContainer().getContainerNoun())%></td></tr>
                     <tr style="height: 1.75em">
                         <td><input <%=h(canChangeFileSettings ? "" : " disabled ")%>
                                 type="radio" name="fileRootOption" id="optionSiteDefault" value="<%=FileRootProp.siteDefault%>"
                                 <%=checked(FileRootProp.siteDefault.name().equals(bean.getFileRootOption()))%>
-                                onclick="updateSelection(true);">
+                                onclick="updateSelection(<%=h(!FileRootProp.siteDefault.name().equals(bean.getFileRootOption()))%>);">
                             Use a default based on the project-level root
                             <input type="text" id="rootPath" size="64" disabled="true" value="<%=h(defaultRoot)%>"></td>
                     </tr>
@@ -125,7 +125,7 @@
                         <td><input <%=h(canChangeFileSettings && hasAdminOpsPerm ? "" : " disabled ")%>
                                 type="radio" name="fileRootOption" id="optionProjectSpecified" value="<%=FileRootProp.folderOverride%>"
                                 <%=checked(FileRootProp.folderOverride.name().equals(bean.getFileRootOption()))%>
-                                onclick="updateSelection(true);">
+                                onclick="updateSelection(<%=h(!FileRootProp.folderOverride.name().equals(bean.getFileRootOption()))%>);">
                             Use a <%=text(getContainer().getContainerNoun())%>-level file root
                             <input type="text" id="folderRootPath" name="folderRootPath" size="64" onchange="onRootChange()" value="<%=h(bean.getFolderRootPath())%>"></td>
                     </tr>
@@ -134,7 +134,7 @@
                         <td><input <%=h(canChangeFileSettings && hasAdminOpsPerm ? "" : " disabled ")%>
                                 type="radio" name="fileRootOption" id="optionCloudRoot" value="<%=FileRootProp.cloudRoot%>"
                                 <%=checked(FileRootProp.cloudRoot.name().equals(bean.getFileRootOption()))%>
-                                onclick="updateSelection(true);">
+                                onclick="updateSelection(<%=h(!FileRootProp.cloudRoot.name().equals(bean.getFileRootOption()))%>);">
                             Use cloud-based file storage
                             <select name="cloudRootName" id="cloudRootName" onchange="updateSelection(true);">
                                 <% for (CloudStoreService.StoreInfo storeInfo : storeInfos.values())
@@ -272,41 +272,61 @@
             if (cloudRootName)
                 document.getElementById('cloudRootName').style.display = '';
         }
-        var migrateFiles = document.getElementById('migrateFilesRow');
-        var notifyAboutPipeline = document.getElementById('notifyAboutPipeline');
-        if (migrateFiles)
+
+        updateMigrateFiles(isChange, optionDisableChecked);
+    }
+
+    function onRootChange()
+    {
+        var value = document.getElementById('folderRootPath').value;
+        if (!value)
         {
-            if (isChange && !optionDisableChecked && !<%=isFolderSetup || isCurrentFileRootOptionDisable%>)
+            return;
+        }
+
+        var isChangeFromExisting = value != <%=q(bean.getFolderRootPath())%>;
+        var optionDisableChecked = document.getElementById('optionDisable').checked;
+        updateMigrateFiles(isChangeFromExisting, optionDisableChecked);
+    }
+
+    function updateMigrateFiles(isChange, optionDisableChecked)
+    {
+        var migrateFiles = document.getElementById('migrateFilesRow');
+        if (!migrateFiles) {
+            return;
+        }
+
+        var optionCloudRoot = document.getElementById('optionCloudRoot');
+        var notifyAboutPipeline = document.getElementById('notifyAboutPipeline');
+        if (isChange && !optionDisableChecked && !<%=isFolderSetup || isCurrentFileRootOptionDisable%>)
+        {
+            migrateFiles.style.display = '';
+            if (notifyAboutPipeline)
             {
-                migrateFiles.style.display = '';
-                if (notifyAboutPipeline)
-                {
-                    if (optionCloudRoot && optionCloudRoot.checked)
-                        notifyAboutPipeline.style.display = '';
-                    else
-                        notifyAboutPipeline.style.display = 'none';
-                }
-                var migrateMoveOption = document.getElementById('migrateMoveOption');
-                if (migrateMoveOption)
-                {
-                    var isNewCloudRootManaged = false;  // TODO: must we prevent moving when switching *TO* unmanaged cloud root?
-                    if ((optionCloudRoot && optionCloudRoot.checked && isNewCloudRootManaged) ||
-                            <%=!isCurrentFileRootManaged%>)
-                    {
-                        migrateMoveOption.setAttribute('hidden', '');
-                    }
-                    else
-                    {
-                        migrateMoveOption.removeAttribute('hidden');
-                    }
-                }
-            }
-            else
-            {
-                migrateFiles.style.display = 'none';
-                if (notifyAboutPipeline)
+                if (optionCloudRoot && optionCloudRoot.checked)
+                    notifyAboutPipeline.style.display = '';
+                else
                     notifyAboutPipeline.style.display = 'none';
             }
+            var migrateMoveOption = document.getElementById('migrateMoveOption');
+            if (migrateMoveOption)
+            {
+                var isNewCloudRootManaged = false;  // TODO: must we prevent moving when switching *TO* unmanaged cloud root?
+                if ((optionCloudRoot && optionCloudRoot.checked && isNewCloudRootManaged) || <%=!isCurrentFileRootManaged%>)
+                {
+                    migrateMoveOption.setAttribute('hidden', '');
+                }
+                else
+                {
+                    migrateMoveOption.removeAttribute('hidden');
+                }
+            }
+        }
+        else
+        {
+            migrateFiles.style.display = 'none';
+            if (notifyAboutPipeline)
+                notifyAboutPipeline.style.display = 'none';
         }
     }
 

--- a/core/src/org/labkey/core/admin/view/filesProjectSettings.jsp
+++ b/core/src/org/labkey/core/admin/view/filesProjectSettings.jsp
@@ -127,7 +127,7 @@
                                 <%=checked(FileRootProp.folderOverride.name().equals(bean.getFileRootOption()))%>
                                 onclick="updateSelection(true);">
                             Use a <%=text(getContainer().getContainerNoun())%>-level file root
-                            <input type="text" id="folderRootPath" name="folderRootPath" size="64" value="<%=h(bean.getFolderRootPath())%>"></td>
+                            <input type="text" id="folderRootPath" name="folderRootPath" size="64" onchange="onRootChange()" value="<%=h(bean.getFolderRootPath())%>"></td>
                     </tr>
                     <% if (cloud != null) { %>
                     <tr style="height: 1.75em">
@@ -292,6 +292,42 @@
                     var isNewCloudRootManaged = false;  // TODO: must we prevent moving when switching *TO* unmanaged cloud root?
                     if ((optionCloudRoot && optionCloudRoot.checked && isNewCloudRootManaged) ||
                             <%=!isCurrentFileRootManaged%>)
+                    {
+                        migrateMoveOption.setAttribute('hidden', '');
+                    }
+                    else
+                    {
+                        migrateMoveOption.removeAttribute('hidden');
+                    }
+                }
+            }
+            else
+            {
+                migrateFiles.style.display = 'none';
+                if (notifyAboutPipeline)
+                    notifyAboutPipeline.style.display = 'none';
+            }
+        }
+    }
+
+    function onRootChange()
+    {
+
+        var value = document.getElementById('folderRootPath').value;
+        var isChangeFromExisting = value != '<%=h(bean.getFolderRootPath())%>';
+
+        var optionCloudRoot = document.getElementById('optionCloudRoot');
+        var migrateFiles = document.getElementById('migrateFilesRow');
+        if (migrateFiles)
+        {
+            if (isChangeFromExisting)
+            {
+                migrateFiles.style.display = '';
+                var migrateMoveOption = document.getElementById('migrateMoveOption');
+                if (migrateMoveOption)
+                {
+                    var isNewCloudRootManaged = false;  // TODO: must we prevent moving when switching *TO* unmanaged cloud root?
+                    if ((optionCloudRoot && optionCloudRoot.checked && isNewCloudRootManaged) || <%=!isCurrentFileRootManaged%>)
                     {
                         migrateMoveOption.setAttribute('hidden', '');
                     }


### PR DESCRIPTION
#### Rationale
The changes to let workbooks manage their file roots more easily narrowly missed the 21.3 branch point

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2070

#### Changes
* Backport changes that let workbooks opt in to file root configuration
* Improve UI to show/hide controls correctly in more combinations of edits/reverts