### PR TITLE
Remove support for Tomcat 8.5.x

### DIFF
--- a/api/src/org/labkey/api/module/TomcatVersion.java
+++ b/api/src/org/labkey/api/module/TomcatVersion.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 public enum TomcatVersion
 {
     TOMCAT_UNSUPPORTED(-1, true),
-    TOMCAT_8_5(85, true),
     TOMCAT_9_0(90, false),
     TOMCAT_FUTURE(Integer.MAX_VALUE, true);
 
@@ -83,7 +82,7 @@ public enum TomcatVersion
             }
         }
 
-        throw new ConfigurationException("Unsupported Tomcat version: " + serverInfo + ". LabKey Server requires Apache Tomcat 8.5.x or 9.0.x.");
+        throw new ConfigurationException("Unsupported Tomcat version: " + serverInfo + ". LabKey Server requires Apache Tomcat 9.0.x.");
     }
 
     private static @NotNull TomcatVersion get(int version)
@@ -105,7 +104,6 @@ public enum TomcatVersion
         public void test()
         {
             // Good
-            test(85, TOMCAT_8_5);
             test(90, TOMCAT_9_0);
 
             // Future
@@ -114,6 +112,8 @@ public enum TomcatVersion
             test(120, TOMCAT_FUTURE);
 
             // Bad
+            test(85, TOMCAT_UNSUPPORTED);
+            test(80, TOMCAT_UNSUPPORTED);
             test(70, TOMCAT_UNSUPPORTED);
             test(60, TOMCAT_UNSUPPORTED);
             test(50, TOMCAT_UNSUPPORTED);


### PR DESCRIPTION
#### Rationale
No reason to support both Tomcat 8.5.x and 9.0.x

#### Related Pull Requests
* https://github.com/LabKey/server/pull/110

#### Changes
* Prevent server startup on Tomcat 8.5.x
