### PR TITLE
Links from "Requested by Enrollment Location" report always throw

### DIFF
--- a/study/api-src/org/labkey/api/specimen/query/SpecimenQueryView.java
+++ b/study/api-src/org/labkey/api/specimen/query/SpecimenQueryView.java
@@ -668,17 +668,18 @@ public class SpecimenQueryView extends BaseSpecimenQueryView
     protected static SimpleFilter addPreviouslyRequestedEnrollmentClause(SimpleFilter filter, Container container, User user, int locationId, boolean completedRequestsOnly)
     {
         SQLFragment sql = getBaseRequestedEnrollmentSql(container, user, completedRequestsOnly);
-        assert 0 == sql.getParams().size();
+
         if (locationId == -1)
         {
             sql.append("IS NULL)");
         }
         else
         {
-            sql.append("= " + locationId + ")");
+            sql.append("= ?)");
+            sql.add(locationId);
         }
 
-        filter.addWhereClause(sql.getSQL(), null, FieldKey.fromParts("GlobalUniqueId"));
+        filter.addWhereClause(sql, FieldKey.fromParts("GlobalUniqueId"));
 
         return filter;
     }


### PR DESCRIPTION
#### Rationale
A `SQLFragment` refactor in 2015 seems to have rendered links from the "Requested by Enrollment Location" report unusable. First problem: `getBaseRequestedEnrollmentSql()` always adds two or three parameters but the assert after the call requires zero parameters, so it always triggers. Remove the assert and you'll encounter the second problem: `filter.addWhereClause()` drops all parameters.

This change removes the assert and should restore correct parameter handling.
