### PR TITLE
Issue 43200: Allow customization of the audit behavior for truncate table (and other) non-DI operations

### DIFF
--- a/api/src/org/labkey/api/audit/AbstractAuditHandler.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditHandler.java
@@ -21,12 +21,12 @@ public abstract class AbstractAuditHandler implements AuditHandler
     protected abstract AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row);
 
     @Override
-    public void addSummaryAuditEvent(User user, Container c, TableInfo table, QueryService.AuditAction action, Integer dataRowCount)
+    public void addSummaryAuditEvent(User user, Container c, TableInfo table, QueryService.AuditAction action, Integer dataRowCount, @Nullable AuditBehaviorType auditBehaviorType)
     {
         if (table.supportsAuditTracking())
         {
-            AuditConfigurable auditConfigurable = (AuditConfigurable)table;
-            AuditBehaviorType auditType = auditConfigurable.getAuditBehavior();
+            AuditConfigurable auditConfigurable = (AuditConfigurable) table;
+            AuditBehaviorType auditType = auditBehaviorType == null ? auditConfigurable.getAuditBehavior() : auditBehaviorType;
 
             if (auditType == SUMMARY)
             {

--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -30,7 +30,7 @@ import static org.labkey.api.gwt.client.AuditBehaviorType.SUMMARY;
 
 public interface AuditHandler
 {
-    void addSummaryAuditEvent(User user, Container c, TableInfo table, QueryService.AuditAction action, Integer dataRowCount);
+    void addSummaryAuditEvent(User user, Container c, TableInfo table, QueryService.AuditAction action, Integer dataRowCount, @Nullable AuditBehaviorType auditBehaviorType);
 
     /* In the case of update the 'existingRows' is the 'before' version of the record. Caller is not expected to provide existingRows without rows. */
     void addAuditEvent(User user, Container c, TableInfo table, @Nullable AuditBehaviorType auditType, @Nullable String userComment, QueryService.AuditAction action,

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -120,7 +120,7 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
     class _DoNothingAuditHandler implements AuditHandler
     {
         @Override
-        public void addSummaryAuditEvent(User user, Container c, TableInfo table, QueryService.AuditAction action, Integer dataRowCount)
+        public void addSummaryAuditEvent(User user, Container c, TableInfo table, QueryService.AuditAction action, Integer dataRowCount, @Nullable AuditBehaviorType auditBehaviorType)
         {
         }
 
@@ -130,9 +130,9 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
         }
     }
 
-    default AuditHandler getAuditHandler()
+    default AuditHandler getAuditHandler(@Nullable AuditBehaviorType auditBehaviorOverride)
     {
-        if (!supportsAuditTracking() || getAuditBehavior()==AuditBehaviorType.NONE)
+        if (!supportsAuditTracking() || auditBehaviorOverride == AuditBehaviorType.NONE || (auditBehaviorOverride == null && getAuditBehavior() == AuditBehaviorType.NONE))
             return new _DoNothingAuditHandler();
         return QueryService.get().getDefaultAuditHandler();
     }

--- a/api/src/org/labkey/api/dataiterator/DetailedAuditLogDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/DetailedAuditLogDataIterator.java
@@ -65,7 +65,7 @@ public class DetailedAuditLogDataIterator extends AbstractDataIterator
         _container = c;
         _userComment = (String) _context.getConfigParameter(AuditConfigs.AuditUserComment);
         _auditAction = auditAction;
-        _auditHandler = table.getAuditHandler();
+        _auditHandler = table.getAuditHandler(DETAILED);
 
         assert DETAILED == table.getAuditBehavior() || DETAILED == context.getConfigParameter(AuditConfigs.AuditBehavior);
         assert !context.getInsertOption().mergeRows || _data.supportsGetExistingRecord();

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -304,7 +304,8 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
             return 0;
         else
         {
-            getQueryTable().getAuditHandler().addSummaryAuditEvent(user, container, getQueryTable(), QueryService.AuditAction.INSERT, count);
+            AuditBehaviorType auditType = (AuditBehaviorType) context.getConfigParameter(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior);
+            getQueryTable().getAuditHandler(auditType).addSummaryAuditEvent(user, container, getQueryTable(), QueryService.AuditAction.INSERT, count, auditType);
             return count;
         }
     }
@@ -508,7 +509,8 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         {
             AuditBehaviorType auditBehavior = configParameters != null ? (AuditBehaviorType) configParameters.get(AuditBehavior) : null;
             String userComment = configParameters == null ? null : (String) configParameters.get(AuditUserComment);
-            getQueryTable().getAuditHandler().addAuditEvent(user, container, getQueryTable(), auditBehavior, userComment, auditAction, rows, existingRows);
+            getQueryTable().getAuditHandler(auditBehavior)
+                    .addAuditEvent(user, container, getQueryTable(), auditBehavior, userComment, auditAction, rows, existingRows);
         }
     }
 

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -1473,7 +1473,7 @@ public class XarReader extends AbstractXarImporter
                 if (dataTable != null)
                 {
                     Map<String, Object> row = BeanObjectFactory.Registry.getFactory(Data.class).toMap(data, null);
-                    dataTable.getAuditHandler().addAuditEvent(getUser(), getContainer(), dataTable, _auditBehaviorType, null, QueryService.AuditAction.INSERT, Collections.singletonList(row), null);
+                    dataTable.getAuditHandler(_auditBehaviorType).addAuditEvent(getUser(), getContainer(), dataTable, _auditBehaviorType, null, QueryService.AuditAction.INSERT, Collections.singletonList(row), null);
                 }
             }
 

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -57,6 +57,7 @@ import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.exp.query.ExpSampleTypeTable;
 import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.exp.query.SamplesSchema;
+import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.inventory.InventoryService;
 import org.labkey.api.query.AliasedColumn;
 import org.labkey.api.query.DetailsURL;
@@ -123,7 +124,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     }
 
     @Override
-    public AuditHandler getAuditHandler()
+    public AuditHandler getAuditHandler(AuditBehaviorType auditBehaviorType)
     {
         if (getUserSchema().getName().equalsIgnoreCase(SamplesSchema.SCHEMA_NAME))
         {
@@ -132,7 +133,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         }
         else
         {
-            return super.getAuditHandler();
+            return super.getAuditHandler(auditBehaviorType);
         }
     }
 

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1298,6 +1298,8 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
             _storage = def.getStorageTableInfo();
             _template = getTemplateTableInfo();
             PHI maxContainedPhi = PHI.NotPHI;
+            if (getXmlAuditBehaviorType() == null) // allow XML to override
+                setAuditBehavior(AuditBehaviorType.SUMMARY); // but default to SUMMARY Issue 43200
 
             // ParticipantId
 

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1298,9 +1298,6 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
             _storage = def.getStorageTableInfo();
             _template = getTemplateTableInfo();
             PHI maxContainedPhi = PHI.NotPHI;
-            if (getXmlAuditBehaviorType() == null) // allow XML to override
-                setAuditBehavior(AuditBehaviorType.SUMMARY); // but default to SUMMARY Issue 43200
-
             // ParticipantId
 
             {
@@ -1610,7 +1607,7 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
         }
 
         @Override
-        public AuditHandler getAuditHandler()
+        public AuditHandler getAuditHandler(AuditBehaviorType auditBehaviorType)
         {
             return new DatasetAuditHandler();
         }
@@ -1619,9 +1616,9 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
     private class DatasetAuditHandler extends AbstractAuditHandler
     {
         @Override
-        public void addSummaryAuditEvent(User user, Container c, TableInfo table, QueryService.AuditAction action, Integer dataRowCount)
+        public void addSummaryAuditEvent(User user, Container c, TableInfo table, QueryService.AuditAction action, Integer dataRowCount, @Nullable AuditBehaviorType auditBehaviorType)
         {
-            QueryService.get().getDefaultAuditHandler().addSummaryAuditEvent(user, c, table, action, dataRowCount);
+            QueryService.get().getDefaultAuditHandler().addSummaryAuditEvent(user, c, table, action, dataRowCount, auditBehaviorType);
         }
 
         @Override

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -32,6 +32,7 @@ import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.DetailedAuditLogDataIterator;
 import org.labkey.api.dataiterator.SimpleTranslator;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.query.AbstractQueryUpdateService;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.InvalidKeyException;
@@ -52,6 +53,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -493,6 +495,16 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
     protected int truncateRows(User user, Container container)
     {
        return _dataset.deleteRows((Date) null);
+    }
+
+    @Override
+    public int truncateRows(User user, Container container, @Nullable Map<Enum, Object> configParameters, @Nullable Map<String, Object> extraScriptContext) throws BatchValidationException, QueryUpdateServiceException, SQLException
+    {
+        Map<Enum, Object> updatedParams = configParameters;
+        if (updatedParams == null)
+            updatedParams = new HashMap<>();
+        updatedParams.put(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior, AuditBehaviorType.SUMMARY);
+        return super.truncateRows(user, container, updatedParams, extraScriptContext);
     }
 
     public String keyFromMap(Map<String, Object> map) throws InvalidKeyException


### PR DESCRIPTION
#### Rationale
[Issue 43200](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=43200) When retrieving audit handlers and adding summary events, we also want to allow an override of the audit behavior type from the table in certain cases.  In this particular case, it is when truncating a table.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/243

#### Changes
* Add nullable `AuditBehaviorType` parameter to `getAuditHandler` and `addSummaryAuditEvent`
