### PR TITLE
42914: Survey entry does not respect returnUrl after save/submission

### DIFF
--- a/survey/webapp/survey/BaseSurveyPanel.js
+++ b/survey/webapp/survey/BaseSurveyPanel.js
@@ -1064,8 +1064,8 @@ Ext4.define('LABKEY.ext4.BaseSurveyPanel', {
     },
 
     leavePage : function(pageId) {
-        if (this.returnURL)
-            window.location = this.returnURL;
+        if (this.returnUrl)
+            window.location = this.returnUrl;
         else if (pageId)
             window.location = LABKEY.ActionURL.buildURL('project', 'begin', null, { pageId: pageId });
         else

--- a/survey/webapp/survey/SurveyPanel.js
+++ b/survey/webapp/survey/SurveyPanel.js
@@ -36,7 +36,7 @@ Ext4.define('LABKEY.ext4.SurveyDisplayPanel', {
             surveyLabel     : this.surveyLabel,
             isSubmitted     : this.isSubmitted,
             canEdit         : this.canEdit,
-            returnURL       : this.returnURL,
+            returnUrl       : this.returnUrl,
             autosaveInterval: this.autosaveInterval,
             disableAutoSave : this.disableAutoSave
         });


### PR DESCRIPTION
#### Rationale
This PR addresses the fix for this issue : https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42914

The survey wizard has always supported a return URL upon submit that is designed to return to the originating page. This was a casing problem from handing off from one component to another which resulted in the default navigation to the project-begin action (with no pageid).