### PR TITLE
Item 8855: Use user authentication attributes as RStudio pro use name

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -1098,8 +1098,14 @@ public class AuthenticationManager
      */
     public static @NotNull Map<String, String> getAuthenticationAttributes(HttpServletRequest request)
     {
-        Map<String, String> attributeMap = null;
         HttpSession session = request.getSession(false);
+
+        return getAuthenticationAttributes(session);
+    }
+
+    public static @NotNull Map<String, String> getAuthenticationAttributes(HttpSession session)
+    {
+        Map<String, String> attributeMap = null;
 
         if (null != session)
             attributeMap = (Map<String, String>)session.getAttribute(SecurityManager.AUTHENTICATION_ATTRIBUTES_KEY);

--- a/api/src/org/labkey/api/websocket/BrowserEndpoint.java
+++ b/api/src/org/labkey/api/websocket/BrowserEndpoint.java
@@ -17,6 +17,7 @@ package org.labkey.api.websocket;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.labkey.api.security.AuthenticationManager;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 
@@ -81,6 +82,7 @@ public abstract class BrowserEndpoint
                 config.getUserProperties().put("httpSession", httpSession);
 
             config.getUserProperties().put("userId", null == user ? 0 : user.getUserId());
+            config.getUserProperties().put("attributes", AuthenticationManager.getAuthenticationAttributes(httpSession));
         }
     }
 


### PR DESCRIPTION
#### Rationale
Some features (such as Shiny app) in RStudio are backed by websockets reather than http request. AuthenticationManager.getAuthenticationAttributes should be able to return user attributes from session, instead of requiring HttpServletRequest.

#### Related Pull Requests
* https://github.com/LabKey/rstudio/pull/87

#### Changes
* Allow getAuthenticationAttributes from HttpSession
