### PR TITLE
Issue 43290: Specimen Requester and Specimen Coordinator role assignments disappeared after 21.3 upgrade

### DIFF
--- a/specimen/src/org/labkey/specimen/security/roles/SpecimenCoordinatorRole.java
+++ b/specimen/src/org/labkey/specimen/security/roles/SpecimenCoordinatorRole.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.specimen.security.roles;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.permissions.EditSharedViewPermission;
@@ -31,6 +32,9 @@ import org.labkey.api.specimen.security.permissions.ManageSpecimenActorsPermissi
 import org.labkey.api.specimen.security.permissions.RequestSpecimensPermission;
 import org.labkey.api.specimen.security.permissions.SetSpecimenCommentsPermission;
 import org.labkey.api.study.security.permissions.ManageStudyPermission;
+
+import java.util.Collection;
+import java.util.Set;
 
 /*
 * User: Dave
@@ -61,5 +65,11 @@ public class SpecimenCoordinatorRole extends AbstractSpecimenRole
         );
         addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));
         addExcludedPrincipal(SecurityManager.getGroup(Group.groupUsers));
+    }
+
+    @Override
+    public @NotNull Collection<String> getSerializationAliases()
+    {
+        return Set.of("org.labkey.study.security.roles.SpecimenCoordinatorRole");
     }
 }

--- a/specimen/src/org/labkey/specimen/security/roles/SpecimenRequesterRole.java
+++ b/specimen/src/org/labkey/specimen/security/roles/SpecimenRequesterRole.java
@@ -15,9 +15,13 @@
  */
 package org.labkey.specimen.security.roles;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.specimen.security.permissions.RequestSpecimensPermission;
+
+import java.util.Collection;
+import java.util.Set;
 
 /*
 * User: Dave
@@ -32,5 +36,11 @@ public class SpecimenRequesterRole extends AbstractSpecimenRole
                 "Specimen Requesters may request specimen vials.",
                 RequestSpecimensPermission.class);
         addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));
+    }
+
+    @Override
+    public @NotNull Collection<String> getSerializationAliases()
+    {
+        return Set.of("org.labkey.study.security.roles.SpecimenRequesterRole");
     }
 }


### PR DESCRIPTION
#### Rationale
`SpecimenRequesterRole` and `SpecimenCoordinatorRole` changed packages when they were moved to the specimen module for 21.3, but they weren't updated to provide a "serialization alias" to the old package name. That means all previous assignments to these roles "disappeared" on 21.3 upgrade. And any references to these roles in archives will not resolve. Adding aliases restores these assignments.

[Issue 43290: Specimen Requester and Specimen Coordinator role assignments disappeared after 21.3 upgrade](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43290)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1862

