### PR TITLE
Issue 43442: samples: not able to delete a Material not in a sample type

### DIFF
--- a/api/src/org/labkey/api/data/SQLFragment.java
+++ b/api/src/org/labkey/api/data/SQLFragment.java
@@ -574,7 +574,7 @@ public class SQLFragment implements Appendable, CharSequence
         return this;
     }
 
-    public SQLFragment appendIf(boolean test, Consumer<SQLFragment> block)
+    public SQLFragment applyIf(boolean test, Consumer<SQLFragment> block)
     {
         if (test)
             block.accept(this);

--- a/api/src/org/labkey/api/data/SQLFragment.java
+++ b/api/src/org/labkey/api/data/SQLFragment.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -566,6 +567,19 @@ public class SQLFragment implements Appendable, CharSequence
         return getSqlCharSequence().subSequence(start, end);
     }
 
+    public SQLFragment appendIf(boolean test, CharSequence s)
+    {
+        if (test)
+            this.append(s);
+        return this;
+    }
+
+    public SQLFragment appendIf(boolean test, Consumer<SQLFragment> block)
+    {
+        if (test)
+            block.accept(this);
+        return this;
+    }
 
     /**
      * KEY is used as a faster way to look for equivalent CTE expressions.

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -821,14 +821,7 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
          */
         HttpServletRequest request = getRequest();
 
-        // TODO: Remove all ~checkboxes handling -- I don't think we ever output this
-        String[] checkboxes = request.getParameterValues("~checkboxes");
-
-        if (null != checkboxes)
-            for (String checkbox : checkboxes)
-                set(checkbox, "0");
-
-        // handle Spring style markers as well
+        // handle Spring style markers
         IteratorUtils.asIterator(request.getParameterNames()).forEachRemaining(name -> {
             if (name.startsWith(SpringActionController.FIELD_MARKER))
                 set(name.substring(SpringActionController.FIELD_MARKER.length()), "0");

--- a/api/src/org/labkey/api/exp/SamplePropertyHelper.java
+++ b/api/src/org/labkey/api/exp/SamplePropertyHelper.java
@@ -18,6 +18,7 @@ package org.labkey.api.exp;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.action.SpringActionController;
 import org.labkey.api.assay.AbstractAssayProvider;
 import org.labkey.api.assay.actions.AssayRunUploadForm;
 import org.labkey.api.assay.actions.UploadWizardAction;
@@ -95,7 +96,11 @@ public abstract class SamplePropertyHelper<ObjectType>
             for (DomainProperty property : _domainProperties)
             {
                 String inputName = UploadWizardAction.getInputName(property, names.get(i));
-                sampleProperties.put(property, request.getParameter(inputName));
+                // handle the hidden input field prefixed with FIELD_MARKER for checkboxes
+                String value = request.getParameter(inputName);
+                if (value == null && request.getParameter(SpringActionController.FIELD_MARKER + inputName) != null)
+                    value = "0";
+                sampleProperties.put(property, value);
             }
             result.put(getObject(i, sampleProperties, parentMaterials), sampleProperties);
         }
@@ -201,7 +206,11 @@ public abstract class SamplePropertyHelper<ObjectType>
             {
                 String name = UploadWizardAction.getInputName(sampleProperty, sampleName);
                 String inputName = ColumnInfo.propNameFromName(name);
-                values.put(sampleProperty, request.getParameter(inputName));
+                // handle the hidden input field prefixed with FIELD_MARKER for checkboxes
+                String value = request.getParameter(inputName);
+                if (value == null && request.getParameter(SpringActionController.FIELD_MARKER + inputName) != null)
+                    value = "0";
+                values.put(sampleProperty, value);
             }
             result.put(sampleName, values);
         }

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -240,7 +240,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
     @Override
     public void delete(User user)
     {
-        ExperimentServiceImpl.get().deleteMaterialByRowIds(user, getContainer(), Collections.singleton(getRowId()));
+        ExperimentServiceImpl.get().deleteMaterialByRowIds(user, getContainer(), Collections.singleton(getRowId()), true, getSampleType());
         // Deleting from search index is handled inside deleteMaterialByRowIds()
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -805,7 +805,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         {
             // Allow read and delete for exp.Materials.
             // Don't allow insert/update on exp.Materials without a sample type.
-            if (perm.isAssignableFrom(DeletePermission.class) || perm.isAssignableFrom(ReadPermission.class))
+            if (perm == DeletePermission.class || perm == ReadPermission.class)
                 return getContainer().hasPermission(user, perm);
             else
                 return false;

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -73,8 +73,10 @@ import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
@@ -799,11 +801,19 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        if (_ss != null)
+        if (_ss == null)
+        {
+            // Allow read and delete for exp.Materials.
+            // Don't allow insert/update on exp.Materials without a sample type.
+            if (perm.isAssignableFrom(DeletePermission.class) || perm.isAssignableFrom(ReadPermission.class))
+                return getContainer().hasPermission(user, perm);
+            else
+                return false;
+        }
+        else
+        {
             return super.hasPermission(user, perm);
-
-        // don't allow insert/update on exp.Materials without a sample type
-        return false;
+        }
     }
 
     @NotNull

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -247,9 +247,10 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                 .append(" d.RowId, d.Name, d.Container, d.Description, d.CreatedBy, d.Created, d.ModifiedBy, d.Modified")
                 .append(" FROM ").append(d, "d")
                 .applyIf(t != null, s ->
-                    s.append("LEFT OUTER JOIN ").append(t, "t")
+                    s.append("LEFT OUTER JOIN ")
+                    .append(t, "t")
+                    .append(" ON d.lsid = t.lsid")
                 )
-                .append(" ON d.lsid = t.lsid")
                 .append(" WHERE d.Container=?").add(container.getEntityId())
                 .append(" AND d.rowid=?").add(keys[0]);
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -246,7 +246,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                 .appendIf(t != null, "t.*,")
                 .append(" d.RowId, d.Name, d.Container, d.Description, d.CreatedBy, d.Created, d.ModifiedBy, d.Modified")
                 .append(" FROM ").append(d, "d")
-                .appendIf(t != null, s ->
+                .applyIf(t != null, s ->
                     s.append("LEFT OUTER JOIN ").append(t, "t")
                 )
                 .append(" ON d.lsid = t.lsid")

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -30,9 +30,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.Filter;
 import org.labkey.api.data.ImportAliasable;
-import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
-import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
@@ -239,22 +237,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
     @Override
     protected Map<String, Object> _select(Container container, Object[] keys) throws ConversionException
     {
-        TableInfo d = getDbTable();
-        TableInfo t = _sampleType == null ? null : _sampleType.getTinfo();
-
-        SQLFragment sql = new SQLFragment("SELECT ")
-                .appendIf(t != null, "t.*,")
-                .append(" d.RowId, d.Name, d.Container, d.Description, d.CreatedBy, d.Created, d.ModifiedBy, d.Modified")
-                .append(" FROM ").append(d, "d")
-                .applyIf(t != null, s ->
-                    s.append("LEFT OUTER JOIN ")
-                    .append(t, "t")
-                    .append(" ON d.lsid = t.lsid")
-                )
-                .append(" WHERE d.Container=?").add(container.getEntityId())
-                .append(" AND d.rowid=?").add(keys[0]);
-
-        return new SqlSelector(getDbTable().getSchema(), sql).getMap();
+        throw new IllegalStateException("Overridden .getRow()/.getRows() calls .getMaterialMap()");
     }
 
     public Set<String> getAliquotSpecificFields()
@@ -392,7 +375,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         List<Integer> id = new LinkedList<>();
         Integer rowId = getMaterialRowId(oldRowMap);
         id.add(rowId);
-        ExperimentServiceImpl.get().deleteMaterialByRowIds(user, container, id);
+        ExperimentServiceImpl.get().deleteMaterialByRowIds(user, container, id, true, _sampleType);
         return oldRowMap;
     }
 
@@ -430,7 +413,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                 result.add(map);
             }
             // TODO check if this handle attachments???
-            ExperimentServiceImpl.get().deleteMaterialByRowIds(user, container, ids);
+            ExperimentServiceImpl.get().deleteMaterialByRowIds(user, container, ids, true, _sampleType);
         }
 
         if (result.size() > 0)

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4899,7 +4899,6 @@ public class ExperimentController extends SpringActionController
                 int i = 0;
                 for (Map.Entry<Lsid, Map<DomainProperty, String>> entry : allProperties.entrySet())
                 {
-                    Map<DomainProperty, String> props = entry.getValue();
                     Lsid lsid = entry.getKey();
                     String name = lsid.getObjectId();
                     assert name != null;

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4783,11 +4783,12 @@ public class ExperimentController extends SpringActionController
                 form.setOutputCount(1);
             }
 
+            if (form.getTargetSampleTypeId() == 0)
+                throw new NotFoundException("Target sample type required for the derived samples");
+
             ExpSampleTypeImpl sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), getUser(), form.getTargetSampleTypeId());
-            if (form.getTargetSampleTypeId() != 0 && sampleType == null)
-            {
+            if (sampleType == null)
                 throw new NotFoundException("Could not find sample type with rowId " + form.getTargetSampleTypeId());
-            }
 
             InsertView insertView = new InsertView(new DataRegion(), errors);
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/SampleTypeContentsView.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/SampleTypeContentsView.java
@@ -161,7 +161,7 @@ public class SampleTypeContentsView extends QueryView
         ActionButton button = super.createDeleteButton();
         if (button != null)
         {
-            button.setScript("LABKEY.experiment.confirmDelete('" + getSchema().getName() + "', '" + getQueryDef().getName() + "', '" + getSelectionKey() + "', 'sample', 'samples')");
+            button.setScript("LABKEY.experiment.confirmDelete('" + this.getDataRegionName() + "', '" + getSchema().getName() + "', '" + getQueryDef().getName() + "', '" + getSelectionKey() + "', 'sample', 'samples')");
             button.setRequiresSelection(true);
         }
         return button;

--- a/experiment/src/org/labkey/experiment/deriveSamplesChooseTarget.jsp
+++ b/experiment/src/org/labkey/experiment/deriveSamplesChooseTarget.jsp
@@ -31,7 +31,6 @@
     DeriveSamplesChooseTargetBean bean = me.getModelBean();
 
     Map<Integer, String> sampleTypeOptions = new LinkedHashMap<>();
-    sampleTypeOptions.put(0, "Not a member of a sample type");
     for (ExpSampleType st : bean.getSampleTypes())
     {
         sampleTypeOptions.put(st.getRowId(), st.getName() + " in " + st.getContainer().getPath());

--- a/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
+++ b/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
@@ -686,7 +686,7 @@ public abstract class UploadSamplesHelper
         final Lsid.LsidBuilder lsidBuilder;
         final ExpMaterialTableImpl materialTable;
 
-        public PrepareDataIteratorBuilder(ExpSampleTypeImpl sampletype, TableInfo materialTable, DataIteratorBuilder in)
+        public PrepareDataIteratorBuilder(@NotNull ExpSampleTypeImpl sampletype, TableInfo materialTable, DataIteratorBuilder in)
         {
             this.sampletype = sampletype;
             this.builder = in;

--- a/experiment/webapp/experiment/confirmDelete.js
+++ b/experiment/webapp/experiment/confirmDelete.js
@@ -1,7 +1,7 @@
 
 Ext4.namespace("LABKEY.experiment");
 
-LABKEY.experiment.confirmDelete = function(schemaName, queryName, selectionKey, nounSingular, nounPlural) {
+LABKEY.experiment.confirmDelete = function(dataRegionName, schemaName, queryName, selectionKey, nounSingular, nounPlural) {
     var loadingMsg = Ext4.Msg.show({
         title: "Retrieving data",
         msg: "Loading ..."
@@ -97,6 +97,13 @@ LABKEY.experiment.confirmDelete = function(schemaName, queryName, selectionKey, 
                                     apiVersion: 13.2
                                 },
                                 success: LABKEY.Utils.getCallbackWrapper(function(response)  {
+                                    let dr = LABKEY.DataRegions[dataRegionName];
+                                    if (dr) {
+                                        dr.clearSelected({
+                                            selectionKey: selectionKey,
+                                        });
+                                    }
+
                                     Ext4.Msg.hide();
                                     var responseMsg = Ext4.Msg.show({
                                         title: "Delete " + totalNoun,

--- a/query/src/org/labkey/query/data/ExternalSchemaTable.java
+++ b/query/src/org/labkey/query/data/ExternalSchemaTable.java
@@ -88,7 +88,7 @@ public class ExternalSchemaTable extends SimpleUserSchema.SimpleTable<ExternalSc
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
         List<ColumnInfo> columns = getPkColumns();
-        return (perm.isAssignableFrom(ReadPermission.class) || (super.hasPermission(user, perm) && getUserSchema().areTablesEditable() && columns.size() > 0));
+        return (perm == ReadPermission.class || (super.hasPermission(user, perm) && getUserSchema().areTablesEditable() && columns.size() > 0));
     }
 
     public void setContainer(String containerId)


### PR DESCRIPTION
#### [Issue 43442](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43442): samples: not able to delete a Material not in a sample type
* SampleTypeUpdateServiceDI needs to handle read and delete without a ExpSampleType
* Disallow deleting samples in a SampleType from exp.Materials QueryUpdateService and vice versa
* Add regression test to verify read, insert, update, delete permissions

#### [Issue 43407](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43407): Required boolean fields cannot be set to false in the sample derivation view
* The action uses custom form binding of the posted parameters and didn't handle the special `@` field prefix for checkbox input parameters.

#### [Issue 43439](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43439): LK Server Allows Insert of Samples Outside a Specific Sample Type
* Remove the option to insert into exp.Materials
* Validate a SampleType was chosen

#### Bonus Round
* Add `SqlFragment.appendIf` for all those conditional sql woes
* Remove obsolete `~checkboxes` parameter handling
* Clear selection after deleting samples