### PR TITLE
Issue 42937: Assay results grid loading performance can degrade with a large number of "copied to study" columns

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -874,9 +874,13 @@ public abstract class AssayProtocolSchema extends AssaySchema
 
                 table.addColumn(studyCopiedColumn);
 
-                visibleColumnNames.add(studyCopiedColumn.getName());
+                // Issue 42937: limit default visible columns to 3 for a given assay protocol
+                if (datasetIndex > 3)
+                    visibleColumnNames.clear();
+                else
+                    visibleColumnNames.add(studyCopiedColumn.getName());
             }
-            if (setVisibleColumns)
+            if (setVisibleColumns && visibleColumnNames.size() > 0)
             {
                 List<FieldKey> visibleColumns = new ArrayList<>(table.getDefaultVisibleColumns());
                 for (String columnName : visibleColumnNames)


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42937
Limit the default visible "copied to ..." study columns to 3, after that we don't add any to the default view and rely on users to customize their views themselves.

#### Changes
* AssayProtocolSchema.addCopiedToStudyColumns to limit default visibileColumnNames to 3
