### PR TITLE
Move lookupBooleanValue to AbstractSettingsGroup

### DIFF
--- a/api/src/org/labkey/api/settings/AbstractSettingsGroup.java
+++ b/api/src/org/labkey/api/settings/AbstractSettingsGroup.java
@@ -45,6 +45,11 @@ public abstract class AbstractSettingsGroup
         return "TRUE".equalsIgnoreCase(lookupStringValue(name, defaultValue ? "TRUE" : "FALSE" ) );
     }
 
+    protected boolean lookupBooleanValue(Container c, String name, boolean defaultValue)
+    {
+        return "TRUE".equalsIgnoreCase(lookupStringValue(c, name, defaultValue ? "TRUE" : "FALSE"));
+    }
+
     protected int lookupIntValue(String name, int defaultValue)
     {
         try

--- a/api/src/org/labkey/api/settings/LookAndFeelFolderProperties.java
+++ b/api/src/org/labkey/api/settings/LookAndFeelFolderProperties.java
@@ -88,11 +88,6 @@ public class LookAndFeelFolderProperties extends AbstractWriteableSettingsGroup
         throw new IllegalStateException("Must provide a container");
     }*/
 
-    protected boolean lookupBooleanValue(Container c, String name, boolean defaultValue)
-    {
-        return "TRUE".equalsIgnoreCase(lookupStringValue(c, name, defaultValue ? "TRUE" : "FALSE"));
-    }
-
     public String getDefaultDateFormat()
     {
         // Look up this value starting from the current container (unlike all the other look & feel settings)


### PR DESCRIPTION
#### Rationale
This PR moves lookupBooleanValue from LookAndFeelFolderProperties to AbstractSettingsGroup because it is useful to other classes (notably NotebookSettingsGroup in my other PR).

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2288
* https://github.com/LabKey/labbook/pull/108
* https://github.com/LabKey/labkey-ui-components/pull/536
* https://github.com/LabKey/biologics/pull/893

#### Changes
* Move lookupBooleanValue from LookAndFeelFolderProperties to AbstractSettingsGroup
