### PR TITLE
Issue32017: Make 'Default' reserved view name

### DIFF
--- a/internal/webapp/internal/ViewDesigner/Designer.js
+++ b/internal/webapp/internal/ViewDesigner/Designer.js
@@ -134,7 +134,7 @@ Ext4.define('LABKEY.internal.ViewDesigner.Designer', {
                             else if (trimmedValue.length > 50)
                                 return "The grid view name must be less than 50 characters long";
                             else if (LABKEY.internal.ViewDesigner.Designer.RESERVED_VIEW_NAMES.indexOf(trimmedValue) > -1) {
-                                return "The grid view name '" + value + "' is not allowed";
+                                return "The name '" + value + "' is not allowed";
                             }
                             return true;
                         },

--- a/internal/webapp/internal/ViewDesigner/Designer.js
+++ b/internal/webapp/internal/ViewDesigner/Designer.js
@@ -130,11 +130,11 @@ Ext4.define('LABKEY.internal.ViewDesigner.Designer', {
                         validator: function(value) {
                             var trimmedValue = value.trim();
                             if (trimmedValue.length == 0)
-                                return "Blank grid view name is not allowed";
+                                return "Blank grid view name is not allowed.";
                             else if (trimmedValue.length > 50)
-                                return "The grid view name must be less than 50 characters long";
+                                return "The grid view name must be less than 50 characters long.";
                             else if (LABKEY.internal.ViewDesigner.Designer.RESERVED_VIEW_NAMES.indexOf(trimmedValue) > -1) {
-                                return "The name '" + value + "' is not allowed";
+                                return "The grid view name '" + value + "' is not allowed.";
                             }
                             return true;
                         },
@@ -205,7 +205,12 @@ Ext4.define('LABKEY.internal.ViewDesigner.Designer', {
                         var nameField = win.down('#nameFieldContainer').items.get(1);
                         if (!nameField.isValid())
                         {
-                            Ext4.Msg.alert("Invalid grid view name", nameField.getErrors());
+                            Ext4.Msg.show({
+                                title:"Invalid grid view name",
+                                msg: nameField.getErrors(),
+                                buttons: Ext4.Msg.OK,
+                                icon: Ext4.Msg.ERROR
+                            });
                             return;
                         }
                         if (!canEdit && viewName == nameField.getValue())

--- a/internal/webapp/internal/ViewDesigner/Designer.js
+++ b/internal/webapp/internal/ViewDesigner/Designer.js
@@ -215,7 +215,12 @@ Ext4.define('LABKEY.internal.ViewDesigner.Designer', {
                         }
                         if (!canEdit && viewName == nameField.getValue())
                         {
-                            Ext4.Msg.alert("Error saving", "This grid view is not editable.  You must save this grid view with an alternate name.");
+                            Ext4.Msg.show({
+                                title:"Error saving",
+                                msg: "This grid view is not editable.  You must save this grid view with an alternate name.",
+                                buttons: Ext4.Msg.OK,
+                                icon: Ext4.Msg.ERROR
+                            });
                             return;
                         }
 

--- a/internal/webapp/internal/ViewDesigner/Designer.js
+++ b/internal/webapp/internal/ViewDesigner/Designer.js
@@ -16,7 +16,7 @@ Ext4.define('LABKEY.internal.ViewDesigner.Designer', {
     bodyStyle: 'background-color: transparent;',
 
     statics: {
-        RESERVED_VIEW_NAMES : ['default', '~~DETAILS~~', '~~INSERT~~', '~~UPDATE~~'],
+        RESERVED_VIEW_NAMES : ['Default', '~~DETAILS~~', '~~INSERT~~', '~~UPDATE~~'],
         saveCustomizeViewPrompt: function(config) {
             var success = config.success,
                     scope = config.scope,


### PR DESCRIPTION
#### Rationale
Previously, the default grid title was changed from "default" to "Default". But "Default" is not a reserved view name like "default" is. This allows you to have two views named "Default". 
This change updates the reserved view name.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2302

#### Changes
* Change reserved view name casing
* Changing the casing caused the error message to display with cut-off text. Update text to fit within popover
