### PR TITLE
42976: SQL wildcard should not be prefixed by '!' in exported scripts

### DIFF
--- a/api/src/org/labkey/api/query/createExportScript.jsp
+++ b/api/src/org/labkey/api/query/createExportScript.jsp
@@ -18,4 +18,4 @@
     JspView<ExportScriptModel> me = (JspView<ExportScriptModel>) HttpView.currentView();
     ExportScriptModel model = me.getModelBean();
     getViewContext().getResponse().setContentType("text/plain");
-%><%=text(model.getScriptExportText())%>
+%><%=text(model.getExportText())%>


### PR DESCRIPTION
#### Rationale
The SQL wildcard '_' is escaped with a '!' when used as the parameter value in the LIKE filters (CONTAINS, CONTAINS_ONE_OF).  When generating an export language snippet for the grid, we used the escaped parameter value rather than the actual filter parameter value.  In addition, the export script generated filter didn't handle values for clauses that contain multiple parameters that include the separator character.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/717

#### Changes
- remove obsolete code in export script model for multi-valued filter types
- use the unescaped parameter value when rendering the export script
- for filters that support multiple values (IN, CONTAINS_ONE_OF, BETWEEN), encode values using the json filter syntax if they contain the separator character
