### PR TITLE
Be tolerant of failure listing tomcat/lib for JDBC JARs

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1297,7 +1297,8 @@ public class DbScope
                 aggregatePredicate.test(name)
             );
 
-            if (existing.length > 0)
+            // Don't fail if we can't get a listing for the directory
+            if (existing != null && existing.length > 0)
             {
                 String path = FileUtil.getAbsoluteCaseSensitiveFile(lib).getAbsolutePath();
                 throw new ConfigurationException("You must delete the following files from " + path + ": " + Arrays.toString(existing));


### PR DESCRIPTION
#### Rationale
We want to warn if a deployment has old JDBC drivers sitting in Tomcat's lib directory. But if we can't list the contents of that directory, we can assume they're not present instead of throwing a NPE

#### Changes
* Check if java.io.File.list() returned null