### PR TITLE
42756: Disable bulk update for Submitters+Readers

### DIFF
--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -49,6 +49,7 @@ import org.labkey.api.reader.TabLoader;
 import org.labkey.api.resource.Resource;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.util.CPUTimer;
 import org.labkey.api.util.FileStream;
 import org.labkey.api.util.PageFlowUtil;
@@ -87,8 +88,6 @@ import static org.labkey.api.query.AbstractQueryUpdateService.createTransactionA
  */
 public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM>
 {
-    public static final String ASYNC_QUERY_IMPORT_PARAM = "useAsync";
-
     public static class ImportViewBean
     {
         public String urlCancel = null;
@@ -175,7 +174,8 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
 
     protected void setShowImportOptions(boolean b)
     {
-        _importViewBean.showImportOptions = b;
+        if (b && canUpdate(getUser()))
+            _importViewBean.showImportOptions = true;
     }
 
     protected void setTypeName(String name)
@@ -188,13 +188,20 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         _importViewBean.acceptZeroResults = acceptZeroResults;
     }
 
+    protected boolean canInsert(User user)
+    {
+        return _target.hasPermission(user, InsertPermission.class);
+    }
+
+    protected boolean canUpdate(User user)
+    {
+        return _target.hasPermission(user, UpdatePermission.class);
+    }
+
     public ModelAndView getDefaultImportView(FORM form, BindException errors)
     {
         ActionURL url = getViewContext().getActionURL();
-        User user = getUser();
         Container c = getContainer();
-
-        validatePermission(user, errors);
 
         if (StringUtils.isBlank(_importViewBean.urlReturn))
         {
@@ -268,12 +275,52 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         }
     }
 
+    enum Params
+    {
+        text,
+        path,
+        module,
+        moduleResource,
+        saveToPipeline,
+        useAsync,
+        importIdentity,
+        importLookupByAlternateKey,
+        format,
+        insertOption
+    }
+
+    @Nullable
+    private String getParam(Params p)
+    {
+        return getViewContext().getRequest().getParameter(p.name());
+    }
+
     public final ApiResponse _execute(FORM form, BindException errors) throws Exception
     {
         initRequest(form);
 
         User user = getUser();
         validatePermission(user, errors);
+        if (!errors.hasErrors())
+        {
+            // validate insert or update permissions based on the insert option
+            QueryUpdateService.InsertOption insertOption = QueryUpdateService.InsertOption.INSERT;
+            String insertOptionParam = getParam(Params.insertOption);
+            if (insertOptionParam != null)
+                insertOption = QueryUpdateService.InsertOption.valueOf(insertOptionParam);
+
+            switch (insertOption)
+            {
+                case MERGE, REPLACE, UPSERT -> {
+                    if (!canUpdate(user))
+                        errors.reject(SpringActionController.ERROR_MSG, "User does not have permission to update rows");
+                }
+                default -> {
+                    if (!canInsert(user))
+                        errors.reject(SpringActionController.ERROR_MSG, "User does not have permission to update rows");
+                }
+            }
+        }
 
         if (errors.hasErrors())
             throw errors;
@@ -284,24 +331,24 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         String originalName = null;
         DataLoader loader = null;
 
-        String text = getViewContext().getRequest().getParameter("text");
-        String path = getViewContext().getRequest().getParameter("path");
+        String text = getParam(Params.text);
+        String path = getParam(Params.path);
 
-        String moduleName = getViewContext().getRequest().getParameter("module");
-        String moduleResource = getViewContext().getRequest().getParameter("moduleResource");
+        String moduleName = getParam(Params.module);
+        String moduleResource = getParam(Params.moduleResource);
 
-        String saveToPipeline = getViewContext().getRequest().getParameter("saveToPipeline"); // saveToPipeline saves import file to pipeline root, but doesn't necessarily do import in a background job
+        String saveToPipeline = getParam(Params.saveToPipeline); // saveToPipeline saves import file to pipeline root, but doesn't necessarily do import in a background job
 
-        if (getViewContext().getRequest().getParameter("useAsync") != null) // useAsync will save import file to pipeline root as well as run import in a background job
-            _useAsync = Boolean.valueOf(getViewContext().getRequest().getParameter(ASYNC_QUERY_IMPORT_PARAM));
+        if (getParam(Params.useAsync) != null) // useAsync will save import file to pipeline root as well as run import in a background job
+            _useAsync = Boolean.valueOf(getParam(Params.useAsync ));
 
 
         // TODO: once importData() is refactored to accept DataIteratorContext, change importIdentity into local variable
-        if (getViewContext().getRequest().getParameter("importIdentity") != null)
-            _importIdentity = Boolean.valueOf(getViewContext().getRequest().getParameter("importIdentity"));
+        if (getParam(Params.importIdentity) != null)
+            _importIdentity = Boolean.valueOf(getParam(Params.importIdentity));
 
-        if (getViewContext().getRequest().getParameter("importLookupByAlternateKey") != null)
-            _importLookupByAlternateKey = Boolean.valueOf(getViewContext().getRequest().getParameter("importLookupByAlternateKey"));
+        if (getParam(Params.importLookupByAlternateKey) != null)
+            _importLookupByAlternateKey = Boolean.valueOf(getParam(Params.importLookupByAlternateKey));
 
         // Check first if the audit behavior has been defined for the table either in code or through XML.
         // If not defined there, check for the audit behavior defined in the action form (getAuditBehaviorType()).
@@ -314,7 +361,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
                 hasPostData = true;
                 originalName = "upload.tsv";
                 TabLoader tabLoader = new TabLoader(text, _hasColumnHeaders);
-                if ("csv".equalsIgnoreCase(getViewContext().getRequest().getParameter("format")))
+                if ("csv".equalsIgnoreCase(getParam(Params.format)))
                 {
                     tabLoader.setDelimiterCharacter(',');
                     originalName = "upload.csv";

--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -317,7 +317,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
                 }
                 default -> {
                     if (!canInsert(user))
-                        errors.reject(SpringActionController.ERROR_MSG, "User does not have permission to update rows");
+                        errors.reject(SpringActionController.ERROR_MSG, "User does not have permission to insert rows");
                 }
             }
         }

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -2380,11 +2380,15 @@ public class StudyController extends BaseStudyController
         }
 
         @Override
-        protected void validatePermission(User user, BindException errors)
+        protected boolean canInsert(User user)
         {
-            if (_def.canInsert(user))
-                return;
-            throw new UnauthorizedException("Can't update dataset: " + _def.getName());
+            return _def.canInsert(user);
+        }
+
+        @Override
+        protected boolean canUpdate(User user)
+        {
+            return _def.canUpdate(user);
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
To address this issue : https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=42756
We want to ensure the bulk update import option is properly hidden if the user doesn't have update permissions. We also need to ensure the update will fail on the same permission check on execute.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/509

#### Changes
- clean up some of the hardcoded URL param string names
- add a permission check on `ImportViewBean.setShowImportOptions`
- introduce `canInsert` and `canUpdate` methods and make the appropriate check against the selected insert option