### PR TITLE
Fix S3ImportTTestt test outage

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -4690,7 +4690,7 @@ public class AdminController extends SpringActionController
                     for (org.labkey.api.writer.Writer child : childWriters)
                     {
                         dataType = child.getDataType();
-                        if (dataType != null)
+                        if (dataType != null && !dataType.endsWith("Dataset Data"))
                             registeredFolderWriters.add(dataType);
                     }
                 }

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -4690,7 +4690,7 @@ public class AdminController extends SpringActionController
                     for (org.labkey.api.writer.Writer child : childWriters)
                     {
                         dataType = child.getDataType();
-                        if (dataType != null && !dataType.endsWith("Dataset Data"))
+                        if (dataType != null)
                             registeredFolderWriters.add(dataType);
                     }
                 }

--- a/study/src/org/labkey/study/writer/AssayDatasetData.java
+++ b/study/src/org/labkey/study/writer/AssayDatasetData.java
@@ -18,4 +18,10 @@ public class AssayDatasetData implements InternalStudyWriter
     public void write(StudyImpl object, StudyExportContext ctx, VirtualFile vf) throws Exception
     {
     }
+
+    @Override
+    public boolean includeWithTemplate()
+    {
+        return false;
+    }
 }

--- a/study/src/org/labkey/study/writer/SampleTypeDatasetData.java
+++ b/study/src/org/labkey/study/writer/SampleTypeDatasetData.java
@@ -18,4 +18,10 @@ public class SampleTypeDatasetData implements InternalStudyWriter
     public void write(StudyImpl object, StudyExportContext ctx, VirtualFile vf) throws Exception
     {
     }
+
+    @Override
+    public boolean includeWithTemplate()
+    {
+        return false;
+    }
 }

--- a/study/src/org/labkey/study/writer/StudyDatasetData.java
+++ b/study/src/org/labkey/study/writer/StudyDatasetData.java
@@ -18,4 +18,10 @@ public class StudyDatasetData implements InternalStudyWriter
     public void write(StudyImpl object, StudyExportContext ctx, VirtualFile vf) throws Exception
     {
     }
+
+    @Override
+    public boolean includeWithTemplate()
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
#### Rationale
Importing a folder from a template should not retain dataset data info, but as of an update to folder export, dataset data was being included within 'Folder Management > Export > Folder objects to export'. 

#### Related Pull Requests
* n/a

#### Changes
* Specifically within folder template export, do not add any 'Dataset Data' writers
