### PR TITLE
Issue 43278- display forbidden exception message in error handling page

### DIFF
--- a/api/src/org/labkey/api/action/PermissionCheckableAction.java
+++ b/api/src/org/labkey/api/action/PermissionCheckableAction.java
@@ -41,7 +41,6 @@ import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.HttpUtil;
 import org.labkey.api.view.BadRequestException;
-import org.labkey.api.view.ForbiddenProjectException;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.RedirectException;
 import org.labkey.api.view.UnauthorizedException;
@@ -155,8 +154,8 @@ public abstract class PermissionCheckableAction implements Controller, Permissio
         User user = context.getUser();
         Class<? extends Controller> actionClass = getClass();
 
-        if (!actionClass.isAnnotationPresent(IgnoresForbiddenProjectCheck.class) && c.isForbiddenProject(user))
-            throw new ForbiddenProjectException();
+        if (!actionClass.isAnnotationPresent(IgnoresForbiddenProjectCheck.class))
+            c.throwIfForbiddenProject(user);
 
         Method method = context.getMethod();
         HttpUtil.Method[] methodsAllowed = arrayGetPost;

--- a/api/src/org/labkey/api/module/SimpleAction.java
+++ b/api/src/org/labkey/api/module/SimpleAction.java
@@ -145,10 +145,8 @@ public class SimpleAction extends BaseViewAction implements NavTrailAction
 
             if (!container.hasPermissions(user, perms))
             {
-                if (container.isForbiddenProject(user))
-                    throw new ForbiddenProjectException();
-                else
-                    throw new UnauthorizedException("You do not have permission to view this content.");
+                container.throwIfForbiddenProject(user);
+                throw new UnauthorizedException("You do not have permission to view this content.");
             }
         }
 
@@ -158,10 +156,8 @@ public class SimpleAction extends BaseViewAction implements NavTrailAction
             {
                 if (!container.hasPermission(user, perm))
                 {
-                    if (container.isForbiddenProject(user))
-                        throw new ForbiddenProjectException();
-                    else
-                        throw new UnauthorizedException("You do not have permission to view this content.");
+                    container.throwIfForbiddenProject(user);
+                    throw new UnauthorizedException("You do not have permission to view this content.");
                 }
             }
         }

--- a/api/src/org/labkey/api/view/ForbiddenProjectException.java
+++ b/api/src/org/labkey/api/view/ForbiddenProjectException.java
@@ -16,15 +16,16 @@
 package org.labkey.api.view;
 
 /**
- * Thrown when admin is impersonating within a project and attempts to access a folder outside that project. Used to
- * provide a more helpful error message compared with a vanilla {@link UnauthorizedException}.
+ * Thrown when a user accesses a forbidden project, for example, when an admin is impersonating within a project and
+ * attempts to access a folder outside that project or when a non-project admin attempts to access a locked project.
+ * Used to provide a more helpful error message compared with a vanilla {@link UnauthorizedException}.
  * User: adam
  * Date: Aug 27, 2008
  */
 public class ForbiddenProjectException extends UnauthorizedException
 {
-    public ForbiddenProjectException()
+    public ForbiddenProjectException(String message)
     {
-        super("You are not allowed to access this folder while impersonating within a different project.");
+        super(message);
     }
 }

--- a/core/src/client/ErrorHandler/ErrorType.tsx
+++ b/core/src/client/ErrorHandler/ErrorType.tsx
@@ -18,7 +18,11 @@ const DETAILS_SUB_INSTRUCTION = (
         </p>
         <p className="labkey-error-details">
             If you are part of a{' '}
-            <a href="https://labkey.com/products-services/labkey-server/#server-editions" rel="noopener noreferrer" target="_blank">
+            <a
+                href="https://labkey.com/products-services/labkey-server/#server-editions"
+                rel="noopener noreferrer"
+                target="_blank"
+            >
                 {' '}
                 LabKey Server Premium Edition
             </a>{' '}
@@ -103,7 +107,10 @@ const NOTFOUND_DETAILS = (errorDetails: ErrorDetails) => (
     </>
 );
 
-const PERMISSION_SUBHEADING = () => 'You do not have the permissions required to access this page.';
+const PERMISSION_SUBHEADING = (errorMessage: string) => (
+    <>{errorMessage !== undefined ? errorMessage : 'You do not have the permissions required to access this page.'}</>
+);
+
 const PERMISSION_INSTRUCTION = () => "Please contact this server's administrator to gain access.";
 const PERMISSION_DETAILS = () => (
     <>
@@ -282,7 +289,7 @@ export const getImage = (errorDetails: ErrorDetails): ReactNode => {
     const info = ERROR_TYPE_INFO[errorDetails.errorType];
     if (!info) return null;
 
-    return <img alt="LabKey Error" src={imageURL('_images', info.imagePath)}/>;
+    return <img alt="LabKey Error" src={imageURL('_images', info.imagePath)} />;
 };
 
 export const getSubHeading = (errorDetails: ErrorDetails): ReactNode => {

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -1992,7 +1992,7 @@ public class CoreController extends SpringActionController
     }
 
     @RequiresNoPermission
-    @IgnoresForbiddenProjectCheck // So we can display an error when visiting a forbidden project, #43278... but this should be called in root
+    @IgnoresForbiddenProjectCheck // Skip the "forbidden project" check since it disallows root. See #43278.
     public class LoadLibraryAction extends ReadOnlyApiAction<LoadLibraryForm>
     {
         @Override

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -9235,7 +9235,7 @@ public class AdminController extends SpringActionController
     @Marshal(Marshaller.Jackson)
     @SuppressWarnings("UnusedDeclaration")
     @RequiresNoPermission
-    @IgnoresForbiddenProjectCheck // This should be called in root
+    @IgnoresForbiddenProjectCheck // Skip the "forbidden project" check since it disallows root
     public static class LogClientExceptionAction extends MutatingApiAction<ExceptionForm>
     {
         @Override


### PR DESCRIPTION
#### Rationale
Display forbidden exception message in error page instead of the general permission exception message.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2452


