### PR TITLE
Item 8856: Enable merge option for bulk list import

### DIFF
--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -77,6 +77,7 @@ import org.labkey.api.query.QueryParam;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryUpdateForm;
+import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.reader.DataLoader;
@@ -729,11 +730,13 @@ public class ListController extends SpringActionController
     public class UploadListItemsAction extends AbstractQueryImportAction<ListDefinitionForm>
     {
         private ListDefinition _list;
+        private QueryUpdateService.InsertOption _insertOption;
 
         @Override
         protected void initRequest(ListDefinitionForm form) throws ServletException
         {
             _list = form.getList();
+            _insertOption = form.getInsertOption();
             setTarget(_list.getTable(getUser(), getContainer()));
         }
 
@@ -741,13 +744,14 @@ public class ListController extends SpringActionController
         public ModelAndView getView(ListDefinitionForm form, BindException errors) throws Exception
         {
             initRequest(form);
+            setShowImportOptions(_list.getKeyType() != ListDefinition.KeyType.AutoIncrementInteger);
             return getDefaultImportView(form, errors);
         }
 
         @Override
         protected int importData(DataLoader dl, FileStream file, String originalName, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, @Nullable TransactionAuditProvider.TransactionAuditEvent auditEvent) throws IOException
         {
-            int count = _list.insertListItems(getUser(),getContainer() , dl, errors, null, null, false, _importLookupByAlternateKey);
+            int count = _list.insertListItems(getUser(), getContainer(), dl, errors, null, null, false, _importLookupByAlternateKey, _insertOption == QueryUpdateService.InsertOption.MERGE);
             return count;
         }
 

--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -745,6 +745,7 @@ public class ListController extends SpringActionController
         {
             initRequest(form);
             setShowImportOptions(_list.getKeyType() != ListDefinition.KeyType.AutoIncrementInteger);
+            setSuccessMessageSuffix("imported");
             return getDefaultImportView(form, errors);
         }
 

--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -751,8 +751,7 @@ public class ListController extends SpringActionController
         @Override
         protected int importData(DataLoader dl, FileStream file, String originalName, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, @Nullable TransactionAuditProvider.TransactionAuditEvent auditEvent) throws IOException
         {
-            int count = _list.insertListItems(getUser(), getContainer(), dl, errors, null, null, false, _importLookupByAlternateKey, _insertOption == QueryUpdateService.InsertOption.MERGE);
-            return count;
+            return _list.insertListItems(getUser(), getContainer(), dl, errors, null, null, false, _importLookupByAlternateKey, _insertOption == QueryUpdateService.InsertOption.MERGE);
         }
 
         @Override

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -205,7 +205,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
                 {
                     //Make entry to audit log if anything was inserted
                     if (inserted > 0)
-                        ListManager.get().addAuditEvent(_list, user, "Bulk inserted " + inserted + " rows to list.");
+                        ListManager.get().addAuditEvent(_list, user, (useMerge ? "Bulk imported " : "Bulk inserted ") + inserted + " rows to list.");
 
                     transaction.commit();
                     ListManager.get().indexList(_list, false); // TODO: Add to a post-commit task?

--- a/list/src/org/labkey/list/view/ListDefinitionForm.java
+++ b/list/src/org/labkey/list/view/ListDefinitionForm.java
@@ -19,6 +19,7 @@ package org.labkey.list.view;
 import org.labkey.api.action.ReturnUrlForm;
 import org.labkey.api.exp.list.ListDefinition;
 import org.labkey.api.exp.list.ListService;
+import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.ViewForm;
 
@@ -29,6 +30,7 @@ public class ListDefinitionForm extends ViewForm
     private boolean _showHistory = false;
     private Integer _listId = null;
     private String _name = null;
+    private QueryUpdateService.InsertOption _insertOption = QueryUpdateService.InsertOption.IMPORT;
 
     public ListDefinition getList()
     {
@@ -98,5 +100,15 @@ public class ListDefinitionForm extends ViewForm
     public void setName(String name)
     {
         _name = name;
+    }
+
+    public QueryUpdateService.InsertOption getInsertOption()
+    {
+        return _insertOption;
+    }
+
+    public void setInsertOption(QueryUpdateService.InsertOption insertOption)
+    {
+        _insertOption = insertOption;
     }
 }


### PR DESCRIPTION
#### Rationale
We allow merging of data for sample types and datasets within the LKS.  This change enables that functionality for lists as well.  

#### Related Pull Requests
* 

#### Changes
* For lists that do not have auto-generated key values, enable the Import Options field to allow merging of list data from the LKS ui.
