### PR TITLE
Issue 43374: + and % in container paths not properly encoded when creating exp.data rows in FileImporter

### DIFF
--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -1372,6 +1372,12 @@ public class FileContentServiceImpl implements FileContentService
                 filesRoot = rootPathVal;
 
             String rootDavUrl = (String) child.get("webdavURL");
+
+            // Hack for issue 43374 - encode special characters in container paths. Need to push this encoding
+            // into FilesWebPart._getRootPath(), but other codepaths are doing their own compensation so it's a more
+            // involved change
+            rootDavUrl = rootDavUrl.replace("%", "%25").replace("+", "%2B");
+
             WebdavResource resource = getResource(rootDavUrl);
             if (resource == null)
                 continue;

--- a/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
+++ b/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
@@ -545,6 +545,11 @@ public class FileQueryUpdateService extends AbstractQueryUpdateService
                 if (rootDavUrl == null)
                     continue;
 
+                // Hack for issue 43374 - encode special characters in container paths. Need to push this encoding
+                // into FilesWebPart._getRootPath(), but other codepaths are doing their own compensation so it's a more
+                // involved change
+                rootDavUrl = rootDavUrl.replace("%", "%25").replace("+", "%2B");
+
                 if (rootDavUrl.endsWith("/"))
                     rootDavUrl = rootDavUrl.substring(0, rootDavUrl.length() - 1);
 


### PR DESCRIPTION
#### Rationale
A previous fix addressed special characters in the files that are part of the folder import, but there's a related problem when the target folder has special characters in its own name

#### Changes
* Hacky encoding for import pathway to hold us over until we can uniformly encode the webdav URL