### PR TITLE
Resource.allowInline()

### DIFF
--- a/api/src/org/labkey/api/resource/Resource.java
+++ b/api/src/org/labkey/api/resource/Resource.java
@@ -86,12 +86,14 @@ public interface Resource
     @Nullable
     InputStream getInputStream() throws IOException;
 
-    // return false to force contentDisposition=="attachment"
+    /**
+     *  Return false to force contentDisposition=attachment.
+     * This does not mean the browser knows how to inline the document.  see MimeType.canInline().
+     */
     @Nullable
-    default boolean canInline()
+    default boolean allowInline()
     {
-        MimeMap.MimeType t = new MimeMap().getMimeTypeFor(getName());
-        return t.canInline();
+        return true;
     }
 
     /**

--- a/api/src/org/labkey/api/resource/Resource.java
+++ b/api/src/org/labkey/api/resource/Resource.java
@@ -16,6 +16,7 @@
 package org.labkey.api.resource;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.util.MimeMap;
 import org.labkey.api.util.Path;
 
 import java.io.IOException;
@@ -84,6 +85,14 @@ public interface Resource
 
     @Nullable
     InputStream getInputStream() throws IOException;
+
+    // return false to force contentDisposition=="attachment"
+    @Nullable
+    default boolean canInline()
+    {
+        MimeMap.MimeType t = new MimeMap().getMimeTypeFor(getName());
+        return t.canInline();
+    }
 
     /**
      * The String returned can be used as a cache key and,

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -129,6 +129,7 @@ import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.HelpTopic;
+import org.labkey.api.util.MimeMap;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.PageFlowUtil.Content;
 import org.labkey.api.util.PageFlowUtil.NoContent;
@@ -482,7 +483,9 @@ public class CoreController extends SpringActionController
             {
                 // If the URL has requested that the content be sent inline or not (instead of as an attachment), respect that
                 // Otherwise, default to sending as attachment
-                PageFlowUtil.streamFile(getViewContext().getResponse(), file, form.getInline() == null || !form.getInline().booleanValue());
+                MimeMap.MimeType mime = (new MimeMap()).getMimeTypeFor(file.getName());
+                boolean canInline = mime.canInline() && mime != MimeMap.MimeType.HTML;
+                PageFlowUtil.streamFile(getViewContext().getResponse(), file, !canInline || form.getInline() == null || !form.getInline().booleanValue());
             }
             return null;
         }

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -144,7 +144,7 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
         }
 
         MimeMap.MimeType mime = _mimeMap.getMimeTypeFor(filename);
-        boolean asAttachment = null==mime || !mime.canInline();
+        boolean asAttachment = null==mime || mime==MimeMap.MimeType.HTML || !mime.canInline();
 
         response.reset();
         writeDocument(new ResponseWriter(response), parent, filename, asAttachment);
@@ -1281,6 +1281,13 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
             initSearchProperties(name, displayTitle, cat);
         }
 
+        @Override
+        public boolean canInline()
+        {
+            if (isFile() && "text/html".equals(getContentType()))
+                return false;
+            return super.canInline();
+        }
 
         private void initSearchProperties(String name, @Nullable String displayTitle, @Nullable SearchService.SearchCategory cat)
         {

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -1282,11 +1282,11 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
         }
 
         @Override
-        public boolean canInline()
+        public boolean allowInline()
         {
             if (isFile() && "text/html".equals(getContentType()))
                 return false;
-            return super.canInline();
+            return super.allowInline();
         }
 
         private void initSearchProperties(String name, @Nullable String displayTitle, @Nullable SearchService.SearchCategory cat)

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -5040,6 +5040,8 @@ public class DavController extends SpringActionController
         String contentDisposition = getRequest().getParameter("contentDisposition");
         if (!StringUtils.equals("attachment",contentDisposition) && !StringUtils.equals("inline",contentDisposition))
             contentDisposition = null;
+        if (!resource.canInline())
+            contentDisposition = "attachment";
 
         if (!StringUtils.isEmpty(contentDisposition))
         {

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -5040,7 +5040,8 @@ public class DavController extends SpringActionController
         String contentDisposition = getRequest().getParameter("contentDisposition");
         if (!StringUtils.equals("attachment",contentDisposition) && !StringUtils.equals("inline",contentDisposition))
             contentDisposition = null;
-        if (!resource.canInline())
+        // default is to let the browser decide whether render inline or download, unless resource does not want to support "inline"
+        if (!resource.allowInline())
             contentDisposition = "attachment";
 
         if (!StringUtils.isEmpty(contentDisposition))


### PR DESCRIPTION
#### Rationale
Resource.allowInline() gives resources more control on how they are rendered.
