### PR TITLE
Ensure that web part cache is cleared after any pending commits

### DIFF
--- a/api/src/org/labkey/api/view/WebPartCache.java
+++ b/api/src/org/labkey/api/view/WebPartCache.java
@@ -26,6 +26,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
@@ -147,6 +148,9 @@ public class WebPartCache
 
     static void remove(Container c)
     {
-        CACHE.remove(c.getId());
+        CoreSchema.getInstance().getSchema().getScope().addCommitTask(
+                () -> CACHE.remove(c.getId()),
+                DbScope.CommitTaskOption.IMMEDIATE,
+                DbScope.CommitTaskOption.POSTCOMMIT);
     }
 }


### PR DESCRIPTION
#### Rationale
We're clearing the cache after making changes to a container's portal configuration. However, if a transaction is pending, it's possible that another thread will repopulate the cache before it's committed, meaning that the cache will be stale.

Discovered in the context of Panorama scenarios that add portal tabs and web parts in the context of a transacted import

#### Changes
* Clear cache immediately and after committing