### PR TITLE
Item 8789: Initial implementation for client side metric counts

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2026,9 +2026,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.25.0-fb-fmCloneFreezers.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.25.0-fb-fmCloneFreezers.0.tgz",
-      "integrity": "sha1-xkqzFT4hm9sYu38wzzdmtKTa+T4=",
+      "version": "2.25.0-fb-fmCloneFreezers.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.25.0-fb-fmCloneFreezers.1.tgz",
+      "integrity": "sha1-o/6wdf1CD51v2BMs9KhdyVTsufQ=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2026,9 +2026,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.25.0-fb-fmCloneFreezers.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.25.0-fb-fmCloneFreezers.2.tgz",
-      "integrity": "sha1-dNhqI5h7/U4I78ZPFqedPKHeFa0=",
+      "version": "2.26.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.26.0.tgz",
+      "integrity": "sha1-eZsdVuqOiPPCqMVynkPnoAgjvaE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2026,9 +2026,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.24.3",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.24.3.tgz",
-      "integrity": "sha1-XsLda/n9o9HDa5Cw/MBRByC2+LM=",
+      "version": "2.25.0-fb-fmCloneFreezers.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.25.0-fb-fmCloneFreezers.0.tgz",
+      "integrity": "sha1-xkqzFT4hm9sYu38wzzdmtKTa+T4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",
@@ -9874,9 +9874,9 @@
       }
     },
     "memoize-one": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -11683,9 +11683,9 @@
       }
     },
     "react-redux": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.3.tgz",
-      "integrity": "sha512-ZhAmQ1lrK+Pyi0ZXNMUZuYxYAZd59wFuVDGUt536kSGdD0ya9Q7BfsE95E3TsFLE3kOSFp5m6G5qbatE+Ic1+w==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz",
+      "integrity": "sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==",
       "requires": {
         "@babel/runtime": "^7.12.1",
         "@types/react-redux": "^7.1.16",
@@ -11867,12 +11867,11 @@
       "integrity": "sha512-uoVmQnZQ+BtKKDKpBdbBri5SLNyIK9ULZGOA504++VbHcwouWE+fJDIo8AuESPF9/EYSkI0v05LDEQK6stCbTA=="
     },
     "redux": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
-      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.0.tgz",
+      "integrity": "sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==",
       "requires": {
-        "loose-envify": "^1.4.0",
-        "symbol-observable": "^1.2.0"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "redux-actions": {
@@ -13353,11 +13352,6 @@
           }
         }
       }
-    },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2026,9 +2026,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.25.0-fb-fmCloneFreezers.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.25.0-fb-fmCloneFreezers.1.tgz",
-      "integrity": "sha1-o/6wdf1CD51v2BMs9KhdyVTsufQ=",
+      "version": "2.25.0-fb-fmCloneFreezers.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.25.0-fb-fmCloneFreezers.2.tgz",
+      "integrity": "sha1-dNhqI5h7/U4I78ZPFqedPKHeFa0=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.2",
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.3.0",
-    "@labkey/components": "2.25.0-fb-fmCloneFreezers.1",
+    "@labkey/components": "2.25.0-fb-fmCloneFreezers.2",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.1.1"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.3.0",
-    "@labkey/components": "2.24.3",
+    "@labkey/components": "2.25.0-fb-fmCloneFreezers.0",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.1.1"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.3.0",
-    "@labkey/components": "2.25.0-fb-fmCloneFreezers.2",
+    "@labkey/components": "2.26.0",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.1.1"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.3.0",
-    "@labkey/components": "2.25.0-fb-fmCloneFreezers.0",
+    "@labkey/components": "2.25.0-fb-fmCloneFreezers.1",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.1.1"
   },

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -2647,14 +2647,30 @@ public class CoreController extends SpringActionController
         public ApiResponse execute(ClientSideMetricForm form, BindException errors)
         {
             ApiSimpleResponse response = new ApiSimpleResponse();
-            response.put(form.getMetricName(), ClientSideMetricManager.get().increment(form.getMetricName()));
+            String name = form.getMetricName();
+            if (!StringUtils.isEmpty(form.getApplicationName()))
+                name = form.getApplicationName() + "_" + name;
+            name = name.replaceAll("\\s","");
+            response.put("name", name);
+            response.put("count", ClientSideMetricManager.get().increment(name));
             return response;
         }
     }
 
     public static class ClientSideMetricForm
     {
+        private String _applicationName;
         private String _metricName;
+
+        public String getApplicationName()
+        {
+            return _applicationName;
+        }
+
+        public void setApplicationName(String applicationName)
+        {
+            _applicationName = applicationName;
+        }
 
         public String getMetricName()
         {

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -2639,37 +2639,36 @@ public class CoreController extends SpringActionController
         @Override
         public void validateForm(ClientSideMetricForm form, Errors errors)
         {
-            if (StringUtils.isEmpty(form.getMetricName()))
-                errors.reject(ERROR_MSG, "Must provide a metricName.");
+            if (StringUtils.isEmpty(form.getFeatureArea()) || StringUtils.isEmpty(form.getMetricName()))
+                errors.reject(ERROR_MSG, "Must provide both a featureArea and metricName.");
         }
 
         @Override
         public ApiResponse execute(ClientSideMetricForm form, BindException errors)
         {
             ApiSimpleResponse response = new ApiSimpleResponse();
-            String name = form.getMetricName();
-            if (!StringUtils.isEmpty(form.getApplicationName()))
-                name = form.getApplicationName() + "_" + name;
-            name = name.replaceAll("\\s","");
-            response.put("name", name);
-            response.put("count", ClientSideMetricManager.get().increment(name));
+            String featureArea = form.getFeatureArea();
+            String metricName = form.getMetricName();
+            response.put("featureArea", featureArea);
+            response.put("metricName", metricName);
+            response.put("count", ClientSideMetricManager.get().increment(featureArea, metricName));
             return response;
         }
     }
 
     public static class ClientSideMetricForm
     {
-        private String _applicationName;
+        private String _featureArea;
         private String _metricName;
 
-        public String getApplicationName()
+        public String getFeatureArea()
         {
-            return _applicationName;
+            return _featureArea;
         }
 
-        public void setApplicationName(String applicationName)
+        public void setFeatureArea(String featureArea)
         {
-            _applicationName = applicationName;
+            _featureArea = featureArea;
         }
 
         public String getMetricName()

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -160,6 +160,7 @@ import org.labkey.api.writer.FileSystemFile;
 import org.labkey.api.writer.VirtualFile;
 import org.labkey.api.writer.Writer;
 import org.labkey.api.writer.ZipUtil;
+import org.labkey.core.metrics.ClientSideMetricManager;
 import org.labkey.core.portal.ProjectController;
 import org.labkey.core.qc.CoreQCStateHandler;
 import org.labkey.core.reports.ExternalScriptEngineDefinitionImpl;
@@ -2633,6 +2634,40 @@ public class CoreController extends SpringActionController
             response.put("body", newBody);
 
             return response;
+        }
+    }
+
+    @RequiresLogin
+    public class IncrementClientSideMetricCountAction extends MutatingApiAction<ClientSideMetricForm>
+    {
+        @Override
+        public void validateForm(ClientSideMetricForm form, Errors errors)
+        {
+            if (StringUtils.isEmpty(form.getMetricName()))
+                errors.reject(ERROR_MSG, "Must provide a metricName.");
+        }
+
+        @Override
+        public ApiResponse execute(ClientSideMetricForm form, BindException errors)
+        {
+            ApiSimpleResponse response = new ApiSimpleResponse();
+            response.put(form.getMetricName(), ClientSideMetricManager.get().increment(form.getMetricName()));
+            return response;
+        }
+    }
+
+    public static class ClientSideMetricForm
+    {
+        private String _metricName;
+
+        public String getMetricName()
+        {
+            return _metricName;
+        }
+
+        public void setMetricName(String metricName)
+        {
+            _metricName = metricName;
         }
     }
 

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -188,6 +188,7 @@ import org.labkey.core.dialect.PostgreSqlVersion;
 import org.labkey.core.junit.JunitController;
 import org.labkey.core.login.DbLoginAuthenticationProvider;
 import org.labkey.core.login.LoginController;
+import org.labkey.core.metrics.ClientSideMetricManager;
 import org.labkey.core.notification.EmailPreferenceConfigServiceImpl;
 import org.labkey.core.notification.EmailPreferenceContainerListener;
 import org.labkey.core.notification.EmailPreferenceUserListener;
@@ -972,6 +973,8 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             results.put("javaRuntime", javaInfo);
             return results;
         });
+
+        ClientSideMetricManager.get().registerUsageMetrics(getName());
 
         if (AppProps.getInstance().isDevMode())
             PremiumService.get().registerAntiVirusProvider(new DummyAntiVirusService.Provider());

--- a/core/src/org/labkey/core/metrics/ClientSideMetricManager.java
+++ b/core/src/org/labkey/core/metrics/ClientSideMetricManager.java
@@ -6,25 +6,23 @@ import org.labkey.api.util.UsageReportingLevel;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class ClientSideMetricManager
 {
     private static final ClientSideMetricManager instance = new ClientSideMetricManager();
-    private static final Map<String, Integer> METRIC_COUNTS = new HashMap<>();
+    private static final Map<String, Map<String, AtomicInteger>> FEATURE_AREA_METRIC_COUNTS = new ConcurrentHashMap<>();
 
     public static ClientSideMetricManager get()
     {
         return instance;
     }
 
-    public Integer increment(String metricName)
+    public int increment(String featureArea, String metricName)
     {
-        if (!METRIC_COUNTS.containsKey(metricName))
-            METRIC_COUNTS.put(metricName, 0);
-
-        Integer count = METRIC_COUNTS.get(metricName) + 1;
-        METRIC_COUNTS.put(metricName, count);
-        return count;
+        FEATURE_AREA_METRIC_COUNTS.computeIfAbsent(featureArea, k -> new HashMap<>());
+        return FEATURE_AREA_METRIC_COUNTS.get(featureArea).computeIfAbsent(metricName, s -> new AtomicInteger(0)).incrementAndGet();
     }
 
     public void registerUsageMetrics(String moduleName)
@@ -32,7 +30,7 @@ public class ClientSideMetricManager
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {
-            svc.registerUsageMetrics(UsageReportingLevel.MEDIUM, moduleName, () -> Collections.singletonMap("clientSideMetricCounts", METRIC_COUNTS));
+            svc.registerUsageMetrics(UsageReportingLevel.MEDIUM, moduleName, () -> Collections.singletonMap("clientSideMetricCounts", FEATURE_AREA_METRIC_COUNTS));
         }
     }
 }

--- a/core/src/org/labkey/core/metrics/ClientSideMetricManager.java
+++ b/core/src/org/labkey/core/metrics/ClientSideMetricManager.java
@@ -1,7 +1,6 @@
 package org.labkey.core.metrics;
 
 import org.labkey.api.usageMetrics.UsageMetricsService;
-import org.labkey.api.util.UsageReportingLevel;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,7 +29,7 @@ public class ClientSideMetricManager
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {
-            svc.registerUsageMetrics(UsageReportingLevel.MEDIUM, moduleName, () -> Collections.singletonMap("clientSideMetricCounts", FEATURE_AREA_METRIC_COUNTS));
+            svc.registerUsageMetrics(moduleName, () -> Collections.singletonMap("clientSideMetricCounts", FEATURE_AREA_METRIC_COUNTS));
         }
     }
 }

--- a/core/src/org/labkey/core/metrics/ClientSideMetricManager.java
+++ b/core/src/org/labkey/core/metrics/ClientSideMetricManager.java
@@ -1,0 +1,38 @@
+package org.labkey.core.metrics;
+
+import org.labkey.api.usageMetrics.UsageMetricsService;
+import org.labkey.api.util.UsageReportingLevel;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ClientSideMetricManager
+{
+    private static final ClientSideMetricManager instance = new ClientSideMetricManager();
+    private static final Map<String, Integer> METRIC_COUNTS = new HashMap<>();
+
+    public static ClientSideMetricManager get()
+    {
+        return instance;
+    }
+
+    public Integer increment(String metricName)
+    {
+        if (!METRIC_COUNTS.containsKey(metricName))
+            METRIC_COUNTS.put(metricName, 0);
+
+        Integer count = METRIC_COUNTS.get(metricName) + 1;
+        METRIC_COUNTS.put(metricName, count);
+        return count;
+    }
+
+    public void registerUsageMetrics(String moduleName)
+    {
+        UsageMetricsService svc = UsageMetricsService.get();
+        if (null != svc)
+        {
+            svc.registerUsageMetrics(UsageReportingLevel.MEDIUM, moduleName, () -> Collections.singletonMap("clientSideMetricCounts", METRIC_COUNTS));
+        }
+    }
+}


### PR DESCRIPTION
#### Rationale
This PR adds the server side implementation for the initial light weight client side metric tracking. This implementation adds a new API action in the core controller and an in memory map to track the counts for various client side metrics grouped by feature area so that those counts can be included with the JSON metric data supplied by the core module. 

Here is an example of what that new JSON data will look like:

```
            "Core": {
                "authenticationConfigurations": {
                    "CAS": 1,
                    "Database": 1
                },
                "buildInfo": {
                    "vcsTag": "Unknown",
                    "buildTime": "Apr 12, 2021, 9:18:25 AM",
                    "vcsBranch": "Unknown",
                    "buildNumber": "Unknown",
                    "vcsUrl": "Unknown",
                    "version": "21.001",
                    "vcsRevision": "Unknown"
                },
                "clientSideMetricCounts": {
                    "Freezer Manager": {
                        "copyFreezerDefinition": 1
                    },
                    "Area1": {
                        "metric1": 2,
                        "metric2": 3
                    }
                },
                ...
            }
```

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/514
* https://github.com/LabKey/platform/pull/2209
* https://github.com/LabKey/inventory/pull/229

#### Changes
* core/package.json @labkey/components version update
* add new CoreController.IncrementClientSideMetricCountAction
* register ClientSideMetricManager usage metrics in CoreModule
* ClientSideMetricManager class to track metric count map by feature area and add to core module JSON metric data
