### PR TITLE
Issue43149 Test Outages: Update snapshots and unit tests

### DIFF
--- a/core/src/client/components/SSOFields.spec.tsx
+++ b/core/src/client/components/SSOFields.spec.tsx
@@ -20,6 +20,20 @@ describe("<SSOFields/>", () => {
         expect(tree).toMatchSnapshot();
     });
 
+    test("With images attached", () => {
+        const component =
+            <SSOFields
+                canEdit={true}
+                headerLogoUrl={"imgURLHeader"}
+                loginLogoUrl={"imgURLLogin"}
+                onFileChange={() => {}}
+                handleDeleteLogo={() => {}}
+            />;
+
+        const tree = renderer.create(component).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+
     test("Editable mode", () => {
         const component =
             <SSOFields

--- a/core/src/client/components/SSOFields.tsx
+++ b/core/src/client/components/SSOFields.tsx
@@ -3,7 +3,6 @@ import { FileAttachmentForm } from '@labkey/components';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faImage, faTimesCircle } from '@fortawesome/free-solid-svg-icons';
-import { ActionURL } from '@labkey/api';
 
 class NoImageSelectedDisplay extends PureComponent {
     render () {

--- a/core/src/client/components/SSOFields.tsx
+++ b/core/src/client/components/SSOFields.tsx
@@ -3,6 +3,7 @@ import { FileAttachmentForm } from '@labkey/components';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faImage, faTimesCircle } from '@fortawesome/free-solid-svg-icons';
+import { ActionURL } from '@labkey/api';
 
 class NoImageSelectedDisplay extends PureComponent {
     render () {

--- a/core/src/client/components/__snapshots__/SSOFields.spec.tsx.snap
+++ b/core/src/client/components/__snapshots__/SSOFields.spec.tsx.snap
@@ -13,36 +13,31 @@ Array [
     <div
       className="sso-fields__image-holder"
     >
-      <div>
-        <div>
-          <img
-            alt="Sign in"
-            className="sso-fields__image__header-logo"
-            onError={[Function]}
-            src="http://localhostnull"
-          />
-        </div>
-        <div
-          className="sso-fields__delete-img-div"
-          onClick={[Function]}
+      <div
+        className="sso-fields__null-image"
+      >
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-image fa-w-16 fa-6x "
+          color="#DCDCDC"
+          data-icon="image"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            className="svg-inline--fa fa-times-circle fa-w-16 sso-fields__delete-img--header-logo sso-fields__delete-img clickable"
-            data-icon="times-circle"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
+          <path
+            d="M464 448H48c-26.51 0-48-21.49-48-48V112c0-26.51 21.49-48 48-48h416c26.51 0 48 21.49 48 48v288c0 26.51-21.49 48-48 48zM112 120c-30.928 0-56 25.072-56 56s25.072 56 56 56 56-25.072 56-56-25.072-56-56-56zM64 384h384V272l-87.515-87.515c-4.686-4.686-12.284-4.686-16.971 0L208 320l-55.515-55.515c-4.686-4.686-12.284-4.686-16.971 0L64 336v48z"
+            fill="currentColor"
             style={Object {}}
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
-              fill="currentColor"
-              style={Object {}}
-            />
-          </svg>
+          />
+        </svg>
+        <div
+          className="sso-fields__null-image__text"
+        >
+          None selected
         </div>
       </div>
     </div>
@@ -113,36 +108,31 @@ Array [
     <div
       className="sso-fields__image-holder"
     >
-      <div>
-        <div>
-          <img
-            alt="Sign in"
-            className="sso-fields__image__page-logo"
-            onError={[Function]}
-            src="http://localhostnull"
-          />
-        </div>
-        <div
-          className="sso-fields__delete-img-div"
-          onClick={[Function]}
+      <div
+        className="sso-fields__null-image"
+      >
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-image fa-w-16 fa-6x "
+          color="#DCDCDC"
+          data-icon="image"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            className="svg-inline--fa fa-times-circle fa-w-16 sso-fields__delete-img--page-logo sso-fields__delete-img clickable"
-            data-icon="times-circle"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
+          <path
+            d="M464 448H48c-26.51 0-48-21.49-48-48V112c0-26.51 21.49-48 48-48h416c26.51 0 48 21.49 48 48v288c0 26.51-21.49 48-48 48zM112 120c-30.928 0-56 25.072-56 56s25.072 56 56 56 56-25.072 56-56-25.072-56-56-56zM64 384h384V272l-87.515-87.515c-4.686-4.686-12.284-4.686-16.971 0L208 320l-55.515-55.515c-4.686-4.686-12.284-4.686-16.971 0L64 336v48z"
+            fill="currentColor"
             style={Object {}}
-            viewBox="0 0 512 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
-              fill="currentColor"
-              style={Object {}}
-            />
-          </svg>
+          />
+        </svg>
+        <div
+          className="sso-fields__null-image__text"
+        >
+          None selected
         </div>
       </div>
     </div>
@@ -215,13 +205,293 @@ Array [
     <div
       className="sso-fields__image-holder"
     >
+      <div
+        className="sso-fields__null-image"
+      >
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-image fa-w-16 fa-6x "
+          color="#DCDCDC"
+          data-icon="image"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M464 448H48c-26.51 0-48-21.49-48-48V112c0-26.51 21.49-48 48-48h416c26.51 0 48 21.49 48 48v288c0 26.51-21.49 48-48 48zM112 120c-30.928 0-56 25.072-56 56s25.072 56 56 56 56-25.072 56-56-25.072-56-56-56zM64 384h384V272l-87.515-87.515c-4.686-4.686-12.284-4.686-16.971 0L208 320l-55.515-55.515c-4.686-4.686-12.284-4.686-16.971 0L64 336v48z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+        <div
+          className="sso-fields__null-image__text"
+        >
+          None selected
+        </div>
+      </div>
+    </div>
+    <div
+      className="sso-fields__file-attachment"
+      id="auth_header_logo"
+    >
+      <span
+        className="translator--toggle__wizard"
+      >
+        <div
+          className="row"
+        >
+          <div
+            className="col-sm-12"
+          >
+            <div
+              className="wizard-row--container"
+            >
+              <div
+                className=""
+              >
+                <div
+                  className="file-upload--container block"
+                >
+                  <label
+                    className="file-upload--label"
+                    htmlFor="fileUpload1"
+                    onDragEnter={[Function]}
+                    onDragLeave={[Function]}
+                    onDragOver={[Function]}
+                    onDrop={[Function]}
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="fa fa-cloud-upload fa-2x cloud-logo"
+                    />
+                    Select file or drag and drop here.
+                  </label>
+                  <input
+                    accept=".jpg,.jpeg,.png,.gif,.tif"
+                    className="file-upload--input"
+                    id="fileUpload1"
+                    multiple={false}
+                    name="fileUpload1"
+                    onChange={[Function]}
+                    type="file"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </span>
+    </div>
+  </div>,
+  <div
+    className="sso-fields__spacer"
+  />,
+  <div
+    className="sso-logo-pane-container"
+  >
+    <div
+      className="sso-fields__label"
+    >
+      Login Page Logo
+    </div>
+    <div
+      className="sso-fields__image-holder"
+    >
+      <div
+        className="sso-fields__null-image"
+      >
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-image fa-w-16 fa-6x "
+          color="#DCDCDC"
+          data-icon="image"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M464 448H48c-26.51 0-48-21.49-48-48V112c0-26.51 21.49-48 48-48h416c26.51 0 48 21.49 48 48v288c0 26.51-21.49 48-48 48zM112 120c-30.928 0-56 25.072-56 56s25.072 56 56 56 56-25.072 56-56-25.072-56-56-56zM64 384h384V272l-87.515-87.515c-4.686-4.686-12.284-4.686-16.971 0L208 320l-55.515-55.515c-4.686-4.686-12.284-4.686-16.971 0L64 336v48z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+        <div
+          className="sso-fields__null-image__text"
+        >
+          None selected
+        </div>
+      </div>
+    </div>
+    <div
+      className="sso-fields__file-attachment"
+      id="auth_login_page_logo"
+    >
+      <span
+        className="translator--toggle__wizard"
+      >
+        <div
+          className="row"
+        >
+          <div
+            className="col-sm-12"
+          >
+            <div
+              className="wizard-row--container"
+            >
+              <div
+                className=""
+              >
+                <div
+                  className="file-upload--container block"
+                >
+                  <label
+                    className="file-upload--label"
+                    htmlFor="fileUpload2"
+                    onDragEnter={[Function]}
+                    onDragLeave={[Function]}
+                    onDragOver={[Function]}
+                    onDrop={[Function]}
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="fa fa-cloud-upload fa-2x cloud-logo"
+                    />
+                    Select file or drag and drop here.
+                  </label>
+                  <input
+                    accept=".jpg,.jpeg,.png,.gif,.tif"
+                    className="file-upload--input"
+                    id="fileUpload2"
+                    multiple={false}
+                    name="fileUpload2"
+                    onChange={[Function]}
+                    type="file"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </span>
+    </div>
+  </div>,
+]
+`;
+
+exports[`<SSOFields/> View-only mode 1`] = `
+Array [
+  <div
+    className="sso-logo-pane-container"
+  >
+    <div
+      className="sso-fields__label"
+    >
+      Page Header Logo
+    </div>
+    <div
+      className="sso-fields__image-holder--view-only"
+    >
+      <div
+        className="sso-fields__null-image"
+      >
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-image fa-w-16 fa-6x "
+          color="#DCDCDC"
+          data-icon="image"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M464 448H48c-26.51 0-48-21.49-48-48V112c0-26.51 21.49-48 48-48h416c26.51 0 48 21.49 48 48v288c0 26.51-21.49 48-48 48zM112 120c-30.928 0-56 25.072-56 56s25.072 56 56 56 56-25.072 56-56-25.072-56-56-56zM64 384h384V272l-87.515-87.515c-4.686-4.686-12.284-4.686-16.971 0L208 320l-55.515-55.515c-4.686-4.686-12.284-4.686-16.971 0L64 336v48z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+        <div
+          className="sso-fields__null-image__text"
+        >
+          None selected
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="sso-fields__spacer"
+  />,
+  <div
+    className="sso-logo-pane-container"
+  >
+    <div
+      className="sso-fields__label"
+    >
+      Login Page Logo
+    </div>
+    <div
+      className="sso-fields__image-holder--view-only"
+    >
+      <div
+        className="sso-fields__null-image"
+      >
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-image fa-w-16 fa-6x "
+          color="#DCDCDC"
+          data-icon="image"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={Object {}}
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M464 448H48c-26.51 0-48-21.49-48-48V112c0-26.51 21.49-48 48-48h416c26.51 0 48 21.49 48 48v288c0 26.51-21.49 48-48 48zM112 120c-30.928 0-56 25.072-56 56s25.072 56 56 56 56-25.072 56-56-25.072-56-56-56zM64 384h384V272l-87.515-87.515c-4.686-4.686-12.284-4.686-16.971 0L208 320l-55.515-55.515c-4.686-4.686-12.284-4.686-16.971 0L64 336v48z"
+            fill="currentColor"
+            style={Object {}}
+          />
+        </svg>
+        <div
+          className="sso-fields__null-image__text"
+        >
+          None selected
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`<SSOFields/> With images attached 1`] = `
+Array [
+  <div
+    className="sso-logo-pane-container"
+  >
+    <div
+      className="sso-fields__label"
+    >
+      Page Header Logo
+    </div>
+    <div
+      className="sso-fields__image-holder"
+    >
       <div>
         <div>
           <img
             alt="Sign in"
             className="sso-fields__image__header-logo"
             onError={[Function]}
-            src="http://localhostnull"
+            src="imgURLHeader"
           />
         </div>
         <div
@@ -321,7 +591,7 @@ Array [
             alt="Sign in"
             className="sso-fields__image__page-logo"
             onError={[Function]}
-            src="http://localhostnull"
+            src="imgURLLogin"
           />
         </div>
         <div
@@ -399,52 +669,6 @@ Array [
           </div>
         </div>
       </span>
-    </div>
-  </div>,
-]
-`;
-
-exports[`<SSOFields/> View-only mode 1`] = `
-Array [
-  <div
-    className="sso-logo-pane-container"
-  >
-    <div
-      className="sso-fields__label"
-    >
-      Page Header Logo
-    </div>
-    <div
-      className="sso-fields__image-holder--view-only"
-    >
-      <img
-        alt="Sign in"
-        className="sso-fields__image__header-logo"
-        onError={[Function]}
-        src="http://localhostnull"
-      />
-    </div>
-  </div>,
-  <div
-    className="sso-fields__spacer"
-  />,
-  <div
-    className="sso-logo-pane-container"
-  >
-    <div
-      className="sso-fields__label"
-    >
-      Login Page Logo
-    </div>
-    <div
-      className="sso-fields__image-holder--view-only"
-    >
-      <img
-        alt="Sign in"
-        className="sso-fields__image__page-logo"
-        onError={[Function]}
-        src="http://localhostnull"
-      />
     </div>
   </div>,
 ]


### PR DESCRIPTION
#### Rationale
I merged an Issue fix having erroneously remembered that the Core JS TC module auto-ran as a pre-merge check when the core .tsx files were touched.   🥲 👎

The fix allowed for the `<ImageAndFileAttachmentForm/>` to receive: 
`imageUrl={this.props.headerLogoUrl}`
instead of 
`imageUrl={ActionURL.getBaseURL(true) + this.props.headerLogoUrl}`. 

This led to snapshot outages since `<ImageAndFileAttachmentForm/>` had previously always been passing at least `ActionURL.getBaseURL(true)` for the imageUrl prop. 

I've scanned and verified the snapshot updates make sense, and also added a "With images attached" unit test to pair with the "No images attached" test.



#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2264

#### Changes
* Update snapshot
* Add "With images attached" test
