### PR TITLE
Issue 43597: don't apply compliance rules before startup is complete

### DIFF
--- a/api/src/org/labkey/api/compliance/ComplianceService.java
+++ b/api/src/org/labkey/api/compliance/ComplianceService.java
@@ -23,6 +23,8 @@ import org.labkey.api.data.Activity;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.PHI;
 import org.labkey.api.query.QueryAction;
+import org.labkey.api.query.column.ColumnInfoFilter;
+import org.labkey.api.query.column.ColumnInfoTransformer;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.util.Pair;
@@ -57,6 +59,9 @@ public interface ComplianceService
         ServiceRegistry.get().registerService(ComplianceService.class, instance);
     }
 
+    ColumnInfoTransformer NOOP_COLUMN_INFO_TRANSFORMER = columnInfo -> columnInfo;
+
+    boolean isComplianceSupported();
     String getModuleName();
     ActionURL urlFor(Container container, QueryAction action, ActionURL queryBasedUrl);
     boolean hasElecSignPermission(@NotNull Container container, @NotNull User user);
@@ -94,8 +99,18 @@ public interface ComplianceService
 
     JSONObject getPageContextJson();
 
+    ColumnInfoFilter filter(@NotNull PhiColumnBehavior behavior, @NotNull PHI maxAllowedPhi);
+
+    ColumnInfoTransformer transformer(@NotNull PhiColumnBehavior behavior, @NotNull PHI maxAllowedPhi);
+
     class DefaultComplianceService implements ComplianceService
     {
+        @Override
+        public boolean isComplianceSupported()
+        {
+            return false;
+        }
+
         @Override
         public String getModuleName()
         {
@@ -172,6 +187,19 @@ public interface ComplianceService
         public JSONObject getPageContextJson()
         {
             return null;
+        }
+
+        @Override
+        public ColumnInfoFilter filter(@NotNull PhiColumnBehavior behavior, @NotNull PHI maxAllowedPhi)
+        {
+            // no-op filter
+            return (col) -> true;
+        }
+
+        @Override
+        public ColumnInfoTransformer transformer(@NotNull PhiColumnBehavior behavior, @NotNull PHI maxAllowedPhi)
+        {
+            return NOOP_COLUMN_INFO_TRANSFORMER;
         }
     }
 }

--- a/api/src/org/labkey/api/query/FilteredTable.java
+++ b/api/src/org/labkey/api/query/FilteredTable.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
+import org.labkey.api.compliance.ComplianceService;
 import org.labkey.api.compliance.TableRules;
 import org.labkey.api.compliance.TableRulesManager;
 import org.labkey.api.data.AbstractTableInfo;
@@ -116,7 +117,7 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
                 applyContainerFilter(getDefaultContainerFilter());
         }
 
-        _rules = supportTableRules() ? TableRulesManager.get().getTableRules(getContainer(), userSchema.getUser()) : TableRules.NOOP_TABLE_RULES;
+        _rules = canApplyTableRules() ? TableRulesManager.get().getTableRules(getContainer(), userSchema.getUser()) : TableRules.NOOP_TABLE_RULES;
     }
 
     @Override
@@ -131,6 +132,14 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
     public boolean supportTableRules()
     {
         return false;
+    }
+
+    /**
+     * Returns true if the table supports rules and the compliance module is available
+     */
+    public final boolean canApplyTableRules()
+    {
+        return supportTableRules() && ComplianceService.get().isComplianceSupported();
     }
 
     @Override
@@ -596,7 +605,7 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
 
     public @NotNull Set<FieldKey> getPHIDataLoggingColumns()
     {
-        if (!supportTableRules() || getUserSchema().getUser().isServiceUser())
+        if (!canApplyTableRules() || getUserSchema().getUser().isServiceUser())
             return Collections.emptySet();
 
         Set<FieldKey> loggingColumns = new LinkedHashSet<>();
@@ -618,7 +627,7 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
 
     protected @NotNull String getPHILoggingComment(@NotNull Set<FieldKey> dataLoggingColumns)
     {
-        if (!supportTableRules() || getUserSchema().getUser().isServiceUser())
+        if (!canApplyTableRules() || getUserSchema().getUser().isServiceUser())
             return "";
 
         return dataLoggingColumns


### PR DESCRIPTION
#### Rationale
The biologics-21.000-21.001 upgrade attempts to get a DataClass table from the exp.data schema before the compliance service is available.  This PR changes FilteredTable to no longer attempt to apply table rules if the service isn't available.  In addition, the two `ComplianceServiceImpl` methods being used by the table rules are added to the `ComplianceService` interface and implemented as no-ops.

#### Changes
* Pull `filter` and `transformer` up to the `ComplianceService` interface
* Check compliance is available in `FilteredTable.canApplyTableRules` before attempting to apply table rules
