### PR TITLE
Item 8908: Enable sample actions from Source sample grid

### DIFF
--- a/api/src/org/labkey/api/data/DataRegionSelection.java
+++ b/api/src/org/labkey/api/data/DataRegionSelection.java
@@ -207,9 +207,14 @@ public class DataRegionSelection
         return asInts(getSelected(context, key, clearSession));
     }
 
+    public static @NotNull Set<String> getSnapshotSelected(ViewContext context, @Nullable String key)
+    {
+        return getSet(context, key, false, true);
+    }
+
     public static @NotNull Set<Integer> getSnapshotSelectedIntegers(ViewContext context, @Nullable String key)
     {
-        Set<String> selected = getSet(context, key, false, true);
+        Set<String> selected = getSnapshotSelected(context, key);
         return asInts(selected == null ? new HashSet<>() : selected);
     }
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -5684,6 +5684,25 @@ public class QueryController extends SpringActionController
         }
     }
 
+    @RequiresPermission(ReadPermission.class)
+    public static class GetSnapshotSelectionAction extends ReadOnlyApiAction<SelectForm>
+    {
+        @Override
+        public void validateForm(SelectForm form, Errors errors)
+        {
+            if (StringUtils.isEmpty(form.getKey()))
+            {
+                errors.reject(ERROR_MSG, "Selection key is required");
+            }
+        }
+
+        @Override
+        public ApiResponse execute(final SelectForm form, BindException errors) throws Exception
+        {
+            Set<String> selected = DataRegionSelection.getSnapshotSelected(getViewContext(), form.getKey());
+            return new ApiSimpleResponse("selected", selected);
+        }
+    }
 
     public static String getMessage(SqlDialect d, SQLException x)
     {


### PR DESCRIPTION
#### Rationale
To allow sample actions from FM storage grids, setSnapshotSelection is utilized to pass inventory grid selection to SM, to allow the set of selected samples to be worked on. This PR add the action to read the snapshot selection.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/552
* https://github.com/LabKey/platform/pull/2328
* https://github.com/LabKey/inventory/pull/252
* https://github.com/LabKey/sampleManagement/pull/591
* https://github.com/LabKey/biologics/pull/905
* 
#### Changes
* add GetSnapshotSelectionAction