### PR TITLE
42606: Assay results LSID required to attach provenance

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -59,6 +59,7 @@ import org.labkey.api.reader.ColumnDescriptor;
 import org.labkey.api.reader.DataLoader;
 import org.labkey.api.reader.TabLoader;
 import org.labkey.api.security.User;
+import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.study.ParticipantVisit;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
@@ -375,10 +376,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
 
                 // call pvs to delete assay result rows provenance
                 ProvenanceService pvs = ProvenanceService.get();
-                if (null != pvs)
-                {
-                    pvs.deleteAssayResultProvenance(assayResultLsidSql);
-                }
+                pvs.deleteAssayResultProvenance(assayResultLsidSql);
 
                 int count = OntologyManager.deleteOntologyObjects(ExperimentService.get().getSchema(), assayResultLsidSql, run.getContainer(), false);
                 LOG.debug("AbstractAssayTsvDataHandler.beforeDeleteData: deleted " + count + " ontology objects for assay result lsids");
@@ -456,7 +454,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
 
             ProvenanceService pvs = ProvenanceService.get();
             Map<Integer, String> rowIdToLsidMap = Collections.emptyMap();
-            if (pvs != null || provider.isPlateMetadataEnabled(protocol))
+            if (provider.isPlateMetadataEnabled(protocol))
             {
                 if (provider.getResultRowLSIDPrefix() == null)
                 {
@@ -525,7 +523,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
 
     private void addAssayResultRowsProvenance(Container container, ExpRun run, List<Map<String, Object>> insertedData, Map<Integer, String> rowIdToLsid)
     {
-        ProvenanceService pvs = ProvenanceService.get();
+        ProvenanceService pvs = ServiceRegistry.get().getService(ProvenanceService.class);
         if (pvs == null)
             return;
 
@@ -1068,9 +1066,6 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
             var provenanceInputs = map.get(ProvenanceService.PROVENANCE_INPUT_PROPERTY);
             if (null != provenanceInputs)
             {
-                if (pvs == null)
-                    throw new ExperimentException("Provenance service not available");
-
                 if (provenanceInputs instanceof JSONArray)
                 {
                     JSONArray inputJSONArr = (JSONArray) provenanceInputs;

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -523,8 +523,8 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
 
     private void addAssayResultRowsProvenance(Container container, ExpRun run, List<Map<String, Object>> insertedData, Map<Integer, String> rowIdToLsid)
     {
-        ProvenanceService pvs = ServiceRegistry.get().getService(ProvenanceService.class);
-        if (pvs == null)
+        ProvenanceService pvs = ProvenanceService.get();
+        if (!pvs.isProvenanceSupported())
             return;
 
         Set<Pair<String, String>> provPairs = new HashSet<>(insertedData.size());

--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -391,9 +391,6 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
             if (provInputsProperty != null)
             {
                 ProvenanceService pvs = ProvenanceService.get();
-                if (pvs == null)
-                    throw new ExperimentException("Provenance service not available");
-
                 Set<String> runInputLSIDs = null;
                 if (provInputsProperty instanceof String)
                 {

--- a/api/src/org/labkey/api/exp/api/DefaultProvenanceProvider.java
+++ b/api/src/org/labkey/api/exp/api/DefaultProvenanceProvider.java
@@ -25,6 +25,12 @@ import java.util.Set;
 public class DefaultProvenanceProvider implements ProvenanceService
 {
     @Override
+    public boolean isProvenanceSupported()
+    {
+        return false;
+    }
+
+    @Override
     public void addProvenanceInputs(Container container, ExpProtocolApplication app, Set<String> inputLSIDs)
     {
 

--- a/api/src/org/labkey/api/exp/api/ExperimentJSONConverter.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentJSONConverter.java
@@ -37,6 +37,7 @@ import org.labkey.api.query.QueryRowReference;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.URIUtil;
 import org.springframework.util.StringUtils;
@@ -401,7 +402,7 @@ public class ExperimentJSONConverter
 
     public static void serializeRunLevelProvenanceProperties(@NotNull JSONObject obj, ExpRun run)
     {
-        ProvenanceService svc = ProvenanceService.get();
+        ProvenanceService svc = ServiceRegistry.get().getService(ProvenanceService.class);
         if (svc == null)
             return;
 
@@ -440,7 +441,7 @@ public class ExperimentJSONConverter
     // }
     public static void provenanceMap(@NotNull JSONObject obj, ExpProtocolApplication app)
     {
-        ProvenanceService svc = ProvenanceService.get();
+        ProvenanceService svc = ServiceRegistry.get().getService(ProvenanceService.class);
         if (svc == null)
             return;
 

--- a/api/src/org/labkey/api/exp/api/ExperimentJSONConverter.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentJSONConverter.java
@@ -402,8 +402,8 @@ public class ExperimentJSONConverter
 
     public static void serializeRunLevelProvenanceProperties(@NotNull JSONObject obj, ExpRun run)
     {
-        ProvenanceService svc = ServiceRegistry.get().getService(ProvenanceService.class);
-        if (svc == null)
+        ProvenanceService svc = ProvenanceService.get();
+        if (!svc.isProvenanceSupported())
             return;
 
         // Include provenance inputs of the run in this format:
@@ -441,8 +441,8 @@ public class ExperimentJSONConverter
     // }
     public static void provenanceMap(@NotNull JSONObject obj, ExpProtocolApplication app)
     {
-        ProvenanceService svc = ServiceRegistry.get().getService(ProvenanceService.class);
-        if (svc == null)
+        ProvenanceService svc = ProvenanceService.get();
+        if (!svc.isProvenanceSupported())
             return;
 
         var outputSet = svc.getProvenanceObjectUris(app.getRowId());

--- a/api/src/org/labkey/api/exp/api/ProvenanceService.java
+++ b/api/src/org/labkey/api/exp/api/ProvenanceService.java
@@ -67,6 +67,11 @@ public interface ProvenanceService
         ServiceRegistry.get().registerService(ProvenanceService.class, impl);
     }
 
+    /**
+     * Determines whether the provider returned supports provenance;
+     */
+    boolean isProvenanceSupported();
+
     void addProvenanceInputs(Container container, ExpProtocolApplication app, Set<String> inputLSIDs);
 
     void addProvenanceOutputs(Container container, ExpProtocolApplication app, Set<String> outputLSIDs);

--- a/api/src/org/labkey/api/exp/api/ProvenanceService.java
+++ b/api/src/org/labkey/api/exp/api/ProvenanceService.java
@@ -55,6 +55,7 @@ public interface ProvenanceService
     String DATA_OUTPUTS = "dataOutputs";
     String PROPERTIES = "properties";
 
+    @NotNull
     static ProvenanceService get()
     {
         ProvenanceService svc = ServiceRegistry.get().getService(ProvenanceService.class);

--- a/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
@@ -175,7 +175,7 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
             OntologyObject objectToDelete = OntologyManager.getOntologyObject(container, objectLsid);
             ProvenanceService pvs = ProvenanceService.get();
 
-            if (null != objectToDelete && null != pvs)
+            if (null != objectToDelete)
             {
                 pvs.deleteObjectProvenance(objectToDelete.getObjectId());
                 OntologyManager.deleteOntologyObject(objectLsid, container, false);

--- a/experiment/src/org/labkey/experiment/ProtocolApplications.jsp
+++ b/experiment/src/org/labkey/experiment/ProtocolApplications.jsp
@@ -96,8 +96,7 @@
         List<? extends ExpDataRunInput> dataRunOutputs = protocolApplication.getDataOutputs();
 
         Set<Pair<String, String>> provenance = Collections.emptySet();
-        if (pvs != null)
-            provenance = pvs.getProvenanceObjectUris(protocolApplication.getRowId());
+        provenance = pvs.getProvenanceObjectUris(protocolApplication.getRowId());
     %>
         <tr class="<%=text(rowCount%2==0 ? "labkey-row" : "labkey-alternate-row")%>">
             <td valign="top">

--- a/experiment/src/org/labkey/experiment/XarExporter.java
+++ b/experiment/src/org/labkey/experiment/XarExporter.java
@@ -470,27 +470,24 @@ public class XarExporter
         }
 
         ProvenanceService pvs = ProvenanceService.get();
-        if (pvs != null)
+        var provURIs = pvs.getProvenanceObjectUris(application.getRowId());
+        if (!provURIs.isEmpty())
         {
-            var provURIs = pvs.getProvenanceObjectUris(application.getRowId());
-            if (!provURIs.isEmpty())
+            ProtocolApplicationBaseType.ProvenanceMap xProvMap = xApplication.addNewProvenanceMap();
+            for (Pair<String, String> pair : provURIs)
             {
-                ProtocolApplicationBaseType.ProvenanceMap xProvMap = xApplication.addNewProvenanceMap();
-                for (Pair<String, String> pair : provURIs)
+                if (StringUtils.isEmpty(pair.first) && StringUtils.isEmpty(pair.second))
+                    continue;
+
+                var objectRefs = xProvMap.addNewObjectRefs();
+                if (!StringUtils.isEmpty(pair.first))
                 {
-                    if (StringUtils.isEmpty(pair.first) && StringUtils.isEmpty(pair.second))
-                        continue;
+                    objectRefs.setFrom(_relativizedLSIDs.relativize(pair.first));
+                }
 
-                    var objectRefs = xProvMap.addNewObjectRefs();
-                    if (!StringUtils.isEmpty(pair.first))
-                    {
-                        objectRefs.setFrom(_relativizedLSIDs.relativize(pair.first));
-                    }
-
-                    if (!StringUtils.isEmpty(pair.second))
-                    {
-                        objectRefs.setTo(_relativizedLSIDs.relativize(pair.second));
-                    }
+                if (!StringUtils.isEmpty(pair.second))
+                {
+                    objectRefs.setTo(_relativizedLSIDs.relativize(pair.second));
                 }
             }
         }

--- a/experiment/src/org/labkey/experiment/api/ExpProtocolApplicationImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpProtocolApplicationImpl.java
@@ -371,8 +371,7 @@ public class ExpProtocolApplicationImpl extends ExpIdentifiableBaseImpl<Protocol
             new SqlExecutor(ExperimentServiceImpl.get().getSchema()).execute(dataSQL);
 
             ProvenanceService pvs = ProvenanceService.get();
-            if (pvs != null)
-                pvs.deleteProvenance(getRowId());
+            pvs.deleteProvenance(getRowId());
 
             Table.delete(ExperimentServiceImpl.get().getTinfoProtocolApplication(), getRowId());
         }
@@ -506,7 +505,7 @@ public class ExpProtocolApplicationImpl extends ExpIdentifiableBaseImpl<Protocol
     public void addProvenanceInput(Set<String> lsids)
     {
         ProvenanceService pvs = ProvenanceService.get();
-        if (null != pvs && !lsids.isEmpty())
+        if (!lsids.isEmpty())
         {
             pvs.addProvenanceInputs(this.getContainer(), this, lsids);
         }
@@ -516,7 +515,7 @@ public class ExpProtocolApplicationImpl extends ExpIdentifiableBaseImpl<Protocol
     public void addProvenanceMapping(Set<Pair<String, String>> lsidPairs)
     {
         ProvenanceService pvs = ProvenanceService.get();
-        if (null != pvs && !lsidPairs.isEmpty())
+        if (!lsidPairs.isEmpty())
         {
             pvs.addProvenance(this.getContainer(), this, lsidPairs);
         }
@@ -526,9 +525,6 @@ public class ExpProtocolApplicationImpl extends ExpIdentifiableBaseImpl<Protocol
     public Set<Pair<String, String>> getProvenanceMapping()
     {
         ProvenanceService pvs = ProvenanceService.get();
-        if (pvs == null)
-            return Collections.emptySet();
-
         return pvs.getProvenanceObjectUris(getRowId());
     }
 }

--- a/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
@@ -581,10 +581,7 @@ public class ExpRunImpl extends ExpIdentifiableEntityImpl<ExperimentRun> impleme
     private void deleteProtocolApplicationProvenance()
     {
         ProvenanceService pvs = ProvenanceService.get();
-        if (pvs != null)
-        {
-            pvs.deleteRunProvenance(getRowId());
-        }
+        pvs.deleteRunProvenance(getRowId());
     }
 
     private void deleteAppParametersAndInputs()

--- a/experiment/src/org/labkey/experiment/pipeline/ExpGeneratorHelper.java
+++ b/experiment/src/org/labkey/experiment/pipeline/ExpGeneratorHelper.java
@@ -440,7 +440,7 @@ public class ExpGeneratorHelper
             }
 
             // add in any provenance mappings and prov object inputs and outputs
-            if (pvs != null && protocol.getLSID().contains(ProvenanceService.PROVENANCE_PROTOCOL_LSID))
+            if (protocol.getLSID().contains(ProvenanceService.PROVENANCE_PROTOCOL_LSID))
             {
                 if (!action.getProvenanceMap().isEmpty())
                     pvs.addProvenance(container, stepApp, action.getProvenanceMap());

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -74,6 +74,7 @@ import org.labkey.api.reader.DataLoader;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyEntity;
@@ -450,7 +451,7 @@ public class StudyPublishManager implements StudyPublishService
             return;
 
         // If provenance module is not present, do nothing
-        ProvenanceService pvs = ProvenanceService.get();
+        ProvenanceService pvs = ServiceRegistry.get().getService(ProvenanceService.class);
         if (pvs == null)
             return;
 

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -451,8 +451,8 @@ public class StudyPublishManager implements StudyPublishService
             return;
 
         // If provenance module is not present, do nothing
-        ProvenanceService pvs = ServiceRegistry.get().getService(ProvenanceService.class);
-        if (pvs == null)
+        ProvenanceService pvs = ProvenanceService.get();
+        if (!pvs.isProvenanceSupported())
             return;
 
         AssayProvider provider = AssayService.get().getProvider(protocol);

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -2826,10 +2826,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
         try (Transaction transaction = StudySchema.getInstance().getSchema().getScope().ensureTransaction())
         {
             ProvenanceService pvs = ProvenanceService.get();
-            if (null != pvs)
-            {
-                deleteProvenance(u, lsids, pvs);
-            }
+            deleteProvenance(u, lsids, pvs);
             deleteRows(lsids);
 
             new DatasetAuditHandler().addAuditEvent(u, getContainer(), null, AuditBehaviorType.DETAILED, null, QueryService.AuditAction.DELETE, oldDatas, null);


### PR DESCRIPTION
#### Rationale
This is a fix for this issue: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42606

Details:
- The ProvenanceService was at some point refactored so that if a provider was not registered, a default noop implementation was returned
- Added a @NotNull annotation to the `get` method
- Removed all null checks for the service, since they are no longer possible
- In the cases where we need to know if the provenance module is present we use the `ServiceRegistry` instead so we can short circuit the code (this is the main bug fix). 