### PR TITLE
Feature Request 43224: TypeAheadSelectDisplayColumn factory which renders React QuerySelect component

### DIFF
--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -598,15 +598,8 @@ public class DataColumn extends DisplayColumn
         return entry.getObject().toString();
     }
 
-    @Override
-    public void renderInputHtml(RenderContext ctx, Writer out, Object value) throws IOException
+    protected String getStringValue(Object value, boolean disabledInput)
     {
-        if (_boundColumn.isVersionColumn() || _inputType.equalsIgnoreCase("none"))
-            return;
-
-        boolean disabledInput = isDisabledInput(ctx);
-        final String formFieldName = getFormFieldName(ctx);
-
         String strVal = "";
         //UNDONE: Should use output format here.
         if (null != value)
@@ -628,6 +621,18 @@ public class DataColumn extends DisplayColumn
             else
                 strVal = ConvertUtils.convert(value);
         }
+        return strVal;
+    }
+
+    @Override
+    public void renderInputHtml(RenderContext ctx, Writer out, Object value) throws IOException
+    {
+        if (_boundColumn.isVersionColumn() || _inputType.equalsIgnoreCase("none"))
+            return;
+
+        boolean disabledInput = isDisabledInput(ctx);
+        final String formFieldName = getFormFieldName(ctx);
+        String strVal = getStringValue(value, disabledInput);
 
         if (_boundColumn.isAutoIncrement())
         {

--- a/api/src/org/labkey/api/view/TypeAheadSelectDisplayColumn.java
+++ b/api/src/org/labkey/api/view/TypeAheadSelectDisplayColumn.java
@@ -78,7 +78,7 @@ public class TypeAheadSelectDisplayColumn extends DataColumn
         sb.append(" });\n");
         sb.append("});\n");
         sb.append("</script>\n");
-        sb.append("<div id='").append(renderId).append("'></div>");
+        sb.append("<div id=").append(PageFlowUtil.jsString(renderId)).append("></div>");
         out.write(sb.toString());
 
         // disabled inputs are not posted with the form, so we output a hidden form element:

--- a/api/src/org/labkey/api/view/TypeAheadSelectDisplayColumn.java
+++ b/api/src/org/labkey/api/view/TypeAheadSelectDisplayColumn.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2014-2017 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.api.view;
+
+import org.apache.commons.collections4.MultiValuedMap;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.ForeignKey;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.UniqueID;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * {@link DisplayColumn} that use a React QuerySelect component input to allow for type-ahead search/filter
+ * for a select input that has too many options for a user to meaningfully scroll through.
+ * TODO: See Issue 43526 for more details on remaining TODOs for full replacement of DataColumn.renderSelectFormInput.
+ */
+public class TypeAheadSelectDisplayColumn extends DataColumn
+{
+    private Integer _maxRows;
+
+    public TypeAheadSelectDisplayColumn(ColumnInfo col, Integer maxRows)
+    {
+        super(col);
+        _maxRows = maxRows;
+    }
+
+    @Override
+    public void renderInputHtml(RenderContext ctx, Writer out, Object value) throws IOException
+    {
+        ForeignKey fk = getBoundColumn().getFk();
+        // currently only supported for lookup columns with a defined schema/query
+        if (fk == null)
+        {
+            out.write("TypeAheadSelectDisplayColumn can only be used with a lookup column.");
+            return;
+        }
+
+        String formFieldName = getFormFieldName(ctx);
+        boolean disabledInput = isDisabledInput(ctx);
+        String strVal = getStringValue(value, disabledInput);
+        String renderId = "query-select-div-" + UniqueID.getRequestScopedUID(HttpView.currentRequest());
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("<script type=\"text/javascript\">");
+        //sb.append("LABKEY.requiresScript('http://localhost:3001/querySelectInput.js', function() {\n");
+        sb.append("LABKEY.requiresScript('gen/querySelectInput', function() {\n");
+        sb.append(" LABKEY.App.loadApp('querySelectInput', ").append(PageFlowUtil.jsString(renderId)).append(", {\n");
+        sb.append("     name: ").append(PageFlowUtil.jsString(getInputPrefix() + formFieldName)).append("\n");
+        sb.append("     ,value: ").append(PageFlowUtil.jsString(strVal)).append("\n");
+        sb.append("     ,disabled: ").append(disabledInput).append("\n");
+        sb.append("     ,schemaName: ").append(PageFlowUtil.jsString(fk.getLookupSchemaName())).append("\n");
+        sb.append("     ,queryName: ").append(PageFlowUtil.jsString(fk.getLookupTableName())).append("\n");
+        if (_maxRows != null)
+            sb.append("     ,maxRows: ").append(_maxRows).append("\n");
+        if (fk.getLookupContainer() != null)
+            sb.append("     ,containerPath: ").append(PageFlowUtil.jsString(fk.getLookupContainer().getPath())).append("\n");
+        sb.append(" });\n");
+        sb.append("});\n");
+        sb.append("</script>\n");
+        sb.append("<div id='").append(renderId).append("'></div>");
+        out.write(sb.toString());
+
+        // disabled inputs are not posted with the form, so we output a hidden form element:
+        if (disabledInput)
+            renderHiddenFormInput(ctx, out, formFieldName, value);
+    }
+
+    public static class Factory implements DisplayColumnFactory
+    {
+        private Integer _maxRows;
+
+        public Factory()
+        {}
+
+        public Factory(MultiValuedMap<String, String> map)
+        {
+            String maxRowsStr = getProperty(map, "maxRows");
+            _maxRows = maxRowsStr != null ? Integer.parseInt(maxRowsStr) : null;
+        }
+
+        private String getProperty(MultiValuedMap<String, String> map, String propertyName)
+        {
+            Collection<String> values = map == null ? Collections.emptyList() : map.get(propertyName);
+            if (!values.isEmpty())
+            {
+                return values.iterator().next();
+            }
+            return null;
+        }
+
+        @Override
+        public DisplayColumn createRenderer(ColumnInfo colInfo)
+        {
+            return new TypeAheadSelectDisplayColumn(colInfo, _maxRows);
+        }
+    }
+}

--- a/api/src/org/labkey/api/view/TypeAheadSelectDisplayColumn.java
+++ b/api/src/org/labkey/api/view/TypeAheadSelectDisplayColumn.java
@@ -96,13 +96,13 @@ public class TypeAheadSelectDisplayColumn extends DataColumn
         public Factory(MultiValuedMap<String, String> map)
         {
             String maxRowsStr = getProperty(map, "maxRows");
-            _maxRows = maxRowsStr != null ? Integer.parseInt(maxRowsStr) : null;
+            _maxRows = maxRowsStr != null && !maxRowsStr.isEmpty() ? Integer.parseInt(maxRowsStr) : null;
         }
 
         private String getProperty(MultiValuedMap<String, String> map, String propertyName)
         {
             Collection<String> values = map == null ? Collections.emptyList() : map.get(propertyName);
-            if (!values.isEmpty())
+            if (values!= null && !values.isEmpty())
             {
                 return values.iterator().next();
             }

--- a/core/src/client/QuerySelectInput/QuerySelectInput.scss
+++ b/core/src/client/QuerySelectInput/QuerySelectInput.scss
@@ -1,0 +1,6 @@
+@import "@labkey/components-scss";
+
+.Select-control {
+  border-radius: unset;
+  border-color: #a9a9a9;
+}

--- a/core/src/client/QuerySelectInput/QuerySelectInput.tsx
+++ b/core/src/client/QuerySelectInput/QuerySelectInput.tsx
@@ -1,0 +1,38 @@
+import React, { FC, memo } from 'react';
+import { QuerySelect, SchemaQuery, } from '@labkey/components';
+
+import './QuerySelectInput.scss';
+
+export interface AppContext {
+    name: string;
+    value: string;
+    containerPath: string;
+    schemaName: string;
+    queryName: string;
+    disabled?: boolean;
+    maxRows?: number;
+}
+
+interface Props {
+    context: AppContext;
+}
+
+export const QuerySelectInput: FC<Props> = memo(props => {
+    const { name, disabled, containerPath, value, schemaName, queryName, maxRows = 100 } = props.context;
+
+    return (
+        <QuerySelect
+            componentId={'query-select' + name}
+            inputClass={'col-sm-8 col-xs-12'}
+            formsy={false}
+            name={name}
+            schemaQuery={SchemaQuery.create(schemaName, queryName)}
+            containerPath={containerPath}
+            showLabel={false}
+            disabled={disabled}
+            value={value}
+            loadOnFocus
+            maxRows={maxRows}
+        />
+    );
+});

--- a/core/src/client/QuerySelectInput/app.tsx
+++ b/core/src/client/QuerySelectInput/app.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { App } from '@labkey/api';
+
+import { AppContext, QuerySelectInput } from './QuerySelectInput';
+
+App.registerApp<AppContext>('querySelectInput', (target, ctx) => {
+    ReactDOM.render(<QuerySelectInput context={ctx} />, document.getElementById(target));
+});

--- a/core/src/client/QuerySelectInput/dev.tsx
+++ b/core/src/client/QuerySelectInput/dev.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { AppContainer } from 'react-hot-loader';
+import { App } from '@labkey/api';
+
+import {AppContext, QuerySelectInput} from './QuerySelectInput';
+
+const render = (target: string, ctx: AppContext) => {
+    ReactDOM.render(
+        <AppContainer>
+            <QuerySelectInput context={ctx}/>
+        </AppContainer>,
+        document.getElementById(target)
+    );
+};
+
+App.registerApp<AppContext>('querySelectInput', render, true);
+
+declare const module: any;
+
+if (module.hot) {
+    module.hot.accept();
+}

--- a/core/src/client/entryPoints.js
+++ b/core/src/client/entryPoints.js
@@ -69,5 +69,10 @@ module.exports = {
         title: 'Concept Filter',
         generateLib: true, // used in FilterDialog.js
         path: './src/client/ConceptFilter'
+    }, {
+        name: 'querySelectInput',
+        title: 'Query Select Input',
+        generateLib: true, // used in TypeAheadSelectDisplayColumn.java
+        path: './src/client/QuerySelectInput'
     }]
 };


### PR DESCRIPTION
#### Rationale
The related PR added a new TypeAheadSelectDisplayColumn factory which can be set for a table's XML metadata to opt-in to using the React QuerySelect component for given columns in the LK insert/update forms. Since the client is planning to install 21.7 soon, this PR backports the core/entryPoint.js code and the TypeAheadSelectDisplayColumn class to 21.7 so that it can be used on their deployment.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2477

#### Changes
* Minor DataColumn.java refactor to pull out a getStringValue() method for use in subclasses
* TypeAheadSelectDisplayColumn to add custom rendering of React entryPoint for QuerySelect component
* core/entryPoint for QuerySelectInput wrapper over QuerySelect component to pass props from columnInfo
