### PR TITLE
Clear selection only for deleted items

### DIFF
--- a/experiment/webapp/experiment/confirmDelete.js
+++ b/experiment/webapp/experiment/confirmDelete.js
@@ -87,7 +87,7 @@ LABKEY.experiment.confirmDelete = function(dataRegionName, schemaName, queryName
                             Ext4.Msg.hide();
                         }
                         else if (btn === 'ok') {
-                            let canDelete = response.data.canDelete;
+                            const canDelete = response.data.canDelete;
                             Ext4.Ajax.request({
                                 url: LABKEY.ActionURL.buildURL('query', 'deleteRows'),
                                 method: 'POST',
@@ -100,11 +100,11 @@ LABKEY.experiment.confirmDelete = function(dataRegionName, schemaName, queryName
                                 success: LABKEY.Utils.getCallbackWrapper(function(response)  {
                                     // clear the selection only for the rows that were deleted
                                     // TODO: support clearing selection in query-deleteRows.api using a selectionKey
-                                    let ids = canDelete.map((row) => row.RowId);
-                                    let dr = LABKEY.DataRegions[dataRegionName];
+                                    const ids = canDelete.map((row) => row.RowId);
+                                    const dr = LABKEY.DataRegions[dataRegionName];
                                     if (dr) {
                                         dr.setSelected({
-                                            ids: ids,
+                                            ids,
                                             checked: false
                                         });
                                     }

--- a/experiment/webapp/experiment/confirmDelete.js
+++ b/experiment/webapp/experiment/confirmDelete.js
@@ -87,20 +87,25 @@ LABKEY.experiment.confirmDelete = function(dataRegionName, schemaName, queryName
                             Ext4.Msg.hide();
                         }
                         else if (btn === 'ok') {
+                            let canDelete = response.data.canDelete;
                             Ext4.Ajax.request({
                                 url: LABKEY.ActionURL.buildURL('query', 'deleteRows'),
                                 method: 'POST',
                                 jsonData: {
                                     schemaName: schemaName,
                                     queryName: queryName,
-                                    rows: response.data.canDelete,
+                                    rows: canDelete,
                                     apiVersion: 13.2
                                 },
                                 success: LABKEY.Utils.getCallbackWrapper(function(response)  {
+                                    // clear the selection only for the rows that were deleted
+                                    // TODO: support clearing selection in query-deleteRows.api using a selectionKey
+                                    let ids = canDelete.map((row) => row.RowId);
                                     let dr = LABKEY.DataRegions[dataRegionName];
                                     if (dr) {
-                                        dr.clearSelected({
-                                            selectionKey: selectionKey,
+                                        dr.setSelected({
+                                            ids: ids,
+                                            checked: false
                                         });
                                     }
 


### PR DESCRIPTION
#### Rationale
The change in #2423 clears all selected items after deleting samples even if the samples can't be deleted.  The `SampleTypeLineageTest.testDeleteSamplesSomeWithDerivedSamples` was relying on this behavior, even if strange.  To not break the test, the selection is only cleared for samples that can be deleted.

#### Related Pull Requests
* #2423
* https://github.com/LabKey/testAutomation/pull/790
