### PR TITLE
Deprecate support for Tomcat 8.5.x

### DIFF
--- a/api/src/org/labkey/api/module/TomcatVersion.java
+++ b/api/src/org/labkey/api/module/TomcatVersion.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 public enum TomcatVersion
 {
     TOMCAT_UNSUPPORTED(-1, true),
-    TOMCAT_8_5(85, false),
+    TOMCAT_8_5(85, true),
     TOMCAT_9_0(90, false),
     TOMCAT_FUTURE(Integer.MAX_VALUE, true);
 


### PR DESCRIPTION
#### Rationale
We've decided to remove support for Tomcat 8.5.x. This deprecates support for 21.7.x. We'll remove support completely in 21.11.x.