### PR TITLE
Initial support for PostgreSQL 14

### DIFF
--- a/core/resources/schemas/dbscripts/postgresql/core-0.00-19.10.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-0.00-19.10.sql
@@ -357,23 +357,9 @@ BEGIN
 END
 $$ LANGUAGE plpgsql;
 
-CREATE AGGREGATE core.array_accum (anyelement)
-(
-  sfunc = array_append,
-  stype = anyarray,
-  initcond = '{}'
-);
-
 CREATE FUNCTION core.sort(anyarray) RETURNS anyarray AS $$
 SELECT ARRAY(SELECT $1[i] FROM generate_series(array_lower($1,1), array_upper($1,1)) g(i) ORDER BY 1)
 $$ LANGUAGE SQL STRICT IMMUTABLE;
-
-CREATE AGGREGATE core.array_accum(text) (
-  SFUNC = array_append,
-  STYPE = text[],
-  INITCOND = '{}',
-  SORTOP = >
-);
 
 CREATE FUNCTION core.fnCalculateAge (startDate timestamp, endDate timestamp) RETURNS INTEGER AS $$
 DECLARE
@@ -415,10 +401,6 @@ CREATE TABLE core.Notifications
 );
 
 /* core-15.30-16.10.sql */
-
--- No longer used; replaced by built-in PostgreSQL function string_to_array()
-DROP AGGREGATE core.array_accum(anyelement);
-DROP AGGREGATE core.array_accum(text);
 
 -- An empty stored procedure (similar to executeJavaUpgradeCode) that, when detected by the script runner,
 -- imports a tabular data file (TSV, XLSX, etc.) into the specified table.

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -161,7 +161,8 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
             good("PostgreSQL", 11.0, 12.0, "", connectionUrl, null, PostgreSql_11_Dialect.class);
             good("PostgreSQL", 12.0, 13.0, "", connectionUrl, null, PostgreSql_12_Dialect.class);
             good("PostgreSQL", 13.0, 14.0, "", connectionUrl, null, PostgreSql_13_Dialect.class);
-            good("PostgreSQL", 14.0, 15.0, "", connectionUrl, null, PostgreSql_13_Dialect.class);
+            good("PostgreSQL", 14.0, 15.0, "", connectionUrl, null, PostgreSql_14_Dialect.class);
+            good("PostgreSQL", 15.0, 16.0, "", connectionUrl, null, PostgreSql_14_Dialect.class);
         }
     }
 
@@ -171,22 +172,22 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
         public void testJavaUpgradeCode()
         {
             String goodSql =
-                    "SELECT core.executeJavaUpgradeCode('upgradeCode');\n" +                       // Normal
-                    "SELECT core.executeJavaInitializationCode('upgradeCode');\n" +                // executeJavaInitializationCode works as a synonym
-                    "    SELECT     core.executeJavaUpgradeCode    ('upgradeCode')    ;     \n" +  // Lots of whitespace
-                    "select CORE.EXECUTEJAVAUPGRADECODE('upgradeCode');\n" +                       // Case insensitive
-                    "SELECT core.executeJavaUpgradeCode('upgradeCode');";                          // No line ending
+                "SELECT core.executeJavaUpgradeCode('upgradeCode');\n" +                       // Normal
+                "SELECT core.executeJavaInitializationCode('upgradeCode');\n" +                // executeJavaInitializationCode works as a synonym
+                "    SELECT     core.executeJavaUpgradeCode    ('upgradeCode')    ;     \n" +  // Lots of whitespace
+                "select CORE.EXECUTEJAVAUPGRADECODE('upgradeCode');\n" +                       // Case insensitive
+                "SELECT core.executeJavaUpgradeCode('upgradeCode');";                          // No line ending
 
             String badSql =
-                    "/* SELECT core.executeJavaUpgradeCode('upgradeCode');\n" +       // Inside block comment
-                    "   more comment\n" +
-                    "*/" +
-                    "    -- SELECT core.executeJavaUpgradeCode('upgradeCode');\n" +   // Inside single-line comment
-                    "SELECTcore.executeJavaUpgradeCode('upgradeCode');\n" +           // Bad syntax
-                    "SELECT core. executeJavaUpgradeCode('upgradeCode');\n" +         // Bad syntax
-                    "SEECT core.executeJavaUpgradeCode('upgradeCode');\n" +           // Misspell SELECT
-                    "SELECT core.executeJaavUpgradeCode('upgradeCode');\n" +          // Misspell function name
-                    "SELECT core.executeJavaUpgradeCode('upgradeCode')\n";            // No semicolon
+                "/* SELECT core.executeJavaUpgradeCode('upgradeCode');\n" +       // Inside block comment
+                "   more comment\n" +
+                "*/" +
+                "    -- SELECT core.executeJavaUpgradeCode('upgradeCode');\n" +   // Inside single-line comment
+                "SELECTcore.executeJavaUpgradeCode('upgradeCode');\n" +           // Bad syntax
+                "SELECT core. executeJavaUpgradeCode('upgradeCode');\n" +         // Bad syntax
+                "SEECT core.executeJavaUpgradeCode('upgradeCode');\n" +           // Misspell SELECT
+                "SELECT core.executeJaavUpgradeCode('upgradeCode');\n" +          // Misspell function name
+                "SELECT core.executeJavaUpgradeCode('upgradeCode')\n";            // No semicolon
 
             SqlDialect dialect = new PostgreSql96Dialect();
             TestUpgradeCode good = new TestUpgradeCode();
@@ -216,7 +217,9 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
                 @Override
                 protected Set<String> getGoodUrls()
                 {
-                    return new CsvSet("jdbc:postgresql:database," +
+                    return new CsvSet
+                    (
+                        "jdbc:postgresql:database," +
                         "jdbc:postgresql://localhost/database," +
                         "jdbc:postgresql://localhost:8300/database," +
                         "jdbc:postgresql://www.host.com/database," +
@@ -225,16 +228,20 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
                         "jdbc:postgresql://localhost/database?user=fred&password=secret&ssl=true," +
                         "jdbc:postgresql://localhost:8672/database?user=fred&password=secret&ssl=true," +
                         "jdbc:postgresql://www.host.com/database?user=fred&password=secret&ssl=true," +
-                        "jdbc:postgresql://www.host.com:8992/database?user=fred&password=secret&ssl=true");
+                        "jdbc:postgresql://www.host.com:8992/database?user=fred&password=secret&ssl=true"
+                    );
                 }
 
                 @NotNull
                 @Override
                 protected Set<String> getBadUrls()
                 {
-                    return new CsvSet("jddc:postgresql:database," +
+                    return new CsvSet
+                    (
+                        "jddc:postgresql:database," +
                         "jdbc:postgres://localhost/database," +
-                        "jdbc:postgresql://www.host.comdatabase");
+                        "jdbc:postgresql://www.host.comdatabase"
+                    );
                 }
             };
 

--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -22,7 +22,8 @@ public enum PostgreSqlVersion
     POSTGRESQL_11(110, false, true, PostgreSql_11_Dialect::new),
     POSTGRESQL_12(120, false, true, PostgreSql_12_Dialect::new),
     POSTGRESQL_13(130, false, true, PostgreSql_13_Dialect::new),
-    POSTGRESQL_FUTURE(Integer.MAX_VALUE, true, false, PostgreSql_13_Dialect::new);
+    POSTGRESQL_14(140, false, false, PostgreSql_14_Dialect::new),
+    POSTGRESQL_FUTURE(Integer.MAX_VALUE, true, false, PostgreSql_14_Dialect::new);
 
     private final int _version;
     private final boolean _deprecated;
@@ -93,11 +94,12 @@ public enum PostgreSqlVersion
             test(110, POSTGRESQL_11);
             test(120, POSTGRESQL_12);
             test(130, POSTGRESQL_13);
+            test(140, POSTGRESQL_14);
 
             // Future
-            test(140, POSTGRESQL_FUTURE);
             test(150, POSTGRESQL_FUTURE);
             test(160, POSTGRESQL_FUTURE);
+            test(170, POSTGRESQL_FUTURE);
 
             // Bad
             test(83, POSTGRESQL_UNSUPPORTED);

--- a/core/src/org/labkey/core/dialect/PostgreSql_14_Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql_14_Dialect.java
@@ -1,0 +1,5 @@
+package org.labkey.core.dialect;
+
+public class PostgreSql_14_Dialect extends PostgreSql_13_Dialect
+{
+}


### PR DESCRIPTION
#### Rationale
PostgreSQL has released version 14 Beta 1; might as well make it work.

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/337

#### Changes
* Remove reference to `array_append`, which PG 14 doesn't seem to like anymore... and we don't care because we don't use it
* Add `PostgreSql_14_Dialect` class and `POSTGRESQL_14` enum constant. Adjust dialect retrieval tests.
