### PR TITLE
43216: Display loading errors for faceted filter pane

### DIFF
--- a/api/webapp/clientapi/ext3/FilterDialog.js
+++ b/api/webapp/clientapi/ext3/FilterDialog.js
@@ -878,6 +878,10 @@ LABKEY.FilterDialog.View.Faceted = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
 
     gridID: Ext.id(),
 
+    loadError: undefined,
+
+    overflow: false,
+
     initComponent : function() {
 
         Ext.apply(this, {
@@ -897,6 +901,12 @@ LABKEY.FilterDialog.View.Faceted = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
                     border: false
                 },
                 items: [{
+                    xtype: 'box',
+                    cls: 'alert alert-danger',
+                    hidden: true,
+                    id: this.gridID + '-error',
+                    style: 'position: relative;',
+                },{
                     xtype: 'label',
                     id: this.gridID + 'OverflowLabel',
                     hidden: true,
@@ -1258,10 +1268,16 @@ LABKEY.FilterDialog.View.Faceted = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
                     div.on('click', grid.onHeaderCellClick, grid);
                 }
 
+                if (this.loadError) {
+                    var errorCmp = Ext.getCmp(this.gridID + '-error');
+                    errorCmp.update(this.loadError);
+                    errorCmp.setVisible(true);
+                }
+
                 // Issue 39727 - show a message if we've capped the number of options shown
                 Ext.getCmp(this.gridID + 'OverflowLabel').setVisible(this.overflow);
 
-                if (this.overflow) {
+                if (this.loadError || this.overflow) {
                     this.fireEvent('invalidfilter');
                 }
             }
@@ -1326,6 +1342,16 @@ LABKEY.FilterDialog.View.Faceted = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
                     this.storeReady = true;
                     this.onViewReady();
                 }
+            },
+            failure: function(err) {
+                if (err && err.exception) {
+                    this.loadError = err.exception;
+                } else {
+                    this.loadError = 'Failed to load faceted data.';
+                }
+                store.isLoading = false;
+                this.storeReady = true;
+                this.onViewReady();
             },
             scope: this
         };


### PR DESCRIPTION
#### Rationale
This PR addresses [43216](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43216) by improving the error handling of the faceted filter panel for Data Regions. Any error that is returned from the server will now be displayed inline on the "Choose Values" pane and the `invalidfilter` event will be fired which is default handled to revert back to the "Choose Filters" pane.

If the user chooses to go back to the "Choose Values" pane they would see something like this:

<img width="444" alt="Screen Shot 2021-05-25 at 1 26 08 PM" src="https://user-images.githubusercontent.com/3926239/119564418-9f784680-bd5d-11eb-8e25-3888192f201c.png">

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2286
* https://github.com/LabKey/testAutomation/pull/740
* https://github.com/LabKey/compliance/pull/115

#### Changes
* Add `loadError` property to `LABKEY.FilterDialog.View.Faceted`. Initialize then display error and fire event if set.
