### PR TITLE
Issue43400: setDefaultDomain() skips audit logging

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -254,11 +254,17 @@ public class AuthenticationManager
         return value == null ? "" : value;
     }
 
+    // To remove along with single usage upon release of 21.11
     public static void setDefaultDomain(String value)
     {
         PropertyMap props = PropertyManager.getWritableProperties(AUTHENTICATION_CATEGORY, true);
         props.put(DEFAULT_DOMAIN, value);
         props.save();
+    }
+
+    public static void setDefaultDomain(User user, String value)
+    {
+        saveAuthSetting(user, DEFAULT_DOMAIN, value);
     }
 
     public static boolean getAuthSetting(String key, boolean defaultValue)

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -254,14 +254,6 @@ public class AuthenticationManager
         return value == null ? "" : value;
     }
 
-    // To remove along with single usage upon release of 21.11
-    public static void setDefaultDomain(String value)
-    {
-        PropertyMap props = PropertyManager.getWritableProperties(AUTHENTICATION_CATEGORY, true);
-        props.put(DEFAULT_DOMAIN, value);
-        props.save();
-    }
-
     public static void setDefaultDomain(User user, String value)
     {
         saveAuthSetting(user, DEFAULT_DOMAIN, value);

--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -622,7 +622,7 @@ class AppPropsImpl extends AbstractWriteableSettingsGroup implements AppProps
                 switch (prop.getName())
                 {
                     case DEFAULT_DOMAIN_PROP -> {
-                        AuthenticationManager.setDefaultDomain(prop.getValue());
+                        AuthenticationManager.setDefaultDomain(UserManager.getGuestUser(), prop.getValue());
                         LOG.warn("Support for the \"SiteSettings.defaultDomain\" startup property will be removed shortly; use \"Authentication.DefaultDomain\" instead.");
                     }
                     case BASE_SERVER_URL_PROP -> writeable.setBaseServerUrl(prop.getValue());

--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -624,7 +624,6 @@ class AppPropsImpl extends AbstractWriteableSettingsGroup implements AppProps
                     case DEFAULT_DOMAIN_PROP -> {
                         AuthenticationManager.setDefaultDomain(prop.getValue());
                         LOG.warn("Support for the \"SiteSettings.defaultDomain\" startup property will be removed shortly; use \"Authentication.DefaultDomain\" instead.");
-
                     }
                     case BASE_SERVER_URL_PROP -> writeable.setBaseServerUrl(prop.getValue());
                     case PIPELINE_TOOLS_DIR_PROP -> writeable.setPipelineToolsDir(prop.getValue());

--- a/core/src/org/labkey/core/CoreUpgradeCode.java
+++ b/core/src/org/labkey/core/CoreUpgradeCode.java
@@ -235,7 +235,7 @@ public class CoreUpgradeCode implements UpgradeCode
                 }
             }).getDefaultDomain();
 
-            AuthenticationManager.setDefaultDomain(defaultDomain);
+            AuthenticationManager.setDefaultDomain(context.getUpgradeUser(), defaultDomain);
         }
     }
 }

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1296,7 +1296,7 @@ public class AdminController extends SpringActionController
 
             WriteableAppProps props = AppProps.getWriteableInstance();
 
-            AuthenticationManager.setDefaultDomain(form.getDefaultDomain());
+            AuthenticationManager.setDefaultDomain(getUser(), form.getDefaultDomain());
             props.setPipelineToolsDir(form.getPipelineToolsDirectory());
             props.setNavAccessOpen(form.isNavAccessOpen());
             props.setSSLRequired(form.isSslRequired());

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1931,7 +1931,7 @@ public class LoginController extends SpringActionController
                         if (atSign > 0 && atSign < userEmailAddress.length() - 1)
                         {
                             String defaultDomain = userEmailAddress.substring(atSign + 1);
-                            AuthenticationManager.setDefaultDomain(defaultDomain);
+                            AuthenticationManager.setDefaultDomain(getUser(), defaultDomain);
                         }
 
                         transaction.commit();


### PR DESCRIPTION
#### Rationale
Previous version of setDefaultDomain() skipped audit logging, which was no good.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2327

#### Changes
* Refactor `setDefaultDomain()` to take in a user and to call `saveAuthSetting()`, which audits properly
* Refactor calls to `setDefaultDomain()`
