### PR TITLE
use getValueSql() instead of getSelectName()

### DIFF
--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -810,7 +810,7 @@ public class AnnouncementManager
         if (null == c || isSecure(c))
             return;
 
-        SQLFragment sql = new SQLFragment("SELECT EntityId FROM " + _comm.getTableInfoThreads());
+        SQLFragment sql = new SQLFragment("SELECT EntityId FROM " + _comm.getTableInfoThreads() + " _t_ ");
         sql.append(" WHERE Container = ?");
         sql.add(containerId);
         String and = " AND ";
@@ -822,7 +822,7 @@ public class AnnouncementManager
         }
         else
         {
-            SQLFragment modified = new SearchService.LastIndexedClause(_comm.getTableInfoThreads(), modifiedSince, null).toSQLFragment(null, null);
+            SQLFragment modified = new SearchService.LastIndexedClause(_comm.getTableInfoThreads(), modifiedSince, "_t_").toSQLFragment(null, null);
             if (!modified.isEmpty())
                 sql.append(and).append(modified);
         }

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -16,6 +16,7 @@
 package org.labkey.api.search;
 
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -28,6 +29,7 @@ import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.dialect.SqlDialect;
+import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.resource.Resource;
 import org.labkey.api.security.SecurableResource;
@@ -469,8 +471,17 @@ public interface SearchService
         private final SQLFragment _sqlf = new SQLFragment();
         private final Set<FieldKey> _fieldKeys = new HashSet<>();
 
+        // for assert
+        private final boolean tableAliasProvidedInConstructor;
+
+        /* NOTE: Some callers construct their own SQL and know the tableAlias and can provide it here
+         * Other usages use TableSelector (et al), and don't know the alias until toSQLFragment() is called.
+         * If the tableAlias is not provided in either the constructor or toSQLFragment() expect a syntax error!
+         */
         public LastIndexedClause(TableInfo info, java.util.Date modifiedSince, String tableAlias)
         {
+            tableAliasProvidedInConstructor = null != tableAlias && !ExprColumn.STR_TABLE_ALIAS.equals(tableAlias);
+
             // Incremental if modifiedSince is set and is more recent than 1967-10-04
             boolean incremental = modifiedSince != null && modifiedSince.compareTo(oldDate) > 0;
             
@@ -480,12 +491,13 @@ public interface SearchService
 
             ColumnInfo modified = info.getColumn("modified");
             ColumnInfo lastIndexed = info.getColumn("lastIndexed");
-            String prefix = null == tableAlias ? " " : tableAlias + ".";
+            if (null == tableAlias)
+                tableAlias = ExprColumn.STR_TABLE_ALIAS;
 
             String or = "";
             if (null != lastIndexed)
             {
-                _sqlf.append(prefix).append(lastIndexed.getSelectName()).append(" IS NULL");
+                _sqlf.append(lastIndexed.getValueSql(tableAlias)).append(" IS NULL");
                 _fieldKeys.add(lastIndexed.getFieldKey());
                 or = " OR ";
             }
@@ -493,7 +505,7 @@ public interface SearchService
             if (null != modified && null != lastIndexed)
             {
                 _sqlf.append(or);
-                _sqlf.append(prefix).append(modified.getSelectName()).append(">").append(prefix).append(lastIndexed.getSelectName());
+                _sqlf.append(modified.getValueSql(tableAlias)).append(">").append(lastIndexed.getValueSql(tableAlias));
                 _fieldKeys.add(modified.getFieldKey());
                 _fieldKeys.add(lastIndexed.getFieldKey());
                 or = " OR ";
@@ -502,7 +514,7 @@ public interface SearchService
             if (null != modifiedSince && null != modified)
             {
                 _sqlf.append(or);
-                _sqlf.append(prefix).append(modified.getSelectName()).append("> ?");
+                _sqlf.append(modified.getValueSql(tableAlias)).append("> ?");
                 _sqlf.add(modifiedSince);
                 _fieldKeys.add(modified.getFieldKey());
             }
@@ -518,6 +530,11 @@ public interface SearchService
             }
         }
 
+        public boolean isEmpty()
+        {
+            return _sqlf.isEmpty();
+        }
+
         @Override
         public String getLabKeySQLWhereClause(Map<FieldKey, ? extends ColumnInfo> columnMap)
         {
@@ -527,7 +544,20 @@ public interface SearchService
         @Override
         public SQLFragment toSQLFragment(Map<FieldKey, ? extends ColumnInfo> columnMap, SqlDialect dialect)
         {
-            return _sqlf;
+            assert tableAliasProvidedInConstructor;
+            return toSQLFragment(null, columnMap, dialect);
+        }
+
+        @Override
+        public SQLFragment toSQLFragment(String tableAlias, Map<FieldKey, ? extends ColumnInfo> columnMap, SqlDialect dialect)
+        {
+            assert tableAliasProvidedInConstructor || tableAlias != null;
+            if (this._sqlf.isEmpty() || null == tableAlias)
+                return _sqlf;
+            String sql = StringUtils.replace(_sqlf.getSQL(), ExprColumn.STR_TABLE_ALIAS, tableAlias);
+            SQLFragment ret = new SQLFragment(sql);
+            ret.addAll(_sqlf.getParams());
+            return ret;
         }
 
         @Override

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -608,9 +608,9 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
     public List<Pair<String,String>> listAttachmentsForIndexing(Collection<String> parents, Date modifiedSince)
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("Parent"), parents, CompareType.IN);
-        SimpleFilter.FilterClause since = new SearchService.LastIndexedClause(coreTables().getTableInfoDocuments(), modifiedSince, null);
+        var since = new SearchService.LastIndexedClause(coreTables().getTableInfoDocuments(), modifiedSince, null);
 
-        if (!since.toSQLFragment(null, null).isEmpty())
+        if (!since.isEmpty())
             filter.addClause(since);
 
         final ArrayList<Pair<String,String>> ret = new ArrayList<>();

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -705,10 +705,10 @@ public class ExperimentServiceImpl implements ExperimentService
     public List<ExpMaterialImpl> getIndexableMaterials(Container container, @Nullable Date modifiedSince)
     {
         // Big hack to prevent indexing study specimens. Also in ExpMaterialImpl.index()
-        SQLFragment sql = new SQLFragment("SELECT * FROM " + getTinfoMaterial() + " WHERE Container = ? AND LSID NOT LIKE '%:"
+        SQLFragment sql = new SQLFragment("SELECT * FROM " + getTinfoMaterial() + " _m_  WHERE Container = ? AND LSID NOT LIKE '%:"
                 + StudyService.SPECIMEN_NAMESPACE_PREFIX + "%'");
         sql.add(container.getId());
-        SQLFragment modifiedSQL = new SearchService.LastIndexedClause(getTinfoMaterial(), modifiedSince, null).toSQLFragment(null, null);
+        SQLFragment modifiedSQL = new SearchService.LastIndexedClause(getTinfoMaterial(), modifiedSince, "_m_").toSQLFragment(null, null);
         if (!modifiedSQL.isEmpty())
             sql.append(" AND ").append(modifiedSQL);
         return ExpMaterialImpl.fromMaterials(new SqlSelector(getSchema(), sql).getArrayList(Material.class));
@@ -716,9 +716,9 @@ public class ExperimentServiceImpl implements ExperimentService
 
     public List<ExpDataImpl> getIndexableData(Container container, @Nullable Date modifiedSince)
     {
-        SQLFragment sql = new SQLFragment("SELECT * FROM " + getTinfoData() + " WHERE Container = ? AND classId IS NOT NULL");
+        SQLFragment sql = new SQLFragment("SELECT * FROM " + getTinfoData() + " _d_ WHERE Container = ? AND classId IS NOT NULL");
         sql.add(container.getId());
-        SQLFragment modifiedSQL = new SearchService.LastIndexedClause(getTinfoData(), modifiedSince, null).toSQLFragment(null, null);
+        SQLFragment modifiedSQL = new SearchService.LastIndexedClause(getTinfoData(), modifiedSince, "_d_").toSQLFragment(null, null);
         if (!modifiedSQL.isEmpty())
             sql.append(" AND ").append(modifiedSQL);
         return ExpDataImpl.fromDatas(new SqlSelector(getSchema(), sql).getArrayList(Data.class));
@@ -726,8 +726,8 @@ public class ExperimentServiceImpl implements ExperimentService
 
     public List<ExpDataClassImpl> getIndexableDataClasses(Container container, @Nullable Date modifiedSince)
     {
-        SQLFragment sql = new SQLFragment("SELECT * FROM " + getTinfoDataClass() + " WHERE Container = ?").add(container.getId());
-        SQLFragment modifiedSQL = new SearchService.LastIndexedClause(getTinfoDataClass(), modifiedSince, null).toSQLFragment(null, null);
+        SQLFragment sql = new SQLFragment("SELECT * FROM " + getTinfoDataClass() + " _x_ WHERE Container = ?").add(container.getId());
+        SQLFragment modifiedSQL = new SearchService.LastIndexedClause(getTinfoDataClass(), modifiedSince, "_x_").toSQLFragment(null, null);
         if (!modifiedSQL.isEmpty())
             sql.append(" AND ").append(modifiedSQL);
         return ExpDataClassImpl.fromDataClasses(new SqlSelector(getSchema(), sql).getArrayList(DataClass.class));
@@ -735,8 +735,8 @@ public class ExperimentServiceImpl implements ExperimentService
 
     public Collection<ExpSampleTypeImpl> getIndexableSampleTypes(Container container, @Nullable Date modifiedSince)
     {
-        SQLFragment sql = new SQLFragment("SELECT * FROM " + getTinfoSampleType() + " WHERE Container = ?").add(container.getId());
-        SQLFragment modifiedSQL = new SearchService.LastIndexedClause(getTinfoSampleType(), modifiedSince, null).toSQLFragment(null, null);
+        SQLFragment sql = new SQLFragment("SELECT * FROM " + getTinfoSampleType() + " _st_ WHERE Container = ?").add(container.getId());
+        SQLFragment modifiedSQL = new SearchService.LastIndexedClause(getTinfoSampleType(), modifiedSince, "_st_").toSQLFragment(null, null);
         if (!modifiedSQL.isEmpty())
             sql.append(" AND ").append(modifiedSQL);
         return ExpSampleTypeImpl.fromMaterialSources(new SqlSelector(getSchema(), sql).getArrayList(MaterialSource.class));

--- a/issues/src/org/labkey/issue/model/IssueManager.java
+++ b/issues/src/org/labkey/issue/model/IssueManager.java
@@ -980,7 +980,7 @@ public class IssueManager
         
         SimpleFilter f = SimpleFilter.createContainerFilter(c);
         SearchService.LastIndexedClause incremental = new SearchService.LastIndexedClause(_issuesSchema.getTableInfoIssues(), modifiedSince, null);
-        if (!incremental.toSQLFragment(null,null).isEmpty())
+        if (!incremental.isEmpty())
             f.addClause(incremental);
         if (f.getClauses().isEmpty())
             f = null;

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -526,6 +526,7 @@ public class SearchController extends SpringActionController
             boolean full = "1".equals(getViewContext().getRequest().getParameter("full"));
             String returnUrl = getViewContext().getRequest().getParameter(ActionURL.Param.returnUrl.name());
             boolean wait = "1".equals(getViewContext().getRequest().getParameter("wait"));
+            boolean since = "1".equals(getViewContext().getRequest().getParameter("since"));
 
             SearchService ss = SearchService.get();
 
@@ -537,6 +538,10 @@ public class SearchController extends SpringActionController
             if (full)
             {
                 ss.indexFull(true);
+            }
+            else if (since)
+            {
+                task = ss.indexContainer(null, getContainer(), new Date(System.currentTimeMillis()- TimeUnit.DAYS.toMillis(1)));
             }
             else
             {

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -4318,7 +4318,7 @@ public class StudyManager
             StudySchema.getInstance().getSqlDialect().appendInClauseSql(f, ptids);
         }
 
-        SQLFragment lastIndexedFragment = new LastIndexedClause(StudySchema.getInstance().getTableInfoParticipant(), null, null).toSQLFragment(null, null);
+        SQLFragment lastIndexedFragment = new LastIndexedClause(StudySchema.getInstance().getTableInfoParticipant(), null, "p").toSQLFragment(null, null);
         if (!lastIndexedFragment.isEmpty())
             f.append(" AND ").append(lastIndexedFragment);
 


### PR DESCRIPTION
#### Rationale
LastIndexedClause was originally designed to work with SchemaTableInfo, but supporting other tables makes sense.  
Issue 43289

#### Related Pull Requests
https://github.com/LabKey/platform/pull/2320
https://github.com/LabKey/sampleManagement/pull/589
