### PR TITLE
Backport log calming since troubleshooting is over in 21.3 as well

### DIFF
--- a/api/src/org/labkey/api/dataiterator/StatementDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/StatementDataIterator.java
@@ -489,7 +489,7 @@ public class StatementDataIterator extends AbstractDataIterator
     private void log(String message)
     {
         if (null != _log)
-            _log.debug(message);
+            _log.trace(message);
     }
 
     private void log(String message, Exception e)


### PR DESCRIPTION
#### Rationale
Troubleshooting is good, but spamming logs is less desirable. This logging helped track down test failures but isn't needed or desired on production servers. Backport change in develop from a larger commit.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2151
* 
#### Changes
* Return logging to trace level