### PR TITLE
43241: display of dates from multi-value columns

### DIFF
--- a/api/src/org/labkey/api/data/DisplayColumnDecorator.java
+++ b/api/src/org/labkey/api/data/DisplayColumnDecorator.java
@@ -605,6 +605,12 @@ public class DisplayColumnDecorator extends DisplayColumn
     }
 
     @Override
+    public void prepare(Container c)
+    {
+        _column.prepare(c);
+    }
+
+    @Override
     public String getFormatString()
     {
         return _column.getFormatString();

--- a/api/src/org/labkey/api/data/MultiValuedLookupColumn.java
+++ b/api/src/org/labkey/api/data/MultiValuedLookupColumn.java
@@ -58,7 +58,8 @@ public class MultiValuedLookupColumn extends LookupColumn
     @Override
     public DisplayColumn getRenderer()
     {
-        return new MultiValuedDisplayColumn(super.getRenderer());
+        // NOTE: Calling `new MultiValuedDisplayColumn(super.getRenderer())` will re-wrap the MVDC which results in arrays of arrays of values
+        return getDisplayColumnFactory().createRenderer(this);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/LineageDisplayColumn.java
+++ b/experiment/src/org/labkey/experiment/api/LineageDisplayColumn.java
@@ -82,6 +82,8 @@ public class LineageDisplayColumn extends DataColumn implements IMultiValuedDisp
         innerDataRegion.setTable(seedTable);
         innerDataRegion.addColumn(bound);
         innerDisplayColumn = innerDataRegion.getDisplayColumn(0);
+        // apply date and number formats
+        innerDataRegion.prepareDisplayColumns(schema.getContainer());
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
The fix in PR #2298 worked for standard MultiValueFKs but not the lineage MVFK.  The inner display column needs to have `prepare()` called to apply the container's date and number formats.  In addition, we were rewrapping MultiValueDisplayColumn with another MultiValueDisplayColumn when calling `getRenderer()` which resulted in the values being rendered as nested arrays in the JSON response.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2298

#### Changes
- Don't wrap the display column with a MultiValuedDisplayColumn twice
- Call DisplayColumnDecorator.prepare() to apply container number and date formats
