### PR TITLE
Issue 43599: Remove error page generic advice for UnauthorizedException subclasses

### DIFF
--- a/api/src/org/labkey/api/security/impersonation/UnauthorizedImpersonationException.java
+++ b/api/src/org/labkey/api/security/impersonation/UnauthorizedImpersonationException.java
@@ -15,11 +15,12 @@
  */
 package org.labkey.api.security.impersonation;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.view.UnauthorizedException;
 
 /**
- * Thrown to indicate that someone attempted to impersonate in an invalid way - such as a project admin trying
- * to access another project while impersonating a user.
+ * Thrown to indicate that someone attempted to impersonate in an invalid way - such as a project admin attempting to
+ * impersonate someone who's not a project user in this project.
  * User: adam
  * Date: 5/6/12
  */
@@ -36,5 +37,11 @@ public class UnauthorizedImpersonationException extends UnauthorizedException
     public ImpersonationContextFactory getFactory()
     {
         return _factory;
+    }
+
+    @Override
+    public @Nullable String getAdvice()
+    {
+        return null;
     }
 }

--- a/api/src/org/labkey/api/util/CSRFException.java
+++ b/api/src/org/labkey/api/util/CSRFException.java
@@ -31,12 +31,18 @@ public class CSRFException extends UnauthorizedException
 
     CSRFException(@Nullable HttpServletRequest request)
     {
-        super("This request has an invalid security context.  You may have signed in or signed out of this session.  Try again by using the 'back' and 'refresh' button in your browser.");
+        super("This request has an invalid security context. You may have signed in or signed out of this session. Try again by using the 'back' and 'refresh' button in your browser.");
         referer = null==request ? null : request.getHeader("referer");
     }
 
     public String getReferer()
     {
         return referer;
+    }
+
+    @Override
+    public @Nullable String getAdvice()
+    {
+        return null;
     }
 }

--- a/api/src/org/labkey/api/util/ErrorRenderer.java
+++ b/api/src/org/labkey/api/util/ErrorRenderer.java
@@ -25,6 +25,7 @@ import org.labkey.api.data.DbScope;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.view.HttpView;
+import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewContext;
 
 import javax.servlet.ServletException;
@@ -42,6 +43,7 @@ public class ErrorRenderer
     private final ErrorRendererProperties _errorRendererProps;
     private final String _title;
     private final String _errorCode;
+    private final String _advice;
 
     private ErrorType _errorType;
 
@@ -65,6 +67,7 @@ public class ErrorRenderer
         _isStartupFailure = isStartupFailure;
         _errorRendererProps = (x instanceof ErrorRendererProperties ? (ErrorRendererProperties)x : null);
         _errorCode = errorCode;
+        _advice = (x instanceof UnauthorizedException ? ((UnauthorizedException) x).getAdvice() : null);
 
         if (null == _errorRendererProps)
         {
@@ -267,5 +270,10 @@ public class ErrorRenderer
     public String getErrorCode()
     {
         return _errorCode;
+    }
+
+    public String getAdvice()
+    {
+        return _advice;
     }
 }

--- a/api/src/org/labkey/api/view/ForbiddenProjectException.java
+++ b/api/src/org/labkey/api/view/ForbiddenProjectException.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.api.view;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Thrown when a user accesses a forbidden project, for example, when an admin is impersonating within a project and
  * attempts to access a folder outside that project or when a non-project admin attempts to access a locked project.
@@ -27,5 +29,11 @@ public class ForbiddenProjectException extends UnauthorizedException
     public ForbiddenProjectException(String message)
     {
         super(message);
+    }
+
+    @Override
+    public @Nullable String getAdvice()
+    {
+        return null;
     }
 }

--- a/api/src/org/labkey/api/view/RequestBasicAuthException.java
+++ b/api/src/org/labkey/api/view/RequestBasicAuthException.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.api.view;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Indicates to the HTTP client that the request needs authentication (status code 401),
  * which could be provided via HTTP BasicAuth.
@@ -27,5 +29,11 @@ public class RequestBasicAuthException extends UnauthorizedException
     {
         super();
         setType(Type.sendBasicAuth);
+    }
+
+    @Override
+    public @Nullable String getAdvice()
+    {
+        return null;
     }
 }

--- a/api/src/org/labkey/api/view/UnauthorizedException.java
+++ b/api/src/org/labkey/api/view/UnauthorizedException.java
@@ -16,7 +16,7 @@
 package org.labkey.api.view;
 
 import org.apache.commons.lang3.StringUtils;
-import org.labkey.api.util.SkipMothershipLogging;
+import org.jetbrains.annotations.Nullable;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -56,5 +56,14 @@ public class UnauthorizedException extends HttpStatusException
     public Type getType()
     {
         return _type;
+    }
+
+    /**
+     * An additional sub-message to show on the error page. If null no additional message is shown.
+     * @return A String with additional advice for the unauthorized user
+     */
+    public @Nullable String getAdvice()
+    {
+        return "Please contact this server's administrator to gain access.";
     }
 }

--- a/api/src/org/labkey/api/view/template/errorView.jsp
+++ b/api/src/org/labkey/api/view/template/errorView.jsp
@@ -53,7 +53,8 @@
                 message: <%=q(model.getHeading())%>,
                 errorType: <%=q(model.getErrorType())%>,
                 stackTrace: <%=q(stackTrace.toString())%>,
-                errorCode: <%=q(model.getErrorCode())%>
+                errorCode: <%=q(model.getErrorCode())%>,
+                advice: <%=q(model.getAdvice())%>
             }
         });
     });

--- a/core/src/client/ErrorHandler/ErrorType.tsx
+++ b/core/src/client/ErrorHandler/ErrorType.tsx
@@ -45,7 +45,7 @@ const NOTFOUND_SUBHEADING = (errorMessage?: string) => (
             : 'It seems like something went wrong.'}
     </>
 );
-const NOTFOUND_INSTRUCTION = (errorCode?: string) => (
+const NOTFOUND_INSTRUCTION = (errorDetails: ErrorDetails) => (
     <>
         <div className="labkey-error-instruction">
             Please contact your admin or reference the{' '}
@@ -53,7 +53,7 @@ const NOTFOUND_INSTRUCTION = (errorCode?: string) => (
                 LabKey support forum.
             </a>
         </div>
-        {errorCode !== undefined && errorCode !== null && (
+        {errorDetails.errorCode !== undefined && errorDetails.errorCode !== null && (
             <div className="labkey-error-instruction">
                 If you would like to file a{' '}
                 <a
@@ -64,7 +64,7 @@ const NOTFOUND_INSTRUCTION = (errorCode?: string) => (
                     {' '}
                     LabKey support ticket
                 </a>
-                , your unique reference code is: {errorCode}
+                , your unique reference code is: {errorDetails.errorCode}
             </div>
         )}
     </>
@@ -111,7 +111,8 @@ const PERMISSION_SUBHEADING = (errorMessage: string) => (
     <>{errorMessage !== undefined ? errorMessage : 'You do not have the permissions required to access this page.'}</>
 );
 
-const PERMISSION_INSTRUCTION = () => "Please contact this server's administrator to gain access.";
+const PERMISSION_INSTRUCTION = (errorDetails: ErrorDetails) => <>{errorDetails.advice} </>;
+
 const PERMISSION_DETAILS = () => (
     <>
         <p className="labkey-error-details labkey-error-details-question">What is a permission error?</p>
@@ -221,7 +222,7 @@ const EXECUTION_SUB_HEADING = (errorMessage?: string) => (
             : 'It seems like there is an issue with this installation of LabKey server.'}
     </>
 );
-const EXECUTION_INSTRUCTION = (errorCode?: string) => (
+const EXECUTION_INSTRUCTION = (errorDetails: ErrorDetails) => (
     <>
         <div className="labkey-error-instruction">
             Please report this bug to{' '}
@@ -233,7 +234,7 @@ const EXECUTION_INSTRUCTION = (errorCode?: string) => (
             below.
         </div>
         <div className="labkey-error-instruction">
-            Your unique reference code is: <b>{errorCode}</b>
+            Your unique reference code is: <b>{errorDetails.errorCode}</b>
         </div>
     </>
 );
@@ -244,7 +245,7 @@ type ErrorTypeInfo = {
     heading: string;
     subHeading: (errorMessage?: string) => ReactNode;
     imagePath: string;
-    instruction: (errorCode?: string) => ReactNode;
+    instruction: (errorDetails?: ErrorDetails) => ReactNode;
 };
 
 const ERROR_TYPE_INFO: { [key in ErrorType]: ErrorTypeInfo } = {
@@ -303,7 +304,7 @@ export const getInstruction = (errorDetails: ErrorDetails): ReactNode => {
     const info = ERROR_TYPE_INFO[errorDetails.errorType];
     if (!info) return null;
 
-    return <div className="labkey-error-instruction">{info.instruction(errorDetails.errorCode)}</div>;
+    return <div className="labkey-error-instruction">{info.instruction(errorDetails)}</div>;
 };
 
 export const getViewDetails = (errorDetails: ErrorDetails): ReactNode => {

--- a/core/src/client/ErrorHandler/model.ts
+++ b/core/src/client/ErrorHandler/model.ts
@@ -11,4 +11,5 @@ export interface ErrorDetails {
     message?: string;
     stackTrace?: string;
     hideViewDetails?: boolean;
+    advice?: string;
 }


### PR DESCRIPTION
#### Rationale
The boilerplate advice on the unauthorized error page ("Contact an administrator for access") makes no sense for subclasses that flag locked projects, CSRF exceptions, bad impersonation scenarios, etc. Each exception should dictate the advice to render (if any).

#### Related Pull Requests
* https://github.com/LabKey/compliance/pull/130
