### PR TITLE
Skip stored procedure check when LabKey connects to LabKey via JDBC

### DIFF
--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -1904,4 +1904,11 @@ public abstract class PostgreSql91Dialect extends SqlDialect
         if (null != _adminWarning)
             warnings.add(_adminWarning);
     }
+
+    @Override
+    public boolean isProcedureExists(DbScope scope, String schema, String name)
+    {
+        // Don't bother querying LabKey for stored procedures
+        return getServerType() != PostgreSqlServerType.LabKey && super.isProcedureExists(scope, schema, name);
+    }
 }

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -59,7 +59,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;


### PR DESCRIPTION
#### Rationale
When connecting to LabKey via PostgreSQL JDBC, don't bother querying for stored procedures

#### Related Pull Requests
* https://github.com/LabKey/connectors/pull/74
