### PR TITLE
Issue 43368: Infinite redirect when hitting assay upload wizard

### DIFF
--- a/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
+++ b/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
@@ -471,7 +471,8 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
         if (!showBatchStep(runForm, uploadDomain))
         {
             ActionURL helper = getViewContext().cloneActionURL();
-            helper.replaceParameter("uploadStep", RunStepHandler.NAME);
+            // Add parameter to say that we've competed the batch step
+            helper.replaceParameter("uploadStep", BatchStepHandler.NAME);
             throw new RedirectException(helper);
         }
         InsertView insertView = createBatchInsertView(runForm, errorReshow, errors);
@@ -913,10 +914,11 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
         @Override
         public ModelAndView getNextStep(FormType form, BindException errors) throws ServletException, SQLException, ExperimentException
         {
-            if (form.isResetDefaultValues() || errors.hasErrors())
+            if ((form.isResetDefaultValues() || errors.hasErrors()) && showBatchStep(form, form.getProvider().getBatchDomain(form.getProtocol())))
                 return getBatchPropertiesView(form, !form.isResetDefaultValues(), errors);
-            else
-                return getRunPropertiesView(form, false, false, errors);
+
+            // Move forward to the run step
+            return getRunPropertiesView(form, false, false, errors);
         }
 
         @Override

--- a/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
+++ b/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
@@ -471,7 +471,7 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
         if (!showBatchStep(runForm, uploadDomain))
         {
             ActionURL helper = getViewContext().cloneActionURL();
-            helper.replaceParameter("uploadStep", BatchStepHandler.NAME);
+            helper.replaceParameter("uploadStep", RunStepHandler.NAME);
             throw new RedirectException(helper);
         }
         InsertView insertView = createBatchInsertView(runForm, errorReshow, errors);


### PR DESCRIPTION
Happens when you have a batchId parameter and no batch properties in design

#### Changes
* Redirect to run page of the wizard as intended. Must be a long-standing copy/paste error