### PR TITLE
Issue 43321: Session-based custom views aren't scoped by the schema name

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -5285,6 +5285,7 @@ public class QueryController extends SpringActionController
         }
     }
 
+    /** Minimalist, secret UI to help users recover if they've created a broken view somehow */
     @RequiresPermission(AdminPermission.class)
     public class ManageViewsAction extends SimpleViewAction<QueryForm>
     {
@@ -5313,6 +5314,7 @@ public class QueryController extends SpringActionController
     }
 
 
+    /** Minimalist, secret UI to help users recover if they've created a broken view somehow */
     @RequiresPermission(AdminPermission.class)
     public class InternalDeleteView extends ConfirmAction<InternalViewForm>
     {
@@ -5343,7 +5345,7 @@ public class QueryController extends SpringActionController
         }
     }
 
-
+    /** Minimalist, secret UI to help users recover if they've created a broken view somehow */
     @RequiresPermission(AdminPermission.class)
     public class InternalSourceViewAction extends FormViewAction<InternalSourceViewForm>
     {
@@ -5391,7 +5393,7 @@ public class QueryController extends SpringActionController
         }
     }
 
-
+    /** Minimalist, secret UI to help users recover if they've created a broken view somehow */
     @RequiresPermission(AdminPermission.class)
     public class InternalNewViewAction extends FormViewAction<InternalNewViewForm>
     {

--- a/query/src/org/labkey/query/view/manageViews.jsp
+++ b/query/src/org/labkey/query/view/manageViews.jsp
@@ -32,6 +32,7 @@
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Objects" %>
+<%@ page import="org.labkey.api.query.SchemaKey" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -68,10 +69,10 @@
         views.addAll(mgr.getCstmViews(c, schemaName, queryName, null, user, false, false));
     }
 
-    // UNDONE: Requires queryName for now.  We need a method to get all session views in a container.
-    if (queryName != null)
+    // UNDONE: Requires queryName and schemaName for now.  We need a method to get all session views in a container.
+    if (queryName != null && schemaName != null && schemaName.length() > 0)
     {
-        views.addAll(CustomViewSetKey.getCustomViewsFromSession(getViewContext().getRequest(), c, queryName).values());
+        views.addAll(CustomViewSetKey.getCustomViewsFromSession(getViewContext().getRequest(), c, queryName, SchemaKey.fromString(schemaName)).values());
     }
 
     views.sort((o1, o2) ->


### PR DESCRIPTION
#### Rationale
Session-based views should be scoped by schema, query, and container, but are currently only using query and container. That's usually enough, but not always.

#### Changes
* Use session as part of key in session grid view map
* Comments to clarify use case for some internal view fixup, semi-secret UI