### PR TITLE
SampleTypeLinkToStudyTest: Add nullcheck to prevent crawler error

### DIFF
--- a/study/src/org/labkey/study/controllers/publish/SampleTypePublishStartAction.java
+++ b/study/src/org/labkey/study/controllers/publish/SampleTypePublishStartAction.java
@@ -104,7 +104,7 @@ public class SampleTypePublishStartAction extends AbstractPublishStartAction<Sam
     protected List<Integer> getDataIDs(SampleTypePublishStartForm form)
     {
         // TODO in later story within epic: Support SampleType-level links
-        if (_ids.isEmpty() && !form.isSampleTypeIds())
+        if (_ids.isEmpty() && !form.isSampleTypeIds() && null != form.getRowId())
         {
             _ids = getCheckboxIds(getViewContext());
             _sampleType = SampleTypeService.get().getSampleType(form.getContainer(), form.getUser(), form.getRowId());


### PR DESCRIPTION
#### Rationale
Upon directly hitting the endpoint `publish-sampleTypePublishStart.view?containerFilterName=Current` without any row selection within a sample type, no rowId will be posted, leading to a NullPointerException. Doing the following check allows for the `sampleTypePublishStart` to display appropriately, and on clicking 'next' to `sampleTypePublishConfirm`, the expected error message "Oops! The requested page cannot be found. Sample Type ID not specified." displays.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2276

#### Changes
* Add nullcheck
