### PR TITLE
Issue41645: Add User button on Project Users Banner

### DIFF
--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -2850,8 +2850,8 @@ public class SecurityManager
 
             if (!context.getContainer().isRoot())
             {
-                LinkBuilder projectGroupLink = new LinkBuilder("here").href(PageFlowUtil.urlProvider(SecurityUrls.class).getPermissionsURL(context.getContainer())).target("_blank").clearClasses();
-                message.append(" Add ").append(email.getEmailAddress()).append(" to a Project Group ").append(projectGroupLink).append(".");
+                LinkBuilder projectGroupLink = new LinkBuilder("here").href(PageFlowUtil.urlProvider(SecurityUrls.class).getPermissionsURL(context.getContainer())).clearClasses();
+                message.append(" Add the new user to a Project Group ").append(projectGroupLink).append(".");
             }
         }
 

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -2804,6 +2804,15 @@ public class SecurityManager
             {
                 message.append(email.getEmailAddress()).append(" added as a new user to the system and emailed successfully.");
                 UserManager.addToUserHistory(newUser, newUser.getEmail() + " was added to the system. Verification email was sent successfully.");
+
+                if (!context.getContainer().isRoot())
+                {
+                    LinkBuilder link = new LinkBuilder("here").href(PageFlowUtil.urlProvider(SecurityUrls.class).getPermissionsURL(context.getContainer())).target("_blank").clearClasses();
+
+                    message.append(HtmlString.unsafe("<p>"));
+                    message.append("Add ").append(email.getEmailAddress()).append(" to a Project Group ").append(link).append(".");
+                    message.append(HtmlString.unsafe("</p>"));
+                }
             }
             else
             {
@@ -2846,7 +2855,10 @@ public class SecurityManager
         if (messageContentsURL != null && provider == null)
         {
             LinkBuilder link = new LinkBuilder("here").href(messageContentsURL).target("_blank").clearClasses();
-            message.append(" Click ").append(link).append(" to see the email.");
+
+            message.append(HtmlString.unsafe("<p>"));
+            message.append("Click ").append(link).append(" to see the email.");
+            message.append(HtmlString.unsafe("</p>"));
         }
 
         return message.getHtmlString();

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -2808,10 +2808,7 @@ public class SecurityManager
                 if (!context.getContainer().isRoot())
                 {
                     LinkBuilder link = new LinkBuilder("here").href(PageFlowUtil.urlProvider(SecurityUrls.class).getPermissionsURL(context.getContainer())).target("_blank").clearClasses();
-
-                    message.append(HtmlString.unsafe("<p>"));
-                    message.append("Add ").append(email.getEmailAddress()).append(" to a Project Group ").append(link).append(".");
-                    message.append(HtmlString.unsafe("</p>"));
+                    message.append(" Add ").append(email.getEmailAddress()).append(" to a Project Group ").append(link).append(".");
                 }
             }
             else
@@ -2855,10 +2852,7 @@ public class SecurityManager
         if (messageContentsURL != null && provider == null)
         {
             LinkBuilder link = new LinkBuilder("here").href(messageContentsURL).target("_blank").clearClasses();
-
-            message.append(HtmlString.unsafe("<p>"));
-            message.append("Click ").append(link).append(" to see the email.");
-            message.append(HtmlString.unsafe("</p>"));
+            message.append(" Click ").append(link).append(" to see the email.");
         }
 
         return message.getHtmlString();

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -2804,12 +2804,6 @@ public class SecurityManager
             {
                 message.append(email.getEmailAddress()).append(" added as a new user to the system and emailed successfully.");
                 UserManager.addToUserHistory(newUser, newUser.getEmail() + " was added to the system. Verification email was sent successfully.");
-
-                if (!context.getContainer().isRoot())
-                {
-                    LinkBuilder link = new LinkBuilder("here").href(PageFlowUtil.urlProvider(SecurityUrls.class).getPermissionsURL(context.getContainer())).target("_blank").clearClasses();
-                    message.append(" Add ").append(email.getEmailAddress()).append(" to a Project Group ").append(link).append(".");
-                }
             }
             else
             {
@@ -2853,6 +2847,12 @@ public class SecurityManager
         {
             LinkBuilder link = new LinkBuilder("here").href(messageContentsURL).target("_blank").clearClasses();
             message.append(" Click ").append(link).append(" to see the email.");
+
+            if (!context.getContainer().isRoot())
+            {
+                LinkBuilder projectGroupLink = new LinkBuilder("here").href(PageFlowUtil.urlProvider(SecurityUrls.class).getPermissionsURL(context.getContainer())).target("_blank").clearClasses();
+                message.append(" Add ").append(email.getEmailAddress()).append(" to a Project Group ").append(projectGroupLink).append(".");
+            }
         }
 
         return message.getHtmlString();


### PR DESCRIPTION
#### Rationale
While the previous dev allowed Project Admins, but not Folder Admins, to add new users to their project via adding a 'Add Users' button on the Project Users grid. Clicking 'Add Users' then redirects to the project's 'Add Users' page.
However, the newly created user doesn't belong to any groups, and so will not show up in the Project Users grid, which may lead to justifiable confusion. The proposed solution is to include a banner message directing the user to add the new user to a Project Group via a link.


#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1631

#### Changes
* (Currently) Include additional message text directing user to add the newly created user to a Project Group
