### PR TITLE
43366: Users without AddUserPermission can still create new users from the manage group UI

### DIFF
--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -834,12 +834,15 @@ public class SecurityController extends SpringActionController
 
                 // issue 43366 : users without the AddUserPermission are still allowed to create new users through the
                 // manage group UI.
-                for (ValidEmail email : addEmails)
+                if (!container.hasPermission(getUser(), AddUserPermission.class))
                 {
-                    if (!UserManager.userExists(email) && !container.hasPermission(getUser(), AddUserPermission.class))
+                    for (ValidEmail email : addEmails)
                     {
-                        errors.reject(ERROR_MSG, "You do not have permissions to create new users.");
-                        break;
+                        if (!UserManager.userExists(email))
+                        {
+                            errors.reject(ERROR_MSG, "You do not have permissions to create new users.");
+                            break;
+                        }
                     }
                 }
 

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -832,7 +832,18 @@ public class SecurityController extends SpringActionController
                     }
                 }
 
-                if (addGroups.size() > 0 || addEmails.size() > 0)
+                // issue 43366 : users without the AddUserPermission are still allowed to create new users through the
+                // manage group UI.
+                for (ValidEmail email : addEmails)
+                {
+                    if (!UserManager.userExists(email) && !container.hasPermission(getUser(), AddUserPermission.class))
+                    {
+                        errors.reject(ERROR_MSG, "You do not have permissions to create new users.");
+                        break;
+                    }
+                }
+
+                if (!errors.hasErrors() && (addGroups.size() > 0 || addEmails.size() > 0))
                 {
                     // add new users
                     List<User> addUsers = new ArrayList<>(addEmails.size());


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=43366

#### Changes
The UI allows adding existing as well as new users to the group, spin through the user list to validate permissions and either fail or succeed the entire (user operation).