### PR TITLE
Improve audit log message when deleting an assay row

### DIFF
--- a/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
@@ -167,7 +167,7 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
 
         Map<String, Object> result = super.deleteRow(user, container, oldRowMap);
 
-        ExperimentService.get().auditRunEvent(user, run.getProtocol(), run, null, "Deleted data row.");
+        ExperimentService.get().auditRunEvent(user, run.getProtocol(), run, null, "Deleted data row, id " + oldRowMap.get("RowId"));
 
         if (null != dataObjectMap)
         {


### PR DESCRIPTION
#### Rationale
Admins can enable editing and deleting individual rows in an assay's result data. Deletions are being audited but don't fully identify the row. This is a minimal change to add more context.

#### Changes
* Include the RowId of the newly deleted row in the message