### PR TITLE
cleanup handling of hidden dataset schema column "_key"

### DIFF
--- a/api/src/org/labkey/api/dataiterator/MapDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/MapDataIterator.java
@@ -21,10 +21,12 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.query.BatchValidationException;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * User: matthewb
@@ -36,7 +38,7 @@ public interface MapDataIterator extends DataIterator
     boolean supportsGetMap();
     Map<String,Object> getMap();
 
-    static class MapDataIteratorImpl implements MapDataIterator, ScrollableDataIterator
+    class MapDataIteratorImpl implements MapDataIterator, ScrollableDataIterator
     {
         DataIterator _input;
         boolean _mutable;
@@ -46,6 +48,11 @@ public interface MapDataIterator extends DataIterator
 
         MapDataIteratorImpl(DataIterator in, boolean mutable)
         {
+            this(in, mutable, Set.of());
+        }
+
+        public MapDataIteratorImpl(DataIterator in, boolean mutable, Set<String> skip)
+        {
             _input = in;
             _mutable = mutable;
             Map map = new CaseInsensitiveHashMap<Integer>(in.getColumnCount()*2);
@@ -53,6 +60,8 @@ public interface MapDataIterator extends DataIterator
             for (int i=0 ; i<=in.getColumnCount() ; i++)
             {
                 String name = in.getColumnInfo(i).getName();
+                if (skip.contains(name))
+                    continue;
                 if (_findMap.containsKey(name))
                 {
                     LogManager.getLogger(MapDataIterator.class).warn("Map already has column named '" + name + "'");

--- a/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
@@ -196,8 +196,7 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
         // match up the columns, validate that there is no more than one source column that matches the target column
         //
         ValidationException setupError = new ValidationException();
-        ArrayList<ColumnInfo> matches = DataIteratorUtil.matchColumns(input, _target, _useImportAliases,
-                DataIteratorUtil.isEtl(context), setupError, _c);
+        ArrayList<ColumnInfo> matches = DataIteratorUtil.matchColumns(input, _target, _useImportAliases, setupError, _c);
 
         ArrayList<TranslateHelper> convertTargetCols = new ArrayList<>(input.getColumnCount()+1);
         for (int i=1 ; i<=input.getColumnCount() ; i++)

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -163,8 +163,7 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
         DatasetColumnsIterator it = new DatasetColumnsIterator(_datasetDefinition, input, context, user);
 
         ValidationException matchError = new ValidationException();
-        ArrayList<ColumnInfo> inputMatches = DataIteratorUtil.matchColumns(input, table, useImportAliases,
-                DataIteratorUtil.isEtl(context), matchError, null);
+        ArrayList<ColumnInfo> inputMatches = DataIteratorUtil.matchColumns(input, table, useImportAliases, matchError, null);
         if (matchError.hasErrors())
             setupError(matchError.getMessage());
 

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -356,8 +356,8 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
             // it.indexKeyPropertyOutput is the index of column with name=DatasetDomainKind._KEY (alias of column indexKeyProperty)
             // CONSIDER: this column is inserted twice, because the _key column is needed for is copied into the exp.datasets for the index (participantid, sequencenum, _key)
             // Since we now actually generate the index per materialized table, we could try to avoid this duplication
-            assert it.getColumnInfo(indexKeyProperty).getName().equals(keyColumnName);
-            it.indexKeyPropertyOutput = it.addAliasColumn(DatasetDomainKind._KEY, indexKeyProperty, keyColumn.getJdbcType());
+            assert null == keyColumnName || it.getColumnInfo(indexKeyProperty).getName().equals(keyColumnName);
+            it.indexKeyPropertyOutput = it.addAliasColumn(DatasetDomainKind._KEY, indexKeyProperty, JdbcType.VARCHAR);
         }
 
         //

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -177,7 +177,7 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
             {
                 ((BaseColumnInfo)inputColumn).setPropertyURI(match.getPropertyURI());
 
-                if (match == lsidColumn || match == seqnumColumn)
+                if (match == lsidColumn || match == seqnumColumn || DatasetDomainKind._KEY.equals(match.getName()))
                     continue;
 
                 // We usually ignore incoming containerColumn.  However, if we're in a dataspace study
@@ -352,7 +352,8 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
 
         if (null != indexKeyProperty)
         {
-            it.indexKeyPropertyOutput = it.addAliasColumn("_key", indexKeyProperty, JdbcType.VARCHAR);
+            // used for generating LSID, not for generating insert/update SQL
+            it.indexKeyPropertyOutput = it.addAliasColumn(DatasetDataIteratorBuilder.class.getName() + "#" + DatasetDomainKind._KEY, indexKeyProperty, JdbcType.VARCHAR);
         }
 
         //

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -352,8 +352,12 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
 
         if (null != indexKeyProperty)
         {
-            // used for generating LSID, not for generating insert/update SQL
-            it.indexKeyPropertyOutput = it.addAliasColumn(DatasetDataIteratorBuilder.class.getName() + "#" + DatasetDomainKind._KEY, indexKeyProperty, JdbcType.VARCHAR);
+            // indexKeyProperty is the index of the column matched to column _datasetDefinition.getKeyPropertyName(), or is a managed key
+            // it.indexKeyPropertyOutput is the index of column with name=DatasetDomainKind._KEY (alias of column indexKeyProperty)
+            // CONSIDER: this column is inserted twice, because the _key column is needed for is copied into the exp.datasets for the index (participantid, sequencenum, _key)
+            // Since we now actually generate the index per materialized table, we could try to avoid this duplication
+            assert it.getColumnInfo(indexKeyProperty).getName().equals(keyColumnName);
+            it.indexKeyPropertyOutput = it.addAliasColumn(DatasetDomainKind._KEY, indexKeyProperty, keyColumn.getJdbcType());
         }
 
         //

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -19,6 +19,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
@@ -30,6 +31,7 @@ import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.DetailedAuditLogDataIterator;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.dataiterator.SimpleTranslator;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.query.AbstractQueryUpdateService;
@@ -43,7 +45,9 @@ import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.security.StudySecurityEscalator;
+import org.labkey.study.model.DatasetDataIteratorBuilder;
 import org.labkey.study.model.DatasetDefinition;
+import org.labkey.study.model.DatasetDomainKind;
 import org.labkey.study.model.StudyImpl;
 import org.labkey.study.model.StudyManager;
 import org.labkey.study.visitmanager.PurgeParticipantsJob.ParticipantPurger;
@@ -282,6 +286,17 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
         try
         {
             boolean hasRowId = _dataset.getKeyManagementType() == Dataset.KeyManagementType.RowId;
+
+            if (null != rows)
+            {
+                // TODO: consider creating DataIterator metadata to mark "internal" cols (not to be returned via API)
+                DataIterator it = etl.getDataIterator(context);
+                DataIteratorBuilder cleanMap = new MapDataIterator.MapDataIteratorImpl(it, true, CaseInsensitiveHashSet.of(
+                        it.getColumnInfo(0).getName(),
+                        DatasetDataIteratorBuilder.class.getName() + "#" + DatasetDomainKind._KEY
+                ));
+                etl = cleanMap;
+            }
 
             if (!hasRowId)
             {

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -292,8 +292,7 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
                 // TODO: consider creating DataIterator metadata to mark "internal" cols (not to be returned via API)
                 DataIterator it = etl.getDataIterator(context);
                 DataIteratorBuilder cleanMap = new MapDataIterator.MapDataIteratorImpl(it, true, CaseInsensitiveHashSet.of(
-                        it.getColumnInfo(0).getName(),
-                        DatasetDataIteratorBuilder.class.getName() + "#" + DatasetDomainKind._KEY
+                        it.getColumnInfo(0).getName()
                 ));
                 etl = cleanMap;
             }


### PR DESCRIPTION
#### Rationale
Fixes incompatibilities with new/simpler matchColumns()

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Dataset insertRows() returns internal columns "_rowNumber" and "_key".  That seems wrong (and illuminated the real bug)
* We don't ignore "_key" in the input data
* We always add "_key" to the DatasetDIB in order to facilitate generating the lsid column, and filling in the provisioned _key column
* The _key column (returned by insert) and the _key column created by DatasetDIB cause a duplicate column error.
