### PR TITLE
Issue 43387: Render errors based on the original URL's container path

### DIFF
--- a/api/src/org/labkey/api/util/ErrorRenderer.java
+++ b/api/src/org/labkey/api/util/ErrorRenderer.java
@@ -184,11 +184,11 @@ public class ErrorRenderer
 
                     out.println("<br><table>\n");
                     out.println("<tr><td colspan=2><b>core schema database configuration</b></td></tr>\n");
-                    out.println("<tr><td>Server URL</td><td>" + scope.getURL() + "</td></tr>\n");
-                    out.println("<tr><td>Product Name</td><td>" + scope.getDatabaseProductName() + "</td></tr>\n");
-                    out.println("<tr><td>Product Version</td><td>" + scope.getDatabaseProductVersion() + "</td></tr>\n");
-                    out.println("<tr><td>Driver Name</td><td>" + scope.getDriverName() + "</td></tr>\n");
-                    out.println("<tr><td>Driver Version</td><td>" + scope.getDriverVersion() + "</td></tr>\n");
+                    out.println("<tr><td>Server URL</td><td>" + PageFlowUtil.filter(scope.getURL()) + "</td></tr>\n");
+                    out.println("<tr><td>Product Name</td><td>" + PageFlowUtil.filter(scope.getDatabaseProductName()) + "</td></tr>\n");
+                    out.println("<tr><td>Product Version</td><td>" + PageFlowUtil.filter(scope.getDatabaseProductVersion()) + "</td></tr>\n");
+                    out.println("<tr><td>Driver Name</td><td>" + PageFlowUtil.filter(scope.getDriverName()) + "</td></tr>\n");
+                    out.println("<tr><td>Driver Version</td><td>" + PageFlowUtil.filter(scope.getDriverVersion()) + "</td></tr>\n");
                     out.println("</table>\n");
                 }
                 catch(Exception e)

--- a/api/src/org/labkey/api/view/ViewServlet.java
+++ b/api/src/org/labkey/api/view/ViewServlet.java
@@ -84,6 +84,7 @@ public class ViewServlet extends HttpServlet
 
     public static final String ORIGINAL_URL_STRING = "LABKEY.OriginalURL";           // String
     public static final String ORIGINAL_URL_URLHELPER = "LABKEY.OriginalURLHelper";  // URLHelper
+    public static final String ORIGINAL_URL_CONTAINER_PATH = "LABKEY.OriginalContainerPath";  // Path
     public static final String REQUEST_ACTION_URL = "LABKEY.RequestURL";             // ActionURL
     public static final String REQUEST_STARTTIME = "LABKEY.StartTime";
     public static final String REQUEST_UID_COUNTER = "LABKEY.Counter";                   // Incrementing counter scoped to a single request
@@ -416,6 +417,8 @@ public class ViewServlet extends HttpServlet
     private Container canonicalizeContainer(HttpServletRequest request, ActionURL url)
     {
         Path path = url.getParsedPath();
+        request.setAttribute(ORIGINAL_URL_CONTAINER_PATH, path);
+
         Container c = ContainerManager.getForPath(path);
         if (null == c)
         {


### PR DESCRIPTION
#### Rationale
We support a number of variants for specifying containers on the URL. It'll be better to maintain consistency with the original request when rendering an error

#### Changes
* Retain original path when bouncing users to the login page
* Don't try to render the header if the user can't see the current container
* HTML encode more stuff