### PR TITLE
Issue38536: Revert refactor of Button.java

### DIFF
--- a/api/src/org/labkey/api/util/Button.java
+++ b/api/src/org/labkey/api/util/Button.java
@@ -231,6 +231,7 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
     {
         boolean iconOnly = getIconCls() != null;
         String submitId = GUID.makeGUID();
+        // In the icon-only button case, use caption as tooltip. This avoids having to set both caption and tooltip
         final HtmlString tip = (null != tooltip ? HtmlString.of(tooltip) : (!iconOnly ? null : html));
         String hrefValue = (null == getHref()) ? "#" : getHref();
 

--- a/api/src/org/labkey/api/util/Button.java
+++ b/api/src/org/labkey/api/util/Button.java
@@ -231,7 +231,7 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
     {
         boolean iconOnly = getIconCls() != null;
         String submitId = GUID.makeGUID();
-        final HtmlString tip = HtmlString.of(tooltip);
+        final HtmlString tip = (null != tooltip ? HtmlString.of(tooltip) : (!iconOnly ? null : html));
         String hrefValue = (null == getHref()) ? "#" : getHref();
 
         var attrs = at(attributes)

--- a/issues/src/org/labkey/issue/view/detailList.jsp
+++ b/issues/src/org/labkey/issue/view/detailList.jsp
@@ -70,7 +70,7 @@
     <div class="col-sm-4" style="margin-bottom: 5px">
         <labkey:form name="jumpToIssue" action="<%= new ActionURL(IssuesController.JumpToIssueAction.class, c) %>" layout="inline">
             <labkey:input name="issueId" placeholder="ID # or Search Term"/>
-            <%= button("Search").iconCls("search").tooltip("Search").submit(true) %>
+            <%= button("Search").iconCls("search").submit(true) %>
         </labkey:form>
     </div>
     <div class="col-sm-5" style="margin-bottom: 5px">

--- a/issues/src/org/labkey/issue/view/detailView.jsp
+++ b/issues/src/org/labkey/issue/view/detailView.jsp
@@ -217,7 +217,7 @@
             <div class="input-group">
                 <labkey:input name="issueId" formGroup="false" placeholder="ID # or Search Term"/>
                 <div class="input-group-btn">
-                    <%= button("Search").addClass("btn btn-default").iconCls("search").tooltip("Search").submit(true) %>
+                    <%= button("Search").addClass("btn btn-default").iconCls("search").submit(true) %>
                 </div>
             </div>
         </labkey:form>

--- a/issues/src/org/labkey/issue/view/list.jsp
+++ b/issues/src/org/labkey/issue/view/list.jsp
@@ -44,7 +44,7 @@
             <div class="input-group">
                 <labkey:input name="issueId" formGroup="false" placeholder="ID # or Search Term"/>
                 <div class="input-group-btn">
-                    <%= button("Search").addClass("btn btn-default").iconCls("search").tooltip("Search").submit(true) %>
+                    <%= button("Search").addClass("btn btn-default").iconCls("search").submit(true) %>
                 </div>
             </div>
         </labkey:form>

--- a/mothership/src/org/labkey/mothership/view/linkBar.jsp
+++ b/mothership/src/org/labkey/mothership/view/linkBar.jsp
@@ -42,7 +42,7 @@
         <div class="input-group">
             <labkey:input name="errorCode" formGroup="false" placeholder="Find Error Code"/>
             <div class="input-group-btn">
-                <%= button("Search").addClass("btn btn-default").iconCls("search").tooltip("Search").submit(true) %>
+                <%= button("Search").addClass("btn btn-default").iconCls("search").submit(true) %>
             </div>
         </div>
     </labkey:form>


### PR DESCRIPTION
#### Rationale
We decided that the prior existing functionality does in fact made sense. In the icon-only button case, using the caption as a tooltip avoids having to set both caption and tooltip. An explanatory comment has been added to avoid confusing later generations.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2383/files

#### Changes
* Revert changes of related pull request
* Add explanatory comment
