### PR TITLE
41705: Support clearing selection from getSelected()

### DIFF
--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -4276,14 +4276,14 @@ if (!LABKEY.DataRegions) {
      * @see LABKEY.DataRegion#clearSelected
      */
     LABKEY.DataRegion.setSelected = function(config) {
-        // Formerly LABKEY.DataRegion.setSelected
-        var url = LABKEY.ActionURL.buildURL("query", "setSelected.api", config.containerPath,
-                { 'key': config.selectionKey, 'checked': config.checked });
-
         LABKEY.Ajax.request({
-            url: url,
-            method: "POST",
-            params: { id: config.ids || config.id },
+            url: LABKEY.ActionURL.buildURL('query', 'setSelected.api', config.containerPath),
+            method: 'POST',
+            jsonData: {
+                checked: config.checked,
+                id: config.ids || config.id,
+                key: config.selectionKey,
+            },
             scope: config.scope,
             success: LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnSuccess(config), config.scope),
             failure: LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnFailure(config), config.scope, true)
@@ -4314,12 +4314,10 @@ if (!LABKEY.DataRegions) {
      * @see LABKEY.DataRegion#getSelected
      */
     LABKEY.DataRegion.clearSelected = function(config) {
-        var url = LABKEY.ActionURL.buildURL('query', 'clearSelected.api', config.containerPath,
-                { 'key': config.selectionKey });
-
         LABKEY.Ajax.request({
+            url: LABKEY.ActionURL.buildURL('query', 'clearSelected.api', config.containerPath),
             method: 'POST',
-            url: url,
+            jsonData: { key: config.selectionKey },
             success: LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnSuccess(config), config.scope),
             failure: LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnFailure(config), config.scope, true)
         });
@@ -4344,16 +4342,24 @@ if (!LABKEY.DataRegions) {
      * </ul>
      * @param {Object} [config.scope] An optional scoping object for the success and error callback functions (default to this).
      * @param {string} [config.containerPath] An alternate container path. If not specified, the current container path will be used.
+     * @param {boolean} [config.clearSelected] If true, clear the session-based selection for this Data Region after
+     * retrieving the current selection. Defaults to false.
      *
      * @see LABKEY.DataRegion#setSelected
      * @see LABKEY.DataRegion#clearSelected
      */
     LABKEY.DataRegion.getSelected = function(config) {
-        var url = LABKEY.ActionURL.buildURL('query', 'getSelected.api', config.containerPath,
-                { 'key': config.selectionKey });
+        var jsonData = { key: config.selectionKey };
+
+        // Issue 41705: Support clearing selection from getSelected()
+        if (config.clearSelected) {
+            jsonData.clearSelected = true;
+        }
 
         LABKEY.Ajax.request({
-            url: url,
+            url: LABKEY.ActionURL.buildURL('query', 'getSelected.api', config.containerPath),
+            method: 'POST',
+            jsonData: jsonData,
             success: LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnSuccess(config), config.scope),
             failure: LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnFailure(config), config.scope, true)
         });

--- a/query/resources/views/QWPDemo.html
+++ b/query/resources/views/QWPDemo.html
@@ -42,6 +42,7 @@
             <div class="tab"><a href="#testFilterOnSortColumn">Filter on "Sort" column</a></div>
             <div class="tab"><a href="#testButtonBarConfig">Use onRender via ButtonBarOptions</a></div>
             <div class="tab"><a href="#testRespectExcludingPrefixes">Exclude "skipPrefixes"</a></div>
+            <div class="tab"><a href="#testGetSelected">Get Selected (Regression #41705)</a></div>
         </td>
         <td valign="top">
             <div id="qwpDiv"></div>

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -5517,7 +5517,18 @@ public class QueryController extends SpringActionController
     @SuppressWarnings({"unused", "WeakerAccess"})
     public static class SelectForm extends QueryForm
     {
+        protected boolean clearSelected;
         protected String key;
+
+        public boolean isClearSelected()
+        {
+            return clearSelected;
+        }
+
+        public void setClearSelected(boolean clearSelected)
+        {
+            this.clearSelected = clearSelected;
+        }
 
         public String getKey()
         {
@@ -5569,12 +5580,12 @@ public class QueryController extends SpringActionController
         {
             if (form.getQueryName() == null)
             {
-                Set<String> selected = DataRegionSelection.getSelected(getViewContext(), form.getKey(), false);
+                Set<String> selected = DataRegionSelection.getSelected(getViewContext(), form.getKey(), form.isClearSelected());
                 return new ApiSimpleResponse("selected", selected);
             }
             else
             {
-                List<String> selected = DataRegionSelection.getSelected(form);
+                List<String> selected = DataRegionSelection.getSelected(form, form.isClearSelected());
                 return new ApiSimpleResponse("selected", selected);
             }
         }


### PR DESCRIPTION
#### Rationale
[Issue 41705](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41705) outlines the desire to have a `clearSelected` parameter made available from `query-getSelected.api`. This is the endpoint that backs `LABKEY.DataRegion.getSelected()`. For more in-depth discussion see https://github.com/LabKey/LabDevKitModules/pull/55#discussion_r504051634.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/789

#### Changes
* Support `clearSelected` for both the form-based and viewContext-based variants of `DataRegionSelection.getSelected()`.
* Add `clearSelected` parameter support into client-side `DataRegion.getSelected()` wrapper.
* Add a regression test is run as a part of `DataRegionTest`.
* Refactor `DataRegionSelection` by removing redundant logic, streamlining null handling, and the following:
  * Centralize logic for computing session key in `getSessionAttributeKey()`.
  * `getSet()` is now `@NotNull` safe as it will always provide a non-null value.
  * Centralize logic for fetching a `QueryView` from a `QueryForm`.
  * Remove redundant logic from `setSelectionForAll` that is found in `getDataRegionContext()`.
  * Coalesce logic for handling fetching a selection from a `ResultSetRowMapFactory` into `createSelectionList()`. 
* Update client-side Data Region selection API wrappers always `POST` as they may mutate server state. Additionally, use payload for parameters rather than URL parameters.
