### PR TITLE
Avoid error "A JSP is attempting to render a string!"

### DIFF
--- a/api/src/org/labkey/api/view/template/PageConfig.java
+++ b/api/src/org/labkey/api/view/template/PageConfig.java
@@ -424,7 +424,7 @@ public class PageConfig
     }
 
     // For now, gives a central place to render messaging
-    public HasHtmlString renderSiteMessages(ViewContext context)
+    public HtmlString renderSiteMessages(ViewContext context)
     {
         HtmlStringBuilder messages = HtmlStringBuilder.of();
 
@@ -456,7 +456,7 @@ public class PageConfig
         messages.append(HtmlString.unsafe("<div class=\"alert alert-warning\" role=\"alert\">JavaScript is disabled. For the full experience enable JavaScript in your browser.</div>"));
         messages.append(HtmlString.unsafe("</noscript>"));
 
-        return messages;
+        return messages.getHtmlString();
     }
 
     public JSONObject getPortalContext()


### PR DESCRIPTION
#### Rationale
Avoid error, it looks like HasHtmlString causes the LabKeyJspWriter.print(String) overload to be called?

java.lang.IllegalStateException: A JSP is attempting to render a string! For help rectifying this problem, review this page https://www.labkey.org/Documentation/21.3/wiki-page.view?name=premServerEncoding or contact your LabKey Account Manager.
       at org.labkey.api.jsp.LabKeyJspWriter.throwException(LabKeyJspWriter.java:59)
       at org.labkey.api.jsp.LabKeyJspWriter.print(LabKeyJspWriter.java:40)

#### Related Pull Requests

#### Changes
