### PR TITLE
ApiModule addition of "moduleNames" to moduleContext for use by change in updated @labkey/components package

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -53,6 +53,7 @@ import org.labkey.api.module.JavaVersion;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.module.ModuleDependencySorter;
 import org.labkey.api.module.ModuleHtmlView;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.module.ModuleXml;
 import org.labkey.api.module.TomcatVersion;
 import org.labkey.api.query.AbstractQueryUpdateService;
@@ -289,6 +290,8 @@ public class ApiModule extends CodeOnlyModule
         AuthenticationConfiguration.SSOAuthenticationConfiguration config = AuthenticationManager.getAutoRedirectSSOAuthConfiguration();
         if (config != null)
             json.put("AutoRedirectSSOAuthConfiguration", config.getDescription());
+
+        json.put("moduleNames", ModuleLoader.getInstance().getModules().stream().map(module -> module.getName().toLowerCase()).toArray());
         return json;
     }
 }


### PR DESCRIPTION
#### Rationale
Note that this change has already been [merged into 21.4](https://github.com/LabKey/platform/pull/2155) but has not yet been merged forward to develop. As a result, this is causing LKB test failures in the related FBs because they pull in the updates on the @labkey/components side which make use of this new moduleContext information.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/492
* https://github.com/LabKey/biologics/pull/847
* https://github.com/LabKey/sampleManagement/pull/538
* https://github.com/LabKey/platform/pull/2163

#### Changes
* Add in ApiModule "moduleNames" to moduleContext
