### PR TITLE
use assay run's LSID as publish audit event sourceLsid

### DIFF
--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -123,6 +123,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -545,20 +546,22 @@ public class StudyPublishManager implements StudyPublishService
     /**
      * To help generate the assay audit record, group the rows by the source type lsid (assay protocol or sample type).
      */
-    private Map<String, List<Map<String, Object>>> groupBySourceLsid(List<Map<String, Object>> dataMaps)
+    private Map<Optional<String>, List<Map<String, Object>>> groupBySourceLsid(List<Map<String, Object>> dataMaps)
     {
-        return dataMaps.stream().collect(Collectors.groupingBy(m -> (String)m.get(SOURCE_LSID_PROPERTY_NAME)));
+        // source LSID may be null
+        return dataMaps.stream().collect(Collectors.groupingBy(m -> Optional.ofNullable((String)m.get(SOURCE_LSID_PROPERTY_NAME))));
     }
 
     // TODO : consider pushing this into PublishSource
     private void logPublishEvent(Dataset.PublishSource publishSource, ExpObject source, List<Map<String, Object>> dataMaps, User user, Container sourceContainer, Container targetContainer, Dataset dataset)
     {
-        Map<String, List<Map<String, Object>>> sourceLSIDCounts = groupBySourceLsid(dataMaps);
+        Map<Optional<String>, List<Map<String, Object>>> sourceLSIDCounts = groupBySourceLsid(dataMaps);
         if (source != null)
         {
-            for (Map.Entry<String, List<Map<String, Object>>> entry : sourceLSIDCounts.entrySet())
+            for (var entry : sourceLSIDCounts.entrySet())
             {
-                String sourceLsid = entry.getKey();
+                // source LSID may be null
+                String sourceLsid = entry.getKey().orElse(null);
                 List<Map<String, Object>> rows = entry.getValue();
                 int recordCount = rows.size();
 

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -563,7 +563,7 @@ public class StudyPublishManager implements StudyPublishService
                 int recordCount = rows.size();
 
                 String auditMessage = publishSource.getLinkToStudyAuditMessage(source, recordCount);
-                PublishAuditProvider.AuditEvent event = new PublishAuditProvider.AuditEvent(sourceContainer.getId(), auditMessage, publishSource, source);
+                PublishAuditProvider.AuditEvent event = new PublishAuditProvider.AuditEvent(sourceContainer.getId(), auditMessage, publishSource, source, sourceLsid);
 
                 event.setTargetStudy(targetContainer.getId());
                 event.setDatasetId(dataset.getDatasetId());
@@ -1280,7 +1280,7 @@ public class StudyPublishManager implements StudyPublishService
                 sourceName = source.getName();
 
             String auditMessage = sourceType.getRecallFromStudyAuditMessage(sourceName, rowCount);
-            PublishAuditProvider.AuditEvent event = new PublishAuditProvider.AuditEvent(sourceContainer.getId(), auditMessage, sourceType, source);
+            PublishAuditProvider.AuditEvent event = new PublishAuditProvider.AuditEvent(sourceContainer.getId(), auditMessage, sourceType, source, null);
 
             event.setTargetStudy(def.getStudy().getContainer().getId());
             event.setDatasetId(def.getDatasetId());

--- a/study/src/org/labkey/study/assay/query/PublishAuditProvider.java
+++ b/study/src/org/labkey/study/assay/query/PublishAuditProvider.java
@@ -63,9 +63,13 @@ public class PublishAuditProvider extends AbstractAuditTypeProvider implements A
     public static final String COLUMN_NAME_SAMPLE_TYPE_ID = "SampleTypeID";
     public static final String COLUMN_NAME_TARGET_STUDY = "TargetStudy";
     public static final String COLUMN_NAME_DATASET_ID = "DatasetId";
+    // Dataset.PublishSource.Assay or SampleType
     public static final String COLUMN_NAME_SOURCE_TYPE = "SourceType";
+    // For samples, the sourceLsid is the SampleType's LSID.
+    // For assay, sourceLsid is typically the assay run's LSID. See AssayProvider.getSourceLSID().
     public static final String COLUMN_NAME_SOURCE_LSID = "SourceLsid";
-    public static final String COLUMN_NAME_SOURCE_NAME = "SourceName"; // assay or sample type name
+    // assay or sample type name
+    public static final String COLUMN_NAME_SOURCE_NAME = "SourceName";
     public static final String COLUMN_NAME_RECORD_COUNT = "RecordCount";
 
     static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
@@ -214,14 +218,14 @@ public class PublishAuditProvider extends AbstractAuditTypeProvider implements A
             super();
         }
 
-        public AuditEvent(String container, String comment, Dataset.PublishSource sourceType, @Nullable ExpObject source)
+        public AuditEvent(String container, String comment, Dataset.PublishSource sourceType, @Nullable ExpObject source, @Nullable String sourceLsid)
         {
             super(PUBLISH_AUDIT_EVENT, container, comment);
             _sourceType = sourceType.name();
+            _sourceLsid = sourceLsid;
             if (source != null)
             {
                 setSourceName(source.getName());
-                setSourceLsid(source.getLSID());
                 switch (sourceType)
                 {
                     case Assay -> {

--- a/study/src/org/labkey/study/controllers/designer/DesignerController.java
+++ b/study/src/org/labkey/study/controllers/designer/DesignerController.java
@@ -91,6 +91,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.labkey.api.study.publish.StudyPublishService.SOURCE_LSID_PROPERTY_NAME;
+
 /**
  * User: jgarms
  */
@@ -466,6 +468,7 @@ public class DesignerController extends SpringActionController
                     {
                         HashMap<String, Object> newMap = new HashMap<>(getParticipants().get(i));
                         newMap.put("Date", newMap.get("StartDate")); //Date of demographic data *is* StartDate by default
+                        newMap.put(SOURCE_LSID_PROPERTY_NAME, null);
                         participantMaps.add(newMap);
                     }
                     Study study = StudyDesignManager.get().generateStudyFromDesign(getUser(), ContainerManager.getForId(form.getParentFolderId()),

--- a/study/src/org/labkey/study/controllers/publish/PublishController.java
+++ b/study/src/org/labkey/study/controllers/publish/PublishController.java
@@ -64,7 +64,6 @@ public class PublishController extends SpringActionController
             AssayPublishConfirmAction.class,
             SampleTypePublishStartAction.class,
             SampleTypePublishConfirmAction.class
-//            SampleTypePublishHistoryAction.class
     );
 
     public PublishController()

--- a/study/src/org/labkey/study/designer/view/StudyDesignsWebPart.java
+++ b/study/src/org/labkey/study/designer/view/StudyDesignsWebPart.java
@@ -67,7 +67,7 @@ public class StudyDesignsWebPart extends GridView
         dr.getDisplayColumn("StudyId").setCaption("Id");
 
         ActionURL helper = new ActionURL(DesignerController.DesignerAction.class, ctx.getContainer());
-        dr.getDisplayColumn("Label").setURL(helper.toString() + "&studyId=${studyId}");
+        dr.getDisplayColumn("Label").setURL(helper.clone().addParameter("studyId", "${studyId}").getLocalURIString(true));
         dr.getDisplayColumn("PublicRevision").setCaption("Revision");
         dr.getDisplayColumn("Container").setVisible(false);
         dr.getDisplayColumn("Active").setVisible(false);


### PR DESCRIPTION
#### Rationale
Fix EvaluationContentTest.validateAssayFolder and AssayTest.  For assay results, use the assay run's LSID as the publish audit event's sourceLsid.  For samples, continue to use the SampleType's LSID as the sourceLsid.

#### Related Pull Requests
* #2216
