### PR TITLE
Issue 43508: Improve visibility of which user ID enabled which ETLs

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementUserListener.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementUserListener.java
@@ -29,16 +29,6 @@ import java.beans.PropertyChangeEvent;
 public class AnnouncementUserListener implements UserListener
 {
     @Override
-    public void propertyChange(PropertyChangeEvent evt)
-    {
-    }
-
-    @Override
-    public void userAddedToSite(User user)
-    {
-    }
-
-    @Override
     public void userDeletedFromSite(User user)
     {
         AnnouncementManager.deleteUserFromAllMemberLists(user);

--- a/api/src/org/labkey/api/security/GroupMembershipCache.java
+++ b/api/src/org/labkey/api/security/GroupMembershipCache.java
@@ -188,11 +188,6 @@ public class GroupMembershipCache
     public static class GroupMembershipUserListener implements UserListener
     {
         @Override
-        public void userAddedToSite(User user)
-        {
-        }
-
-        @Override
         public void userDeletedFromSite(User user)
         {
             // Blow away groups immediately after user is deleted, otherwise this user's groups, and therefore permissions, will remain active
@@ -211,11 +206,6 @@ public class GroupMembershipCache
         public void userAccountEnabled(User user)
         {
             uncache(user);
-        }
-
-        @Override
-        public void propertyChange(PropertyChangeEvent evt)
-        {
         }
     }
 }

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -390,13 +390,6 @@ public class SecurityManager
 
     private static class SecurityUserListener implements UserManager.UserListener
     {
-
-        @Override
-        public void userAddedToSite(User user)
-        {
-            // do nothing
-        }
-
         @Override
         public void userDeletedFromSite(User user)
         {
@@ -409,18 +402,6 @@ public class SecurityManager
         {
             // This clears the cache of security policies. It does not remove the policies themselves.
             SecurityPolicyManager.removeAll();
-        }
-
-        @Override
-        public void userAccountEnabled(User user)
-        {
-            // do nothing
-        }
-
-        @Override
-        public void propertyChange(PropertyChangeEvent evt)
-        {
-            // do nothing
         }
     }
 

--- a/core/src/org/labkey/core/notification/EmailPreferenceUserListener.java
+++ b/core/src/org/labkey/core/notification/EmailPreferenceUserListener.java
@@ -8,29 +8,9 @@ import java.beans.PropertyChangeEvent;
 public class EmailPreferenceUserListener implements UserManager.UserListener
 {
     @Override
-    public void userAddedToSite(User user)
-    {
-    }
-
-    @Override
     public void userDeletedFromSite(User user)
     {
         //when user is deleted from site, remove any corresponding record from EmailPrefs table.
         EmailPreferenceConfigManager.deleteUserEmailPref(user, null);
-    }
-
-    @Override
-    public void userAccountDisabled(User user)
-    {
-    }
-
-    @Override
-    public void userAccountEnabled(User user)
-    {
-    }
-
-    @Override
-    public void propertyChange(PropertyChangeEvent evt)
-    {
     }
 }

--- a/core/src/org/labkey/core/user/deactivateUsers.jsp
+++ b/core/src/org/labkey/core/user/deactivateUsers.jsp
@@ -20,6 +20,8 @@
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.core.user.DeactivateUsersBean" %>
+<%@ page import="org.labkey.api.security.UserManager" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
@@ -35,8 +37,16 @@
     <%
         for (User user : bean.getUsers())
         {
-            %><li><%=h(user.getDisplayName(currentUser))%></li><%
-        } 
+            %><li><%=h(user.getDisplayName(currentUser))%><%
+            if (!bean.isActivate()) { %>
+                <ul>
+                    <% for (HtmlString message : UserManager.previewUserAccountDeactivated(user)) { %>
+                    <li><%= message %></li>
+                    <% } %>
+                </ul>
+            <% } %>
+            </li> <%
+        }
     %>
     </ul>
 <labkey:form action="<%=urlPost%>" method="post">

--- a/core/src/org/labkey/core/user/deleteUsers.jsp
+++ b/core/src/org/labkey/core/user/deleteUsers.jsp
@@ -21,6 +21,8 @@
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.core.user.DeleteUsersBean" %>
 <%@ page import="org.labkey.core.user.UserController.DeactivateUsersAction" %>
+<%@ page import="org.labkey.api.security.UserManager" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
@@ -36,10 +38,16 @@
 the following <%=h(bean.getUsers().size() > 1 ? "users" : "user")%>?
 This action cannot be undone.</p>
     <ul>
-    <%
-        for (User user : bean.getUsers())
-        {
-            %><li><%=h(user.getDisplayName(currentUser))%></li><%
+        <%
+            for (User user : bean.getUsers())
+            {
+        %><li><%=h(user.getDisplayName(currentUser))%>
+        <ul>
+            <% for (HtmlString message : UserManager.previewUserAccountDeleted(user)) { %>
+            <li><%= message %></li>
+            <% } %>
+        </ul>
+    </li> <%
         }
     %>
     </ul>

--- a/issues/src/org/labkey/issue/IssueUserListener.java
+++ b/issues/src/org/labkey/issue/IssueUserListener.java
@@ -54,11 +54,6 @@ public class IssueUserListener implements UserListener
     }
 
     @Override
-    public void propertyChange(PropertyChangeEvent evt)
-    {
-    }
-
-    @Override
     public void userPropertiesUpdated(int userid)
     {
         IssueManager.uncache(); // Might change assigned to lists (e.g., display name, see #9611)

--- a/mothership/src/org/labkey/mothership/MothershipModule.java
+++ b/mothership/src/org/labkey/mothership/MothershipModule.java
@@ -173,29 +173,9 @@ public class MothershipModule extends DefaultModule
         UserManager.addUserListener(new UserManager.UserListener()
         {
             @Override
-            public void userAddedToSite(User user)
-            {
-            }
-
-            @Override
             public void userDeletedFromSite(User user)
             {
                 MothershipManager.get().deleteForUser(user);
-            }
-
-            @Override
-            public void userAccountDisabled(User user)
-            {
-            }
-
-            @Override
-            public void userAccountEnabled(User user)
-            {
-            }
-
-            @Override
-            public void propertyChange(PropertyChangeEvent evt)
-            {
             }
         });
     }


### PR DESCRIPTION
#### Rationale
Disabling or deleting users may have important side effects. We want to preview these for admins

#### Changes
* Let UserListeners give feedback on what will happen if a user is deleted or deactivated
* Don't force UserListener implementations to implement every method