### PR TITLE
Issue 42708: Exported XAR fails to reimport due to mismatched materialLSIDPrefix

### DIFF
--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -534,7 +534,8 @@ public class XarReader extends AbstractXarImporter
                 // Issue 37936 - Skip validation of description for the magic specimen/sample link, which is auto-generated based on the container name
                 if (!existingMaterialSource.getName().equalsIgnoreCase(SpecimenService.SAMPLE_TYPE_NAME))
                 {
-                    IdentifiableEntity.diff(materialSource.getMaterialLSIDPrefix(), existingMaterialSource.getMaterialLSIDPrefix(), "Material LSID prefix", diffs);
+                    // Issue 42708 - don't compare the material LSID prefix. Just keep the current one, which should be
+                    // enough to assign unique LSIDs for new entries
                     IdentifiableEntity.diff(materialSource.getDescription(), existingMaterialSource.getDescription(), "Description", diffs);
                 }
                 if (!diffs.isEmpty())


### PR DESCRIPTION
#### Rationale
We want to do better at merging incoming XAR-based sample types, samples, and runs with that's already in the target container

#### Changes
* Be flexible on the materialLSIDPrefix from the XAR, and just use the one that's already in the target (if present)