### PR TITLE
Feature Request 43224: TypeAheadSelectDisplayColumn to render select input using React QuerySelect

### DIFF
--- a/api/src/org/labkey/api/view/TypeAheadSelectDisplayColumn.java
+++ b/api/src/org/labkey/api/view/TypeAheadSelectDisplayColumn.java
@@ -78,7 +78,7 @@ public class TypeAheadSelectDisplayColumn extends DataColumn
         sb.append(" });\n");
         sb.append("});\n");
         sb.append("</script>\n");
-        sb.append("<div id='").append(renderId).append("'></div>");
+        sb.append("<div id=").append(PageFlowUtil.jsString(renderId)).append("></div>");
         out.write(sb.toString());
 
         // disabled inputs are not posted with the form, so we output a hidden form element:

--- a/api/src/org/labkey/api/view/TypeAheadSelectDisplayColumn.java
+++ b/api/src/org/labkey/api/view/TypeAheadSelectDisplayColumn.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2014-2017 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.api.view;
+
+import org.apache.commons.collections4.MultiValuedMap;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.ForeignKey;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.UniqueID;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * {@link DisplayColumn} that use a React QuerySelect component input to allow for type-ahead search/filter
+ * for a select input that has too many options for a user to meaningfully scroll through.
+ */
+public class TypeAheadSelectDisplayColumn extends DataColumn
+{
+    private Integer _maxRows;
+
+    public TypeAheadSelectDisplayColumn(ColumnInfo col, Integer maxRows)
+    {
+        super(col);
+        _maxRows = maxRows;
+    }
+
+    @Override
+    public void renderInputHtml(RenderContext ctx, Writer out, Object value) throws IOException
+    {
+        ForeignKey fk = getBoundColumn().getFk();
+        // currently only supported for lookup columns with a defined schema/query
+        if (fk == null)
+        {
+            out.write("TypeAheadSelectDisplayColumn can only be used with a lookup column.");
+            return;
+        }
+
+        String formFieldName = getFormFieldName(ctx);
+        boolean disabledInput = isDisabledInput(ctx);
+        String strVal = getStringValue(value, disabledInput);
+        String renderId = "query-select-div-" + UniqueID.getRequestScopedUID(HttpView.currentRequest());
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("<script type=\"text/javascript\">");
+        //sb.append("LABKEY.requiresScript('http://localhost:3001/querySelectInput.js', function() {\n");
+        sb.append("LABKEY.requiresScript('gen/querySelectInput', function() {\n");
+        sb.append(" LABKEY.App.loadApp('querySelectInput', ").append(PageFlowUtil.jsString(renderId)).append(", {\n");
+        sb.append("     name: ").append(PageFlowUtil.jsString(getInputPrefix() + formFieldName)).append("\n");
+        sb.append("     ,value: ").append(PageFlowUtil.jsString(strVal)).append("\n");
+        sb.append("     ,disabled: ").append(disabledInput).append("\n");
+        sb.append("     ,schemaName: ").append(PageFlowUtil.jsString(fk.getLookupSchemaName())).append("\n");
+        sb.append("     ,queryName: ").append(PageFlowUtil.jsString(fk.getLookupTableName())).append("\n");
+        if (_maxRows != null)
+            sb.append("     ,maxRows: ").append(_maxRows).append("\n");
+        if (fk.getLookupContainer() != null)
+            sb.append("     ,containerPath: ").append(PageFlowUtil.jsString(fk.getLookupContainer().getPath())).append("\n");
+        sb.append(" });\n");
+        sb.append("});\n");
+        sb.append("</script>\n");
+        sb.append("<div id='").append(renderId).append("'></div>");
+        out.write(sb.toString());
+
+        // disabled inputs are not posted with the form, so we output a hidden form element:
+        if (disabledInput)
+            renderHiddenFormInput(ctx, out, formFieldName, value);
+    }
+
+    public static class Factory implements DisplayColumnFactory
+    {
+        private Integer _maxRows;
+
+        public Factory()
+        {}
+
+        public Factory(MultiValuedMap<String, String> map)
+        {
+            String maxRowsStr = getProperty(map, "maxRows");
+            _maxRows = maxRowsStr != null ? Integer.parseInt(maxRowsStr) : null;
+        }
+
+        private String getProperty(MultiValuedMap<String, String> map, String propertyName)
+        {
+            Collection<String> values = map == null ? Collections.emptyList() : map.get(propertyName);
+            if (!values.isEmpty())
+            {
+                return values.iterator().next();
+            }
+            return null;
+        }
+
+        @Override
+        public DisplayColumn createRenderer(ColumnInfo colInfo)
+        {
+            return new TypeAheadSelectDisplayColumn(colInfo, _maxRows);
+        }
+    }
+}

--- a/api/src/org/labkey/api/view/TypeAheadSelectDisplayColumn.java
+++ b/api/src/org/labkey/api/view/TypeAheadSelectDisplayColumn.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 /**
  * {@link DisplayColumn} that use a React QuerySelect component input to allow for type-ahead search/filter
  * for a select input that has too many options for a user to meaningfully scroll through.
+ * TODO: See Issue 43526 for more details on remaining TODOs for full replacement of DataColumn.renderSelectFormInput.
  */
 public class TypeAheadSelectDisplayColumn extends DataColumn
 {

--- a/core/src/client/QuerySelectInput/QuerySelectInput.tsx
+++ b/core/src/client/QuerySelectInput/QuerySelectInput.tsx
@@ -10,6 +10,7 @@ export interface AppContext {
     schemaName: string;
     queryName: string;
     disabled?: boolean;
+    maxRows?: number;
 }
 
 interface Props {
@@ -17,7 +18,7 @@ interface Props {
 }
 
 export const QuerySelectInput: FC<Props> = memo(props => {
-    const { name, disabled, containerPath, value, schemaName, queryName } = props.context;
+    const { name, disabled, containerPath, value, schemaName, queryName, maxRows = 100 } = props.context;
 
     return (
         <QuerySelect
@@ -31,7 +32,7 @@ export const QuerySelectInput: FC<Props> = memo(props => {
             disabled={disabled}
             value={value}
             loadOnFocus
-            maxRows={100}
+            maxRows={maxRows}
         />
     );
 });

--- a/core/src/client/entryPoints.js
+++ b/core/src/client/entryPoints.js
@@ -72,7 +72,7 @@ module.exports = {
     }, {
         name: 'querySelectInput',
         title: 'Query Select Input',
-        generateLib: true, // used in DataColumn.java
+        generateLib: true, // used in TypeAheadSelectDisplayColumn.java
         path: './src/client/QuerySelectInput'
     }]
 };


### PR DESCRIPTION
#### Rationale
The related PR added an experimental feature to toggle the LabKey insert/update forms to use the React QuerySelect component in place of a standard HTML select input. This experimental feature is nice for testing, but is an "all or nothing" approach. This PR adds a new TypeAheadSelectDisplayColumn factory which can be set for a table's XML metadata to opt-in to using this React component for given columns.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2443

#### Changes
* factor out TypeAheadSelectDisplayColumn from DataColumn 
* use TypeAheadSelectDisplayColumn in DataColumn.renderInputHtml() when experimental feature enabled
* allow for "maxRows" value to be passed as XML `<properties>` for the `<displayColumnFactory>` definition
