### PR TITLE
Issue 43526: Add experimental feature to test usages of QuerySelect component in place of DataColumn renderSelectFormInput

### DIFF
--- a/core/src/client/QuerySelectInput/QuerySelectInput.scss
+++ b/core/src/client/QuerySelectInput/QuerySelectInput.scss
@@ -1,0 +1,6 @@
+@import "@labkey/components-scss";
+
+.Select-control {
+  border-radius: unset;
+  border-color: #a9a9a9;
+}

--- a/core/src/client/QuerySelectInput/QuerySelectInput.tsx
+++ b/core/src/client/QuerySelectInput/QuerySelectInput.tsx
@@ -1,0 +1,37 @@
+import React, { FC, memo } from 'react';
+import { QuerySelect, SchemaQuery, } from '@labkey/components';
+
+import './QuerySelectInput.scss';
+
+export interface AppContext {
+    name: string;
+    value: string;
+    containerPath: string;
+    schemaName: string;
+    queryName: string;
+    disabled?: boolean;
+}
+
+interface Props {
+    context: AppContext;
+}
+
+export const QuerySelectInput: FC<Props> = memo(props => {
+    const { name, disabled, containerPath, value, schemaName, queryName } = props.context;
+
+    return (
+        <QuerySelect
+            componentId={'query-select' + name}
+            inputClass={'col-sm-8 col-xs-12'}
+            formsy={false}
+            name={name}
+            schemaQuery={SchemaQuery.create(schemaName, queryName)}
+            containerPath={containerPath}
+            showLabel={false}
+            disabled={disabled}
+            value={value}
+            loadOnFocus
+            maxRows={100}
+        />
+    );
+});

--- a/core/src/client/QuerySelectInput/app.tsx
+++ b/core/src/client/QuerySelectInput/app.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { App } from '@labkey/api';
+
+import { AppContext, QuerySelectInput } from './QuerySelectInput';
+
+App.registerApp<AppContext>('querySelectInput', (target, ctx) => {
+    ReactDOM.render(<QuerySelectInput context={ctx} />, document.getElementById(target));
+});

--- a/core/src/client/QuerySelectInput/dev.tsx
+++ b/core/src/client/QuerySelectInput/dev.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { AppContainer } from 'react-hot-loader';
+import { App } from '@labkey/api';
+
+import {AppContext, QuerySelectInput} from './QuerySelectInput';
+
+const render = (target: string, ctx: AppContext) => {
+    ReactDOM.render(
+        <AppContainer>
+            <QuerySelectInput context={ctx}/>
+        </AppContainer>,
+        document.getElementById(target)
+    );
+};
+
+App.registerApp<AppContext>('querySelectInput', render, true);
+
+declare const module: any;
+
+if (module.hot) {
+    module.hot.accept();
+}

--- a/core/src/client/entryPoints.js
+++ b/core/src/client/entryPoints.js
@@ -69,5 +69,10 @@ module.exports = {
         title: 'Concept Filter',
         generateLib: true, // used in FilterDialog.js
         path: './src/client/ConceptFilter'
+    }, {
+        name: 'querySelectInput',
+        title: 'Query Select Input',
+        generateLib: true, // used in DataColumn.java
+        path: './src/client/QuerySelectInput'
     }]
 };

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -387,6 +387,10 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         AdminConsole.addExperimentalFeatureFlag(RemapCache.EXPERIMENTAL_RESOLVE_LOOKUPS_BY_VALUE, "Resolve lookups by Value",
                 "This feature will attempt to resolve lookups by value through the UI insert/update form. This can be useful when the " +
                         "lookup list is long (> 10000) and the UI stops rendering a dropdown.", false);
+        AdminConsole.addExperimentalFeatureFlag(DataColumn.EXPERIMENTAL_USE_QUERYSELECT_COMPONENT, "Use QuerySelect for row insert/update form",
+                "This feature will switch the query based select inputs on the row insert/update form to use the React QuerySelect" +
+                        "component. This will allow for a user to view the first 100 options in the select but then use type ahead" +
+                        "search to find the other select values.", false);
 
         SiteValidationService svc = SiteValidationService.get();
         if (null != svc)


### PR DESCRIPTION
#### Rationale
Issue [43526](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43526): Use the React QuerySelect / SelectInput components on the row insert/update form to allow better UX for lookups with >10,000 options/rows

#### Changes
* Add experimental feature EXPERIMENTAL_USE_QUERYSELECT_COMPONENT
* Add core module entryPoint for wrapper around React QuerySelect component
* Conditionally use renderQuerySelectFormInput() instead of renderSelectFormInput() in DataColumn.java
