### PR TITLE
Issue 43516: "Resolve lookup by value" experimental feature flag does not work for the "Derive Samples" insert form

### DIFF
--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -1013,9 +1013,10 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
     public static List<ValidationError> validateColumnProperties(ContainerUser context, Map<ColumnInfo, String> properties)
     {
         List<ValidationError> errors = new ArrayList<>();
+        RemapCache cache = new RemapCache();
         for (Map.Entry<ColumnInfo, String> entry : properties.entrySet())
         {
-            validateProperty(context, entry.getKey(), entry.getValue(), errors);
+            validateProperty(context, entry.getKey(), entry.getValue(), cache, errors);
         }
         return errors;
     }
@@ -1023,14 +1024,15 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
     public static List<ValidationError> validateProperties(ContainerUser context, Map<DomainProperty, String> properties)
     {
         List<ValidationError> errors = new ArrayList<>();
+        RemapCache cache = new RemapCache();
         for (Map.Entry<DomainProperty, String> entry : properties.entrySet())
         {
-            validateProperty(context, entry.getKey(), entry.getValue(), errors);
+            validateProperty(context, entry.getKey(), entry.getValue(), cache, errors);
         }
         return errors;
     }
 
-    private static void validateProperty(ContainerUser context, ColumnInfo columnInfo, String value, List<ValidationError> errors)
+    private static void validateProperty(ContainerUser context, ColumnInfo columnInfo, String value, RemapCache cache, List<ValidationError> errors)
     {
         Lookup lookup = null;
         if (columnInfo.isLookup())
@@ -1042,7 +1044,7 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
                 false, lookup, columnInfo.getJavaClass(), cache, errors);
     }
 
-    private static void validateProperty(ContainerUser context, DomainProperty dp, String value, List<ValidationError> errors)
+    private static void validateProperty(ContainerUser context, DomainProperty dp, String value, RemapCache cache, List<ValidationError> errors)
     {
         String label = dp.getPropertyDescriptor().getNonBlankCaption();
         PropertyType type = dp.getPropertyDescriptor().getPropertyType();
@@ -1056,7 +1058,6 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
     {
         boolean missing = (value == null || value.length() == 0);
         int rowNum = 0;
-        RemapCache cache = new RemapCache();
 
         if (required && missing)
         {

--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -60,8 +60,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import static org.labkey.api.data.RemapCache.EXPERIMENTAL_RESOLVE_LOOKUPS_BY_VALUE;
-
 /** Subclass that wraps a ColumnInfo to pull values from the database */
 public class DataColumn extends DisplayColumn
 {
@@ -688,26 +686,36 @@ public class DataColumn extends DisplayColumn
     protected void renderSelectFormInput(RenderContext ctx, Writer out, String formFieldName, Object value, String strVal, boolean disabledInput)
             throws IOException
     {
-        NamedObjectList entryList = _boundColumn.getFk().getSelectList(ctx);
+        ForeignKey boundColumnFK = _boundColumn.getFk();
+        NamedObjectList entryList = boundColumnFK.getSelectList(ctx);
         if (!entryList.isComplete())
         {
             // When incomplete, there are too many select options to render -- use a simple text input instead.
-            // TODO: if the FK target is public, we can generate an auto-complete input
             String textInputValue = strVal;
-            if (ExperimentalFeatureService.get().isFeatureEnabled(EXPERIMENTAL_RESOLVE_LOOKUPS_BY_VALUE))
+            Object displayValue = null;
+            TableViewForm viewForm = ctx.getForm();
+            if (viewForm != null && viewForm.contains(this, ctx))
             {
-                Object displayValue = null;
-                TableViewForm viewForm = ctx.getForm();
-                if (viewForm != null && viewForm.contains(this, ctx))
-                {
-                    // On error reshow, use the user supplied form value
-                    displayValue = viewForm.get(formFieldName);
-                }
-                if (displayValue == null)
-                    displayValue = getDisplayValue(ctx);
-                textInputValue = Objects.toString(displayValue, strVal);
+                // On error reshow, use the user supplied form value
+                displayValue = viewForm.get(formFieldName);
             }
-            renderTextFormInput(ctx, out, formFieldName, value, textInputValue, disabledInput);
+            if (displayValue == null)
+                displayValue = getDisplayValue(ctx);
+            textInputValue = Objects.toString(displayValue, strVal);
+
+//            if (boundColumnFK.getLookupTableInfo().isPublic())
+//            {
+//                Container lookupContainer = boundColumnFK.getLookupContainer() != null ? boundColumnFK.getLookupContainer() : ctx.getContainer();
+//                ActionURL autoCompleteURL = new ActionURL("query", "lookupAutoComplete", lookupContainer);
+//                autoCompleteURL.addParameter("schemaName", boundColumnFK.getLookupSchemaName());
+//                autoCompleteURL.addParameter("queryName", boundColumnFK.getLookupTableName());
+//                // TODO boundColumnFK.getLookupColumnName()
+//                // TODO boundColumnFK.getLookupDisplayName()
+//                // TODO "query.maxRows"?
+//                renderAutoCompleteFormInput(ctx, out, formFieldName, value, textInputValue, disabledInput, autoCompleteURL);
+//            }
+//            else
+                renderTextFormInput(ctx, out, formFieldName, value, textInputValue, disabledInput);
         }
         else
         {

--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -703,19 +703,7 @@ public class DataColumn extends DisplayColumn
                 displayValue = getDisplayValue(ctx);
             textInputValue = Objects.toString(displayValue, strVal);
 
-//            if (boundColumnFK.getLookupTableInfo().isPublic())
-//            {
-//                Container lookupContainer = boundColumnFK.getLookupContainer() != null ? boundColumnFK.getLookupContainer() : ctx.getContainer();
-//                ActionURL autoCompleteURL = new ActionURL("query", "lookupAutoComplete", lookupContainer);
-//                autoCompleteURL.addParameter("schemaName", boundColumnFK.getLookupSchemaName());
-//                autoCompleteURL.addParameter("queryName", boundColumnFK.getLookupTableName());
-//                // TODO boundColumnFK.getLookupColumnName()
-//                // TODO boundColumnFK.getLookupDisplayName()
-//                // TODO "query.maxRows"?
-//                renderAutoCompleteFormInput(ctx, out, formFieldName, value, textInputValue, disabledInput, autoCompleteURL);
-//            }
-//            else
-                renderTextFormInput(ctx, out, formFieldName, value, textInputValue, disabledInput);
+            renderTextFormInput(ctx, out, formFieldName, value, textInputValue, disabledInput);
         }
         else
         {

--- a/api/src/org/labkey/api/data/RemapCache.java
+++ b/api/src/org/labkey/api/data/RemapCache.java
@@ -33,7 +33,6 @@ import java.util.Objects;
  */
 public class RemapCache
 {
-    public static final String EXPERIMENTAL_RESOLVE_LOOKUPS_BY_VALUE = "resolve-lookups-by-value";
     Map<Key, SimpleTranslator.RemapPostConvert> remaps = new HashMap<>();
     private final boolean _allowBulkLoads;
 

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -477,8 +477,8 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
                 if (col != null && col.getFk() != null)
                 {
                     ForeignKey fk = col.getFk();
-                    Object remappedValue = cache.remap(SchemaKey.fromParts(fk.getLookupSchemaName()), fk.getLookupTableName(), getUser(), getContainer(), ContainerFilter.Type.CurrentPlusProjectAndShared, str);
-
+                    Container container = fk.getLookupContainer() != null ? fk.getLookupContainer() : getContainer();
+                    Object remappedValue = cache.remap(SchemaKey.fromParts(fk.getLookupSchemaName()), fk.getLookupTableName(), getUser(), container, ContainerFilter.Type.CurrentPlusProjectAndShared, str);
                     if (remappedValue != null)
                     {
                         values.put(propName, remappedValue);

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -62,8 +62,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.labkey.api.data.RemapCache.EXPERIMENTAL_RESOLVE_LOOKUPS_BY_VALUE;
-
 /**
  * Basic form for handling posts into views.
  * Supports insert, update, delete functionality with a minimum of fuss
@@ -408,7 +406,7 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
          */
         Map<String, Object> values = new CaseInsensitiveHashMap<>();
         Set<String> keys = _stringValues.keySet();
-        RemapCache cache = new RemapCache();        // only used if the experimental feature : EXPERIMENTAL_RESOLVE_LOOKUPS_BY_VALUE is enabled
+        RemapCache cache = new RemapCache();
 
         for (String propName : keys)
         {
@@ -474,19 +472,17 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
             {
                 boolean skipError = false;
 
-                if (ExperimentalFeatureService.get().isFeatureEnabled(EXPERIMENTAL_RESOLVE_LOOKUPS_BY_VALUE))
+                // Attempt to resolve lookups by display value
+                ColumnInfo col = getColumnByFormFieldName(propName);
+                if (col != null && col.getFk() != null)
                 {
-                    ColumnInfo col = getColumnByFormFieldName(propName);
-                    if (col != null && col.getFk() != null)
-                    {
-                        ForeignKey fk = col.getFk();
-                        Object remappedValue = cache.remap(SchemaKey.fromParts(fk.getLookupSchemaName()), fk.getLookupTableName(), getUser(), getContainer(), ContainerFilter.Type.CurrentPlusProjectAndShared, str);
+                    ForeignKey fk = col.getFk();
+                    Object remappedValue = cache.remap(SchemaKey.fromParts(fk.getLookupSchemaName()), fk.getLookupTableName(), getUser(), getContainer(), ContainerFilter.Type.CurrentPlusProjectAndShared, str);
 
-                        if (remappedValue != null)
-                        {
-                            values.put(propName, remappedValue);
-                            skipError = true;
-                        }
+                    if (remappedValue != null)
+                    {
+                        values.put(propName, remappedValue);
+                        skipError = true;
                     }
                 }
 

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -384,9 +384,6 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
 
         AdminConsole.addExperimentalFeatureFlag(NotificationMenuView.EXPERIMENTAL_NOTIFICATION_MENU, "Notifications Menu",
                 "Notifications 'inbox' count display in the header bar with click to show the notifications panel of unread notifications.", false);
-        AdminConsole.addExperimentalFeatureFlag(RemapCache.EXPERIMENTAL_RESOLVE_LOOKUPS_BY_VALUE, "Resolve lookups by Value",
-                "This feature will attempt to resolve lookups by value through the UI insert/update form. This can be useful when the " +
-                        "lookup list is long (> 10000) and the UI stops rendering a dropdown.", false);
 
         SiteValidationService svc = SiteValidationService.get();
         if (null != svc)

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -566,7 +566,8 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
                     boolean skipError = false;
                     if (dp.getLookup() != null)
                     {
-                        Object remappedValue = cache.remap(SchemaKey.fromParts(dp.getLookup().getSchemaName()), dp.getLookup().getQueryName(), user, getContainer(), ContainerFilter.Type.CurrentPlusProjectAndShared, String.valueOf(value));
+                        Container container = dp.getLookup().getContainer() != null ? dp.getLookup().getContainer() : getContainer();
+                        Object remappedValue = cache.remap(SchemaKey.fromParts(dp.getLookup().getSchemaName()), dp.getLookup().getQueryName(), user, container, ContainerFilter.Type.CurrentPlusProjectAndShared, String.valueOf(value));
                         if (remappedValue != null)
                         {
                             value = remappedValue;

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -23,9 +23,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.DbSequenceManager;
+import org.labkey.api.data.RemapCache;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SqlExecutor;
@@ -50,6 +52,7 @@ import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryRowReference;
+import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
@@ -531,6 +534,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
         ExpSampleTypeImpl st = (ExpSampleTypeImpl) getSampleType();
         Map<String, Object> values = new HashMap<>(values_);
         Map<String,Object> converted = new HashMap<>();
+        RemapCache cache = new RemapCache();
 
         TableInfo ti = null==st ? null : st.getTinfo();
         if (null != ti)
@@ -558,7 +562,20 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
                 }
                 catch (ConversionException x)
                 {
-                    throw new ValidationException(ConvertHelper.getStandardConversionErrorMessage(value, dp.getName(), dp.getPropertyDescriptor().getPropertyType().getJavaType()));
+                    // Attempt to resolve lookups by display value
+                    boolean skipError = false;
+                    if (dp.getLookup() != null)
+                    {
+                        Object remappedValue = cache.remap(SchemaKey.fromParts(dp.getLookup().getSchemaName()), dp.getLookup().getQueryName(), user, getContainer(), ContainerFilter.Type.CurrentPlusProjectAndShared, String.valueOf(value));
+                        if (remappedValue != null)
+                        {
+                            value = remappedValue;
+                            skipError = true;
+                        }
+                    }
+
+                    if (!skipError)
+                        throw new ValidationException(ConvertHelper.getStandardConversionErrorMessage(value, dp.getName(), dp.getPropertyDescriptor().getPropertyType().getJavaType()));
                 }
                 converted.put(dp.getName(), value);
                 values.remove(key);

--- a/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
@@ -924,7 +924,8 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
                                 }
                                 catch (ConversionException e)
                                 {
-                                    Object remappedValue = _cache.remap(SchemaKey.fromParts(fk.getLookupSchemaName()), fk.getLookupTableName(), user, container, ContainerFilter.Type.CurrentPlusProjectAndShared, String.valueOf(value));
+                                    Container remapContainer = fk.getLookupContainer() != null ? fk.getLookupContainer() : container;
+                                    Object remappedValue = _cache.remap(SchemaKey.fromParts(fk.getLookupSchemaName()), fk.getLookupTableName(), user, remapContainer, ContainerFilter.Type.CurrentPlusProjectAndShared, String.valueOf(value));
                                     if (remappedValue != null)
                                         value = remappedValue;
                                 }


### PR DESCRIPTION
#### Rationale
Issue [43516](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43516): "Resolve lookup by value" experimental feature flag does not work for the "Derive Samples" insert form

This PR removes the experimental feature for "Resolve lookup by value" to make it the default behavior for the existing locations where it is implemented. It also adds support for this lookup value resolution to the "Derive Samples" form code path.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/788

#### Changes
* Remove "resolve lookups by value" experimental feature 
* Use cache.remap() to resolve lookup value in Derive Samples form code path
