### PR TITLE
Item 8784: Support CRUD operations for picklist data

### DIFF
--- a/api/src/org/labkey/api/settings/AppProps.java
+++ b/api/src/org/labkey/api/settings/AppProps.java
@@ -49,7 +49,6 @@ public interface AppProps
     String EXPERIMENTAL_RESOLVE_PROPERTY_URI_COLUMNS = "resolve-property-uri-columns";
     String EXPERIMENTAL_NO_QUESTION_MARK_URL = "noQuestionMarkUrl";
     String EXPERIMENTAL_ERROR_PAGE = "errorPage";
-    String EXPERIMENTAL_SAMPLE_PICKLIST = "samplePicklist";
 
     String UNKNOWN_VERSION = "Unknown Release Version";
 

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -2115,7 +2115,6 @@ public class PageFlowUtil
         experimental.put(AppProps.EXPERIMENTAL_JAVASCRIPT_MOTHERSHIP, AppProps.getInstance().isExperimentalFeatureEnabled(AppProps.EXPERIMENTAL_JAVASCRIPT_MOTHERSHIP));
         experimental.put(AppProps.EXPERIMENTAL_JAVASCRIPT_SERVER, AppProps.getInstance().isExperimentalFeatureEnabled(AppProps.EXPERIMENTAL_JAVASCRIPT_SERVER));
         experimental.put(AppProps.EXPERIMENTAL_NO_GUESTS, AppProps.getInstance().isExperimentalFeatureEnabled(AppProps.EXPERIMENTAL_NO_GUESTS));
-        experimental.put(AppProps.EXPERIMENTAL_SAMPLE_PICKLIST, AppProps.getInstance().isExperimentalFeatureEnabled(AppProps.EXPERIMENTAL_SAMPLE_PICKLIST));
         json.put("experimental", experimental);
 
         json.put("contextPath", contextPath);

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -188,9 +188,6 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
         AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_RESOLVE_PROPERTY_URI_COLUMNS, "Resolve property URIs as columns on experiment tables",
                 "If a column is not found on an experiment table, attempt to resolve the column name as a Property URI and add it as a property column", false);
 
-        AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_SAMPLE_PICKLIST, "Sample picklists",
-                "Support creation of sample picklists", false);
-
         RoleManager.registerPermission(new DesignVocabularyPermission(), true);
 
         AttachmentService.get().registerAttachmentType(ExpRunAttachmentType.get());

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -53,6 +53,7 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.DataLoader;
 import org.labkey.api.security.User;
 import org.labkey.api.util.UnexpectedException;
+import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.writer.VirtualFile;
 import org.labkey.list.view.ListItemAttachmentParent;
 
@@ -146,7 +147,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
         }
 
         DataIteratorContext context = getDataIteratorContext(errors, InsertOption.INSERT, configParameters);
-        List<Map<String, Object>> result = super._insertRowsUsingDIB(user, container, rows, context, extraScriptContext);
+        List<Map<String, Object>> result = this._insertRowsUsingDIB(user, container, rows, context, extraScriptContext);
 
         if (null != result)
         {
@@ -169,6 +170,15 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
         }
 
         return result;
+    }
+
+    @Override
+    protected @Nullable List<Map<String, Object>> _insertRowsUsingDIB(User user, Container container, List<Map<String, Object>> rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
+    {
+        if (!_list.isVisible(user))
+            throw new UnauthorizedException("You do not have permission to insert data into this table.");
+
+        return super._insertRowsUsingDIB(user, container, rows, context, extraScriptContext);
     }
 
     public int insertUsingDataIterator(DataLoader loader, User user, Container container, BatchValidationException errors, @Nullable VirtualFile attachmentDir,

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -184,6 +184,9 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
     public int insertUsingDataIterator(DataLoader loader, User user, Container container, BatchValidationException errors, @Nullable VirtualFile attachmentDir,
                                        @Nullable ListImportProgress progress, boolean supportAutoIncrementKey, boolean importLookupsByAlternateKey, boolean useMerge)
     {
+        if (!_list.isVisible(user))
+            throw new UnauthorizedException("You do not have permission to insert data into this table.");
+
         DataIteratorContext context = new DataIteratorContext(errors);
         context.setFailFast(false);
         context.setInsertOption(useMerge ? InsertOption.MERGE : InsertOption.IMPORT);    // this method is used by ListImporter and BackgroundListImporter
@@ -221,6 +224,9 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
     public int mergeRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors,
                          @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
     {
+        if (!_list.isVisible(user))
+            throw new UnauthorizedException("You do not have permission to update data into this table.");
+
         return _importRowsUsingDIB(user, container, rows, null, getDataIteratorContext(errors, InsertOption.MERGE, configParameters), extraScriptContext);
     }
 
@@ -229,8 +235,11 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
     public int importRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors,
                           Map<Enum,Object> configParameters, Map<String, Object> extraScriptContext)
     {
+        if (!_list.isVisible(user))
+            throw new UnauthorizedException("You do not have permission to insert data into this table.");
+
         DataIteratorContext context = getDataIteratorContext(errors, InsertOption.IMPORT, configParameters);
-        int count = super._importRowsUsingDIB(user, container, rows, null, context, extraScriptContext);
+        int count = _importRowsUsingDIB(user, container, rows, null, context, extraScriptContext);
         if (count > 0 && !errors.hasErrors())
             ListManager.get().indexList(_list, false);
         return count;
@@ -241,6 +250,9 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
                                                 @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
             throws InvalidKeyException, BatchValidationException, QueryUpdateServiceException, SQLException
     {
+        if (!_list.isVisible(user))
+            throw new UnauthorizedException("You do not have permission to update data into this table.");
+
         List<Map<String, Object>> result = super.updateRows(user, container, rows, oldKeys, configParameters, extraScriptContext);
         if (result.size() > 0)
             ListManager.get().indexList(_list, false);

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -418,6 +418,9 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
     @Override
     protected Map<String, Object> deleteRow(User user, Container container, Map<String, Object> oldRowMap) throws InvalidKeyException, QueryUpdateServiceException, SQLException
     {
+        if (!_list.isVisible(user))
+            throw new UnauthorizedException("You do not have permission to delete data from this table.");
+
         Map<String, Object> result = super.deleteRow(user, container, oldRowMap);
 
         if (null != result)


### PR DESCRIPTION
#### Rationale
For LKSM we are adding the ability to create picklists of samples and various actions on these collections of samples. We need to update some permission checks for this.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/576
* https://github.com/LabKey/labkey-ui-components/pull/531

#### Changes
* Add some permission checks for operations on picklists
