### PR TITLE
Always include required modules in the container.getActiveModules() set

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -931,7 +931,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
 
     public Set<Module> getRequiredModules()
     {
-        Set<Module> requiredModules = new HashSet<>(getFolderType().getActiveModules());
+        Set<Module> requiredModules = new HashSet<>(getRequiredModulesForFolderType(getFolderType()));
         requiredModules.add(ModuleLoader.getInstance().getModule("API"));
         requiredModules.add(ModuleLoader.getInstance().getModule("Internal"));
 
@@ -939,11 +939,28 @@ public class Container implements Serializable, Comparable<Container>, Securable
         {
             if (child.isWorkbook())
             {
-                requiredModules.addAll(child.getFolderType().getActiveModules());
+                requiredModules.addAll(getRequiredModulesForFolderType(child.getFolderType()));
             }
         }
 
         return requiredModules;
+    }
+
+    public Set<Module> getRequiredModulesForFolderType(FolderType folderType)
+    {
+        Set<Module> modules = new HashSet<>();
+        if (!folderType.equals(FolderType.NONE))
+        {
+            for (Module module : folderType.getActiveModules())
+            {
+                // check for null, since there's no guarantee that a third-party folder type has all its
+                // active modules installed on this system (so nulls may end up in the list- bug 6757):
+                // Don't restrict based on userHasEnableRestrictedModules, since user is already accessing folder
+                if (module != null && module.canBeEnabled(this))
+                    modules.add(module);
+            }
+        }
+        return modules;
     }
 
     @NotNull
@@ -1166,6 +1183,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
         Set<Module> modules = new HashSet<>();
 
         // always put the required modules in the set
+        // note that this will pickup the modules from the folder type's getActiveModules()
         modules.addAll(getRequiredModules());
 
         // add all modules found in user preferences:
@@ -1174,19 +1192,6 @@ public class Container implements Serializable, Comparable<Container>, Securable
             Module module = ModuleLoader.getInstance().getModule(moduleName);
             if (module != null && module.canBeEnabled(this))
                 modules.add(module);
-        }
-
-        // ensure all modules for folder type are added (may have been added after save)
-        if (!getFolderType().equals(FolderType.NONE))
-        {
-            for (Module module : getFolderType().getActiveModules())
-            {
-                // check for null, since there's no guarantee that a third-party folder type has all its
-                // active modules installed on this system (so nulls may end up in the list- bug 6757):
-                // Don't restrict based on userHasEnableRestrictedModules, since user is already accessing folder
-                if (module != null && module.canBeEnabled(this))
-                    modules.add(module);
-            }
         }
 
         // add all 'always display' modules, remove all 'never display' modules:

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1164,6 +1164,10 @@ public class Container implements Serializable, Comparable<Container>, Securable
         }
 
         Set<Module> modules = new HashSet<>();
+
+        // always put the required modules in the set
+        modules.addAll(getRequiredModules());
+
         // add all modules found in user preferences:
         for (String moduleName : props.keySet())
         {


### PR DESCRIPTION
#### Rationale
We have recently been adding some more server level context to the LABKEY JS object using the "api" module for use in the client side via the LABKEY.moduleContext.api. Some examples include allowing the shared components code to be able to tell which modules are available on the given server (i.e. do we have the "premium" module? do we have the "ontology" module). We also use this for the new session invalid behavior property for compliance settings as a way to make sure the property value is available in the client side code for all LK containers.

However, it looks like there are some scenarios which create a LK project or container via an API call which can results in the "API" module not being considered part of the active modules set. This PR make sure that the required modules are always added to the container.getActiveModules() set (they are required after all).

#### Changes
* Add required modules to the container.getActiveModules() set
