### PR TITLE
Make more server-side tests compatible with a base module set

### DIFF
--- a/api/src/org/labkey/api/data/ExcelColumn.java
+++ b/api/src/org/labkey/api/data/ExcelColumn.java
@@ -44,6 +44,7 @@ import org.apache.poi.xssf.usermodel.XSSFClientAnchor;
 import org.apache.poi.xssf.usermodel.XSSFPicture;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.labkey.api.action.NullSafeBindException;
@@ -843,6 +844,8 @@ public class ExcelColumn extends RenderColumn
         @BeforeClass
         public static void initialSetUp() throws Exception
         {
+            Assume.assumeTrue("This test requires the list module.", ListService.get() != null);
+
             doInitialSetUp(PROJECT_NAME);
         }
 

--- a/experiment/src/org/labkey/experiment/api/LineageTest.java
+++ b/experiment/src/org/labkey/experiment/api/LineageTest.java
@@ -4,6 +4,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
@@ -327,6 +328,7 @@ public class LineageTest extends ExpProvisionedTableTestHelper
     @Test
     public void testListAndSampleLineage() throws Exception
     {
+        Assume.assumeTrue("This test requires the list module.", ListService.get() != null);
         final User user = TestContext.get().getUser();
 
         // setup sample type

--- a/query/src/org/labkey/query/QueryServiceImplTestCase.jsp
+++ b/query/src/org/labkey/query/QueryServiceImplTestCase.jsp
@@ -1,9 +1,10 @@
 <%@ page import="org.junit.AfterClass" %>
+<%@ page import="org.junit.Assume" %>
 <%@ page import="org.junit.BeforeClass" %>
 <%@ page import="org.junit.Test" %>
 <%@ page import="org.labkey.api.data.Container" %>
-<%@ page import="org.labkey.api.data.DbScope" %>
 <%@ page import="static org.junit.Assert.*" %>
+<%@ page import="org.labkey.api.data.DbScope" %>
 <%@ page import="org.labkey.api.data.JdbcType" %>
 <%@ page import="org.labkey.api.data.PropertyStorageSpec" %>
 <%@ page import="org.labkey.api.data.SQLFragment" %>
@@ -28,7 +29,6 @@
 <%@ page import="java.sql.SQLException" %>
 <%@ page import="java.util.Arrays" %>
 <%@ page import="java.util.List" %>
-<%@ page import="java.util.Map" %>
 <%@ page extends="org.labkey.api.jsp.JspTest.DRT" %>
 <%!
     final static String tableName = "testGetSelectSqlSort";
@@ -129,7 +129,9 @@
     @BeforeClass
     public static void createList() throws Exception
     {
-        deleteList();
+        Assume.assumeTrue("This test requires the list module.", ListService.get() != null);
+
+        JunitUtil.deleteTestContainer();
 
         User user = TestContext.get().getUser();
         Container c = JunitUtil.getTestContainer();
@@ -145,14 +147,9 @@
 
 
     @AfterClass
-    public static void deleteList() throws Exception
+    public static void cleanup() throws Exception
     {
-        User user = TestContext.get().getUser();
-        Container c = JunitUtil.getTestContainer();
-        ListService s = ListService.get();
-        Map<String, ListDefinition> m = s.getLists(c);
-        if (m.containsKey(tableName))
-            m.get(tableName).delete(user);
+        JunitUtil.deleteTestContainer();
     }
 
 

--- a/visualization/src/org/labkey/visualization/sql/VisualizationCDSGenerator.java
+++ b/visualization/src/org/labkey/visualization/sql/VisualizationCDSGenerator.java
@@ -20,6 +20,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.labkey.api.action.NullSafeBindException;
 import org.labkey.api.data.ColumnInfo;
@@ -521,6 +523,12 @@ public class VisualizationCDSGenerator
             ctx.setContainer(JunitUtil.getTestContainer());
             ctx.setUser( TestContext.get().getUser());
             this.context = ctx;
+        }
+
+        @BeforeClass
+        public static void preTest()
+        {
+            Assume.assumeTrue("This test requires the study module.", StudyService.get() != null);
         }
 
         Results getResults(VisDataRequest q) throws SQLGenerationException, SQLException


### PR DESCRIPTION
#### Rationale
Several tests assume that the list and study module will be available and fail on a server running a more limited set of modules.

#### Changes
* Skip server-side tests that assume modules are present
* Refactor `WorkbookContainerType.AbstractTestCase` setup to not assume list module
