### PR TITLE
Issue 43374: Some characters in file names cause a problem when creating exp.data rows in FileImporter

### DIFF
--- a/api/src/org/labkey/api/data/ExcelColumn.java
+++ b/api/src/org/labkey/api/data/ExcelColumn.java
@@ -44,6 +44,7 @@ import org.apache.poi.xssf.usermodel.XSSFClientAnchor;
 import org.apache.poi.xssf.usermodel.XSSFPicture;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.labkey.api.action.NullSafeBindException;
@@ -843,6 +844,8 @@ public class ExcelColumn extends RenderColumn
         @BeforeClass
         public static void initialSetUp() throws Exception
         {
+            Assume.assumeTrue("This test requires the list module.", ListService.get() != null);
+
             doInitialSetUp(PROJECT_NAME);
         }
 

--- a/experiment/src/org/labkey/experiment/api/LineageTest.java
+++ b/experiment/src/org/labkey/experiment/api/LineageTest.java
@@ -4,6 +4,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
@@ -327,6 +328,7 @@ public class LineageTest extends ExpProvisionedTableTestHelper
     @Test
     public void testListAndSampleLineage() throws Exception
     {
+        Assume.assumeTrue("This test requires the list module.", ListService.get() != null);
         final User user = TestContext.get().getUser();
 
         // setup sample type

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -1456,9 +1456,9 @@ public class FileContentServiceImpl implements FileContentService
         return selector.getArrayList(String.class);
     }
 
-    public Path getPath(String uri)
+    public Path getPath(String uri, boolean encoded)
     {
-        Path path = Path.decode(uri);
+        Path path = encoded ? Path.decode(uri) : Path.parse(uri);
 
         if (!path.startsWith(WebdavService.getPath()) && path.contains(WebdavService.getPath().getName()))
         {
@@ -1474,10 +1474,21 @@ public class FileContentServiceImpl implements FileContentService
         return path;
     }
 
+    public Path getPath(String uri)
+    {
+        return getPath(uri, true);
+    }
+
     @Nullable
     public WebdavResource getResource(String uri)
     {
-        Path path = getPath(uri);
+        return getResource(uri, true);
+    }
+
+    @Nullable
+    public WebdavResource getResource(String uri, boolean encoded)
+    {
+        Path path = getPath(uri, encoded);
         return WebdavService.get().getResolver().lookup(path);
     }
 

--- a/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
+++ b/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
@@ -550,7 +550,7 @@ public class FileQueryUpdateService extends AbstractQueryUpdateService
                     offset = offset.substring(1);
 
                 String davUrl = rootDavUrl + "/" + offset;
-                WebdavResource resource = FileContentServiceImpl.getInstance().getResource(davUrl);
+                WebdavResource resource = FileContentServiceImpl.getInstance().getResource(davUrl, false);
                 if (targetResource == null)
                     targetResource = resource;
                 else

--- a/query/src/org/labkey/query/QueryServiceImplTestCase.jsp
+++ b/query/src/org/labkey/query/QueryServiceImplTestCase.jsp
@@ -1,9 +1,10 @@
 <%@ page import="org.junit.AfterClass" %>
+<%@ page import="org.junit.Assume" %>
 <%@ page import="org.junit.BeforeClass" %>
 <%@ page import="org.junit.Test" %>
 <%@ page import="org.labkey.api.data.Container" %>
-<%@ page import="org.labkey.api.data.DbScope" %>
 <%@ page import="static org.junit.Assert.*" %>
+<%@ page import="org.labkey.api.data.DbScope" %>
 <%@ page import="org.labkey.api.data.JdbcType" %>
 <%@ page import="org.labkey.api.data.PropertyStorageSpec" %>
 <%@ page import="org.labkey.api.data.SQLFragment" %>
@@ -28,7 +29,6 @@
 <%@ page import="java.sql.SQLException" %>
 <%@ page import="java.util.Arrays" %>
 <%@ page import="java.util.List" %>
-<%@ page import="java.util.Map" %>
 <%@ page extends="org.labkey.api.jsp.JspTest.DRT" %>
 <%!
     final static String tableName = "testGetSelectSqlSort";
@@ -129,7 +129,9 @@
     @BeforeClass
     public static void createList() throws Exception
     {
-        deleteList();
+        Assume.assumeTrue("This test requires the list module.", ListService.get() != null);
+
+        JunitUtil.deleteTestContainer();
 
         User user = TestContext.get().getUser();
         Container c = JunitUtil.getTestContainer();
@@ -145,14 +147,9 @@
 
 
     @AfterClass
-    public static void deleteList() throws Exception
+    public static void cleanup() throws Exception
     {
-        User user = TestContext.get().getUser();
-        Container c = JunitUtil.getTestContainer();
-        ListService s = ListService.get();
-        Map<String, ListDefinition> m = s.getLists(c);
-        if (m.containsKey(tableName))
-            m.get(tableName).delete(user);
+        JunitUtil.deleteTestContainer();
     }
 
 

--- a/specimen/src/org/labkey/specimen/security/roles/SpecimenCoordinatorRole.java
+++ b/specimen/src/org/labkey/specimen/security/roles/SpecimenCoordinatorRole.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.specimen.security.roles;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.permissions.EditSharedViewPermission;
@@ -31,6 +32,9 @@ import org.labkey.api.specimen.security.permissions.ManageSpecimenActorsPermissi
 import org.labkey.api.specimen.security.permissions.RequestSpecimensPermission;
 import org.labkey.api.specimen.security.permissions.SetSpecimenCommentsPermission;
 import org.labkey.api.study.security.permissions.ManageStudyPermission;
+
+import java.util.Collection;
+import java.util.Set;
 
 /*
 * User: Dave
@@ -61,5 +65,11 @@ public class SpecimenCoordinatorRole extends AbstractSpecimenRole
         );
         addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));
         addExcludedPrincipal(SecurityManager.getGroup(Group.groupUsers));
+    }
+
+    @Override
+    public @NotNull Collection<String> getSerializationAliases()
+    {
+        return Set.of("org.labkey.study.security.roles.SpecimenCoordinatorRole");
     }
 }

--- a/specimen/src/org/labkey/specimen/security/roles/SpecimenRequesterRole.java
+++ b/specimen/src/org/labkey/specimen/security/roles/SpecimenRequesterRole.java
@@ -15,9 +15,13 @@
  */
 package org.labkey.specimen.security.roles;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.specimen.security.permissions.RequestSpecimensPermission;
+
+import java.util.Collection;
+import java.util.Set;
 
 /*
 * User: Dave
@@ -32,5 +36,11 @@ public class SpecimenRequesterRole extends AbstractSpecimenRole
                 "Specimen Requesters may request specimen vials.",
                 RequestSpecimensPermission.class);
         addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));
+    }
+
+    @Override
+    public @NotNull Collection<String> getSerializationAliases()
+    {
+        return Set.of("org.labkey.study.security.roles.SpecimenRequesterRole");
     }
 }

--- a/visualization/src/org/labkey/visualization/sql/VisualizationCDSGenerator.java
+++ b/visualization/src/org/labkey/visualization/sql/VisualizationCDSGenerator.java
@@ -20,6 +20,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.labkey.api.action.NullSafeBindException;
 import org.labkey.api.data.ColumnInfo;
@@ -521,6 +523,12 @@ public class VisualizationCDSGenerator
             ctx.setContainer(JunitUtil.getTestContainer());
             ctx.setUser( TestContext.get().getUser());
             this.context = ctx;
+        }
+
+        @BeforeClass
+        public static void preTest()
+        {
+            Assume.assumeTrue("This test requires the study module.", StudyService.get() != null);
         }
 
         Results getResults(VisDataRequest q) throws SQLGenerationException, SQLException


### PR DESCRIPTION
#### Rationale
FileImporter, that is used with the Panorama Public copy pipeline,  creates rows in exp.data for each file that is copied to the new folder. I found two problems with this:
1. If there is a '+' character in the file name, it is replaced with a space in the name that is saved to the 'Name' column of exp.data
2. If there is a '%' character in the file name,  an exception is thrown when trying to save a row for the file. Exp.data rows are not saved for any of the remaining files

This is described here: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43374
