### PR TITLE
Issue 43420: Swap jTidy --> jSoup

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -81,7 +81,7 @@ List others = [
         "org.apache.xmlgraphics:fop:${fopVersion}",
         "flyingsaucer:core-renderer:${flyingsaucerVersion}",
         "com.google.guava:guava:${guavaVersion}",
-        "net.sf.jtidy:jtidy:${jtidyVersion}",
+        "org.jsoup:jsoup:${jsoupVersion}",
         "org.quartz-scheduler:quartz:${quartzVersion}",
         "net.coobird:thumbnailator:${thumbnailatorVersion}",
         "org.apache.xmlbeans:xmlbeans:${xmlbeansVersion}",

--- a/api/src/org/labkey/api/util/TidyUtil.java
+++ b/api/src/org/labkey/api/util/TidyUtil.java
@@ -15,24 +15,18 @@
  */
 package org.labkey.api.util;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
+import org.jsoup.Jsoup;
+import org.jsoup.helper.W3CDom;
+import org.jsoup.parser.Parser;
+import org.jsoup.parser.XmlTreeBuilder;
 import org.junit.Assert;
 import org.junit.Test;
-import org.w3c.dom.CharacterData;
 import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.w3c.tidy.Tidy;
 
-import java.io.ByteArrayInputStream;
-import java.io.PrintWriter;
-import java.io.StringReader;
-import java.io.StringWriter;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.LinkedList;
-import java.util.Map;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -47,20 +41,7 @@ public class TidyUtil
     @Nullable
     public static Document convertHtmlToDocument(final String html, final boolean asXML, final Collection<String> errors)
     {
-        Tidy tidy = configureHtmlTidy(asXML);
-        return tidyParseDOM(tidy, html, errors);
-    }
-
-    public static String tidyHTML(final String html, boolean asXML, final Collection<String> errors)
-    {
-        Tidy tidy = configureHtmlTidy(asXML);
-        return tidyParse(tidy, html, errors);
-    }
-
-    public static String tidyXML(final String xml, final Collection<String> errors)
-    {
-        Tidy tidy = configureXmlTidy();
-        return tidyParse(tidy, xml, errors);
+        return W3CDom.convert(asXML ? parseXmlDOM(html, errors) : parseHtmlDOM(html, errors));
     }
 
     // helper for script validation
@@ -69,144 +50,170 @@ public class TidyUtil
         return tidyHTML(html, true, errors);
     }
 
-    private static Tidy configureHtmlTidy(final boolean asXML)
+    public static String tidyHTML(final String html, boolean asXML, final Collection<String> errors)
     {
-        Tidy tidy = new Tidy();
-        if (asXML)
-            tidy.setXHTML(true);
-        tidy.setShowWarnings(false);
-        tidy.setIndentContent(false);
-        tidy.setSmartIndent(false);
-        tidy.setInputEncoding("UTF-8");
-        tidy.setOutputEncoding("UTF-8");
-        tidy.setDropEmptyParas(false); // radeox wikis use <p/> -- don't remove them
-        tidy.setTrimEmptyElements(false); // keeps tidy from converting <p/> to <br><br>
-        tidy.setWraplen(0);
-        tidy.setWrapAttVals(false);
-
-        return tidy;
+        return asXML ? parseXmlDOM(html, errors).toString() : parseHtmlDOM(html, errors).toString();
     }
 
-    private static Tidy configureXmlTidy()
+    public static String tidyXML(final String xml, final Collection<String> errors)
     {
-        Tidy tidy = new Tidy();
-        tidy.setXmlOut(true);
-        tidy.setXmlTags(true);
-        tidy.setShowWarnings(false);
-        tidy.setIndentContent(false);
-        tidy.setSmartIndent(false);
-        tidy.setInputEncoding("UTF-8"); // utf8
-        tidy.setOutputEncoding("UTF-8"); // utf8
-
-        return tidy;
+        return parseXmlDOM(xml, errors).toString();
     }
 
-    private static String tidyParse(final Tidy tidy, final String content, final Collection<String> errors)
+//
+//    private static Tidy configureHtmlTidy(final boolean asXML)
+//    {
+//
+//        Tidy tidy = new Tidy();
+//        if (asXML)
+//            tidy.setXHTML(true);
+//        tidy.setShowWarnings(false);
+//        tidy.setIndentContent(false);
+//        tidy.setSmartIndent(false);
+//        tidy.setInputEncoding("UTF-8");
+//        tidy.setOutputEncoding("UTF-8");
+//        tidy.setDropEmptyParas(false); // radeox wikis use <p/> -- don't remove them
+//        tidy.setTrimEmptyElements(false); // keeps tidy from converting <p/> to <br><br>
+//        tidy.setWraplen(0);
+//        tidy.setWrapAttVals(false);
+//
+//        return tidy;
+//    }
+//
+//    private static XmlTreeBuilder configureXmlTidy()
+//    {
+//        Tidy tidy = new Tidy();
+//        tidy.setXmlOut(true);
+//        tidy.setXmlTags(true);
+//        tidy.setShowWarnings(false);
+//        tidy.setIndentContent(false);
+//        tidy.setSmartIndent(false);
+//        tidy.setInputEncoding("UTF-8"); // utf8
+//        tidy.setOutputEncoding("UTF-8"); // utf8
+//
+//        return tidy;
+//    }
+
+//    private static String tidyParse(final Tidy tidy, final String content, final Collection<String> errors)
+//    {
+//        StringWriter err = new StringWriter();
+//        tidy.setErrout(new PrintWriter(err));
+//        StringWriter out = new StringWriter();
+//        try
+//        {
+//            tidy.parse(new StringReader(content), out);
+//        }
+//        catch (NullPointerException e)
+//        {
+//            errors.add("Tidy failed to parse html. Check that all html tags are valid and not malformed.");
+//        }
+//        tidy.getErrout().close();
+//
+//        collectErrors(err, errors);
+//
+//        return out.getBuffer().toString();
+//    }
+
+    private static org.jsoup.nodes.Document parseXmlDOM(String content, final Collection<String> errors)
     {
-        StringWriter err = new StringWriter();
-        tidy.setErrout(new PrintWriter(err));
-        StringWriter out = new StringWriter();
-        try
-        {
-            tidy.parse(new StringReader(content), out);
-        }
-        catch (NullPointerException e)
-        {
-            errors.add("Tidy failed to parse html. Check that all html tags are valid and not malformed.");
-        }
-        tidy.getErrout().close();
-
-        collectErrors(err, errors);
-
-        return out.getBuffer().toString();
-    }
-
-    @Nullable
-    private static Document tidyParseDOM(final Tidy tidy, final String content, final Collection<String> errors)
-    {
-        // TIDY does not properly parse the contents of script tags!
-        // see bug 5007
-        // CONSIDER: fix jtidy see ParserImpl$ParseScript
-        Map<String,String> scriptMap = new HashMap<>();
-        StringBuffer stripped = new StringBuffer(content.length());
-        Matcher scriptMatcher = scriptPattern.matcher(content);
-        int unique = content.hashCode();
-        int count = 0;
-
-        while (scriptMatcher.find())
-        {
-            count++;
-            String key = "{{{" + unique + ":::" + count + "}}}";
-            String match = scriptMatcher.group(2);
-            scriptMap.put(key,match);
-            scriptMatcher.appendReplacement(stripped, "$1" + key + "$3");
-        }
-        scriptMatcher.appendTail(stripped);
-
-        StringWriter err = new StringWriter();
-        // parse wants to use streams
-        tidy.setErrout(new PrintWriter(err));
-
-        String strippedString = stripped.toString().trim();
-
-        if (strippedString.isEmpty())
+        if (StringUtils.isBlank(content))
             return null;
 
-        Document doc = null;
-        try
-        {
-            doc = tidy.parseDOM(new ByteArrayInputStream(strippedString.getBytes(StringUtilsLabKey.DEFAULT_CHARSET)), null);
-        }
-        catch (NullPointerException e)
-        {
-            errors.add("Tidy failed to parse html. Check that all html tags are valid and not malformed.");
-        }
-
-        // fix up scripts
-        if (null != doc && null != doc.getDocumentElement())
-        {
-            NodeList nl = doc.getDocumentElement().getElementsByTagName("script");
-            for (int i=0 ; i<nl.getLength() ; i++)
-            {
-                Node script = nl.item(i);
-                NodeList childNodes = script.getChildNodes();
-                if (childNodes.getLength() != 1)
-                    continue;
-                Node child = childNodes.item(0);
-                if (!(child instanceof CharacterData))
-                    continue;
-                String contents = ((CharacterData)child).getData();
-                String replace = scriptMap.get(contents);
-                if (null == replace)
-                    continue;
-                doc.createTextNode(replace);
-                script.removeChild(childNodes.item(0));
-                script.appendChild(doc.createTextNode(replace));
-            }
-        }
-
-        tidy.getErrout().close();
-        collectErrors(err, errors);
-
-        return doc;
+        Parser parser = new Parser(new XmlTreeBuilder());
+        return parser.parseInput(content, "");
     }
 
-    private static void collectErrors(final StringWriter err, final Collection<String> errors)
+    private static org.jsoup.nodes.Document parseHtmlDOM(String content, final Collection<String> errors)
     {
-        String errorString = err.toString();
-
-        for (String error : errorString.split("\n"))
-        {
-            if (error.contains("Error:"))
-                errors.add(error.trim());
-        }
-
-        // Provide a generic error when JTidy flips out and doesn't report the actual error
-        String genericError = "This document has errors that must be fixed";
-
-        if (errors.isEmpty() && errorString.contains(genericError))
-            errors.add(genericError);
+        return Jsoup.parse(content);
     }
+
+//    @Nullable
+//    private static Document tidyParseDOM(final Tidy tidy, final String content, final Collection<String> errors)
+//    {
+//        // TIDY does not properly parse the contents of script tags!
+//        // see bug 5007
+//        // CONSIDER: fix jtidy see ParserImpl$ParseScript
+//        Map<String,String> scriptMap = new HashMap<>();
+//        StringBuffer stripped = new StringBuffer(content.length());
+//        Matcher scriptMatcher = scriptPattern.matcher(content);
+//        int unique = content.hashCode();
+//        int count = 0;
+//
+//        while (scriptMatcher.find())
+//        {
+//            count++;
+//            String key = "{{{" + unique + ":::" + count + "}}}";
+//            String match = scriptMatcher.group(2);
+//            scriptMap.put(key,match);
+//            scriptMatcher.appendReplacement(stripped, "$1" + key + "$3");
+//        }
+//        scriptMatcher.appendTail(stripped);
+//
+//        StringWriter err = new StringWriter();
+//        // parse wants to use streams
+//        tidy.setErrout(new PrintWriter(err));
+//
+//        String strippedString = stripped.toString().trim();
+//
+//        if (strippedString.isEmpty())
+//            return null;
+//
+//        Document doc = null;
+//        try
+//        {
+//            doc = tidy.parseDOM(new ByteArrayInputStream(strippedString.getBytes(StringUtilsLabKey.DEFAULT_CHARSET)), null);
+//        }
+//        catch (NullPointerException e)
+//        {
+//            errors.add("Tidy failed to parse html. Check that all html tags are valid and not malformed.");
+//        }
+//
+//        // fix up scripts
+//        if (null != doc && null != doc.getDocumentElement())
+//        {
+//            NodeList nl = doc.getDocumentElement().getElementsByTagName("script");
+//            for (int i=0 ; i<nl.getLength() ; i++)
+//            {
+//                Node script = nl.item(i);
+//                NodeList childNodes = script.getChildNodes();
+//                if (childNodes.getLength() != 1)
+//                    continue;
+//                Node child = childNodes.item(0);
+//                if (!(child instanceof CharacterData))
+//                    continue;
+//                String contents = ((CharacterData)child).getData();
+//                String replace = scriptMap.get(contents);
+//                if (null == replace)
+//                    continue;
+//                doc.createTextNode(replace);
+//                script.removeChild(childNodes.item(0));
+//                script.appendChild(doc.createTextNode(replace));
+//            }
+//        }
+//
+//        tidy.getErrout().close();
+//        collectErrors(err, errors);
+//
+//        return doc;
+//    }
+
+//    private static void collectErrors(final StringWriter err, final Collection<String> errors)
+//    {
+//        String errorString = err.toString();
+//
+//        for (String error : errorString.split("\n"))
+//        {
+//            if (error.contains("Error:"))
+//                errors.add(error.trim());
+//        }
+//
+//        // Provide a generic error when JTidy flips out and doesn't report the actual error
+//        String genericError = "This document has errors that must be fixed";
+//
+//        if (errors.isEmpty() && errorString.contains(genericError))
+//            errors.add(genericError);
+//    }
 
 
     // TODO: Add many more test cases... jtidy behaves very badly


### PR DESCRIPTION
#### Rationale
jTidy appears abandoned and doesn't support common HTML5 tag elements

[Issue #43420: Replace jTidy with jSoup...or similar](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43420)

#### Related Pull Requests
* https://github.com/LabKey/server/pull/95

#### Changes
* Swapped jSoup library in place of jTidy
* TODOs
  * Additional code clean up
  * Expand unit tests
  * Use experimental flag/deprecation scheme?
