### PR TITLE
Issue 42613 - Combine low and medium usage reporting levels

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -1369,7 +1369,7 @@ public class AuthenticationManager
 
     public static void registerMetricsProvider()
     {
-        UsageMetricsService.get().registerUsageMetrics(UsageReportingLevel.ON, ModuleLoader.getInstance().getCoreModule().getName(), () -> {
+        UsageMetricsService.get().registerUsageMetrics(ModuleLoader.getInstance().getCoreModule().getName(), () -> {
             Map<String, Long> map = AuthenticationConfigurationCache.getActive(AuthenticationConfiguration.class).stream()
                 .collect(Collectors.groupingBy(config->config.getAuthenticationProvider().getName(), Collectors.counting()));
 

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -1369,7 +1369,7 @@ public class AuthenticationManager
 
     public static void registerMetricsProvider()
     {
-        UsageMetricsService.get().registerUsageMetrics(UsageReportingLevel.MEDIUM, ModuleLoader.getInstance().getCoreModule().getName(), () -> {
+        UsageMetricsService.get().registerUsageMetrics(UsageReportingLevel.ON, ModuleLoader.getInstance().getCoreModule().getName(), () -> {
             Map<String, Long> map = AuthenticationConfigurationCache.getActive(AuthenticationConfiguration.class).stream()
                 .collect(Collectors.groupingBy(config->config.getAuthenticationProvider().getName(), Collectors.counting()));
 

--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -496,11 +496,11 @@ class AppPropsImpl extends AbstractWriteableSettingsGroup implements AppProps
     {
         try
         {
-            return UsageReportingLevel.valueOf(lookupStringValue(USAGE_REPORTING_LEVEL, isDevMode() ? UsageReportingLevel.NONE.toString() : UsageReportingLevel.MEDIUM.toString()));
+            return UsageReportingLevel.valueOf(lookupStringValue(USAGE_REPORTING_LEVEL, isDevMode() ? UsageReportingLevel.NONE.toString() : UsageReportingLevel.ON.toString()));
         }
         catch (IllegalArgumentException e)
         {
-            return UsageReportingLevel.LOW;
+            return UsageReportingLevel.ON;
         }
     }
 

--- a/api/src/org/labkey/api/usageMetrics/UsageMetricsService.java
+++ b/api/src/org/labkey/api/usageMetrics/UsageMetricsService.java
@@ -29,7 +29,7 @@ import java.util.Map;
  *         UsageMetricsService svc = UsageMetricsService.get();
  *         if (null != svc)
  *         {
- *             svc.registerUsageMetrics(UsageReportingLevel.MEDIUM, NAME, () -> {
+ *             svc.registerUsageMetrics(UsageReportingLevel.ON, NAME, () -> {
  *                 Map<String, Object> metric = new HashMap<>();
  *                 metric.put("etlRunCount", new SqlSelector(DbSchema.get("dataintegration", DbSchemaType.Module), "SELECT COUNT(*) FROM dataintegration.TransformRun").getObject(Long.class));
  *                 return metric;
@@ -55,10 +55,7 @@ public interface UsageMetricsService
 
     /**
      *  Method to register a module's metrics. Call from doStartup() / startupAfterSpringConfiguration()
-     *  Metrics can be included at UsageReportingLevel LOW or MEDIUM. Note that metrics reported at MEDIUM level
-     *  are a superset of what is reported at LOW level.
-     *  If a given module has one set of metrics which should be included at LOW level, and an additional set
-     *  to report at MEDIUM level, call this method twice.
+     *  Metrics can be included at UsageReportingLevel OFF or ON. Usage metrics will only be sent for ON.
      *
      * @param level The UsageReportingLevel at which to include these metrics, LOW or MEDIUM.
      * @param moduleName The name of the module

--- a/api/src/org/labkey/api/usageMetrics/UsageMetricsService.java
+++ b/api/src/org/labkey/api/usageMetrics/UsageMetricsService.java
@@ -29,7 +29,7 @@ import java.util.Map;
  *         UsageMetricsService svc = UsageMetricsService.get();
  *         if (null != svc)
  *         {
- *             svc.registerUsageMetrics(UsageReportingLevel.ON, NAME, () -> {
+ *             svc.registerUsageMetrics(moduleName, () -> {
  *                 Map<String, Object> metric = new HashMap<>();
  *                 metric.put("etlRunCount", new SqlSelector(DbSchema.get("dataintegration", DbSchemaType.Module), "SELECT COUNT(*) FROM dataintegration.TransformRun").getObject(Long.class));
  *                 return metric;

--- a/api/src/org/labkey/api/usageMetrics/UsageMetricsService.java
+++ b/api/src/org/labkey/api/usageMetrics/UsageMetricsService.java
@@ -51,16 +51,15 @@ public interface UsageMetricsService
     }
 
     /** @return map of module name to a map of metric names/values */
-    @Nullable Map<String, Map<String, Object>> getModuleUsageMetrics(UsageReportingLevel level);
+    @Nullable Map<String, Map<String, Object>> getModuleUsageMetrics();
 
     /**
      *  Method to register a module's metrics. Call from doStartup() / startupAfterSpringConfiguration()
      *  Metrics can be included at UsageReportingLevel OFF or ON. Usage metrics will only be sent for ON.
      *
-     * @param level The UsageReportingLevel at which to include these metrics, LOW or MEDIUM.
      * @param moduleName The name of the module
      * @param metrics Implementation of the functional interface UsageMetricsProvider.getUsageMetrics() method. Typically
      *                this will return a map of metric name -> value pairs.
      */
-    void registerUsageMetrics(UsageReportingLevel level, String moduleName, UsageMetricsProvider metrics);
+    void registerUsageMetrics(String moduleName, UsageMetricsProvider metrics);
 }

--- a/api/src/org/labkey/api/util/UsageReportingLevel.java
+++ b/api/src/org/labkey/api/util/UsageReportingLevel.java
@@ -128,15 +128,6 @@ public enum UsageReportingLevel
 
             report.addHostName();
         }
-    },
-
-    DIAGNOSTICS
-    {
-        @Override
-        protected void addExtraParams(MothershipReport report, Map<String, Object> metrics)
-        {
-            // no op
-        }
     };
 
     protected abstract void addExtraParams(MothershipReport report, Map<String, Object> metrics);
@@ -247,7 +238,7 @@ public enum UsageReportingLevel
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {
-            Map<String, Map<String, Object>> allRegisteredMetrics = svc.getModuleUsageMetrics(this);
+            Map<String, Map<String, Object>> allRegisteredMetrics = svc.getModuleUsageMetrics();
             if (null != allRegisteredMetrics)
             {
                 allRegisteredMetrics.forEach((module, metrics) ->

--- a/api/src/org/labkey/api/util/UsageReportingLevel.java
+++ b/api/src/org/labkey/api/util/UsageReportingLevel.java
@@ -72,8 +72,21 @@ public enum UsageReportingLevel
             return null;
         }
     },
-    /** Captures only very basic user and container count information */
-    LOW
+
+    /**
+     * Captures basic User info, container count information and Site Settings info to help identify the organization running the install,
+     * and more detailed stats about how many items exist or actions have been invoked.
+     *
+     * May capture site-wide usage information, including counts for certain data types, such as assay designs,
+     * reports of a specific type, or lists. May also capture the number of times a certain feature was used in a
+     * given time window, such as since the server was last restarted.
+     *
+     * Per policy, this should not capture the names of specific objects like container names, dataset names, etc.
+     *
+     * Also per policy, this should not capture metrics at a container or other similar granularity. For example,
+     * metrics should not break down the number of lists defined in each folder (even if that folder was de-identified).
+     */
+    ON
     {
         @Override
         protected void addExtraParams(MothershipReport report, Map<String, Object> metrics)
@@ -97,32 +110,6 @@ public enum UsageReportingLevel
             metrics.put("recentAvgSessionDuration", null == averageRecentDuration ? -1 : averageRecentDuration);
             metrics.put("mostRecentLogin", DateUtil.formatDateISO8601(UserManager.getMostRecentLogin()));
 
-            @SuppressWarnings("unchecked")
-            Map<String, Map<String, Object>> modulesMap = (Map<String, Map<String, Object>>)metrics.computeIfAbsent("modules", s -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
-            putModulesMetrics(modulesMap);
-            putModulesBuildInfo(modulesMap);
-        }
-    },
-    /**
-     * Captures Site Settings info to help identify the organization running the install, and more detailed stats
-     * about how many items exist or actions have been invoked.
-     *
-     * May capture site-wide usage information, including counts for certain data types, such as assay designs,
-     * reports of a specific type, or lists. May also capture the number of times a certain feature was used in a
-     * given time window, such as since the server was last restarted.
-     *
-     * Per policy, this should not capture the names of specific objects like container names, dataset names, etc.
-     *
-     * Also per policy, this should not capture metrics at a container or other similar granularity. For example,
-     * metrics should not break down the number of lists defined in each folder (even if that folder was deidentified).
-     */
-    MEDIUM
-    {
-        @Override
-        protected void addExtraParams(MothershipReport report, Map<String, Object> metrics)
-        {
-            LOW.addExtraParams(report, metrics);
-
             LookAndFeelProperties laf = LookAndFeelProperties.getInstance(ContainerManager.getRoot());
             report.addParam("logoLink", laf.getLogoHref());
             report.addParam("organizationName", laf.getCompanyName());
@@ -135,6 +122,8 @@ public enum UsageReportingLevel
 
             putModuleControllerHits(modulesMap);
             putModulesMetrics(modulesMap);
+            putModulesBuildInfo(modulesMap);
+
             metrics.put("folderTypeCounts", ContainerManager.getFolderTypeNameContainerCounts(ContainerManager.getRoot()));
 
             report.addHostName();

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 21.001
+SchemaVersion: 21.002
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/prop-21.001-21.002.sql
+++ b/core/resources/schemas/dbscripts/postgresql/prop-21.001-21.002.sql
@@ -4,4 +4,5 @@ WHERE   Set IN
         (SELECT Set
         FROM prop.PropertySets
         WHERE Category = 'SiteConfig')
-AND     Name = 'usageReportingLevel';
+AND     Name = 'usageReportingLevel'
+AND     value = 'MEDIUM';

--- a/core/resources/schemas/dbscripts/postgresql/prop-21.001-21.002.sql
+++ b/core/resources/schemas/dbscripts/postgresql/prop-21.001-21.002.sql
@@ -1,0 +1,7 @@
+UPDATE  prop.Properties
+SET     value = 'ON'
+WHERE   Set IN
+        (SELECT Set
+        FROM prop.PropertySets
+        WHERE Category = 'SiteConfig')
+AND     Name = 'usageReportingLevel';

--- a/core/resources/schemas/dbscripts/postgresql/prop-21.001-21.002.sql
+++ b/core/resources/schemas/dbscripts/postgresql/prop-21.001-21.002.sql
@@ -5,4 +5,4 @@ WHERE   Set IN
         FROM prop.PropertySets
         WHERE Category = 'SiteConfig')
 AND     Name = 'usageReportingLevel'
-AND     value = 'MEDIUM';
+AND     value IN ('MEDIUM', 'LOW');

--- a/core/resources/schemas/dbscripts/sqlserver/prop-21.001-21.002.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/prop-21.001-21.002.sql
@@ -4,4 +4,5 @@ WHERE   [Set] IN
         (SELECT [Set]
         FROM prop.PropertySets
         WHERE Category = 'SiteConfig')
-AND     Name = 'usageReportingLevel';
+AND     Name = 'usageReportingLevel'
+AND     value = 'MEDIUM';

--- a/core/resources/schemas/dbscripts/sqlserver/prop-21.001-21.002.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/prop-21.001-21.002.sql
@@ -1,0 +1,7 @@
+UPDATE  prop.Properties
+SET     value = 'ON'
+WHERE   [Set] IN
+        (SELECT [Set]
+        FROM prop.PropertySets
+        WHERE Category = 'SiteConfig')
+AND     Name = 'usageReportingLevel';

--- a/core/resources/schemas/dbscripts/sqlserver/prop-21.001-21.002.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/prop-21.001-21.002.sql
@@ -5,4 +5,4 @@ WHERE   [Set] IN
         FROM prop.PropertySets
         WHERE Category = 'SiteConfig')
 AND     Name = 'usageReportingLevel'
-AND     value = 'MEDIUM';
+AND     value IN ('MEDIUM', 'LOW');

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -964,7 +964,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         AuthenticationManager.populateSettingsWithStartupProps();
         AnalyticsServiceImpl.populateSettingsWithStartupProps();
 
-        UsageMetricsService.get().registerUsageMetrics(UsageReportingLevel.ON, getName(), () -> {
+        UsageMetricsService.get().registerUsageMetrics(getName(), () -> {
             Map<String, Object> results = new HashMap<>();
             Map<String, Object> javaInfo = new HashMap<>();
             javaInfo.put("java.vendor", System.getProperty("java.vendor"));

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -964,7 +964,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         AuthenticationManager.populateSettingsWithStartupProps();
         AnalyticsServiceImpl.populateSettingsWithStartupProps();
 
-        UsageMetricsService.get().registerUsageMetrics(UsageReportingLevel.LOW, getName(), () -> {
+        UsageMetricsService.get().registerUsageMetrics(UsageReportingLevel.ON, getName(), () -> {
             Map<String, Object> results = new HashMap<>();
             Map<String, Object> javaInfo = new HashMap<>();
             javaInfo.put("java.vendor", System.getProperty("java.vendor"));

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -3712,7 +3712,7 @@ public class AdminController extends SpringActionController
                 if (form.isAllowReporting() && appProps.getExceptionReportingLevel() == ExceptionReportingLevel.NONE)
                 {
                     appProps.setExceptionReportingLevel(ExceptionReportingLevel.MEDIUM);
-                    appProps.setUsageReportingLevel(UsageReportingLevel.MEDIUM);
+                    appProps.setUsageReportingLevel(UsageReportingLevel.ON);
                 }
                 else if (!form.isAllowReporting())
                 {
@@ -9515,7 +9515,7 @@ public class AdminController extends SpringActionController
     static class MothershipReportSelectionForm
     {
         private String _type = MothershipReport.Type.CheckForUpdates.toString();
-        private String _level = UsageReportingLevel.MEDIUM.toString();
+        private String _level = UsageReportingLevel.ON.toString();
         private boolean _submit = false;
         private String _forwardedFor = null;
         // indicates action is being invoked for dev/test

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -217,16 +217,11 @@ Click the Save button at any time to accept the current settings and continue.</
             <tr>
                 <td valign="top">
                     <label>
-                        <input type="radio" name="usageReportingLevel" id="usageReportingLevel2" onchange="enableUsageTest();" value="LOW"<%=checked("LOW".equals(appProps.getUsageReportingLevel().toString()))%>>
-                        <strong>ON, low</strong> - Check for updates and report system information.
-                    </label>
-                </td>
-            </tr>
-            <tr>
-                <td valign="top">
-                    <label>
-                        <input type="radio" name="usageReportingLevel" id="usageReportingLevel3" onchange="enableUsageTest();" value="MEDIUM"<%=checked("MEDIUM".equals(appProps.getUsageReportingLevel().toString()))%>>
-                        <strong>ON, medium</strong> - Check for updates and report system information, usage data, and organization details.
+                        <input type="radio" name="usageReportingLevel" id="usageReportingLevel2" onchange="enableUsageTest();"
+                               value="ON"<%=checked("MEDIUM".equals(appProps.getUsageReportingLevel().toString()) ||
+                               "LOW".equals(appProps.getUsageReportingLevel().toString()) ||
+                               "ON".equals(appProps.getUsageReportingLevel().toString()))%>>
+                        <strong>ON</strong> - Check for updates and report system information, usage data, and organization details.
                     </label>
                 </td>
             </tr>

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -218,9 +218,7 @@ Click the Save button at any time to accept the current settings and continue.</
                 <td valign="top">
                     <label>
                         <input type="radio" name="usageReportingLevel" id="usageReportingLevel2" onchange="enableUsageTest();"
-                               value="ON"<%=checked("MEDIUM".equals(appProps.getUsageReportingLevel().toString()) ||
-                               "LOW".equals(appProps.getUsageReportingLevel().toString()) ||
-                               "ON".equals(appProps.getUsageReportingLevel().toString()))%>>
+                               value="ON"<%=checked("ON".equals(appProps.getUsageReportingLevel().toString()))%>>
                         <strong>ON</strong> - Check for updates and report system information, usage data, and organization details.
                     </label>
                 </td>

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -425,7 +425,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {
-            svc.registerUsageMetrics(UsageReportingLevel.ON, MODULE_NAME, () -> {
+            svc.registerUsageMetrics(MODULE_NAME, () -> {
                 Map<String, Object> results = new HashMap<>();
                 if (AssayService.get() != null)
                 {

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -425,7 +425,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {
-            svc.registerUsageMetrics(UsageReportingLevel.MEDIUM, MODULE_NAME, () -> {
+            svc.registerUsageMetrics(UsageReportingLevel.ON, MODULE_NAME, () -> {
                 Map<String, Object> results = new HashMap<>();
                 if (AssayService.get() != null)
                 {

--- a/list/src/org/labkey/list/ListModule.java
+++ b/list/src/org/labkey/list/ListModule.java
@@ -152,7 +152,7 @@ public class ListModule extends SpringModule
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {
-            svc.registerUsageMetrics(UsageReportingLevel.MEDIUM, getName(), () -> {
+            svc.registerUsageMetrics(UsageReportingLevel.ON, getName(), () -> {
                 Map<String, Object> metric = new HashMap<>();
                 metric.put("listCount", new SqlSelector(DbSchema.get("exp", DbSchemaType.Module), "SELECT COUNT(*) FROM exp.list").getObject(Long.class));
                 return metric;

--- a/list/src/org/labkey/list/ListModule.java
+++ b/list/src/org/labkey/list/ListModule.java
@@ -152,7 +152,7 @@ public class ListModule extends SpringModule
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {
-            svc.registerUsageMetrics(UsageReportingLevel.ON, getName(), () -> {
+            svc.registerUsageMetrics(getName(), () -> {
                 Map<String, Object> metric = new HashMap<>();
                 metric.put("listCount", new SqlSelector(DbSchema.get("exp", DbSchemaType.Module), "SELECT COUNT(*) FROM exp.list").getObject(Long.class));
                 return metric;

--- a/mothership/src/org/labkey/mothership/MothershipController.java
+++ b/mothership/src/org/labkey/mothership/MothershipController.java
@@ -690,7 +690,7 @@ public class MothershipController extends SpringActionController
         @Override
         public Object execute(Object o, BindException errors)
         {
-            MothershipReport report = UsageReportingLevel.generateReport(UsageReportingLevel.MEDIUM, MothershipReport.Target.local);
+            MothershipReport report = UsageReportingLevel.generateReport(UsageReportingLevel.ON, MothershipReport.Target.local);
             if (report != null)
             {
                 report.run();

--- a/query/src/org/labkey/query/persist/QueryManager.java
+++ b/query/src/org/labkey/query/persist/QueryManager.java
@@ -980,7 +980,7 @@ public class QueryManager
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {
-            svc.registerUsageMetrics(UsageReportingLevel.MEDIUM, moduleName, () -> {
+            svc.registerUsageMetrics(UsageReportingLevel.ON, moduleName, () -> {
                 Bag<String> bag = DbScope.getDbScopes().stream()
                         .filter(scope -> !scope.isLabKeyScope()).map(DbScope::getDatabaseProductName)
                         .collect(Collectors.toCollection(HashBag::new));

--- a/query/src/org/labkey/query/persist/QueryManager.java
+++ b/query/src/org/labkey/query/persist/QueryManager.java
@@ -980,7 +980,7 @@ public class QueryManager
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {
-            svc.registerUsageMetrics(UsageReportingLevel.ON, moduleName, () -> {
+            svc.registerUsageMetrics(moduleName, () -> {
                 Bag<String> bag = DbScope.getDbScopes().stream()
                         .filter(scope -> !scope.isLabKeyScope()).map(DbScope::getDatabaseProductName)
                         .collect(Collectors.toCollection(HashBag::new));

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -445,7 +445,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {
-            svc.registerUsageMetrics(UsageReportingLevel.ON, MODULE_NAME, () -> {
+            svc.registerUsageMetrics(MODULE_NAME, () -> {
                 Map<String, Object> metric = new HashMap<>();
                 metric.put("studyCount", new SqlSelector(StudySchema.getInstance().getSchema(), "SELECT COUNT(*) FROM study.study").getObject(Long.class));
                 metric.put("datasetCount", new SqlSelector(StudySchema.getInstance().getSchema(), "SELECT COUNT(*) FROM study.dataset").getObject(Long.class));

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -445,7 +445,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {
-            svc.registerUsageMetrics(UsageReportingLevel.MEDIUM, MODULE_NAME, () -> {
+            svc.registerUsageMetrics(UsageReportingLevel.ON, MODULE_NAME, () -> {
                 Map<String, Object> metric = new HashMap<>();
                 metric.put("studyCount", new SqlSelector(StudySchema.getInstance().getSchema(), "SELECT COUNT(*) FROM study.study").getObject(Long.class));
                 metric.put("datasetCount", new SqlSelector(StudySchema.getInstance().getSchema(), "SELECT COUNT(*) FROM study.dataset").getObject(Long.class));
@@ -808,7 +808,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
                 "reportCountsByType"
             );
             assertTrue("Mothership report missing expected metrics",
-                    UsageReportingLevel.MothershipReportTestHelper.getModuleMetrics(UsageReportingLevel.MEDIUM, MODULE_NAME)
+                    UsageReportingLevel.MothershipReportTestHelper.getModuleMetrics(UsageReportingLevel.ON, MODULE_NAME)
                     .keySet().containsAll(metricNames));
         }
     }

--- a/survey/src/org/labkey/survey/SurveyModule.java
+++ b/survey/src/org/labkey/survey/SurveyModule.java
@@ -130,7 +130,7 @@ public class SurveyModule extends DefaultModule
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {
-            svc.registerUsageMetrics(UsageReportingLevel.MEDIUM, NAME, () -> {
+            svc.registerUsageMetrics(UsageReportingLevel.ON, NAME, () -> {
                 Map<String, Object> metric = new HashMap<>();
                 metric.put("surveyDesigns", new SqlSelector(DbSchema.get("survey", DbSchemaType.Module), "SELECT COUNT(*) FROM survey.SurveyDesigns").getObject(Long.class));
                 metric.put("surveys", new SqlSelector(DbSchema.get("survey", DbSchemaType.Module), "SELECT COUNT(*) FROM survey.Surveys").getObject(Long.class));

--- a/survey/src/org/labkey/survey/SurveyModule.java
+++ b/survey/src/org/labkey/survey/SurveyModule.java
@@ -130,7 +130,7 @@ public class SurveyModule extends DefaultModule
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {
-            svc.registerUsageMetrics(UsageReportingLevel.ON, NAME, () -> {
+            svc.registerUsageMetrics(NAME, () -> {
                 Map<String, Object> metric = new HashMap<>();
                 metric.put("surveyDesigns", new SqlSelector(DbSchema.get("survey", DbSchemaType.Module), "SELECT COUNT(*) FROM survey.SurveyDesigns").getObject(Long.class));
                 metric.put("surveys", new SqlSelector(DbSchema.get("survey", DbSchemaType.Module), "SELECT COUNT(*) FROM survey.Surveys").getObject(Long.class));


### PR DESCRIPTION
#### Rationale
We want to reduce the complexity for implementing usage metrics and in choosing the configuration for a given installation. Right now we have three options - off, low, and medium.

We want to switch to just off and on. The on level will send the same content as the medium level does today.

During upgrade, servers that are currently at low or medium will be switch to the "on" setting.

#### Related Pull Requests
* 

#### Changes
* Remove "MEDIUM" and "LOW" usage levels
* sql upgrade script to update "MEDIUM" and "LOW" to "ON"
