### PR TITLE
matchColumns() cleanup

### DIFF
--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Spliterator;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -128,58 +129,79 @@ public class DataIteratorUtil
         return targetAliasesMap;
     }
 
-    enum MatchType {propertyuri, name, alias, jdbcname, tsvColumn}
 
+    // rank of a match of import column NAME matching various properties of target column
+    // MatchType.low is used for matches based on something other than name
+    enum MatchType {propertyuri, name, alias, jdbcname, tsvColumn, low}
+
+
+    /**
+     * NOTE: matchColumns() handles multiple source columns matching the same target column (usually a data file problem
+     * for the user to fix), we don't handle one source column matching multiple target columns (more of an admin design problem).
+     * One idea would be to return MultiValuedMap<String,Pair<>>, or check for duplicates entries of the same MatchType.
+     */
     protected static Map<String,Pair<ColumnInfo,MatchType>> _createTableMap(TableInfo target, boolean useImportAliases)
     {
-        List<ColumnInfo> cols = target.getColumns();
+        /* CONSIDER: move this functionality into a TableInfo method so this map (or maps) can be cached */
+        List<ColumnInfo> cols = target.getColumns().stream()
+                .filter(col -> !col.isMvIndicatorColumn() && !col.isRawValueColumn())
+                .collect(Collectors.toList());
+
         Map<String, Pair<ColumnInfo,MatchType>> targetAliasesMap = new CaseInsensitiveHashMap<>(cols.size()*4);
+
+        // should this be under the useImportAliases flag???
         for (ColumnInfo col : cols)
         {
-            if (col.isMvIndicatorColumn() || col.isRawValueColumn())
-                continue;
-            final String name = col.getName();
-            targetAliasesMap.put(name, new Pair<>(col,MatchType.name));
+            // Issue 21015: Dataset snapshot over flow assay dataset doesn't pick up stat column values
+            // TSVColumnWriter.ColumnHeaderType.queryColumnName format is a FieldKey display value from the column name. Blech.
+            String tsvQueryColumnName = FieldKey.fromString(col.getName()).toDisplayString();
+            targetAliasesMap.put(tsvQueryColumnName, new Pair<>(col, MatchType.tsvColumn));
+        }
+
+        // should this be under the useImportAliases flag???
+        for (ColumnInfo col : cols)
+        {
+            // Jdbc resultset names have substitutions for special characters. If this is such a column, need the substituted name to match on
+            targetAliasesMap.put(col.getJdbcRsName(), new Pair<>(col, MatchType.jdbcname));
+        }
+
+        for (ColumnInfo col : cols)
+        {
+            if (useImportAliases || "folder".equalsIgnoreCase(col.getName()))
+            {
+                for (String alias : col.getImportAliasSet())
+                    targetAliasesMap.put(alias, new Pair<>(col, MatchType.alias));
+
+                // Be sure we have an alias the column name we generate for TSV exports. See issue 21774
+                String translatedFieldKey = FieldKey.fromString(col.getName()).toDisplayString();
+                targetAliasesMap.put(translatedFieldKey, new Pair<>(col, MatchType.alias));
+            }
+        }
+
+        for (ColumnInfo col : cols)
+        {
+            String label = col.getLabel();
+            if (null != label)
+                targetAliasesMap.put(label, new Pair<>(col, MatchType.alias));
+        }
+
+        for (ColumnInfo col : cols)
+        {
             String uri = col.getPropertyURI();
             if (null != uri)
             {
-                if (!targetAliasesMap.containsKey(uri))
-                    targetAliasesMap.put(uri, new Pair<>(col, MatchType.propertyuri));
+                targetAliasesMap.put(uri, new Pair<>(col, MatchType.propertyuri));
                 String propName = uri.substring(uri.lastIndexOf('#')+1);
-                if (!targetAliasesMap.containsKey(propName))
-                    targetAliasesMap.put(propName, new Pair<>(col, MatchType.alias));
+                targetAliasesMap.put(propName, new Pair<>(col, MatchType.alias));
             }
-            String label = col.getLabel();
-            if (null != label && !targetAliasesMap.containsKey(label))
-                targetAliasesMap.put(label, new Pair<>(col, MatchType.alias));
-            String translatedFieldKey;
-            if (useImportAliases || "folder".equalsIgnoreCase(name))
-            {
-                for (String alias : col.getImportAliasSet())
-                {
-                    if (!targetAliasesMap.containsKey(alias))
-                        targetAliasesMap.put(alias, new Pair<>(col, MatchType.alias));
-                }
-                // Be sure we have an alias the column name we generate for TSV exports. See issue 21774
-                translatedFieldKey = FieldKey.fromString(name).toDisplayString();
-                if (!targetAliasesMap.containsKey(translatedFieldKey))
-                {
-                    targetAliasesMap.put(translatedFieldKey, new Pair<>(col, MatchType.alias));
-                }
-            }
-            // Jdbc resultset names have substitutions for special characters. If this is such a column, need the substituted name to match on
-            translatedFieldKey = col.getJdbcRsName();
-            if (!name.equals(translatedFieldKey))
-            {
-                targetAliasesMap.put(translatedFieldKey, new Pair<>(col, MatchType.jdbcname));
-            }
-
-            // Issue 21015: Dataset snapshot over flow assay dataset doesn't pick up stat column values
-            // TSVColumnWriter.ColumnHeaderType.queryColumnName format is a FieldKey display value from the column name. Blech.
-            String tsvQueryColumnName = FieldKey.fromString(name).toDisplayString();
-            if (!targetAliasesMap.containsKey(tsvQueryColumnName))
-                targetAliasesMap.put(tsvQueryColumnName, new Pair<>(col, MatchType.tsvColumn));
         }
+
+        for (ColumnInfo col : cols)
+        {
+            String name = col.getName();
+            targetAliasesMap.put(name, new Pair<>(col,MatchType.name));
+        }
+
         return targetAliasesMap;
     }
 
@@ -191,7 +213,6 @@ public class DataIteratorUtil
         ArrayList<Pair<ColumnInfo,MatchType>> matches = new ArrayList<>(input.getColumnCount()+1);
         matches.add(null);
 
-        // match columns to target columninfos (duplicates StandardDataIteratorBuilder, extract shared method?)
         for (int i=1 ; i<=input.getColumnCount() ; i++)
         {
             ColumnInfo from = input.getColumnInfo(i);
@@ -200,11 +221,16 @@ public class DataIteratorUtil
                 matches.add(null);
                 continue;
             }
-            Pair<ColumnInfo,MatchType> to = null;
-            if (null != from.getPropertyURI())
+
+            Pair<ColumnInfo,MatchType> to = targetMap.get(from.getName());
+            if (null == to && null != from.getPropertyURI())
+            {
+                // Do we actually rely on this anywhere???
+                // Like maybe ETL from one study to another where subject name does not match? or assay publish?
                 to = targetMap.get(from.getPropertyURI());
-            if (null == to)
-                to = targetMap.get(from.getName());
+                if (null != to)
+                    to = new Pair<>(to.first, MatchType.low);
+            }
             if (null == to)
             {
                 // Check to see if the column i.e. propURI has a property descriptor and vocabulary domain is present
@@ -274,13 +300,10 @@ public class DataIteratorUtil
     }
 
 
-
-
     // NOTE: first consider if using QueryUpdateService is better
     // this is just a point-to-point copy _without_ triggers
     public static int copy(File from, TableInfo to, Container c, User user) throws IOException, BatchValidationException
     {
-
         BatchValidationException errors = new BatchValidationException();
         DataIteratorContext context = new DataIteratorContext(errors);
         DataLoader loader = DataLoaderService.get().createLoader(from, null, true, c, TabLoader.TSV_FILE_TYPE);


### PR DESCRIPTION
#### Rationale
Address Issue 43009: ETL fails when aliasing built-in columns
The primary way we match import columns is by name, however there is code to also match propertyuri-propertyuri (todo verify this is still used?).  The problem is that this match is treated as _higher_ priority than a name match, and is somewhat susceptible to generating duplicate/ambiguous matches (see issue).

The proposed fix is to treat a propertyuri-propertyuri match as low priority.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/2222
https://github.com/LabKey/dataintegration/pull/105
https://github.com/LabKey/platform/pull/2263

