### PR TITLE
improve support for using samples to link assay data to studies

### DIFF
--- a/api/src/org/labkey/api/study/assay/SampleParticipantVisitResolver.java
+++ b/api/src/org/labkey/api/study/assay/SampleParticipantVisitResolver.java
@@ -2,15 +2,25 @@ package org.labkey.api.study.assay;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.action.NullSafeBindException;
+import org.labkey.api.collections.ResultSetRowMapFactory;
+import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.Filter;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.data.Results;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QueryService;
+import org.labkey.api.query.QuerySettings;
+import org.labkey.api.query.QueryView;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.ParticipantVisit;
@@ -18,17 +28,23 @@ import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.publish.StudyPublishService;
 import org.labkey.api.study.query.PublishResultsQueryView;
+import org.labkey.api.util.Pair;
+import org.labkey.api.view.DataView;
+import org.springframework.beans.MutablePropertyValues;
 
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.labkey.api.study.query.PublishResultsQueryView.ExtraColFieldKeys;
 
 /**
  * Resolver that tries to resolve subject and timepoint information using sample IDs
  */
 public class SampleParticipantVisitResolver extends StudyParticipantVisitResolver
 {
-    private final Map<Integer, ParticipantVisit> _resolvedSamples = new HashMap<>();
+    private final Map<Integer, Pair<Boolean, ParticipantVisit>> _resolvedSamples = new HashMap<>();
+    private Map<ExtraColFieldKeys, FieldKey> _fieldKeyMap;
 
     public SampleParticipantVisitResolver(Container runContainer, @Nullable Container targetStudyContainer, User user)
     {
@@ -39,12 +55,15 @@ public class SampleParticipantVisitResolver extends StudyParticipantVisitResolve
     protected @NotNull ParticipantVisit resolveParticipantVisit(String sampleId, String participantID, Double visitID, Date date, Container targetStudyContainer)
     {
         ParticipantVisitImpl originalInfo = new ParticipantVisitImpl(sampleId, participantID, visitID, date, getRunContainer(), targetStudyContainer);
-        if (targetStudyContainer != null)
+        if (targetStudyContainer != null && sampleId != null)
         {
             Integer id = Integer.valueOf(sampleId);
 
             if (_resolvedSamples.containsKey(id))
-                return mergeParticipantVisitInfo(originalInfo, _resolvedSamples.get(id));
+            {
+                ParticipantVisit studyInfo = _resolvedSamples.get(id).getValue();
+                return studyInfo != null ? mergeParticipantVisitInfo(originalInfo, studyInfo) : originalInfo;
+            }
 
             ExpMaterial expMaterial = ExperimentService.get().getExpMaterial(id);
             if (expMaterial != null)
@@ -52,6 +71,7 @@ public class SampleParticipantVisitResolver extends StudyParticipantVisitResolve
                 ExpSampleType sampleType = expMaterial.getSampleType();
                 if (sampleType != null)
                 {
+                    Study study = StudyService.get().getStudy(targetStudyContainer);
                     for (Dataset dataset : StudyPublishService.get().getDatasetsForPublishSource(sampleType.getRowId(), Dataset.PublishSource.SampleType))
                     {
                         if (dataset.getContainer() == targetStudyContainer)
@@ -61,7 +81,6 @@ public class SampleParticipantVisitResolver extends StudyParticipantVisitResolve
                             Map<String, Object> row = new TableSelector(tableInfo, datasetFilter, null).getMap();
                             if (row != null && !row.isEmpty())
                             {
-                                Study study = StudyService.get().getStudy(targetStudyContainer);
                                 ParticipantVisit studyInfo =  new ParticipantVisitImpl(sampleId,
                                         String.valueOf(row.get(study.getSubjectColumnName())),
                                         PublishResultsQueryView.convertObjectToDouble(row.get("SequenceNum")),
@@ -70,8 +89,74 @@ public class SampleParticipantVisitResolver extends StudyParticipantVisitResolve
                                         targetStudyContainer);
 
                                 // remember resolved samples
-                                _resolvedSamples.put(id, studyInfo);
+                                _resolvedSamples.put(id, new Pair<>(true, studyInfo));
                                 return mergeParticipantVisitInfo(originalInfo, studyInfo);
+                            }
+                        }
+                    }
+
+                    // attempt to match up the subject/timepoint information even if the sample has not been published to
+                    // a study yet, this includes traversing any parent lineage samples for corresponding information
+                    QuerySettings qs = new QuerySettings(new MutablePropertyValues(), QueryView.DATAREGIONNAME_DEFAULT);
+                    qs.setSchemaName(SamplesSchema.SCHEMA_NAME);
+                    qs.setQueryName(sampleType.getName());
+
+                    if (_fieldKeyMap == null)
+                        _fieldKeyMap = StudyPublishService.get().getSamplePublishFieldKeys(getUser(), getRunContainer(), sampleType, qs);
+
+                    if (!_fieldKeyMap.isEmpty())
+                    {
+                        UserSchema schema = QueryService.get().getUserSchema(getUser(), getRunContainer(), qs.getSchemaName());
+                        if (schema != null)
+                        {
+                            qs.setBaseFilter(new SimpleFilter(FieldKey.fromParts("RowId"), id));
+                            QueryView view = new QueryView(schema, qs, new NullSafeBindException(new Object(), "form"));
+                            DataView dataView = view.createDataView();
+                            RenderContext ctx = dataView.getRenderContext();
+                            Map<FieldKey, ColumnInfo> selectColumns = dataView.getDataRegion().getSelectColumns();
+
+                            try (Results rs = view.getResults())
+                            {
+                                ctx.setResults(rs);
+                                ResultSetRowMapFactory factory = ResultSetRowMapFactory.create(rs);
+                                if (rs.next())
+                                {
+                                    ctx.setRow(factory.getRowMap(rs));
+                                    String ptid = null;
+                                    Double visitId = null;
+                                    Date visitDate = null;
+
+                                    if (_fieldKeyMap.containsKey(ExtraColFieldKeys.ParticipantId) &&
+                                            selectColumns.containsKey(_fieldKeyMap.get(ExtraColFieldKeys.ParticipantId)))
+                                    {
+                                        var col = selectColumns.get(_fieldKeyMap.get(ExtraColFieldKeys.ParticipantId));
+                                        ptid = PublishResultsQueryView.convertObjectToString(PublishResultsQueryView.getColumnValue(col, ctx));
+                                    }
+                                    if (_fieldKeyMap.containsKey(ExtraColFieldKeys.VisitId) &&
+                                            selectColumns.containsKey(_fieldKeyMap.get(ExtraColFieldKeys.VisitId)))
+                                    {
+                                        var col = selectColumns.get(_fieldKeyMap.get(ExtraColFieldKeys.VisitId));
+                                        visitId = PublishResultsQueryView.convertObjectToDouble(PublishResultsQueryView.getColumnValue(col, ctx));
+                                    }
+                                    if (_fieldKeyMap.containsKey(ExtraColFieldKeys.Date) &&
+                                            selectColumns.containsKey(_fieldKeyMap.get(ExtraColFieldKeys.Date)))
+                                    {
+                                        var col = selectColumns.get(_fieldKeyMap.get(ExtraColFieldKeys.Date));
+                                        visitDate = PublishResultsQueryView.convertObjectToDate(getRunContainer(), PublishResultsQueryView.getColumnValue(col, ctx));
+                                    }
+
+                                    ParticipantVisit studyInfo =  new ParticipantVisitImpl(sampleId, ptid, visitId, visitDate,
+                                            getRunContainer(),
+                                            targetStudyContainer);
+
+                                    // remember resolved samples
+                                    _resolvedSamples.put(id, new Pair<>(false, studyInfo));
+                                    return mergeParticipantVisitInfo(originalInfo, studyInfo);
+                                }
+                            }
+                            catch (Exception e)
+                            {
+                                throw new RuntimeException(e);
                             }
                         }
                     }
@@ -79,7 +164,7 @@ public class SampleParticipantVisitResolver extends StudyParticipantVisitResolve
             }
 
             // cache the miss
-            _resolvedSamples.put(id, originalInfo);
+            _resolvedSamples.put(id, new Pair<>(false, null));
         }
         return originalInfo;
     }
@@ -89,6 +174,11 @@ public class SampleParticipantVisitResolver extends StudyParticipantVisitResolve
      */
     public boolean isSampleMatched(Integer sampleId)
     {
-        return _resolvedSamples.containsKey(sampleId);
+        if (_resolvedSamples.containsKey(sampleId))
+        {
+            Pair<Boolean, ParticipantVisit> studyInfo = _resolvedSamples.get(sampleId);
+            return studyInfo.getKey();
+        }
+        return false;
     }
 }

--- a/api/src/org/labkey/api/study/publish/StudyPublishService.java
+++ b/api/src/org/labkey/api/study/publish/StudyPublishService.java
@@ -26,12 +26,16 @@ import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
+import org.labkey.api.exp.api.ExpSampleType;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QuerySettings;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.TimepointType;
+import org.labkey.api.study.query.PublishResultsQueryView;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
 
@@ -119,4 +123,12 @@ public interface StudyPublishService
     Set<? extends Dataset> getDatasetsForAssayRuns(Collection<ExpRun> runs, User user);
 
     void addRecallAuditEvent(Container sourceContainer, User user, Dataset def, int rowCount, @Nullable Collection<Pair<String,Integer>> datasetRowLsidAndSourceRowIds);
+
+    /**
+     * For a given sample, helps identify the special columns : subject/visit/date that are needed to publish sample rows to a
+     * study target.
+     *
+     * @param qs an optional query settings if custom view fields should be additionally inspected for publish relevant columns.
+     */
+    Map<PublishResultsQueryView.ExtraColFieldKeys, FieldKey> getSamplePublishFieldKeys(User user, Container container, ExpSampleType sampleType, @Nullable QuerySettings qs);
 }

--- a/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
+++ b/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
@@ -294,6 +294,21 @@ public class PublishResultsQueryView extends QueryView
         return visitId;
     }
 
+    public static Object getColumnValue(ColumnInfo col, RenderContext ctx)
+    {
+        DisplayColumn dc = col.getRenderer();
+        if (dc instanceof IMultiValuedDisplayColumn)
+        {
+            // support for lineage and multivalue columns
+            List<Object> values = ((IMultiValuedDisplayColumn)dc).getDisplayValues(ctx);
+            if (values.size() == 1)
+                return values.get(0);
+            else
+                LOG.warn("Unable to use the value returned from column : " + col.getName() + " because this multi-value column returned more than a single value.");
+        }
+        return col.getValue(ctx);
+    }
+
     public static class ResolverHelper
     {
         private final Dataset.PublishSource _publishSource;
@@ -473,21 +488,6 @@ public class PublishResultsQueryView extends QueryView
                 result = pv == null ? null : pv.getDate();
             }
             return includeTimestamp ? DateUtil.formatDateTimeISO8601(result) : DateUtil.formatDateISO8601(result);
-        }
-
-        private Object getColumnValue(ColumnInfo col, RenderContext ctx)
-        {
-            DisplayColumn dc = col.getRenderer();
-            if (dc instanceof IMultiValuedDisplayColumn)
-            {
-                // support for lineage and multivalue columns
-                List<Object> values = ((IMultiValuedDisplayColumn)dc).getDisplayValues(ctx);
-                if (values.size() == 1)
-                    return values.get(0);
-                else
-                    LOG.warn("Unable to use the value returned from column : " + col.getName() + " because this multi-value column returned more than a single value.");
-            }
-            return col.getValue(ctx);
         }
 
         public Container getUserTargetStudy(RenderContext ctx)

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -36,6 +36,7 @@ import org.labkey.api.audit.SampleTimelineAuditEvent;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.CsvSet;
+import org.labkey.api.collections.LabKeyCollectors;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -43,7 +44,9 @@ import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
+import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.Filter;
+import org.labkey.api.data.ILineageDisplayColumn;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SqlSelector;
@@ -64,6 +67,7 @@ import org.labkey.api.exp.api.ProvenanceService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.PropertyService;
+import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
@@ -72,7 +76,9 @@ import org.labkey.api.qc.QCStateManager;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
+import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.DataLoader;
@@ -87,6 +93,7 @@ import org.labkey.api.study.StudyUrls;
 import org.labkey.api.study.TimepointType;
 import org.labkey.api.study.publish.PublishKey;
 import org.labkey.api.study.publish.StudyPublishService;
+import org.labkey.api.study.query.PublishResultsQueryView;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.FileStream;
 import org.labkey.api.util.FileUtil;
@@ -94,6 +101,7 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
+import org.labkey.api.view.DataView;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.study.StudySchema;
@@ -1324,5 +1332,62 @@ public class StudyPublishManager implements StudyPublishService
                 AuditLogService.get().addEvents(user, events);
             }
         }
+    }
+
+    @Override
+    public Map<PublishResultsQueryView.ExtraColFieldKeys, FieldKey> getSamplePublishFieldKeys(User user, Container container,
+                                                                                              ExpSampleType sampleType,
+                                                                                              @Nullable QuerySettings qs)
+    {
+        Map<PublishResultsQueryView.ExtraColFieldKeys, FieldKey> fieldKeyMap = new HashMap<>();
+        if (sampleType != null)
+        {
+            UserSchema userSchema = QueryService.get().getUserSchema(user, container, SamplesSchema.SCHEMA_NAME);
+            TableInfo tableInfo = userSchema.getTable(sampleType.getName());
+            if (tableInfo == null)
+                throw new IllegalStateException(String.format("Sample Type %s not found", sampleType.getName()));
+
+            Map<FieldKey, ColumnInfo> columns = tableInfo.getColumns().stream()
+                    .collect(LabKeyCollectors.toLinkedMap(ColumnInfo::getFieldKey, c -> c));
+
+            // optionally add columns added through a view, useful for picking up any lineage fields
+            if (qs != null)
+            {
+                QueryView view = new QueryView(userSchema, qs, null);
+                DataView dataView = view.createDataView();
+                for (Map.Entry<FieldKey, ColumnInfo> entry : dataView.getDataRegion().getSelectColumns().entrySet())
+                {
+                    if (!columns.containsKey(entry.getKey()))
+                        columns.put(entry.getKey(), entry.getValue());
+                }
+            }
+
+            for (ColumnInfo ci : columns.values())
+            {
+                ColumnInfo col = ci;
+                DisplayColumn dc = col.getRenderer();
+
+                // hack to pull in lineage concept URI info, because the metadata doesn't get propagated
+                // to the actual lookup column
+                if (dc instanceof ILineageDisplayColumn)
+                {
+                    col = ((ILineageDisplayColumn) dc).getInnerBoundColumn();
+                }
+
+                if (org.labkey.api.gwt.client.ui.PropertyType.VISIT_CONCEPT_URI.equalsIgnoreCase(col.getConceptURI()))
+                {
+                    if (!fieldKeyMap.containsKey(PublishResultsQueryView.ExtraColFieldKeys.VisitId) && col.getJdbcType().isReal())
+                        fieldKeyMap.put(PublishResultsQueryView.ExtraColFieldKeys.VisitId, ci.getFieldKey());
+                    if (!fieldKeyMap.containsKey(PublishResultsQueryView.ExtraColFieldKeys.Date) && col.getJdbcType().isDateOrTime())
+                        fieldKeyMap.put(PublishResultsQueryView.ExtraColFieldKeys.Date, ci.getFieldKey());
+                }
+
+                if (!fieldKeyMap.containsKey(PublishResultsQueryView.ExtraColFieldKeys.ParticipantId) && org.labkey.api.gwt.client.ui.PropertyType.PARTICIPANT_CONCEPT_URI.equalsIgnoreCase(col.getConceptURI()))
+                {
+                    fieldKeyMap.put(PublishResultsQueryView.ExtraColFieldKeys.ParticipantId, ci.getFieldKey());
+                }
+            }
+        }
+        return fieldKeyMap;
     }
 }


### PR DESCRIPTION
#### Rationale
Previously we added support to be able to resolve subject and timepoint information for assays through any samples that had been published to the target study. This change expands that support to include samples that haven't been published to the study but still contains subject and timepoint information communicated through the concept URIs.

Summary:
- Published samples will be checked first
- Non-published samples will also include traversing any parent samples that may be pulled in through the default view
- Non-published samples will show up as unmatched in the publish confirm view (since they technically don't exist in the target study)