### PR TITLE
Item 9014 - Support for version 10 of Oracle db

### DIFF
--- a/bigiron/src/org/labkey/bigiron/oracle/OracleDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/oracle/OracleDialectFactory.java
@@ -81,6 +81,9 @@ public class OracleDialectFactory implements SqlDialectFactory
 
         VersionNumber versionNumber = new VersionNumber(databaseProductVersion.substring(startIndex, endIndex));
 
+        if (versionNumber.getMajor() == 10)
+            return new Oracle11gR1Dialect();
+
         // Restrict to 11g
         if (versionNumber.getMajor() == 11)
         {

--- a/bigiron/src/org/labkey/bigiron/oracle/OracleDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/oracle/OracleDialectFactory.java
@@ -81,6 +81,7 @@ public class OracleDialectFactory implements SqlDialectFactory
 
         VersionNumber versionNumber = new VersionNumber(databaseProductVersion.substring(startIndex, endIndex));
 
+        // piggy back on Oracle11gDialect until incompatibilities are discovered
         if (versionNumber.getMajor() == 10)
             return new Oracle11gR1Dialect();
 


### PR DESCRIPTION
#### Rationale
This PR adds the support for Oracle 10 database as an external datasource (primarily used by NIRC)

#### Related Pull Requests
* https://github.com/LabKey/nircEHRModules/pull/6

