### PR TITLE
Fix auto generated aliquot name override

### DIFF
--- a/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
+++ b/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
@@ -814,7 +814,16 @@ public abstract class UploadSamplesHelper
                 boolean isAliquot = !StringUtils.isEmpty(aliquotedFrom);
                 if (isAliquot)
                 {
-                    generatedName = aliquotedFrom + "-" + getAliquotSequence(aliquotedFrom).next();
+                    String aliquotName = null;
+                    // If a name is already provided, just use it as is
+                    Object currNameObj = map.get("Name");
+                    if (currNameObj != null)
+                        aliquotName = currNameObj.toString();
+
+                    if (StringUtils.isEmpty(aliquotName))
+                        aliquotName = aliquotedFrom + "-" + getAliquotSequence(aliquotedFrom).next();
+
+                    generatedName = aliquotName;
                 }
                 else
                     generatedName = nameGen.generateName(nameState, map);


### PR DESCRIPTION
#### Rationale
Aliquot sample names can be autogenerated regardless of sample type's name expression. However, there is a bug when an explicit sample name is provided for an aliquot, it's ignored and the name is still saved using the auto name. 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Use provided name for aliquots, if present
