### PR TITLE
Issue 43567: Add an option to set the default folder type on the Folder Types admin settings page

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -184,6 +184,7 @@ import org.labkey.api.writer.ZipUtil;
 import org.labkey.bootstrap.ExplodedModuleService;
 import org.labkey.core.admin.miniprofiler.MiniProfilerController;
 import org.labkey.core.admin.sql.SqlScriptController;
+import org.labkey.core.portal.CollaborationFolderType;
 import org.labkey.core.portal.ProjectController;
 import org.labkey.core.query.CoreQuerySchema;
 import org.labkey.core.security.SecurityController;
@@ -6699,6 +6700,15 @@ public class AdminController extends SpringActionController
         {
             VBox vbox = new VBox();
 
+            if (!reshow)
+            {
+                FolderType folderType = FolderTypeManager.get().getDefaultFolderType();
+                if (null != folderType)
+                {
+                    // If a default folder type has been configured by a site admin set that as the default folder type choice
+                    form.setFolderType(folderType.getName());
+                }
+            }
             JspView statusView = new JspView<>("/org/labkey/core/admin/createFolder.jsp", form, errors);
             vbox.addView(statusView);
 
@@ -8445,11 +8455,13 @@ public class AdminController extends SpringActionController
     {
         private final Collection<FolderType> _allFolderTypes;
         private final Collection<FolderType> _enabledFolderTypes;
+        private final FolderType _defaultFolderType;
 
-        public FolderTypesBean(Collection<FolderType> allFolderTypes, Collection<FolderType> enabledFolderTypes)
+        public FolderTypesBean(Collection<FolderType> allFolderTypes, Collection<FolderType> enabledFolderTypes, FolderType defaultFolderType)
         {
             _allFolderTypes = allFolderTypes;
             _enabledFolderTypes = enabledFolderTypes;
+            _defaultFolderType = defaultFolderType;
         }
 
         public Collection<FolderType> getAllFolderTypes()
@@ -8460,6 +8472,11 @@ public class AdminController extends SpringActionController
         public Collection<FolderType> getEnabledFolderTypes()
         {
             return _enabledFolderTypes;
+        }
+
+        public FolderType getDefaultFolderType()
+        {
+            return _defaultFolderType;
         }
     }
 
@@ -8475,13 +8492,51 @@ public class AdminController extends SpringActionController
         @Override
         public ModelAndView getView(Object form, boolean reshow, BindException errors)
         {
-            return new JspView<>("/org/labkey/core/admin/enabledFolderTypes.jsp", new FolderTypesBean(FolderTypeManager.get().getAllFolderTypes(), FolderTypeManager.get().getEnabledFolderTypes()));
+            FolderTypesBean bean;
+            if (reshow)
+            {
+                bean = getOptionsFromRequest();
+            }
+            else
+            {
+                FolderTypeManager manager = FolderTypeManager.get();
+                var defaultFolderType = manager.getDefaultFolderType();
+                // If a default folder type has not yet been configuration use "Collaboration" folder type as the default
+                defaultFolderType = defaultFolderType != null ? defaultFolderType : manager.getFolderType(CollaborationFolderType.TYPE_NAME);
+                bean = new FolderTypesBean(manager.getAllFolderTypes(), manager.getEnabledFolderTypes(), defaultFolderType);
+            }
+
+            return new JspView<>("/org/labkey/core/admin/enabledFolderTypes.jsp", bean, errors);
         }
 
         @Override
         public boolean handlePost(Object form, BindException errors)
         {
+            FolderTypesBean bean = getOptionsFromRequest();
+            var defaultFolderType = bean.getDefaultFolderType();
+            if (defaultFolderType == null)
+            {
+                errors.reject(ERROR_MSG, "Please select a default folder type.");
+                return false;
+            }
+            var enabledFolderTypes = bean.getEnabledFolderTypes();
+            if (!enabledFolderTypes.contains(defaultFolderType))
+            {
+                errors.reject(ERROR_MSG, "Folder type selected as the default, '" + defaultFolderType.getName() + "', must be enabled.");
+                return false;
+            }
+
+            FolderTypeManager.get().setEnabledFolderTypes(enabledFolderTypes, defaultFolderType);
+            return true;
+        }
+
+        private FolderTypesBean getOptionsFromRequest()
+        {
+            var allFolderTypes = FolderTypeManager.get().getAllFolderTypes();
             List<FolderType> enabledFolderTypes = new ArrayList<>();
+            FolderType defaultFolderType = null;
+            String defaultFolderTypeParam = getViewContext().getRequest().getParameter(FolderTypeManager.FOLDER_TYPE_DEFAULT);
+
             for (FolderType folderType : FolderTypeManager.get().getAllFolderTypes())
             {
                 boolean enabled = Boolean.TRUE.toString().equalsIgnoreCase(getViewContext().getRequest().getParameter(folderType.getName()));
@@ -8489,9 +8544,12 @@ public class AdminController extends SpringActionController
                 {
                     enabledFolderTypes.add(folderType);
                 }
+                if (folderType.getName().equals(defaultFolderTypeParam))
+                {
+                    defaultFolderType = folderType;
+                }
             }
-            FolderTypeManager.get().setEnabledFolderTypes(enabledFolderTypes);
-            return true;
+            return new FolderTypesBean(allFolderTypes, enabledFolderTypes, defaultFolderType);
         }
 
         @Override

--- a/core/src/org/labkey/core/admin/createFolder.jsp
+++ b/core/src/org/labkey/core/admin/createFolder.jsp
@@ -23,6 +23,7 @@
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.core.admin.AdminController" %>
 <%@ page import="org.labkey.core.portal.ProjectController" %>
+<%@ page import="org.labkey.core.portal.CollaborationFolderType" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
     @Override
@@ -41,7 +42,7 @@
 
     String name = form.getName();
     String title = form.getTitle();
-    String folderTypeName = form.getFolderType() != null ? form.getFolderType() : "Collaboration"; //default to Collaboration
+    String folderTypeName = form.getFolderType() != null ? form.getFolderType() : CollaborationFolderType.TYPE_NAME; //default to Collaboration
 
     JSONArray modulesOut = new JSONArray();
     String[] activeModules = form.getActiveModules();

--- a/core/src/org/labkey/core/admin/enabledFolderTypes.jsp
+++ b/core/src/org/labkey/core/admin/enabledFolderTypes.jsp
@@ -20,6 +20,7 @@
 <%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.core.admin.AdminController" %>
+<%@ page import="org.labkey.api.module.FolderTypeManager" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
@@ -32,12 +33,15 @@
 <div>
     If a folder type is disabled, it will not be available as a choice when setting the type for a folder or project.
     Any folders that are already using it will be unaffected.
+<br/>
+    The folder type selected as the default will be used as the default choice in the new project / folder creation form.
 </div>
 <br/>
-<labkey:form method="post">
+<labkey:form method="post" onsubmit="return validate();">
     <table class="labkey-data-region-legacy labkey-show-borders">
         <tr>
             <td class="labkey-column-header">Enabled</td>
+            <td class="labkey-column-header">Default</td>
             <td class="labkey-column-header">Name</td>
             <td class="labkey-column-header">Description</td>
         </tr>
@@ -47,7 +51,9 @@
             {
         %>
             <tr class="<%=h(rowCount % 2 == 0 ? "labkey-alternate-row" : "labkey-row")%>">
-                <td><input type="checkbox" name="<%= h(folderType.getName())%>"<%=checked(bean.getEnabledFolderTypes().contains(folderType))%> value="true" /></td>
+                <td><input type="checkbox" name="<%= h(folderType.getName())%>"<%=checked(bean.getEnabledFolderTypes().contains(folderType))%> value="true" onchange="removeAsDefaultIfDisabled(this)"/></td>
+                <td><input type="radio" name="<%= h(FolderTypeManager.FOLDER_TYPE_DEFAULT)%>" value="<%= h(folderType.getName()) %>"
+                        <%=checked(folderType.equals(bean.getDefaultFolderType()))%> onchange="ensureEnabledIfDefault(this)"/></td>
                 <td><%= h(folderType.getName()) %></td>
                 <td><%= h(folderType.getDescription()) %></td>
             </tr>
@@ -60,3 +66,49 @@
     <%= hasAdminPerm ? button("Save").submit(true) : HtmlString.EMPTY_STRING %>
     <%= generateBackButton(!hasAdminPerm ? "Done" : "Cancel") %>
 </labkey:form>
+<script type="text/javascript">
+
+    // If a folder type is disabled but it is currently selected as the default folder type, uncheck the radio button.
+    function removeAsDefaultIfDisabled(checkbox)
+    {
+        if (!checkbox.checked)
+        {
+            // Get the radio button for the folder type that is selected as the default folder type
+            var defaultFolderTypeRb = getDefaultFolderTypeRb();
+            if (defaultFolderTypeRb && defaultFolderTypeRb.value === checkbox.name)
+            {
+               defaultFolderTypeRb.checked = false;
+            }
+        }
+    }
+
+    function getDefaultFolderTypeRb()
+    {
+        return document.querySelector('input[type=radio][name="<%=h(FolderTypeManager.FOLDER_TYPE_DEFAULT)%>"]:checked');
+    }
+
+    // If a folder type was selected as the default make sure that it is enabled
+    function ensureEnabledIfDefault(radiobutton)
+    {
+        if (radiobutton.checked)
+        {
+            // Get the check box for the corresponding folder type
+            var folderTypeCb = document.querySelector('input[type=checkbox][name="' + radiobutton.value + '"]');
+            if (folderTypeCb && !folderTypeCb.checked)
+            {
+                folderTypeCb.checked = true; // enable the folder type
+            }
+        }
+    }
+
+    function validate()
+    {
+        var defaultFolderTypeRb = getDefaultFolderTypeRb()
+        if(!defaultFolderTypeRb)
+        {
+            alert("Please select a default folder type.");
+            return false;
+        }
+        return true;
+    }
+</script>


### PR DESCRIPTION
#### Rationale
We would like to add an admin setting on PanoramaWeb that will let us change the default folder type that is chosen when users create a new folder. The default option is "Collaboration" but most of the time users want a "Panorama" folder on PanoramaWeb and are confused when they are unable to upload Skyline documents to a new folder or don't see the familiar folder layout because they forgot to select "Panorama" when they created the folder.

