### PR TITLE
Issue 43557: JSON date format doesn't parse in Safari

### DIFF
--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -959,14 +959,14 @@ validNum:       {
     {
         // 1. added milliseconds (.SSS) to gap the discrepancy of milliseconds portion stored in database
         // but not being used while checking for work during a remote ETL run as part of implementing Issue 35780.
-        // Without millisecond portion here, datetime comparision would show these datetimes as equals,
+        // Without millisecond portion here, datetime comparison would show these datetimes as equals,
         // ex: 2019/01/01 11:11:11.117 and 2019/01/01 11:11:11.399 - since milliseconds would be ignored, this would result in No Work.
 
         // 2. Separately, adding .SSS to the existing string (yyyy/MM/dd HH:mm:ss) worked on Chrome (and MS Edge), but not on Firefox.
         // Strangely, Firefox seem to adhere strictly to ECMA Specification of date string interchange format (i.e. date with
         // hyphens instead of forward slashes) in this particular case with milliseconds. Hence had to modify the previous string from yyyy/MM/dd to yyyy-MM-dd.
         // Chrome seem to behave as expected with this change (and so does MS Edge, but extensive testing has not been done on this browser).
-        return "yyyy-MM-dd HH:mm:ss.SSS";
+        return "yyyy-MM-dd'T'HH:mm:ss.SSS";
     }
 
 
@@ -1618,6 +1618,12 @@ Parse:
             assertEquals(datetimeLocal, parseDateTimeUS("2001-02-03T04:05:06", DateTimeOption.DateTime, true));
             assertEquals(datetimeUTC, parseDateTimeUS("2001-02-03 04:05:06Z", DateTimeOption.DateTime, true));
             assertEquals(datetimeUTC, parseDateTimeUS("2001-02-03T04:05:06Z", DateTimeOption.DateTime, true));
+
+            // Now try with milliseconds too
+            assertEquals(datetimeLocal + 213, parseDateTimeUS("2001-02-03 04:05:06.213", DateTimeOption.DateTime, true));
+            assertEquals(datetimeLocal + 213, parseDateTimeUS("2001-02-03T04:05:06.213", DateTimeOption.DateTime, true));
+            assertEquals(datetimeUTC + 213, parseDateTimeUS("2001-02-03 04:05:06.213Z", DateTimeOption.DateTime, true));
+            assertEquals(datetimeUTC + 213, parseDateTimeUS("2001-02-03T04:05:06.213Z", DateTimeOption.DateTime, true));
 
             assertIllegalDateTime("20131113_Guide Set plate 1.xls");
         }

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -1135,13 +1135,7 @@ validNum:       {
             ViewContext context = HttpView.currentContext();
             if (context != null && context.getRequest() != null)
             {
-                String userAgent = context.getRequest().getHeader("User-Agent");
-                if (userAgent != null)
-                {
-                    // Chrome includes "Safari" in its user agent, so be sure to filter it out
-                    userAgent = userAgent.toLowerCase();
-                    isSafari = userAgent.contains("safari") && !chromePattern.matcher(userAgent).find();
-                }
+                isSafari = HttpUtil.isSafari(context.getRequest());
             }
         }
         return isSafari ? safariJsonDateFormat.format(date) : jsonDateFormat.format(date);

--- a/api/src/org/labkey/api/util/HttpUtil.java
+++ b/api/src/org/labkey/api/util/HttpUtil.java
@@ -28,6 +28,7 @@ import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.ExecutionContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.action.BaseApiAction;
 import org.labkey.api.miniprofiler.CustomTiming;
 import org.labkey.api.miniprofiler.MiniProfiler;
@@ -230,7 +231,7 @@ public class HttpUtil
      * Check for cases that should not respond with a Redirect, used by getUpgradeMaintenanceRedirect()
      * @return true if this seems like an API request based on the HTTP headers, including Content-Type and User-Agent
      */
-    public static boolean isApiLike(HttpServletRequest request, Controller action)
+    public static boolean isApiLike(@NotNull HttpServletRequest request, Controller action)
     {
         boolean throwUnauthorized = StringUtils.equals("UNAUTHORIZED",request.getHeader("X-ONUNAUTHORIZED"));
         boolean xmlhttp = StringUtils.equals("XMLHttpRequest", request.getHeader("x-requested-with"));
@@ -241,7 +242,7 @@ public class HttpUtil
     }
 
     /** @return best guess if the request is from a browser vs. a WebDAV client or client API */
-    public static boolean isBrowser(HttpServletRequest request)
+    public static boolean isBrowser(@NotNull HttpServletRequest request)
     {
         if ("XMLHttpRequest".equals(request.getHeader("x-requested-with")))
             return true;
@@ -252,14 +253,20 @@ public class HttpUtil
     }
 
     /** @return best guess if the request came from a Chrome browser */
-    public static boolean isChrome(HttpServletRequest request)
+    public static boolean isChrome(@NotNull HttpServletRequest request)
     {
         String userAgent = request.getHeader("User-Agent");
         return StringUtils.contains(userAgent, "Chrome/") || StringUtils.contains(userAgent, "Chromium/");
     }
 
+    public static boolean isSafari(@NotNull HttpServletRequest request)
+    {
+        String userAgent = request.getHeader("User-Agent");
+        return !isChrome(request) && StringUtils.containsIgnoreCase(userAgent, "safari");
+    }
+
     /** @return best guess if the request came from the OSX integrated WebDAV client */
-    public static boolean isMacFinder(HttpServletRequest request)
+    public static boolean isMacFinder(@NotNull HttpServletRequest request)
     {
         String userAgent = request.getHeader("User-Agent");
         if (null == userAgent)
@@ -268,13 +275,11 @@ public class HttpUtil
     }
 
     /** @return best guess if the request came from the Windows Explorer integrated WebDAV client */
-    public static boolean isWindowsExplorer(HttpServletRequest request)
+    public static boolean isWindowsExplorer(@NotNull HttpServletRequest request)
     {
         String userAgent = request.getHeader("User-Agent");
         if (null == userAgent)
             return false;
         return userAgent.startsWith("Microsoft-WebDAV");
     }
-
-
 }

--- a/core/resources/scripts/labkey/Utils.js
+++ b/core/resources/scripts/labkey/Utils.js
@@ -42,7 +42,7 @@ LABKEY.Utils = new function()
             'j-n-y|j-n-Y|' +
             'j-M-y|j-M-Y|' + DATEALTFORMATS_Either;
 
-    var DATETIMEFORMAT_WithMS = 'Y-m-d H:i:s.u'; //24 hr format with milliseconds
+    var DATETIMEFORMAT_WithMS = 'Y-m-d\\TH:i:s.u'; //24 hr format with milliseconds
 
     function isObject(v)
     {

--- a/core/resources/scripts/labkey/Utils.js
+++ b/core/resources/scripts/labkey/Utils.js
@@ -42,11 +42,7 @@ LABKEY.Utils = new function()
             'j-n-y|j-n-Y|' +
             'j-M-y|j-M-Y|' + DATEALTFORMATS_Either;
 
-    // Match ExtJS detection - Both Chrome and Safari report that they're Safari, so eliminate Chrome when checking
-    var isSafari = !/\bchrome\b/.test(navigator.userAgent.toLowerCase()) && /safari/.test(navigator.userAgent.toLowerCase());
-
-    // Issue 43557 - Safari needs a 'T' between the date and time to parse dates via native Date constructor, so match here
-    var DATETIMEFORMAT_WithMS = isSafari ? 'Y-m-d\\TH:i:s.u' : 'Y-m-d H:i:s.u'; //24 hr format with milliseconds
+    var DATETIMEFORMAT_WithMS = 'Y-m-d H:i:s.u'; //24 hr format with milliseconds
 
     function isObject(v)
     {

--- a/core/resources/scripts/labkey/Utils.js
+++ b/core/resources/scripts/labkey/Utils.js
@@ -42,7 +42,11 @@ LABKEY.Utils = new function()
             'j-n-y|j-n-Y|' +
             'j-M-y|j-M-Y|' + DATEALTFORMATS_Either;
 
-    var DATETIMEFORMAT_WithMS = 'Y-m-d\\TH:i:s.u'; //24 hr format with milliseconds
+    // Match ExtJS detection - Both Chrome and Safari report that they're Safari, so eliminate Chrome when checking
+    var isSafari = !/\bchrome\b/.test(navigator.userAgent.toLowerCase()) && /safari/.test(navigator.userAgent.toLowerCase());
+
+    // Issue 43557 - Safari needs a 'T' between the date and time to parse dates via native Date constructor, so match here
+    var DATETIMEFORMAT_WithMS = isSafari ? 'Y-m-d\\TH:i:s.u' : 'Y-m-d H:i:s.u'; //24 hr format with milliseconds
 
     function isObject(v)
     {


### PR DESCRIPTION
#### Rationale
When we changed our JSON date representation to include milliseconds, we ended up adopting a variant that doesn't parse with Safari's standard Date JS object

#### Changes
* Use a format closer to ISO that includes a T between the date and time, which appears to parse in all browsers and hopefully other client API languages