### PR TITLE
Issue 42897: remove getDefaultSampleTypeMaterialLsidPrefix

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -260,23 +260,6 @@ public interface ExperimentService extends ExperimentRunTypeSource
      */
     List<? extends ExpMaterial> getExpMaterials(Container container, User user, Collection<Integer> rowIds, @Nullable ExpSampleType sampleType);
 
-    /**
-     * Get materials with the given names, optionally within the provided sample type.
-     * If the materials don't exist, throw an exception if <code>throwIfMissing</code> is true
-     * or create new materials if <code>createIfMissing</code> is true, otherwise missing samples
-     * will be ignored.
-     *
-     * @param container       Samples will be found within this container, project, or shared container.
-     * @param user            Samples will only be resolved within containers that the user has ReadPermission.
-     * @param sampleNames     The set of samples to be resolved by name.
-     * @param sampleType      Optional sample type that the samples must live in.
-     * @param throwIfMissing  Throw ExperimentException if any of the sampleNames do not exist.
-     * @param createIfMissing Create missing samples in the given <code>sampleType</code>.
-     * @return Resolved samples
-     * @throws ExperimentException
-     */
-    @NotNull List<? extends ExpMaterial> getExpMaterials(Container container, @Nullable User user, Set<String> sampleNames, @Nullable ExpSampleType sampleType, boolean throwIfMissing, boolean createIfMissing) throws ExperimentException;
-
     /* This version of createExpMaterial() takes name from lsid.getObjectId() */
     ExpMaterial createExpMaterial(Container container, Lsid lsid);
 

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -117,9 +117,6 @@ public interface SampleTypeService
      */
     ExpSampleType getSampleType(@NotNull Container scope, @NotNull User user, int rowId);
 
-    String getDefaultSampleTypeLsid();
-    String getDefaultSampleTypeMaterialLsidPrefix();
-
     Lsid getSampleTypeLsid(String name, Container container);
 
     /**

--- a/assay/api-src/org/labkey/api/assay/matrix/AbstractMatrixDataHandler.java
+++ b/assay/api-src/org/labkey/api/assay/matrix/AbstractMatrixDataHandler.java
@@ -16,12 +16,18 @@
 package org.labkey.api.assay.matrix;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbScope;
+import org.labkey.api.data.RemapCache;
+import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlExecutor;
+import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.api.AbstractExperimentDataHandler;
@@ -29,9 +35,19 @@ import org.labkey.api.exp.api.DataType;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpRun;
+import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.exp.query.SamplesSchema;
+import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
+import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.DuplicateKeyException;
+import org.labkey.api.query.QueryService;
+import org.labkey.api.query.QueryUpdateServiceException;
+import org.labkey.api.query.UserSchema;
+import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.ColumnDescriptor;
 import org.labkey.api.reader.DataLoader;
 import org.labkey.api.reader.DataLoaderFactory;
@@ -42,6 +58,8 @@ import org.labkey.api.view.ViewBackgroundInfo;
 
 import java.io.File;
 import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,6 +67,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
 
 public abstract class AbstractMatrixDataHandler extends AbstractExperimentDataHandler
 {
@@ -67,7 +88,7 @@ public abstract class AbstractMatrixDataHandler extends AbstractExperimentDataHa
     }
 
     public abstract DbSchema getDbSchema();
-    public abstract void insertMatrixData(Container c, User user, Map<String, Integer> samplesMap, DataLoader loader, Map<String, String> runProps, Integer dataRowId) throws ExperimentException;
+    public abstract void insertMatrixData(Container c, User user, Map<String, ExpMaterial> samplesMap, DataLoader loader, Map<String, String> runProps, Integer dataRowId) throws ExperimentException;
 
     public String getIdColumnName()
     {
@@ -155,7 +176,7 @@ public abstract class AbstractMatrixDataHandler extends AbstractExperimentDataHa
             throw new ExperimentException(idColumnName + " column header must be present and cannot be blank");
     }
 
-    public static Map<String, Integer> ensureSamples(Container container, User user, Collection<String> columnNames, String columnName) throws ExperimentException
+    public static Map<String, ExpMaterial> ensureSamples(Container container, User user, Collection<String> columnNames, String columnName, @NotNull RemapCache cache, @NotNull Map<Integer, ExpMaterial> materialCache) throws ExperimentException
     {
         Set<String> sampleNames = new HashSet<>(columnNames.size());
         for (String name : columnNames)
@@ -167,14 +188,120 @@ public abstract class AbstractMatrixDataHandler extends AbstractExperimentDataHa
         }
         LOG.debug("All samples in matrix: " + StringUtils.join(sampleNames, ", "));
 
-        List<? extends ExpMaterial> samples = ExperimentService.get().getExpMaterials(container, user, sampleNames, null, !autoCreateSamples, autoCreateSamples);
-        Map<String, Integer> sampleMap = new HashMap<>(samples.size());
-        for (ExpMaterial sample : samples)
+        Set<String> unresolved = new HashSet<>();
+        Map<String, ExpMaterial> sampleMap = new HashMap<>(sampleNames.size());
+        for (String sampleName : sampleNames)
         {
-            sampleMap.put(sample.getName(), sample.getRowId());
+            ExpMaterial m;
+            try
+            {
+                m = ExperimentService.get().findExpMaterial(container, user, null, null, sampleName, cache, materialCache);
+            }
+            catch (ValidationException e)
+            {
+                throw new ExperimentException(e);
+            }
+
+            if (m != null)
+            {
+                sampleMap.put(m.getName(), m);
+            }
+            else
+            {
+                unresolved.add(sampleName);
+            }
+        }
+
+        if (!unresolved.isEmpty())
+        {
+            if (!autoCreateSamples)
+                throw new ExperimentException("No samples found for: " + StringUtils.join(unresolved, ", "));
+
+            List<? extends ExpMaterial> created = createExpMaterials(container, user, unresolved);
+            for (ExpMaterial m : created)
+            {
+                sampleMap.put(m.getName(), m);
+            }
         }
 
         return sampleMap;
+    }
+
+    private static List<? extends ExpMaterial> createExpMaterials(Container c, User user, Set<String> sampleNames) throws ExperimentException
+    {
+        ExpSampleType sampleType = ensureSampleType(c, user);
+
+        UserSchema schema = QueryService.get().getUserSchema(user, c, SamplesSchema.SCHEMA_NAME);
+        TableInfo table = schema.getTable(sampleType.getName());
+
+        List<Integer> rowIds;
+        try (DbScope.Transaction tx = schema.getDbSchema().getScope().ensureTransaction())
+        {
+            List<Map<String, Object>> rows = new ArrayList<>(sampleNames.size());
+            for (String sampleName : sampleNames)
+                rows.add(CaseInsensitiveHashMap.of("Name", sampleName));
+
+            BatchValidationException errors = new BatchValidationException();
+            List<Map<String, Object>> inserted = table.getUpdateService().insertRows(user, c, rows, errors, null, null);
+            if (errors.hasErrors())
+                throw new ExperimentException(errors.getMessage(), errors);
+
+            if (inserted.size() != sampleNames.size())
+                throw new ExperimentException("Expected to insert " + sampleNames.size() + " samples; only inserted " + inserted.size());
+
+            rowIds = inserted.stream().map(m -> (Integer)m.get("rowId")).collect(Collectors.toList());
+            tx.commit();
+        }
+        catch (SQLException e)
+        {
+            throw new RuntimeSQLException(e);
+        }
+        catch (DuplicateKeyException | QueryUpdateServiceException | BatchValidationException e)
+        {
+            throw new ExperimentException(e.getMessage(), e);
+        }
+
+        if (rowIds.isEmpty())
+            return Collections.emptyList();
+
+        return ExperimentService.get().getExpMaterials(rowIds);
+    }
+
+    // Get a SampleType in the current, project, or shared container.
+    // If more than one SampleType exists, an exception is thrown.
+    // If none exist, a new SampleType named "Samples" is created.
+    private static @NotNull ExpSampleType ensureSampleType(Container c, User user) throws ExperimentException
+    {
+        List<? extends ExpSampleType> sampleTypes = SampleTypeService.get().getSampleTypes(c, user, true);
+        if (sampleTypes.isEmpty())
+        {
+            return createSampleType(c, user);
+        }
+        else if (sampleTypes.size() == 1)
+        {
+            return sampleTypes.get(0);
+        }
+        else
+        {
+            throw new ExperimentException("More than one SampleType in scope: " + sampleTypes.stream().map(ExpSampleType::getName).collect(Collectors.joining(", ")));
+        }
+    }
+
+    private static @NotNull ExpSampleType createSampleType(Container c, User user) throws ExperimentException
+    {
+        // Create a new SampleSet in the current container
+        List<GWTPropertyDescriptor> properties = new ArrayList<>();
+        properties.add(new GWTPropertyDescriptor("Name", "http://www.w3.org/2001/XMLSchema#string"));
+        try
+        {
+            ExpSampleType sampleType = SampleTypeService.get().createSampleType(c, user, "Samples", null, properties, emptyList(), -1, -1, -1, -1, "${Name}");
+            LOG.info("Created new SampleType in " + c.getName() + ": " + sampleType.getLSID());
+            return sampleType;
+        }
+        catch (SQLException e)
+        {
+            throw new RuntimeSQLException(e);
+        }
     }
 
     public  Map<String, String> getRunPropertyValues(ExpRun run, Domain domain)

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -559,7 +559,7 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
     @Override
     public void save(User user)
     {
-        if (SampleTypeService.get().getDefaultSampleTypeLsid().equals(getLSID()))
+        if (SampleTypeServiceImpl.get().getDefaultSampleTypeLsid().equals(getLSID()))
             throw new IllegalStateException("Can't create or update the default SampleType");
 
         boolean isNew = _object.getRowId() == 0;

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -559,9 +559,6 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
     @Override
     public void save(User user)
     {
-        if (SampleTypeServiceImpl.get().getDefaultSampleTypeLsid().equals(getLSID()))
-            throw new IllegalStateException("Can't create or update the default SampleType");
-
         boolean isNew = _object.getRowId() == 0;
         save(user, ExperimentServiceImpl.get().getTinfoSampleType(), true);
         if (isNew)

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -19,6 +19,7 @@ package org.labkey.experiment.api;
 import com.google.common.collect.Iterables;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -139,7 +140,22 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Timestamp;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Predicate;
@@ -175,7 +191,9 @@ public class ExperimentServiceImpl implements ExperimentService
         return Collections.unmodifiableSortedSet(new TreeSet<>(new TableSelector(getTinfoDataClass(), filter, null).getCollection(DataClass.class)));
     });
 
-    public static final String DEFAULT_MATERIAL_SOURCE_NAME = "Unspecified";
+    @Deprecated
+    private static final String DEFAULT_MATERIAL_SOURCE_NAME = "Unspecified";
+
     public static final String EXPERIMENTAL_DOMAIN_DESIGNER = "experimental-uxdomaindesigner";
 
     private static final List<ExperimentListener> _listeners = new CopyOnWriteArrayList<>();
@@ -656,94 +674,6 @@ public class ExperimentServiceImpl implements ExperimentService
                 .stream()
                 .map(ExpMaterialImpl::new)
                 .collect(toList());
-    }
-
-    @Override
-    @NotNull
-    public List<ExpMaterialImpl> getExpMaterials(Container container, User user, Set<String> sampleNames, @Nullable ExpSampleType sampleType, boolean throwIfMissing, boolean createIfMissing)
-            throws ExperimentException
-    {
-        if (throwIfMissing && createIfMissing)
-            throw new IllegalArgumentException("Either throwIfMissing or createIfMissing can be true; not both.");
-
-        SimpleFilter filter = new SimpleFilter();
-        filter.addInClause(FieldKey.fromParts("Name"), sampleNames);
-        if (sampleType != null)
-            filter.addCondition(FieldKey.fromParts("CpasType"), sampleType.getLSID());
-
-        // SampleType may live in different container
-        ContainerFilter.CurrentPlusProjectAndShared containerFilter = new ContainerFilter.CurrentPlusProjectAndShared(container, user);
-        SimpleFilter.FilterClause clause = containerFilter.createFilterClause(getSchema(), FieldKey.fromParts("Container"));
-        filter.addClause(clause);
-
-        Set<String> selectNames = new LinkedHashSet<>();
-        selectNames.add("Name");
-        selectNames.add("RowId");
-        TableSelector sampleTableSelector = new TableSelector(getTinfoMaterial(), selectNames, filter, null);
-        Map<String, Integer> sampleMap = sampleTableSelector.getValueMap();
-
-        List<ExpMaterialImpl> resolvedSamples = getExpMaterials(sampleMap.values());
-
-        if (sampleMap.size() < sampleNames.size())
-        {
-            Set<String> missingSamples = new HashSet<>(sampleNames);
-            missingSamples.removeAll(sampleMap.keySet());
-            if (throwIfMissing)
-                throw new ExperimentException("No samples found for: " + StringUtils.join(missingSamples, ", "));
-
-            if (createIfMissing)
-                resolvedSamples.addAll(createExpMaterials(container, user, sampleType, missingSamples));
-        }
-
-        return resolvedSamples;
-    }
-
-    // Insert new materials into the given sample type or the default (unspecified) sample type if none is provided.
-    private List<ExpMaterialImpl> createExpMaterials(Container container, User user, @Nullable ExpSampleType sampleType, Set<String> sampleNames)
-    {
-        List<ExpMaterialImpl> materials = new ArrayList<>(sampleNames.size());
-
-        try (DbScope.Transaction transaction = ensureTransaction())
-        {
-            final String cpasType;
-            final String materialLsidPrefix;
-            if (sampleType != null)
-            {
-                cpasType = sampleType.getLSID();
-                materialLsidPrefix = sampleType.getMaterialLSIDPrefix();
-            }
-            else
-            {
-                cpasType = SampleTypeServiceImpl.get().getDefaultSampleTypeLsid();
-                materialLsidPrefix = SampleTypeServiceImpl.get().getDefaultSampleTypeMaterialLsidPrefix();
-            }
-
-            // Create materials directly using Name.
-            for (String name : sampleNames)
-            {
-                List<ExpMaterialImpl> existingMaterials = getExpMaterialsByName(name, container, user);
-                if (existingMaterials.size() > 0)
-                {
-                    ExpMaterialImpl material = existingMaterials.get(0);
-                    materials.add(material);
-                }
-                else
-                {
-                    Lsid.LsidBuilder lsid = new Lsid.LsidBuilder(materialLsidPrefix + "test");
-                    lsid.setObjectId(name);
-                    String materialLsid = lsid.toString();
-
-                    ExpMaterialImpl material = createExpMaterial(container, materialLsid, name);
-                    material.setCpasType(cpasType);
-                    material.save(user);
-
-                    materials.add(material);
-                }
-            }
-
-            transaction.commit();
-            return materials;
-        }
     }
 
     @Override
@@ -1271,7 +1201,7 @@ public class ExperimentServiceImpl implements ExperimentService
     public String generateLSID(Container container, Class<? extends ExpObject> clazz, @NotNull String name)
     {
         if (clazz == ExpSampleType.class && name.equals(DEFAULT_MATERIAL_SOURCE_NAME) && ContainerManager.getSharedContainer().equals(container))
-            return SampleTypeService.get().getDefaultSampleTypeLsid();
+            throw new IllegalArgumentException("Default 'Unspecified' SampleType is not supported");
         return generateLSID(container, getNamespacePrefix(clazz), name);
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -191,9 +191,6 @@ public class ExperimentServiceImpl implements ExperimentService
         return Collections.unmodifiableSortedSet(new TreeSet<>(new TableSelector(getTinfoDataClass(), filter, null).getCollection(DataClass.class)));
     });
 
-    @Deprecated
-    private static final String DEFAULT_MATERIAL_SOURCE_NAME = "Unspecified";
-
     public static final String EXPERIMENTAL_DOMAIN_DESIGNER = "experimental-uxdomaindesigner";
 
     private static final List<ExperimentListener> _listeners = new CopyOnWriteArrayList<>();
@@ -1200,8 +1197,6 @@ public class ExperimentServiceImpl implements ExperimentService
     @Override
     public String generateLSID(Container container, Class<? extends ExpObject> clazz, @NotNull String name)
     {
-        if (clazz == ExpSampleType.class && name.equals(DEFAULT_MATERIAL_SOURCE_NAME) && ContainerManager.getSharedContainer().equals(container))
-            throw new IllegalArgumentException("Default 'Unspecified' SampleType is not supported");
         return generateLSID(container, getNamespacePrefix(clazz), name);
     }
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -355,10 +355,6 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     @Override
     public ExpSampleTypeImpl getSampleTypeByType(@NotNull String lsid, Container hint)
     {
-        // Default sample type has been removed -- see LabKey/platform#2140
-        if (getDefaultSampleTypeLsid().equals(lsid))
-            throw new IllegalArgumentException("Default SampleType is not supported: " + lsid);
-
         Container c = hint;
         String id = sampleTypeCache.get(lsid);
         if (null != id && (null == hint || !id.equals(hint.getId())))
@@ -428,13 +424,6 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("LSID"), lsid);
         return new TableSelector(getTinfoMaterialSource(), filter, null).getObject(MaterialSource.class);
-    }
-
-    /** The default 'Unspecified' SampleType is no longer supported. */
-    @Deprecated
-    public String getDefaultSampleTypeLsid()
-    {
-        return new Lsid.LsidBuilder("SampleSource", "Default").toString();
     }
 
     public DbScope.Transaction ensureTransaction()

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -355,6 +355,10 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     @Override
     public ExpSampleTypeImpl getSampleTypeByType(@NotNull String lsid, Container hint)
     {
+        // Default sample type has been removed -- see LabKey/platform#2140
+        if (getDefaultSampleTypeLsid().equals(lsid))
+            throw new IllegalArgumentException("Default SampleType is not supported: " + lsid);
+
         Container c = hint;
         String id = sampleTypeCache.get(lsid);
         if (null != id && (null == hint || !id.equals(hint.getId())))
@@ -426,16 +430,11 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         return new TableSelector(getTinfoMaterialSource(), filter, null).getObject(MaterialSource.class);
     }
 
-    @Override
+    /** The default 'Unspecified' SampleType is no longer supported. */
+    @Deprecated
     public String getDefaultSampleTypeLsid()
     {
         return new Lsid.LsidBuilder("SampleSource", "Default").toString();
-    }
-
-    @Override
-    public String getDefaultSampleTypeMaterialLsidPrefix()
-    {
-        return new Lsid.LsidBuilder("Sample", ExperimentServiceImpl.DEFAULT_MATERIAL_SOURCE_NAME).toString() + "#";
     }
 
     public DbScope.Transaction ensureTransaction()

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3440,12 +3440,6 @@ public class ExperimentController extends SpringActionController
         public ModelAndView getView(DeleteForm deleteForm, boolean reshow, BindException errors)
         {
             List<ExpSampleType> sampleTypes = getSampleTypes(deleteForm);
-            String defaultSampleType = SampleTypeServiceImpl.get().getDefaultSampleTypeLsid();
-            if (sampleTypes.stream().anyMatch(ss -> defaultSampleType.equals(ss.getLSID())))
-            {
-                throw new RedirectException(ExperimentUrlsImpl.get().getShowSampleTypeListURL(getContainer(), "You cannot delete the default sample type."));
-            }
-
             if (!ensureCorrectContainer(sampleTypes))
             {
                 throw new RedirectException(ExperimentUrlsImpl.get().getShowSampleTypeListURL(getContainer(), "To delete a sample type, you must be in its folder or project."));

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3440,7 +3440,7 @@ public class ExperimentController extends SpringActionController
         public ModelAndView getView(DeleteForm deleteForm, boolean reshow, BindException errors)
         {
             List<ExpSampleType> sampleTypes = getSampleTypes(deleteForm);
-            String defaultSampleType = SampleTypeService.get().getDefaultSampleTypeLsid();
+            String defaultSampleType = SampleTypeServiceImpl.get().getDefaultSampleTypeLsid();
             if (sampleTypes.stream().anyMatch(ss -> defaultSampleType.equals(ss.getLSID())))
             {
                 throw new RedirectException(ExperimentUrlsImpl.get().getShowSampleTypeListURL(getContainer(), "You cannot delete the default sample type."));

--- a/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
+++ b/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
@@ -268,12 +268,10 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
     @Override
     public boolean canEditDefinition(User user, Domain domain)
     {
-        // Cannot edit default sample type
         ExpSampleType st = getSampleType(domain);
-        if (st == null || SampleTypeService.get().getDefaultSampleTypeLsid().equals(domain.getTypeURI()))
-        {
+        if (st == null)
             return false;
-        }
+
         return domain.getContainer().hasPermission(user, DesignSampleTypePermission.class);
     }
 


### PR DESCRIPTION
#### Rationale
The default "Unspecified" SampleType has been deprecated since 19.1, but the `ExperimentService.getExpMaterials()` method could create new samples using the default SampleType's LSID prefix.  This PR removes `getExpMaterials` method as well as the public `SampleTypeService` methods related to the default SampleType.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2140
* https://github.com/LabKey/commonAssays/pull/320

#### Changes
- remove `SampleTypeService.getDefaultSampleTypeLsid()` and `getDefaultSampleTypeMaterialLsidPrefix()`
- remove `ExperimentService.getExpMaterials()` and usages in favor of `findExpMaterial()`
- unresolved samples during matrix assay import will be created in a SampleType, if possible