### PR TITLE
Support queuing study reloads and ETLs as part of an EHR module upgrade

### DIFF
--- a/api/src/org/labkey/api/data/UpgradeCode.java
+++ b/api/src/org/labkey/api/data/UpgradeCode.java
@@ -24,4 +24,12 @@ package org.labkey.api.data;
  */
 public interface UpgradeCode
 {
+    /**
+     * Allow upgrade code to handle arbitrary 'method names', essentially allowing parameterized Java upgrade code.
+     * For example, the method name could include the name of an ETL to execute
+     */
+    default void fallthroughHandler(String methodName)
+    {
+        throw new RuntimeException("Can't find method " + methodName + "(ModuleContext moduleContext) on class " + this.getClass().getName());
+    }
 }

--- a/api/src/org/labkey/api/di/DataIntegrationService.java
+++ b/api/src/org/labkey/api/di/DataIntegrationService.java
@@ -47,6 +47,8 @@ public interface DataIntegrationService
     void registerStepProviders();
     @Nullable Integer runTransformNow(Container c, User u, String transformId) throws PipelineJobException, NotFoundException;
 
+    Map<String, String> truncateTargets(Container c, User user, String transformId);
+
     RemoteConnection getRemoteConnection(String name, Container c, @Nullable Logger log);
 
     /**
@@ -58,7 +60,7 @@ public interface DataIntegrationService
      *
      * Target table must have columns diModified (TIMESTAMP) and/or diImportHash (VARCHAR)
      *   if it exists diModified column will be matched to input column "modified"
-     *   if it exists diImportHash columnm will be matched against an MD5 hash of the raw (unconverted) data values from input dataiterator
+     *   if it exists diImportHash column will be matched against an MD5 hash of the raw (unconverted) data values from input dataiterator
      * NOTE: if dataiterator contains generated data (e.g. LSID, they can be excluded form hash using setHashColumns)
      * NOTE: hash is column order sensitive
      *
@@ -94,7 +96,7 @@ public interface DataIntegrationService
         void setModifiedSince(Timestamp modifiedSince);
 
         /** config params to pass to QUS insert/merge */
-        public void setConfigParameters(Map<Enum,Object> config);
+        void setConfigParameters(Map<Enum, Object> config);
 
         /** check that this Reimport configuration is valid (valid target table, valid options etc) */
         void validate();

--- a/api/src/org/labkey/api/study/StudyService.java
+++ b/api/src/org/labkey/api/study/StudyService.java
@@ -179,7 +179,7 @@ public interface StudyService
 
     Set<? extends Study> getAllStudies(Container root);
 
-    boolean runStudyImportJob(Container c, User user, ActionURL url, File studyXml, String originalFilename, BindException errors, PipeRoot pipelineRoot, ImportOptions options);
+    boolean runStudyImportJob(Container c, User user, @Nullable ActionURL url, File studyXml, String originalFilename, BindException errors, PipeRoot pipelineRoot, ImportOptions options);
 
     ColumnInfo createAlternateIdColumn(TableInfo ti, ColumnInfo column, Container c);
 

--- a/study/src/org/labkey/study/StudyServiceImpl.java
+++ b/study/src/org/labkey/study/StudyServiceImpl.java
@@ -566,7 +566,7 @@ public class StudyServiceImpl implements StudyService
     }
 
     @Override
-    public boolean runStudyImportJob(Container c, User user, ActionURL url, File studyXml, String originalFilename, BindException errors, PipeRoot pipelineRoot, ImportOptions options)
+    public boolean runStudyImportJob(Container c, User user, @Nullable ActionURL url, File studyXml, String originalFilename, BindException errors, PipeRoot pipelineRoot, ImportOptions options)
     {
         try
         {


### PR DESCRIPTION
#### Rationale
We want to enable more dev-ops style upgrade operations, including automatically kicking off study reloads and ETLs as part of an EHR module upgrade sequence

#### Changes
* Let UpgradeCode implementations recognize Java upgrade code requests that don't map directly to a Java method
* Expose truncate API for ETLs