### PR TITLE
EntityInsertPanelTest fix - wrap LabKeyUIComponentsPage with ServerContextProvider

### DIFF
--- a/core/src/client/LabKeyUIComponentsPage/LabKeyUIComponentsPage.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/LabKeyUIComponentsPage.tsx
@@ -35,6 +35,7 @@ import {
     ChangePasswordModal,
     UserDetailHeader,
     SelectInput,
+    ServerContextProvider,
 } from '@labkey/components';
 import { getServerContext } from "@labkey/api";
 import { CREATE_ROW, GRID_COLUMNS, GRID_DATA, SEARCH_RESULT_HITS } from './constants';
@@ -164,19 +165,17 @@ export class App extends React.Component<any, State> {
         this.setState((state) => ({showChangePassword: !state.showChangePassword}));
     };
 
-    onFileUpload(attachments: Map<string, File>) {
-        alert("Uploading " + attachments.size + " files...just kidding, not actually uploading those files.");
-    }
-
     onToggleButtonsClick = (selectedToggleButton: string) => {
         this.setState(() => ({selectedToggleButton}));
     };
 
     render() {
         const { selected, showProgress, showConfirm, showLoadingModal, showChangePassword } = this.state;
+        const serverContext = getServerContext();
+        const ctx = Object.assign({}, serverContext, { user: new User(serverContext.user) });
 
         return (
-            <>
+            <ServerContextProvider initialContext={ctx}>
                 <p>
                     This page is setup to show examples of shared React components from
                     the <a href={'https://github.com/LabKey/labkey-ui-components'} target={'_blank'}>labkey-ui-components</a> repository.
@@ -370,7 +369,7 @@ export class App extends React.Component<any, State> {
                 {selected === 'PageDetailHeader' &&
                     this.renderPanel('PageDetailHeader',
                         <PageDetailHeader
-                            user={new User(getServerContext().user)}
+                            user={ctx.user}
                             iconDir={'_images'}
                             title={'Page Detail Header'}
                             subTitle={'With a subtitle'}
@@ -451,15 +450,15 @@ export class App extends React.Component<any, State> {
                     this.renderPanel('UserDetailHeader',
                         <>
                             <UserDetailHeader
-                                title={'Welcome, ' + getServerContext().user.displayName}
-                                user={new User(getServerContext().user)}
+                                title={'Welcome, ' + ctx.user.displayName}
+                                user={ctx.user}
                                 userProperties={fromJS({})}
-                                dateFormat={getServerContext().container.formats.dateFormat.toUpperCase()}
+                                dateFormat={ctx.container.formats.dateFormat.toUpperCase()}
                                 renderButtons={() => <Button onClick={this.toggleChangePassword} disabled={showChangePassword}>Change Password</Button>}
                             />
                             {showChangePassword &&
                             <ChangePasswordModal
-                                    user={new User(getServerContext().user)}
+                                    user={ctx.user}
                                     onSuccess={() => {
                                         alert('Your password has been changed.');
                                     }}
@@ -470,7 +469,7 @@ export class App extends React.Component<any, State> {
                     )
                 }
                 {selected === 'UserProfile' &&
-                    <UserProfilePage user={new User(getServerContext().user)}/>
+                    <UserProfilePage user={ctx.user}/>
                 }
                 {selected === 'WizardNavButtons' &&
                     this.renderPanel('WizardNavButtons',
@@ -482,7 +481,7 @@ export class App extends React.Component<any, State> {
                         />
                     )
                 }
-            </>
+            </ServerContextProvider>
         )
     }
 }

--- a/core/src/client/LabKeyUIComponentsPage/SampleInsertPage.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/SampleInsertPage.tsx
@@ -7,7 +7,8 @@ import {
     Alert,
     EntityInsertPanel,
     initQueryGridState,
-    SampleTypeDataType
+    SampleTypeDataType,
+    Location,
 } from '@labkey/components';
 
 export const SampleInsertPage: FC = memo(() => {
@@ -36,6 +37,7 @@ export const SampleInsertPage: FC = memo(() => {
                 }}
                 nounPlural="samples"
                 nounSingular="sample"
+                location={{ query: {} } as Location}
             />
         </>
     );


### PR DESCRIPTION
#### Rationale
The related PR added a call to useServerContext() for the EntityInsertPanel.tsx shared component. This ended up causing a failure in the EntityInsertPanelTest which uses that component in the core-components page. The error was that the components page usage wasn't using the ServerContextProvider needed to allow that useServerContext() call to get the user object.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/509

#### Changes
* wrap LabKeyUIComponentsPage with ServerContextProvider
