### PR TITLE
After upgrade scripts run, re-prepare only the previously initialized dialects

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1640,7 +1640,7 @@ public class DbScope
      * Returns all DbScopes that have been successfully initialized, ignoring those that haven't been initialized yet
      * @return A collection of initialized DbScopes
      */
-    private static @NotNull Collection<DbScope> getInitializedDbScopes()
+    public static @NotNull Collection<DbScope> getInitializedDbScopes()
     {
         return getLoaders().stream()
             .map(DbScopeLoader::getIfPresent)

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -678,10 +678,11 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         // Allow dialect to make adjustments to the just upgraded core database (e.g., install aggregate functions, etc.)
         CoreSchema.getInstance().getSqlDialect().afterCoreUpgrade(moduleContext);
 
-        // The core SQL scripts install aggregate functions and other objects that dialects need to know about. Prepare the
-        // dialects again to make sure they're aware of all the changes. Prepare all the scopes because we could have more
-        // than one scope pointed at the core database (e.g., external schemas). See #17077 (pg example) and #19177 (ss example)
-        for (DbScope scope : DbScope.getDbScopes())
+        // The core SQL scripts install aggregate functions and other objects that dialects need to know about. Prepare
+        // the previously initialized dialects again to make sure they're aware of all the changes. Prepare all the
+        // initialized scopes because we could have more than one scope pointed at the core database (e.g., external
+        // schemas). See #17077 (pg example) and #19177 (ss example).
+        for (DbScope scope : DbScope.getInitializedDbScopes())
             scope.getSqlDialect().prepare(scope);
 
         // Now that we know the standard containers have been created, add a listener that warms the just-cleared caches with


### PR DESCRIPTION
#### Rationale
After upgrade, we call `prepare()` on all data source dialects to make them aware of changes such as newly installed aggregate functions. Now that we defer data source initialization until first reference, we shouldn't involve uninitialized data sources at this step. At best, it slows down startup unnecessarily and at worst, it causes exceptions for data sources that aren't ready this early.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2160