### PR TITLE
43561: Pass nameExpression via ColumnInfo

### DIFF
--- a/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
@@ -250,6 +250,12 @@ public abstract class AbstractWrappedColumnInfo implements ColumnInfo
     }
 
     @Override
+    public String getNameExpression()
+    {
+        return delegate.getNameExpression();
+    }
+
+    @Override
     public boolean isAutoIncrement()
     {
         return delegate.isAutoIncrement();

--- a/api/src/org/labkey/api/data/ColumnRenderProperties.java
+++ b/api/src/org/labkey/api/data/ColumnRenderProperties.java
@@ -82,6 +82,8 @@ public interface ColumnRenderProperties extends ImportAliasable
 
     DefaultScaleType getDefaultScale();
 
+    String getNameExpression();
+
     boolean isDimension();
 
     boolean isMeasure();

--- a/api/src/org/labkey/api/data/ColumnRenderPropertiesImpl.java
+++ b/api/src/org/labkey/api/data/ColumnRenderPropertiesImpl.java
@@ -75,6 +75,7 @@ public abstract class ColumnRenderPropertiesImpl implements MutableColumnRenderP
     protected String _shortLabel;
     protected String _description;
     protected boolean _hidden;
+    protected String _nameExpression;
     protected Boolean _measure;
     protected Boolean _dimension;
     protected Boolean _recommendedVariable = false;
@@ -553,6 +554,17 @@ public abstract class ColumnRenderPropertiesImpl implements MutableColumnRenderP
             return inferIsMeasure(getName(), getLabel(), isNumericType(), isAutoIncrement(), isLookup(), isHidden());
         else
             return _measure;
+    }
+
+    public String getNameExpression()
+    {
+        return _nameExpression;
+    }
+
+    public void setNameExpression(String nameExpression)
+    {
+        assert _checkLocked();
+        _nameExpression = nameExpression;
     }
 
     /** value must not be null/empty */

--- a/api/src/org/labkey/api/data/JsonWriter.java
+++ b/api/src/org/labkey/api/data/JsonWriter.java
@@ -261,6 +261,9 @@ public class JsonWriter
 
                 props.put("crosstabColumnDimension", cinfo.getCrosstabColumnDimension());
             }
+
+            if (cinfo.getNameExpression() != null)
+                props.put("nameExpression", cinfo.getNameExpression());
         }
         else
         {

--- a/api/src/org/labkey/api/data/MutableColumnRenderProperties.java
+++ b/api/src/org/labkey/api/data/MutableColumnRenderProperties.java
@@ -58,6 +58,8 @@ public interface MutableColumnRenderProperties extends ColumnRenderProperties
 
     void setDimension(boolean dimension);
 
+    void setNameExpression(String nameExpression);
+
     void setNullable(boolean nullable);
 
     void setRequired(boolean required);

--- a/api/src/org/labkey/api/data/WrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/WrappedColumnInfo.java
@@ -395,6 +395,20 @@ public class WrappedColumnInfo
         }
 
         @Override
+        public void setNameExpression(String nameExpression)
+        {
+            checkLocked();
+            delegate = new AbstractWrappedColumnInfo(delegate)
+            {
+                @Override
+                public String getNameExpression()
+                {
+                    return nameExpression;
+                }
+            };
+        }
+
+        @Override
         public void setMeasure(boolean measure)
         {
             checkLocked();

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -200,6 +200,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 var c = wrapColumn(alias, getRealTable().getColumn(column.name()));
                 // TODO: Name is editable in insert view, but not in update view
                 String nameExpression = _dataClass.getNameExpression();
+                c.setNameExpression(nameExpression);
                 c.setNullable(nameExpression != null);
                 String desc = ExpMaterialTableImpl.appendNameExpressionDescription(c.getDescription(), nameExpression);
                 c.setDescription(desc);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -480,8 +480,10 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             // Show the Name field but don't mark is as required when using name expressions
             if (st.hasNameExpression())
             {
+                var nameExpression = st.getNameExpression();
+                nameCol.setNameExpression(nameExpression);
                 nameCol.setNullable(true);
-                String desc = appendNameExpressionDescription(nameCol.getDescription(), st.getNameExpression());
+                String desc = appendNameExpressionDescription(nameCol.getDescription(), nameExpression);
                 nameCol.setDescription(desc);
             }
             else


### PR DESCRIPTION
#### Rationale
Adds support for passing the `nameExpression` to a `ColumnInfo` so it can be serialized to the client.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/959
* https://github.com/LabKey/platform/pull/2510
* https://github.com/LabKey/recipe/pull/56
* https://github.com/LabKey/labkey-api-js/pull/107
* https://github.com/LabKey/labkey-ui-components/pull/593

#### Changes
* Set the name expression on the column info for `ExpDataClassDataTable` and `ExpMaterialTable` implementations.
* Serialize in `JsonWriter`.
