### PR TITLE
Switch to java.sql.Date due to Jackson serialization issues with LocalDate

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1661,13 +1661,26 @@ public class Container implements Serializable, Comparable<Container>, Securable
         _lockState = lockState;
     }
 
-    public @Nullable LocalDate getExpirationDate()
+    @Deprecated
+    public @Nullable LocalDate getExpirationDateLD()
     {
         return _expirationDate;
     }
 
-    public void setExpirationDate(LocalDate expirationDate)
+    @Deprecated
+    public void setExpirationDateLD(LocalDate expirationDate)
     {
         _expirationDate = expirationDate;
+    }
+
+    // TODO: Convert to LocalDate once we fix Jackson serialization of LocalDate
+    public java.sql.Date getExpirationDate()
+    {
+        return java.sql.Date.valueOf(_expirationDate);
+    }
+
+    public void setExpirationDate(java.sql.Date expirationDate)
+    {
+        _expirationDate = expirationDate.toLocalDate();
     }
 }

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1661,7 +1661,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
         _lockState = lockState;
     }
 
-    @Deprecated
+    @Deprecated @JsonIgnore
     public @Nullable LocalDate getExpirationDateLD()
     {
         return _expirationDate;

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -2779,7 +2779,7 @@ public class ContainerManager
             d.setType(type);
             d.setTitle(title);
             d.setLockState(lockState);
-            d.setExpirationDate(expirationDate);
+            d.setExpirationDateLD(expirationDate);
             return d;
         }
 


### PR DESCRIPTION
#### Rationale
Our version of Jackson can't serialize `LocalDate`

#### Related Pull Requests
* https://github.com/LabKey/compliance/pull/121