### PR TITLE
Issue 43584: JS error when creating related issue with no priority

### DIFF
--- a/issues/src/org/labkey/issue/view/detailView.jsp
+++ b/issues/src/org/labkey/issue/view/detailView.jsp
@@ -120,7 +120,7 @@
     relatedIssues.append(", title :").append(q(issue.getTitle()));
     relatedIssues.append(", skipPost :").append(true);
     relatedIssues.append(", assignedTo :").append(issue.getAssignedTo());
-    relatedIssues.append(", priority :").append(issue.getProperty(Issue.Prop.priority));
+    relatedIssues.append(", priority :").append(q(issue.getProperty(Issue.Prop.priority)));
     relatedIssues.append(", related :").append(issue.getIssueId());
     relatedIssues.append("})");
 


### PR DESCRIPTION
#### Rationale
You should be able to create a related issue from any other issue, including one without a priority set

#### Changes
* Treat the priority value as a string so that it gets quoted (even if its null, which renders as an empty string)