### PR TITLE
Item 9065: Support linking samples to study in LKSM 

### DIFF
--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -86,6 +86,8 @@ public interface SampleTypeService
     @Nullable
     ExpSampleType getSampleType(String lsid);
 
+    void removeAutoLinkedStudy(@NotNull Container studyContainer, @Nullable User user);
+
     /**
      * @param includeOtherContainers whether sample types from the shared container or the container's project should be included
      */

--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -207,6 +207,7 @@ public interface Dataset extends StudyEntity, StudyCachable<Dataset>
                     public ActionURL getSourceActionURL(ExpObject sourceObject, Container container)
                     {
                         ActionURL url;
+                        // When the sample management module is enabled in the sample type's container, we want to link into the application
                         if (container.getActiveModules().contains(ModuleLoader.getInstance().getModule("sampleManagement")))
                         {
                             url = new ActionURL("sampleManager", "app", container);

--- a/api/src/org/labkey/api/study/query/SourceDataLinkDisplayColumn.java
+++ b/api/src/org/labkey/api/study/query/SourceDataLinkDisplayColumn.java
@@ -21,7 +21,6 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpSampleType;
-import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
@@ -77,7 +76,7 @@ public class SourceDataLinkDisplayColumn extends DataInputColumn
                     ExpObject expObject = _publishSource.resolvePublishSource(sourceId);
                     if (expObject instanceof ExpSampleType)
                     {
-                        ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getShowSampleTypeURL((ExpSampleType)expObject);
+                        ActionURL url = _publishSource.getSourceActionURL(expObject, ctx.getContainer());
                         // by default the container is where the sample definition lives, use the current container instead so
                         // the user is returned to the original folder that the link was attempted from.
                         url.setContainer(ctx.getContainer());

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -4373,9 +4373,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.46.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.46.0.tgz",
-      "integrity": "sha1-d6ZIehqYmzasXqdim7eBIOjukD4=",
+      "version": "2.49.0-smLinkToStudy.0",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.49.0-smLinkToStudy.0.tgz",
+      "integrity": "sha1-x24W1611XQEvqwyxNR4EB+5Avmk=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -4373,9 +4373,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.49.0-smLinkToStudy.1",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.49.0-smLinkToStudy.1.tgz",
-      "integrity": "sha1-fpXQ79KL46OfV4uLC0isirM6vXs=",
+      "version": "2.50.0-smLinkToStudy.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.50.0-smLinkToStudy.2.tgz",
+      "integrity": "sha1-Ko8k9A/oABtGMVDE2Js4DO0p6OE=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -4373,9 +4373,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.51.0-smLinkToStudy.3",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.51.0-smLinkToStudy.3.tgz",
-      "integrity": "sha1-4IJ0IEZRLdtdNkLqwjifE/wwIV4=",
+      "version": "2.50.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.50.2.tgz",
+      "integrity": "sha1-zLmTX3Dg1xSdC/dEtQ7QMBjwBKA=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -4373,9 +4373,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.51.0-smLinkToStudy.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.51.0-smLinkToStudy.2.tgz",
-      "integrity": "sha1-BRs4/50gUHp2CEokNh6hzA3Z378=",
+      "version": "2.51.0-smLinkToStudy.3",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.51.0-smLinkToStudy.3.tgz",
+      "integrity": "sha1-4IJ0IEZRLdtdNkLqwjifE/wwIV4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -4373,9 +4373,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.49.0-smLinkToStudy.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.49.0-smLinkToStudy.0.tgz",
-      "integrity": "sha1-x24W1611XQEvqwyxNR4EB+5Avmk=",
+      "version": "2.49.0-smLinkToStudy.1",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.49.0-smLinkToStudy.1.tgz",
+      "integrity": "sha1-fpXQ79KL46OfV4uLC0isirM6vXs=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -4373,9 +4373,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.50.0-smLinkToStudy.2",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.50.0-smLinkToStudy.2.tgz",
-      "integrity": "sha1-Ko8k9A/oABtGMVDE2Js4DO0p6OE=",
+      "version": "2.51.0-smLinkToStudy.2",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.51.0-smLinkToStudy.2.tgz",
+      "integrity": "sha1-BRs4/50gUHp2CEokNh6hzA3Z378=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.6.0",
-    "@labkey/components": "2.49.0-smLinkToStudy.1",
+    "@labkey/components": "2.50.0-smLinkToStudy.2",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.2.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.6.0",
-    "@labkey/components": "2.50.0-smLinkToStudy.2",
+    "@labkey/components": "2.51.0-smLinkToStudy.2",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.2.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.6.0",
-    "@labkey/components": "2.51.0-smLinkToStudy.2",
+    "@labkey/components": "2.51.0-smLinkToStudy.3",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.2.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.6.0",
-    "@labkey/components": "2.49.0-smLinkToStudy.0",
+    "@labkey/components": "2.49.0-smLinkToStudy.1",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.2.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.6.0",
-    "@labkey/components": "2.46.0",
+    "@labkey/components": "2.49.0-smLinkToStudy.0",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.2.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.6.0",
-    "@labkey/components": "2.51.0-smLinkToStudy.3",
+    "@labkey/components": "2.50.2",
     "@labkey/eslint-config-react": "0.0.8",
     "@labkey/themes": "1.2.0"
   },

--- a/core/src/client/SampleTypeDesigner/SampleTypeDesigner.tsx
+++ b/core/src/client/SampleTypeDesigner/SampleTypeDesigner.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import React from 'react'
-import { ActionURL, getServerContext } from "@labkey/api";
+import React from 'react';
+import { ActionURL, getServerContext } from '@labkey/api';
 import {
     Alert,
     BeforeUnload,
@@ -26,9 +26,9 @@ import {
     LoadingSpinner,
     SampleTypeDesigner,
     SampleTypeModel
-} from "@labkey/components"
+} from '@labkey/components';
 
-import "../DomainDesigner.scss"
+import '../DomainDesigner.scss';
 
 interface State {
     sampleType?: DomainDetails
@@ -157,6 +157,7 @@ export class App extends React.PureComponent<any, State> {
                     includeDataClasses={true}
                     useTheme={true}
                     appPropertiesOnly={false}
+                    showLinkToStudy={true}
                     successBsStyle={'primary'}
                 />
             </BeforeUnload>

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -389,7 +389,9 @@ public class ExpDataIterators
                 return false;
             }
 
-            if (_participantIDCol != null && _rowIdCol != null && _lsidCol != null && (_dateCol != null || _visitIdCol != null))
+            boolean isVisitBased = _study.getTimepointType().isVisitBased();
+            boolean haveVisitCol = isVisitBased ? _visitIdCol != null : _dateCol != null;
+            if (_participantIDCol != null && _rowIdCol != null && _lsidCol != null && haveVisitCol)
             {
                 String participantId = _participantIDCol.get() != null ? _participantIDCol.get().toString() : null;
                 Object date = _dateCol != null ? _dateCol.get() : null;
@@ -398,14 +400,14 @@ public class ExpDataIterators
                 int rowId = ((Number) _rowIdCol.get()).intValue();
 
                 // Only link rows that have a participant and a visit/date. Return if this is not the case
-                if (participantId == null || (date == null && visit == null))
+                if (participantId == null || (isVisitBased && visit == null) || (!isVisitBased && date == null))
                     return true;
 
                 Float visitId = null;
                 Date dateId = null;
 
                 // 13647: Conversion exception in auto link to study
-                if (_study.getTimepointType().isVisitBased())
+                if (isVisitBased)
                 {
                     visitId = Float.parseFloat(visit.toString());
                 }

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -395,7 +395,7 @@ public class ExpDataIterators
             {
                 String participantId = _participantIDCol.get() != null ? _participantIDCol.get().toString() : null;
                 Object date = _dateCol != null ? _dateCol.get() : null;
-                Object visit = _visitIdCol.get();
+                Object visit = _visitIdCol != null ? _visitIdCol.get(): null;
                 Object lsid = _lsidCol.get();
                 int rowId = ((Number) _rowIdCol.get()).intValue();
 
@@ -413,7 +413,7 @@ public class ExpDataIterators
                 }
                 else
                 {
-                    dateId = (Date) ConvertUtils.convert(visit.toString(), Date.class);
+                    dateId = (Date) ConvertUtils.convert(date.toString(), Date.class);
                 }
 
                 Map<String,Object> row = new HashMap<>();

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -310,6 +310,15 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     }
 
     @Override
+    public void removeAutoLinkedStudy(@NotNull Container studyContainer, @Nullable User user)
+    {
+        SQLFragment sql = new SQLFragment("UPDATE ").append(getTinfoMaterialSource())
+                .append(" SET autolinkTargetContainer = NULL WHERE autolinkTargetContainer = ?")
+                .add(studyContainer.getId());
+        new SqlExecutor(ExperimentService.get().getSchema()).execute(sql);
+    }
+
+    @Override
     public List<ExpSampleTypeImpl> getSampleTypes(@NotNull Container container, @Nullable User user, boolean includeOtherContainers)
     {
         List<String> containerIds = ExperimentServiceImpl.get().createContainerList(container, user, includeOtherContainers);

--- a/study/src/org/labkey/study/StudyContainerListener.java
+++ b/study/src/org/labkey/study/StudyContainerListener.java
@@ -17,6 +17,7 @@ package org.labkey.study;
 
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.security.User;
 import org.labkey.study.model.StudyImpl;
 import org.labkey.study.model.StudyManager;
@@ -40,6 +41,7 @@ public class StudyContainerListener extends ContainerManager.AbstractContainerLi
             ancillaryStudy.setSourceStudyContainerId(null);
             StudyManager.getInstance().updateStudy(user, ancillaryStudy);
         }
+        SampleTypeService.get().removeAutoLinkedStudy(c, user);
     }
 
     @Override

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -476,7 +476,7 @@ public class DatasetQueryView extends StudyQueryView
             if (c.hasPermission(getUser(), ReadPermission.class))
             {
                 ActionButton btn = _dataset.getPublishSource().getSourceButton(_dataset.getPublishSourceId(),
-                        ContainerFilter.Type.CurrentAndSubfolders.create(getSchema()));
+                        ContainerFilter.Type.CurrentAndSubfolders.create(getSchema()), c);
                 if (btn != null)
                     bar.add(btn);
             }


### PR DESCRIPTION
#### Rationale
When the study module is present along with sample manager, we want to be able to link samples to study datasets from within the application.  We also want to link into LKSM when the source type's container has that module enabled.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/607
* https://github.com/LabKey/labkey-ui-components/pull/564
* https://github.com/LabKey/biologics/pull/919

#### Changes
* Update links to the source type of a sample data set to go to LKSM when the source container has that module enabled.
* Use newly parameterized SampleTypeDesigner
