### PR TITLE
Item 9134: Show Shared Sample Types in Sample Manager

### DIFF
--- a/core/api-src/org/labkey/api/products/MenuItem.java
+++ b/core/api-src/org/labkey/api/products/MenuItem.java
@@ -27,19 +27,11 @@ public class MenuItem
     private Boolean _requiresLogin = false; // indicates if link should be shown if not logged in.
     private String _productId = null; // indicates the product/application this link should direct to.  Can (should?) be null if the current application is to be used.
 
-    public boolean isHasActiveJob()
-    {
-        return _hasActiveJob;
-    }
-
-    public void setHasActiveJob(boolean hasActiveJob)
-    {
-        _hasActiveJob = hasActiveJob;
-    }
-
     private boolean _hasActiveJob; // if there is an active pipeline job associated with this item
 
-    public MenuItem(String label, String url, Integer id, String key, Integer orderNum, String productId, boolean hasActiveJob)
+    private boolean _fromSharedContainer; // if the item comes from the /Shared container
+
+    public MenuItem(String label, String url, Integer id, String key, Integer orderNum, String productId, boolean hasActiveJob, boolean isSharedContainer)
     {
         _label = label;
         _id = id;
@@ -48,16 +40,27 @@ public class MenuItem
         _orderNum = orderNum == null ? -1 : orderNum;
         _productId = productId;
         _hasActiveJob = hasActiveJob;
+        _fromSharedContainer = isSharedContainer;
+    }
+
+    public MenuItem(String label, String url, Integer id, String key, Integer orderNum, String productId, boolean hasActiveJob)
+    {
+        this(label, url, id, key, orderNum, productId, hasActiveJob, false);
+    }
+
+    public MenuItem(String label, ActionURL url, Integer id, String key, Integer orderNum, String productId, boolean hasActiveJob)
+    {
+        this(label, url == null ? null : url.toString(), id, key, orderNum, productId, hasActiveJob, false);
     }
 
     public MenuItem(String label, ActionURL url, Integer id, String key, Integer orderNum, String productId)
     {
-        this(label, url == null ? null : url.toString(), id, key, orderNum, productId, false);
+        this(label, url == null ? null : url.toString(), id, key, orderNum, productId, false, false);
     }
 
     public MenuItem(String label, String url, Integer id, String key, Integer orderNum, String productId)
     {
-        this(label, url, id, key, orderNum, productId, false);
+        this(label, url, id, key, orderNum, productId, false, false);
     }
 
     public MenuItem(String label, ActionURL url, Integer id, Integer orderNum, String productId)
@@ -144,5 +147,26 @@ public class MenuItem
     {
         _requiresLogin = requiresLogin;
     }
+
+    public boolean isFromSharedContainer()
+    {
+        return _fromSharedContainer;
+    }
+
+    public void setFromSharedContainer(boolean fromSharedContainer)
+    {
+        _fromSharedContainer = fromSharedContainer;
+    }
+
+    public boolean isHasActiveJob()
+    {
+        return _hasActiveJob;
+    }
+
+    public void setHasActiveJob(boolean hasActiveJob)
+    {
+        _hasActiveJob = hasActiveJob;
+    }
+
 
 }

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTableImpl.java
@@ -77,7 +77,9 @@ public class ExpSampleTypeTableImpl extends ExpTableImpl<ExpSampleTypeTable.Colu
             {
                 SQLFragment sql = new SQLFragment("(SELECT COUNT(*) FROM " +
                     ExperimentServiceImpl.get().getTinfoMaterial() +
-                    " m WHERE m.CpasType = " + ExprColumn.STR_TABLE_ALIAS + ".LSID)");
+                    " m WHERE m.CpasType = " + ExprColumn.STR_TABLE_ALIAS + ".LSID" +
+                    " AND m.container = ?)")
+                    .add(_userSchema.getContainer().getEntityId());
                 ExprColumn sampleCountColumnInfo = new ExprColumn(this, "SampleCount", sql, JdbcType.INTEGER);
                 sampleCountColumnInfo.setDescription("Contains the number of samples currently stored in this sample type");
                 return sampleCountColumnInfo;

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -670,10 +670,23 @@ public class ExperimentController extends SpringActionController
                     ActionURL updateURL = new ActionURL(EditSampleTypeAction.class, _sampleType.getContainer());
                     updateURL.addParameter("RowId", _sampleType.getRowId());
                     updateURL.addReturnURL(getViewContext().getActionURL());
-                    ActionButton updateButton = new ActionButton(updateURL, "Edit Type", ActionButton.Action.LINK);
-                    updateButton.setDisplayPermission(DesignSampleTypePermission.class);
-                    updateButton.setPrimary(true);
-                    detailsView.getDataRegion().getButtonBar(DataRegion.MODE_DETAILS).add(updateButton);
+
+                    if (!getContainer().equals(_sampleType.getContainer()))
+                    {
+                        String editLink = updateURL.toString();
+                        ActionButton updateButton = new ActionButton("Edit Type");
+                        updateButton.setURL("javascript:void(0)");
+                        updateButton.setActionType(ActionButton.Action.SCRIPT);
+                        updateButton.setScript("javascript: if (window.confirm('This sample type is defined in the " + _sampleType.getContainer().getPath() + " folder. Would you still like to edit it?')) { window.location = '" + editLink + "' }");
+                        detailsView.getDataRegion().getButtonBar(DataRegion.MODE_DETAILS).add(updateButton);
+                    }
+                    else
+                    {
+                        ActionButton updateButton = new ActionButton(updateURL, "Edit Type", ActionButton.Action.LINK);
+                        updateButton.setDisplayPermission(DesignSampleTypePermission.class);
+                        updateButton.setPrimary(true);
+                        detailsView.getDataRegion().getButtonBar(DataRegion.MODE_DETAILS).add(updateButton);
+                    }
 
                     ActionURL deleteURL = new ActionURL(DeleteSampleTypesAction.class, _sampleType.getContainer());
                     deleteURL.addParameter("singleObjectRowId", _sampleType.getRowId());


### PR DESCRIPTION
#### Rationale
When a sample type is defined in the Shared project, it is available in other projects and folders. While the type definitions are shared, sample instances created from the shared type are not shared and should only be visible to the container that they are created. This pr modifies Exp.SampleTypes SampleCount to correct reflects the #samples in the current container. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2421
* https://github.com/LabKey/labkey-ui-components/pull/575
* https://github.com/LabKey/inventory/pull/268
* https://github.com/LabKey/sampleManagement/pull/618
* https://github.com/LabKey/biologics/pull/932

#### Changes
* 
* Fix Exp.SampleTypes table SampleCount to only include samples in the current container, but don't include samples in shared container if current container is different. 
* add fromSharedContainer field to MenuItem
