### PR TITLE
Suggest UTF-8 character encoding for all text files (e.g., text/html)

### DIFF
--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -538,7 +538,8 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
                 metadata.add(Metadata.CONTENT_TYPE, r.getContentType());
 
                 // Tika guesses content encoding of "IBM500" for short text and html documents, so suggest UTF-8. Seems
-                // related to https://issues.apache.org/jira/browse/TIKA-2771
+                // related to https://issues.apache.org/jira/browse/TIKA-2771. This is just a hint, but I hope that's
+                // sufficient. If not, TikaCoreProperties.CONTENT_TYPE_OVERRIDE is an option to force UTF-8.
                 if (r.getContentType().startsWith("text"))
                     metadata.add(Metadata.CONTENT_ENCODING, StringUtilsLabKey.DEFAULT_CHARSET.name());
 

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -537,9 +537,9 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
                 metadata.add(Metadata.RESOURCE_NAME_KEY, PageFlowUtil.encode(r.getName()));
                 metadata.add(Metadata.CONTENT_TYPE, r.getContentType());
 
-                // Tika guesses content encoding of "IBM500" for short text documents, so suggest UTF-8. Seems related
-                // to https://issues.apache.org/jira/browse/TIKA-2771
-                if ("text/plain".equals(r.getContentType()))
+                // Tika guesses content encoding of "IBM500" for short text and html documents, so suggest UTF-8. Seems
+                // related to https://issues.apache.org/jira/browse/TIKA-2771
+                if (r.getContentType().startsWith("text"))
                     metadata.add(Metadata.CONTENT_ENCODING, StringUtilsLabKey.DEFAULT_CHARSET.name());
 
                 ContentHandler handler = new BodyContentHandler(-1);     // no write limit on the handler -- rely on file size check to limit content


### PR DESCRIPTION
#### Rationale
In addition to small text/plain documents, Tika detects some small text/html documents as IBM500 character encoding (see https://issues.apache.org/jira/browse/TIKA-2771). The WikiLongTest WIKI_PAGE7 Markdown Test document showed this problem.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2186

#### Changes
* Suggest UTF-8 character encoding for all text files
