### PR TITLE
Issue 43636: Eliminate syntax error from having two AS clauses

### DIFF
--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -6980,7 +6980,17 @@ public class ExperimentController extends SpringActionController
             if (!haveData) // no data to return but return data in the expected shape.
             {
                 sql = new SQLFragment("SELECT\n");
-                sql.append(orderedIdCols.stream().map(col -> "NULL AS " + col).collect(Collectors.joining(",\t\n")));
+                sql.append(orderedIdCols.stream()
+                        .map(col -> {
+                            int asIndex = col.indexOf("AS");
+                            if (asIndex > 0)
+                            {
+                                return "NULL AS " + col.substring(asIndex+ 3);
+                            }
+                            else
+                                return "NULL AS " + col;
+                        })
+                        .collect(Collectors.joining(",\t\n")));
                 sql.append(",\t\n").append(StringUtils.join(sampleColumns, ",\t\n"));
                 sql.append("\nFROM ").append(samplesTable).append(" S WHERE 1 = 2");
                 return sql;

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -6984,9 +6984,7 @@ public class ExperimentController extends SpringActionController
                         .map(col -> {
                             int asIndex = col.indexOf("AS");
                             if (asIndex > 0)
-                            {
                                 return "NULL AS " + col.substring(asIndex+ 3);
-                            }
                             else
                                 return "NULL AS " + col;
                         })


### PR DESCRIPTION
#### Rationale
Where there are no data columns available, we want the SQL to have all the columns that would have appeared, but we can't alias the NULL value for the ID twice.  We had been producing SQL like "NULL AS ID AS ProvidedID".  Now we produce "NULL AS ProvidedID".

#### Related Pull Requests
#2444 

#### Changes
* Update empty results SQL
