### PR TITLE
41914: Support Query.ContainerFilter in server-side JS

### DIFF
--- a/core/resources/scripts/labkey/Query.js
+++ b/core/resources/scripts/labkey/Query.js
@@ -130,6 +130,16 @@ LABKEY.Query = new function()
         return 'GET';
     }
 
+    var containerFilter = {
+        current: "Current",
+        currentAndFirstChildren: "CurrentAndFirstChildren",
+        currentAndSubfolders: "CurrentAndSubfolders",
+        currentPlusProject: "CurrentPlusProject",
+        currentAndParents: "CurrentAndParents",
+        currentPlusProjectAndShared: "CurrentPlusProjectAndShared",
+        allFolders: "AllFolders"
+    };
+
     // public methods:
     /** @scope LABKEY.Query */
     return {
@@ -149,15 +159,8 @@ LABKEY.Query = new function()
          * <li><b>allFolders:</b> Include all folders for which the user has read permission</li>
          * </ul>
          */
-        containerFilter : {
-            current: "Current",
-            currentAndFirstChildren: "CurrentAndFirstChildren",
-            currentAndSubfolders: "CurrentAndSubfolders",
-            currentPlusProject: "CurrentPlusProject",
-            currentAndParents: "CurrentAndParents",
-            currentPlusProjectAndShared: "CurrentPlusProjectAndShared",
-            allFolders: "AllFolders"
-        },
+        containerFilter : containerFilter,
+        ContainerFilter : containerFilter,
 
         /**
          * Execute arbitrary LabKey SQL. For more information, see the


### PR DESCRIPTION
#### Rationale
This introduces the redundant `Query.ContainerFilter` (with an uppercase "C") constant to server-side JS scripts. This is a reference to the same Object as `Query.containerFilter` (with a lowercase "c"). Some users were getting confused as to what was available where and since they are both available from `@labkey/api` I've elected to make them both available on the server-side as well.

#### Changes
* Declare `ContainerFilter` in `Query` namespace for server-side JS scripts.
