### PR TITLE
Issue 42944: Avoid NPE with StudyService is not available 

### DIFF
--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
@@ -125,7 +125,7 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
         for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(ctx.getContainer(), ctx.getUser(), true))
         {
             // ignore the magic sample type that is used for the specimen repository, it is managed by the specimen importer
-            if (StudyService.get().getStudy(ctx.getContainer()) != null && SpecimenService.SAMPLE_TYPE_NAME.equals(sampleType.getName()))
+            if (StudyService.get() != null && StudyService.get().getStudy(ctx.getContainer()) != null && SpecimenService.SAMPLE_TYPE_NAME.equals(sampleType.getName()))
                 continue;
 
             // ignore sample types that are filtered out


### PR DESCRIPTION
#### Rationale
[Issue 42944](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42944).  When exporting a LKSM folder within a distribution that does not include the study module, we get an NPE.

#### Changes
* Add NPE check