### PR TITLE
Issue 41854: Wording updates for conversion error messages

### DIFF
--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -1262,7 +1262,7 @@ public abstract class CompareType
             return Double.compare(((Number) a).doubleValue(), ((Number) b).doubleValue());
         }
 
-        return ((Comparable)a).compareTo(b);
+        return a.compareTo(b);
     }
 
     // Converts parameter value to the proper type based on the SQL type of the ColumnInfo

--- a/api/src/org/labkey/api/data/PkFilter.java
+++ b/api/src/org/labkey/api/data/PkFilter.java
@@ -19,6 +19,7 @@ package org.labkey.api.data;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.labkey.api.data.dialect.SqlDialect;
+import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.GUID;
 import org.labkey.api.view.NotFoundException;
@@ -62,7 +63,7 @@ public class PkFilter extends SimpleFilter
                     }
                     catch (ConversionException e)
                     {
-                        throw new NotFoundException("Failed to convert '" + value + "' for '" + fieldKey + "', should be of type " + targetClass.getName());
+                        throw new NotFoundException(OntologyManager.getStandardConversionErrorMessage(value, fieldKey.toString(), true, targetClass));
                     }
                 }
                 else if (SqlDialect.isGUIDType(columnPK.get(i).getSqlTypeName()))
@@ -73,7 +74,7 @@ public class PkFilter extends SimpleFilter
                     }
                     catch (IllegalArgumentException e)
                     {
-                        throw new NotFoundException("Failed to convert '" + value + "' for '" + fieldKey + "', should be of type GUID");
+                        throw new NotFoundException(OntologyManager.getStandardConversionErrorMessage(value, fieldKey.toString(), true, GUID.class));
                     }
                 }
             }

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -48,6 +48,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.TestSchema;
 import org.labkey.api.exp.MvFieldWrapper;
+import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.query.AbstractQueryUpdateService;
@@ -163,8 +164,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         String msg;
         if (null != value && null != target)
         {
-            String fromType = (value instanceof String) ? "" : "(" + (value.getClass().getSimpleName() + ") ");
-            msg = "Could not convert " + fromType + "'" + value + "' for field " + fieldName + ", should be of type " + target.getJavaClass().getSimpleName();
+            msg = OntologyManager.getStandardConversionErrorMessage(value, fieldName, true, target.getJavaClass());
         }
         else if (null != x)
             msg = StringUtils.defaultString(x.getMessage(), x.toString());

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -341,7 +341,7 @@ public class OntologyManager
                     }
                     catch (ConversionException e)
                     {
-                        throw new ValidationException("Could not convert '" + value + "' for field " + pd.getName() + ", should be of type " + pd.getPropertyType().getJavaType().getSimpleName());
+                        throw new ValidationException(getStandardConversionErrorMessage(value, pd.getName(), true, pd.getPropertyType().getJavaType()));
                     }
                 }
                 assert ensure.stop();
@@ -590,7 +590,7 @@ public class OntologyManager
                     }
                     catch (ConversionException e)
                     {
-                        throw new ValidationException("Could not convert '" + value + "' for field " + pd.getName() + ", should be of type " + propertyTypes[i].getJavaType().getSimpleName());
+                        throw new ValidationException(getStandardConversionErrorMessage(value, pd.getName(), true, propertyTypes[i].getJavaType()));
                     }
                 }
 
@@ -632,6 +632,12 @@ public class OntologyManager
         }
 
         return results;
+    }
+
+    public static String getStandardConversionErrorMessage(Object value, String fieldName, boolean useField, Class<?> expectedClass)
+    {
+        String fromType = (value instanceof String) ? "" : "(" + (value.getClass().getSimpleName() + ") ");
+        return "Could not convert value " + fromType + "'" + value + "' for " + (useField ? "field" : "column") + " '" + fieldName + "'; expected type " + expectedClass.getSimpleName();
     }
 
     // TODO: Consolidate with ColumnValidator

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -110,7 +110,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
     public void setLSID(Lsid lsid)
     {
         if (null != getName() && !getName().equals(lsid.getObjectId()))
-            throw new IllegalStateException("name="+getName() + " lsid="+lsid.toString());
+            throw new IllegalStateException("name=" + getName() + " lsid=" + lsid);
         super.setLSID(lsid);
     }
 
@@ -534,7 +534,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
                 }
                 catch (ConversionException x)
                 {
-                    throw new ValidationException("Could not convert '" + value + "' for field " + dp.getName() + ", should be of type " + dp.getPropertyDescriptor().getPropertyType().getJavaType().getSimpleName());
+                    throw new ValidationException(OntologyManager.getStandardConversionErrorMessage(value, dp.getName(), true, dp.getPropertyDescriptor().getPropertyType().getJavaType()));
                 }
                 converted.put(dp.getName(), value);
                 values.remove(key);

--- a/study/src/org/labkey/study/model/DatasetImportTestCase.jsp
+++ b/study/src/org/labkey/study/model/DatasetImportTestCase.jsp
@@ -381,8 +381,8 @@ private void _testDatasetUpdateService(StudyImpl study) throws Throwable
     rows.clear(); errors.clear();
     rows.add(PageFlowUtil.mapInsensitive("SubjectId", "A1", "Date", Jan1, "Measure", "Test" + (++counterRow), "Value", "N/A"));
     qus.insertRows(_context.getUser(), study.getContainer(), rows, errors, null, null);
-    //study:Label: Could not convert 'N/A' for field Value, should be of type Double
-    assertTrue(errors.getRowErrors().get(0).getMessage().contains("should be of type Double"));
+    //study:Label: Could not convert value 'N/A' for field 'Value'; expected type Double
+    assertTrue(errors.getRowErrors().get(0).getMessage().contains("expected type Double"));
 
     // conversion test
     rows.clear(); errors.clear();


### PR DESCRIPTION
#### Rationale
Our conversion error messages are inconsistent and unclear. This PR adds a standard method that generates conversion error messages (for consistency) and improves the format of the standard message.

[Issue 41854: Wording updates for domain designer error dialog](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41854)

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->
