### PR TITLE
Tolerate schema changes to the core.Containers table

### DIFF
--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1053,7 +1053,7 @@ public class ContainerManager
         {
             return getForPath("/");
         }
-        catch (IllegalStateException e)
+        catch (Exception e)
         {
             throw new RootContainerException("Root container can't be retrieved", e);
         }


### PR DESCRIPTION
#### Rationale
`CoreModule.init()` is checking an experimental feature which ends up referencing the root container very early, before core upgrade has taken place. This fails because we've added a couple new properties to `Container` but the corresponding columns aren't present yet. We're already catching a specific exception to accommodate the bootstrap case, so simply broaden this check to all exceptions.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2312
