### PR TITLE
fix permission exception subheading text failure

### DIFF
--- a/core/src/client/ErrorHandler/ErrorHandler.spec.tsx
+++ b/core/src/client/ErrorHandler/ErrorHandler.spec.tsx
@@ -54,9 +54,8 @@ describe('ErrorHandler', () => {
         getServerContext().impersonatingUser = { displayName: impersonatedUser };
         getServerContext().user = { displayName: realUser, isSignedIn: true };
 
-        const subheading = 'You do not have the permissions required to access this page.';
         const wrapper = shallow(<ErrorHandler context={{ errorDetails }} />);
-        expect(wrapper.find('.labkey-error-subheading').text().includes(subheading)).toBeTruthy();
+        expect(wrapper.find('.labkey-error-subheading').text().includes(errorDetails.message)).toBeTruthy();
         expect(wrapper.find('.error-details-container')).toHaveLength(0);
 
         wrapper.setState({ showDetails: true });


### PR DESCRIPTION
#### Rationale
This fixes the error text in subheading for the permission exception for related changes.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/2472

#### Changes
* check exception message
