### PR TITLE
Option to retrieve user attributes at authentication time and stash in session

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -1092,6 +1092,10 @@ public class AuthenticationManager
         return ret;
     }
 
+    /**
+     * @return A case-insensitive map of user attribute names and values that was stashed in the associated session at
+     * authentication time. This map will often be empty but will never be null.
+     */
     public static @NotNull Map<String, String> getAuthenticationAttributes(HttpServletRequest request)
     {
         Map<String, String> attributeMap = null;

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -74,7 +74,6 @@ import org.labkey.api.util.Rate;
 import org.labkey.api.util.RateLimiter;
 import org.labkey.api.util.SessionHelper;
 import org.labkey.api.util.URLHelper;
-import org.labkey.api.util.UsageReportingLevel;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.NavTree;
@@ -1093,6 +1092,16 @@ public class AuthenticationManager
         return ret;
     }
 
+    public static @NotNull Map<String, String> getAuthenticationAttributes(HttpServletRequest request)
+    {
+        Map<String, String> attributeMap = null;
+        HttpSession session = request.getSession(false);
+
+        if (null != session)
+            attributeMap = (Map<String, String>)session.getAttribute(SecurityManager.AUTHENTICATION_ATTRIBUTES_KEY);
+
+        return null != attributeMap ? attributeMap : Collections.emptyMap();
+    }
 
     private static boolean areNotBlank(String id, String password)
     {
@@ -1310,8 +1319,8 @@ public class AuthenticationManager
         LoginReturnProperties properties = getLoginReturnProperties(request);
         URLHelper url = getAfterLoginURL(c, properties, primaryAuthUser);
 
-        // Prep the new session and set the user attribute
-        session = SecurityManager.setAuthenticatedUser(request, primaryAuthResult.getResponse().getConfiguration(), primaryAuthUser, true);
+        // Prep the new session and set the user & authentication-related attributes
+        session = SecurityManager.setAuthenticatedUser(request, primaryAuthResult.getResponse(), primaryAuthUser, true);
 
         if (session.isNew() && !primaryAuthUser.isGuest())
         {

--- a/api/src/org/labkey/api/security/AuthenticationProvider.java
+++ b/api/src/org/labkey/api/security/AuthenticationProvider.java
@@ -326,9 +326,11 @@ public interface AuthenticationProvider
         }
 
         /**
-         * Creates an authentication provider response that includes a validator to be called on every request
+         * Creates an authentication provider response that can include a validator to be called on every request and a
+         * map of user attributes
          * @param email Valid email address of the authenticated user
          * @param validator An authentication validator
+         * @param attributeMap A <b>case-insensitive</b> map of attribute names and values associated with this authentication
          * @return A new successful authentication response containing the email address of the authenticated user and a validator
          */
         public static AuthenticationResponse createSuccessResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, ValidEmail email, @Nullable AuthenticationValidator validator, @NotNull Map<String, String> attributeMap)
@@ -380,6 +382,9 @@ public interface AuthenticationProvider
             return _redirectURL;
         }
 
+        /**
+         * @return A case-insensitive map of attribute names and values. This will often be empty but will never be null.
+         */
         public @NotNull Map<String, String> getAttributeMap()
         {
             return _attributeMap;

--- a/api/src/org/labkey/api/security/AuthenticationProvider.java
+++ b/api/src/org/labkey/api/security/AuthenticationProvider.java
@@ -293,12 +293,14 @@ public interface AuthenticationProvider
         private final @Nullable AuthenticationValidator _validator;
         private final @Nullable FailureReason _failureReason;
         private final @Nullable ActionURL _redirectURL;
+        private final @NotNull Map<String, String> _attributeMap;
 
-        private AuthenticationResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @NotNull ValidEmail email, @Nullable AuthenticationValidator validator)
+        private AuthenticationResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @NotNull ValidEmail email, @Nullable AuthenticationValidator validator, @NotNull Map<String, String> attributeMap)
         {
             _configuration = configuration;
             _email = email;
             _validator = validator;
+            _attributeMap = attributeMap;
             _failureReason = null;
             _redirectURL = null;
         }
@@ -310,6 +312,7 @@ public interface AuthenticationProvider
             _validator = null;
             _failureReason = failureReason;
             _redirectURL = redirectURL;
+            _attributeMap = Collections.emptyMap();
         }
 
         /**
@@ -319,7 +322,7 @@ public interface AuthenticationProvider
          */
         public static AuthenticationResponse createSuccessResponse(PrimaryAuthenticationConfiguration<?> configuration, ValidEmail email)
         {
-            return createSuccessResponse(configuration, email, null);
+            return createSuccessResponse(configuration, email, null, Collections.emptyMap());
         }
 
         /**
@@ -328,9 +331,9 @@ public interface AuthenticationProvider
          * @param validator An authentication validator
          * @return A new successful authentication response containing the email address of the authenticated user and a validator
          */
-        public static AuthenticationResponse createSuccessResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, ValidEmail email, @Nullable AuthenticationValidator validator)
+        public static AuthenticationResponse createSuccessResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, ValidEmail email, @Nullable AuthenticationValidator validator, @NotNull Map<String, String> attributeMap)
         {
-            return new AuthenticationResponse(configuration, email, validator);
+            return new AuthenticationResponse(configuration, email, validator, attributeMap);
         }
 
         public static AuthenticationResponse createFailureResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, FailureReason failureReason)
@@ -375,6 +378,11 @@ public interface AuthenticationProvider
         public @Nullable ActionURL getRedirectURL()
         {
             return _redirectURL;
+        }
+
+        public @NotNull Map<String, String> getAttributeMap()
+        {
+            return _attributeMap;
         }
     }
 

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -53,6 +53,7 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.AuthenticationConfiguration.PrimaryAuthenticationConfiguration;
 import org.labkey.api.security.AuthenticationManager.AuthenticationValidator;
+import org.labkey.api.security.AuthenticationProvider.AuthenticationResponse;
 import org.labkey.api.security.AuthenticationProvider.ResetPasswordProvider;
 import org.labkey.api.security.ValidEmail.InvalidEmailException;
 import org.labkey.api.security.impersonation.DisallowGlobalRolesContext;
@@ -162,7 +163,9 @@ public class SecurityManager
     private static final String IMPERSONATION_CONTEXT_FACTORY_KEY = User.class.getName() + "$ImpersonationContextFactoryKey";
     private static final String AUTHENTICATION_VALIDATORS_KEY = SecurityManager.class.getName() + "$AuthenticationValidators";
     private static final String AUTHENTICATION_METHOD = "SecurityManager.authenticationMethod";
+
     public static final String PRIMARY_AUTHENTICATION_CONFIGURATION = PrimaryAuthenticationConfiguration.class.getName();
+    public static final String AUTHENTICATION_ATTRIBUTES_KEY = User.class.getName() + "$AuthenticationAttributes";
 
     static
     {
@@ -718,7 +721,7 @@ public class SecurityManager
             return createTransformSession(context.getUser());
     }
 
-    public static HttpSession setAuthenticatedUser(HttpServletRequest request, @Nullable PrimaryAuthenticationConfiguration<?> configuration, User user, boolean invalidate)
+    public static HttpSession setAuthenticatedUser(HttpServletRequest request, @Nullable AuthenticationResponse response, User user, boolean invalidate)
     {
         SessionHelper.clearSession(request, invalidate, PageFlowUtil.set(WikiTermsOfUseProvider.TERMS_APPROVED_KEY));
         if (!user.isGuest() && request instanceof AuthenticatedRequest)
@@ -728,8 +731,12 @@ public class SecurityManager
         newSession.setAttribute(USER_ID_KEY, user.getUserId());
         newSession.setAttribute("LABKEY.username", user.getName());
 
-        if (null != configuration)
+        if (null != response)
+        {
+            PrimaryAuthenticationConfiguration<?> configuration = response.getConfiguration();
             newSession.setAttribute(PRIMARY_AUTHENTICATION_CONFIGURATION, configuration.getRowId());
+            newSession.setAttribute(AUTHENTICATION_ATTRIBUTES_KEY, response.getAttributeMap());
+        }
 
         return newSession;
     }

--- a/core/src/client/components/DynamicConfigurationModal.tsx
+++ b/core/src/client/components/DynamicConfigurationModal.tsx
@@ -167,7 +167,8 @@ export default class DynamicConfigurationModal extends PureComponent<Props, Part
             queryString = {
                 server: fieldValues.servers,
                 principal: fieldValues.principalTemplate,
-                sasl: fieldValues.SASL,
+                sasl: fieldValues.sasl,
+                readAttributes: fieldValues.readAttributes
             };
         }
 


### PR DESCRIPTION
#### Rationale
A client wants to configure RStudio to identify the current user via a specific LDAP attribute instead of their email address. This PR adds generic mechanisms for providers (like LDAP) to stash their attributes in session and for other code paths (like RStudio) to retrieve these attributes.

#### Related Pull Requests
* https://github.com/LabKey/ldap/pull/43

#### Changes
* Add the ability for authentication providers to set an attribute map that gets stashed in session
* Add `AuthenticationManager.getAuthenticationAttributes(HttpServletRequest)` to retrieve user attributes