### PR TITLE
Issue43511: Update System Default Domain tooltip href

### DIFF
--- a/core/src/client/components/GlobalSettings.tsx
+++ b/core/src/client/components/GlobalSettings.tsx
@@ -39,7 +39,7 @@ class DefaultDomainField extends PureComponent<DefaultDomainProps> {
                 <LabelHelpTip title="Tip">
                     <div>
                         <div> Default domain for user sign in.</div>
-                        <a href="https://www.labkey.org/Documentation/wiki-page.view?name=configAdmin">More info</a>
+                        <a href="https://www.labkey.org/Documentation/wiki-page.view?name=authenticationModule#dom">More info</a>
                     </div>
                 </LabelHelpTip>
                 <span className="global-settings__default-domain-field">

--- a/core/src/client/components/GlobalSettings.tsx
+++ b/core/src/client/components/GlobalSettings.tsx
@@ -39,7 +39,7 @@ class DefaultDomainField extends PureComponent<DefaultDomainProps> {
                 <LabelHelpTip title="Tip">
                     <div>
                         <div> Default domain for user sign in.</div>
-                        { helpLinkNode("authenticationModule#dom", "More info") }
+                        {helpLinkNode('authenticationModule#dom', 'More info')}
                     </div>
                 </LabelHelpTip>
                 <span className="global-settings__default-domain-field">

--- a/core/src/client/components/GlobalSettings.tsx
+++ b/core/src/client/components/GlobalSettings.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Panel, FormControl } from 'react-bootstrap';
-import { LabelHelpTip } from '@labkey/components';
+import { helpLinkNode, LabelHelpTip } from '@labkey/components';
 
 import FACheckBox from './FACheckBox';
 import { GlobalSettingsOptions } from './models';
@@ -39,7 +39,7 @@ class DefaultDomainField extends PureComponent<DefaultDomainProps> {
                 <LabelHelpTip title="Tip">
                     <div>
                         <div> Default domain for user sign in.</div>
-                        <a href="https://www.labkey.org/Documentation/wiki-page.view?name=authenticationModule#dom">More info</a>
+                        { helpLinkNode("authenticationModule#dom", "More info") }
                     </div>
                 </LabelHelpTip>
                 <span className="global-settings__default-domain-field">


### PR DESCRIPTION
#### Rationale
Previously, the System Default Domain tooltip pointed to the `configAdmin` page. Now, it correctly points to `authenticationModule#dom`.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2327

#### Changes
* Update href
