### PR TITLE
Update signature of ExperimentListener to pass use on run delete

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentListener.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentListener.java
@@ -45,7 +45,7 @@ public interface ExperimentListener
     }
 
     // called before the experiment run is deleted
-    default void beforeRunDelete(ExpProtocol protocol, ExpRun run){}
+    default void beforeRunDelete(ExpProtocol protocol, ExpRun run, User user){}
 
     /** Called before deleting the datas. */
     default void beforeDataDelete(Container c, User user, List<? extends ExpData> data)

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -3251,7 +3251,7 @@ public class ExperimentServiceImpl implements ExperimentService
 
         for (ExperimentListener listener : _listeners)
         {
-            listener.beforeRunDelete(run.getProtocol(), run);
+            listener.beforeRunDelete(run.getProtocol(), run, user);
         }
 
         // Note: At the moment, FlowRun is the only example of an ExpRun attachment parent, but we're keeping this general


### PR DESCRIPTION
@labkey-jeckels This is related to this issue: https://www.labkey.org/ONPRC/Support%20Tickets/issues-details.view?issueId=42943

This overall idea is that I'd like to audit deletions to an assay. On delete, I need result-level detail. When results are deleted directly, they go through the query layer so I can audit them. Assay run deletes do not, but they do support ExperimentListeners. The snag is that the existing beforeDelete method doesnt pass user. 

This proposal will modify the signature of the existing method. I cant find any code using it, but there might be repos I dont see. If this is a problem, a slightly less clean approach would be to support 2 methods (the interface has default implementations, so it would be a no-op), and call both.

What do you think? Is there another approach I could be using to audit assay run deletes?