### PR TITLE
Add null checks to _target table in AbstractQueryImportAction

### DIFF
--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -190,12 +190,16 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
 
     protected boolean canInsert(User user)
     {
-        return _target.hasPermission(user, InsertPermission.class);
+        return _target != null
+                ? _target.hasPermission(user, InsertPermission.class)
+                : getContainer().hasPermission(user, InsertPermission.class);
     }
 
     protected boolean canUpdate(User user)
     {
-        return _target.hasPermission(user, UpdatePermission.class);
+        return _target != null
+                ? _target.hasPermission(user, UpdatePermission.class)
+                : getContainer().hasPermission(user, UpdatePermission.class);
     }
 
     public ModelAndView getDefaultImportView(FORM form, BindException errors)

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -7280,6 +7280,12 @@ public class StudyController extends BaseStudyController
         }
 
         @Override
+        protected boolean canInsert(User user)
+        {
+            return getContainer().hasPermission(user, ManageStudyPermission.class);
+        }
+
+        @Override
         protected int importData(DataLoader dl, FileStream file, String originalName, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, TransactionAuditProvider.@Nullable TransactionAuditEvent auditEvent) throws IOException
         {
             if (null == _study)

--- a/study/src/org/labkey/study/controllers/specimen/SpecimenController.java
+++ b/study/src/org/labkey/study/controllers/specimen/SpecimenController.java
@@ -5330,6 +5330,12 @@ public class SpecimenController extends BaseStudyController
         }
 
         @Override
+        protected boolean canInsert(User user)
+        {
+            return getContainer().hasPermission(user, RequestSpecimensPermission.class);
+        }
+
+        @Override
         protected int importData(DataLoader dl, FileStream file, String originalName, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, @Nullable TransactionAuditProvider.TransactionAuditEvent auditEvent) throws IOException
         {
             List<String> errorList = new LinkedList<>();


### PR DESCRIPTION
#### Rationale
This recent PR https://github.com/LabKey/platform/pull/2193 resulted in test failures for
- AliquotTest
- SpecimenTest
- StudyPHIExportTest

Because the new permission checks assume there is always a target tableInfo to test for permissions. Additionally, some actions don't test for the standard insert permission and instead test for an alternate permission:
- ImportAlternateIdMappingAction `ManageStudyPermission.class`
- ImportVialIdsAction `RequestSpecimensPermission.class`

#### Related PR
https://github.com/LabKey/commonAssays/pull/325

#### Changes
- Add a null check and fall back to the container to test for insert or update permissions.
- Override `canInsert` for those actions that require a different permission (no need to do the same for `canUpdate` since those actions don't support it yet).
