### PR TITLE
More appropriate return value

### DIFF
--- a/api/src/org/labkey/api/view/template/PageConfig.java
+++ b/api/src/org/labkey/api/view/template/PageConfig.java
@@ -24,7 +24,6 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.data.DataRegion;
 import org.labkey.api.module.Module;
-import org.labkey.api.util.HasHtmlString;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
@@ -424,7 +423,7 @@ public class PageConfig
     }
 
     // For now, gives a central place to render messaging
-    public HasHtmlString renderSiteMessages(ViewContext context)
+    public HtmlStringBuilder renderSiteMessages(ViewContext context)
     {
         HtmlStringBuilder messages = HtmlStringBuilder.of();
 


### PR DESCRIPTION
#### Rationale
`HasHtmlString` was the wrong return value for `renderSiteMessages()`; the intent was likely `SafeToRender`. `HtmlStringBuilder` happens to implement both, so this is not a serious problem, but `HasHtmlString` is confusing, gets flagged in static analysis, and could become a problem if `renderSiteMessages()` is refactored to return something else.
