### PR TITLE
Issue 43463: NullPointerException attempting to access study design tables

### DIFF
--- a/study/resources/schemas/dbscripts/postgresql/study-21.003-21.004.sql
+++ b/study/resources/schemas/dbscripts/postgresql/study-21.003-21.004.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('ensureDesignDomains');

--- a/study/resources/schemas/dbscripts/sqlserver/study-21.003-21.004.sql
+++ b/study/resources/schemas/dbscripts/sqlserver/study-21.003-21.004.sql
@@ -1,0 +1,1 @@
+EXEC core.executeJavaUpgradeCode 'ensureDesignDomains';

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -235,7 +235,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
     @Override
     public Double getSchemaVersion()
     {
-        return 21.003;
+        return 21.004;
     }
 
     @Override

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -4690,6 +4690,19 @@ public class StudyManager
                 StudyManager.getInstance().enableSpecimenModuleInStudyFolders(context.getUpgradeUser());
             }
         }
+
+        @SuppressWarnings({"UnusedDeclaration"})
+        @DeferredUpgrade
+        public void ensureDesignDomains(final ModuleContext context)
+        {
+            if (!context.isNewInstall())
+            {
+                _log.info("Ensuring study design domains in all studies");
+                StudyDesignManager mgr = StudyDesignManager.get();
+                StudyManager.getInstance().getAllStudies()
+                    .forEach(study->mgr.ensureStudyDesignDomains(study.getContainer(), context.getUpgradeUser()));
+            }
+        }
     }
 
     // Enable the specimen module (if it exists) in all studies that have specimen rows


### PR DESCRIPTION
#### Rationale
Lazy ensure domain on the study design tables was removed for 21.3. To avoid this NPE we need to proactively ensure domain on all study design tables.

[Issue 43463: NullPointerException attempting to access study design tables](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43463)
