### PR TITLE
Issue 42873: Standard assay SQL exception joining to inputs materials…

### DIFF
--- a/experiment/src/org/labkey/experiment/api/LineageForeignKey.java
+++ b/experiment/src/org/labkey/experiment/api/LineageForeignKey.java
@@ -160,7 +160,10 @@ class LineageForeignKey extends AbstractForeignKey
         // that's why we extend AbstractForeignKey instead of LookupForeignKey.
         // CONSIDER: we could consider adding a "really don't add any joins" flag to LookupForeignKey for this pattern
         SQLFragment sql = parent.getValueSql(ExprColumn.STR_TABLE_ALIAS);
-        var col = new ExprColumn(parent.getParentTable(), new FieldKey(parent.getFieldKey(), displayField), sql, JdbcType.INTEGER);
+
+        // Issue 42873 - need to include parent as a dependency so that it can be resolved when we're not coming from
+        // the base table of the query, but are instead being resolved through a lookup
+        var col = new ExprColumn(parent.getParentTable(), new FieldKey(parent.getFieldKey(), displayField), sql, JdbcType.INTEGER, parent);
         col.setFk(lookup.getFk());
         col.setUserEditable(false);
         col.setReadOnly(true);


### PR DESCRIPTION
… name without DataId also in the view

#### Rationale
The Data and Material table's "Inputs" column work well when viewed from those tables as the base, but if you're joining via a lookup and not including the Data or Material column itself, we'll generate incomplete SQL

#### Changes
* Include parent column as a dependency so that we're sure to include the right table in the FROM clause for the SQL