### PR TITLE
Issue 42990: System Maintenance task update to all for non-configurable, single-use tasks to be registered

### DIFF
--- a/api/src/org/labkey/api/util/SystemMaintenance.java
+++ b/api/src/org/labkey/api/util/SystemMaintenance.java
@@ -265,5 +265,14 @@ public class SystemMaintenance
         {
             return false;
         }
+
+        /**
+         * Specify if the task is meant to be configurable and therefore shown in the group of maintenance tasks
+         * that can be enabled / disabled as part of the daily/nightly schedule.
+         */
+        default boolean isConfigurable()
+        {
+            return true;
+        }
     }
 }

--- a/api/src/org/labkey/api/util/SystemMaintenance.java
+++ b/api/src/org/labkey/api/util/SystemMaintenance.java
@@ -267,10 +267,10 @@ public class SystemMaintenance
         }
 
         /**
-         * Specify if the task is meant to be configurable and therefore shown in the group of maintenance tasks
-         * that can be enabled / disabled as part of the daily/nightly schedule.
+         * Specify if the task is meant to be configurable / recurring and therefore shown in the group of maintenance
+         * tasks that can be enabled / disabled as part of the daily/nightly schedule.
          */
-        default boolean isConfigurable()
+        default boolean isRecurring()
         {
             return true;
         }

--- a/api/src/org/labkey/api/util/SystemMaintenanceJob.java
+++ b/api/src/org/labkey/api/util/SystemMaintenanceJob.java
@@ -90,8 +90,10 @@ public class SystemMaintenanceJob implements org.quartz.Job, Callable<String>
             }
             else
             {
-                // If the task can't be disabled or isn't disabled now then include it
-                if (!task.canDisable() || !disabledTasks.contains(task.getName()))
+                // If the task can't be disabled or isn't disabled now, then include it.
+                // Also, skip over any of the non-configurable tasks.
+                boolean taskEnabled = !task.canDisable() || !disabledTasks.contains(task.getName());
+                if (taskEnabled && task.isConfigurable())
                 {
                     tasksToRun.add(task);
                 }

--- a/api/src/org/labkey/api/util/SystemMaintenanceJob.java
+++ b/api/src/org/labkey/api/util/SystemMaintenanceJob.java
@@ -93,7 +93,7 @@ public class SystemMaintenanceJob implements org.quartz.Job, Callable<String>
                 // If the task can't be disabled or isn't disabled now, then include it.
                 // Also, skip over any of the non-configurable tasks.
                 boolean taskEnabled = !task.canDisable() || !disabledTasks.contains(task.getName());
-                if (taskEnabled && task.isConfigurable())
+                if (taskEnabled && task.isRecurring())
                 {
                     tasksToRun.add(task);
                 }

--- a/core/src/org/labkey/core/admin/systemMaintenance.jsp
+++ b/core/src/org/labkey/core/admin/systemMaintenance.jsp
@@ -46,6 +46,19 @@
     tasks.sort(Comparator.comparing(MaintenanceTask::getDescription, String.CASE_INSENSITIVE_ORDER));
     String initialTime = SystemMaintenance.formatSystemMaintenanceTime(props.getSystemMaintenanceTime());
     Set<String> disabled = props.getDisabledTasks();
+
+    List<MaintenanceTask> configurableTasks = new ArrayList<>();
+    List<MaintenanceTask> singleUseTasks = new ArrayList<>();
+    for (MaintenanceTask task : tasks)
+    {
+        if (!task.hideFromAdminPage())
+        {
+            if (task.isConfigurable())
+                configurableTasks.add(task);
+            else
+                singleUseTasks.add(task);
+        }
+    }
 %>
 <style>
     .labkey-enabled-option
@@ -55,39 +68,43 @@
 </style>
 
 <labkey:form name="systemMaintenanceSettings" method="post">
-    <table width="1000">
-        <%=getTroubleshooterWarning(hasAdminOpsPerms, HtmlString.unsafe("<tr><td colspan=2>"), HtmlString.unsafe("<br></td></tr>"))%>
-        <tr>
-            <td colspan="2">The following tasks are (typically) run every night to clear unused data, update database statistics, perform nightly data refreshes,
-                and generally keep this server running smoothly and quickly. We recommend leaving all system maintenance tasks enabled, but some
-                of the tasks can be disabled if absolutely necessary. See the LabKey documentation for <%=helpLink("systemMaint", "more information.")%></td>
-        </tr>
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title pull-left">Configurable Maintenance Tasks</h3>
+        <div class="clearfix"></div>
+    </div>
+    <div class="panel-body">
+        <table>
+            <%=getTroubleshooterWarning(hasAdminOpsPerms, HtmlString.unsafe("<tr><td colspan=2>"), HtmlString.unsafe("<br></td></tr>"))%>
+            <tr>
+                <td colspan="2">The following tasks are (typically) run every night to clear unused data, update database statistics, perform nightly data refreshes,
+                    and generally keep this server running smoothly and quickly. We recommend leaving all system maintenance tasks enabled, but some
+                    of the tasks can be disabled if absolutely necessary. See the LabKey documentation for <%=helpLink("systemMaint", "more information.")%></td>
+            </tr>
 
-        <%
-            if (hasAdminOpsPerms)
-            {
-        %>
-        <tr>
-            <td style="padding-top: 10px;" colspan="2">You can run all enabled maintenance tasks now: <%=link("Run all tasks").href("javascript:submitSystemMaintenance()")%></td>
-        </tr>
+            <%
+                if (hasAdminOpsPerms)
+                {
+            %>
+            <tr>
+                <td style="padding-top: 10px;" colspan="2">You can run all enabled maintenance tasks now: <%=link("Run all tasks").href("javascript:submitSystemMaintenance()")%></td>
+            </tr>
 
-        <tr>
-            <td style="padding-top: 10px;" colspan="2">You can also run individual tasks, disable tasks, and change the maintenance time.
-                Click a task description to invoke that task. Uncheck a checkbox (and save) to disable a task.</td>
-        </tr>
-        <%
-            }
-        %>
-        <tr>
-            <td style="padding-top: 10px; font-weight: bold;">Tasks </td>
-        </tr>
+            <tr>
+                <td style="padding-top: 10px;" colspan="2">You can also run individual tasks, disable tasks, and change the maintenance time.
+                    Click a task description to invoke that task. Uncheck a checkbox (and save) to disable a task.</td>
+            </tr>
+            <%
+                }
+            %>
+            <tr>
+                <td style="padding-top: 10px; font-weight: bold;">Tasks </td>
+            </tr>
 
-        <tr><td style="vertical-align: top;">
-            <table>
-                <%
-                    for (MaintenanceTask task : tasks)
-                    {
-                        if (!task.hideFromAdminPage())
+            <tr><td style="vertical-align: top;">
+                <table>
+                    <%
+                        for (MaintenanceTask task : configurableTasks)
                         {
                             SafeToRender description;
                             if (hasAdminOpsPerms)
@@ -99,38 +116,67 @@
                                     .append(HtmlString.unsafe("</span>"));
                             if (!task.canDisable())
                             {
-                %><tr><td><input type="checkbox" disabled checked/><%=description%></td></tr><%
+                    %><tr><td><input type="checkbox" disabled checked/><%=description%></td></tr><%
                             }
                             else
                             {
                                 String checkboxDisabled = hasAdminOpsPerms ? "" : "disabled";
-                %><tr><td><input name="enable" <%=text(checkboxDisabled)%> value="<%=h(task.getName())%>" type="checkbox"<%=checked(!disabled.contains(task.getName()))%>/><%=description%></td></tr><%
+                    %><tr><td><input name="enable" <%=text(checkboxDisabled)%> value="<%=h(task.getName())%>" type="checkbox"<%=checked(!disabled.contains(task.getName()))%>/><%=description%></td></tr><%
                             }
                         }
-                    }
-                %>
-            </table>
-        </td>
-        </tr>
-
-        <tr>
-            <td style="padding-top: 7px;" colspan="2"><div style="" id='timePicker'></div></td>
-        </tr>
-        <%
-            if (AppProps.getInstance().isDevMode() && hasAdminOpsPerms)
-            {
-        %><tr><td colspan="2"><table><tr><td><labkey:checkbox id="enableSystemMaintenance" name="enableSystemMaintenance" value="true" checked="<%=!SystemMaintenance.isTimerDisabled()%>"/>Enable daily system maintenance (dev mode only; system maintenance is re-enabled after every server restart)</td></tr></table></td></tr><%
-            }
-        %>
-        <tr>
-            <td style="padding-top: 10px;">
-                <%= hasAdminOpsPerms ? button("Save").submit(true).onClick("return validateForm();") : HtmlString.EMPTY_STRING %>
-                <%= button(!hasAdminOpsPerms ? "Done" : "Cancel").href(new AdminUrlsImpl().getAdminConsoleURL()) %>
+                    %>
+                </table>
             </td>
-        </tr>
-    </table>
+            </tr>
+
+            <tr>
+                <td style="padding-top: 7px;" colspan="2"><div style="" id='timePicker'></div></td>
+            </tr>
+            <%
+                if (AppProps.getInstance().isDevMode() && hasAdminOpsPerms)
+                {
+            %><tr><td colspan="2"><table><tr><td><labkey:checkbox id="enableSystemMaintenance" name="enableSystemMaintenance" value="true" checked="<%=!SystemMaintenance.isTimerDisabled()%>"/>Enable daily system maintenance (dev mode only; system maintenance is re-enabled after every server restart)</td></tr></table></td></tr><%
+                }
+            %>
+            <tr>
+                <td style="padding-top: 10px;">
+                    <%= hasAdminOpsPerms ? button("Save").submit(true).onClick("return validateForm();") : HtmlString.EMPTY_STRING %>
+                    <%= button(!hasAdminOpsPerms ? "Done" : "Cancel").href(new AdminUrlsImpl().getAdminConsoleURL()) %>
+                </td>
+            </tr>
+        </table>
+    </div>
+</div>
 </labkey:form>
 <labkey:form name="systemMaintenance" action="<%=urlFor(SystemMaintenanceAction.class)%>" method="post" target="systemMaintenance"><input type="hidden" name="taskName"/></labkey:form>
+
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title pull-left">Special Maintenance and Upgrade Tasks</h3>
+        <div class="clearfix"></div>
+    </div>
+    <div class="panel-body">
+        <p>
+            The following tasks are single-use tasks which will not be run as part of the daily system maintenance
+            schedule defined above. These tasks can only be triggered by clicking on the task in the list below.
+        </p>
+        <%
+            for (MaintenanceTask task : singleUseTasks)
+            {
+                SafeToRender description;
+                if (hasAdminOpsPerms)
+                    description = link(task.getDescription()).href("javascript:submitSystemMaintenance(" + q(task.getName()) + ")");
+                else
+                    description = HtmlStringBuilder
+                            .of(HtmlString.unsafe("<span class=\"labkey-disabled-text-link labkey-enabled-option\">"))
+                            .append(task.getDescription())
+                            .append(HtmlString.unsafe("</span>"));
+                %><div><%=description%></div><%
+            }
+        %>
+    </div>
+</div>
+
 <script type="text/javascript">
 
     // global functions for script calls from this Form

--- a/core/src/org/labkey/core/admin/systemMaintenance.jsp
+++ b/core/src/org/labkey/core/admin/systemMaintenance.jsp
@@ -53,7 +53,7 @@
     {
         if (!task.hideFromAdminPage())
         {
-            if (task.isConfigurable())
+            if (task.isRecurring())
                 configurableTasks.add(task);
             else
                 singleUseTasks.add(task);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42990

This PR adds a new option to maintenance tasks so that we can register special / single-use type of tasks with the system maintenance UI which will not be included in the configurable set of daily maintenance tasks. 
<img width="1308" alt="Screen Shot 2021-04-21 at 4 35 08 PM" src="https://user-images.githubusercontent.com/6411206/115624428-3ade4d80-a2c0-11eb-8fda-ec5325d8fbf7.png">

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/326
* https://github.com/LabKey/platform/pull/2206

#### Changes
* MaintenanceTask.isConfigurable(), default to true
* Update SystemMaintenanceJob to skip over any non-configurable tasks
* Configure System Maintenance page display updates to split configurable vs non-configurable tasks into separate panels
