### PR TITLE
Issue 43009: ETL fails when aliasing built-in columns

### DIFF
--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -210,6 +210,7 @@ public class DataIteratorUtil
             }
 
             Pair<ColumnInfo,MatchType> to = null;
+            // Only do propertyURI matching if not an ETL
             if (null != from.getPropertyURI() && !isEtl)
                 to = targetMap.get(from.getPropertyURI());
             if (null == to)

--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -207,7 +207,7 @@ public class DataIteratorUtil
             // If name matches, check if property URI matches for higher priority match type
             if (null != to && null != from.getPropertyURI())
             {
-                // Renamed columns in queries will not match. Just stick with name match.
+                // Built-in columns aliased in source query will not match. Just stick with name match.
                 if (from.getPropertyURI().equals(to.first.getPropertyURI())) {
                     Pair<ColumnInfo,MatchType> toUri = targetMap.get(from.getPropertyURI());
                     if (null != toUri)

--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -200,11 +200,21 @@ public class DataIteratorUtil
                 matches.add(null);
                 continue;
             }
-            Pair<ColumnInfo,MatchType> to = null;
-            if (null != from.getPropertyURI())
-                to = targetMap.get(from.getPropertyURI());
-            if (null == to)
-                to = targetMap.get(from.getName());
+
+            // Match by name first
+            Pair<ColumnInfo,MatchType> to = targetMap.get(from.getName());
+
+            // If name matches, check if property URI matches for higher priority match type
+            if (null != to && null != from.getPropertyURI())
+            {
+                // Renamed columns in queries will not match. Just stick with name match.
+                if (from.getPropertyURI().equals(to.first.getPropertyURI())) {
+                    Pair<ColumnInfo,MatchType> toUri = targetMap.get(from.getPropertyURI());
+                    if (null != toUri)
+                        to = toUri;
+                }
+            }
+
             if (null == to)
             {
                 // Check to see if the column i.e. propURI has a property descriptor and vocabulary domain is present

--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -215,7 +215,9 @@ public class DataIteratorUtil
                 // If name matches, check if property URI matches for higher priority match type
                 if (null != to && null != from.getPropertyURI())
                 {
-                    // Renamed columns in queries will not match. Just stick with name match.
+                    // Renamed built-in columns (ex. LSID, ParticipantId) in source queries will not match propertyURI with
+                    // target. In that case, just stick with name match. Otherwise check for propertyURI match for higher priority match
+                    // (this is primarily for ParticipantId which can have two columns with same name in the dataiterator)
                     if (from.getPropertyURI().equals(to.first.getPropertyURI())) {
                         Pair<ColumnInfo,MatchType> toUri = targetMap.get(from.getPropertyURI());
                         if (null != toUri)

--- a/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
@@ -195,7 +195,8 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
         // match up the columns, validate that there is no more than one source column that matches the target column
         //
         ValidationException setupError = new ValidationException();
-        ArrayList<ColumnInfo> matches = DataIteratorUtil.matchColumns(input, _target, _useImportAliases, setupError, _c);
+        ArrayList<ColumnInfo> matches = DataIteratorUtil.matchColumns(input, _target, _useImportAliases,
+                DataIteratorUtil.isEtl(context), setupError, _c);
 
         ArrayList<TranslateHelper> convertTargetCols = new ArrayList<>(input.getColumnCount()+1);
         for (int i=1 ; i<=input.getColumnCount() ; i++)

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -613,7 +613,7 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
 
         int translatePtid(Integer indexPtidInput, User user) throws ValidationException
         {
-            ColumnInfo col = new BaseColumnInfo("ParticipantAliasId", JdbcType.VARCHAR);
+            ColumnInfo col = new BaseColumnInfo("ParticipantId", JdbcType.VARCHAR);
             ParticipantIdImportHelper piih = new ParticipantIdImportHelper(_datasetDefinition.getStudy(), user, _datasetDefinition);
             Callable call = piih.getCallable(getInput(), indexPtidInput);
             return addColumn(col, call);

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -163,7 +163,8 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
         DatasetColumnsIterator it = new DatasetColumnsIterator(_datasetDefinition, input, context, user);
 
         ValidationException matchError = new ValidationException();
-        ArrayList<ColumnInfo> inputMatches = DataIteratorUtil.matchColumns(input, table, useImportAliases, matchError, null);
+        ArrayList<ColumnInfo> inputMatches = DataIteratorUtil.matchColumns(input, table, useImportAliases,
+                DataIteratorUtil.isEtl(context), matchError, null);
         if (matchError.hasErrors())
             setupError(matchError.getMessage());
 

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -251,18 +251,13 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
 
         // do a conversion for PTID aliasing
         Integer translatedIndexPTID = indexPTID;
-
-        // Add translate columninfo if subjectCol is aliased
-        if (!subjectCol.getName().equals("ParticipantId"))
+        try
         {
-            try
-            {
-                translatedIndexPTID = it.translatePtid(indexPTIDInput, user);
-            }
-            catch (ValidationException e)
-            {
-                context.getErrors().addRowError(e);
-            }
+            translatedIndexPTID = it.translatePtid(indexPTIDInput, user);
+        }
+        catch (ValidationException e)
+        {
+            context.getErrors().addRowError(e);
         }
 
         // For now, just specify null for sequence num index... we'll add it below
@@ -617,7 +612,7 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
 
         int translatePtid(Integer indexPtidInput, User user) throws ValidationException
         {
-            ColumnInfo col = new BaseColumnInfo("ParticipantId", JdbcType.VARCHAR);
+            ColumnInfo col = new BaseColumnInfo("ParticipantAliasId", JdbcType.VARCHAR);
             ParticipantIdImportHelper piih = new ParticipantIdImportHelper(_datasetDefinition.getStudy(), user, _datasetDefinition);
             Callable call = piih.getCallable(getInput(), indexPtidInput);
             return addColumn(col, call);

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -252,8 +252,8 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
         // do a conversion for PTID aliasing
         Integer translatedIndexPTID = indexPTID;
 
-        // If not an ETL then get ParticipantId translate column
-        if (context.getDataSource() == null || !context.getDataSource().equals("etl"))
+        // Add translate columninfo if subjectCol is aliased
+        if (!subjectCol.getName().equals("ParticipantId"))
         {
             try
             {

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -251,13 +251,18 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
 
         // do a conversion for PTID aliasing
         Integer translatedIndexPTID = indexPTID;
-        try
+
+        // If not an ETL then get ParticipantId translate column
+        if (context.getDataSource() == null || !context.getDataSource().equals("etl"))
         {
-            translatedIndexPTID = it.translatePtid(indexPTIDInput, user);
-        }
-        catch (ValidationException e)
-        {
-            context.getErrors().addRowError(e);
+            try
+            {
+                translatedIndexPTID = it.translatePtid(indexPTIDInput, user);
+            }
+            catch (ValidationException e)
+            {
+                context.getErrors().addRowError(e);
+            }
         }
 
         // For now, just specify null for sequence num index... we'll add it below

--- a/study/src/org/labkey/study/model/ParticipantIdImportHelper.java
+++ b/study/src/org/labkey/study/model/ParticipantIdImportHelper.java
@@ -137,7 +137,7 @@ public class ParticipantIdImportHelper implements ParticipantIdTranslator
     }
 
     /*
-     * The getCallable method returns a collable object that translates the participantId to its alias on lookup
+     * The getCallable method returns a callable object that translates the participantId to its alias on lookup
      */
     public Callable<Object> getCallable(@NotNull final DataIterator it, @Nullable final Integer participantIndex)
     {


### PR DESCRIPTION
#### Rationale
For built-in columns like ParticipantId, if they are aliased in the source query we are passing through propertyURIs of the original column which can cause duplicate matches based on propertyURI alone.  This update is scoped to ETLs and matches on the following:
- Name and PropertyURI - Top match (This is really just necessary for ParticipantId)
- Name - Second match
- Vocabulary match - Same as before

Ran this across most of the core tests and dataintegration.

#### Related Pull Requests
* https://github.com/LabKey/dataintegration/pull/105

#### Changes
* Update DataIteratorUtil._matchColumns as described above
