### PR TITLE
Issue 43440: Sample Type Dataset shows superfluous Linked To Study column

### DIFF
--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -168,8 +168,11 @@ public class SamplesSchema extends AbstractExpSchema
         return (ExpMaterialTable) getTable(st.getName(), cf);
     }
 
-    /** Creates a table of materials, scoped to the given sample type and including its custom columns, if provided */
-    private ExpMaterialTable createSampleTable(@Nullable ExpSampleType st, ContainerFilter cf)
+    /**
+     * Creates a table of materials, scoped to the given sample type and including its custom columns, if provided.
+     * Does not include any linked-to-study columns or apply XML metadata overrides
+     */
+    public ExpMaterialTable createSampleTable(@Nullable ExpSampleType st, ContainerFilter cf)
     {
         if (log.isTraceEnabled())
         {

--- a/study/src/org/labkey/study/query/SampleDatasetTable.java
+++ b/study/src/org/labkey/study/query/SampleDatasetTable.java
@@ -113,7 +113,7 @@ public class SampleDatasetTable extends DatasetTableImpl
             // Hide 'linked' column for Sample Type Datasets
             if (userSchema instanceof SamplesSchema)
             {
-                _sampleTable = ((SamplesSchema) userSchema).getTable(sampleType, ContainerFilter.EVERYTHING);
+                _sampleTable = ((SamplesSchema) userSchema).createSampleTable(sampleType, ContainerFilter.EVERYTHING);
             }
             else
             {


### PR DESCRIPTION
#### Rationale
Once a sample type is linked to a study dataset, we don't want to show the columns with link info on the dataset side

#### Changes
* Expose a way to get a sample type table without the linked columns added (or XML metadata from the sample type side of things applied)