### PR TITLE
43241: display of dates from multi-value columns

### DIFF
--- a/api/src/org/labkey/api/data/MultiValuedDisplayColumn.java
+++ b/api/src/org/labkey/api/data/MultiValuedDisplayColumn.java
@@ -121,7 +121,7 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
     @Override
     public List<String> renderURLs(RenderContext ctx)
     {
-        return values(ctx, super::renderURL);
+        return values(ctx, _column::renderURL);
     }
 
     @Override
@@ -171,7 +171,7 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
     @Override
     public List<Object> getDisplayValues(RenderContext ctx)
     {
-        return values(ctx, super::getDisplayValue);
+        return values(ctx, _column::getDisplayValue);
     }
 
     @Override
@@ -183,13 +183,13 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
     @Override
     public List<String> getTsvFormattedValues(RenderContext ctx)
     {
-        return values(ctx, super::getTsvFormattedValue);
+        return values(ctx, _column::getTsvFormattedValue);
     }
 
     @Override
     public List<String> getFormattedTexts(RenderContext ctx)
     {
-        return values(ctx, super::getFormattedText);
+        return values(ctx, _column::getFormattedText);
     }
 
     @Override
@@ -201,7 +201,7 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
     @Override
     public List<Object> getJsonValues(RenderContext ctx)
     {
-        return values(ctx, super::getJsonValue);
+        return values(ctx, _column::getJsonValue);
     }
 
     @Override
@@ -215,6 +215,6 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
     @Override
     public Object getInputValue(RenderContext ctx)
     {
-        return values(ctx, super::getInputValue);
+        return values(ctx, _column::getInputValue);
     }
 }

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -74,7 +74,6 @@ import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.UpdatePermission;
-import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpression;

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -338,7 +338,6 @@ public class QueryModule extends DefaultModule
     {
         return Set.of(
             ModuleReportCache.TestCase.class,
-            MultiValueTest.class,
             OlapController.TestCase.class,
             Query.QueryTestCase.class,
             QueryController.TestCase.class,
@@ -353,6 +352,7 @@ public class QueryModule extends DefaultModule
     public @NotNull List<Factory<Class<?>>> getIntegrationTestFactories()
     {
         List<Factory<Class<?>>> ret = new ArrayList<>(super.getIntegrationTestFactories());
+        ret.add(new JspTestCase("/org/labkey/query/MultiValueTest.jsp"));
         ret.add(new JspTestCase("/org/labkey/query/olap/OlapTestCase.jsp"));
         ret.add(new JspTestCase("/org/labkey/query/QueryServiceImplTestCase.jsp"));
         return ret;

--- a/query/webapp/query/browser/view/QueryDetails.js
+++ b/query/webapp/query/browser/view/QueryDetails.js
@@ -57,6 +57,11 @@ Ext4.define('LABKEY.query.browser.view.QueryDetails', {
             label: 'Calculated',
             description: 'This column contains a calculated expression'
         },
+        multiValue: {
+            abbreviation: 'MVFK',
+            label: 'Multi-Value Foreign Key',
+            description: 'This column is a multi-valued lookup'
+        },
         phi: {
             enumeration: {
                 PHI: {


### PR DESCRIPTION
#### Rationale
When rendering the JSON response, super.getFormattedText() calls getDisplayValue() which stringifies the values.
The fix is to call the bound column's getFormattedText() instead to format the date.

#### Changes
- MultiValueDisplayColumn should invoke the bound column's rendering methods
- Add hint to schema browser for columns with a MVFK
- regression test using material and aliases