### PR TITLE
33960: recipe needs ${genId} to correctly generate it's name

### DIFF
--- a/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
+++ b/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
@@ -281,6 +281,12 @@ public class PropertyController extends SpringActionController
                 if (templateGroup == null)
                     throw new NotFoundException("Domain template group '" + domainGroup + "' not found");
 
+                if (templateGroup.hasErrors())
+                {
+                    errors.reject(ERROR_MSG, "Domain template group '" + domainGroup + "' has errors: " + StringUtils.join(templateGroup.getErrors(), "\n"));
+                    return null;
+                }
+
                 if (domainTemplate != null)
                 {
                     DomainTemplate template = templateGroup.getTemplate(domainTemplate, kindName, true);
@@ -298,12 +304,6 @@ public class PropertyController extends SpringActionController
                 }
                 else
                 {
-                    if (templateGroup.hasErrors())
-                    {
-                        errors.reject(ERROR_MSG, "Domain template group '" + domainGroup + "' has errors: " + StringUtils.join(templateGroup.getErrors(), "\n"));
-                        return null;
-                    }
-
                     domains = templateGroup.createAndImport(getContainer(), getUser(), /*TODO: allow specifying a domain name for each template?, */ createDomain, importData);
                 }
             }


### PR DESCRIPTION
#### Rationale
When creating a recipe batch, we need to generate the output sample name before the sample is created.  To do this, we invoke the name generator directly.  LabKey/recipe#53 includes the sample's properties in the name generator's context.  This PR passes the SampleType's ${genId} DbSequence to the name generator for incrementing.

#### Related Pull Requests
* https://github.com/LabKey/recipe/pull/54
* https://github.com/LabKey/recipe/pull/53

#### Changes
- pass SampleType DbSequence into name generator
- add regression test in recipe
