### PR TITLE
fix assay publish history url

### DIFF
--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -989,7 +989,7 @@ public class StudyPublishManager implements StudyPublishService
             switch (source)
             {
                 case Assay -> {
-                    ActionURL url = new ActionURL(PublishController.PublishAssayHistoryAction.class, container).addParameter("publishSourceId", publishSourceId);
+                    ActionURL url = new ActionURL(PublishController.PublishAssayHistoryAction.class, container).addParameter("rowId", publishSourceId);
                     if (containerFilter != null && containerFilter.getType() != null)
                         url.addParameter("containerFilterName", containerFilter.getType().name());
                     return url;


### PR DESCRIPTION
Inadvertently change a parameter on the assay publish history URL.

### Related Pull Requests
* https://github.com/LabKey/platform/pull/2216