### PR TITLE
Use new conversion error message helper method to fix tests

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyManualTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyManualTest.java
@@ -25,6 +25,8 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.StudyHelper;
 
 import java.io.File;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
 
 public abstract class StudyManualTest extends StudyTest
 {
@@ -229,8 +231,8 @@ public abstract class StudyManualTest extends StudyTest
 
         String errorRow = "\tbadvisitd\t1/1/2006\t\ttext\t";
         setFormElement(Locator.name("text"), _tsv + "\n" + errorRow);
-        _listHelper.submitImportTsv_error("Could not convert 'badvisitd'");
-        assertTextPresent("Could not convert 'text'");
+        _listHelper.submitImportTsv_error(getConversionErrorMessage("badvisitd", "SequenceNum", BigDecimal.class));
+        assertTextPresent(getConversionErrorMessage("text", "DateField", Timestamp.class));
 
         _listHelper.submitTsvData(_tsv);
         assertTextPresent("1234", "2006-02-01", "1.2", "aliasedData");


### PR DESCRIPTION
#### Rationale
Study export tests were failing due to hard-coded assumptions about error messages. Use the helper method to keep tests in sync with product.