### PR TITLE
43092: Export of study with samples including 'experiments, protocols, and runs' does not produce a valid archive

### DIFF
--- a/experiment/src/org/labkey/experiment/XarExporter.java
+++ b/experiment/src/org/labkey/experiment/XarExporter.java
@@ -455,8 +455,11 @@ public class XarExporter
                 // include a file path in the export, though.  We use "Data" + rowId of the data object as the file name
                 // to ensure that the path won't collide with other output data from exported runs in the xar archive,
                 // but we don't want to include data classes as part of this behavior.
-                if (data.getDataFileUrl() == null && data.isFinalRunOutput() && (data.getDataClass(null) == null))
+                if ((data.getDataFileUrl() == null) && data.isFinalRunOutput() &&
+                        (data.getDataClass(null) == null) && (run.getFilePathRoot() != null))
+                {
                     data.setDataFileURI(run.getFilePathRootPath().resolve("Data" + data.getRowId()).toUri());
+                }
                 DataBaseType xData = outputDataObjects.addNewData();
                 populateData(xData, data, null, run);
             }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43092
Not a common scenario, but this was caused by an ETL which copied rows from a dataset to a dataclass. In this case we create a run with a blank `FilePathRoot`
