### PR TITLE
Better error handling for crawler hitting 'query-testRemoteConnection'

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -363,6 +363,10 @@ public class QueryController extends SpringActionController
 
             // Extract the username, password, and container from the secure property store
             Map<String, String> singleConnectionMap = RemoteConnections.getRemoteConnection(RemoteConnections.REMOTE_QUERY_CONNECTIONS_CATEGORY, name, getContainer());
+            if (singleConnectionMap.isEmpty())
+            {
+                throw new NotFoundException("Remote connection not found: '" + name + "'");
+            }
             String url = singleConnectionMap.get(RemoteConnections.FIELD_URL);
             String user = singleConnectionMap.get(RemoteConnections.FIELD_USER);
             String password = singleConnectionMap.get(RemoteConnections.FIELD_PASSWORD);


### PR DESCRIPTION
#### Rationale
Crawler might hit 'query-testRemoteConnection' for a remote connection that has been deleted.

#### Changes
* Update `TestRemoteConnectionAction` to `404` for undefined remote connections
