### PR TITLE
Issue 43548: Stop reporting exceptions from request.getSession(true) == null

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticatedRequest.java
+++ b/api/src/org/labkey/api/security/AuthenticatedRequest.java
@@ -213,7 +213,10 @@ public class AuthenticatedRequest extends HttpServletRequestWrapper implements A
                 try { inner = getInnermostRequest(); } catch (Exception x){}
                 if (null == inner)
                     inner = getRequest();
-                throw new NullPointerException("Request.getSession(true) returned null: " + inner.getClass().getName());
+                // Issue 43548 - ignore failures to create sessions
+                NullPointerException npe = new NullPointerException("Request.getSession(true) returned null: " + inner.getClass().getName());
+                ExceptionUtil.decorateException(npe, ExceptionUtil.ExceptionInfo.SkipMothershipLogging, "true", true);
+                throw npe;
             }
             if (s.isNew())
             {

--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -503,6 +503,7 @@ public class ExceptionUtil
                 null != decorations.get(ExceptionInfo.SkipMothershipLogging) ||
                 ex instanceof SkipMothershipLogging ||
                 isClientAbortException(ex) ||
+                (ex instanceof IllegalStateException && "Page needs a session and none is available".equalsIgnoreCase(ex.getMessage())) ||
                 JOB_RUNNER.getJobCount() > 10;
     }
 


### PR DESCRIPTION
#### Rationale
We get many unactionable exception reports when Tomcat fails to create sessions, likely at the end of a long-running request

#### Changes
* Silence the two most common culprits