### PR TITLE
Issue 43349: SampleTypeUpdateServiceDI.getExistingRows() performance

### DIFF
--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -285,6 +285,8 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
                 if (rowNumber <= lastPrefetchRowNumber)
                     return;
 
+                existingRecords.clear();
+
                 int rowsToFetch = 50;
                 Map<Integer, Map<String,Object>> keysMap = new LinkedHashMap<>();
                 do
@@ -294,10 +296,9 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
                     for (int p=0 ; p<pkColumns.size() ; p++)
                         keyMap.put(pkColumns.get(p).getColumnName(), pkSuppliers.get(p).get());
                     keysMap.put(lastPrefetchRowNumber, keyMap);
+                    existingRecords.put(lastPrefetchRowNumber, Map.of());
                 }
                 while (--rowsToFetch > 0 && _delegate.next());
-
-                existingRecords.clear();
 
                 Map<Integer, Map<String, Object>> rowsMap = qus.getExistingRows(user, c, keysMap);
                 for (Map.Entry<Integer, Map<String, Object>> rowMap : rowsMap.entrySet())

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -100,6 +100,7 @@ import java.io.StringReader;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -161,6 +162,23 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
             Map<String, Object> row = getRow(user, container, rowKeys);
             if (row != null)
                 result.add(row);
+        }
+        return result;
+    }
+
+    @Override
+    public Map<Integer, Map<String, Object>> getExistingRows(User user, Container container, Map<Integer, Map<String, Object>> keys)
+            throws InvalidKeyException, QueryUpdateServiceException, SQLException
+    {
+        if (!hasPermission(user, ReadPermission.class))
+            throw new UnauthorizedException("You do not have permission to read data from this table.");
+
+        Map<Integer, Map<String, Object>> result = new LinkedHashMap<>();
+        for (Map.Entry<Integer, Map<String, Object>> key : keys.entrySet())
+        {
+            Map<String, Object> row = getRow(user, container, key.getValue());
+            if (row != null)
+                result.put(key.getKey(), row);
         }
         return result;
     }

--- a/api/src/org/labkey/api/query/CacheClearingQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/CacheClearingQueryUpdateService.java
@@ -51,6 +51,15 @@ public abstract class CacheClearingQueryUpdateService implements QueryUpdateServ
     }
 
     @Override
+    public Map<Integer, Map<String, Object>> getExistingRows(User user, Container container, Map<Integer, Map<String, Object>> keys)
+            throws InvalidKeyException, QueryUpdateServiceException, SQLException
+    {
+        var ret = _service.getExistingRows(user, container, keys);
+        clearCache();
+        return ret;
+    }
+
+    @Override
     public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext) throws SQLException
     {
         int ret = _service.loadRows(user, container, rows, context, extraScriptContext);

--- a/api/src/org/labkey/api/query/QueryImportPipelineJob.java
+++ b/api/src/org/labkey/api/query/QueryImportPipelineJob.java
@@ -255,7 +255,7 @@ public class QueryImportPipelineJob extends PipelineJob
         try
         {
             setStatus(TaskStatus.running);
-            getLogger().info("Starting importing " + getDescription());
+            getLogger().info("Starting import " + getDescription());
 
             if (notificationProvider != null)
                 notificationProvider.onJobStart(this);
@@ -264,7 +264,7 @@ public class QueryImportPipelineJob extends PipelineJob
             TableInfo target = schema.getTable(_importContextBuilder.getQueryName(), true);
 
             if (null == target)
-                throw new PipelineValidationException("TableInfo not found.");
+                throw new PipelineValidationException("Table not found: " + _importContextBuilder.getQueryName());
 
             QueryUpdateService updateService = target.getUpdateService();
 

--- a/api/src/org/labkey/api/query/QueryUpdateService.java
+++ b/api/src/org/labkey/api/query/QueryUpdateService.java
@@ -110,20 +110,17 @@ public interface QueryUpdateService extends HasPermission
             throws InvalidKeyException, QueryUpdateServiceException, SQLException;
 
     /**
-     * Same as getRows(), but used by ExistingRecordsDataIterator, this exisits because SampleTypeUpdateService is special.
+     * Similar to getRows(), but used by ExistingRecordsDataIterator, this exists because SampleTypeUpdateService is special.
      * @param user      The current user.
      * @param container The container in which the data should exist.
-     * @param keys      A map of primary key values.
-     * @return The row data as maps.
+     * @param keys      A map of primary key values for each rowNumber.
+     * @return The rows data as maps for each rowNumber.
      * @throws InvalidKeyException         Thrown if the key value(s) is(are) not valid.
      * @throws SQLException                Thrown if there was an error communicating with the database.
      * @throws QueryUpdateServiceException Thrown for implementation-specific exceptions.
      */
-    default List<Map<String, Object>> getExistingRows(User user, Container container, List<Map<String, Object>> keys)
-            throws InvalidKeyException, QueryUpdateServiceException, SQLException
-    {
-        return getRows(user, container, keys);
-    }
+    Map<Integer, Map<String, Object>> getExistingRows(User user, Container container, Map<Integer, Map<String, Object>> keys)
+            throws InvalidKeyException, QueryUpdateServiceException, SQLException;
 
     /**
      * Inserts or merges the given values into the source table of this query.

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -2019,6 +2019,35 @@ public class ExperimentServiceImpl implements ExperimentService
         return lineage.findNearestParentMaterials(start);
     }
 
+    public Map<String, Pair<Set<ExpMaterial>, Set<ExpData>>> getParentMaterialAndDataMap(Container c, User user, Set<Identifiable> seeds)
+    {
+        Map<String, Pair<Set<ExpMaterial>, Set<ExpData>>> results = new HashMap<>();
+        ExpLineageOptions options = new ExpLineageOptions();
+        options.setChildren(false);
+        options.setDepth(2); // 2 because of the ExpRun that will always be in between.
+
+        ExpLineage lineage = getLineage(c, user, seeds, options);
+
+        for (Identifiable seed : seeds)
+        {
+            Set<ExpMaterial> materials = new HashSet<>();
+            Set<ExpData> datas = new HashSet<>();
+
+            for (ExpRunItem item : lineage.findNearestParentMaterialsAndDatas(seed))
+            {
+                if (item instanceof ExpMaterial)
+                    materials.add((ExpMaterial) item);
+                else if (item instanceof ExpData)
+                    datas.add((ExpData) item);
+            }
+
+            if (!materials.isEmpty() || !datas.isEmpty())
+                results.put(seed.getLSID(), new Pair<>(materials, datas));
+        }
+
+        return results;
+    }
+
     @Override
     @NotNull
     public Set<ExpData> getNearestParentDatas(Container c, User user, ExpMaterial start)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -70,8 +70,8 @@ import org.springframework.util.StringUtils;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -569,7 +569,6 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             }
         }
 
-
         if (!lsidRowNumMap.isEmpty())
         {
             Filter filter = new SimpleFilter(FieldKey.fromParts(ExpMaterialTable.Column.LSID), lsidRowNumMap.keySet(), CompareType.IN);
@@ -583,15 +582,9 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             }
         }
 
-        Set<Identifiable> lsids = new LinkedHashSet<>(keys.size());
-        for (String sampleLsid : rowNumLsid.values())
-        {
-            Identifiable id = LsidManager.get().getObject(sampleLsid);
-            if (id != null)
-                lsids.add(id);
-        }
+        List<ExpMaterialImpl> materials = ExperimentServiceImpl.get().getExpMaterialsByLSID(rowNumLsid.values());
 
-        Map<String, Pair<Set<ExpMaterial>, Set<ExpData>>> parents = ExperimentServiceImpl.get().getParentMaterialAndDataMap(container, user, lsids);
+        Map<String, Pair<Set<ExpMaterial>, Set<ExpData>>> parents = ExperimentServiceImpl.get().getParentMaterialAndDataMap(container, user, new HashSet<>(materials));
 
         for (Map.Entry<Integer, Map<String, Object>> rowNumSampleRow : sampleRows.entrySet())
         {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
@@ -535,7 +536,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         Map<Integer, String> rowNumLsid = new HashMap<>();
 
         Map<Integer, Integer> rowIdRowNumMap = new LinkedHashMap<>();
-        Map<String, Integer> lsidRowNumMap = new LinkedHashMap<>();
+        Map<String, Integer> lsidRowNumMap = new CaseInsensitiveMapWrapper<>(new LinkedHashMap<>());
         for (Map.Entry<Integer, Map<String, Object>> keyMap : keys.entrySet())
         {
             Integer rowNum = keyMap.getKey();


### PR DESCRIPTION
#### Rationale
Sample import with merge is slow due to lineage queries (one for parent material and one for parent data) that's done for each row of data in SampleTypeUpdateServiceDI.getExistingRows(). Those queries are needed for sample detailed audit log, which is used by sample timeline. This PR merges data and material parent into one query, and additionally handle 50 rows in a single query, which should reduce the number of lineage queries by ~99%. 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* new ExperimentServiceImpl.getParentMaterialAndDataMap function that gets both parent data and parent material for a set of sample lsid in a single query
* SampleTypeUpdateServiceDI.getExistingRows to use getParentMaterialAndDataMap
* Update ExistingDataIteratorsGetRows to get 50 rows a time
