### PR TITLE
DDIB should not output two subject columns.

### DIFF
--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -54,7 +54,7 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
     {
         super(in);
 
-        // NOTE in might get wrapped with a LoggingDataIterator, so remember the original DataIterator
+        // NOTE it might get wrapped with a LoggingDataIterator, so remember the original DataIterator
         this._unwrapped = useMark ? (CachingDataIterator)in : null;
 
         this.target = target;

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -198,6 +198,22 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
                     continue;
                 }
 
+                if (match == subjectCol)
+                {
+                    try
+                    {
+                        // translate the incoming participant column
+                        // do a conversion for PTID aliasing
+                        it.translatePtid(in, user);
+                        continue;
+                    }
+                    catch (ValidationException e)
+                    {
+                        setupError(e.getMessage());
+                        return it;
+                    }
+                }
+
                 int out;
                 if (DefaultStudyDesignWriter.isColumnNumericForeignKeyToDataspaceTable(match.getFk(), true))
                 {
@@ -249,19 +265,8 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
         Integer indexContainer = outputMap.get(containerColumn);
         Integer indexReplace = outputMap.get("replace");
 
-        // do a conversion for PTID aliasing
-        Integer translatedIndexPTID = indexPTID;
-        try
-        {
-            translatedIndexPTID = it.translatePtid(indexPTIDInput, user);
-        }
-        catch (ValidationException e)
-        {
-            context.getErrors().addRowError(e);
-        }
-
         // For now, just specify null for sequence num index... we'll add it below
-        it.setSpecialOutputColumns(translatedIndexPTID, null, indexVisitDate, indexKeyProperty, indexContainer);
+        it.setSpecialOutputColumns(indexPTID, null, indexVisitDate, indexKeyProperty, indexContainer);
         it.setTimepointType(timetype);
 
         /* NOTE: these columns must be added in dependency order
@@ -411,11 +416,11 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
         {
             Integer indexVisit = timetype.isVisitBased() ? it.indexSequenceNumOutput : indexVisitDate;
             // no point if required columns are missing
-            if (null != translatedIndexPTID && null != indexVisit)
+            if (null != indexPTID && null != indexVisit)
             {
                 ScrollableDataIterator scrollable = DataIteratorUtil.wrapScrollable(ret);
                 _datasetDefinition.checkForDuplicates(scrollable, indexLSID,
-                        translatedIndexPTID, null == indexVisit ? -1 : indexVisit, null == indexKeyProperty ? -1 : indexKeyProperty, null == indexReplace ? -1 : indexReplace,
+                        indexPTID, null == indexVisit ? -1 : indexVisit, null == indexKeyProperty ? -1 : indexKeyProperty, null == indexReplace ? -1 : indexReplace,
                         context, null,
                         checkDuplicates);
                 scrollable.beforeFirst();
@@ -612,7 +617,7 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
 
         int translatePtid(Integer indexPtidInput, User user) throws ValidationException
         {
-            ColumnInfo col = new BaseColumnInfo("ParticipantId", JdbcType.VARCHAR);
+            ColumnInfo col = new BaseColumnInfo(_datasetDefinition.getStudy().getSubjectColumnName(), JdbcType.VARCHAR);
             ParticipantIdImportHelper piih = new ParticipantIdImportHelper(_datasetDefinition.getStudy(), user, _datasetDefinition);
             Callable call = piih.getCallable(getInput(), indexPtidInput);
             return addColumn(col, call);


### PR DESCRIPTION
#### Rationale
DatasetDataIteratorBuilder should not output two subject columns.
Currently it outputs the original column and the translated column, this depends on subtle behavior in matchColumns() to not break things.  Subtle is bad and we don't need both columns.

#### Related Pull Requests
https://github.com/LabKey/premium/pull/246

#### Changes
