### PR TITLE
Issue 43404: Name Expression Counter Column is producing error

### DIFF
--- a/api/src/org/labkey/api/exp/query/DataClassUserSchema.java
+++ b/api/src/org/labkey/api/exp/query/DataClassUserSchema.java
@@ -23,15 +23,17 @@ import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.api.ExpDataClass;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.ViewContext;
 import org.springframework.validation.BindException;
 
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 
@@ -122,4 +124,19 @@ public class DataClassUserSchema extends AbstractExpSchema
         return mts.getDomain().getTypeURI();
     }
 
+
+    @Override
+    public NavTree getSchemaBrowserLinks(User user)
+    {
+        NavTree root = super.getSchemaBrowserLinks(user);
+        if (getContainer().hasPermission(user, ReadPermission.class))
+            root.addChild("Manage DataClasses", ExperimentUrls.get().getDataClassListURL(getContainer()));
+        return root;
+    }
+
+    @Override
+    public boolean hasRegisteredSchemaLinks()
+    {
+        return true;
+    }
 }

--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -29,6 +29,7 @@ import org.labkey.api.data.ForeignKey;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.module.Module;
@@ -39,9 +40,11 @@ import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.publish.StudyPublishService;
 import org.labkey.api.util.StringExpression;
+import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.ViewContext;
 import org.springframework.validation.BindException;
@@ -233,5 +236,20 @@ public class SamplesSchema extends AbstractExpSchema
             throw new NotFoundException("Sample type '" + queryName + "' not found in this container '" + container.getPath() + "'.");
 
         return st.getDomain().getTypeURI();
+    }
+
+    @Override
+    public NavTree getSchemaBrowserLinks(User user)
+    {
+        NavTree root = super.getSchemaBrowserLinks(user);
+        if (getContainer().hasPermission(user, ReadPermission.class))
+            root.addChild("Manage SampleTypes", ExperimentUrls.get().getShowSampleTypeListURL(getContainer()));
+        return root;
+    }
+
+    @Override
+    public boolean hasRegisteredSchemaLinks()
+    {
+        return true;
     }
 }

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -136,7 +136,7 @@ public class ExpDataIterators
 
             SimpleTranslator counterTranslator = new SimpleTranslator(pre, context);
             counterTranslator.setDebugName("Counter Def");
-            Set<String> skipColumns = new HashSet<>();
+            Set<String> skipColumns = new CaseInsensitiveHashSet();
             Map<String, Integer> columnNameMap = DataIteratorUtil.createColumnNameMap(pre);
 
 

--- a/experiment/src/org/labkey/experiment/api/UniqueValueCounterTestCase.java
+++ b/experiment/src/org/labkey/experiment/api/UniqueValueCounterTestCase.java
@@ -95,11 +95,11 @@ public class UniqueValueCounterTestCase
         // setup
         List<GWTPropertyDescriptor> props = new ArrayList<>();
         props.add(new GWTPropertyDescriptor("name", "string"));
-        props.add(new GWTPropertyDescriptor("vessel", "string"));
-        props.add(new GWTPropertyDescriptor("one", "string"));
-        props.add(new GWTPropertyDescriptor("two", "int"));
-        props.add(new GWTPropertyDescriptor("three", "int"));
-        props.add(new GWTPropertyDescriptor("suffix", "string"));
+        props.add(new GWTPropertyDescriptor("Vessel", "string"));
+        props.add(new GWTPropertyDescriptor("One", "string"));
+        props.add(new GWTPropertyDescriptor("Two", "int"));
+        props.add(new GWTPropertyDescriptor("Three", "int"));
+        props.add(new GWTPropertyDescriptor("Suffix", "string"));
 
         final String nameExpression = "${vessel}.${one}.${three}.${suffix}";
 
@@ -122,18 +122,19 @@ public class UniqueValueCounterTestCase
 
         // GOOD INSERT - combinations of the paired columns
         List<Map<String, Object>> rows = new ArrayList<>();
-        rows.add(CaseInsensitiveHashMap.of("vessel", "STP", "one", 10, "two", 1, "suffix", "SUF1"));
-        rows.add(CaseInsensitiveHashMap.of("vessel", "STP", "one", 10, "two", 1, "suffix", "SUF1"));
-        rows.add(CaseInsensitiveHashMap.of("vessel", "STP", "one", 10, "two", 1, "suffix", "SUF2"));
-        rows.add(CaseInsensitiveHashMap.of("vessel", "STP", "one", 10, "two", 1, "suffix", "SUF2"));
-        rows.add(CaseInsensitiveHashMap.of("vessel", "STP", "one", 12, "two", 1, "suffix", "SUF4"));
-        rows.add(CaseInsensitiveHashMap.of("vessel", "STP", "one", 12, "two", 1, "suffix", "SUF4"));
-        rows.add(CaseInsensitiveHashMap.of("vessel", "STP", "one", 12, "two", 2, "suffix", "SUF4A"));
-        rows.add(CaseInsensitiveHashMap.of("vessel", "STP", "one", 12, "two", 2, "suffix", "SUF4A"));
+        rows.add(CaseInsensitiveHashMap.of("Vessel", "STP", "One", 10, "Two", 1, "Suffix", "SUF1"));
+        rows.add(CaseInsensitiveHashMap.of("Vessel", "STP", "One", 10, "Two", 1, "Suffix", "SUF1"));
+        rows.add(CaseInsensitiveHashMap.of("Vessel", "STP", "One", 10, "Two", 1, "Suffix", "SUF2"));
+        rows.add(CaseInsensitiveHashMap.of("Vessel", "STP", "One", 10, "Two", 1, "Suffix", "SUF2"));
+        rows.add(CaseInsensitiveHashMap.of("Vessel", "STP", "One", 12, "Two", 1, "Suffix", "SUF4"));
+        rows.add(CaseInsensitiveHashMap.of("Vessel", "STP", "One", 12, "Two", 1, "Suffix", "SUF4"));
+        rows.add(CaseInsensitiveHashMap.of("Vessel", "STP", "One", 12, "Two", 2, "Suffix", "SUF4A"));
+        rows.add(CaseInsensitiveHashMap.of("Vessel", "STP", "One", 12, "Two", 2, "Suffix", "SUF4A"));
 
         BatchValidationException errors = new BatchValidationException();
         List<Map<String, Object>> inserted = svc.insertRows(user, c, rows, errors, null, null);
-        assertFalse(errors.hasErrors());
+        if (errors.hasErrors())
+            throw errors;
         assertEquals(8, inserted.size());
         assertEquals("STP.10.1.SUF1", inserted.get(0).get("name"));
         assertEquals("STP.10.2.SUF1", inserted.get(1).get("name"));
@@ -147,10 +148,11 @@ public class UniqueValueCounterTestCase
 
         // GOOD INSERT - providing a counter value is ok if it is less than or equal to the current value
         rows = new ArrayList<>();
-        rows.add(CaseInsensitiveHashMap.of("vessel", "STP", "one", 12, "two", 2, "suffix", "SUF4B", "three", 1));  // Specify attached field value < current value is ok
+        rows.add(CaseInsensitiveHashMap.of("VESSEL", "STP", "ONE", 12, "TWO", 2, "SUFFIX", "SUF4B", "THREE", 1));  // Specify attached field value < current value is ok
         errors = new BatchValidationException();
         inserted = svc.insertRows(user, c, rows, errors, null, null);
-        assertFalse(errors.hasErrors());
+        if (errors.hasErrors())
+            throw errors;
         assertEquals(1, inserted.size());
         assertEquals("STP.12.1.SUF4B", inserted.get(0).get("name"));
 
@@ -160,7 +162,8 @@ public class UniqueValueCounterTestCase
         rows.add(CaseInsensitiveHashMap.of("vessel", "STP", "one", 10, "two", 1, "suffix", "SUF1"));
         errors = new BatchValidationException();
         inserted = svc.insertRows(user, c, rows, errors, null, null);
-        assertFalse(errors.hasErrors());
+        if (errors.hasErrors())
+            throw errors;
         assertEquals(1, inserted.size());
         assertEquals("STP.10.5.SUF1", inserted.get(0).get("name"));
 
@@ -193,7 +196,7 @@ public class UniqueValueCounterTestCase
         inserted = svc.insertRows(user, c, rows, errors, null, null);
         assertTrue(errors.hasErrors());
         assertThat(errors.getMessage(),
-                containsString("Paired column 'two' must not be null for counter '" + counterName + "'"));
+                containsString("Paired column 'Two' must not be null for counter '" + counterName + "'"));
 
 
         // BAD INSERT - Specifying attached field with value beyond current counter
@@ -203,7 +206,7 @@ public class UniqueValueCounterTestCase
         inserted = svc.insertRows(user, c, rows, errors, null, null);
         assertTrue(errors.hasErrors());
         assertThat(errors.getMessage(),
-                containsString("Value (20) of paired column 'three' is greater than the current counter value (5) for counter '" + counterName + "'"));
+                containsString("Value (20) of paired column 'Three' is greater than the current counter value (5) for counter '" + counterName + "'"));
     }
 
 


### PR DESCRIPTION
#### Changes
- ExpDataIterators.CounterDataIteratorBuilder use case insensitive hash to avoid duplicate column error
- add regression test to UniqueValueCounterTestCase
- bonus: add schema browser links to manage sample types and data classes