### PR TITLE
Issues list related field - fix for multi value FK to not attempt to resolve lookup by value

### DIFF
--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -474,7 +474,7 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
 
                 // Attempt to resolve lookups by display value
                 ColumnInfo col = getColumnByFormFieldName(propName);
-                if (col != null && col.getFk() != null && !(col.getFk() instanceof MultiValuedForeignKey))
+                if (col != null && col.getFk() != null && col.getFk().allowImportByAlternateKey())
                 {
                     ForeignKey fk = col.getFk();
                     Container container = fk.getLookupContainer() != null ? fk.getLookupContainer() : getContainer();

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -474,7 +474,7 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
 
                 // Attempt to resolve lookups by display value
                 ColumnInfo col = getColumnByFormFieldName(propName);
-                if (col != null && col.getFk() != null)
+                if (col != null && col.getFk() != null && !(col.getFk() instanceof MultiValuedForeignKey))
                 {
                     ForeignKey fk = col.getFk();
                     Container container = fk.getLookupContainer() != null ? fk.getLookupContainer() : getContainer();


### PR DESCRIPTION
#### Rationale
See related PR. The change their removed the experimental feature that was conditionally attempting to resolve a lookup by value in the event of a conversion error (i.e. the lookup points to an integer PK but the user is providing the display value) on data entry. This ended up breaking the Issues list related issues field (as caught by the IssuesTest case). This PR fixes this case by skipping the "resolve by value" code in the multi value FK case.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2429

#### Changes
* TableViewForm update to if statement to skip "resolve lookup by display value" if not fk.allowImportByAlternateKey()