### PR TITLE
Fix SMAliquotImportExportTest.testCreateRootAliquotAndSubAliquot

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -6452,7 +6452,11 @@ public class ExperimentServiceImpl implements ExperimentService
                 if (rec._action.getActionSequence() == SIMPLE_PROTOCOL_CORE_STEP_SEQUENCE)
                 {
                     ExpMaterial parent = rec._runRecord.getAliquotInput();
-                    boolean isParentRootMaterial = StringUtils.isEmpty(parent.getAliquotedFromLSID());
+
+                    // in the case when a sample, its aliquots, and subaliquots are imported/created together, the subaliquots's parent aliquot might not have AliquotedFromLSID yet.
+                    // Use cache to double check detemine subaliquots's root
+                    boolean isParentRootMaterial = StringUtils.isEmpty(parent.getAliquotedFromLSID()) && !_aliquotRootCache.containsKey(parent.getLSID());
+
                     for (ExpMaterial outputAliquot : rec._runRecord.getAliquotOutputs())
                     {
                         SQLFragment sql = new SQLFragment("UPDATE ").append(getTinfoMaterial(), "").


### PR DESCRIPTION
#### Rationale
A bug is revealed for subaliquot import by test automation. Specifically, if a sample, its aliquots and subaliquots are imported at the same time, the subalqiuots might not have the correct root sample populated.

Sample import processes lineage in a batch. In the case when a sample, its aliquots, and subaliquots are imported/created together and processed in the same batch, the subaliquots's parent aliquot might not have AliquotedFromLSID set yet. This is resulting in the subaliquots to not correctly finding its root sample. We should not rely on AliquotedFromLSID solely to determine its aliquot's root sample during import.
                   
#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/637

#### Changes
* Check _aliquotRootCache for aliquot parents that are newly created
