### PR TITLE
43552: Adding participants to a group from a dataset only choosing participants on the first page

### DIFF
--- a/study/src/org/labkey/study/controllers/ParticipantGroupController.java
+++ b/study/src/org/labkey/study/controllers/ParticipantGroupController.java
@@ -420,11 +420,6 @@ public class ParticipantGroupController extends BaseStudyController
                 Set<String> ptids = new LinkedHashSet<>();
 
                 QuerySettings settings = form.getQuerySettings();
-                ActionURL url = new ActionURL();
-                url.setRawQuery(form.getRequestURL());
-                form.getQuerySettings().setSortFilterURL(url);
-                settings.setMaxRows(Table.ALL_ROWS);
-
                 UserSchema schema = QueryService.get().getUserSchema(getUser(), getContainer(), form.getSchemaName());
                 if (schema == null)
                 {

--- a/study/webapp/study/ParticipantGroup.js
+++ b/study/webapp/study/ParticipantGroup.js
@@ -38,7 +38,11 @@ Ext4.define('Study.window.ParticipantGroup', {
                     };
 
                 if (fromSelection) {
-                    jsonData.selections = checked;
+                    // issue 43552 : if all rows are selected from the message bar, don't use the checkbox selectors
+                    if (region.totalRows === region.selectedCount)
+                        jsonData.selectAll = true;
+                    else
+                        jsonData.selections = checked;
                 }
                 else {
                     jsonData.selectAll = true;


### PR DESCRIPTION
#### Rationale
If you had a paginated dataset, selected some rows and then used the buttons to select all rows. Creating a participant group from the selections would only use participants from the first page.

More details in the issue: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43552

#### Changes
- Dataregion selections only tracks the check box selectors, we need to look at the selected count as well.
- Cleaned up some code in the `GetParticipantsFromSelectionAction`, where we don't need to initialize the `QuerySettings` object the way we were, since the passed in view isn't used to get the list of participants (the tableInfo is).
