### PR TITLE
Issue43330: Sample Type delete message displays names in random order

### DIFF
--- a/experiment/webapp/experiment/confirmDelete.js
+++ b/experiment/webapp/experiment/confirmDelete.js
@@ -48,7 +48,12 @@ LABKEY.experiment.confirmDelete = function(schemaName, queryName, selectionKey, 
                 if (associatedDatasetsLength > 0) {
                     text += "<br/><br/> The selected row(s) will also be deleted from the linked dataset(s) in the following studies:";
                     text += "<ul>";
-                    associatedDatasets.forEach(dataset => {
+                    // Alphabetize by dataset name before displaying text rows
+                    associatedDatasets.sort((dataset1, dataset2) => {
+                        if(dataset1.name < dataset2.name) { return -1; }
+                        if(dataset1.name > dataset2.name) { return 1; }
+                        return 0;
+                    }).forEach(dataset => {
                         text += `<li> <a href="${dataset.url}" target="_blank"> ${dataset.name} </a> </li>`
                     });
                     text += "</ul>";


### PR DESCRIPTION
#### Rationale
Currently `associatedDatasets` is essentially randomized due to being the result of a json payload. The result is a list of study names within the sample type delete dialogue (if rows are linked to studies) that is in random order, which could both be hard to parse for longer lists and confuses the tests.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2276

#### Changes
* Sort array alphabetically by dataset name before displaying
