### PR TITLE
CachedResultSet: implement getBigDecimal() methods

### DIFF
--- a/api/src/org/labkey/api/data/CachedResultSet.java
+++ b/api/src/org/labkey/api/data/CachedResultSet.java
@@ -446,6 +446,18 @@ public class CachedResultSet implements ResultSet, TableResultSet
         return null;
     }
 
+    public BigDecimal _decimal(Object o) throws SQLException
+    {
+        if (null == o)
+            return null;
+        if (o instanceof BigDecimal)
+        {
+            return (BigDecimal) o;
+        }
+        throwConversionError("Can't convert '" + o.getClass() + "' to BigDecimal");
+        return null;
+    }
+
     @Override
     public byte[] getBytes(int columnIndex) throws SQLException
     {
@@ -667,15 +679,15 @@ public class CachedResultSet implements ResultSet, TableResultSet
     }
 
     @Override
-    public BigDecimal getBigDecimal(int columnIndex)
+    public BigDecimal getBigDecimal(int columnIndex) throws SQLException
     {
-        return null;
+        return _decimal(getObject(columnIndex));
     }
 
     @Override
-    public BigDecimal getBigDecimal(String columnName)
+    public BigDecimal getBigDecimal(String columnName) throws SQLException
     {
-        return null;
+        return _decimal(getObject(columnName));
     }
 
     @Override

--- a/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
+++ b/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
@@ -96,6 +96,7 @@ import java.util.stream.Collectors;
 public class PublishResultsQueryView extends QueryView
 {
     private static final Logger LOG = Logger.getLogger(PublishResultsQueryView.class);
+
     private final SimpleFilter _filter;
     private final Container _targetStudyContainer;
     private final boolean _mismatched;
@@ -106,12 +107,13 @@ public class PublishResultsQueryView extends QueryView
     private final Map<Object, String> _reshowPtids;
     private final Map<Object, String> _reshowTargetStudies;
     private final boolean _includeTimestamp;
+    private final Map<ExtraColFieldKeys, FieldKey> _additionalColumns;
+    private final Map<String, Object> _hiddenFormFields;
+    private final Set<String> _hiddenColumnCaptions;
+    private final FieldKey _objectIdFieldKey;
+    private final Dataset.PublishSource _publishSource;
+
     private List<ActionButton> _buttons = null;
-    private Map<ExtraColFieldKeys, FieldKey> _additionalColumns;
-    private Map<String, Object> _hiddenFormFields;
-    private Set<String> _hiddenColumnCaptions;
-    private FieldKey _objectIdFieldKey;
-    private Dataset.PublishSource _publishSource;
 
     public enum ExtraColFieldKeys
     {

--- a/specimen/src/org/labkey/specimen/actions/SpecimenController.java
+++ b/specimen/src/org/labkey/specimen/actions/SpecimenController.java
@@ -5549,7 +5549,7 @@ public class SpecimenController extends SpringActionController
                 }
                 else
                 {
-                    Visit visit = pd.getSequenceNum() != null ? UpdateSpecimenCommentsBean.getVisitForSequence(study, pd.getSequenceNum()) : null;
+                    Visit visit = pd.getSequenceNum() != null ? StudyInternalService.get().getVisitForSequence(study, pd.getSequenceNum()) : null;
                     ptidVisits.add(new Pair<>(pd.getParticipantId(), visit != null ? visit.getLabel() : "" + StudyInternalService.get().formatSequenceNum(pd.getSequenceNum())));
                 }
             }

--- a/specimen/src/org/labkey/specimen/actions/UpdateSpecimenCommentsBean.java
+++ b/specimen/src/org/labkey/specimen/actions/UpdateSpecimenCommentsBean.java
@@ -8,6 +8,7 @@ import org.labkey.api.specimen.SpecimenManager;
 import org.labkey.api.specimen.Vial;
 import org.labkey.api.specimen.model.SpecimenComment;
 import org.labkey.api.study.Study;
+import org.labkey.api.study.StudyInternalService;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.StudyUrls;
 import org.labkey.api.study.TimepointType;
@@ -102,7 +103,7 @@ public class UpdateSpecimenCommentsBean extends SpecimensViewBean
             if (visit != null)
             {
                 String ptid = vial.getPtid();
-                Visit v = getVisitForSequence(study, visit);
+                Visit v = StudyInternalService.get().getVisitForSequence(study, visit);
                 if (ptid != null && v != null)
                 {
                     if (!pvMap.containsKey(ptid))
@@ -142,16 +143,5 @@ public class UpdateSpecimenCommentsBean extends SpecimensViewBean
     public Map<String, Map<String, Long>> getParticipantVisitMap()
     {
         return _participantVisitMap;
-    }
-
-    public static Visit getVisitForSequence(Study study, double seqNum)
-    {
-        List<? extends Visit> visits = VisitService.get().getVisits(study, Visit.Order.SEQUENCE_NUM);
-        for (Visit v : visits)
-        {
-            if (seqNum >= v.getSequenceNumMinDouble() && seqNum <= v.getSequenceNumMaxDouble())
-                return v;
-        }
-        return null;
     }
 }

--- a/study/api-src/org/labkey/api/study/StudyInternalService.java
+++ b/study/api-src/org/labkey/api/study/StudyInternalService.java
@@ -1,19 +1,15 @@
 package org.labkey.api.study;
 
-import org.jetbrains.annotations.Nullable;
-import org.labkey.api.annotations.Migrate;
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.SecurityManager.ViewFactory;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
-import org.labkey.api.specimen.query.SpecimenQueryView;
-import org.labkey.api.specimen.requirements.SpecimenRequest;
 import org.labkey.api.study.model.ParticipantDataset;
 import org.labkey.api.study.model.ParticipantInfo;
 import org.labkey.api.view.ViewContext;
-import org.springframework.validation.BindException;
 
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +63,11 @@ public interface StudyInternalService
 
     void saveCommentsSettings(Study study, User user, Integer participantCommentDatasetId, String participantCommentProperty, Integer participantVisitCommentDatasetId, String participantVisitCommentProperty);
 
-    String formatSequenceNum(double d);
+    String formatSequenceNum(BigDecimal d);
+
+    Visit getVisitForSequence(Study study, BigDecimal seqNum);
+
+    Visit getVisitForSequence(Study study, double seqNum);
 
     ActionButton createParticipantGroupButton(ViewContext context, String dataRegionName, CohortFilter cohortFilter, boolean hasCreateGroupFromSelection);
 }

--- a/study/api-src/org/labkey/api/study/model/ParticipantDataset.java
+++ b/study/api-src/org/labkey/api/study/model/ParticipantDataset.java
@@ -18,6 +18,7 @@ package org.labkey.api.study.model;
 
 import org.labkey.api.data.Container;
 
+import java.math.BigDecimal;
 import java.util.Date;
 
 /**
@@ -29,7 +30,7 @@ public class ParticipantDataset
 {
     private String _lsid;
     private Container _container;
-    private Double _sequenceNum;
+    private BigDecimal _sequenceNum;
     private Date _visitDate;
     private Integer _studyDatasetId;
     private String _studyParticipantId;
@@ -74,12 +75,12 @@ public class ParticipantDataset
         _lsid = lsid;
     }
 
-    public Double getSequenceNum()
+    public BigDecimal getSequenceNum()
     {
         return _sequenceNum;
     }
 
-    public void setSequenceNum(Double sequenceNum)
+    public void setSequenceNum(BigDecimal sequenceNum)
     {
         _sequenceNum = sequenceNum;
     }

--- a/study/src/org/labkey/study/StudyInternalServiceImpl.java
+++ b/study/src/org/labkey/study/StudyInternalServiceImpl.java
@@ -9,6 +9,7 @@ import org.labkey.api.study.Dataset;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyInternalService;
 import org.labkey.api.study.TimepointType;
+import org.labkey.api.study.Visit;
 import org.labkey.api.study.model.ParticipantDataset;
 import org.labkey.api.study.model.ParticipantInfo;
 import org.labkey.api.view.ViewContext;
@@ -18,6 +19,7 @@ import org.labkey.study.model.StudyImpl;
 import org.labkey.study.model.StudyManager;
 import org.labkey.study.model.VisitImpl;
 
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -126,9 +128,21 @@ public class StudyInternalServiceImpl implements StudyInternalService
     }
 
     @Override
-    public String formatSequenceNum(double d)
+    public String formatSequenceNum(BigDecimal d)
     {
         return VisitImpl.formatSequenceNum(d);
+    }
+
+    @Override
+    public Visit getVisitForSequence(Study study, BigDecimal seqNum)
+    {
+        return StudyManager.getInstance().getVisitForSequence(study, seqNum);
+    }
+
+    @Override
+    public Visit getVisitForSequence(Study study, double seqNum)
+    {
+        return StudyManager.getInstance().getVisitForSequence(study, seqNum);
     }
 
     @Override

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -2142,7 +2142,6 @@ public class StudyManager
         }
     }
 
-
     public VisitImpl getVisitForSequence(Study study, double seqNum)
     {
         List<VisitImpl> visits = getVisits(study, Visit.Order.SEQUENCE_NUM);
@@ -2169,7 +2168,6 @@ public class StudyManager
     {
         return getDatasetDefinitions(study, null);
     }
-
 
     public List<DatasetDefinition> getDatasetDefinitions(Study study, @Nullable Cohort cohort, String... types)
     {
@@ -2957,7 +2955,7 @@ public class StudyManager
                 pd.setLsid(rs.getString("LSID"));
                 if (!dataset.isDemographicData())
                 {
-                    pd.setSequenceNum(rs.getDouble("SequenceNum"));
+                    pd.setSequenceNum(rs.getBigDecimal("SequenceNum"));
                     pd.setVisitDate(rs.getTimestamp("_VisitDate"));
                 }
                 pd.setParticipantId(rs.getString("ParticipantId"));

--- a/study/src/org/labkey/study/model/VisitImpl.java
+++ b/study/src/org/labkey/study/model/VisitImpl.java
@@ -297,14 +297,6 @@ public class VisitImpl extends AbstractStudyEntity<VisitImpl> implements Cloneab
         return new BigDecimal(s);
     }
 
-
-    @Deprecated // use BigDecimal version instead
-    public static String formatSequenceNum(double d)
-    {
-        d = Math.round(d * SCALE_FACTOR) / SCALE_FACTOR;
-        return SEQUENCE_FORMAT.format(d);
-    }
-
     public static String formatSequenceNum(BigDecimal bd)
     {
         return SEQUENCE_FORMAT.format(bd);

--- a/study/src/org/labkey/study/reports/AssayProgressReport.java
+++ b/study/src/org/labkey/study/reports/AssayProgressReport.java
@@ -150,10 +150,12 @@ public class AssayProgressReport extends AbstractReport
 
             for (SpecimenStatus status : SpecimenStatus.values())
             {
-                data.add(PageFlowUtil.map("name", status.getName(),
-                        "label", status.getLabel(),
-                        "description", status.getDescription(),
-                        "icon-class", status.getIconClass()));
+                data.add(PageFlowUtil.map(
+                    "name", status.getName(),
+                    "label", status.getLabel(),
+                    "description", status.getDescription(),
+                    "icon-class", status.getIconClass())
+                );
             }
             return data;
         }
@@ -192,8 +194,8 @@ public class AssayProgressReport extends AbstractReport
 
         // get all current visits in the study
         Map<Integer, Visit> visitMap = study.getVisits(Visit.Order.CHRONOLOGICAL)
-                .stream()
-                .collect(Collectors.toMap(Visit::getId, e -> e));
+            .stream()
+            .collect(Collectors.toMap(Visit::getId, e -> e));
 
         ListValuedMap<Integer, Integer> scheduledVisits = new ArrayListValuedHashMap<>();
         new TableSelector(StudySchema.getInstance().getTableInfoAssaySpecimenVisit(), TableSelector.ALL_COLUMNS, SimpleFilter.createContainerFilter(context.getContainer()), null)
@@ -211,18 +213,15 @@ public class AssayProgressReport extends AbstractReport
         if (jsonData != null)
         {
             JSONArray assays = new JSONArray(jsonData);
-            if (assays != null)
+            for (JSONObject assay : assays.toJSONObjectArray())
             {
-                for (JSONObject assay : assays.toJSONObjectArray())
-                {
-                    String rowId = assay.getString("RowId");
-                    String assayName = assay.getString("AssayName");
-                    String schemaName = assay.getString("schemaName");
-                    String queryName = assay.getString("queryName");
+                String rowId = assay.getString("RowId");
+                String assayName = assay.getString("AssayName");
+                String schemaName = assay.getString("schemaName");
+                String queryName = assay.getString("queryName");
 
-                    if (rowId != null && assayName != null && schemaName != null && queryName != null)
-                        assayConfigMap.put(NumberUtils.toInt(rowId), assay);
-                }
+                if (rowId != null && assayName != null && schemaName != null && queryName != null)
+                    assayConfigMap.put(NumberUtils.toInt(rowId), assay);
             }
         }
 
@@ -264,11 +263,11 @@ public class AssayProgressReport extends AbstractReport
                 getDatasetData(assay, study, context);
 
                 List<Integer> visits = assaySource.getVisits(context).stream()
-                        .map(Visit::getId)
-                        .collect(Collectors.toList());
+                    .map(Visit::getId)
+                    .collect(Collectors.toList());
                 List<String> visitLabels = assaySource.getVisits(context).stream()
-                        .map(Visit::getDisplayString)
-                        .collect(Collectors.toList());
+                    .map(Visit::getDisplayString)
+                    .collect(Collectors.toList());
 
                 data.put(NAME, assay.getAssayName());
                 data.put(VISITS, visits);
@@ -307,8 +306,8 @@ public class AssayProgressReport extends AbstractReport
             if (specimenStatus != null)
             {
                 heatmap.put(status.getKey().getKey(), PageFlowUtil.map("iconcls", specimenStatus.getIconClass(),
-                        "tooltip", specimenStatus.getDescription(),
-                        "status", specimenStatus.getName()));
+                    "tooltip", specimenStatus.getDescription(),
+                    "status", specimenStatus.getName()));
             }
             else
                 throw new IllegalStateException("Specimen status : " + status.getValue() + " is not a valid status code");
@@ -319,8 +318,8 @@ public class AssayProgressReport extends AbstractReport
         for (ParticipantVisit visit : _linkedToStudyData.get(assay.getAssayName()))
         {
             heatmap.put(visit.getKey(), PageFlowUtil.map("iconcls", available.getIconClass(),
-                    "tooltip", available.getDescription(),
-                    "status", available.getName()));
+                "tooltip", available.getDescription(),
+                "status", available.getName()));
         }
         return heatmap;
     }
@@ -343,7 +342,7 @@ public class AssayProgressReport extends AbstractReport
 
                         String ptid = rs.getString(FieldKey.fromParts("participantId"));
                         //String specimenId = rs.getString(FieldKey.fromParts("specimenId"));
-                        Integer visitId = rs.getInt(FieldKey.fromParts("visitRowId"));
+                        int visitId = rs.getInt(FieldKey.fromParts("visitRowId"));
 
                         if (ptid != null && visitId != 0)
                         {
@@ -371,8 +370,8 @@ public class AssayProgressReport extends AbstractReport
 
     public static class AssayReportBean
     {
-        private ReportIdentifier _id;
-        private Map<Integer, Map<String, Object>> _assayData;
+        private final ReportIdentifier _id;
+        private final Map<Integer, Map<String, Object>> _assayData;
 
         public AssayReportBean(ReportIdentifier id, Map<Integer, Map<String, Object>> assayData)
         {
@@ -452,8 +451,8 @@ public class AssayProgressReport extends AbstractReport
 
     public static class ParticipantVisit
     {
-        private String _ptid;
-        private int _visitId;
+        private final String _ptid;
+        private final int _visitId;
 
         public ParticipantVisit(String ptid, int visitId)
         {

--- a/study/src/org/labkey/study/reports/QueryAssayProgressSource.java
+++ b/study/src/org/labkey/study/reports/QueryAssayProgressSource.java
@@ -38,11 +38,11 @@ import java.util.Set;
  */
 public class QueryAssayProgressSource implements AssayProgressReport.AssayData
 {
-    private AssayProgressReport.AssayExpectation _expectation;
-    private Study _study;
-    private List<String> _participants = new ArrayList<>();
-    private List<Visit> _visits = new ArrayList<>();
-    private List<Pair<AssayProgressReport.ParticipantVisit, String>> _specimenStatus = new ArrayList<>();
+    private final AssayProgressReport.AssayExpectation _expectation;
+    private final Study _study;
+    private final List<String> _participants = new ArrayList<>();
+    private final List<Visit> _visits = new ArrayList<>();
+    private final List<Pair<AssayProgressReport.ParticipantVisit, String>> _specimenStatus = new ArrayList<>();
 
     public QueryAssayProgressSource(AssayProgressReport.AssayExpectation expectation, Study study)
     {
@@ -149,8 +149,8 @@ public class QueryAssayProgressSource implements AssayProgressReport.AssayData
 
     private static class PtidSequenceNum
     {
-        private String _ptid;
-        private Double _sequenceNum;
+        private final String _ptid;
+        private final Double _sequenceNum;
 
         public PtidSequenceNum(String ptid, Double sequenceNum)
         {

--- a/study/src/org/labkey/study/visualization/StudyVisualizationProvider.java
+++ b/study/src/org/labkey/study/visualization/StudyVisualizationProvider.java
@@ -78,10 +78,7 @@ public class StudyVisualizationProvider extends VisualizationProvider<StudyQuery
 
         String name = column.getOriginalName().toLowerCase();
 
-        if (subjectColName.equals(name) || name.startsWith(subjectVisitName) || "container".equals(name))
-            return true;
-
-        return false;
+        return subjectColName.equals(name) || name.startsWith(subjectVisitName) || "container".equals(name);
     }
 
     @Override
@@ -110,7 +107,6 @@ public class StudyVisualizationProvider extends VisualizationProvider<StudyQuery
         }
     }
 
-
     @Override
     public void addExtraColumnProperties(ColumnInfo column, TableInfo table, Map<String, Object> props)
     {
@@ -127,7 +123,6 @@ public class StudyVisualizationProvider extends VisualizationProvider<StudyQuery
             props.put("uniqueKeys", alternateKeys);
         }
     }
-
 
     @Override
     public void appendAggregates(StringBuilder sql, Map<String, Set<VisualizationSourceColumn>> columnAliases, Map<String, VisualizationIntervalColumn> intervals, String queryAlias, IVisualizationSourceQuery joinQuery, boolean forSelect)
@@ -161,7 +156,6 @@ public class StudyVisualizationProvider extends VisualizationProvider<StudyQuery
             }
         }
     }
-
 
     @Override
     public List<Pair<VisualizationSourceColumn, VisualizationSourceColumn>> getJoinColumns(VisualizationSourceColumn.Factory factory, IVisualizationSourceQuery first, IVisualizationSourceQuery second, boolean isGroupByQuery)
@@ -313,20 +307,20 @@ public class StudyVisualizationProvider extends VisualizationProvider<StudyQuery
         if (study != null)
         {
             study.getDatasets()
-                    .stream()
-                    .filter(Dataset::isDemographicData)
-                    .filter(Dataset::isShowByDefault)
-                    .forEach(ds ->
+                .stream()
+                .filter(Dataset::isDemographicData)
+                .filter(Dataset::isShowByDefault)
+                .forEach(ds ->
+                {
+                    Pair<QueryDefinition, TableInfo> entry = getTableAndQueryDef(ds.getName(), ColumnMatchType.DATETIME_COLS, false);
+                    if (entry != null)
                     {
-                        Pair<QueryDefinition, TableInfo> entry = getTableAndQueryDef(ds.getName(), ColumnMatchType.DATETIME_COLS, false);
-                        if (entry != null)
-                        {
-                            QueryDefinition query = entry.getKey();
-                            query.getColumns(null, entry.getValue()).stream()
-                                    .filter(col -> col != null && ColumnMatchType.DATETIME_COLS.match(col))
-                                    .forEach(col -> measures.put(Pair.of(col.getFieldKey(), col), query));
-                        }
-                    });
+                        QueryDefinition query = entry.getKey();
+                        query.getColumns(null, entry.getValue()).stream()
+                            .filter(col -> col != null && ColumnMatchType.DATETIME_COLS.match(col))
+                            .forEach(col -> measures.put(Pair.of(col.getFieldKey(), col), query));
+                    }
+                });
         }
         return measures;
     }


### PR DESCRIPTION
#### Rationale
Sequence numbers want to be represented by `BigDecimal` objects

#### Changes
* Add proper support for BigDecimal types in our `ResultSet` wrapper
* Eliminate a few `Double` references in favor of BigDecimal