### PR TITLE
Issue 43107: Add back strictFieldValidation property for study dataset and data class domain creation

### DIFF
--- a/api/src/org/labkey/api/exp/api/DataClassDomainKindProperties.java
+++ b/api/src/org/labkey/api/exp/api/DataClassDomainKindProperties.java
@@ -13,6 +13,7 @@ public class DataClassDomainKindProperties
     private String nameExpression;
     private Integer sampleType;
     private String category;
+    private boolean _strictFieldValidation = true; // Set as false to skip validation check in ExperimentServiceImpl.createDataClass (used in Rlabkey labkey.domain.createAndLoad)
 
     public DataClassDomainKindProperties()
     {}
@@ -129,5 +130,15 @@ public class DataClassDomainKindProperties
     public void setDomainId(int domainId)
     {
         this.domainId = domainId;
+    }
+
+    public boolean isStrictFieldValidation()
+    {
+        return _strictFieldValidation;
+    }
+
+    public void setStrictFieldValidation(boolean strictFieldValidation)
+    {
+        _strictFieldValidation = strictFieldValidation;
     }
 }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -6538,11 +6538,14 @@ public class ExperimentServiceImpl implements ExperimentService
         {
             String propertyName = pd.getName().toLowerCase();
             if (lowerReservedNames.contains(propertyName))
-                throw new IllegalArgumentException("Property name '" + propertyName + "' is a reserved name.");
+            {
+                if (options.isStrictFieldValidation())
+                    throw new IllegalArgumentException("Property name '" + propertyName + "' is a reserved name.");
+            }
             else if (domain.getPropertyByName(propertyName) != null) // issue 25275
                 throw new IllegalArgumentException("Property name '" + propertyName + "' is already defined for this domain.");
-
-            DomainUtil.addProperty(domain, pd, defaultValues, propertyUris, null);
+            else
+                DomainUtil.addProperty(domain, pd, defaultValues, propertyUris, null);
         }
 
         Set<PropertyStorageSpec.Index> propertyIndices = new HashSet<>();

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -389,7 +389,6 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
         boolean useTimeKeyField = arguments.isUseTimeKeyField();
         boolean showByDefault = arguments.isShowByDefault();
         String dataSharing = arguments.getDataSharing();
-        boolean strictFieldValidation = arguments.isStrictFieldValidation();
 
         // general dataset validation
         validateDatasetProperties(arguments, container, user, domain, null);
@@ -469,7 +468,7 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
                     {
                         if (lowerReservedNames.contains(pd.getName().toLowerCase()) || existingProperties.contains(pd.getName().toLowerCase()))
                         {
-                            if (strictFieldValidation)
+                            if (arguments.isStrictFieldValidation())
                                 throw new IllegalArgumentException("Property: " + pd.getName() + " is reserved or exists in the current domain.");
                         }
                         else

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -389,6 +389,7 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
         boolean useTimeKeyField = arguments.isUseTimeKeyField();
         boolean showByDefault = arguments.isShowByDefault();
         String dataSharing = arguments.getDataSharing();
+        boolean strictFieldValidation = arguments.isStrictFieldValidation();
 
         // general dataset validation
         validateDatasetProperties(arguments, container, user, domain, null);
@@ -467,7 +468,10 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
                     for (GWTPropertyDescriptor pd : properties)
                     {
                         if (lowerReservedNames.contains(pd.getName().toLowerCase()) || existingProperties.contains(pd.getName().toLowerCase()))
-                            throw new IllegalArgumentException("Property: " + pd.getName() + " is reserved or exists in the current domain.");
+                        {
+                            if (strictFieldValidation)
+                                throw new IllegalArgumentException("Property: " + pd.getName() + " is reserved or exists in the current domain.");
+                        }
                         else
                             DomainUtil.addProperty(newDomain, pd, defaultValues, propertyUris, null);
                     }

--- a/study/src/org/labkey/study/model/DatasetDomainKindProperties.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKindProperties.java
@@ -31,6 +31,7 @@ public class DatasetDomainKindProperties implements Cloneable
     private String _sourceAssayUrl;
     private String _dataSharing;
     private boolean _useTimeKeyField = false;
+    private boolean _strictFieldValidation = true; // Set as false to skip validation check in DatasetDomainKind.createDomain (used in Rlabkey labkey.domain.createAndLoad)
 
     private int _domainId;
 
@@ -305,5 +306,15 @@ public class DatasetDomainKindProperties implements Cloneable
     public void setCategoryName(String categoryName)
     {
         _categoryName = categoryName;
+    }
+
+    public boolean isStrictFieldValidation()
+    {
+        return _strictFieldValidation;
+    }
+
+    public void setStrictFieldValidation(boolean strictFieldValidation)
+    {
+        _strictFieldValidation = strictFieldValidation;
     }
 }


### PR DESCRIPTION
#### Rationale
Issue [43107](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43107): createAndLoad for Lists or Datasets using R returns an error

In a previous [PR](https://github.com/LabKey/platform/pull/1069), I told Rosaline that she could remove the strictFieldValidation property from the study dataset domain creation because we couldn't find any usages. Turns out the usage was in the labkey-api-r Rlabkey package. This PR adds that back in and also adds a comment about where to find the usage.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-r/pull/68
* https://github.com/LabKey/platform/pull/2265
* https://github.com/LabKey/testAutomation/pull/724

#### Changes
* Add strictFieldValidation property for DataClassDomainKindProperties and DatasetDomainKindProperties
* Respect the strictFieldValidation property on dataset and data class domain creation
