### PR TITLE
Issue 42948: Remove use of inefficient HTMLContentExtractor

### DIFF
--- a/api/src/org/labkey/api/util/HTMLContentExtractor.java
+++ b/api/src/org/labkey/api/util/HTMLContentExtractor.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 
+// Warning: This is not an efficient parser. See Issue 42948.
 public abstract class HTMLContentExtractor extends HTMLEditorKit.ParserCallback
 {
     private StringBuilder _text = new StringBuilder();
@@ -89,6 +90,7 @@ public abstract class HTMLContentExtractor extends HTMLEditorKit.ParserCallback
     }
 
     // Extract readable text between <body> </body>
+    // Warning: This is not an efficient parser. See Issue 42948.
     public static class GenericHTMLExtractor extends HTMLContentExtractor
     {
         public GenericHTMLExtractor(String html)

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -536,7 +536,10 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
                 Metadata metadata = new Metadata();
                 metadata.add(Metadata.RESOURCE_NAME_KEY, PageFlowUtil.encode(r.getName()));
                 metadata.add(Metadata.CONTENT_TYPE, r.getContentType());
-                if ("text/plain".equals(r.getContentType())) // Tika sometimes guesses the wrong charset... suggest UTF-8
+
+                // Tika guesses content encoding of "IBM500" for short text documents, so suggest UTF-8. Seems related
+                // to https://issues.apache.org/jira/browse/TIKA-2771
+                if ("text/plain".equals(r.getContentType()))
                     metadata.add(Metadata.CONTENT_ENCODING, StringUtilsLabKey.DEFAULT_CHARSET.name());
 
                 ContentHandler handler = new BodyContentHandler(-1);     // no write limit on the handler -- rely on file size check to limit content

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -97,6 +97,7 @@ import org.labkey.api.util.MultiPhaseCPUTimer.InvocationTimer;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
@@ -535,10 +536,11 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
                 Metadata metadata = new Metadata();
                 metadata.add(Metadata.RESOURCE_NAME_KEY, PageFlowUtil.encode(r.getName()));
                 metadata.add(Metadata.CONTENT_TYPE, r.getContentType());
+                if ("text/plain".equals(r.getContentType())) // Tika sometimes guesses the wrong charset... suggest UTF-8
+                    metadata.add(Metadata.CONTENT_ENCODING, StringUtilsLabKey.DEFAULT_CHARSET.name());
+
                 ContentHandler handler = new BodyContentHandler(-1);     // no write limit on the handler -- rely on file size check to limit content
-
                 parse(r, fs, is, handler, metadata, isTooBig(fs, type));
-
                 body = handler.toString();
 
                 if (StringUtils.isBlank(title))

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -89,7 +89,6 @@ import org.labkey.api.util.FileStream;
 import org.labkey.api.util.FileStream.FileFileStream;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
-import org.labkey.api.util.HTMLContentExtractor;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.MinorConfigurationException;
@@ -535,20 +534,8 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
 
                 boolean tooBig = isTooBig(fs, type);
 
-                if ("text/html".equals(type))
-                {
-                    String html;
-                    if (tooBig)
-                        html = "<html><body></body></html>";
-                    else
-                        html = PageFlowUtil.getStreamContentsAsString(is);
-
-                    body = new HTMLContentExtractor.GenericHTMLExtractor(html).extract();
-
-                    if (null == title)
-                        logBadDocument("Null title", r);
-                }
-                else if (type.startsWith("text/") && !type.contains("xml") && !StringUtils.equals(type, "text/comma-separated-values"))
+                // Consider: Remove special handling for text files? Just delegate to Tika instead?
+                if (type.startsWith("text/") && !type.contains("xml") && !type.contains("html") && !StringUtils.equals(type, "text/comma-separated-values"))
                 {
                     if (tooBig)
                         body = "";
@@ -2136,5 +2123,4 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
             /* pass */
         }
     }
-
 }


### PR DESCRIPTION
#### Rationale
Our full-text search indexer has special handling that parses HTML files using `HTMLContentExtractor`. This class extends the JDK's `HTMLEditorKit.ParserCallback`, which is very inefficient with large HTML files. Tika seems to have a perfectly fine HTML parser (which uses TagSoup), so we remove our special handling and just let Tika do its thing. See [Issue 42948: org.labkey.api.util.HTMLContentExtractor uses JDK's very inefficient HTML parser](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42948)

Also taking the opportunity to remove special handling for certain text files; this code doesn't have the problems of HTMLContentExtractor, but we might as well delegate to Tika here as well. I had to add a metadata hint for "content encoding = UTF-8" for text/plain parsing, otherwise, Tika sometimes guesses IBM500 (!!) for short text bodies. See https://issues.apache.org/jira/browse/TIKA-2771 