### PR TITLE
Changing the test class category.

### DIFF
--- a/experiment/test/src/org/labkey/test/tests/experiment/VocabularyViewSupportTest.java
+++ b/experiment/test/src/org/labkey/test/tests/experiment/VocabularyViewSupportTest.java
@@ -17,7 +17,7 @@ import org.labkey.remoteapi.query.InsertRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.Locator;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.components.html.Table;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
@@ -36,7 +36,7 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 public class VocabularyViewSupportTest extends ProvenanceAssayHelper
 {
 

--- a/mothership/test/src/org/labkey/test/tests/mothership/MothershipReportTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/MothershipReportTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.TestTimeoutException;
-import org.labkey.test.categories.DailyB;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.core.admin.CustomizeSitePage;
 import org.labkey.test.pages.mothership.ShowInstallationDetailPage;
 import org.labkey.test.pages.test.TestActions;
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.labkey.test.TestProperties.isTestRunningOnTeamCity;
 import static org.labkey.test.util.mothership.MothershipHelper.MOTHERSHIP_PROJECT;
 
-@Category({DailyB.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 4)
 public class MothershipReportTest extends BaseWebDriverTest implements PostgresOnlyTest
 {

--- a/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
@@ -26,7 +26,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.categories.DailyB;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.issues.InsertPage;
 import org.labkey.test.pages.mothership.EditUpgradeMessagePage;
 import org.labkey.test.pages.mothership.ShowExceptionsPage;
@@ -53,7 +53,7 @@ import static org.junit.Assert.fail;
 import static org.labkey.test.pages.test.TestActions.ExceptionActions;
 import static org.labkey.test.util.mothership.MothershipHelper.MOTHERSHIP_PROJECT;
 
-@Category({DailyB.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTest
 {

--- a/query/test/src/org/labkey/test/tests/query/ContainerFilterQueryTest.java
+++ b/query/test/src/org/labkey/test/tests/query/ContainerFilterQueryTest.java
@@ -8,7 +8,7 @@ import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locators;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.APIContainerHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
@@ -32,7 +32,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 public class ContainerFilterQueryTest extends BaseWebDriverTest
 {
     private static final String OTHER_PROJECT = "Other ContainerFilterQueryTest Project"; // for permissions and linked schema tests

--- a/study/test/src/org/labkey/test/tests/experiment/ExpSchemaPropagateFilterTest.java
+++ b/study/test/src/org/labkey/test/tests/experiment/ExpSchemaPropagateFilterTest.java
@@ -10,7 +10,7 @@ import org.labkey.remoteapi.CommandException;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PortalHelper;
@@ -26,7 +26,7 @@ import java.util.Map;
 
 // Regression coverage for Issue 38448: ExpSchema lookups do not propagate ContainerFilter of parent table
 
-@Category({DailyC.class})
+@Category({Daily.class})
 public class ExpSchemaPropagateFilterTest extends BaseWebDriverTest
 {
 

--- a/study/test/src/org/labkey/test/tests/experiment/ExperimentAPITest.java
+++ b/study/test/src/org/labkey/test/tests/experiment/ExperimentAPITest.java
@@ -49,7 +49,7 @@ import org.labkey.remoteapi.domain.PropertyDescriptor;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.ReactAssayDesignerPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
@@ -69,7 +69,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 public class ExperimentAPITest extends BaseWebDriverTest
 {
     @Override

--- a/study/test/src/org/labkey/test/tests/search/DataClassSearchTest.java
+++ b/study/test/src/org/labkey/test/tests/search/DataClassSearchTest.java
@@ -32,7 +32,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.categories.DailyA;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Search;
 import org.labkey.test.util.SearchHelper;
 import org.labkey.test.util.search.SearchAdminAPIHelper;
@@ -44,7 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@Category({DailyA.class, Search.class})
+@Category({Daily.class, Search.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class DataClassSearchTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/search/SearchSyntaxTest.java
+++ b/study/test/src/org/labkey/test/tests/search/SearchSyntaxTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Search;
 import org.labkey.test.util.SearchHelper;
 
@@ -28,7 +28,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 
-@Category({DailyC.class, Search.class})
+@Category({Daily.class, Search.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 1)
 public class SearchSyntaxTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/search/SearchTestDefault.java
+++ b/study/test/src/org/labkey/test/tests/search/SearchTestDefault.java
@@ -16,11 +16,11 @@
 package org.labkey.test.tests.search;
 
 import org.junit.experimental.categories.Category;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Search;
 import org.labkey.test.util.search.SearchAdminAPIHelper;
 
-@Category({Search.class, DailyC.class})
+@Category({Search.class, Daily.class})
 public class SearchTestDefault extends SearchTest
 {
     @Override

--- a/study/test/src/org/labkey/test/tests/study/AncillaryStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AncillaryStudyTest.java
@@ -20,7 +20,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.tests.StudyBaseTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.StudyHelper;
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.DataRegionTable.DataRegion;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
 public class AncillaryStudyTest extends StudyBaseTest
 {

--- a/study/test/src/org/labkey/test/tests/study/AssayTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AssayTest.java
@@ -22,7 +22,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Assays;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.components.domain.DomainFieldRow;
 import org.labkey.test.components.domain.DomainFormPanel;
@@ -42,7 +42,7 @@ import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
 
-@Category({DailyC.class, Assays.class})
+@Category({Daily.class, Assays.class})
 public class AssayTest extends AbstractAssayTest
 {
     private static final String INVESTIGATOR = "Dr. No";

--- a/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
@@ -9,7 +9,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Assays;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.StudyHelper;
@@ -17,7 +17,7 @@ import org.labkey.test.util.StudyHelper;
 import java.io.File;
 import java.util.List;
 
-@Category({DailyC.class, Assays.class})
+@Category({Daily.class, Assays.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 4)
 public class AutoLinkToStudyTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/study/CohortTest.java
+++ b/study/test/src/org/labkey/test/tests/study/CohortTest.java
@@ -23,7 +23,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.SortDirection;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyB;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.ParticipantListWebPart;
 import org.labkey.test.pages.study.ManageVisitPage;
 import org.labkey.test.util.DataRegionTable;
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@Category({DailyB.class})
+@Category({Daily.class})
 public class CohortTest extends BaseWebDriverTest
 {
     private static final String PROJECT_NAME = "Cohort Test Project";

--- a/study/test/src/org/labkey/test/tests/study/ExtraKeyStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/ExtraKeyStudyTest.java
@@ -19,7 +19,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.tests.StudyBaseTest;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 8)
 public class ExtraKeyStudyTest extends StudyBaseTest
 {

--- a/study/test/src/org/labkey/test/tests/study/LinkAssayToStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/LinkAssayToStudyTest.java
@@ -23,7 +23,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Assays;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.tests.AbstractAssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
@@ -38,7 +38,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Category({DailyC.class, Assays.class})
+@Category({Daily.class, Assays.class})
 public class LinkAssayToStudyTest extends AbstractAssayTest
 {
     @Override

--- a/study/test/src/org/labkey/test/tests/study/ProgressReportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/ProgressReportTest.java
@@ -22,7 +22,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.studydesigner.AssayScheduleWebpart;
 import org.labkey.test.components.studydesigner.BaseManageVaccineDesignVisitPage;
 import org.labkey.test.components.studydesigner.ManageAssaySchedulePage;
@@ -38,7 +38,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 7)
 public class ProgressReportTest extends ReportTest
 {

--- a/study/test/src/org/labkey/test/tests/study/SCHARPStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SCHARPStudyTest.java
@@ -20,7 +20,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyA;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PostgresOnlyTest;
 
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
 
 import static org.junit.Assert.fail;
 
-@Category({DailyA.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class SCHARPStudyTest extends BaseWebDriverTest implements PostgresOnlyTest
 {

--- a/study/test/src/org/labkey/test/tests/study/SampleMindedImportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SampleMindedImportTest.java
@@ -21,7 +21,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
-import org.labkey.test.categories.DailyB;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Specimen;
 import org.labkey.test.util.DataRegionTable;
 
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Imports a SampleMinded data export (.xlsx) into the specimen repository.
  */
-@Category({DailyB.class, Specimen.class})
+@Category({Daily.class, Specimen.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 7)
 public class SampleMindedImportTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
@@ -29,7 +29,7 @@ import org.labkey.test.Locators;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.categories.DailyA;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.ParticipantListWebPart;
 import org.labkey.test.components.studydesigner.ManageAssaySchedulePage;
 import org.labkey.test.pages.DatasetInsertPage;
@@ -51,7 +51,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
-@Category({DailyA.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 9)
 public class SharedStudyTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/study/SpecimenMergeTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SpecimenMergeTest.java
@@ -21,7 +21,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
-import org.labkey.test.categories.DailyB;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Specimen;
 import org.labkey.test.util.StudyHelper;
 
@@ -32,7 +32,7 @@ import java.util.List;
 /**
  * CreateVialsTest also uses the specimen merge feature.
  */
-@Category({DailyB.class, Specimen.class})
+@Category({Daily.class, Specimen.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 7)
 public class SpecimenMergeTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/study/SpecimenReplaceTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SpecimenReplaceTest.java
@@ -20,12 +20,12 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyA;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Specimen;
 
 import java.io.File;
 
-@Category({DailyA.class, Specimen.class})
+@Category({Daily.class, Specimen.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class SpecimenReplaceTest extends SpecimenMergeTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyCohortExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyCohortExportTest.java
@@ -17,10 +17,10 @@ package org.labkey.test.tests.study;
 
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.util.DataRegionTable;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 13)
 public class StudyCohortExportTest extends StudyExportTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyContinuousTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyContinuousTest.java
@@ -16,7 +16,7 @@
 package org.labkey.test.tests.study;
 
 import org.junit.experimental.categories.Category;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,7 +24,7 @@ import java.util.Map;
 /**
  * Created by RyanS on 5/18/2017.
  */
-@Category({DailyC.class})
+@Category({Daily.class})
 public class StudyContinuousTest extends AbstractStudyTimeKeyFieldTest
 {
     @Override

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetDefaultViewTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetDefaultViewTest.java
@@ -7,7 +7,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyA;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.components.study.ViewPreferencesPage;
 import org.labkey.test.util.DataRegionTable;
@@ -16,7 +16,7 @@ import org.labkey.test.util.PortalHelper;
 import java.util.Arrays;
 import java.util.List;
 
-@Category({DailyA.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 3)
 public class StudyDatasetDefaultViewTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetDomainTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetDomainTest.java
@@ -14,7 +14,7 @@ import org.labkey.remoteapi.domain.GetDomainCommand;
 import org.labkey.remoteapi.domain.PropertyDescriptor;
 import org.labkey.remoteapi.domain.SaveDomainCommand;
 import org.labkey.test.BaseWebDriverTest;
-import org.labkey.test.categories.DailyA;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.study.CreateStudyPage;
 import org.labkey.test.util.StudyHelper;
 
@@ -27,7 +27,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-@Category({DailyA.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class StudyDatasetDomainTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
@@ -8,7 +8,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyA;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.DatasetInsertPage;
 import org.labkey.test.pages.study.DatasetDesignerPage;
@@ -26,7 +26,7 @@ Added the test to provide additional test coverage for below mentioned issue
 https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=42309
  */
 
-@Category({DailyA.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class StudyDatasetFileFieldTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetIndexTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetIndexTest.java
@@ -20,13 +20,13 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.tests.StudyBaseTest;
 import org.labkey.test.util.LogMethod;
 
 import java.io.File;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 12)
 public class StudyDatasetIndexTest extends StudyBaseTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetReloadTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetReloadTest.java
@@ -19,7 +19,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.DatasetPropertiesPage;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.tests.StudyBaseTest;
@@ -30,7 +30,7 @@ import java.io.File;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 7)
 public class StudyDatasetReloadTest extends StudyBaseTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
@@ -25,7 +25,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyA;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.LookAndFeelScatterPlot;
 import org.labkey.test.components.LookAndFeelTimeChart;
 import org.labkey.test.components.PagingWidget;
@@ -53,7 +53,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.labkey.test.components.ext4.Window.Window;
 
-@Category({DailyA.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
 public class StudyDatasetsTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyDataspaceTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDataspaceTest.java
@@ -23,7 +23,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.studydesigner.ManageAssaySchedulePage;
 import org.labkey.test.components.studydesigner.ManageStudyProductsPage;
 import org.labkey.test.components.studydesigner.ManageTreatmentsPage;
@@ -42,7 +42,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
 public class StudyDataspaceTest extends StudyBaseTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyDateAndContinuousTimepointTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDateAndContinuousTimepointTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
-import org.labkey.test.categories.DailyA;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.CustomizeView;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.study.DatasetDesignerPage;
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 
-@Category({DailyA.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 4)
 public class StudyDateAndContinuousTimepointTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyDateBasedTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDateBasedTest.java
@@ -16,7 +16,7 @@
 package org.labkey.test.tests.study;
 
 import org.junit.experimental.categories.Category;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,7 +24,7 @@ import java.util.Map;
 /**
  * Created by RyanS on 5/18/2017.
  */
-@Category({DailyC.class})
+@Category({Daily.class})
 public class StudyDateBasedTest extends AbstractStudyTimeKeyFieldTest
 {
 //    @Override

--- a/study/test/src/org/labkey/test/tests/study/StudyDemoModeTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDemoModeTest.java
@@ -19,7 +19,7 @@ package org.labkey.test.tests.study;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.tests.StudyBaseTest;
 import org.labkey.test.util.Crawler;
 
@@ -30,7 +30,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class StudyDemoModeTest extends StudyBaseTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyExportTest.java
@@ -23,7 +23,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.SortDirection;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.domain.DomainFieldRow;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.components.html.Checkbox;
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 25)
 public class StudyExportTest extends StudyManualTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyMergeParticipantsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyMergeParticipantsTest.java
@@ -20,14 +20,14 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.tests.StudyBaseTest;
 import org.labkey.test.util.Ext4Helper;
 
 import java.io.File;
 
-@Category(DailyC.class)
+@Category(Daily.class)
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class StudyMergeParticipantsTest extends StudyBaseTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyPHIExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPHIExportTest.java
@@ -20,7 +20,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.SortDirection;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
 public class StudyPHIExportTest extends StudyExportTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyProtocolDesignerTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyProtocolDesignerTest.java
@@ -28,7 +28,7 @@ import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyB;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.studydesigner.AssayScheduleWebpart;
 import org.labkey.test.components.studydesigner.BaseManageVaccineDesignVisitPage;
 import org.labkey.test.components.studydesigner.ImmunizationScheduleWebpart;
@@ -55,7 +55,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@Category({DailyB.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 9)
 public class StudyProtocolDesignerTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
@@ -30,7 +30,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.ChartQueryDialog;
 import org.labkey.test.components.ChartTypeDialog;
 import org.labkey.test.components.DomainDesignerPage;
@@ -68,7 +68,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 30)
 public class StudyPublishTest extends StudyPHIExportTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyReloadColumnInferenceTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyReloadColumnInferenceTest.java
@@ -21,7 +21,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.tests.StudyBaseTest;
@@ -32,7 +32,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class StudyReloadColumnInferenceTest extends StudyBaseTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyReloadTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyReloadTest.java
@@ -19,12 +19,12 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.tests.StudyBaseTest;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PipelineStatusTable;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class StudyReloadTest extends StudyBaseTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyScheduleTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyScheduleTest.java
@@ -19,7 +19,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.ext4.RadioButton;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.pages.study.ManageVisitPage;
@@ -39,7 +39,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.function.Function;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
 public class StudyScheduleTest extends StudyBaseTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudySecurityTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudySecurityTest.java
@@ -24,7 +24,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.study.StudySecurityPage;
 import org.labkey.test.pages.study.StudySecurityPage.GroupSecuritySetting;
 import org.labkey.test.pages.study.StudySecurityPage.DatasetRoles;
@@ -37,7 +37,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
 public class StudySecurityTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
@@ -25,7 +25,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.components.DomainDesignerPage;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.ImportDataPage;
@@ -60,7 +60,7 @@ import static org.junit.Assert.fail;
  * The @BeforeClass creates a new study manually using the default settings.
  * Each @Test then sets a property in that study, exports the study, and reimports it into a subfolder
  */
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 28)
 public class StudySimpleExportTest extends StudyBaseTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyTest.java
@@ -29,7 +29,7 @@ import org.labkey.test.Locators;
 import org.labkey.test.SortDirection;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Specimen;
 import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.pages.DatasetPropertiesPage;
@@ -65,7 +65,7 @@ import static org.junit.Assert.fail;
 import static org.labkey.test.util.DataRegionTable.DataRegion;
 import static org.labkey.test.util.PasswordUtil.getUsername;
 
-@Category({Specimen.class, DailyC.class})
+@Category({Specimen.class, Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
 public class StudyTest extends StudyBaseTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
@@ -32,7 +32,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Study;
 import org.labkey.test.pages.StartImportPage;
 import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
@@ -53,7 +53,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Category({DailyC.class, Study.class})
+@Category({Daily.class, Study.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class StudyVisitManagementTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyVisitTagTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyVisitTagTest.java
@@ -21,7 +21,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyC;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.tests.StudyBaseTest;
 import org.labkey.test.util.DataRegionTable;
 
@@ -32,7 +32,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-@Category({DailyC.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 7)
 public class StudyVisitTagTest extends StudyBaseTest
 {

--- a/study/test/src/org/labkey/test/tests/study/TargetStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/TargetStudyTest.java
@@ -23,7 +23,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.SortDirection;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Assays;
-import org.labkey.test.categories.DailyB;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.tests.AbstractAssayTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
@@ -35,10 +35,9 @@ import java.io.File;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
-@Category({DailyB.class, Assays.class})
+@Category({Daily.class, Assays.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class TargetStudyTest extends AbstractAssayTest
 {

--- a/study/test/src/org/labkey/test/tests/study/TruncationTest.java
+++ b/study/test/src/org/labkey/test/tests/study/TruncationTest.java
@@ -22,7 +22,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.DailyA;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Specimen;
 import org.labkey.test.pages.DatasetPropertiesPage;
 import org.labkey.test.pages.ManageDatasetsPage;
@@ -34,7 +34,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-@Category({DailyA.class, Specimen.class})
+@Category({Daily.class, Specimen.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class TruncationTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/study/VaccineProtocolTest.java
+++ b/study/test/src/org/labkey/test/tests/study/VaccineProtocolTest.java
@@ -22,7 +22,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
-import org.labkey.test.categories.DailyA;
+import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.DesignerController.DesignerTester;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.util.DataRegionTable;
@@ -33,7 +33,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
-@Category({DailyA.class})
+@Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 8)
 public class VaccineProtocolTest extends BaseWebDriverTest
 {


### PR DESCRIPTION
#### Rationale
Changing the Category from DailyA, DailyB and DailyC to Daily to be more inline with new teamcity configuration of daily suits

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/802
https://github.com/LabKey/targetedms/pull/405
https://github.com/LabKey/commonAssays/pull/349

#### Changes
Changed the test categories from DailyA -> Daily, DailyB -> Daily and DailyC -> Daily
