### PR TITLE
Issue 43246: Lineage query NPE while processing an UploadedFile

### DIFF
--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -811,7 +811,7 @@ public class OntologyManager
     }
 
 
-    public static int deleteOntologyObjects(DbSchema schema, SQLFragment sub, Container c, boolean deleteOwnedObjects)
+    public static int deleteOntologyObjects(DbSchema schema, SQLFragment sub, @Nullable Container c, boolean deleteOwnedObjects)
     {
         // we have different levels of optimization possible here deleteOwned=true/false, scope=/<>exp
 
@@ -828,15 +828,29 @@ public class OntologyManager
         else
         {
             SQLFragment sqlDeleteProperties = new SQLFragment();
-            sqlDeleteProperties.append("DELETE FROM ").append(getTinfoObjectProperty().getSelectName()).append(" WHERE ObjectId IN\n").append("(SELECT ObjectId FROM ").append(String.valueOf(getTinfoObject())).append("\n").append(" WHERE Container = ? AND ObjectURI IN (");
-            sqlDeleteProperties.add(c.getId());
+            sqlDeleteProperties.append("DELETE FROM ").append(getTinfoObjectProperty().getSelectName())
+                    .append(" WHERE ObjectId IN\n")
+                    .append("(SELECT ObjectId FROM ")
+                    .append(String.valueOf(getTinfoObject())).append("\n")
+                    .append(" WHERE ");
+            if (c != null)
+            {
+                sqlDeleteProperties.append(" Container = ?").add(c.getId());
+                sqlDeleteProperties.append(" AND ");
+            }
+            sqlDeleteProperties.append("ObjectUri IN (");
             sqlDeleteProperties.append(sub);
             sqlDeleteProperties.append("))");
             new SqlExecutor(getExpSchema()).execute(sqlDeleteProperties);
 
             SQLFragment sqlDeleteObjects = new SQLFragment();
-            sqlDeleteObjects.append("DELETE FROM ").append(getTinfoObject().getSelectName()).append(" WHERE Container = ? AND ObjectURI IN (");
-            sqlDeleteObjects.add(c.getId());
+            sqlDeleteObjects.append("DELETE FROM ").append(getTinfoObject().getSelectName()).append(" WHERE ");
+            if (c != null)
+            {
+                sqlDeleteProperties.append(" Container = ?").add(c.getId());
+                sqlDeleteProperties.append(" AND ");
+            }
+            sqlDeleteObjects.append("ObjectURI IN (");
             sqlDeleteObjects.append(sub);
             sqlDeleteObjects.append(")");
             return new SqlExecutor(getExpSchema()).execute(sqlDeleteObjects);

--- a/api/src/org/labkey/api/files/FileContentService.java
+++ b/api/src/org/labkey/api/files/FileContentService.java
@@ -22,6 +22,7 @@ import org.labkey.api.attachments.AttachmentDirectory;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.exp.api.DataType;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.query.ExpDataTable;
 import org.labkey.api.query.QueryUpdateService;
@@ -43,6 +44,9 @@ import java.util.Map;
  */
 public interface FileContentService
 {
+    String UPLOADED_FILE_NAMESPACE_PREFIX = "UploadedFile";
+    DataType UPLOADED_FILE = new DataType(UPLOADED_FILE_NAMESPACE_PREFIX);
+
     String FILES_LINK = "@files";
     String FILE_SETS_LINK = "@filesets";
     String PIPELINE_LINK = "@pipeline";

--- a/core/src/org/labkey/core/admin/AbstractFileSiteSettingsAction.java
+++ b/core/src/org/labkey/core/admin/AbstractFileSiteSettingsAction.java
@@ -30,7 +30,6 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.exp.api.DataType;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.files.FileContentService;
@@ -48,6 +47,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.labkey.api.files.FileContentService.UPLOADED_FILE;
 
 /**
  * User: jeckels
@@ -268,7 +269,7 @@ public abstract class AbstractFileSiteSettingsAction<FormType extends FileSettin
 
                                 if ((user != null && !user.isGuest()) && data == null)
                                 {
-                                    data = ExperimentService.get().createData(c, new DataType("UploadedFile"));
+                                    data = ExperimentService.get().createData(c, UPLOADED_FILE);
                                     data.setDataFileURI(file.toURI());
                                     data.setName(file.getName());
                                     data.save(user);

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -179,6 +179,7 @@ import java.util.zip.ZipOutputStream;
 
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 import static org.labkey.api.action.ApiJsonWriter.CONTENT_TYPE_JSON;
+import static org.labkey.api.files.FileContentService.UPLOADED_FILE;
 
 
 /**
@@ -3446,7 +3447,7 @@ public class DavController extends SpringActionController
 
                 if (data == null)
                 {
-                    data = ExperimentService.get().createData(c, new DataType("UploadedFile"));
+                    data = ExperimentService.get().createData(c, UPLOADED_FILE);
                     data.setName(FileUtil.getFileName(file));
                     data.setDataFileURI(file.toUri());
                 }

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-21.004-21.005.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-21.004-21.005.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('deleteOrphanedUploadedFileObjects');

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-21.004-21.005.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-21.004-21.005.sql
@@ -1,0 +1,1 @@
+EXEC core.executeJavaUpgradeCode 'deleteOrphanedUploadedFileObjects';

--- a/experiment/src/org/labkey/experiment/ExpDataFileListener.java
+++ b/experiment/src/org/labkey/experiment/ExpDataFileListener.java
@@ -18,7 +18,6 @@ package org.labkey.experiment;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
-import org.labkey.api.exp.api.DataType;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.files.TableUpdaterFileListener;
@@ -28,6 +27,8 @@ import org.labkey.api.util.FileUtil;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import static org.labkey.api.files.FileContentService.UPLOADED_FILE;
 
 /**
  * User: jeckels
@@ -58,7 +59,7 @@ public class ExpDataFileListener extends TableUpdaterFileListener
             // Do not create a new ExpData for directories
         if (data == null && !Files.isDirectory(dest) && c != null)
         {
-            data = ExperimentService.get().createData(c, new DataType("UploadedFile"));
+            data = ExperimentService.get().createData(c, UPLOADED_FILE);
         }
 
         if (data != null && src.equals(data.getFilePath()) && !src.equals(dest))

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -72,7 +72,6 @@ import org.labkey.api.settings.AppProps;
 import org.labkey.api.usageMetrics.UsageMetricsService;
 import org.labkey.api.util.JspTestCase;
 import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.util.UsageReportingLevel;
 import org.labkey.api.view.AlwaysAvailableWebPartFactory;
 import org.labkey.api.view.BaseWebPartFactory;
 import org.labkey.api.view.HttpView;
@@ -84,7 +83,25 @@ import org.labkey.api.view.WebPartView;
 import org.labkey.api.vocabulary.security.DesignVocabularyPermission;
 import org.labkey.api.webdav.WebdavResource;
 import org.labkey.api.webdav.WebdavService;
-import org.labkey.experiment.api.*;
+import org.labkey.experiment.api.DataClassDomainKind;
+import org.labkey.experiment.api.ExpDataClassImpl;
+import org.labkey.experiment.api.ExpDataClassType;
+import org.labkey.experiment.api.ExpDataImpl;
+import org.labkey.experiment.api.ExpDataTableImpl;
+import org.labkey.experiment.api.ExpMaterialImpl;
+import org.labkey.experiment.api.ExpProtocolImpl;
+import org.labkey.experiment.api.ExpSampleTypeImpl;
+import org.labkey.experiment.api.ExperimentServiceImpl;
+import org.labkey.experiment.api.ExperimentStressTest;
+import org.labkey.experiment.api.GraphAlgorithms;
+import org.labkey.experiment.api.LineagePerfTest;
+import org.labkey.experiment.api.LineageTest;
+import org.labkey.experiment.api.LogDataType;
+import org.labkey.experiment.api.Protocol;
+import org.labkey.experiment.api.SampleTypeDomainKind;
+import org.labkey.experiment.api.SampleTypeServiceImpl;
+import org.labkey.experiment.api.UniqueValueCounterTestCase;
+import org.labkey.experiment.api.VocabularyDomainKind;
 import org.labkey.experiment.api.data.ChildOfCompareType;
 import org.labkey.experiment.api.data.ChildOfMethod;
 import org.labkey.experiment.api.data.LineageCompareType;
@@ -142,7 +159,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     public Double getSchemaVersion()
     {
-        return 21.004;
+        return 21.005;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/api/ExpIdentifiableBaseImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpIdentifiableBaseImpl.java
@@ -70,7 +70,7 @@ public abstract class ExpIdentifiableBaseImpl<Type extends IdentifiableBase> ext
         ensureUnlocked();
         if (!Objects.equals(_object.getLSID(), lsid))
         {
-            _prevLsid = _object.getLSID();///
+            _prevLsid = _object.getLSID();
         }
         _object.setLSID(lsid);
     }
@@ -137,7 +137,7 @@ public abstract class ExpIdentifiableBaseImpl<Type extends IdentifiableBase> ext
         {
             try (DbScope.Transaction tx = table.getSchema().getScope().ensureTransaction())
             {
-                // Create a new exp.object if the LSID changed XXX
+                // Create a new exp.object if the LSID changed
                 if (_prevLsid != null && ensureObject)
                 {
                     assert !Objects.equals(_prevLsid, getLSID());

--- a/experiment/src/org/labkey/experiment/api/ExpIdentifiableBaseImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpIdentifiableBaseImpl.java
@@ -70,7 +70,7 @@ public abstract class ExpIdentifiableBaseImpl<Type extends IdentifiableBase> ext
         ensureUnlocked();
         if (!Objects.equals(_object.getLSID(), lsid))
         {
-            _prevLsid = _object.getLSID();
+            _prevLsid = _object.getLSID();///
         }
         _object.setLSID(lsid);
     }
@@ -137,7 +137,7 @@ public abstract class ExpIdentifiableBaseImpl<Type extends IdentifiableBase> ext
         {
             try (DbScope.Transaction tx = table.getSchema().getScope().ensureTransaction())
             {
-                // Create a new exp.object if the LSID changed
+                // Create a new exp.object if the LSID changed XXX
                 if (_prevLsid != null && ensureObject)
                 {
                     assert !Objects.equals(_prevLsid, getLSID());

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -2856,8 +2856,7 @@ public class ExperimentServiceImpl implements ExperimentService
         timer.start();
 
         LOG.debug((verifyEdgesNoInsert ? "Verifying" : "Rebuilding") + " edges for runId " + runId);
-        try (DbScope.Transaction tx = getExpSchema().getScope().ensureTransaction();
-            var x = verifyEdgesNoInsert ? SpringActionController.disallowSqlUpdates() : SpringActionController.ignoreSqlUpdates())
+        try (DbScope.Transaction tx = getExpSchema().getScope().ensureTransaction())
         {
             // NOTE: Originally, we just filtered exp.data by runId.  This works for most runs but includes intermediate exp.data nodes and caused the ExpTest to fail
             SQLFragment datas = new SQLFragment()

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -2701,8 +2701,7 @@ public class ExperimentServiceImpl implements ExperimentService
         else
         {
             Identifiable to = identifiableMap.computeIfAbsent(objectId, this::fetchIdent);
-            String lsid = to.getLSID().replace("justbiotherapeutics.com", "justbio");
-            sb.append("{name=").append(to.getName()).append(", oid=").append(objectId).append(", lsid=").append(lsid).append("}");
+            sb.append("{name=").append(to.getName()).append(", oid=").append(objectId).append(", lsid=").append(to.getLSID()).append("}");
         }
     }
 
@@ -3676,7 +3675,6 @@ public class ExperimentServiceImpl implements ExperimentService
                                 UserSchema schema = QueryService.get().getUserSchema(user, dataset.getContainer(), "study");
                                 TableInfo tableInfo = schema.getTable(dataset.getName());
 
-                                // TODO: add recall events for SampleType rows as well
                                 AssayProvider provider = AssayService.get().getProvider(protocol);
                                 if (provider != null)
                                 {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -73,8 +73,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.labkey.api.exp.query.ExpMaterialTable.Column.RootMaterialLSID;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.AliquotedFromLSID;
+import static org.labkey.api.exp.query.ExpMaterialTable.Column.RootMaterialLSID;
 
 /**
  *

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -6466,6 +6466,44 @@ public class ExperimentController extends SpringActionController
         }
     }
 
+    private static class VerifyEdgesForm extends ExperimentRunForm
+    {
+        private Integer _limit;
+
+        public Integer getLimit()
+        {
+            return _limit;
+        }
+
+        public void setLimit(Integer limit)
+        {
+            _limit = limit;
+        }
+    }
+
+    @Marshal(Marshaller.Jackson)
+    @RequiresPermission(AdminPermission.class)
+    public class VerifyEdgesAction extends ReadOnlyApiAction<VerifyEdgesForm>
+    {
+        @Override
+        public Object execute(VerifyEdgesForm form, BindException errors)
+        {
+            if (form.getRowId() != 0 || form.getLsid() != null)
+            {
+                ExpRunImpl run = form.lookupRun();
+                if (!run.getContainer().hasPermission(getUser(), ReadPermission.class))
+                    throw new UnauthorizedException("Not permitted");
+
+                ExperimentServiceImpl.get().verifyRunEdges(run);
+            }
+            else
+            {
+                ExperimentServiceImpl.get().verifyAllEdges(getContainer(), form.getLimit());
+            }
+            return success();
+        }
+    }
+
     @Marshal(Marshaller.Jackson)
     @RequiresPermission(AdminPermission.class)
     public class CheckDataClassesIndexedAction extends ReadOnlyApiAction

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -47,7 +47,6 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.WorkbookContainerType;
 import org.labkey.api.exp.Lsid;
-import org.labkey.api.exp.api.DataType;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
@@ -1031,7 +1030,7 @@ public class FileContentServiceImpl implements FileContentService
 
             if (data == null && create)
             {
-                data = ExperimentService.get().createData(c, new DataType("UploadedFile"));
+                data = ExperimentService.get().createData(c, FileContentService.UPLOADED_FILE);
                 data.setName(file.getName());
                 data.setDataFileURI(file.toURI());
                 data.save(user);
@@ -1645,7 +1644,7 @@ public class FileContentServiceImpl implements FileContentService
             File childFile = new File(fileRoot, TXT_FILE);
             childFile.createNewFile();
 
-            ExpData data = ExperimentService.get().createData(subsubfolder, new DataType("FileContentTest"));
+            ExpData data = ExperimentService.get().createData(subsubfolder, UPLOADED_FILE);
             data.setDataFileURI(childFile.toPath().toUri());
             data.save(TestContext.get().getUser());
 

--- a/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
+++ b/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
@@ -32,7 +32,6 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.DomainDescriptor;
 import org.labkey.api.exp.OntologyManager;
-import org.labkey.api.exp.api.DataType;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.Domain;
@@ -74,6 +73,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.labkey.api.files.FileContentService.PIPELINE_LINK;
+import static org.labkey.api.files.FileContentService.UPLOADED_FILE;
 
 /**
  * User: klum
@@ -384,7 +384,7 @@ public class FileQueryUpdateService extends AbstractQueryUpdateService
             {
                 _log.debug("Auto-creating ExpData object, as one was not already available. DataFileURL : " + dataFileUrl);
 
-                data = ExperimentService.get().createData(container, new DataType("UploadedFile"));
+                data = ExperimentService.get().createData(container, UPLOADED_FILE);
                 data.setName(resource.getName());
                 URI uri = null;
                 try


### PR DESCRIPTION
Prior to fixing Issue 41675, it was possible that a UploadedFile exp.data
imported into an assay could create a new exp.data and exp.object with
a different LSID and leave the old exp.object in the edge table.  The exp.edge
table and the run ended up out of sync.

This PR finds all orphaned UploadedFile exp.object that are outputs of a run,
rebuilds the runs, and removes the orphaned exp.object rows.

#### Related Issues:
- Issue 41675: exp.object deleted when detaching exp.data from run
- Issue 41675: allow updating the LSID of an existing exp.data

#### Related Pull Requests:
- #1741
- #1758

#### Changes:
- upgrade script to remove orphaned UploadedFile exp.objects and rebuild edge table
- add experiment-verifyRunEdges.api utility action