### PR TITLE
Fix for provenance exception during assay import

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -454,7 +454,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
 
             ProvenanceService pvs = ProvenanceService.get();
             Map<Integer, String> rowIdToLsidMap = Collections.emptyMap();
-            if (provider.isPlateMetadataEnabled(protocol))
+            if (pvs.isProvenanceSupported() || provider.isPlateMetadataEnabled(protocol))
             {
                 if (provider.getResultRowLSIDPrefix() == null)
                 {


### PR DESCRIPTION
#### Rationale
This change fixes the exception : `java.lang.IllegalStateException: Assay results LSID required to attach provenance` seen during assay run import. The previous refactor was causing the rowId to Lsid map to be empty even if the provenance module was present.