### PR TITLE
Issue 43096: Dynamic warning providers should suppress warnings for non-admins

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -510,7 +510,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
             WarningService.get().register(new WarningProvider()
             {
                 @Override
-                public void addStaticWarnings(Warnings warnings)
+                public void addStaticWarnings(@NotNull Warnings warnings)
                 {
                     for (HtmlString error : _duplicateModuleErrors)
                     {
@@ -591,7 +591,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
             WarningService.get().register(new WarningProvider()
             {
                 @Override
-                public void addStaticWarnings(Warnings warnings)
+                public void addStaticWarnings(@NotNull Warnings warnings)
                 {
                     warnings.add(HtmlString.of(message));
                 }
@@ -1654,10 +1654,14 @@ public class ModuleLoader implements Filter, MemTrackerListener
         WarningService.get().register(new WarningProvider()
         {
             @Override
-            public void addDynamicWarnings(Warnings warnings, ViewContext context)
+            public void addDynamicWarnings(@NotNull Warnings warnings, @NotNull ViewContext context)
             {
-                if (WarningService.get().showAllWarnings() || !_missingViews.isEmpty())
-                    warnings.add(HtmlStringBuilder.of("The following required database views are not present: " + _missingViews + ". This is a serious problem that indicates the LabKey database schemas did not upgrade correctly and are in a bad state."));
+                if (context.getUser().hasSiteAdminPermission())
+                {
+                    if (WarningService.get().showAllWarnings() || !_missingViews.isEmpty())
+                        warnings.add(HtmlStringBuilder.of("The following required database views are not present: " + _missingViews +
+                            ". This is a serious problem that indicates the LabKey database schemas did not upgrade correctly and are in a bad state."));
+                }
             }
         });
         refreshMissingViews();

--- a/api/src/org/labkey/api/view/template/PageConfig.java
+++ b/api/src/org/labkey/api/view/template/PageConfig.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.data.DataRegion;
 import org.labkey.api.module.Module;
+import org.labkey.api.util.HasHtmlString;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
@@ -79,6 +80,10 @@ public class PageConfig
 		Default, True, False
 	}
 
+    private final LinkedHashSet<ClientDependency> _resources = new LinkedHashSet<>();
+    private final MultiValuedMap<String, String> _meta = new ArrayListValuedHashMap<>();
+    private final JSONObject _portalContext = new JSONObject();
+
     private Template _template = Template.Home;
     private String _title;
     private HelpTopic _helpTopic;
@@ -92,15 +97,12 @@ public class PageConfig
     private boolean _includeLoginLink = true;
     private boolean _includeSearch = true;
     private int _minimumWidth = 400;
-    private LinkedHashSet<ClientDependency> _resources = new LinkedHashSet<>();
     private TrueFalse _showHeader = TrueFalse.Default;
     private List<NavTree> _navTrail;
     private AppBar _appBar;
-    private MultiValuedMap<String, String> _meta = new ArrayListValuedHashMap<>();
     private FrameOption _frameOption = FrameOption.ALLOW;
     private boolean _trackingScript = true;
     private String _canonicalLink = null;
-    private JSONObject _portalContext = new JSONObject();
     private boolean _includePostParameters = false;
 
     public PageConfig()
@@ -422,12 +424,12 @@ public class PageConfig
     }
 
     // For now, gives a central place to render messaging
-    public String renderSiteMessages(ViewContext context)
+    public HasHtmlString renderSiteMessages(ViewContext context)
     {
-        StringBuilder messages = new StringBuilder();
+        HtmlStringBuilder messages = HtmlStringBuilder.of();
 
         // Keep an empty div for re-addition of dismissable messages onto the page
-        messages.append("<div class=\"lk-dismissable-alert-ct\">");
+        messages.append(HtmlString.unsafe("<div class=\"lk-dismissable-alert-ct\">"));
         if (context != null && context.getRequest() != null)
         {
             Warnings warnings = WarningService.get().getWarnings(context);
@@ -447,14 +449,14 @@ public class PageConfig
                 messages.append(WarningService.get().getWarningsHtml(warnings, context));
             }
         }
-        messages.append("</div>");
+        messages.append(HtmlString.unsafe("</div>"));
 
         // Display a <noscript> warning message
-        messages.append("<noscript>");
-        messages.append("<div class=\"alert alert-warning\" role=\"alert\">JavaScript is disabled. For the full experience enable JavaScript in your browser.</div>");
-        messages.append("</noscript>");
+        messages.append(HtmlString.unsafe("<noscript>"));
+        messages.append(HtmlString.unsafe("<div class=\"alert alert-warning\" role=\"alert\">JavaScript is disabled. For the full experience enable JavaScript in your browser.</div>"));
+        messages.append(HtmlString.unsafe("</noscript>"));
 
-        return messages.toString();
+        return messages;
     }
 
     public JSONObject getPortalContext()

--- a/api/src/org/labkey/api/view/template/WarningProvider.java
+++ b/api/src/org/labkey/api/view/template/WarningProvider.java
@@ -15,18 +15,27 @@
  */
 package org.labkey.api.view.template;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.view.ViewContext;
 
 public interface WarningProvider
 {
-    // Add warnings for conditions that will never change while the server is running (e.g., size of JVM heap or Tomcat version).
-    // These are displayed to site administrators only.
-    default void addStaticWarnings(Warnings warnings)
+    /**
+     * Add warnings for conditions that will never change while the server is running (e.g., size of JVM heap or Tomcat
+     * version). These warnings are displayed to site administrators only.
+     * @param warnings A @NotNull Warnings collector
+     */
+    default void addStaticWarnings(@NotNull Warnings warnings)
     {
     }
 
-    // Add warnings based on the current context (folder, user, page, etc.).
-    default void addDynamicWarnings(Warnings warnings, ViewContext context)
+    /**
+     * Add warnings based on the current context (folder, user, page, etc.). Implementations must check permissions on
+     * the context to limit who sees the warning(s); otherwise, ALL users (including guests) will see the warning(s).
+     * @param warnings A @NotNull Warnings collector
+     * @param context A @NotNull ViewContext that also guarantees a @NotNull getUser() and @NotNull getRequest()
+     */
+    default void addDynamicWarnings(@NotNull Warnings warnings, @NotNull ViewContext context)
     {
     }
 }

--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -16,13 +16,13 @@
 package org.labkey.core.view.template.bootstrap;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.data.ConnectionWrapper;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.module.JavaVersion;
 import org.labkey.api.module.ModuleHtmlView;
 import org.labkey.api.module.ModuleLoader;
-import org.labkey.api.security.User;
 import org.labkey.api.security.impersonation.AbstractImpersonationContextFactory;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.HelpTopic;
@@ -53,7 +53,7 @@ public class CoreWarningProvider implements WarningProvider
     }
 
     @Override
-    public void addStaticWarnings(Warnings warnings)
+    public void addStaticWarnings(@NotNull Warnings warnings)
     {
         // Warn if running on a deprecated database version or some other non-fatal database configuration issue
         DbScope labkeyScope = DbScope.getLabKeyScope();
@@ -69,40 +69,36 @@ public class CoreWarningProvider implements WarningProvider
     }
 
     @Override
-    public void addDynamicWarnings(Warnings warnings, ViewContext context)
+    public void addDynamicWarnings(@NotNull Warnings warnings, @NotNull ViewContext context)
     {
-        if (context != null && context.getRequest() != null)
+        if (context.getUser().hasSiteAdminPermission())
         {
-            User user = context.getUser();
-            if (null != user && user.hasSiteAdminPermission())
+            getUserRequestedAdminOnlyModeWarnings(warnings);
+
+            getModuleErrorWarnings(warnings, context);
+
+            getProbableLeakCountWarnings(warnings);
+
+            //upgrade message--show to admins
+            HtmlString upgradeMessage = UsageReportingLevel.getUpgradeMessage();
+
+            if (null == upgradeMessage && SHOW_ALL_WARNINGS)
             {
-                getUserRequestedAdminOnlyModeWarnings(warnings);
-
-                getModuleErrorWarnings(warnings, context);
-
-                getProbableLeakCountWarnings(warnings);
-
-                //upgrade message--show to admins
-                HtmlString upgradeMessage = UsageReportingLevel.getUpgradeMessage();
-
-                if (null == upgradeMessage && SHOW_ALL_WARNINGS)
-                {
-                    // Mock upgrade message for testing
-                    upgradeMessage = HtmlStringBuilder.of("You really ought to upgrade this server! ").append(new LinkBuilder("Click here!").href(AppProps.getInstance().getHomePageActionURL()).clearClasses()).getHtmlString();
-                }
-
-                if (null != upgradeMessage)
-                {
-                    warnings.add(upgradeMessage);
-                }
+                // Mock upgrade message for testing
+                upgradeMessage = HtmlStringBuilder.of("You really ought to upgrade this server! ").append(new LinkBuilder("Click here!").href(AppProps.getInstance().getHomePageActionURL()).clearClasses()).getHtmlString();
             }
 
-            if (AppProps.getInstance().isShowRibbonMessage() && !StringUtils.isEmpty(AppProps.getInstance().getRibbonMessageHtml()))
+            if (null != upgradeMessage)
             {
-                String message = AppProps.getInstance().getRibbonMessageHtml();
-                message = ModuleHtmlView.replaceTokens(message, context);
-                warnings.add(HtmlString.unsafe(message));  // We trust that the site admin has provided valid HTML
+                warnings.add(upgradeMessage);
             }
+        }
+
+        if (AppProps.getInstance().isShowRibbonMessage() && !StringUtils.isEmpty(AppProps.getInstance().getRibbonMessageHtml()))
+        {
+            String message = AppProps.getInstance().getRibbonMessageHtml();
+            message = ModuleHtmlView.replaceTokens(message, context);
+            warnings.add(HtmlString.unsafe(message));  // We trust that the site admin has provided valid HTML
         }
     }
 

--- a/core/src/org/labkey/core/view/template/bootstrap/WarningServiceImpl.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/WarningServiceImpl.java
@@ -97,6 +97,13 @@ public class WarningServiceImpl implements WarningService
     @Override
     public Warnings getWarnings(ViewContext context)
     {
+        if (null == context)
+            throw new IllegalStateException("ViewContext was null");
+        if (null == context.getUser())
+            throw new IllegalStateException("ViewContext.getUser() was null");
+        if (null == context.getRequest())
+            throw new IllegalStateException("ViewContext.getUser() was null");
+
         // Collect warnings
         List<HtmlString> warningMessages = new LinkedList<>();
         User user = context.getUser();

--- a/core/src/org/labkey/core/view/template/bootstrap/body.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/body.jsp
@@ -62,7 +62,7 @@
 <div class="container">
     <div class="row">
         <div class="col-md-12">
-            <%= text(pageConfig.renderSiteMessages(getViewContext())) %>
+            <%=pageConfig.renderSiteMessages(getViewContext())%>
             <% if (pageConfig.showHeader() != PageConfig.TrueFalse.False && null != pageConfig.getAppBar())
                {
                    String trail = renderTrail(pageConfig.getAppBar().getNavTrail());

--- a/core/src/org/labkey/core/view/template/bootstrap/dialog.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/dialog.jsp
@@ -27,7 +27,7 @@
 <div class="container">
     <div class="row content-row">
         <div class="content-left">
-            <%= text(pageConfig.renderSiteMessages(getViewContext())) %>
+            <%=pageConfig.renderSiteMessages(getViewContext())%>
             <div class="well">
                 <% me.include(me.getBody(), out); %>
             </div>

--- a/core/src/org/labkey/core/view/template/bootstrap/wizard.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/wizard.jsp
@@ -28,7 +28,7 @@
 <div class="container">
     <div class="row content-row">
     <div class="content-left">
-    <%= text(pageConfig.renderSiteMessages(getViewContext())) %>
+    <%=pageConfig.renderSiteMessages(getViewContext())%>
     <div class="labkey-wizard-container">
         <div class="well">
             <span class="labkey-nav-page-header"><%= h(pageConfig.getTitle()) %></span>


### PR DESCRIPTION
#### Rationale
[Issue 43096: Dynamic warning providers should suppress warnings for non-admins](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43096)

#### Changes
* Show missing views warning to site admins only
* Refactor to ensure non-null ViewContext, User, and Request
