### PR TITLE
Switch to case-insensitive check to fix "duplicate" parameter error

### DIFF
--- a/api/src/org/labkey/api/collections/LabKeyCollectors.java
+++ b/api/src/org/labkey/api/collections/LabKeyCollectors.java
@@ -12,6 +12,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
@@ -100,6 +101,13 @@ public class LabKeyCollectors
         return JSONArray.collector();
     }
 
+    /**
+     * Returns a {@link Collector} that builds a {@link CaseInsensitiveHashSet} from a {@link Stream} of {@link String}s
+     */
+    public static Collector<String, ?, Set<String>> toCaseInsensitiveHashSet()
+    {
+        return Collectors.toCollection(CaseInsensitiveHashSet::new);
+    }
 
     public static class TestCase extends Assert
     {

--- a/issues/src/org/labkey/issue/IssueUpdateEmailTemplate.java
+++ b/issues/src/org/labkey/issue/IssueUpdateEmailTemplate.java
@@ -18,6 +18,7 @@ package org.labkey.issue;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.attachments.AttachmentFile;
+import org.labkey.api.collections.LabKeyCollectors;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
@@ -33,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * User: jeckels
@@ -193,8 +193,12 @@ public class IssueUpdateEmailTemplate extends UserOriginatedEmailTemplate
             sb.append(attachment.getFilename());
         }
         _attachments = sb.toString();
-        Set<String> existingParams = _replacements.stream().map(ReplacementParam::getName).collect(Collectors.toSet());
-        _allReplacements.addAll(_replacements);
+        Set<String> existingParams = _replacements.stream()
+            .map(ReplacementParam::getName)
+            .collect(LabKeyCollectors.toCaseInsensitiveHashSet());
+
+        Replacements allReplacements = new Replacements(_allReplacements);
+        _replacements.forEach(allReplacements::add);
 
         // inject any custom fields into the replacement parameters
         for (Map.Entry<String, Object> prop : issueProperties.entrySet())
@@ -205,19 +209,19 @@ public class IssueUpdateEmailTemplate extends UserOriginatedEmailTemplate
 
                 if (value instanceof Integer)
                 {
-                    _allReplacements.add(new CustomFieldReplacementParam<>(prop.getKey(), (Integer)value, Integer.class));
+                    allReplacements.add(new CustomFieldReplacementParam<>(prop.getKey(), (Integer)value, Integer.class));
                 }
                 else if (value instanceof Date)
                 {
-                    _allReplacements.add(new CustomFieldReplacementParam<>(prop.getKey(), (Date)value, Date.class));
+                    allReplacements.add(new CustomFieldReplacementParam<>(prop.getKey(), (Date)value, Date.class));
                 }
                 else if (value instanceof Double)
                 {
-                    _allReplacements.add(new CustomFieldReplacementParam<>(prop.getKey(), (Double)value, Double.class));
+                    allReplacements.add(new CustomFieldReplacementParam<>(prop.getKey(), (Double)value, Double.class));
                 }
                 else
                 {
-                    _allReplacements.add(new CustomFieldReplacementParam<>(prop.getKey(), String.valueOf(value), String.class));
+                    allReplacements.add(new CustomFieldReplacementParam<>(prop.getKey(), String.valueOf(value), String.class));
                 }
             }
         }


### PR DESCRIPTION
#### Rationale
`IssueUpdateEmailTemplate` used a case-sensitive check to detect existing parameters. Because of field name casing differences, this meant duplicate replacements were being added to the list. Recently added strict test flagged this bug.

#### Changes
* Use a case-insensitive hash map to check existing parameters
* For convenience, add a new `Collector` that produces case-insensitive hash maps
* For consistency, use the `Replacement` class to add parameters within issue's funky custom field handling