### PR TITLE
42919: Deleting an issue list definition domain fails to clean up properly

### DIFF
--- a/internal/src/org/labkey/api/issues/IssuesListDefService.java
+++ b/internal/src/org/labkey/api/issues/IssuesListDefService.java
@@ -191,5 +191,12 @@ public interface IssuesListDefService
      * @param container
      */
     void uncache(Container container);
+
+    /**
+     * Deletes all issue list definitions including associated data that is using the specified domain. This method
+     * is generally used in preparation to dropping the domain, but won't delete the domain.
+     * @param domain The domain to clean up
+     */
+    void deleteIssueDefsForDomain(User user, Domain domain);
 }
 

--- a/issues/src/org/labkey/issue/model/IssueListDef.java
+++ b/issues/src/org/labkey/issue/model/IssueListDef.java
@@ -247,7 +247,20 @@ public class IssueListDef extends Entity
     public static SimpleFilter.FilterClause createFilterClause(IssueListDef issueListDef, User user)
     {
         Domain domain = issueListDef.getDomain(user);
+        ContainerFilter containerFilter = getContainerFilter(domain, user);
+        if (containerFilter != null)
+        {
+            return containerFilter.createFilterClause(IssuesSchema.getInstance().getSchema(), FieldKey.fromParts("container"));
+        }
+        return null;
+    }
 
+    /**
+     * Returns the container filter with the proper scope for the issue list definition domain
+     */
+    @Nullable
+    public static ContainerFilter getContainerFilter(Domain domain, User user)
+    {
         if (domain != null)
         {
             ContainerFilter containerFilter = null;
@@ -258,8 +271,7 @@ public class IssueListDef extends Entity
             else if (domainContainer.isProject())
                 containerFilter = ContainerFilter.Type.CurrentAndSubfolders.create(domainContainer, user);
 
-            if (containerFilter != null)
-                return containerFilter.createFilterClause(IssuesSchema.getInstance().getSchema(), FieldKey.fromParts("container"));
+            return containerFilter;
         }
         return null;
     }

--- a/issues/src/org/labkey/issue/model/IssuesListDefServiceImpl.java
+++ b/issues/src/org/labkey/issue/model/IssuesListDefServiceImpl.java
@@ -299,4 +299,10 @@ public class IssuesListDefServiceImpl implements IssuesListDefService
     {
         IssueListDefCache.uncache(container);
     }
+
+    @Override
+    public void deleteIssueDefsForDomain(User user, Domain domain)
+    {
+        IssueManager.deleteIssueDefsForDomain(user, domain);
+    }
 }

--- a/issues/src/org/labkey/issue/query/IssueDefDomainKind.java
+++ b/issues/src/org/labkey/issue/query/IssueDefDomainKind.java
@@ -140,7 +140,7 @@ public class IssueDefDomainKind extends AbstractIssuesListDefDomainKind
     }
 
     @Override
-    public void deleteDomain(User user, Domain domain)
+    public void beforeDeleteDomain(User user, Domain domain)
     {
         try
         {
@@ -150,7 +150,6 @@ public class IssueDefDomainKind extends AbstractIssuesListDefDomainKind
             deleteLookup(domain, user, TYPE_LOOKUP);
             deleteLookup(domain, user, MILESTONE_LOOKUP);
             deleteLookup(domain, user, RESOLUTION_LOOKUP);
-            domain.delete(user);
         }
         catch (DomainNotFoundException e)
         {


### PR DESCRIPTION
#### Rationale
This addresses [#42919](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42919) by wiring up deletion of an issue tracker domain to properly clean up any associated issue list definitions. Formerly, this would not clean up when attempting to delete the domain via API.

#### Related Pull Requests
* https://github.com/LabKey/hjfSampleRequests/pull/1
* https://github.com/LabKey/platform/pull/2171
* https://github.com/LabKey/assayRequest/pull/33

#### Changes
* Fix for [#42919](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42919).
* Expose basic user metadata for all users involved in an issue via `issues-getIssues.api`.
