### PR TITLE
Issue 43279: XML Metadata: GUI editor loses previous changes

### DIFF
--- a/api/src/org/labkey/api/exp/query/DataClassUserSchema.java
+++ b/api/src/org/labkey/api/exp/query/DataClassUserSchema.java
@@ -92,11 +92,10 @@ public class DataClassUserSchema extends AbstractExpSchema
         return createTable(dataClass, cf);
     }
 
-    public ExpDataClassDataTable createTable(@NotNull ExpDataClass dataClass, ContainerFilter cf)
+    private ExpDataClassDataTable createTable(@NotNull ExpDataClass dataClass, ContainerFilter cf)
     {
         ExpDataClassDataTable ret = ExperimentService.get().createDataClassDataTable(dataClass.getName(), this, cf, dataClass);
         ret.populate();
-        ret.overlayMetadata(ret.getPublicName(), DataClassUserSchema.this, new ArrayList<>());
         return ret;
     }
 

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -117,8 +117,9 @@ public class ExpSchema extends AbstractExpSchema
             {
                 SamplesSchema schema = new SamplesSchema(expSchema.getPath(), expSchema.getUser(), expSchema.getContainer());
                 schema.setContainerFilter(expSchema._containerFilter);
-                ExpMaterialTable result = schema.getSampleTable(null, cf);
-                return result;
+                ExpMaterialTable ret = ExperimentService.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), expSchema, cf);
+                ret.populate(null, true);
+                return ret;
             }
         },
         MaterialInputs

--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -132,18 +132,19 @@ public class SamplesSchema extends AbstractExpSchema
         if (st == null)
             return null;
 
+        AbstractTableInfo tableInfo = (AbstractTableInfo) createSampleTable(st, cf);
+
         // Get linked to study columns
         StudyPublishService studyPublishService = StudyPublishService.get();
         if (studyPublishService != null)
         {
-            AbstractTableInfo tableInfo = (AbstractTableInfo) getSampleTable(st, cf);
-            int rowId = getSampleTypes().get(tableInfo.getName()).getRowId();
+            int rowId = st.getRowId();
             String rowIdNameString = ExpMaterialTable.Column.RowId.toString();
             studyPublishService.addLinkedToStudyColumns(tableInfo, Dataset.PublishSource.SampleType, true, rowId, rowIdNameString, getUser());
             return tableInfo;
         }
         
-        return getSampleTable(st, cf);
+        return tableInfo;
     }
 
     @Override
@@ -158,8 +159,14 @@ public class SamplesSchema extends AbstractExpSchema
         return queryView;
     }
 
+    /** Convenience method that takes a sample type instead of a string to provide a more robust mapping */
+    public ExpMaterialTable getTable(@NotNull ExpSampleType st, @Nullable ContainerFilter cf)
+    {
+        return (ExpMaterialTable) getTable(st.getName(), cf);
+    }
+
     /** Creates a table of materials, scoped to the given sample type and including its custom columns, if provided */
-    public ExpMaterialTable getSampleTable(@Nullable ExpSampleType st, ContainerFilter cf)
+    private ExpMaterialTable createSampleTable(@Nullable ExpSampleType st, ContainerFilter cf)
     {
         if (log.isTraceEnabled())
         {
@@ -167,7 +174,6 @@ public class SamplesSchema extends AbstractExpSchema
         }
         ExpMaterialTable ret = ExperimentService.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), this, cf);
         ret.populate(st, true);
-        ret.overlayMetadata(ret.getPublicName(), SamplesSchema.this, new ArrayList<>());
         return ret;
     }
 

--- a/experiment/src/org/labkey/experiment/api/LineageTableInfo.java
+++ b/experiment/src/org/labkey/experiment/api/LineageTableInfo.java
@@ -176,9 +176,7 @@ public class LineageTableInfo extends VirtualTable
                         _table = getUserSchema().getCachedLookupTableInfo(getClass().getName() + "/Samples/" + st.getRowId() + "/" + st.getName(), () ->
                         {
                             SamplesSchema samplesSchema = new SamplesSchema(_userSchema);
-                            var ret = samplesSchema.getSampleTable(st, null);
-                            ret.setLocked(true);
-                            return ret;
+                            return samplesSchema.getTable(st, null);
                         });
                     return _table;
                 }
@@ -207,9 +205,7 @@ public class LineageTableInfo extends VirtualTable
                         _table = getUserSchema().getCachedLookupTableInfo(getClass().getName() + "/DataClass/" + dc.getRowId() + "/" + dc.getName(), () ->
                         {
                             DataClassUserSchema dcus = new DataClassUserSchema(_userSchema.getContainer(), _userSchema.getUser());
-                            var ret = dcus.createTable(dc, getLookupContainerFilter());
-                            ret.setLocked(true);
-                            return ret;
+                            return dcus.getTable(dc.getName(), getLookupContainerFilter());
                         });
                     return _table;
                 }

--- a/study/src/org/labkey/study/query/SampleDatasetTable.java
+++ b/study/src/org/labkey/study/query/SampleDatasetTable.java
@@ -113,7 +113,7 @@ public class SampleDatasetTable extends DatasetTableImpl
             // Hide 'linked' column for Sample Type Datasets
             if (userSchema instanceof SamplesSchema)
             {
-                _sampleTable = ((SamplesSchema) userSchema).getSampleTable(sampleType, ContainerFilter.EVERYTHING);
+                _sampleTable = ((SamplesSchema) userSchema).getTable(sampleType, ContainerFilter.EVERYTHING);
             }
             else
             {


### PR DESCRIPTION
#### Rationale
TableInfos should generally be created via UserSchema.getTable() which applies XML metadata by default, but callers can opt-out when we're wanting to diff the configuration against the "real" table as opposed to the customized table

Sample types and data classes were always applying the XML customizations, messing up the diffing, and making subsequent edits destructive of prior changes

#### Changes
* Let getTable() control how XML metadata is applied
* Make it harder to call methods that are for internal schema implementation