### PR TITLE
small fixes to query-import.api

### DIFF
--- a/api/src/org/labkey/api/action/ExtFormResponseWriter.java
+++ b/api/src/org/labkey/api/action/ExtFormResponseWriter.java
@@ -145,10 +145,13 @@ public class ExtFormResponseWriter extends ApiJsonWriter
     @Override
     public void writeAndClose(Errors errors) throws IOException
     {
+        String message = null;
         JSONObject jsonErrors = new JSONObject();
-        for(ObjectError error : errors.getAllErrors())
+        for (ObjectError error : errors.getAllErrors())
         {
             String msg = error.getDefaultMessage();
+            if (message == null)
+                message = msg;
             String key = "_form";
             if (error instanceof FieldError)
                 key = ((FieldError)error).getField();
@@ -159,6 +162,8 @@ public class ExtFormResponseWriter extends ApiJsonWriter
 
         JSONObject root = new JSONObject();
         root.put("success", false); //used by Ext forms
+        // used by client api for FormApiActions (e.g. query-import.api and ImportDataCommand in java clientapi)
+        root.put("exception", message == null ? "(No error message)" : message);
         root.put("errors", jsonErrors);
         try
         {

--- a/api/src/org/labkey/api/query/QueryUpdateService.java
+++ b/api/src/org/labkey/api/query/QueryUpdateService.java
@@ -52,8 +52,15 @@ public interface QueryUpdateService extends HasPermission
 
         // bulk
         IMPORT(true, false, true, false, false),
-        MERGE(true, true, false, false, false),   // insert or update
-        REPLACE(true, true, false, true, false),  // insert or replace, like merge but NULL out columns not in the import
+        /**
+         * Insert or updates a subset of columns.
+         * NOTE: Not supported for all tables -- tables with auto-increment primary keys in particular.
+         */
+        MERGE(true, true, false, false, false),
+        /**
+         * Like MERGE, but will insert or "re-insert" (NULLs values that are not in the import column set.)
+         */
+        REPLACE(true, true, false, true, false),
         IMPORT_IDENTITY(true, false, true, false, true);
 
         final public boolean batch;


### PR DESCRIPTION
#### Changes
* `path` parameter resolves files under pipeline root
* return error message as top-level `exception` property for client api libraries
