### PR TITLE
Improve messaging on login failures

### DIFF
--- a/core/webapp/login.js
+++ b/core/webapp/login.js
@@ -52,8 +52,16 @@
                     window.location = response.returnUrl;
                 }
             }, this),
-            failure: LABKEY.Utils.getCallbackWrapper(function(response) {
-                setSubmitting(false, response ? response.exception : '');
+            failure: LABKEY.Utils.getCallbackWrapper(function(response, request) {
+                let message;
+                if (response && response.exception) {
+                    message = response.exception;
+                }
+                else {
+                    message = request && request.readyState === 4 && request.status === 0 ? 'Login failed. The server may be offline.' : 'Login failed.';
+                }
+
+                setSubmitting(false, message);
                 if (response && response.returnUrl) {
                     window.location = response.returnUrl;
                 }


### PR DESCRIPTION
#### Rationale
If the client can't contact the server, the login dialog spins briefly to show it's trying but then clears the spinner and shows no error info

#### Changes
* Include a generic failure message (or a more specific one if we detect that the client couldn't contact the server) when we don't get a response with an exception message from the server