### PR TITLE
Fb issue 43456

### DIFF
--- a/experiment/resources/schemas/dbscripts/postgresql/exp-21.007-21.008.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-21.007-21.008.sql
@@ -1,0 +1,4 @@
+-- move the StudyPublishProtocol container to the shared folder
+UPDATE exp.protocol
+    SET container = (SELECT entityid FROM core.containers WHERE name = 'Shared')
+    WHERE lsid LIKE 'urn:lsid:labkey.org:Protocol:StudyPublishProtocol%';

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-21.007-21.008.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-21.007-21.008.sql
@@ -1,0 +1,4 @@
+-- move the StudyPublishProtocol container to the shared folder
+UPDATE exp.protocol
+    SET container = (SELECT entityid FROM core.containers WHERE name = 'Shared')
+    WHERE lsid LIKE 'urn:lsid:labkey.org:Protocol:StudyPublishProtocol%';

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -159,7 +159,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     public Double getSchemaVersion()
     {
-        return 21.007;
+        return 21.008;
     }
 
     @Nullable

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -1270,7 +1270,7 @@ public class StudyPublishManager implements StudyPublishService
 
         if (protocol == null)
         {
-            ExpProtocol baseProtocol = ExperimentService.get().createExpProtocol(container, ExpProtocol.ApplicationType.ExperimentRun, protocolName);
+            ExpProtocol baseProtocol = ExperimentService.get().createExpProtocol(ContainerManager.getSharedContainer(), ExpProtocol.ApplicationType.ExperimentRun, protocolName);
             baseProtocol.setLSID(protocolLsid);
             baseProtocol.setMaxInputMaterialPerInstance(0);
             baseProtocol.setProtocolDescription("Simple protocol for publishing study using link to study.");


### PR DESCRIPTION
#### Rationale
We create a single StudyPublishProtocol for the provenance run when either assay or sample data is linked to a study. While we ensure that a single protocol exists for the site, the protocol is created in the container that it is first requested from. If we try to export and reimport that folder into a new folder the import will fail because the new protocol doesn't match the existing protocol's container.

- https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43456

#### Changes
- In the future create the protocol in the shared folder, the XarReader will allow usage if the existing protocol container is in the shared folder.
- Upgrade existing StudyPublishProtocols and move them to the shared folder.
