### PR TITLE
Issue 43135: attach material outputs to run from final provenance recording step

### DIFF
--- a/experiment/src/org/labkey/experiment/api/AbstractRunItemImpl.java
+++ b/experiment/src/org/labkey/experiment/api/AbstractRunItemImpl.java
@@ -79,7 +79,7 @@ public abstract class AbstractRunItemImpl<Type extends RunItem> extends ExpIdent
     public List<ExpRun> getSuccessorRuns()
     {
         if (null == _successorRunIdList)
-            throw new IllegalStateException("successorRunIdList not populated");
+            throw new IllegalStateException("successorRunIdList not populated for '" + this.getName() + "'");
         List<ExpRun> result = new ArrayList<>();
         for (Integer integer : _successorRunIdList)
         {

--- a/experiment/src/org/labkey/experiment/pipeline/ExpGeneratorHelper.java
+++ b/experiment/src/org/labkey/experiment/pipeline/ExpGeneratorHelper.java
@@ -53,6 +53,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.util.FileUtil;
 import org.labkey.experiment.ExperimentRunGraph;
 import org.labkey.experiment.api.ExpDataImpl;
+import org.labkey.experiment.api.ExpMaterialImpl;
 import org.labkey.experiment.api.ExpRunImpl;
 import org.labkey.experiment.api.ExperimentServiceImpl;
 
@@ -259,8 +260,6 @@ public class ExpGeneratorHelper
                 }
             }
 
-            log.debug("File check complete");
-
             try (DbScope.Transaction transaction = ExperimentService.get().getSchema().getScope().ensureTransaction())
             {
                 run = _insertRun(container, user, runName, runJobId, protocol, actionSet.getActions(), source, runOutputsWithRoles, runInputsWithRoles, fromProvenanceRecording);
@@ -386,18 +385,17 @@ public class ExpGeneratorHelper
             // material outputs
             for (String lsid : action.getMaterialOutputs())
             {
-                ExpMaterial material = ExperimentService.get().getExpMaterial(lsid);
-                // set up the input to the run
+                ExpMaterialImpl material = (ExpMaterialImpl) ExperimentService.get().getExpMaterial(lsid);
+                material.setSourceApplication(stepApp);
+                // set up the output to the run
                 if (action.isEnd())
                 {
                     material.setRun(run);
+                    material.addSuccessorRunId(run.getRowId());
                     stepApp.addMaterialInput(user, material, null, null);
                 }
-                else
-                {
-                    material.setSourceApplication(stepApp);
-                    material.save(user);
-                }
+
+                material.save(user);
             }
 
             // Set up the inputs


### PR DESCRIPTION
#### Rationale
In provenance recording steps, output materials from run were not getting source output application and successor run id that caused the following error in run graph:
`java.lang.IllegalStateException: successorRunIdList not populated
       at org.labkey.experiment.api.AbstractRunItemImpl.getSuccessorRuns(AbstractRunItemImpl.java:82)
       at org.labkey.experiment.ExperimentRunGraph.generateSummaryGraph(ExperimentRunGraph.java:559)
       at org.labkey.experiment.ExperimentRunGraph.generateRunGraph(ExperimentRunGraph.java:197)`

#### Related Pull Requests
* https://github.com/LabKey/provenance/pull/70

#### Changes
* attach source output application to material outputs of run
* add successor runId to output material of run
