### PR TITLE
43373: Link to study : Assay's don't support fields with Visit concept URIs

### DIFF
--- a/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
+++ b/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
@@ -86,6 +86,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * User: brittp
@@ -1002,6 +1003,19 @@ public class PublishResultsQueryView extends QueryView
         ColumnInfo specimenDateCol = colInfos.get(_additionalColumns.get(ExtraColFieldKeys.SpecimenDate));
         ColumnInfo targetStudyCol = colInfos.get(_additionalColumns.get(ExtraColFieldKeys.TargetStudy));
         ColumnInfo sampleIdCol = colInfos.get(_additionalColumns.get(ExtraColFieldKeys.SampleId));
+
+        // if visit or date columns don't exist, see if they can be resolved through the standard concept URIs
+        List<ColumnInfo> timepointCols = selectColumns.stream()
+                .filter(c -> PropertyType.VISIT_CONCEPT_URI.equalsIgnoreCase(c.getConceptURI()))
+                .collect(Collectors.toList());
+
+        for (ColumnInfo col : timepointCols)
+        {
+            if (dateCol == null && col.getJdbcType().isDateOrTime())
+                dateCol = col;
+            if (visitIDCol == null && col.getJdbcType().isReal())
+                visitIDCol = col;
+        }
 
         ResolverHelper resolverHelper = new ResolverHelper(
                 _targetStudyContainer, getUser(),

--- a/study/src/org/labkey/study/assay/AssayPublishConfirmAction.java
+++ b/study/src/org/labkey/study/assay/AssayPublishConfirmAction.java
@@ -247,7 +247,7 @@ public class AssayPublishConfirmAction extends AbstractPublishConfirmAction<Assa
         if (sampleCols.size() == 1)
             additionalCols.put(ExtraColFieldKeys.SampleId, sampleCols.get(0).getFieldKey());
 
-        if ((additionalCols.get(ExtraColFieldKeys.Date) == null))
+        if (!selectColumns.containsKey(additionalCols.get(ExtraColFieldKeys.Date)))
         {
             // issue 41982 : look for an alternate date column if the standard assay date field does not exist
             List<ColumnInfo> dateCols = selectColumns.values().stream()


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43373

#### Changes
- In the `PublishResultsQueryView` if either the visit or date columns have not resolved, search the columns in the current view that have the VISIT concept URI and add if appropriate, this is the current behavior for the participant ID.
- Those fields can originate from a sample type and don't need to be on the base assay results table, but do need to be pulled into the default data view.