### PR TITLE
fix Biologics genbank import for new coerce step

### DIFF
--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -267,6 +267,10 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             if (null == k)
                 return null;
 
+            // Don't attempt to convert List or Map values
+            if (k instanceof Map || k instanceof List)
+                return k;
+
             List<Triple<ColumnInfo, ColumnInfo, MultiValuedMap<?,?>>> maps = getMaps();
 
             if (_pkColumnLookupMap != null)


### PR DESCRIPTION
#### Rationale
Fixes the `BiologicsBulkDataTest.fileUploadConstructGenBank` and `fileUploadVectorGenBank` tests.  Using a Map as a jdbc parameter attempts to use postgres hstore.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2165

#### Changes
- don't use List or Map as parameter values when looking up alternate keys

#### Stacktrace
```
ERROR Parameter                2021-04-11T18:55:59,924    http-nio-8111-exec-11 : Exception converting "{DataFileUrl=file:/.../pZCAA.gb, sequence=gcgccca..., Description=Cloning vector, Alias=[AM697672.1], annotations=[{name=centromere A, start=556, end=1371}]}" to type null
ERROR Table                    2021-04-11T18:55:59,925    http-nio-8111-exec-11 : SQL Exception
org.postgresql.util.PSQLException: No hstore extension installed.
	at org.postgresql.jdbc.PgPreparedStatement.setMap(PgPreparedStatement.java:480) ~[postgresql-42.2.14.jar:42.2.14]
	at org.postgresql.jdbc.PgPreparedStatement.setObject(PgPreparedStatement.java:965) ~[postgresql-42.2.14.jar:42.2.14]
	at org.apache.tomcat.dbcp.dbcp2.DelegatingPreparedStatement.setObject(DelegatingPreparedStatement.java:519) ~[tomcat-dbcp.jar:9.0.27]
	at org.apache.tomcat.dbcp.dbcp2.DelegatingPreparedStatement.setObject(DelegatingPreparedStatement.java:519) ~[tomcat-dbcp.jar:9.0.27]
	at org.labkey.api.data.dialect.StatementWrapper.setObject(StatementWrapper.java:1599) ~[api-21.5-SNAPSHOT.jar:?]
	at org.labkey.api.data.Parameter.setObject(Parameter.java:362) ~[api-21.5-SNAPSHOT.jar:?]
	at org.labkey.api.data.Parameter.setValue(Parameter.java:320) ~[api-21.5-SNAPSHOT.jar:?]
	at org.labkey.api.data.Table.setParameters(Table.java:155) [api-21.5-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutingSelector$ExecutingResultSetFactory.executeQuery(SqlExecutingSelector.java:503) [api-21.5-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutingSelector$ExecutingResultSetFactory.handleResultSet(SqlExecutingSelector.java:406) [api-21.5-SNAPSHOT.jar:?]
	at org.labkey.api.data.BaseSelector.fillValues(BaseSelector.java:567) [api-21.5-SNAPSHOT.jar:?]
	at org.labkey.api.data.BaseSelector.fillMultiValuedMap(BaseSelector.java:600) [api-21.5-SNAPSHOT.jar:?]
	at org.labkey.api.dataiterator.SimpleTranslator$RemapPostConvert.fetch(SimpleTranslator.java:333) [api-21.5-SNAPSHOT.jar:?]
	at org.labkey.api.dataiterator.SimpleTranslator$RemapPostConvert.mappedValue(SimpleTranslator.java:281) [api-21.5-SNAPSHOT.jar:?]
	at org.labkey.api.dataiterator.SimpleTranslator$RemapPostConvertColumn.convert(SimpleTranslator.java:941) [api-21.5-SNAPSHOT.jar:?]
	at org.labkey.api.dataiterator.SimpleTranslator$SimpleConvertColumn.get(SimpleTranslator.java:602) [api-21.5-SNAPSHOT.jar:?]
	at org.labkey.api.dataiterator.SimpleTranslator.next(SimpleTranslator.java:1719) [api-21.5-SNAPSHOT.jar:?]
	at org.labkey.api.dataiterator.CoerceDataIterator.next(CoerceDataIterator.java:96) [api-21.5-SNAPSHOT.jar:?]
```