### PR TITLE
Issue 43009: Backport dataiterator fixes

### DIFF
--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -228,7 +228,7 @@ public class DataIteratorUtil
                 // Like maybe ETL from one study to another where subject name does not match? or assay publish?
                 to = targetMap.get(from.getPropertyURI());
                 if (null != to)
-                    to = new Pair<>(to.first, MatchType.low);
+                    to = new Pair<>(to.first, org.labkey.api.dataiterator.DataIteratorUtil.MatchType.low);
             }
             if (null == to)
             {

--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Spliterator;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -129,58 +130,79 @@ public class DataIteratorUtil
         return targetAliasesMap;
     }
 
-    enum MatchType {propertyuri, name, alias, jdbcname, tsvColumn}
 
+    // rank of a match of import column NAME matching various properties of target column
+    // MatchType.low is used for matches based on something other than name
+    enum MatchType {propertyuri, name, alias, jdbcname, tsvColumn, low}
+
+
+    /**
+     * NOTE: matchColumns() handles multiple source columns matching the same target column (usually a data file problem
+     * for the user to fix), we don't handle one source column matching multiple target columns (more of an admin design problem).
+     * One idea would be to return MultiValuedMap<String,Pair<>>, or check for duplicates entries of the same MatchType.
+     */
     protected static Map<String,Pair<ColumnInfo,MatchType>> _createTableMap(TableInfo target, boolean useImportAliases)
     {
-        List<ColumnInfo> cols = target.getColumns();
+        /* CONSIDER: move this functionality into a TableInfo method so this map (or maps) can be cached */
+        List<ColumnInfo> cols = target.getColumns().stream()
+                .filter(col -> !col.isMvIndicatorColumn() && !col.isRawValueColumn())
+                .collect(Collectors.toList());
+
         Map<String, Pair<ColumnInfo,MatchType>> targetAliasesMap = new CaseInsensitiveHashMap<>(cols.size()*4);
+
+        // should this be under the useImportAliases flag???
         for (ColumnInfo col : cols)
         {
-            if (col.isMvIndicatorColumn() || col.isRawValueColumn())
-                continue;
-            final String name = col.getName();
-            targetAliasesMap.put(name, new Pair<>(col,MatchType.name));
+            // Issue 21015: Dataset snapshot over flow assay dataset doesn't pick up stat column values
+            // TSVColumnWriter.ColumnHeaderType.queryColumnName format is a FieldKey display value from the column name. Blech.
+            String tsvQueryColumnName = FieldKey.fromString(col.getName()).toDisplayString();
+            targetAliasesMap.put(tsvQueryColumnName, new Pair<>(col, MatchType.tsvColumn));
+        }
+
+        // should this be under the useImportAliases flag???
+        for (ColumnInfo col : cols)
+        {
+            // Jdbc resultset names have substitutions for special characters. If this is such a column, need the substituted name to match on
+            targetAliasesMap.put(col.getJdbcRsName(), new Pair<>(col, MatchType.jdbcname));
+        }
+
+        for (ColumnInfo col : cols)
+        {
+            if (useImportAliases || "folder".equalsIgnoreCase(col.getName()))
+            {
+                for (String alias : col.getImportAliasSet())
+                    targetAliasesMap.put(alias, new Pair<>(col, MatchType.alias));
+
+                // Be sure we have an alias the column name we generate for TSV exports. See issue 21774
+                String translatedFieldKey = FieldKey.fromString(col.getName()).toDisplayString();
+                targetAliasesMap.put(translatedFieldKey, new Pair<>(col, MatchType.alias));
+            }
+        }
+
+        for (ColumnInfo col : cols)
+        {
+            String label = col.getLabel();
+            if (null != label)
+                targetAliasesMap.put(label, new Pair<>(col, MatchType.alias));
+        }
+
+        for (ColumnInfo col : cols)
+        {
             String uri = col.getPropertyURI();
             if (null != uri)
             {
-                if (!targetAliasesMap.containsKey(uri))
-                    targetAliasesMap.put(uri, new Pair<>(col, MatchType.propertyuri));
+                targetAliasesMap.put(uri, new Pair<>(col, MatchType.propertyuri));
                 String propName = uri.substring(uri.lastIndexOf('#')+1);
-                if (!targetAliasesMap.containsKey(propName))
-                    targetAliasesMap.put(propName, new Pair<>(col, MatchType.alias));
+                targetAliasesMap.put(propName, new Pair<>(col, MatchType.alias));
             }
-            String label = col.getLabel();
-            if (null != label && !targetAliasesMap.containsKey(label))
-                targetAliasesMap.put(label, new Pair<>(col, MatchType.alias));
-            String translatedFieldKey;
-            if (useImportAliases || "folder".equalsIgnoreCase(name))
-            {
-                for (String alias : col.getImportAliasSet())
-                {
-                    if (!targetAliasesMap.containsKey(alias))
-                        targetAliasesMap.put(alias, new Pair<>(col, MatchType.alias));
-                }
-                // Be sure we have an alias the column name we generate for TSV exports. See issue 21774
-                translatedFieldKey = FieldKey.fromString(name).toDisplayString();
-                if (!targetAliasesMap.containsKey(translatedFieldKey))
-                {
-                    targetAliasesMap.put(translatedFieldKey, new Pair<>(col, MatchType.alias));
-                }
-            }
-            // Jdbc resultset names have substitutions for special characters. If this is such a column, need the substituted name to match on
-            translatedFieldKey = col.getJdbcRsName();
-            if (!name.equals(translatedFieldKey))
-            {
-                targetAliasesMap.put(translatedFieldKey, new Pair<>(col, MatchType.jdbcname));
-            }
-
-            // Issue 21015: Dataset snapshot over flow assay dataset doesn't pick up stat column values
-            // TSVColumnWriter.ColumnHeaderType.queryColumnName format is a FieldKey display value from the column name. Blech.
-            String tsvQueryColumnName = FieldKey.fromString(name).toDisplayString();
-            if (!targetAliasesMap.containsKey(tsvQueryColumnName))
-                targetAliasesMap.put(tsvQueryColumnName, new Pair<>(col, MatchType.tsvColumn));
         }
+
+        for (ColumnInfo col : cols)
+        {
+            String name = col.getName();
+            targetAliasesMap.put(name, new Pair<>(col,MatchType.name));
+        }
+
         return targetAliasesMap;
     }
 
@@ -196,7 +218,6 @@ public class DataIteratorUtil
         ArrayList<Pair<ColumnInfo,MatchType>> matches = new ArrayList<>(input.getColumnCount()+1);
         matches.add(null);
 
-        // match columns to target columninfos (duplicates StandardDataIteratorBuilder, extract shared method?)
         for (int i=1 ; i<=input.getColumnCount() ; i++)
         {
             ColumnInfo from = input.getColumnInfo(i);
@@ -205,34 +226,15 @@ public class DataIteratorUtil
                 matches.add(null);
                 continue;
             }
-
-            Pair<ColumnInfo,MatchType> to = null;
-            if (isEtl)
+            Pair<ColumnInfo,MatchType> to = targetMap.get(from.getName());
+            if (null == to && null != from.getPropertyURI())
             {
-                // Match by name first
-                to = targetMap.get(from.getName());
-
-                // If name matches, check if property URI matches for higher priority match type
-                if (null != to && null != from.getPropertyURI())
-                {
-                    // Renamed built-in columns (ex. LSID, ParticipantId) in source queries will not match propertyURI with
-                    // target. In that case, just stick with name match. Otherwise check for propertyURI match for higher priority match
-                    // (this is primarily for ParticipantId which can have two columns with same name in the dataiterator)
-                    if (from.getPropertyURI().equals(to.first.getPropertyURI())) {
-                        Pair<ColumnInfo,MatchType> toUri = targetMap.get(from.getPropertyURI());
-                        if (null != toUri)
-                            to = toUri;
-                    }
-                }
+                // Do we actually rely on this anywhere???
+                // Like maybe ETL from one study to another where subject name does not match? or assay publish?
+                to = targetMap.get(from.getPropertyURI());
+                if (null != to)
+                    to = new Pair<>(to.first, MatchType.low);
             }
-            else
-            {
-                if (null != from.getPropertyURI())
-                    to = targetMap.get(from.getPropertyURI());
-                if (null == to)
-                    to = targetMap.get(from.getName());
-            }
-
             if (null == to)
             {
                 // Check to see if the column i.e. propURI has a property descriptor and vocabulary domain is present
@@ -302,13 +304,10 @@ public class DataIteratorUtil
     }
 
 
-
-
     // NOTE: first consider if using QueryUpdateService is better
     // this is just a point-to-point copy _without_ triggers
     public static int copy(File from, TableInfo to, Container c, User user) throws IOException, BatchValidationException
     {
-
         BatchValidationException errors = new BatchValidationException();
         DataIteratorContext context = new DataIteratorContext(errors);
         DataLoader loader = DataLoaderService.get().createLoader(from, null, true, c, TabLoader.TSV_FILE_TYPE);

--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -21,7 +21,6 @@ import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
@@ -206,13 +205,9 @@ public class DataIteratorUtil
         return targetAliasesMap;
     }
 
-    public static boolean isEtl(@NotNull DataIteratorContext context)
-    {
-        return context.getDataSource() != null && context.getDataSource().equals(ETL_DATA_SOURCE);
-    }
 
     /* NOTE doesn't check column mapping collisions */
-    protected static ArrayList<Pair<ColumnInfo,MatchType>> _matchColumns(DataIterator input, TableInfo target, boolean useImportAliases, boolean isEtl, Container container)
+    protected static ArrayList<Pair<ColumnInfo,MatchType>> _matchColumns(DataIterator input, TableInfo target, boolean useImportAliases, Container container)
     {
         Map<String,Pair<ColumnInfo,MatchType>> targetMap = _createTableMap(target, useImportAliases);
         ArrayList<Pair<ColumnInfo,MatchType>> matches = new ArrayList<>(input.getColumnCount()+1);
@@ -255,9 +250,9 @@ public class DataIteratorUtil
 
 
     /** throws ValidationException only if there are unresolvable ambiguity in the source->destination column mapping */
-    public static ArrayList<ColumnInfo> matchColumns(DataIterator input, TableInfo target, boolean useImportAliases, boolean isEtl, ValidationException setupError, @Nullable Container container)
+    public static ArrayList<ColumnInfo> matchColumns(DataIterator input, TableInfo target, boolean useImportAliases, ValidationException setupError, @Nullable Container container)
     {
-        ArrayList<Pair<ColumnInfo,MatchType>> matches = _matchColumns(input, target, useImportAliases, isEtl, container);
+        ArrayList<Pair<ColumnInfo,MatchType>> matches = _matchColumns(input, target, useImportAliases, container);
         MultiValuedMap<FieldKey,Integer> duplicatesMap = new ArrayListValuedHashMap<>(input.getColumnCount()+1);
 
         for (int i=1 ; i<= input.getColumnCount() ; i++)

--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -39,6 +39,7 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
 {
     public static final String EXISTING_RECORD_COLUMN_NAME = "_" + ExistingRecordDataIterator.class.getName() + "#EXISTING_RECORD_COLUMN_NAME";
 
+    final CachingDataIterator _unwrapped;
     final TableInfo target;
     final ArrayList<ColumnInfo> pkColumns = new ArrayList<>();
     final ArrayList<Supplier<Object>> pkSuppliers = new ArrayList<>();
@@ -52,6 +53,10 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
     ExistingRecordDataIterator(DataIterator in, TableInfo target, @Nullable Set<String> keys, boolean useMark)
     {
         super(in);
+
+        // NOTE it might get wrapped with a LoggingDataIterator, so remember the original DataIterator
+        this._unwrapped = useMark ? (CachingDataIterator)in : null;
+
         this.target = target;
         this.existingColIndex = in.getColumnCount()+1;
         this.useMark = useMark;
@@ -130,7 +135,7 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
     {
         // NOTE: we have to call mark() before we call next() if we want the 'next' row to be cached
         if (useMark)
-            ((CachingDataIterator)_delegate).mark();
+            _unwrapped.mark();  // unwrapped _delegate
         boolean ret = super.next();
         if (ret && !pkColumns.isEmpty())
             prefetchExisting();
@@ -251,7 +256,7 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
                 existingRecords.put(r,(Map<String,Object>)map);
             });
             // backup to where we started so caller can iterate through them one at a time
-            ((CachingDataIterator)_delegate).reset();
+            _unwrapped.reset(); // unwrapped _delegate
             _delegate.next();
         }
     }

--- a/api/src/org/labkey/api/dataiterator/MapDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/MapDataIterator.java
@@ -21,10 +21,12 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.query.BatchValidationException;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * User: matthewb
@@ -36,7 +38,7 @@ public interface MapDataIterator extends DataIterator
     boolean supportsGetMap();
     Map<String,Object> getMap();
 
-    static class MapDataIteratorImpl implements MapDataIterator, ScrollableDataIterator
+    class MapDataIteratorImpl implements MapDataIterator, ScrollableDataIterator
     {
         DataIterator _input;
         boolean _mutable;
@@ -46,6 +48,11 @@ public interface MapDataIterator extends DataIterator
 
         MapDataIteratorImpl(DataIterator in, boolean mutable)
         {
+            this(in, mutable, Set.of());
+        }
+
+        public MapDataIteratorImpl(DataIterator in, boolean mutable, Set<String> skip)
+        {
             _input = in;
             _mutable = mutable;
             Map map = new CaseInsensitiveHashMap<Integer>(in.getColumnCount()*2);
@@ -53,6 +60,8 @@ public interface MapDataIterator extends DataIterator
             for (int i=0 ; i<=in.getColumnCount() ; i++)
             {
                 String name = in.getColumnInfo(i).getName();
+                if (skip.contains(name))
+                    continue;
                 if (_findMap.containsKey(name))
                 {
                     LogManager.getLogger(MapDataIterator.class).warn("Map already has column named '" + name + "'");

--- a/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
@@ -195,8 +195,7 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
         // match up the columns, validate that there is no more than one source column that matches the target column
         //
         ValidationException setupError = new ValidationException();
-        ArrayList<ColumnInfo> matches = DataIteratorUtil.matchColumns(input, _target, _useImportAliases,
-                DataIteratorUtil.isEtl(context), setupError, _c);
+        ArrayList<ColumnInfo> matches = DataIteratorUtil.matchColumns(input, _target, _useImportAliases, setupError, _c);
 
         ArrayList<TranslateHelper> convertTargetCols = new ArrayList<>(input.getColumnCount()+1);
         for (int i=1 ; i<=input.getColumnCount() ; i++)

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -163,8 +163,7 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
         DatasetColumnsIterator it = new DatasetColumnsIterator(_datasetDefinition, input, context, user);
 
         ValidationException matchError = new ValidationException();
-        ArrayList<ColumnInfo> inputMatches = DataIteratorUtil.matchColumns(input, table, useImportAliases,
-                DataIteratorUtil.isEtl(context), matchError, null);
+        ArrayList<ColumnInfo> inputMatches = DataIteratorUtil.matchColumns(input, table, useImportAliases, matchError, null);
         if (matchError.hasErrors())
             setupError(matchError.getMessage());
 

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -199,6 +199,22 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
                     continue;
                 }
 
+                if (match == subjectCol)
+                {
+                    try
+                    {
+                        // translate the incoming participant column
+                        // do a conversion for PTID aliasing
+                        it.translatePtid(in, user);
+                        continue;
+                    }
+                    catch (ValidationException e)
+                    {
+                        setupError(e.getMessage());
+                        return it;
+                    }
+                }
+
                 int out;
                 if (DefaultStudyDesignWriter.isColumnNumericForeignKeyToDataspaceTable(match.getFk(), true))
                 {
@@ -250,19 +266,8 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
         Integer indexContainer = outputMap.get(containerColumn);
         Integer indexReplace = outputMap.get("replace");
 
-        // do a conversion for PTID aliasing
-        Integer translatedIndexPTID = indexPTID;
-        try
-        {
-            translatedIndexPTID = it.translatePtid(indexPTIDInput, user);
-        }
-        catch (ValidationException e)
-        {
-            context.getErrors().addRowError(e);
-        }
-
         // For now, just specify null for sequence num index... we'll add it below
-        it.setSpecialOutputColumns(translatedIndexPTID, null, indexVisitDate, indexKeyProperty, indexContainer);
+        it.setSpecialOutputColumns(indexPTID, null, indexVisitDate, indexKeyProperty, indexContainer);
         it.setTimepointType(timetype);
 
         /* NOTE: these columns must be added in dependency order
@@ -412,11 +417,11 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
         {
             Integer indexVisit = timetype.isVisitBased() ? it.indexSequenceNumOutput : indexVisitDate;
             // no point if required columns are missing
-            if (null != translatedIndexPTID && null != indexVisit)
+            if (null != indexPTID && null != indexVisit)
             {
                 ScrollableDataIterator scrollable = DataIteratorUtil.wrapScrollable(ret);
                 _datasetDefinition.checkForDuplicates(scrollable, indexLSID,
-                        translatedIndexPTID, null == indexVisit ? -1 : indexVisit, null == indexKeyProperty ? -1 : indexKeyProperty, null == indexReplace ? -1 : indexReplace,
+                        indexPTID, null == indexVisit ? -1 : indexVisit, null == indexKeyProperty ? -1 : indexKeyProperty, null == indexReplace ? -1 : indexReplace,
                         context, null,
                         checkDuplicates);
                 scrollable.beforeFirst();
@@ -613,7 +618,7 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
 
         int translatePtid(Integer indexPtidInput, User user) throws ValidationException
         {
-            ColumnInfo col = new BaseColumnInfo("ParticipantId", JdbcType.VARCHAR);
+            ColumnInfo col = new BaseColumnInfo(_datasetDefinition.getStudy().getSubjectColumnName(), JdbcType.VARCHAR);
             ParticipantIdImportHelper piih = new ParticipantIdImportHelper(_datasetDefinition.getStudy(), user, _datasetDefinition);
             Callable call = piih.getCallable(getInput(), indexPtidInput);
             return addColumn(col, call);

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -177,7 +177,7 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
             {
                 ((BaseColumnInfo)inputColumn).setPropertyURI(match.getPropertyURI());
 
-                if (match == lsidColumn || match == seqnumColumn)
+                if (match == lsidColumn || match == seqnumColumn || DatasetDomainKind._KEY.equals(match.getName()))
                     continue;
 
                 // We usually ignore incoming containerColumn.  However, if we're in a dataspace study
@@ -352,7 +352,12 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
 
         if (null != indexKeyProperty)
         {
-            it.indexKeyPropertyOutput = it.addAliasColumn("_key", indexKeyProperty, JdbcType.VARCHAR);
+            // indexKeyProperty is the index of the column matched to column _datasetDefinition.getKeyPropertyName(), or is a managed key
+            // it.indexKeyPropertyOutput is the index of column with name=DatasetDomainKind._KEY (alias of column indexKeyProperty)
+            // CONSIDER: this column is inserted twice, because the _key column is needed for is copied into the exp.datasets for the index (participantid, sequencenum, _key)
+            // Since we now actually generate the index per materialized table, we could try to avoid this duplication
+            assert null == keyColumnName || it.getColumnInfo(indexKeyProperty).getName().equals(keyColumnName);
+            it.indexKeyPropertyOutput = it.addAliasColumn(DatasetDomainKind._KEY, indexKeyProperty, JdbcType.VARCHAR);
         }
 
         //

--- a/study/src/org/labkey/study/model/ParticipantIdImportHelper.java
+++ b/study/src/org/labkey/study/model/ParticipantIdImportHelper.java
@@ -137,7 +137,7 @@ public class ParticipantIdImportHelper implements ParticipantIdTranslator
     }
 
     /*
-     * The getCallable method returns a callable object that translates the participantId to its alias on lookup
+     * The getCallable method returns a collable object that translates the participantId to its alias on lookup
      */
     public Callable<Object> getCallable(@NotNull final DataIterator it, @Nullable final Integer participantIndex)
     {

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -19,6 +19,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
@@ -30,6 +31,7 @@ import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.DetailedAuditLogDataIterator;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.dataiterator.SimpleTranslator;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.gwt.client.AuditBehaviorType;
@@ -44,7 +46,9 @@ import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.security.StudySecurityEscalator;
+import org.labkey.study.model.DatasetDataIteratorBuilder;
 import org.labkey.study.model.DatasetDefinition;
+import org.labkey.study.model.DatasetDomainKind;
 import org.labkey.study.model.StudyImpl;
 import org.labkey.study.model.StudyManager;
 import org.labkey.study.visitmanager.PurgeParticipantsJob.ParticipantPurger;
@@ -284,6 +288,16 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
         try
         {
             boolean hasRowId = _dataset.getKeyManagementType() == Dataset.KeyManagementType.RowId;
+
+            if (null != rows)
+            {
+                // TODO: consider creating DataIterator metadata to mark "internal" cols (not to be returned via API)
+                DataIterator it = etl.getDataIterator(context);
+                DataIteratorBuilder cleanMap = new MapDataIterator.MapDataIteratorImpl(it, true, CaseInsensitiveHashSet.of(
+                        it.getColumnInfo(0).getName()
+                ));
+                etl = cleanMap;
+            }
 
             if (!hasRowId)
             {


### PR DESCRIPTION
#### Rationale
Backporting PRs from develop branch with dataiterator updates handling participantId, key column and column matching.  Revert ETL only fix.

#### Changes
* Backport https://github.com/LabKey/platform/pull/2271
* Backport https://github.com/LabKey/platform/pull/2268
* Backport https://github.com/LabKey/platform/pull/2263
* Revert https://github.com/LabKey/platform/pull/2222
