### PR TITLE
Issue 41854: Wording updates for conversion error messages

### DIFF
--- a/api/src/org/labkey/api/action/BaseViewAction.java
+++ b/api/src/org/labkey/api/action/BaseViewAction.java
@@ -437,7 +437,7 @@ public abstract class BaseViewAction<FORM> extends PermissionCheckableAction imp
             }
             catch (ConversionException x)
             {
-                errors.addError(new FieldError(commandName, propertyName, value, true, new String[] {"ConversionError", "typeMismatch"}, null, "Could not convert to value: " + String.valueOf(value)));
+                errors.addError(new FieldError(commandName, propertyName, value, true, new String[] {"ConversionError", "typeMismatch"}, null, "Could not convert to value: " + value));
             }
             catch (Exception x)
             {

--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -1262,7 +1262,7 @@ public abstract class CompareType
             return Double.compare(((Number) a).doubleValue(), ((Number) b).doubleValue());
         }
 
-        return ((Comparable)a).compareTo(b);
+        return a.compareTo(b);
     }
 
     // Converts parameter value to the proper type based on the SQL type of the ColumnInfo

--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -30,6 +30,7 @@ import org.labkey.api.data.SimpleFilter.ColumnNameFormatter;
 import org.labkey.api.data.SimpleFilter.FilterClause;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.exp.MvColumn;
+import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.query.AliasedColumn;
@@ -906,13 +907,14 @@ public abstract class CompareType
     }
 
 
-    private String _preferredURLKey;
+    private final String _preferredURLKey;
     private final OperatorType.Enum _xmlType;
-    private Set<String> _urlKeys = new CaseInsensitiveHashSet();
-    private String _displayValue;
-    private boolean _dataValueRequired;
-    private String _sql;
-    private String _scriptName;
+    private final Set<String> _urlKeys = new CaseInsensitiveHashSet();
+    private final String _displayValue;
+    private final boolean _dataValueRequired;
+    private final String _sql;
+    private final String _scriptName;
+
     private String _valueSeparator;
 
     protected CompareType(String displayValue, String[] urlKeys, boolean dataValueRequired, String sql, String scriptName, OperatorType.Enum xmlType)
@@ -1336,11 +1338,8 @@ public abstract class CompareType
             lookupQueryName = ((PropertyDescriptor)col).getLookupQuery();
         }
 
-        if ("core".equalsIgnoreCase(lookupSchemaName) &&
-                ("users".equalsIgnoreCase(lookupQueryName) || "usersdata".equalsIgnoreCase(lookupQueryName)))
-            return true;
-
-        return false;
+        return "core".equalsIgnoreCase(lookupSchemaName) &&
+                ("users".equalsIgnoreCase(lookupQueryName) || "usersdata".equalsIgnoreCase(lookupQueryName));
     }
 
     // TODO: How can I tell if this column is the core.Users DisplayName display column?
@@ -1353,8 +1352,7 @@ public abstract class CompareType
         if (col instanceof LookupColumn || (col instanceof AliasedColumn && ((AliasedColumn)col).getColumn() instanceof LookupColumn))
         {
             String propertyURI = col.getPropertyURI();
-            if (propertyURI != null && (propertyURI.endsWith("core#UsersData.DisplayName") || propertyURI.endsWith("core#Users.DisplayName")))
-                return true;
+            return propertyURI != null && (propertyURI.endsWith("core#UsersData.DisplayName") || propertyURI.endsWith("core#Users.DisplayName"));
         }
 
         return false;
@@ -1365,10 +1363,7 @@ public abstract class CompareType
         JdbcType type = colInfo.getJdbcType();
         switch (type)
         {
-            case INTEGER:
-            case TINYINT:
-            case SMALLINT:
-            {
+            case INTEGER, TINYINT, SMALLINT -> {
                 // Treat the empty string as null
                 stringValue = StringUtils.trimToNull(stringValue);
                 if (stringValue == null)
@@ -1381,24 +1376,20 @@ public abstract class CompareType
                 }
                 catch (NumberFormatException e)
                 {
-                    throw new RuntimeSQLException(new SQLGenerationException("Could not convert '" + stringValue + "' to an integer for column '" + colInfo.getName() + "'"));
+                    throwConversionException(stringValue, colInfo, Integer.class);
                 }
             }
-
-            case BIGINT:
-            {
+            case BIGINT -> {
                 try
                 {
                     return Long.valueOf(stringValue);
                 }
                 catch (NumberFormatException e)
                 {
-                    throw new RuntimeSQLException(new SQLGenerationException("Could not convert '" + stringValue + "' to a long for column '" + colInfo.getName() + "'"));
+                    throwConversionException(stringValue, colInfo, Long.class);
                 }
             }
-
-            case BOOLEAN:
-            {
+            case BOOLEAN -> {
                 try
                 {
                     // Treat the empty string as null
@@ -1411,29 +1402,21 @@ public abstract class CompareType
                 }
                 catch (Exception e)
                 {
-                    throw new RuntimeSQLException(new SQLGenerationException("Could not convert '" + stringValue + "' to a boolean for column '" + colInfo.getName() + "'"));
+                    throwConversionException(stringValue, colInfo, Boolean.class);
                 }
             }
-
-            case TIMESTAMP:
-            case DATE:
-            case TIME:
-            {
+            case TIMESTAMP, DATE, TIME -> {
                 try
                 {
                     return ConvertUtils.convert(stringValue, Date.class);
                 }
                 catch (ConversionException e)
                 {
-                    throw new RuntimeSQLException(new SQLGenerationException("Could not convert '" + stringValue + "' to a date for column '" + colInfo.getName() + "'"));
+                    throwConversionException(stringValue, colInfo, Date.class);
                 }
             }
-
             //FALL THROUGH! (Decimal is better than nothing)
-            case DECIMAL:
-            case REAL:
-            case DOUBLE:
-            {
+            case DECIMAL, REAL, DOUBLE -> {
                 try
                 {
                     // Treat the empty string as null
@@ -1446,14 +1429,17 @@ public abstract class CompareType
                 }
                 catch (NumberFormatException e)
                 {
-                    throw new RuntimeSQLException(new SQLGenerationException("Could not convert '" + stringValue + "' to a number for column '" + colInfo.getName() + "'"));
+                    throwConversionException(stringValue, colInfo, Number.class);
                 }
             }
         }
-
         return stringValue;
     }
 
+    private static void throwConversionException(String value, ColumnRenderProperties column, Class<?> expectedClass)
+    {
+        throw new RuntimeSQLException(new SQLGenerationException(OntologyManager.getStandardConversionErrorMessage(value, column.getName(), true, expectedClass)));
+    }
 
     public static Date asDate(Object v)
     {

--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -1438,7 +1438,7 @@ public abstract class CompareType
 
     private static void throwConversionException(String value, ColumnRenderProperties column, Class<?> expectedClass)
     {
-        throw new RuntimeSQLException(new SQLGenerationException(OntologyManager.getStandardConversionErrorMessage(value, column.getName(), true, expectedClass)));
+        throw new RuntimeSQLException(new SQLGenerationException(OntologyManager.getStandardConversionErrorMessage(value, column.getName(), expectedClass)));
     }
 
     public static Date asDate(Object v)

--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -30,7 +30,6 @@ import org.labkey.api.data.SimpleFilter.ColumnNameFormatter;
 import org.labkey.api.data.SimpleFilter.FilterClause;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.exp.MvColumn;
-import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.query.AliasedColumn;
@@ -1438,7 +1437,7 @@ public abstract class CompareType
 
     private static void throwConversionException(String value, ColumnRenderProperties column, Class<?> expectedClass)
     {
-        throw new RuntimeSQLException(new SQLGenerationException(OntologyManager.getStandardConversionErrorMessage(value, column.getName(), expectedClass)));
+        throw new RuntimeSQLException(new SQLGenerationException(ConvertHelper.getStandardConversionErrorMessage(value, column.getName(), expectedClass)));
     }
 
     public static Date asDate(Object v)

--- a/api/src/org/labkey/api/data/ConvertHelper.java
+++ b/api/src/org/labkey/api/data/ConvertHelper.java
@@ -204,7 +204,7 @@ public class ConvertHelper implements PropertyEditorRegistrar
 
     public static class NullSafeConverter implements Converter
     {
-        private Converter _converter;
+        private final Converter _converter;
 
         public NullSafeConverter(Converter converter)
         {
@@ -230,7 +230,7 @@ public class ConvertHelper implements PropertyEditorRegistrar
     // For example, array_to_string(array_agg(array[true, false]), '|') ==> returns 't|f'
     public static class BooleanConverter implements Converter
     {
-        private org.apache.commons.beanutils.converters.BooleanConverter _nested = new org.apache.commons.beanutils.converters.BooleanConverter();
+        private final org.apache.commons.beanutils.converters.BooleanConverter _nested = new org.apache.commons.beanutils.converters.BooleanConverter();
 
         @Override
         public Object convert(Class type, Object value)
@@ -295,7 +295,7 @@ public class ConvertHelper implements PropertyEditorRegistrar
      */
     public static class LenientTimestampConverter implements Converter
     {
-        private LenientDateConverter _dateConverter = new LenientDateConverter();
+        private final LenientDateConverter _dateConverter = new LenientDateConverter();
 
         @Override
         public Object convert(Class clss, Object o)
@@ -366,7 +366,7 @@ public class ConvertHelper implements PropertyEditorRegistrar
 
     public static class DateFriendlyStringConverter implements Converter
     {
-        private static Converter _stringConverter = new StringConverter();
+        private static final Converter _stringConverter = new StringConverter();
 
         @Override
         public Object convert(Class clss, Object o)
@@ -641,9 +641,9 @@ public class ConvertHelper implements PropertyEditorRegistrar
 
     public static class ConvertUtilsEditor extends PropertyEditorSupport
     {
-        private Class _class;
+        private final Class<?> _class;
 
-        ConvertUtilsEditor(Class c)
+        ConvertUtilsEditor(Class<?> c)
         {
             _class = c;
         }
@@ -691,7 +691,7 @@ public class ConvertHelper implements PropertyEditorRegistrar
     // see bug 5340 : Spring Data binding bizarreness. Crash when edit visit in study with exactly one dataset
     public static class StringArrayConverter implements Converter
     {
-        private org.apache.commons.beanutils.converters.StringArrayConverter _nested =
+        private final org.apache.commons.beanutils.converters.StringArrayConverter _nested =
                 new org.apache.commons.beanutils.converters.StringArrayConverter();
 
         @Override
@@ -881,5 +881,12 @@ public class ConvertHelper implements PropertyEditorRegistrar
             cal.set(1999, Calendar.JUNE,10,0,0,0);
             assertEquals("Wrong date", DateUtil.getDateOnly(cal.getTime()), DateUtil.getDateOnly((Timestamp)convertedDate));
         }
+    }
+
+    // Note: Keep in sync with LabKeySiteWrapper.getConversionErrorMessage()
+    // Example: "Could not convert value '2.34' (Double) for Boolean field 'Medical History.Dep Diagnosed in Last 18 Months'"
+    public static String getStandardConversionErrorMessage(Object value, String fieldName, Class<?> expectedClass)
+    {
+        return "Could not convert value '" + value + "' (" + value.getClass().getSimpleName() + ") for " + expectedClass.getSimpleName() + " field '" + fieldName + "'";
     }
 }

--- a/api/src/org/labkey/api/data/PkFilter.java
+++ b/api/src/org/labkey/api/data/PkFilter.java
@@ -63,7 +63,7 @@ public class PkFilter extends SimpleFilter
                     }
                     catch (ConversionException e)
                     {
-                        throw new NotFoundException(OntologyManager.getStandardConversionErrorMessage(value, fieldKey.toString(), true, targetClass));
+                        throw new NotFoundException(OntologyManager.getStandardConversionErrorMessage(value, fieldKey.toString(), targetClass));
                     }
                 }
                 else if (SqlDialect.isGUIDType(columnPK.get(i).getSqlTypeName()))
@@ -74,7 +74,7 @@ public class PkFilter extends SimpleFilter
                     }
                     catch (IllegalArgumentException e)
                     {
-                        throw new NotFoundException(OntologyManager.getStandardConversionErrorMessage(value, fieldKey.toString(), true, GUID.class));
+                        throw new NotFoundException(OntologyManager.getStandardConversionErrorMessage(value, fieldKey.toString(), GUID.class));
                     }
                 }
             }

--- a/api/src/org/labkey/api/data/PkFilter.java
+++ b/api/src/org/labkey/api/data/PkFilter.java
@@ -19,6 +19,7 @@ package org.labkey.api.data;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.labkey.api.data.dialect.SqlDialect;
+import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.GUID;
 import org.labkey.api.view.NotFoundException;
@@ -62,7 +63,7 @@ public class PkFilter extends SimpleFilter
                     }
                     catch (ConversionException e)
                     {
-                        throw new NotFoundException("Failed to convert '" + value + "' for '" + fieldKey + "', should be of type " + targetClass.getName());
+                        throw new NotFoundException(OntologyManager.getStandardConversionErrorMessage(value, fieldKey.toString(), true, targetClass));
                     }
                 }
                 else if (SqlDialect.isGUIDType(columnPK.get(i).getSqlTypeName()))
@@ -73,7 +74,7 @@ public class PkFilter extends SimpleFilter
                     }
                     catch (IllegalArgumentException e)
                     {
-                        throw new NotFoundException("Failed to convert '" + value + "' for '" + fieldKey + "', should be of type GUID");
+                        throw new NotFoundException(OntologyManager.getStandardConversionErrorMessage(value, fieldKey.toString(), true, GUID.class));
                     }
                 }
             }

--- a/api/src/org/labkey/api/data/PkFilter.java
+++ b/api/src/org/labkey/api/data/PkFilter.java
@@ -19,7 +19,6 @@ package org.labkey.api.data;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.labkey.api.data.dialect.SqlDialect;
-import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.GUID;
 import org.labkey.api.view.NotFoundException;
@@ -63,7 +62,7 @@ public class PkFilter extends SimpleFilter
                     }
                     catch (ConversionException e)
                     {
-                        throw new NotFoundException(OntologyManager.getStandardConversionErrorMessage(value, fieldKey.toString(), targetClass));
+                        throw new NotFoundException(ConvertHelper.getStandardConversionErrorMessage(value, fieldKey.toString(), targetClass));
                     }
                 }
                 else if (SqlDialect.isGUIDType(columnPK.get(i).getSqlTypeName()))
@@ -74,7 +73,7 @@ public class PkFilter extends SimpleFilter
                     }
                     catch (IllegalArgumentException e)
                     {
-                        throw new NotFoundException(OntologyManager.getStandardConversionErrorMessage(value, fieldKey.toString(), GUID.class));
+                        throw new NotFoundException(ConvertHelper.getStandardConversionErrorMessage(value, fieldKey.toString(), GUID.class));
                     }
                 }
             }

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -48,6 +48,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.TestSchema;
 import org.labkey.api.exp.MvFieldWrapper;
+import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.query.AbstractQueryUpdateService;
@@ -163,8 +164,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         String msg;
         if (null != value && null != target)
         {
-            String fromType = (value instanceof String) ? "" : "(" + (value.getClass().getSimpleName() + ") ");
-            msg = "Could not convert " + fromType + "'" + value + "' for field " + fieldName + ", should be of type " + target.getJavaClass().getSimpleName();
+            msg = OntologyManager.getStandardConversionErrorMessage(value, fieldName, true, target.getJavaClass());
         }
         else if (null != x)
             msg = StringUtils.defaultString(x.getMessage(), x.toString());

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -34,6 +34,7 @@ import org.labkey.api.data.AbstractForeignKey;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.CounterDefinition;
 import org.labkey.api.data.DbSequence;
 import org.labkey.api.data.DbSequenceManager;
@@ -48,7 +49,6 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.TestSchema;
 import org.labkey.api.exp.MvFieldWrapper;
-import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.query.AbstractQueryUpdateService;
@@ -164,7 +164,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         String msg;
         if (null != value && null != target)
         {
-            msg = OntologyManager.getStandardConversionErrorMessage(value, fieldName, target.getJavaClass());
+            msg = ConvertHelper.getStandardConversionErrorMessage(value, fieldName, target.getJavaClass());
         }
         else if (null != x)
             msg = StringUtils.defaultString(x.getMessage(), x.toString());

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -164,7 +164,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         String msg;
         if (null != value && null != target)
         {
-            msg = OntologyManager.getStandardConversionErrorMessage(value, fieldName, true, target.getJavaClass());
+            msg = OntologyManager.getStandardConversionErrorMessage(value, fieldName, target.getJavaClass());
         }
         else if (null != x)
             msg = StringUtils.defaultString(x.getMessage(), x.toString());

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -341,7 +341,7 @@ public class OntologyManager
                     }
                     catch (ConversionException e)
                     {
-                        throw new ValidationException(getStandardConversionErrorMessage(value, pd.getName(), true, pd.getPropertyType().getJavaType()));
+                        throw new ValidationException(getStandardConversionErrorMessage(value, pd.getName(), pd.getPropertyType().getJavaType()));
                     }
                 }
                 assert ensure.stop();
@@ -543,7 +543,7 @@ public class OntologyManager
                             }
                             catch (ConversionException e)
                             {
-                                throw new ValidationException(getStandardConversionErrorMessage(value, pd.getName(), true, pd.getJavaClass()));
+                                throw new ValidationException(getStandardConversionErrorMessage(value, pd.getName(), pd.getJavaClass()));
                             }
                         }
                     }
@@ -590,7 +590,7 @@ public class OntologyManager
                     }
                     catch (ConversionException e)
                     {
-                        throw new ValidationException(getStandardConversionErrorMessage(value, pd.getName(), true, propertyTypes[i].getJavaType()));
+                        throw new ValidationException(getStandardConversionErrorMessage(value, pd.getName(), propertyTypes[i].getJavaType()));
                     }
                 }
 
@@ -634,11 +634,11 @@ public class OntologyManager
         return results;
     }
 
-    // Note: Keep in sync with BaseWebDriverTest.getConversionErrorMessage()
-    public static String getStandardConversionErrorMessage(Object value, String fieldName, boolean useField, Class<?> expectedClass)
+    // Note: Keep in sync with LabKeySiteWrapper.getConversionErrorMessage()
+    // Example: "Could not convert value '2.34' (Double) for Boolean field 'Medical History.Dep Diagnosed in Last 18 Months'"
+    public static String getStandardConversionErrorMessage(Object value, String fieldName, Class<?> expectedClass)
     {
-        String fromType = (value instanceof String) ? "" : "(" + (value.getClass().getSimpleName() + ") ");
-        return "Could not convert value " + fromType + "'" + value + "' for " + (useField ? "field" : "column") + " '" + fieldName + "'; expected type " + expectedClass.getSimpleName();
+        return "Could not convert value '" + value + "' (" + value.getClass().getSimpleName() + ") for " + expectedClass.getSimpleName() + " field '" + fieldName + "'";
     }
 
     // TODO: Consolidate with ColumnValidator

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -341,7 +341,7 @@ public class OntologyManager
                     }
                     catch (ConversionException e)
                     {
-                        throw new ValidationException(getStandardConversionErrorMessage(value, pd.getName(), pd.getPropertyType().getJavaType()));
+                        throw new ValidationException(ConvertHelper.getStandardConversionErrorMessage(value, pd.getName(), pd.getPropertyType().getJavaType()));
                     }
                 }
                 assert ensure.stop();
@@ -543,7 +543,7 @@ public class OntologyManager
                             }
                             catch (ConversionException e)
                             {
-                                throw new ValidationException(getStandardConversionErrorMessage(value, pd.getName(), pd.getJavaClass()));
+                                throw new ValidationException(ConvertHelper.getStandardConversionErrorMessage(value, pd.getName(), pd.getJavaClass()));
                             }
                         }
                     }
@@ -590,7 +590,7 @@ public class OntologyManager
                     }
                     catch (ConversionException e)
                     {
-                        throw new ValidationException(getStandardConversionErrorMessage(value, pd.getName(), propertyTypes[i].getJavaType()));
+                        throw new ValidationException(ConvertHelper.getStandardConversionErrorMessage(value, pd.getName(), propertyTypes[i].getJavaType()));
                     }
                 }
 
@@ -632,13 +632,6 @@ public class OntologyManager
         }
 
         return results;
-    }
-
-    // Note: Keep in sync with LabKeySiteWrapper.getConversionErrorMessage()
-    // Example: "Could not convert value '2.34' (Double) for Boolean field 'Medical History.Dep Diagnosed in Last 18 Months'"
-    public static String getStandardConversionErrorMessage(Object value, String fieldName, Class<?> expectedClass)
-    {
-        return "Could not convert value '" + value + "' (" + value.getClass().getSimpleName() + ") for " + expectedClass.getSimpleName() + " field '" + fieldName + "'";
     }
 
     // TODO: Consolidate with ColumnValidator

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -543,7 +543,7 @@ public class OntologyManager
                             }
                             catch (ConversionException e)
                             {
-                                throw new ValidationException("Could not convert value '" + value + "' for field '" + pd.getName() + "'", pd.getName());
+                                throw new ValidationException(getStandardConversionErrorMessage(value, pd.getName(), true, pd.getJavaClass()));
                             }
                         }
                     }

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -341,7 +341,7 @@ public class OntologyManager
                     }
                     catch (ConversionException e)
                     {
-                        throw new ValidationException("Could not convert '" + value + "' for field " + pd.getName() + ", should be of type " + pd.getPropertyType().getJavaType().getSimpleName());
+                        throw new ValidationException(getStandardConversionErrorMessage(value, pd.getName(), true, pd.getPropertyType().getJavaType()));
                     }
                 }
                 assert ensure.stop();
@@ -590,7 +590,7 @@ public class OntologyManager
                     }
                     catch (ConversionException e)
                     {
-                        throw new ValidationException("Could not convert '" + value + "' for field " + pd.getName() + ", should be of type " + propertyTypes[i].getJavaType().getSimpleName());
+                        throw new ValidationException(getStandardConversionErrorMessage(value, pd.getName(), true, propertyTypes[i].getJavaType()));
                     }
                 }
 
@@ -632,6 +632,12 @@ public class OntologyManager
         }
 
         return results;
+    }
+
+    public static String getStandardConversionErrorMessage(Object value, String fieldName, boolean useField, Class<?> expectedClass)
+    {
+        String fromType = (value instanceof String) ? "" : "(" + (value.getClass().getSimpleName() + ") ");
+        return "Could not convert value " + fromType + "'" + value + "' for " + (useField ? "field" : "column") + " '" + fieldName + "'; expected type " + expectedClass.getSimpleName();
     }
 
     // TODO: Consolidate with ColumnValidator

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -634,6 +634,7 @@ public class OntologyManager
         return results;
     }
 
+    // Note: Keep in sync with BaseWebDriverTest.getConversionErrorMessage()
     public static String getStandardConversionErrorMessage(Object value, String fieldName, boolean useField, Class<?> expectedClass)
     {
         String fromType = (value instanceof String) ? "" : "(" + (value.getClass().getSimpleName() + ") ");

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -110,7 +110,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
     public void setLSID(Lsid lsid)
     {
         if (null != getName() && !getName().equals(lsid.getObjectId()))
-            throw new IllegalStateException("name="+getName() + " lsid="+lsid.toString());
+            throw new IllegalStateException("name=" + getName() + " lsid=" + lsid);
         super.setLSID(lsid);
     }
 
@@ -534,7 +534,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
                 }
                 catch (ConversionException x)
                 {
-                    throw new ValidationException("Could not convert '" + value + "' for field " + dp.getName() + ", should be of type " + dp.getPropertyDescriptor().getPropertyType().getJavaType().getSimpleName());
+                    throw new ValidationException(OntologyManager.getStandardConversionErrorMessage(value, dp.getName(), true, dp.getPropertyDescriptor().getPropertyType().getJavaType()));
                 }
                 converted.put(dp.getName(), value);
                 values.remove(key);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.DbSequenceManager;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
@@ -534,7 +535,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
                 }
                 catch (ConversionException x)
                 {
-                    throw new ValidationException(OntologyManager.getStandardConversionErrorMessage(value, dp.getName(), dp.getPropertyDescriptor().getPropertyType().getJavaType()));
+                    throw new ValidationException(ConvertHelper.getStandardConversionErrorMessage(value, dp.getName(), dp.getPropertyDescriptor().getPropertyType().getJavaType()));
                 }
                 converted.put(dp.getName(), value);
                 values.remove(key);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -534,7 +534,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
                 }
                 catch (ConversionException x)
                 {
-                    throw new ValidationException(OntologyManager.getStandardConversionErrorMessage(value, dp.getName(), true, dp.getPropertyDescriptor().getPropertyType().getJavaType()));
+                    throw new ValidationException(OntologyManager.getStandardConversionErrorMessage(value, dp.getName(), dp.getPropertyDescriptor().getPropertyType().getJavaType()));
                 }
                 converted.put(dp.getName(), value);
                 values.remove(key);

--- a/issues/src/org/labkey/issue/actions/IssueValidation.java
+++ b/issues/src/org/labkey/issue/actions/IssueValidation.java
@@ -23,11 +23,11 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.validator.ColumnValidator;
 import org.labkey.api.data.validator.ColumnValidators;
-import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.issues.IssuesSchema;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
@@ -91,7 +91,7 @@ public class IssueValidation
                     }
                     catch (ConversionException e)
                     {
-                        errors.reject(SpringActionController.ERROR_MSG, OntologyManager.getStandardConversionErrorMessage(entry.getValue(), col.getName(), col.getJavaClass()));
+                        errors.reject(SpringActionController.ERROR_MSG, ConvertHelper.getStandardConversionErrorMessage(entry.getValue(), col.getName(), col.getJavaClass()));
                     }
                 }
             }

--- a/issues/src/org/labkey/issue/actions/IssueValidation.java
+++ b/issues/src/org/labkey/issue/actions/IssueValidation.java
@@ -91,7 +91,7 @@ public class IssueValidation
                     }
                     catch (ConversionException e)
                     {
-                        errors.reject(SpringActionController.ERROR_MSG, OntologyManager.getStandardConversionErrorMessage(entry.getValue(), col.getName(), true, col.getJavaClass()));
+                        errors.reject(SpringActionController.ERROR_MSG, OntologyManager.getStandardConversionErrorMessage(entry.getValue(), col.getName(), col.getJavaClass()));
                     }
                 }
             }

--- a/issues/src/org/labkey/issue/actions/IssueValidation.java
+++ b/issues/src/org/labkey/issue/actions/IssueValidation.java
@@ -27,6 +27,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.validator.ColumnValidator;
 import org.labkey.api.data.validator.ColumnValidators;
+import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.issues.IssuesSchema;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
@@ -90,7 +91,7 @@ public class IssueValidation
                     }
                     catch (ConversionException e)
                     {
-                        errors.reject(SpringActionController.ERROR_MSG, String.format("Could not convert '%s' to an %s", entry.getValue(), col.getJavaClass().getSimpleName()));
+                        errors.reject(SpringActionController.ERROR_MSG, OntologyManager.getStandardConversionErrorMessage(entry.getValue(), col.getName(), true, col.getJavaClass()));
                     }
                 }
             }

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -2389,7 +2389,7 @@ public class QueryServiceImpl implements QueryService
             }
             catch (ConversionException e)
             {
-                throw new RuntimeSQLException(new SQLGenerationException(OntologyManager.getStandardConversionErrorMessage(value, p.getName(), true, p.getJdbcType().getJavaClass())));
+                throw new RuntimeSQLException(new SQLGenerationException(OntologyManager.getStandardConversionErrorMessage(value, p.getName(), p.getJdbcType().getJavaClass())));
             }
         }
     }

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -40,6 +40,7 @@ import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.LabKeyCollectors;
+import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.query.column.ColumnInfoTransformer;
 import org.labkey.api.data.*;
 import org.labkey.api.data.dialect.SqlDialect;
@@ -2388,7 +2389,7 @@ public class QueryServiceImpl implements QueryService
             }
             catch (ConversionException e)
             {
-                throw new RuntimeSQLException(new SQLGenerationException("Could not convert '" + value + "' to a " + p.getJdbcType() + " for column '" + p.getName() + "'"));
+                throw new RuntimeSQLException(new SQLGenerationException(OntologyManager.getStandardConversionErrorMessage(value, p.getName(), true, p.getJdbcType().getJavaClass())));
             }
         }
     }

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -40,7 +40,6 @@ import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.LabKeyCollectors;
-import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.query.column.ColumnInfoTransformer;
 import org.labkey.api.data.*;
 import org.labkey.api.data.dialect.SqlDialect;
@@ -2389,7 +2388,7 @@ public class QueryServiceImpl implements QueryService
             }
             catch (ConversionException e)
             {
-                throw new RuntimeSQLException(new SQLGenerationException(OntologyManager.getStandardConversionErrorMessage(value, p.getName(), p.getJdbcType().getJavaClass())));
+                throw new RuntimeSQLException(new SQLGenerationException(ConvertHelper.getStandardConversionErrorMessage(value, p.getName(), p.getJdbcType().getJavaClass())));
             }
         }
     }

--- a/study/src/org/labkey/study/model/DatasetImportTestCase.jsp
+++ b/study/src/org/labkey/study/model/DatasetImportTestCase.jsp
@@ -381,8 +381,8 @@ private void _testDatasetUpdateService(StudyImpl study) throws Throwable
     rows.clear(); errors.clear();
     rows.add(PageFlowUtil.mapInsensitive("SubjectId", "A1", "Date", Jan1, "Measure", "Test" + (++counterRow), "Value", "N/A"));
     qus.insertRows(_context.getUser(), study.getContainer(), rows, errors, null, null);
-    //study:Label: Could not convert value 'N/A' for field 'Value'; expected type Double
-    assertTrue(errors.getRowErrors().get(0).getMessage().contains("expected type Double"));
+    //study:Label: Value: Could not convert value 'N/A' (String) for Double field 'Value'
+    assertTrue(errors.getRowErrors().get(0).getMessage().endsWith(OntologyManager.getStandardConversionErrorMessage("N/A", "Value", Double.class)));
 
     // conversion test
     rows.clear(); errors.clear();

--- a/study/src/org/labkey/study/model/DatasetImportTestCase.jsp
+++ b/study/src/org/labkey/study/model/DatasetImportTestCase.jsp
@@ -4,12 +4,12 @@
 <%@ page import="org.jetbrains.annotations.Nullable" %>
 <%@ page import="org.junit.Test" %>
 <%@ page import="org.labkey.api.audit.AuditLogService" %>
-<%@ page import="static org.junit.Assert.*" %>
 <%@ page import="org.labkey.api.collections.CaseInsensitiveHashMap" %>
 <%@ page import="org.labkey.api.data.ColumnInfo" %>
 <%@ page import="org.labkey.api.data.CompareType" %>
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.data.ContainerManager" %>
+<%@ page import="org.labkey.api.data.ConvertHelper" %>
 <%@ page import="org.labkey.api.data.DbScope" %>
 <%@ page import="org.labkey.api.data.MvUtil" %>
 <%@ page import="org.labkey.api.data.Results" %>
@@ -31,6 +31,7 @@
 <%@ page import="org.labkey.api.exp.property.PropertyService" %>
 <%@ page import="org.labkey.api.gwt.client.AuditBehaviorType" %>
 <%@ page import="org.labkey.api.gwt.client.model.PropertyValidatorType" %>
+<%@ page import="org.labkey.api.module.FolderTypeManager" %>
 <%@ page import="org.labkey.api.qc.QCState" %>
 <%@ page import="org.labkey.api.qc.QCStateManager" %>
 <%@ page import="org.labkey.api.query.BatchValidationException" %>
@@ -52,6 +53,7 @@
 <%@ page import="org.labkey.api.util.JunitUtil" %>
 <%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.api.util.TestContext" %>
+<%@ page import="org.labkey.study.StudyFolderType" %>
 <%@ page import="org.labkey.study.StudySchema" %>
 <%@ page import="org.labkey.study.dataset.DatasetAuditProvider" %>
 <%@ page import="org.labkey.study.model.DatasetDefinition" %>
@@ -70,10 +72,9 @@
 <%@ page import="java.util.LinkedHashSet" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="static org.junit.Assert.*" %>
 <%@ page import="static org.labkey.study.model.StudyManager.TEST_LOGGER" %>
 <%@ page import="static org.labkey.study.dataset.DatasetAuditProvider.DATASET_AUDIT_EVENT" %>
-<%@ page import="org.labkey.study.StudyFolderType" %>
-<%@ page import="org.labkey.api.module.FolderTypeManager" %>
 <%@ page extends="org.labkey.api.jsp.JspTest.DRT" %>
 
 
@@ -382,7 +383,7 @@ private void _testDatasetUpdateService(StudyImpl study) throws Throwable
     rows.add(PageFlowUtil.mapInsensitive("SubjectId", "A1", "Date", Jan1, "Measure", "Test" + (++counterRow), "Value", "N/A"));
     qus.insertRows(_context.getUser(), study.getContainer(), rows, errors, null, null);
     //study:Label: Value: Could not convert value 'N/A' (String) for Double field 'Value'
-    assertTrue(errors.getRowErrors().get(0).getMessage().endsWith(OntologyManager.getStandardConversionErrorMessage("N/A", "Value", Double.class)));
+    assertTrue(errors.getRowErrors().get(0).getMessage().endsWith(ConvertHelper.getStandardConversionErrorMessage("N/A", "Value", Double.class)));
 
     // conversion test
     rows.clear(); errors.clear();

--- a/study/src/org/labkey/study/model/DatasetImportTestCase.jsp
+++ b/study/src/org/labkey/study/model/DatasetImportTestCase.jsp
@@ -381,8 +381,8 @@ private void _testDatasetUpdateService(StudyImpl study) throws Throwable
     rows.clear(); errors.clear();
     rows.add(PageFlowUtil.mapInsensitive("SubjectId", "A1", "Date", Jan1, "Measure", "Test" + (++counterRow), "Value", "N/A"));
     qus.insertRows(_context.getUser(), study.getContainer(), rows, errors, null, null);
-    //study:Label: Could not convert 'N/A' for field Value, should be of type Double
-    assertTrue(errors.getRowErrors().get(0).getMessage().contains("should be of type Double"));
+    //study:Label: Could not convert value 'N/A' for field 'Value'; expected type Double
+    assertTrue(errors.getRowErrors().get(0).getMessage().contains("expected type Double"));
 
     // conversion test
     rows.clear(); errors.clear();


### PR DESCRIPTION
#### Rationale
[Issue 41854: Wording updates for domain designer error dialog](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41854)

Our conversion error messages are inconsistent and unclear. This PR adds a standard method that generates conversion error messages (for consistency) and improves the format of the standard message. The tests now delegate to a matching standard method, making it easy to update the standard message over time.

A couple examples of the new standard wording:

- Could not convert value 'xyz' (String) for Boolean field 'Medical History.Dep Diagnosed in Last 18 Months'
- Could not convert value '2.34' (Double) for Integer field 'WeeklyCigars'

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/712
* https://github.com/LabKey/sampleManagement/pull/562