### PR TITLE
Project locking compliance feature

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -60,6 +60,7 @@ import org.labkey.api.util.GUID;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.SafeToRenderEnum;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.FolderTab;
 import org.labkey.api.view.Portal;
@@ -127,7 +128,16 @@ public class Container implements Serializable, Comparable<Container>, Securable
     // Only one state for now, but we expect to add more in the future (e.g., ReadOnly)
     public enum LockState
     {
-        Inaccessible
+        Inaccessible()
+        {
+            @Override
+            public String getDescription()
+            {
+                return "inaccessible to everyone except administrators";
+            }
+        };
+
+        public abstract String getDescription();
     }
 
     // UNDONE: BeanFactory for Container

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -729,6 +729,18 @@ public class ContainerManager
         _removeFromCache(container);
     }
 
+    public static void updateLockState(Container container, LockState lockState, User user)
+    {
+        //For some reason there is no primary key defined on core.containers
+        //so we can't use Table.update here
+        StringBuilder sql = new StringBuilder("UPDATE ");
+        sql.append(CORE.getTableInfoContainers());
+        sql.append(" SET LockState = ? WHERE RowID = ?");
+        new SqlExecutor(CORE.getSchema()).execute(sql, lockState, container.getRowId());
+
+        _removeFromCache(container);
+    }
+
     public static void updateType(Container container, String newType, User user)
     {
         //For some reason there is no primary key defined on core.containers

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -2231,7 +2231,8 @@ public class ContainerManager
 
     static volatile LockedProjectHandler LOCKED_PROJECT_HANDLER = (project, user, lockState) -> false;
 
-    public static void registerLockedProjectHandler(LockedProjectHandler handler)
+    // Replaces any previously set LockedProjectHandler
+    public static void setLockedProjectHandler(LockedProjectHandler handler)
     {
         LOCKED_PROJECT_HANDLER = handler;
     }

--- a/api/src/org/labkey/api/data/ConvertHelper.java
+++ b/api/src/org/labkey/api/data/ConvertHelper.java
@@ -177,6 +177,7 @@ public class ConvertHelper implements PropertyEditorRegistrar
         _register(new ExpDataFileConverter(), File.class);
         _register(new FacetingBehaviorTypeConverter(), FacetingBehaviorType.class);
         _register(new DefaultScaleConverter(), DefaultScaleType.class);
+        _register(new LockStateConverter(), Container.LockState.class);
         _register(new SchemaKey.Converter(), SchemaKey.class);
         _register(new FieldKey.Converter(), FieldKey.class);
         _register(new JSONTypeConverter(), JSONObject.class);
@@ -753,6 +754,20 @@ public class ConvertHelper implements PropertyEditorRegistrar
             else
             {
                 return DefaultScaleType.valueOf(value.toString());
+            }
+        }
+    }
+
+    public static class LockStateConverter implements Converter
+    {
+        @Override
+        public Object convert(Class type, Object value)
+        {
+            if (value == null || value.equals("null") || !type.equals(Container.LockState.class))
+                return null;
+            else
+            {
+                return Container.LockState.valueOf(value.toString());
             }
         }
     }

--- a/api/src/org/labkey/api/data/LockedProjectHandler.java
+++ b/api/src/org/labkey/api/data/LockedProjectHandler.java
@@ -1,0 +1,8 @@
+package org.labkey.api.data;
+
+import org.labkey.api.security.User;
+
+public interface LockedProjectHandler
+{
+    boolean isForbidden(Container project, User user, Container.LockState lockState);
+}

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 21.002
+SchemaVersion: 21.003
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/core.xml
+++ b/core/resources/schemas/core.xml
@@ -33,6 +33,8 @@
       <column columnName="Type"/>
       <column columnName="Title"/>
       <column columnName="Searchable"/>
+      <column columnName="LockState"/>
+      <column columnName="ExpirationDate"/>
     </columns>
   </table>
   <table tableName="Documents" tableDbType="TABLE">

--- a/core/resources/schemas/dbscripts/postgresql/core-21.002-21.003.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-21.002-21.003.sql
@@ -1,0 +1,2 @@
+ALTER TABLE core.Containers ADD LockState VARCHAR(25) NULL;
+ALTER TABLE core.Containers ADD ExpirationDate TIMESTAMP NULL;

--- a/core/resources/schemas/dbscripts/sqlserver/core-21.002-21.003.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-21.002-21.003.sql
@@ -1,0 +1,2 @@
+ALTER TABLE core.Containers ADD LockState VARCHAR(25) NULL;
+ALTER TABLE core.Containers ADD ExpirationDate DATETIME NULL;

--- a/core/resources/schemas/test.xml
+++ b/core/resources/schemas/test.xml
@@ -87,6 +87,8 @@
             <column columnName="Type"/>
             <column columnName="Title"/>
             <column columnName="Searchable"/>
+            <column columnName="LockState"/>
+            <column columnName="ExpirationDate"/>
         </columns>
     </table>
     <table tableName="ContainerAliases2" tableDbType="UNKNOWN">


### PR DESCRIPTION
#### Rationale
This introduces a project locking feature for archival and compliance purposes. Administrators can manually lock a project, which makes it inaccessible to non-administrators (i.e., non-admin role assignments in every folder of the project are ignored). Administrators can unlock a project to re-enable all the role assignments.

#### Related Pull Requests
* https://github.com/LabKey/compliance/pull/116

#### Changes
* Add `LockState` and `ExpirationDate` columns to `core.Containers` table, `Container`, and `ContainerFactory`
* During permission checks, invoke current `LockedProjectHandler` if the project's `LockState` is non-null* 