### PR TITLE
Finish double -> BigDecimal sequence num migration

### DIFF
--- a/api/src/org/labkey/api/study/Visit.java
+++ b/api/src/org/labkey/api/study/Visit.java
@@ -37,13 +37,7 @@ public interface Visit extends StudyEntity
 
     BigDecimal getSequenceNumMin();
 
-    @Deprecated // Use getSequenceNumMin()
-    double getSequenceNumMinDouble();
-
     BigDecimal getSequenceNumMax();
-
-    @Deprecated // Use getSequenceNumMax()
-    double getSequenceNumMaxDouble();
 
     BigDecimal getProtocolDay();
 

--- a/specimen/src/org/labkey/specimen/actions/UpdateSpecimenCommentsBean.java
+++ b/specimen/src/org/labkey/specimen/actions/UpdateSpecimenCommentsBean.java
@@ -17,6 +17,7 @@ import org.labkey.api.view.RedirectException;
 import org.labkey.api.view.ViewContext;
 import org.labkey.specimen.SpecimenManager;
 
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -102,7 +103,8 @@ public class UpdateSpecimenCommentsBean extends SpecimensViewBean
             if (visit != null)
             {
                 String ptid = vial.getPtid();
-                Visit v = StudyInternalService.get().getVisitForSequence(study, visit);
+                BigDecimal sequenceNum = StudyInternalService.get().getSequenceNum(visit);
+                Visit v = StudyInternalService.get().getVisitForSequence(study, sequenceNum);
                 if (ptid != null && v != null)
                 {
                     if (!pvMap.containsKey(ptid))

--- a/study/api-src/org/labkey/api/study/StudyInternalService.java
+++ b/study/api-src/org/labkey/api/study/StudyInternalService.java
@@ -70,7 +70,7 @@ public interface StudyInternalService
 
     Visit getVisitForSequence(Study study, BigDecimal seqNum);
 
-    Visit getVisitForSequence(Study study, double seqNum);
+    BigDecimal getSequenceNum(double sequenceNumDouble);
 
     ActionButton createParticipantGroupButton(ViewContext context, String dataRegionName, CohortFilter cohortFilter, boolean hasCreateGroupFromSelection);
 

--- a/study/src/org/labkey/study/StudyInternalServiceImpl.java
+++ b/study/src/org/labkey/study/StudyInternalServiceImpl.java
@@ -152,9 +152,9 @@ public class StudyInternalServiceImpl implements StudyInternalService
     }
 
     @Override
-    public Visit getVisitForSequence(Study study, double seqNum)
+    public BigDecimal getSequenceNum(double sequenceNumDouble)
     {
-        return StudyManager.getInstance().getVisitForSequence(study, seqNum);
+        return VisitImpl.getSequenceNum(sequenceNumDouble);
     }
 
     @Override

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -1907,7 +1907,7 @@ public class StudyController extends BaseStudyController
                 if (v.getRowId() == postedVisit.getRowId())
                     continue;
                 BigDecimal maxL = v.getSequenceNumMin().max(postedVisit.getSequenceNumMin());
-                BigDecimal minR = v.getSequenceNumMax().max(postedVisit.getSequenceNumMax());
+                BigDecimal minR = v.getSequenceNumMax().min(postedVisit.getSequenceNumMax());
                 if (maxL.compareTo(minR) <= 0)
                 {
                     errors.reject("visitSummary", getVisitLabel() + " range overlaps with '" + v.getDisplayString() + "'");

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -228,6 +228,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.math.BigDecimal;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -1905,9 +1906,9 @@ public class StudyController extends BaseStudyController
             {
                 if (v.getRowId() == postedVisit.getRowId())
                     continue;
-                double maxL = Math.max(v.getSequenceNumMinDouble(), postedVisit.getSequenceNumMinDouble());
-                double minR = Math.min(v.getSequenceNumMaxDouble(), postedVisit.getSequenceNumMaxDouble());
-                if (maxL<=minR)
+                BigDecimal maxL = v.getSequenceNumMin().max(postedVisit.getSequenceNumMin());
+                BigDecimal minR = v.getSequenceNumMax().max(postedVisit.getSequenceNumMax());
+                if (maxL.compareTo(minR) <= 0)
                 {
                     errors.reject("visitSummary", getVisitLabel() + " range overlaps with '" + v.getDisplayString() + "'");
                     validRange = false;

--- a/study/src/org/labkey/study/designer/StudyDefinitionServiceImpl.java
+++ b/study/src/org/labkey/study/designer/StudyDefinitionServiceImpl.java
@@ -32,7 +32,6 @@ import org.labkey.api.reports.model.ViewCategoryManager;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.study.Dataset;
-import org.labkey.api.study.Dataset.KeyManagementType;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.TimepointType;
 import org.labkey.api.study.Visit;
@@ -49,6 +48,7 @@ import org.labkey.study.model.StudyManager;
 import org.labkey.study.model.VisitImpl;
 import org.labkey.study.xml.StudyDesignDocument;
 
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 
@@ -245,7 +245,7 @@ public class StudyDefinitionServiceImpl extends BaseRemoteService implements Stu
                 startDay = Math.max(previousDay + 1, startDay - 15);
                 endDay = Math.min(nextDay - 1, endDay + 15);
             }
-            VisitImpl visit = new VisitImpl(getContainer(), startDay, endDay, timepoint.toString(), Visit.Type.REQUIRED_BY_TERMINATION);
+            VisitImpl visit = new VisitImpl(getContainer(), BigDecimal.valueOf(startDay), BigDecimal.valueOf(endDay), timepoint.toString(), Visit.Type.REQUIRED_BY_TERMINATION);
             StudyManager.getInstance().createVisit(study, getUser(), visit);
             previousDay = endDay;
         }

--- a/study/src/org/labkey/study/designer/StudyDesignManager.java
+++ b/study/src/org/labkey/study/designer/StudyDesignManager.java
@@ -75,6 +75,7 @@ import org.labkey.study.query.studydesign.StudyTreatmentProductDomainKind;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -443,7 +444,7 @@ public class StudyDesignManager
                 startDay = Math.max(previousDay + 1, startDay - 15);
                 endDay = Math.min(nextDay - 1, endDay + 15);
             }
-            VisitImpl visit = new VisitImpl(studyFolder, startDay, endDay, timepoint.toString(), Visit.Type.REQUIRED_BY_TERMINATION);
+            VisitImpl visit = new VisitImpl(studyFolder, BigDecimal.valueOf(startDay), BigDecimal.valueOf(endDay), timepoint.toString(), Visit.Type.REQUIRED_BY_TERMINATION);
             StudyManager.getInstance().createVisit(study, user, visit);
             previousDay = endDay;
         }

--- a/study/src/org/labkey/study/importer/VisitMapImporter.java
+++ b/study/src/org/labkey/study/importer/VisitMapImporter.java
@@ -192,7 +192,7 @@ public class VisitMapImporter
                 throw new VisitMapImportException(errorMsg);
             uniqueSequenceNums.add(record.getSequenceNumMin());
 
-            if (!record.getSequenceNumMax().equals(record.getSequenceNumMin()) && uniqueSequenceNums.contains(record.getSequenceNumMax()))
+            if (record.getSequenceNumMax().compareTo(record.getSequenceNumMin()) != 0 && uniqueSequenceNums.contains(record.getSequenceNumMax()))
                 throw new VisitMapImportException(errorMsg);
             uniqueSequenceNums.add(record.getSequenceNumMax());
         }
@@ -241,7 +241,7 @@ public class VisitMapImporter
             VisitImpl visit = visitManager.findVisitBySequence(record.getSequenceNumMin());
 
             // we're using sequenceNumMin as the key in this instance
-            if (visit != null && !visit.getSequenceNumMin().equals(record.getSequenceNumMin()))
+            if (visit != null && visit.getSequenceNumMin().compareTo(record.getSequenceNumMin()) != 0)
                 visit = null;
 
             if (visit == null)
@@ -277,7 +277,7 @@ public class VisitMapImporter
                     visit = _ensureMutable(visit);
                     visit.setVisitDateDatasetId(record.getVisitDatePlate());
                 }
-                if (!visit.getSequenceNumMax().equals(record.getSequenceNumMax()))
+                if (visit.getSequenceNumMax().compareTo(record.getSequenceNumMax()) != 0)
                 {
                     visit = _ensureMutable(visit);
                     visit.setSequenceNumMax(record.getSequenceNumMax());

--- a/study/src/org/labkey/study/model/SequenceNumImportHelper.java
+++ b/study/src/org/labkey/study/model/SequenceNumImportHelper.java
@@ -41,8 +41,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import static org.labkey.study.model.VisitImpl.normalizeSequenceNum;
-
 /**
  * User: matthewb
  * Date: 2012-10-11
@@ -201,7 +199,7 @@ translateToDouble:
             return sequencenum;
 
         // handle log-type events which can be unique'd by date
-        Visit v = _sequenceNumMap.get(normalizeSequenceNum(new BigDecimal(sequencenum)));
+        Visit v = _sequenceNumMap.get(VisitImpl.getSequenceNum(sequencenum));
         if (null != v && v.getSequenceNumHandlingEnum() == SequenceHandling.logUniqueByDate)
         {
             int daysSinceEpoch = convertToDaysSinceEpoch(date);

--- a/study/src/org/labkey/study/model/SequenceNumImportHelper.java
+++ b/study/src/org/labkey/study/model/SequenceNumImportHelper.java
@@ -242,7 +242,7 @@ translateToDouble:
         @Override
         public Visit get(BigDecimal seq)
         {
-            SequenceHandling sh = BigDecimal.valueOf(9999).equals(seq.setScale(0, RoundingMode.FLOOR)) ? SequenceHandling.logUniqueByDate : SequenceHandling.normal;
+            SequenceHandling sh = BigDecimal.valueOf(9999).compareTo(seq.setScale(0, RoundingMode.FLOOR)) == 0 ? SequenceHandling.logUniqueByDate : SequenceHandling.normal;
 
             return new VisitImpl()
             {

--- a/study/src/org/labkey/study/model/StudyImpl.java
+++ b/study/src/org/labkey/study/model/StudyImpl.java
@@ -1215,11 +1215,12 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
 
         if (sequenceNum != null)
         {
+            BigDecimal sequenceNumBD = VisitImpl.getSequenceNum(sequenceNum);
             // Look up the visit if we have a sequencenum
-            VisitImpl result = StudyManager.getInstance().getVisitForSequence(this, sequenceNum);
+            VisitImpl result = StudyManager.getInstance().getVisitForSequence(this, sequenceNumBD);
             if (result == null && returnPotentialTimepoints)
             {
-                result = StudyManager.getInstance().ensureVisit(this, null, sequenceNum, null, false);
+                result = StudyManager.getInstance().ensureVisit(this, null, sequenceNumBD, null, false);
             }
             return result;
         }

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -5050,8 +5050,8 @@ public class StudyManager
                 assertNotSame("Should be a new visit", newVisit, existingVisit);
             }
             assertEquals("Shouldn't have a rowId yet", 0, newVisit.getRowId());
-            assertEquals("Wrong sequenceNumMin", seqNumMin, newVisit.getSequenceNumMinDouble(), DELTA);
-            assertEquals("Wrong sequenceNumMax", seqNumMax, newVisit.getSequenceNumMaxDouble(), DELTA);
+            assertEquals("Wrong sequenceNumMin", VisitImpl.normalizeSequenceNum(new BigDecimal(seqNumMin)), newVisit.getSequenceNumMin());
+            assertEquals("Wrong sequenceNumMax", VisitImpl.normalizeSequenceNum(new BigDecimal(seqNumMax)), newVisit.getSequenceNumMax());
         }
     }
 

--- a/study/src/org/labkey/study/model/VisitImpl.java
+++ b/study/src/org/labkey/study/model/VisitImpl.java
@@ -78,25 +78,15 @@ public class VisitImpl extends AbstractStudyEntity<VisitImpl> implements Cloneab
     {
     }
 
-
-    @Deprecated // Use BigDecimal constructor instead
-    public VisitImpl(Container container, double seqMin, double seqMax, String label, @Nullable Type type)
-    {
-        this(container, BigDecimal.valueOf(seqMin), BigDecimal.valueOf(seqMax), label, null == type ? null : type.getCode());
-    }
-
-
     public VisitImpl(Container container, @NotNull BigDecimal seqMin, String label, Type type)
     {
         this(container, seqMin, seqMin, label, null == type ? null : type.getCode());
     }
 
-
     public VisitImpl(Container container, BigDecimal seqMin, BigDecimal seqMax, String label, @Nullable Type type)
     {
         this(container, seqMin, seqMax, label, null == type ? null : type.getCode());
     }
-
 
     public VisitImpl(Container container, @NotNull BigDecimal seqMin, @NotNull BigDecimal seqMax, String name, @Nullable Character typeCode)
     {
@@ -108,7 +98,6 @@ public class VisitImpl extends AbstractStudyEntity<VisitImpl> implements Cloneab
         _typeCode = typeCode;
         _showByDefault = true;
     }
-
 
     @Override
     public String getSequenceString()
@@ -222,13 +211,6 @@ public class VisitImpl extends AbstractStudyEntity<VisitImpl> implements Cloneab
     }
 
     @Override
-    @Deprecated // Use getSequenceNumMin()
-    public double getSequenceNumMinDouble()
-    {
-        return _sequenceMin.doubleValue();
-    }
-
-    @Override
     public BigDecimal getSequenceNumMin()
     {
         return _sequenceMin;
@@ -242,13 +224,6 @@ public class VisitImpl extends AbstractStudyEntity<VisitImpl> implements Cloneab
     public String getFormattedSequenceNumMin()
     {
         return formatSequenceNum(_sequenceMin);
-    }
-
-    @Override
-    @Deprecated // Use getSequenceNumMax()
-    public double getSequenceNumMaxDouble()
-    {
-        return _sequenceMax.doubleValue();
     }
 
     @Override
@@ -297,6 +272,16 @@ public class VisitImpl extends AbstractStudyEntity<VisitImpl> implements Cloneab
     public static BigDecimal parseSequenceNum(String s)
     {
         return normalizeSequenceNum(new BigDecimal(s));
+    }
+
+    public static BigDecimal getSequenceNum(double seqnum)
+    {
+        return normalizeSequenceNum(BigDecimal.valueOf(seqnum));
+    }
+
+    public static BigDecimal getSequenceNum(int seqnum)
+    {
+        return normalizeSequenceNum(BigDecimal.valueOf(seqnum));
     }
 
     public static String formatSequenceNum(BigDecimal bd)

--- a/study/src/org/labkey/study/model/VisitImpl.java
+++ b/study/src/org/labkey/study/model/VisitImpl.java
@@ -119,7 +119,7 @@ public class VisitImpl extends AbstractStudyEntity<VisitImpl> implements Cloneab
 
     public static String getSequenceString(BigDecimal min, BigDecimal max)
     {
-        if (min.equals(max))
+        if (min.compareTo(max) == 0)
             return formatSequenceNum(min);
         else
             return formatSequenceNum(min) + " - " + formatSequenceNum(max);

--- a/study/src/org/labkey/study/query/ParticipantVisitDatasetTable.java
+++ b/study/src/org/labkey/study/query/ParticipantVisitDatasetTable.java
@@ -100,14 +100,14 @@ public class ParticipantVisitDatasetTable extends VirtualTable<StudyQuerySchema>
                 continue;
             sequenceSet.add(visit.getSequenceNumMin());
         }
+
         //Now find all the sequenceNums where data actually exists.
         //Make sure their visits show up...
-        List<Double> currentSequenceNumbers = _userSchema.getSequenceNumsForDataset(_dataset);
+        List<BigDecimal> currentSequenceNumbers = _userSchema.getSequenceNumsForDataset(_dataset);
         if (null != currentSequenceNumbers)
         {
-            for (Double d : currentSequenceNumbers)
+            for (BigDecimal seq : currentSequenceNumbers)
             {
-                BigDecimal seq = BigDecimal.valueOf(d);  // TODO: Migrate getSequenceNumsForDataset() to BigDecimal
                 sequenceSet.add(seq);
                 VisitImpl visit = visitManager.findVisitBySequence(seq);
                 if (null != visit && visitIds.add(visit.getRowId()))

--- a/study/src/org/labkey/study/query/ParticipantVisitDatasetTable.java
+++ b/study/src/org/labkey/study/query/ParticipantVisitDatasetTable.java
@@ -133,7 +133,7 @@ public class ParticipantVisitDatasetTable extends VirtualTable<StudyQuerySchema>
         for (VisitImpl visit : visitList)
         {
             boolean uniqueLabel = labelMap.get(visit.getLabel()).size() == 1;
-            boolean hasSequenceRange = !visit.getSequenceNumMin().equals(visit.getSequenceNumMax());
+            boolean hasSequenceRange = visit.getSequenceNumMin().compareTo(visit.getSequenceNumMax()) != 0;
 
             // add columns for each sequence, show if there is a sequence range
             for (BigDecimal seq : sequenceSet)
@@ -305,7 +305,7 @@ public class ParticipantVisitDatasetTable extends VirtualTable<StudyQuerySchema>
 
         for (VisitImpl v : StudyManager.getInstance().getVisits(_study, Visit.Order.SEQUENCE_NUM))
         {
-            if (name.equals(v.getLabel()) || (!NEG_ONE.equals(seq) && v.isInRange(seq)))
+            if (name.equals(v.getLabel()) || (NEG_ONE.compareTo(seq) != 0 && v.isInRange(seq)))
             {
                 if (null != visitMatch)
                     return null;        // ambiguous
@@ -313,7 +313,7 @@ public class ParticipantVisitDatasetTable extends VirtualTable<StudyQuerySchema>
                 seq = v.getSequenceNumMin();
             }
         }
-        if (NEG_ONE.equals(seq))
+        if (NEG_ONE.compareTo(seq) == 0)
             return null;
 
         if (visitMatch == null)

--- a/study/src/org/labkey/study/query/StudyQuerySchema.java
+++ b/study/src/org/labkey/study/query/StudyQuerySchema.java
@@ -88,6 +88,7 @@ import org.labkey.study.query.studydesign.StudyTreatmentVisitMapTable;
 import org.labkey.study.visualization.StudyVisualizationProvider;
 import org.springframework.validation.BindException;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -160,7 +161,7 @@ public class StudyQuerySchema extends UserSchema
     final boolean _mustCheckPermissions;
     private boolean _dontAliasColumns = false;
 
-    private Map<Integer, List<Double>> _datasetSequenceMap;
+    private Map<Integer, List<BigDecimal>> _datasetSequenceMap;
     public static final String STUDY_DATA_TABLE_NAME = "StudyData";
     public static final String QCSTATE_TABLE_NAME = "QCState";
     protected Set<String> _tableNames;
@@ -421,7 +422,7 @@ public class StudyQuerySchema extends UserSchema
         }
     }
 
-    synchronized List<Double> getSequenceNumsForDataset(Dataset dsd)
+    synchronized List<BigDecimal> getSequenceNumsForDataset(Dataset dsd)
     {
         if (null == _datasetSequenceMap)
             _datasetSequenceMap =  StudyManager.getInstance().getVisitManager(_study).getDatasetSequenceNums();

--- a/study/src/org/labkey/study/reports/QueryAssayProgressSource.java
+++ b/study/src/org/labkey/study/reports/QueryAssayProgressSource.java
@@ -26,6 +26,7 @@ import org.labkey.api.util.Pair;
 import org.labkey.api.view.ViewContext;
 import org.labkey.study.model.StudyManager;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -92,7 +93,7 @@ public class QueryAssayProgressSource implements AssayProgressReport.AssayData
                     new TableSelector(tableInfo).forEach(rs ->
                     {
                         String ptid = rs.getString("ParticipantId");
-                        Double sequenceNum = rs.getDouble("SequenceNum");
+                        BigDecimal sequenceNum = rs.getBigDecimal("SequenceNum");
                         String status = rs.getString("Status");
 
                         if (ptid != null)
@@ -133,9 +134,9 @@ public class QueryAssayProgressSource implements AssayProgressReport.AssayData
     private static class PtidSequenceNum
     {
         private final String _ptid;
-        private final Double _sequenceNum;
+        private final BigDecimal _sequenceNum;
 
-        public PtidSequenceNum(String ptid, Double sequenceNum)
+        public PtidSequenceNum(String ptid, BigDecimal sequenceNum)
         {
             _ptid = ptid;
             _sequenceNum = sequenceNum;
@@ -152,7 +153,8 @@ public class QueryAssayProgressSource implements AssayProgressReport.AssayData
         {
             if (obj instanceof PtidSequenceNum)
             {
-                return ((PtidSequenceNum)obj)._ptid.equals(_ptid) && ((PtidSequenceNum)obj)._sequenceNum.equals(_sequenceNum);
+                // Note: BigDecimal.compareTo() means this equals() check ignores scale... I THINK that's right
+                return ((PtidSequenceNum)obj)._ptid.equals(_ptid) && ((PtidSequenceNum)obj)._sequenceNum.compareTo(_sequenceNum) == 0;
             }
             return false;
         }

--- a/study/src/org/labkey/study/view/createVisit.jsp
+++ b/study/src/org/labkey/study/view/createVisit.jsp
@@ -73,7 +73,7 @@ is uploaded along with the data. This form allows you to define a range of seque
         <tr>
             <td class="labkey-form-label"><%=h(isDateBased ? "Day Range" : "VisitId/Sequence Range")%></td>
             <td>
-                <input type="text" size="26" name="sequenceNumMin" value="<%=h(v.getFormattedSequenceNumMin())%>">-<input type="text" size="26" name="sequenceNumMax" value="<%=v.getSequenceNumMin().equals(v.getSequenceNumMax()) ? HtmlString.EMPTY_STRING : h(v.getFormattedSequenceNumMax())%>">
+                <input type="text" size="26" name="sequenceNumMin" value="<%=h(v.getFormattedSequenceNumMin())%>">-<input type="text" size="26" name="sequenceNumMax" value="<%=v.getSequenceNumMin().compareTo(v.getSequenceNumMax()) == 0 ? HtmlString.EMPTY_STRING : h(v.getFormattedSequenceNumMax())%>">
             </td>
         </tr>
         <tr>

--- a/study/src/org/labkey/study/visitmanager/RelativeDateVisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/RelativeDateVisitManager.java
@@ -44,6 +44,7 @@ import org.labkey.study.query.DataspaceQuerySchema;
 import org.labkey.study.query.ParticipantGroupFilterClause;
 import org.labkey.study.query.StudyQuerySchema;
 
+import java.math.BigDecimal;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
@@ -274,10 +275,10 @@ public class RelativeDateVisitManager extends VisitManager
         sql.add(getStudy().getContainer());
 
         // Build up a set so that we can create all of them in bulk
-        Set<Double> daysToEnsure = new HashSet<>();
+        Set<BigDecimal> daysToEnsure = new HashSet<>();
 
         new SqlSelector(schema, sql).forEach(Integer.class, day -> {
-            double seqNum = null != day ? day : 0;
+            BigDecimal seqNum = VisitImpl.getSequenceNum(null != day ? day : 0);
             daysToEnsure.add(seqNum);
         });
 

--- a/study/src/org/labkey/study/visitmanager/SequenceVisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/SequenceVisitManager.java
@@ -534,7 +534,7 @@ public class SequenceVisitManager extends VisitManager
         if (visits.size() <= 16)
         {
             StringBuilder sb = new StringBuilder();
-            boolean allEqual = visits.stream().allMatch(v -> v.getSequenceNumMin().equals(v.getSequenceNumMax()));
+            boolean allEqual = visits.stream().allMatch(v -> v.getSequenceNumMin().compareTo(v.getSequenceNumMax()) == 0);
             if (allEqual)
             {
                 _indent(sb,indent);
@@ -554,7 +554,7 @@ public class SequenceVisitManager extends VisitManager
                 _indent(sb,indent); sb.append("CASE");
                 for (VisitImpl v : visits)
                 {
-                    if (v.getSequenceNumMin().equals(v.getSequenceNumMax()))
+                    if (v.getSequenceNumMin().compareTo(v.getSequenceNumMax()) == 0)
                     {
                         _indent(sb, indent);
                         sb.append(" WHEN ").append(sn).append(" = ");

--- a/study/src/org/labkey/study/visitmanager/SequenceVisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/SequenceVisitManager.java
@@ -49,6 +49,7 @@ import org.labkey.study.query.DatasetTableImpl;
 import org.labkey.study.query.ParticipantGroupFilterClause;
 import org.labkey.study.query.StudyQuerySchema;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -494,10 +495,10 @@ public class SequenceVisitManager extends VisitManager
                 "WHERE Container = ? AND (VisitRowId IS NULL OR VisitRowId = -1)");
         sql.add(getStudy().getContainer().getId());
 
-        final TreeSet<Double> sequenceNums = new TreeSet<>();
+        final TreeSet<BigDecimal> sequenceNums = new TreeSet<>();
 
         info(logger, "Select distinct sequence numbers from participant visit table");
-        new SqlSelector(schema, sql).forEach(rs -> sequenceNums.add(rs.getDouble(1)));
+        new SqlSelector(schema, sql).forEach(rs -> sequenceNums.add(rs.getBigDecimal(1)));
 
         if (sequenceNums.size() > 0)
         {

--- a/study/src/org/labkey/study/visitmanager/VisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/VisitManager.java
@@ -348,16 +348,16 @@ public abstract class VisitManager
     // Return sql for fetching all datasets and their visit sequence numbers, given a container
     protected abstract SQLFragment getDatasetSequenceNumsSQL(Study study);
 
-    public Map<Integer, List<Double>> getDatasetSequenceNums()
+    public Map<Integer, List<BigDecimal>> getDatasetSequenceNums()
     {
         SQLFragment sql = getDatasetSequenceNumsSQL(getStudy());
-        final Map<Integer, List<Double>> ret = new HashMap<>();
+        final Map<Integer, List<BigDecimal>> ret = new HashMap<>();
 
         new SqlSelector(StudySchema.getInstance().getSchema(), sql).forEach(rs ->
         {
             Integer datasetId = rs.getInt(1);
-            Double sequenceNum = rs.getDouble(2);
-            List<Double> l = ret.computeIfAbsent(datasetId, k -> new ArrayList<>());
+            BigDecimal sequenceNum = rs.getBigDecimal(2);
+            List<BigDecimal> l = ret.computeIfAbsent(datasetId, k -> new ArrayList<>());
             l.add(sequenceNum);
         });
 

--- a/study/src/org/labkey/study/writer/XmlVisitMapWriter.java
+++ b/study/src/org/labkey/study/writer/XmlVisitMapWriter.java
@@ -90,7 +90,7 @@ public class XmlVisitMapWriter implements Writer<StudyImpl, StudyExportContext>
 
                 visitXml.setSequenceNum(visit.getSequenceNumMin());
 
-                if (!visit.getSequenceNumMin().equals(visit.getSequenceNumMax()))
+                if (visit.getSequenceNumMin().compareTo(visit.getSequenceNumMax()) != 0)
                     visitXml.setMaxSequenceNum(visit.getSequenceNumMax());
 
                 if (null != visit.getProtocolDay())


### PR DESCRIPTION
#### Rationale
`BigDecimal`s are better than doubles

#### Changes
* Convert `ensureVisitWithoutSaving()` to `BigDecimal`
* Switch `BigDecimal.equals()` usages to `compareTo()` to ensure no scale problems
* Eliminate all usage of `getSequenceNumMinDouble()` and `getSequenceNumMaxDouble()`; remove these methods
* Eliminate double constructors