### PR TITLE
Remove unnecessary call to retrieve all runs for the current container

### DIFF
--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
@@ -162,12 +162,6 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
             exportTypes = true;
         }
 
-        // add any sample derivation or aliquot runs
-        List<ExpRun> runs = ExperimentService.get().getExpRuns(ctx.getContainer(), null, null).stream()
-                .filter(run -> run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID)
-                || run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_LSID))
-                .collect(Collectors.toList());
-
         // get the list of runs with the materials or data we expect to export, these will be the sample derivation
         // protocol runs to track the lineage
         Set<ExpRun> exportedRuns = new HashSet<>();


### PR DESCRIPTION
#### Rationale
This change addresses this issue : https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43078

It looks like the previous code which materialized all runs for the container crept back into the code due to some bad merges. The collection of runs that is returned is never used, but this call can take some time if made from a folder with many runs (including lineage runs).

The previous PR that contained these changes was https://github.com/LabKey/platform/pull/2159.