### PR TITLE
43615: Can't create or load a dataset via a file watcher when the dataset name has a number in it.

### DIFF
--- a/study/src/org/labkey/study/pipeline/DatasetInferSchemaReader.java
+++ b/study/src/org/labkey/study/pipeline/DatasetInferSchemaReader.java
@@ -45,7 +45,8 @@ import java.util.stream.Collectors;
  */
 public class DatasetInferSchemaReader extends DatasetFileReader implements SchemaReader
 {
-    protected Pattern _filePattern = Pattern.compile("(^.*).(?:tsv|txt|xls|xlsx)$");
+    protected Pattern _filePattern = Pattern.compile("^(.*)\.(?:tsv|txt|xls|xlsx)$");
+
     private Map<Integer, DatasetImportInfo> _datasetInfoMap = new LinkedHashMap<>();
     private List<ImportTypesHelper.Builder> _builders = new ArrayList<>();
     private Map<File, Pair<String, String>> _inputDataMap;

--- a/study/src/org/labkey/study/pipeline/DatasetInferSchemaReader.java
+++ b/study/src/org/labkey/study/pipeline/DatasetInferSchemaReader.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
  */
 public class DatasetInferSchemaReader extends DatasetFileReader implements SchemaReader
 {
-    protected Pattern _filePattern = Pattern.compile("^(.*)\.(?:tsv|txt|xls|xlsx)$");
+    protected Pattern _filePattern = Pattern.compile("^(.*)\\.(?:tsv|txt|xls|xlsx)$");
 
     private Map<Integer, DatasetImportInfo> _datasetInfoMap = new LinkedHashMap<>();
     private List<ImportTypesHelper.Builder> _builders = new ArrayList<>();

--- a/study/src/org/labkey/study/pipeline/DatasetInferSchemaReader.java
+++ b/study/src/org/labkey/study/pipeline/DatasetInferSchemaReader.java
@@ -45,7 +45,7 @@ import java.util.stream.Collectors;
  */
 public class DatasetInferSchemaReader extends DatasetFileReader implements SchemaReader
 {
-    protected Pattern _filePattern = Pattern.compile("(^\\D*).(?:tsv|txt|xls|xlsx)$");
+    protected Pattern _filePattern = Pattern.compile("(^.*).(?:tsv|txt|xls|xlsx)$");
     private Map<Integer, DatasetImportInfo> _datasetInfoMap = new LinkedHashMap<>();
     private List<ImportTypesHelper.Builder> _builders = new ArrayList<>();
     private Map<File, Pair<String, String>> _inputDataMap;


### PR DESCRIPTION
#### Rationale
This fixes the problem detailed in this issue:
- https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43615

There are some scenarios where trying to create a new dataset using a file watcher will fail if the triggered file has a number in it's name.

#### Changes
- update the regular expression used in the file watcher schema reader so that all characters (in the name) are accepted.