### PR TITLE
Import performance fixes

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -269,6 +270,7 @@ public class NameGenerator
         private final boolean _incrementSampleCounts;
 
         private final Map<String, Object> _batchExpressionContext;
+        private Function<Map<String,Long>,Map<String,Long>> getSampleCountsFunction;
         private final Map<String, Integer> _newNames = new CaseInsensitiveHashMap<>();
 
         private int _rowNumber = 0;
@@ -336,8 +338,12 @@ public class NameGenerator
             Map<String, Long> sampleCounts = null;
             if (_incrementSampleCounts && !_exprHasSampleCounterFormats)
             {
-                Date now = (Date)_batchExpressionContext.get("now");
-                sampleCounts = SampleTypeService.get().incrementSampleCounts(now);
+                if (null == getSampleCountsFunction)
+                {
+                    Date now = (Date)_batchExpressionContext.get("now");
+                    getSampleCountsFunction = SampleTypeService.get().getSampleCountsFunction(now);
+                }
+                sampleCounts = getSampleCountsFunction.apply(null);
             }
 
             // If a name is already provided, just use it as is

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -34,6 +34,7 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public interface SampleTypeService
 {
@@ -122,8 +123,25 @@ public interface SampleTypeService
     /**
      * Increment and get the sample counters for the given date, or the current date if no date is supplied.
      * The resulting map has keys "dailySampleCount", "weeklySampleCount", "monthlySampleCount", and "yearlySampleCount".
+     * <p>
+     * In a loop getSampleCountsFunction() is preferred.
      */
-    Map<String, Long> incrementSampleCounts(@Nullable Date counterDate);
+    default Map<String, Long> incrementSampleCounts(@Nullable Date counterDate)
+    {
+        return getSampleCountsFunction(counterDate).apply(null);
+    }
+
+    /**
+     * Increment and get the sample counters for the given date, or the current date if no date is supplied.
+     * The resulting map has keys "dailySampleCount", "weeklySampleCount", "monthlySampleCount", and "yearlySampleCount".
+     *
+     * You can pass in a Map<> to reuse, or just pass in null each time. e.g.
+     *      once:
+     *          fn = getSampleCountsFunction(date);
+     *      then:
+     *          counts = fn.apply(null);
+     */
+    Function<Map<String,Long>,Map<String,Long>> getSampleCountsFunction(@Nullable Date counterDate);
 
     void deleteSampleType(int rowId, Container c, User user) throws ExperimentException;
 

--- a/api/src/org/labkey/api/reader/TabLoader.java
+++ b/api/src/org/labkey/api/reader/TabLoader.java
@@ -309,7 +309,7 @@ public class TabLoader extends DataLoader
         value = StringUtils.trimToEmpty(value);
         if ("\\N".equals(value))
             return _preserveEmptyString ? null : "";
-        if (_unescapeBackslashes)
+        if (_unescapeBackslashes && value.indexOf('\\') >= 0)   // unescapeJava() is really slow
         {
             try
             {

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -182,6 +182,11 @@ public interface SearchService
          */
         void setReady();
 
+        default void addRunnable(@NotNull SearchService.PRIORITY pri, @NotNull Runnable r)
+        {
+            addRunnable(r, pri);
+        }
+
         void addRunnable(@NotNull Runnable r, @NotNull SearchService.PRIORITY pri);
 
         void addResource(@NotNull String identifier, SearchService.PRIORITY pri);


### PR DESCRIPTION
#### Rationale
1. incrementSampleCounts - cache the DbSequence objects, and use getPreallocatingSequence()
2. unescapeJava - unescapeJava() is _really_ slow. Don't use if there are no backslashes.
3. queue search items in background - Don't need to synchronously expand the list of searchable items
