### PR TITLE
Issue43218: Allow MultiAuthConfigs to specify "dictateFieldVisibility"

### DIFF
--- a/core/src/client/components/DynamicConfigurationModal.tsx
+++ b/core/src/client/components/DynamicConfigurationModal.tsx
@@ -31,7 +31,7 @@ export default class DynamicConfigurationModal extends PureComponent<Props, Part
         const {authConfig, modalType} = this.props;
         const fieldValues: any = {};
         this.props.modalType.settingsFields.forEach(field => {
-            const value = this.props.authConfig[field.name] != null ? this.props.authConfig[field.name] : "";
+            const value = this.props.authConfig[field.name] != null ? this.props.authConfig[field.name] : '';
             fieldValues[field.name] = field.name in this.props.authConfig ? value : field.defaultValue;
         });
 
@@ -68,7 +68,7 @@ export default class DynamicConfigurationModal extends PureComponent<Props, Part
 
         Object.keys(this.state.fieldValues).map(item => {
             const itemValue = this.state.fieldValues[item];
-            if (itemValue !== null && itemValue !== "") {
+            if (itemValue !== null && itemValue !== '' && itemValue.trim() !== '') {
                 form.append(item, itemValue);
             }
         });

--- a/core/src/client/components/DynamicConfigurationModal.tsx
+++ b/core/src/client/components/DynamicConfigurationModal.tsx
@@ -68,7 +68,7 @@ export default class DynamicConfigurationModal extends PureComponent<Props, Part
 
         Object.keys(this.state.fieldValues).map(item => {
             const itemValue = this.state.fieldValues[item];
-            if (itemValue !== null && itemValue !== '' && itemValue.trim() !== '') {
+            if (itemValue !== null && itemValue !== '' && (typeof itemValue !== 'string' || itemValue.trim() !== '')) {
                 form.append(item, itemValue);
             }
         });

--- a/core/src/client/components/DynamicConfigurationModal.tsx
+++ b/core/src/client/components/DynamicConfigurationModal.tsx
@@ -67,7 +67,10 @@ export default class DynamicConfigurationModal extends PureComponent<Props, Part
         }
 
         Object.keys(this.state.fieldValues).map(item => {
-            form.append(item, this.state.fieldValues[item]);
+            const itemValue = this.state.fieldValues[item];
+            if (itemValue !== null && itemValue !== "") {
+                form.append(item, itemValue);
+            }
         });
 
         Ajax.request({

--- a/core/src/client/components/DynamicConfigurationModal.tsx
+++ b/core/src/client/components/DynamicConfigurationModal.tsx
@@ -31,7 +31,8 @@ export default class DynamicConfigurationModal extends PureComponent<Props, Part
         const {authConfig, modalType} = this.props;
         const fieldValues: any = {};
         this.props.modalType.settingsFields.forEach(field => {
-            fieldValues[field.name] = field.name in this.props.authConfig ? this.props.authConfig[field.name] : field.defaultValue;
+            const value = this.props.authConfig[field.name] != null ? this.props.authConfig[field.name] : "";
+            fieldValues[field.name] = field.name in this.props.authConfig ? value : field.defaultValue;
         });
 
         if (modalType.sso) {

--- a/core/src/client/components/DynamicFields.tsx
+++ b/core/src/client/components/DynamicFields.tsx
@@ -251,11 +251,19 @@ export class DynamicFields extends PureComponent<DynamicFieldsProps> {
             fieldValues,
             authConfig,
         } = this.props;
-        let stopPoint = fields.findIndex(field => 'dictateFieldVisibility' in field) + 1;
-        if (stopPoint === 0) {
-            stopPoint = fields.length;
-        }
-        const fieldsToCreate = fieldValues.search ? fields : fields.slice(0, stopPoint);
+
+        // If dictateFieldVisibility is set on a checkbox field, its value determines the visibility of all subsequent
+        // fields until the next checkbox with a dictateFieldVisibility value, or the end of the form
+        let on = true;
+        const fieldsToCreate = fields.filter(field => {
+            const returnVal = on;
+
+            if ('dictateFieldVisibility' in field) {
+                on = fieldValues[field['name']];
+                return true;
+            }
+            return returnVal;
+        });
 
         const allFields = fieldsToCreate.map((field, index) => {
             const requiredFieldEmpty = emptyRequiredFields.indexOf(field.name) !== -1;

--- a/core/src/client/components/DynamicFields.tsx
+++ b/core/src/client/components/DynamicFields.tsx
@@ -17,6 +17,7 @@ interface TextInputProps extends InputFieldProps {
 export class TextInput extends PureComponent<TextInputProps> {
     render() {
         const { description, caption, required, canEdit, requiredFieldEmpty, onChange, name, type, value } = this.props;
+        const inputValue = value != null ? value : "";
 
         return (
             <div className="modal__text-input">
@@ -36,7 +37,7 @@ export class TextInput extends PureComponent<TextInputProps> {
                     <FormControl
                         name={name}
                         type={type}
-                        value={value}
+                        value={inputValue}
                         onChange={onChange}
                         className={
                             'modal__text-input-field' + (requiredFieldEmpty ? ' modal__text-input-field--error' : '')

--- a/core/src/client/components/DynamicFields.tsx
+++ b/core/src/client/components/DynamicFields.tsx
@@ -17,7 +17,6 @@ interface TextInputProps extends InputFieldProps {
 export class TextInput extends PureComponent<TextInputProps> {
     render() {
         const { description, caption, required, canEdit, requiredFieldEmpty, onChange, name, type, value } = this.props;
-        const inputValue = value != null ? value : "";
 
         return (
             <div className="modal__text-input">
@@ -37,7 +36,7 @@ export class TextInput extends PureComponent<TextInputProps> {
                     <FormControl
                         name={name}
                         type={type}
-                        value={inputValue}
+                        value={value}
                         onChange={onChange}
                         className={
                             'modal__text-input-field' + (requiredFieldEmpty ? ' modal__text-input-field--error' : '')


### PR DESCRIPTION
#### Rationale
We now have a second checkbox on the LDAP authentication configuration page ("Read LDAP attributes") that needs to reveal additional properties when checked. The original code was only configured to reveal additional properties for one checkbox—this update allows for any number of 'dictateFieldVisibility' checkboxes.

#### Related Pull Requests
* https://github.com/LabKey/ldap/pull/46

#### Changes
* Determine whether a field should be displayed according to relevant field's 'dictateFieldVisibility' setting
