### PR TITLE
Issue 43334: Check for LABKEY.moduleContext to prevent JS error if session invalid check called when the moduleContext isn't available

### DIFF
--- a/api/webapp/clientapi/dom/WebSocket.js
+++ b/api/webapp/clientapi/dom/WebSocket.js
@@ -108,7 +108,10 @@ LABKEY.WebSocket = new function ()
     }
 
     function isSessionInvalidBackgroundHideEnabled() {
-        if (LABKEY.moduleContext.api.compliance) {
+        // Issue 43334: JS error if this is called when the moduleContext isn't available, err on the side of compliance
+        if (!LABKEY.moduleContext || !LABKEY.moduleContext.api) {
+            return true;
+        } else if (LABKEY.moduleContext.api.compliance) {
             return LABKEY.moduleContext.api.compliance.sessionInvalidBackgroundHideEnabled
         }
         return false;


### PR DESCRIPTION
#### Rationale
Issue [43334](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43334): LABKEY.moduleContext.api is undefined in WebSocket's isSessionInvalidBackgroundHideEnabled() function

I don't have a local repro for this, but this PR adds in some extra checks for the LABKEY.moduleContext when the check is made to see if the session invalid compliance property is set. In the event that we don't have a LABKEY.moduleContext, I decided to err on the side of compliance and go with the blurred background behavior.

#### Changes
* Add checks in isSessionInvalidBackgroundHideEnabled() to make sure LABKEY.moduleContext is defined
