### PR TITLE
Issue 43648: Study dataset reorder page jumps to top when there are enough datasets to make the page include a scrollbar

### DIFF
--- a/core/src/org/labkey/core/admin/reorderFolders.jsp
+++ b/core/src/org/labkey/core/admin/reorderFolders.jsp
@@ -41,6 +41,12 @@
             isCustomOrder = true;
     }
 %>
+<style>
+    .button-reordering {
+        width: 85px;
+        margin-bottom: 5px;
+    }
+</style>
 <script type="text/javascript">
 function saveList()
 {
@@ -136,9 +142,9 @@ function toggleItemSelector()
                 %>
                 </select>
             </td>
-            <td>
-                <%= button("Move Up").submit(true).onClick("return orderModule(0)") %><br><br>
-                <%= button("Move Down").submit(true).onClick("return orderModule(1)") %>
+            <td align="center" valign="center" style="padding-left: 10px;">
+                <%= button("Move Up").addClass("button-reordering").onClick("return orderModule(0)") %><br>
+                <%= button("Move Down").addClass("button-reordering").onClick("return orderModule(1)") %>
             </td>
         </tr>
     </table>

--- a/study/src/org/labkey/study/view/datasetDisplayOrder.jsp
+++ b/study/src/org/labkey/study/view/datasetDisplayOrder.jsp
@@ -23,12 +23,10 @@
 <%@ page extends="org.labkey.study.view.BaseStudyPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <script>
-function saveList(listName)
-{
+function saveList() {
     var itemList = "";
     var itemSelect = document.reorder.items;
-    for (var i = 0; i < itemSelect.length; i++)
-    {
+    for (var i = 0; i < itemSelect.length; i++) {
         itemList += itemSelect.item(i).value;
         if (i < itemSelect.length - 1)
             itemList += ",";
@@ -36,45 +34,32 @@ function saveList(listName)
     document.reorder.order.value = itemList;
 }
 
-function submitReset()
-{
+function submitReset() {
     var form = document.reorder;
     var itemSelect = form.resetOrder.value = true;
     form.submit();
     return false;
 }
 
-function orderModule(down)
-{
+function moveDatasetItem(action) {
     var itemSelect = document.reorder.items;
     var selIndex = itemSelect.selectedIndex;
-    if (selIndex != -1)
-    {
-        var swapItem = null;
-        if (selIndex > 0 && down == 0)
-        {
-            swapItem = itemSelect.item(selIndex - 1);
-            itemSelect.selectedIndex--;
+    if (selIndex !== -1) {
+        var selItem = itemSelect.item(selIndex);
+        var isFirst = selIndex === 0;
+        var isLast = selIndex === itemSelect.length - 1;
+
+        if (action === 'top' && !isFirst) {
+            document.reorder.items.insertBefore(selItem, itemSelect.item(0));
+        } else if (action === 'bottom' && !isLast) {
+            document.reorder.items.appendChild(selItem);
+        } else if (action === 'up' && !isFirst) {
+            document.reorder.items.insertBefore(selItem, itemSelect.item(selIndex - 1));
+        } else if (action === 'down' && !isLast) {
+            document.reorder.items.insertBefore(selItem, itemSelect.item(selIndex + 2));
         }
-        else if (selIndex < itemSelect.length-1 && down == 1)
-        {
-            swapItem = itemSelect.item(selIndex + 1);
-            itemSelect.selectedIndex++;
-        }
-        if (swapItem != null)
-        {
-            var selItem = itemSelect.item(selIndex);
-            var selText = selItem.text;
-            var selValue = selItem.value;
-            selItem.text = swapItem.text;
-            selItem.value = swapItem.value;
-            swapItem.text = selText;
-            swapItem.value = selValue;
-            saveList();
-        }
-    }
-    else
-    {
+        saveList();
+    } else {
         alert("Please select a dataset first.");
     }
     return false;
@@ -115,9 +100,11 @@ function orderModule(down)
                 %>
                 </select>
             </td>
-            <td align="center" valign="center">
-                <%= button("Move Up").submit(true).onClick("return orderModule(0)") %><br><br>
-                <%= button("Move Down").submit(true).onClick("return orderModule(1)") %>
+            <td align="center" valign="center" style="padding-left: 10px;">
+                <%= button("Move Up").onClick("return moveDatasetItem('up')") %><br>
+                <%= button("Move Down").onClick("return moveDatasetItem('down')") %><br><br>
+                <%= button("Move to Top").onClick("return moveDatasetItem('top')") %><br>
+                <%= button("Move to Bottom").onClick("return moveDatasetItem('bottom')") %>
             </td>
         </tr>
     </table>

--- a/study/src/org/labkey/study/view/datasetDisplayOrder.jsp
+++ b/study/src/org/labkey/study/view/datasetDisplayOrder.jsp
@@ -22,6 +22,12 @@
 <%@ page import="java.util.List" %>
 <%@ page extends="org.labkey.study.view.BaseStudyPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+<style>
+    .button-reordering {
+        width: 115px;
+        margin-bottom: 5px;
+    }
+</style>
 <script>
 function saveList() {
     var itemList = "";
@@ -74,7 +80,7 @@ function moveDatasetItem(action) {
                     List<DatasetDefinition> defs = getDatasets();
                     boolean first = true;
                 %>
-                <select name="items" size="<%= defs.size() %>">
+                <select name="items" style="width: 400px;" size="<%=Math.min(Math.max(defs.size(), 10), 25)%>">
                 <%
                 for (Dataset def: defs)
                 {
@@ -101,10 +107,10 @@ function moveDatasetItem(action) {
                 </select>
             </td>
             <td align="center" valign="center" style="padding-left: 10px;">
-                <%= button("Move Up").onClick("return moveDatasetItem('up')") %><br>
-                <%= button("Move Down").onClick("return moveDatasetItem('down')") %><br><br>
-                <%= button("Move to Top").onClick("return moveDatasetItem('top')") %><br>
-                <%= button("Move to Bottom").onClick("return moveDatasetItem('bottom')") %>
+                <%= button("Move Up").addClass("button-reordering").onClick("return moveDatasetItem('up')") %><br>
+                <%= button("Move Down").addClass("button-reordering").onClick("return moveDatasetItem('down')") %><br><br>
+                <%= button("Move to Top").addClass("button-reordering").onClick("return moveDatasetItem('top')") %><br>
+                <%= button("Move to Bottom").addClass("button-reordering").onClick("return moveDatasetItem('bottom')") %>
             </td>
         </tr>
     </table>

--- a/study/src/org/labkey/study/view/visitOrder.jsp
+++ b/study/src/org/labkey/study/view/visitOrder.jsp
@@ -34,6 +34,16 @@
     if (null == returnURL)
         returnURL = urlFor(ManageVisitsAction.class);
 %>
+<style>
+    .button-reordering {
+        width: 85px;
+        margin-bottom: 5px;
+    }
+
+    .section-spacing {
+        padding-left: 50px;
+    }
+</style>
 <script type="text/javascript">
 function saveList(listName, hiddenElName)
 {
@@ -90,7 +100,7 @@ function orderModule(listName, hiddenElName, down)
             <th style="font-weight: bold;" colspan="2">Display Order<%= helpPopup("Display Order", "Display order determines the order in which visits appear in reports and views for all " +
                     "study and specimen data. By default, visits are displayed in order of increasing visit ID for visit-based studies, and in date " +
                     "order for date-based studies.")%></th>
-            <th style="font-weight: bold;" colspan="2">Chronological Order<%= helpPopup("Chronological Order", "Chronological visit order is used to determine which visits occurred before " +
+            <th class="section-spacing" style="font-weight: bold;" colspan="2">Chronological Order<%= helpPopup("Chronological Order", "Chronological visit order is used to determine which visits occurred before " +
                     "or after others. Visits are chronologically ordered when all participants move only downward through the visit list. Any given " +
                     StudyService.get().getSubjectNounSingular(getContainer()).toLowerCase() + " may skip some visits, depending on " +
                     "cohort assignment or other factors. It is generally not useful to set a chronological order for date-based studies.")%></th>
@@ -108,14 +118,14 @@ function orderModule(listName, hiddenElName, down)
             }
         %>
         <tr>
-            <td colspan="2" style="padding-right: 50px;">
+            <td colspan="2">
                 <input type="checkbox"
                        name="explicitDisplayOrder"
                        value="true"<%=checked(displayEnabled)%>
                        onClick="document.reorder.displayOrderItems.disabled = !this.checked;">
                 Explicitly set display order
             </td>
-            <td colspan="2">
+            <td colspan="2" class="section-spacing">
                 <input type="checkbox"
                        name="explicitChronologicalOrder"
                        value="true"<%=checked(chronologicalEnabled) %>
@@ -125,7 +135,7 @@ function orderModule(listName, hiddenElName, down)
         </tr>
         <tr>
             <td>
-                <select multiple name="displayOrderItems" size="<%= Math.min(visits.size(), 25) %>"<%=disabled(!displayEnabled)%>>
+                <select multiple name="displayOrderItems" style="width: 200px;" size="<%= Math.min(visits.size(), 25) %>"<%=disabled(!displayEnabled)%>>
                 <%
                     boolean first = true;
                     StringBuilder orderedList = new StringBuilder();
@@ -150,13 +160,13 @@ function orderModule(listName, hiddenElName, down)
                 </select>
                 <input type="hidden" name="displayOrder" value="<%= h(orderedList) %>">
             </td>
-            <td align="center" valign="center">
-                <%= button("Move Up").href("#").onClick("return orderModule('displayOrderItems', 'displayOrder', 0);") %><br><br>
-                <%= button("Move Down").href("#").onClick("return orderModule('displayOrderItems', 'displayOrder', 1);") %>
+            <td align="center" valign="center" style="padding-left: 10px;">
+                <%= button("Move Up").addClass("button-reordering").onClick("return orderModule('displayOrderItems', 'displayOrder', 0);") %><br>
+                <%= button("Move Down").addClass("button-reordering").onClick("return orderModule('displayOrderItems', 'displayOrder', 1);") %>
             </td>
 
-            <td>
-                <select multiple name="chronologicalOrderItems" size="<%= Math.min(visits.size(), 25) %>"<%=disabled(!chronologicalEnabled)%>>
+            <td class="section-spacing">
+                <select multiple name="chronologicalOrderItems" style="width: 200px;" size="<%= Math.min(visits.size(), 25) %>"<%=disabled(!chronologicalEnabled)%>>
                 <%
                     visits = getVisits(Visit.Order.CHRONOLOGICAL);
                     first = true;
@@ -183,9 +193,9 @@ function orderModule(listName, hiddenElName, down)
                 <input type="hidden" name="chronologicalOrder" value="<%= h(orderedList) %>">
                 <%=generateReturnUrlFormField(returnURL)%>
             </td>
-            <td align="center" valign="center">
-                <%= button("Move Up").href("#").onClick("return orderModule('chronologicalOrderItems', 'chronologicalOrder', 0)") %><br><br>
-                <%= button("Move Down").href("#").onClick("return orderModule('chronologicalOrderItems', 'chronologicalOrder', 1)") %>
+            <td align="center" valign="center" style="padding-left: 10px;">
+                <%= button("Move Up").addClass("button-reordering").onClick("return orderModule('chronologicalOrderItems', 'chronologicalOrder', 0)") %><br>
+                <%= button("Move Down").addClass("button-reordering").onClick("return orderModule('chronologicalOrderItems', 'chronologicalOrder', 1)") %>
             </td>
         </tr>
     </table>


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43648

Client reported that with a 21.3.4 change it got much more difficult to reorder study datasets when there are a large number of datasets in the study (i.e. in their example, see support ticket details, they have >200 datasets). In addition to fixing the "page jump" issue, this PR adds in new "move to top" and "move to bottom" buttons to help with the client scenario.

#### Changes
* update datasetDisplayOrder.jsp to use insertBefore() and appendChilde() to move select option items 
* remove "submit" from move buttons to prevent page jump on click
* add "move to top" and "move to bottom" buttons
* similar button styling updates for Manage Visit Order and Project Display Order pages