### PR TITLE
Use ValidEmail objects instead of Integer in test to appease JDK 16

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -247,7 +247,7 @@ public class AuthenticationManager
 
     public static boolean isSelfServiceEmailChangesEnabled() { return getAuthSetting(SELF_SERVICE_EMAIL_CHANGES_KEY, false);}
 
-    public static String getDefaultDomain()
+    public static @NotNull String getDefaultDomain()
     {
         Map<String, String> props = PropertyManager.getProperties(AUTHENTICATION_CATEGORY);
         String value = props.get(DEFAULT_DOMAIN);

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -3499,7 +3499,7 @@ public class SecurityManager
 
             String defaultDomain = ValidEmail.getDefaultDomain();
             // If default domain is defined this should succeed; if it's not defined, this should fail.
-            testEmail("foo", defaultDomain != null && defaultDomain.length() > 0);
+            testEmail("foo", defaultDomain.length() > 0);
 
             testEmail("~()@bar.com", false);
             testEmail("this@that.com@con", false);

--- a/api/src/org/labkey/api/security/ValidEmail.java
+++ b/api/src/org/labkey/api/security/ValidEmail.java
@@ -19,6 +19,7 @@ package org.labkey.api.security;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.data.ColumnInfo;
@@ -147,7 +148,7 @@ public class ValidEmail
             LOG.debug("Resolving user name '" + rawEmail + "' using default domain '" + getDefaultDomain() + "'");
             String domain = getDefaultDomain();
 
-            if (null != domain && domain.length() > 0)
+            if (domain.length() > 0)
                 return trimmed + "@" + domain;
         }
 
@@ -163,7 +164,7 @@ public class ValidEmail
     }
 
 
-    public static String getDefaultDomain()
+    public static @NotNull String getDefaultDomain()
     {
         return AuthenticationManager.getDefaultDomain();
     }

--- a/api/src/org/labkey/api/util/MemTracker.java
+++ b/api/src/org/labkey/api/util/MemTracker.java
@@ -25,6 +25,8 @@ import org.junit.Test;
 import org.labkey.api.miniprofiler.MiniProfiler;
 import org.labkey.api.miniprofiler.RequestInfo;
 import org.labkey.api.security.User;
+import org.labkey.api.security.ValidEmail;
+import org.labkey.api.security.ValidEmail.InvalidEmailException;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
 
@@ -41,8 +43,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
-
-import static org.labkey.api.util.HtmlString.unsafe;
 
 /**
  * Tracks objects that may be expensive, commonly allocated so that we know that they're not being held and creating
@@ -132,7 +132,7 @@ public class MemTracker
         public String getClassName()
         {
             if (_reference instanceof Class)
-                return ((Class) _reference).getName();
+                return ((Class<?>) _reference).getName();
             else
                 return _reference.getClass().getName();
         }
@@ -456,7 +456,7 @@ public class MemTracker
     public static class TestCase extends Assert
     {
         @Test
-        public void testIdentity()
+        public void testIdentity() throws InvalidEmailException
         {
             MemTracker t = new MemTracker();
 
@@ -467,10 +467,9 @@ public class MemTracker
             t._put(a);
             assertEquals(1, t.getReferences().size());
 
-            // Intentional use of deprecated constructor below because we want distinct instances of the same integer;
-            // Integer.valueOf() will return the same object.
-            @SuppressWarnings({"deprecation", "CachedNumberConstructorCall"}) Object b = new Integer(1);
-            @SuppressWarnings({"deprecation", "CachedNumberConstructorCall"}) Object c = new Integer(1);
+            // Test with arbitrary class that implements equals()
+            Object b = new ValidEmail("test@test.com");
+            Object c = new ValidEmail("test@test.com");
             assertNotSame(b, c);
             assertEquals(b, c);
             t._put(b);

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -339,7 +339,7 @@ public class LoginController extends SpringActionController
                 String defaultDomain = ValidEmail.getDefaultDomain();
                 StringBuilder sb = new StringBuilder();
                 sb.append("Please sign in using your full email address, for example: ");
-                if (defaultDomain != null && defaultDomain.length() > 0)
+                if (defaultDomain.length() > 0)
                 {
                     sb.append("employee@");
                     sb.append(defaultDomain);

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -2067,7 +2067,7 @@ public class UserController extends SpringActionController
                 String defaultDomain = ValidEmail.getDefaultDomain();
                 StringBuilder sb = new StringBuilder();
                 sb.append("Please sign in using your full email address, for example: ");
-                if (defaultDomain != null && defaultDomain.length() > 0)
+                if (defaultDomain.length() > 0)
                 {
                     sb.append("employee@");
                     sb.append(defaultDomain);


### PR DESCRIPTION
#### Rationale
"Boxed primitive constructors" (e.g., new Integer(2)) have been deprecated since JDK 9 and marked for removal as of JDK 16. Update the test to use ValidEmail instead of Integer.
