### PR TITLE
validate list entityId

### DIFF
--- a/api/src/org/labkey/api/attachments/BaseDownloadAction.java
+++ b/api/src/org/labkey/api/attachments/BaseDownloadAction.java
@@ -17,6 +17,8 @@ package org.labkey.api.attachments;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.ExportAction;
+import org.labkey.api.action.ExportException;
+import org.labkey.api.action.SimpleErrorView;
 import org.labkey.api.util.Pair;
 import org.springframework.validation.BindException;
 
@@ -35,6 +37,9 @@ public abstract class BaseDownloadAction<FORM> extends ExportAction<FORM>
     @Override
     public void export(FORM form, HttpServletResponse response, BindException errors) throws Exception
     {
+        if (errors.hasErrors())
+            throw new ExportException(new SimpleErrorView(errors, true));
+
         Pair<AttachmentParent, String> attachment = getAttachment(form);
 
         if (null != attachment)

--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -92,6 +92,7 @@ import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.util.FileStream;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.GUID;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
@@ -926,6 +927,15 @@ public class ListController extends SpringActionController
     @RequiresPermission(ReadPermission.class)
     public class DownloadAction extends BaseDownloadAction<ListAttachmentForm>
     {
+        @Override
+        public void validate(ListAttachmentForm form, BindException errors)
+        {
+            if (!GUID.isGUID(form.getEntityId()))
+            {
+                errors.rejectValue("entityId", ERROR_MSG, "entityId is not a GUID: " + form.getEntityId());
+            }
+        }
+
         @Nullable
         @Override
         public Pair<AttachmentParent, String> getAttachment(ListAttachmentForm form)


### PR DESCRIPTION
#### Rationale
Crawler hit an exception in the list-download.view action with an invalid entityId

#### Related Issues
* [Issue 43392](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43392): refactor form beans, models, and server-side APIs with entityId parameters to use GUID java class
