### PR TITLE
delete cross-run data outputs

### DIFF
--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -107,7 +107,7 @@ import static java.util.Collections.unmodifiableCollection;
 public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> implements AssayRunCreator<ProviderType>
 {
     private static final Logger LOG = LogManager.getLogger(DefaultAssayRunCreator.class);
-    private static final String CROSS_RUN_DATA_INPUT_ROLE = "cross run input";
+    public static final String CROSS_RUN_DATA_INPUT_ROLE = "cross run input";
 
     private final ProviderType _provider;
 

--- a/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
@@ -652,7 +652,10 @@ public class DefaultQueryUpdateService extends AbstractQueryUpdateService
         // get rid of the properties for this table
         if (null != getObjectUriColumn())
         {
-            SQLFragment lsids = new SQLFragment("SELECT t." + getObjectUriColumn().getColumnName() + " FROM ").append(getDbTable(), "t");
+            SQLFragment lsids = new SQLFragment()
+                    .append("SELECT t.").append(getObjectUriColumn().getColumnName())
+                    .append(" FROM ").append(getDbTable(), "t")
+                    .append(" WHERE t.").append(getObjectUriColumn().getColumnName()).append(" IS NOT NULL");
             OntologyManager.deleteOntologyObjects(ExperimentService.get().getSchema(), lsids, container, false);
         }
 

--- a/assay/src/org/labkey/assay/AssayIntegrationTestCase.jsp
+++ b/assay/src/org/labkey/assay/AssayIntegrationTestCase.jsp
@@ -377,5 +377,12 @@
         var dataList = ExperimentService.get().getAllExpDataByURL(firstData.getDataFileUrl(), null);
         assertEquals(assayOutputData, dataList.get(0));
         assertEquals(firstData, dataList.get(1));
+        assertEquals(dataList.size(), 2);
+
+        log.info("delete the run and verify the duplicate exp.data was also deleted");
+        assayRun.delete(user);
+        dataList = ExperimentService.get().getAllExpDataByURL(firstData.getDataFileUrl(), null);
+        assertEquals(firstData, dataList.get(0));
+        assertEquals(dataList.size(), 1);
     }
 %>

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -3788,6 +3788,15 @@ public class ExperimentServiceImpl implements ExperimentService
                     {
                         for (ExpDataImpl output : datasToDelete)
                         {
+                            // Don't delete the exp.data output if it is being used in other runs
+                            List<? extends ExpRun> otherUsages = ExperimentService.get().getRunsUsingDatas(List.of(output));
+                            otherUsages.remove(run);
+                            if (!otherUsages.isEmpty())
+                            {
+                                LOG.debug("Skipping delete of cross-run data '" + output.getName() + "' (" + output.getRowId() + ") used by other runs: " + otherUsages.stream().map(ExpRun::getName).collect(Collectors.joining(", ")));
+                                continue;
+                            }
+
                             for (ExpDataImpl input : inputData)
                             {
                                 if (input.getDataFileUrl().equals(output.getDataFileUrl()))

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -40,6 +40,7 @@ import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.AssayTableMetadata;
 import org.labkey.api.assay.AssayWellExclusionService;
+import org.labkey.api.assay.DefaultAssayRunCreator;
 import org.labkey.api.attachments.AttachmentParent;
 import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.audit.AuditLogService;
@@ -3780,6 +3781,21 @@ public class ExperimentServiceImpl implements ExperimentService
                     // Grab these to delete after we've deleted the Data rows
                     List<ExpDataImpl> datasToDelete = getAllDataOwnedByRun(runId);
 
+                    // Find the cross-run file inputs: data outputs that are have the same dataFileUrl as an input
+                    List<ExpDataImpl> crossRun = new ArrayList<>();
+                    List<ExpDataImpl> inputData = run.getInputDatas(DefaultAssayRunCreator.CROSS_RUN_DATA_INPUT_ROLE, null);
+                    if (!inputData.isEmpty())
+                    {
+                        for (ExpDataImpl output : datasToDelete)
+                        {
+                            for (ExpDataImpl input : inputData)
+                            {
+                                if (input.getDataFileUrl().equals(output.getDataFileUrl()))
+                                    crossRun.add(output);
+                            }
+                        }
+                    }
+
                     // Archive all data files prior to deleting
                     //  ideally this would be transacted as a commit task but we decided against it due to complications
                     run.archiveDataFiles(user);
@@ -3790,6 +3806,13 @@ public class ExperimentServiceImpl implements ExperimentService
                     {
                         ExperimentDataHandler handler = data.findDataHandler();
                         handler.deleteData(data, container, user);
+                    }
+
+                    // Delete the cross run data completely
+                    for (ExpDataImpl data : crossRun)
+                    {
+                        LOG.debug("Deleting cross-run data: name=" + data.getName() + ", rowId=" + data.getRowId() + ", dataFileUrl=" + data.getDataFileUrl());
+                        data.delete(user, false);
                     }
 
                     if (protocolImpl != null)


### PR DESCRIPTION
#### Rationale
When deleting a run, delete any duplicated exp.data outputs created when importing a file into an assay that are already claimed as an output of a run.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2445
* https://github.com/LabKey/platform/pull/2466

#### Changes
* Clean up the duplicate exp.data identified with the "cross run input" role and the same dataFileUrl path
* When truncating a table, select non-null LSID values to delete ontology objects
