### PR TITLE
Issue 42865: Initial user creation overwrites system email from startup props

### DIFF
--- a/api/src/org/labkey/api/settings/LookAndFeelProperties.java
+++ b/api/src/org/labkey/api/settings/LookAndFeelProperties.java
@@ -163,6 +163,12 @@ public class LookAndFeelProperties extends LookAndFeelFolderProperties
         return systemEmailAddress;
     }
 
+    /** Let callers peek if there's an address configured without logging a error */
+    public boolean hasSystemEmailAddress()
+    {
+        return lookupStringValue(SYSTEM_EMAIL_ADDRESS_PROP, null) != null;
+    }
+
     public String getUnsubstitutedReportAProblemPath()
     {
         return lookupStringValue(REPORT_A_PROBLEM_PATH_PROP, "${contextPath}/project" + ContainerManager.DEFAULT_SUPPORT_PROJECT_PATH + "/begin.view");

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1913,7 +1913,7 @@ public class LoginController extends SpringActionController
                     {
                         SecurityManager.addMember(SecurityManager.getGroup(Group.groupAdministrators), newUserBean.getUser());
 
-                        if (StringUtils.isEmpty(LookAndFeelProperties.getInstance(ContainerManager.getRoot()).getSystemEmailAddress()))
+                        if (!LookAndFeelProperties.getInstance(ContainerManager.getRoot()).hasSystemEmailAddress())
                         {
                             // set default "from" address for system emails to first registered user, but don't stomp
                             // over a value that might have been set by a startup property (issue 42865)

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1913,10 +1913,14 @@ public class LoginController extends SpringActionController
                     {
                         SecurityManager.addMember(SecurityManager.getGroup(Group.groupAdministrators), newUserBean.getUser());
 
-                        //set default "from" address for system emails to first registered user
-                        WriteableLookAndFeelProperties laf = LookAndFeelProperties.getWriteableInstance(ContainerManager.getRoot());
-                        laf.setSystemEmailAddress(newUserBean.getEmail());
-                        laf.save();
+                        if (StringUtils.isEmpty(LookAndFeelProperties.getInstance(ContainerManager.getRoot()).getSystemEmailAddress()))
+                        {
+                            // set default "from" address for system emails to first registered user, but don't stomp
+                            // over a value that might have been set by a startup property (issue 42865)
+                            WriteableLookAndFeelProperties laf = LookAndFeelProperties.getWriteableInstance(ContainerManager.getRoot());
+                            laf.setSystemEmailAddress(newUserBean.getEmail());
+                            laf.save();
+                        }
 
                         //set default domain to user email domain
                         String userEmailAddress = newUserBean.getEmail().getEmailAddress();


### PR DESCRIPTION
#### Rationale
Creating the initial user through the bootstrapping UI always sets that email address as the server's from email address, even if a separate value was specified via a startup property

#### Changes
* Check if another address was already set before using the initial user's