### PR TITLE
Issue43119: Layout problems on Link to Study page

### DIFF
--- a/api/src/org/labkey/api/study/publish/publishChooseStudy.jsp
+++ b/api/src/org/labkey/api/study/publish/publishChooseStudy.jsp
@@ -77,10 +77,20 @@
 <style>
     .control-label {
         width: 270px !important;
+        padding-top: 0 !important;
+    }
+
+    .col-sm-9 {
+        width: 400px !important;
     }
 
     .col-lg-10 {
-        width: 45px !important;
+        min-width: 400px !important;
+        width: 40vw !important;
+    }
+
+    .form-control {
+        width: inherit !important;
     }
 
     .form-control-static {


### PR DESCRIPTION
#### Rationale
I overlooked a regression, or something odd, in my prior fix for the width juddering on the Assay Run Link to Study Page. This PR resolves the layout issues.
Note: I asked about this on the frontend gRoom for the prior fix, and the advice was to not change the <labkey:input type="checkbox"/>, but to override styles and shift around the html.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2276

#### Changes
* Issue43119: Fix UI snapping on publishChooseStudy.jsp in assay run case when screen is horizontally resized
