### PR TITLE
AnnouncementServiceImpl: Fix NPE in getDiscussionSrcTypeProvider

### DIFF
--- a/announcements/src/org/labkey/announcements/api/AnnouncementServiceImpl.java
+++ b/announcements/src/org/labkey/announcements/api/AnnouncementServiceImpl.java
@@ -181,8 +181,11 @@ public class AnnouncementServiceImpl implements AnnouncementService
     }
 
     @Override
-    public @Nullable DiscussionSrcTypeProvider getDiscussionSrcTypeProvider(String type)
+    public @Nullable DiscussionSrcTypeProvider getDiscussionSrcTypeProvider(@Nullable String type)
     {
+        if (type == null)
+            return null;
+
         return _discussionSrcTypeProviders.get(type);
     }
 


### PR DESCRIPTION
#### Rationale
This change fixes the failing tests (AnnouncementAPITest, ModeratorReviewTest, AnnouncementsPermissionTest)

#### Related Pull Requests
* n/a

#### Changes
* Null check in getDiscussionSrcTypeProvider
