### PR TITLE
Fix failing junit test

### DIFF
--- a/api/src/org/labkey/api/Constants.java
+++ b/api/src/org/labkey/api/Constants.java
@@ -49,7 +49,7 @@ public class Constants
      */
     public static String getDocumentationVersion()
     {
-        return "21.3";
+        return "21.7";
     }
 
     /**


### PR DESCRIPTION
#### Rationale
The documentation version needs to be updated when we bump to an official release version number. `org.labkey.api.Constants$TestCase` junit test keeps us honest.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/83
