### PR TITLE
Issue 43649: Support substitutions in URL fragment

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -60,6 +60,7 @@ import org.labkey.api.module.ModuleXml;
 import org.labkey.api.module.TomcatVersion;
 import org.labkey.api.query.AbstractQueryUpdateService;
 import org.labkey.api.query.AliasManager;
+import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.reader.ExcelFactory;
@@ -152,6 +153,7 @@ public class ApiModule extends CodeOnlyModule
             DatabaseCache.TestCase.class,
             DataIteratorUtil.TestCase.class,
             DateUtil.TestCase.class,
+            DetailsURL.TestCase.class,
             DbScope.DialectTestCase.class,
             DiskCachingDataIterator.DiskTestCase.class,
             EmailTemplate.TestCase.class,


### PR DESCRIPTION
#### Rationale
Allows for URL Fragments to be processed and passed through for `DetailURL` objects. This was already supported by default URL string processing but `DetailsURL` had incorrect assumptions about the composition of the URL, namely, that only the query string exists beyond the path.

#### Changes
* Support processing URL Fragments in `DetailsURL`.
* Add unit test coverage
