### PR TITLE
43297: Import Samples via File Watcher, File Extension was kept as part of the Sample name

### DIFF
--- a/experiment/src/org/labkey/experiment/pipeline/SampleReloadTask.java
+++ b/experiment/src/org/labkey/experiment/pipeline/SampleReloadTask.java
@@ -86,7 +86,7 @@ public class SampleReloadTask extends PipelineJob.Task<SampleReloadTask.Factory>
         }
 
         ExpSampleType sampleType = null;
-        String sampleName = dataFile.getName();
+        String sampleName = FileUtil.getBaseName(dataFile.getName());
 
         if (params.containsKey(SAMPLE_NAME_KEY))
         {


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43297

#### Changes
- When creating a new sample type from a file watcher file, just use the base name and exclude the file extension (if any)