### PR TITLE
Issue 43200: Update default audit log behavior for dataset table

### DIFF
--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1298,6 +1298,8 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
             _storage = def.getStorageTableInfo();
             _template = getTemplateTableInfo();
             PHI maxContainedPhi = PHI.NotPHI;
+            if (getXmlAuditBehaviorType() == null) // allow XML to override
+                setAuditBehavior(AuditBehaviorType.SUMMARY); // but default to SUMMARY Issue 43200
 
             // ParticipantId
 


### PR DESCRIPTION
#### Rationale
When truncating a dataset, our default audit log level is NONE but the expectation is that we will at least create a summary record.  This change overrides the default from NONE to SUMMARY.  The audit log will appear in the Query Update Events instead.  Attempts to set this audit behavior on the configParameters within `truncateRows` were not successful because we still call `getAuditBehavior` to figure out which AuditHandler to return.

#### Changes
* set default audit behavior for `DatasetDefinition`
