### PR TITLE
remove adding legacy session cookies to the R script prolog

### DIFF
--- a/api/src/org/labkey/api/reports/report/RReport.java
+++ b/api/src/org/labkey/api/reports/report/RReport.java
@@ -421,18 +421,6 @@ public class RReport extends ExternalScriptEngineReport
             // The ${apikey} token will be replaced by the value in the map stashed in script context bindings ExternalScriptEngine.PARAM_REPLACEMENT_MAP
             // CONSIDER: Should we use: labkey.setDefaults(apiKey=\"${apikey}\")
             labkey.append("labkey.apiKey <- \"${" + SecurityManager.API_KEY + "}\"\n");
-
-            // session information - deprecate for ${apiKey} or labkey.apiKey ?
-            if (context.getRequest() != null)
-            {
-                String session = PageFlowUtil.getCookieValue(context.getRequest().getCookies(), CSRFUtil.SESSION_COOKIE_NAME, "");
-                String sessionName = CSRFUtil.SESSION_COOKIE_NAME;
-
-                labkey.append("labkey.sessionCookieName = \"").append(sessionName).append("\"\n");
-                labkey.append("labkey.sessionCookieContents = \"");
-                labkey.append(session);
-                labkey.append("\"\n");
-            }
         }
 
         labkey.append(getKnitrEndChunk());


### PR DESCRIPTION
#### Rationale
To help with running R script tasks using the RunReportTask in an ETL, we are removing the legacy cookie from the R script prolog. The script will authenticate seamlessly using the newer API key property that uses the temporary API key that we generate for LabKey controlled scripts.