### PR TITLE
Extensibility for protein sequence and annotations

### DIFF
--- a/api/src/org/labkey/api/protein/ProteinFeature.java
+++ b/api/src/org/labkey/api/protein/ProteinFeature.java
@@ -1,0 +1,86 @@
+package org.labkey.api.protein;
+
+public class ProteinFeature
+{
+    int startIndex;
+    int endIndex;
+    String type;
+    String description;
+    String original;
+    String variation;
+
+    public ProteinFeature() {}
+
+    public ProteinFeature(int startIndex, int endIndex, String type, String original, String variation, String description)
+    {
+        this.startIndex = startIndex;
+        this.endIndex = endIndex;
+        this.type = type;
+        this.original = original;
+        this.variation = variation;
+        this.description = description;
+    }
+
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public void setDescription(String description)
+    {
+        this.description = description;
+    }
+
+    public int getStartIndex()
+    {
+        return startIndex;
+    }
+
+    public void setStartIndex(int startIndex)
+    {
+        this.startIndex = startIndex;
+    }
+
+    public int getEndIndex()
+    {
+        return endIndex;
+    }
+
+    public void setEndIndex(int endIndex)
+    {
+        this.endIndex = endIndex;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public void setType(String type)
+    {
+        this.type = type;
+    }
+
+    public String getOriginal()
+    {
+        return original;
+    }
+
+    public void setOriginal(String original)
+    {
+        this.original = original;
+    }
+
+    public String getVariation()
+    {
+        return variation;
+    }
+
+    public void setVariation(String variation)
+    {
+        this.variation = variation;
+    }
+    public boolean isVariation() {
+        return "sequence variant".equals(type);
+    }
+}

--- a/api/src/org/labkey/api/protein/ProteinService.java
+++ b/api/src/org/labkey/api/protein/ProteinService.java
@@ -20,10 +20,15 @@ import org.labkey.api.action.QueryViewAction;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.services.ServiceRegistry;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.WebPartView;
 import org.springframework.validation.BindException;
+import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,10 +75,10 @@ public interface ProteinService
     List<QueryViewProvider<PeptideSearchForm>> getPeptideSearchViews();
 
     /** @param aaRowWidth the number of amino acids to display in a single row */
-    WebPartView getProteinCoverageView(int seqId, String[] peptides, int aaRowWidth, boolean showEntireFragmentInCoverage);
+    WebPartView<?> getProteinCoverageView(int seqId, String[] peptides, int aaRowWidth, boolean showEntireFragmentInCoverage, @Nullable String accessionForFeatures);
 
     /** @return a web part with all of the annotations and identifiers we know for a given protein */
-    WebPartView getAnnotationsView(int seqId);
+    WebPartView<?> getAnnotationsView(int seqId, Map<String, Collection<HtmlString>> extraAnnotations);
 
     String getProteinSequence(int seqId);
 
@@ -269,4 +274,7 @@ public interface ProteinService
             _location = location;
         }
     }
+
+    List<ProteinFeature> getProteinFeatures(String accession) throws IOException, ParserConfigurationException, SAXException;
+
 }


### PR DESCRIPTION
#### Rationale
Expand extensibility for protein sequence and annotation views, allowing modules to supply additional annotations and request that protein features be shown on the sequence

#### Changes
* Pass-throughs for protein feature metadata and other configuration