### PR TITLE
Display trigger information in schema browser

### DIFF
--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -1616,20 +1616,20 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
 
     private final Map<Class<? extends TriggerFactory>, TriggerFactory> _triggerFactories = new LinkedHashMap<>();
 
-    public void addTriggerFactory(TriggerFactory factory)
+    public final void addTriggerFactory(TriggerFactory factory)
     {
         checkLocked();
         _triggerFactories.put(factory.getClass(), factory);
     }
 
     @Override
-    public boolean hasTriggers(@Nullable Container c)
+    public final boolean hasTriggers(@Nullable Container c)
     {
         return !getTriggers(c).isEmpty();
     }
 
     @Override
-    public boolean canStreamTriggers(Container c)
+    public final boolean canStreamTriggers(Container c)
     {
         for (Trigger script : getTriggers(c))
         {
@@ -1644,7 +1644,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     private Collection<Trigger> _triggers = null;
 
     @NotNull
-    protected Collection<Trigger> getTriggers(@Nullable Container c)
+    public final Collection<Trigger> getTriggers(@Nullable Container c)
     {
         if (_triggers == null)
         {
@@ -1655,7 +1655,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
 
 
     @NotNull
-    private Collection<Trigger> loadTriggers(@Nullable Container c)
+    private final Collection<Trigger> loadTriggers(@Nullable Container c)
     {
         if (_triggerFactories.isEmpty())
             return Collections.emptyList();
@@ -1669,20 +1669,20 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         if (LOG.isDebugEnabled() && !scripts.isEmpty())
         {
             LOG.debug("Trigger scripts for '" + getPublicSchemaName() + "', '" + getName() + "': " +
-                    scripts.stream().map(Trigger::getDebugName).collect(Collectors.joining(", ")));
+                    scripts.stream().map(Trigger::getName).collect(Collectors.joining(", ")));
         }
 
         return scripts;
     }
 
     @Override
-    public void resetTriggers(Container c)
+    public final void resetTriggers(Container c)
     {
         _triggers = null;
     }
 
     @Override
-    public void fireBatchTrigger(Container c, User user, TriggerType type, boolean before, BatchValidationException batchErrors, Map<String, Object> extraContext)
+    public final void fireBatchTrigger(Container c, User user, TriggerType type, boolean before, BatchValidationException batchErrors, Map<String, Object> extraContext)
             throws BatchValidationException
     {
         assert batchErrors != null;

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -408,6 +408,14 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
         }
     }
 
+    enum TriggerMethod
+    {
+        init, complete,
+        beforeInsert, afterInsert,
+        beforeUpdate, afterUpdate,
+        beforeDelete, afterDelete
+    }
+
 
     /**
      * Queries may have named parameters, SELECT queries (the only kind we have right now) may

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -408,6 +408,9 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
         }
     }
 
+    /**
+     * Enumeration of trigger methods that may be implemented in trigger scripts.
+     */
     enum TriggerMethod
     {
         init, complete,

--- a/api/src/org/labkey/api/data/triggers/Trigger.java
+++ b/api/src/org/labkey/api/data/triggers/Trigger.java
@@ -16,6 +16,7 @@
 package org.labkey.api.data.triggers;
 
 import org.jetbrains.annotations.Nullable;
+import org.json.JSONObject;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.BatchValidationException;
@@ -173,4 +174,17 @@ public interface Trigger
     {
     }
 
+
+    /**
+     * JSON serialization for query-getQueryDetails.api
+     */
+    default JSONObject toJSON()
+    {
+        return new JSONObject()
+                .put("name", getName())
+                .put("description", getDescription())
+                .put("module", getModuleName())
+                .put("source", getSource())
+                .put("events", getEvents());
+    }
 }

--- a/api/src/org/labkey/api/data/triggers/Trigger.java
+++ b/api/src/org/labkey/api/data/triggers/Trigger.java
@@ -24,11 +24,10 @@ import org.labkey.api.security.User;
 import org.labkey.api.util.UnexpectedException;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -60,25 +59,24 @@ public interface Trigger
      */
     default List<TableInfo.TriggerMethod> getEvents()
     {
-        List<TableInfo.TriggerMethod> events = new ArrayList<>(8);
         try
         {
-            Class cls = getClass();
-            Method[] methods = cls.getDeclaredMethods();
-            Set<String> names = Arrays.stream(methods).map(Method::getName).collect(Collectors.toSet());
-
-            for (TableInfo.TriggerMethod m : TableInfo.TriggerMethod.values())
-            {
-                if (names.contains(m.name()))
-                    events.add(m);
-            }
+            Class<Trigger> triggerInterface = Trigger.class;
+            Class<?> cls = getClass();
+            return Arrays.stream(cls.getMethods())
+                    .filter(m -> triggerInterface != m.getDeclaringClass())
+                    .map(Method::getName)
+                    .map(name -> {
+                        try { return TableInfo.TriggerMethod.valueOf(name); }
+                        catch (IllegalArgumentException e) { return null; }
+                    })
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
         }
         catch (SecurityException e)
         {
-            UnexpectedException.wrap(e);
+            throw UnexpectedException.wrap(e);
         }
-
-        return events;
     }
 
     /**

--- a/api/src/org/labkey/api/script/ScriptReference.java
+++ b/api/src/org/labkey/api/script/ScriptReference.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.api.script;
 
+import org.labkey.api.util.Path;
+
 import javax.script.ScriptContext;
 import javax.script.ScriptException;
 import java.util.Map;
@@ -24,6 +26,12 @@ import java.util.Map;
  */
 public interface ScriptReference
 {
+    /** The module where the script is defined. */
+    String getModuleName();
+
+    /** Script source path. */
+    Path getPath();
+
     /**
      * The context in which the script will run when {@link #eval()} or {@link #invoke()} is called.
      */

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -4314,9 +4314,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.6.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.0.tgz",
-      "integrity": "sha1-EUgPzrGrq1KLsQyFaG3zpuwR+8o="
+      "version": "1.6.3",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.3.tgz",
+      "integrity": "sha1-TDvflKWLM9jUb427JB0bLIuVQEs="
     },
     "@labkey/build": {
       "version": "4.0.0",

--- a/core/package.json
+++ b/core/package.json
@@ -51,7 +51,7 @@
     "testResultsProcessor": "jest-teamcity-reporter"
   },
   "dependencies": {
-    "@labkey/api": "1.6.0",
+    "@labkey/api": "1.6.3-SNAPSHOT",
     "@labkey/components": "2.54.0",
     "@labkey/themes": "1.2.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -51,7 +51,7 @@
     "testResultsProcessor": "jest-teamcity-reporter"
   },
   "dependencies": {
-    "@labkey/api": "1.6.3-SNAPSHOT",
+    "@labkey/api": "1.6.3",
     "@labkey/components": "2.54.0",
     "@labkey/themes": "1.2.0"
   },

--- a/internal/src/org/labkey/api/script/RhinoService.java
+++ b/internal/src/org/labkey/api/script/RhinoService.java
@@ -271,7 +271,7 @@ class ScriptReferenceImpl implements ScriptReference
             RhinoEngine engine = RhinoService.RHINO_FACTORY.getScriptEngine();
             Context ctx = Context.enter();
 
-            LOG.info("Compiling script '" + r.toString() + "'");
+            LOG.debug("Compiling script '" + r.toString() + "'");
 
             try (Reader reader = Readers.getReader(r.getInputStream()))
             {
@@ -323,6 +323,19 @@ class ScriptReferenceImpl implements ScriptReference
         MemTracker.getInstance().put(this);
     }
 
+    @Override
+    public String getModuleName()
+    {
+        return _module.getName();
+    }
+
+    @Override
+    public Path getPath()
+    {
+        return _path;
+    }
+
+    @Override
     public String toString()
     {
         return "[" + _module.getName() + "] " + _path.toString();
@@ -653,7 +666,7 @@ class RhinoEngine extends RhinoScriptEngine
 
             if (topLevel == null)
             {
-                LOG.info("RhinoEngine.createTopLevel: initialize cache");
+                LOG.debug("RhinoEngine.createTopLevel: initialize cache");
                 // Create the shared module script cache.
                 // This cache is managed by Rhino's module provider implementation.
                 ModuleSourceProvider moduleSourceProvider = new LabKeyModuleSourceProvider();

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -34,6 +34,7 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.JsonWriter;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.triggers.Trigger;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainKind;
 import org.labkey.api.exp.property.PropertyService;
@@ -71,12 +72,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 
 /**
  * User: dave
  * Date: Sep 3, 2009
- * Time: 3:36:07 PM
  */
 @RequiresPermission(ReadPermission.class)
 @Action(ActionType.SelectMetaData.class)
@@ -214,6 +215,18 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
             }
         }
 
+        if (form.isIncludeTriggers() && tinfo instanceof AbstractTableInfo)
+        {
+            Collection<Trigger> triggers = ((AbstractTableInfo)tinfo).getTriggers(container);
+            resp.put("triggers", triggers.stream().map(t -> new JSONObject()
+                    .put("name", t.getName())
+                    .put("description", t.getDescription())
+                    .put("module", t.getModuleName())
+                    .put("source", t.getSource())
+                    .put("events", t.getEvents())
+            ).collect(Collectors.toList()));
+        }
+
         Map<FieldKey, Map<String, Object>> columnMetadata;
 
         //if the caller asked us to chase a foreign key, do that.  Note that any call to get a lookup table can throw a
@@ -308,7 +321,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
             Map<String, CustomView> allViews = queryDef.getCustomViews(getUser(), getViewContext().getRequest(), true, false);
             Set<String> viewNames = new CaseInsensitiveHashSet("");
             if (form.getViewName() != null)
-                viewNames.addAll(Arrays.stream(form.getViewName()).map(String::trim).collect(Collectors.toList()));
+                viewNames.addAll(Arrays.stream(form.getViewName()).map(String::trim).collect(toList()));
 
             if (viewNames.contains("*"))
             {
@@ -434,6 +447,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
         private String[] _additionalFields;
         private boolean _initializeMissingView;
         private boolean _includeSuggestedQueryColumns = true;
+        private boolean _includeTriggers;
 
         public String getSchemaName()
         {
@@ -503,6 +517,16 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
         public void setIncludeSuggestedQueryColumns(boolean includeSuggestedQueryColumns)
         {
             _includeSuggestedQueryColumns = includeSuggestedQueryColumns;
+        }
+
+        public boolean isIncludeTriggers()
+        {
+            return _includeTriggers;
+        }
+
+        public void setIncludeTriggers(boolean includeTriggers)
+        {
+            _includeTriggers = includeTriggers;
         }
     }
 }

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -218,13 +218,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
         if (form.isIncludeTriggers() && tinfo instanceof AbstractTableInfo)
         {
             Collection<Trigger> triggers = ((AbstractTableInfo)tinfo).getTriggers(container);
-            resp.put("triggers", triggers.stream().map(t -> new JSONObject()
-                    .put("name", t.getName())
-                    .put("description", t.getDescription())
-                    .put("module", t.getModuleName())
-                    .put("source", t.getSource())
-                    .put("events", t.getEvents())
-            ).collect(Collectors.toList()));
+            resp.put("triggers", triggers.stream().map(Trigger::toJSON).collect(Collectors.toList()));
         }
 
         Map<FieldKey, Map<String, Object>> columnMetadata;

--- a/query/webapp/query/browser/Caches.js
+++ b/query/webapp/query/browser/Caches.js
@@ -146,6 +146,8 @@ Ext4.define('LABKEY.query.browser.cache.QueryDetails', {
                 schemaName: '' + schemaName, // stringify LABKEY.SchemaKey
                 queryName: queryName,
                 fk: fk,
+                // Only fetch trigger scripts for the top-level table or query
+                includeTriggers: fk === undefined,
                 success: function(json) {
                     this.detailsCache[cacheKey] = json;
                     this.fireEvent('newdetails', json);

--- a/query/webapp/query/browser/view/QueryDetails.js
+++ b/query/webapp/query/browser/view/QueryDetails.js
@@ -359,6 +359,41 @@ Ext4.define('LABKEY.query.browser.view.QueryDetails', {
         return rows;
     },
 
+    formatTriggers: function (queryDetails) {
+        if (!queryDetails.triggers || queryDetails.triggers.length === 0)
+            return;
+
+        var tpl = new Ext4.XTemplate(
+            '<table class="lk-qd-coltable" style="margin-top: 1em;">',
+                '<thead>',
+                    '<tr><td colspan="4" class="lk-qd-collist-title">Triggers</td></tr>',
+                    '<tr>',
+                        '<td class="lk-qd-colheader">Name</td>',
+                        '<td class="lk-qd-colheader">Description</td>',
+                        '<td class="lk-qd-colheader">Module</td>',
+                        '<td class="lk-qd-colheader">Events</td>',
+                    '</tr>',
+                '</thead>',
+                '<tbody>',
+                '<tpl foreach="triggers">',
+                    '<tr>',
+                        '<td>{[Ext4.htmlEncode(values.name)]}</td>',
+                        '<td>{[Ext4.htmlEncode(values.description)]}</td>',
+                        '<td>{[Ext4.htmlEncode(values.module)]}</td>',
+                        '<td>{[Ext4.htmlEncode(values.events.join(", "))]}</td>',
+                    '</tr>',
+                '</tpl>',
+                '</tbody>',
+            '</table>'
+        );
+
+        return {
+            tag: 'div',
+            cls: 'lk-qd-triggers',
+            html: tpl.apply(queryDetails)
+        };
+    },
+
     formatIndices: function (queryDetails) {
         // If no indices are present, don't render anything
         if (!queryDetails.indices || !this.hasProperties(queryDetails.indices))
@@ -561,6 +596,10 @@ Ext4.define('LABKEY.query.browser.view.QueryDetails', {
             var indices = this.formatIndices(queryDetails);
             if (indices)
                 children.push(indices);
+
+            let triggers = this.formatTriggers(queryDetails);
+            if (triggers)
+                children.push(triggers);
         }
 
         return Ext4.create('Ext.Component', {


### PR DESCRIPTION
#### Rationale
To help developers with debugging triggers, list the triggers attached to a table in the schema browser.  Both Java and JavaScript triggers are supported.

<img width="788" alt="Screen Shot 2021-07-09 at 12 28 45 AM" src="https://user-images.githubusercontent.com/3923845/125040544-5e987f00-e0ca-11eb-9e0d-685a24d45003.png">

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/935
* https://github.com/LabKey/labkey-api-js/pull/105

#### Changes
- add `includeTriggers` to query-getQueryDetails.api
- render grid of triggers and the supported events
- add trigger information to the DataIterator trace logging
