### PR TITLE
Disallow overriding email template replacement parameters

### DIFF
--- a/announcements/src/org/labkey/announcements/model/AnnouncementDigestProvider.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementDigestProvider.java
@@ -138,7 +138,7 @@ public class AnnouncementDigestProvider implements MessageDigest.Provider
 
     public static class DailyDigestEmailTemplate extends EmailTemplate
     {
-        protected static final String DEFAULT_SUBJECT = "New posts to ^folderName^";
+        protected static final String DEFAULT_SUBJECT = "New posts to ^folderPath^";
         protected static final String DEFAULT_DESCRIPTION = "Message board daily digest notification";
         protected static final String NAME = "Message board daily digest";
         protected static final String BODY_PATH = "/org/labkey/announcements/dailyDigest.txt";
@@ -177,7 +177,6 @@ public class AnnouncementDigestProvider implements MessageDigest.Provider
         @Override
         protected void addCustomReplacements(Replacements replacements)
         {
-            replacements.add("folderName", String.class, "Folder that user subscribed to", ContentType.Plain, Container::getPath);
             replacements.add("postList", String.class, "List of new posts", ContentType.HTML, c -> posts);
             replacements.add("reasonFooter", String.class, "Footer message explaining why user is receiving this digest", ContentType.HTML, c -> reasonForEmail);
         }

--- a/api/src/org/labkey/api/util/emailTemplate/EmailTemplate.java
+++ b/api/src/org/labkey/api/util/emailTemplate/EmailTemplate.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.util.emailTemplate;
 
+import com.google.common.collect.Streams;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -422,12 +423,19 @@ public abstract class EmailTemplate
 
         public void add(ReplacementParam<?> replacementParam)
         {
+            assert !replacementExists(replacementParam) : "Replacement \"" + replacementParam.getName() + "\" already exists!";
             _params.add(replacementParam);
         }
 
+        private boolean replacementExists(ReplacementParam<?> newParam)
+        {
+            return Streams.concat(STANDARD_REPLACEMENTS.stream(), _params.stream())
+                .anyMatch(r -> r.getName().equalsIgnoreCase(newParam.getName()));
+         }
+
         public <Type> void add(@NotNull String name, Class<Type> valueType, String description, ContentType contentType, Function<Container, Type> valueGetter)
         {
-            _params.add(new ReplacementParam<>(name, valueType, description, contentType)
+            add(new ReplacementParam<>(name, valueType, description, contentType)
             {
                 @Override
                 public Type getValue(Container c)

--- a/api/src/org/labkey/api/util/emailTemplate/EmailTemplate.java
+++ b/api/src/org/labkey/api/util/emailTemplate/EmailTemplate.java
@@ -431,7 +431,7 @@ public abstract class EmailTemplate
         {
             return Streams.concat(STANDARD_REPLACEMENTS.stream(), _params.stream())
                 .anyMatch(r -> r.getName().equalsIgnoreCase(newParam.getName()));
-         }
+        }
 
         public <Type> void add(@NotNull String name, Class<Type> valueType, String description, ContentType contentType, Function<Container, Type> valueGetter)
         {

--- a/api/src/org/labkey/api/view/JspTemplate.java
+++ b/api/src/org/labkey/api/view/JspTemplate.java
@@ -62,7 +62,7 @@ public class JspTemplate<ModelClass> extends JspView<ModelClass>
         @Test
         public void test() throws Exception
         {
-            String test = (new JspTemplate("/org/labkey/api/view/jspTemplateTest.jsp")).render();
+            String test = (new JspTemplate<>("/org/labkey/api/view/jspTemplateTest.jsp")).render();
             assertEquals("This is a JSP used by the JspTemplate.TestCase", test);
 
             RReport r = new RReport();

--- a/query/src/org/labkey/query/reports/view/ReportAndDatasetChangeDigestEmailTemplate.java
+++ b/query/src/org/labkey/query/reports/view/ReportAndDatasetChangeDigestEmailTemplate.java
@@ -16,7 +16,6 @@
 package org.labkey.query.reports.view;
 
 import org.labkey.api.data.Container;
-import org.labkey.api.portal.ProjectUrls;
 import org.labkey.api.reports.model.NotificationInfo;
 import org.labkey.api.reports.model.ViewCategory;
 import org.labkey.api.reports.report.ReportUrls;
@@ -43,7 +42,6 @@ public class ReportAndDatasetChangeDigestEmailTemplate extends EmailTemplate
 {
     private static final String DEFAULT_SUBJECT = "Report/Dataset Change Notification";
 
-    private ActionURL _folderUrl;
     private ActionURL _emailPrefsUrl;
     private String _reportAndDatasetList;
 
@@ -71,8 +69,6 @@ public class ReportAndDatasetChangeDigestEmailTemplate extends EmailTemplate
     @Override
     protected void addCustomReplacements(Replacements replacements)
     {
-        replacements.add("folderUrl", String.class, "URL to folder", ContentType.Plain, c -> _folderUrl == null ? null : _folderUrl.getURIString());
-        replacements.add("folderPath", String.class, "Path to folder", ContentType.Plain, c -> PageFlowUtil.filter(c.getPath()));
         replacements.add("emailPrefsUrl", String.class, "URL to set email preferences", ContentType.Plain, c -> _emailPrefsUrl == null ? null : _emailPrefsUrl.getURIString());
         replacements.add("reportAndDatasetList", String.class, "Formatted list of changed reports/datasets", ContentType.HTML, c -> _reportAndDatasetList);
     }
@@ -80,7 +76,6 @@ public class ReportAndDatasetChangeDigestEmailTemplate extends EmailTemplate
     public void init(Container c, Map<ViewCategory, List<NotificationInfo>> reports)
     {
         _emailPrefsUrl = PageFlowUtil.urlProvider(ReportUrls.class).urlManageNotifications(c);
-        _folderUrl = PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(c);
         _reportAndDatasetList = buildReportAndDatasetList(c, reports);
     }
 

--- a/query/src/org/labkey/query/reports/view/reportAndDatasetChangeDigestNotify.txt
+++ b/query/src/org/labkey/query/reports/view/reportAndDatasetChangeDigestNotify.txt
@@ -9,7 +9,7 @@
 </head>
 <body>
 <table width="100%">
-    <tr><td>Summary of report and dataset changes for folder <a href="^folderUrl^">^folderPath^</a>.</td></tr>
+    <tr><td>Summary of report and dataset changes for folder <a href="^folderURL^">^folderPath^</a>.</td></tr>
 </table>
 <hr size="1"/>
 <br>
@@ -22,7 +22,7 @@
 
 <table width="100%">
     <tr><td>You have received this email because
-        you are signed up to receive notifications about changes to reports and datasets at <a href="^folderUrl^">^folderPath^</a>.
+        you are signed up to receive notifications about changes to reports and datasets at <a href="^folderURL^">^folderPath^</a>.
         If you no longer wish to receive these notifications you can <a href="^emailPrefsUrl^">change your email preferences</a>.
     </td></tr>
 </table>


### PR DESCRIPTION
#### Rationale
`EmailTemplate` seems to let subclasses override replacement parameters, but the behavior is inconsistent (e.g., duplicate parameters appear on the customize page). This just seems like a bad idea, so remove existing overrides and add a check to prevent others in the future. Should fix `MessagesLongTest`, which flagged a related change in behavior.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2439

#### Changes
* `AnnouncementDigestProvider`: remove redundant override of `folderName`; just use `folderPath`
* `ReportAndDatasetChangeDigestEmailTemplate`: remove redundant overrides of `folderUrl` and `folderPath`
* Add assert that disallows adding a parameter that matches an existing parameter name for that template