### PR TITLE
Issue 43647: SM: creating aliquots for a sample type with a required field gives an error

### DIFF
--- a/api/src/org/labkey/api/data/validator/ColumnValidator.java
+++ b/api/src/org/labkey/api/data/validator/ColumnValidator.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.data.validator;
 
+import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.exp.property.ValidatorContext;
 
 /**
@@ -25,4 +26,10 @@ public interface ColumnValidator
     String validate(int rowNum, Object value);
 
     String validate(int rowNum, Object value, ValidatorContext validatorContext);
+
+    default String validate(int rowNum, Object value, DataIterator data)
+    {
+        return validate(rowNum, value);
+    }
+
 }

--- a/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
@@ -105,7 +105,7 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
         dontRequire.add(name);
     }
 
-    private static class TranslateHelper
+    public static class TranslateHelper
     {
         TranslateHelper(ColumnInfo col, DomainProperty dp)
         {
@@ -116,6 +116,17 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
         int indexMv = SimpleTranslator.NO_MV_INDEX;
         ColumnInfo target;
         DomainProperty dp;
+
+        public ColumnInfo getTarget()
+        {
+            return target;
+        }
+
+        public DomainProperty getDp()
+        {
+            return dp;
+        }
+
     }
 
     @Override
@@ -271,8 +282,7 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
 
         if (_validate)
         {
-            ValidatorIterator validate = new ValidatorIterator(LoggingDataIterator.wrap(validateInput), context, _c, _user);
-            validate.setDebugName("StandardDIB validate");
+            ValidatorIterator validate = getValidatorIterator(validateInput, context, translateHelperMap, _c, _user);
 
             for (int index = 1; index <= validateInput.getColumnCount(); index++)
             {
@@ -290,7 +300,14 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
         return LoggingDataIterator.wrap(ErrorIterator.wrap(last, context, false, setupError));
     }
 
-    private String getTranslateHelperKey(ColumnInfo col)
+    protected ValidatorIterator getValidatorIterator(DataIterator validateInput, DataIteratorContext context, Map<String, TranslateHelper> translateHelperMap, Container c, User user)
+    {
+        ValidatorIterator validate = new ValidatorIterator(LoggingDataIterator.wrap(validateInput), context, c, user);
+        validate.setDebugName("StandardDIB validate");
+        return validate;
+    }
+
+    protected String getTranslateHelperKey(ColumnInfo col)
     {
         return col.getPropertyURI() + ":" + col.getName().toLowerCase();
     }

--- a/api/src/org/labkey/api/dataiterator/ValidatorIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ValidatorIterator.java
@@ -167,12 +167,8 @@ public class ValidatorIterator extends AbstractDataIterator implements DataItera
                 for (ColumnValidator v : l)
                 {
                     Object value = _data.get(i);
-                    String msg;
-                    // CONSIDER: add validatorContext to ColumnValidator.validate() always
-                    if (v instanceof PropertyValidator)
-                        msg = v.validate(rowNum, value, validatorContext);
-                    else
-                        msg = v.validate(rowNum, value);
+                    String msg = validate(v, rowNum, value, _data);
+
                     if (null != msg)
                     {
                         addFieldError(_data.getColumnInfo(i).getName(), msg);
@@ -209,6 +205,17 @@ public class ValidatorIterator extends AbstractDataIterator implements DataItera
         return true;
     }
 
+    protected String validate(ColumnValidator v, int rowNum, Object value, DataIterator data)
+    {
+        String msg;
+        // CONSIDER: add validatorContext to ColumnValidator.validate() always
+        if (v instanceof PropertyValidator)
+            msg = v.validate(rowNum, value, validatorContext);
+        else
+            msg = v.validate(rowNum, value);
+
+        return msg;
+    }
 
     @Override
     public Object get(int i)

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -218,7 +218,19 @@ public class ExpDataIterators
             if (!(v instanceof RequiredValidator) || _aliquotedFromColInd < 0)
                 return super.validate(v, rowNum, value, data);
 
-            String aliquotedFromValue = (String) data.get(_aliquotedFromColInd);
+            String aliquotedFromValue = null;
+            Object aliquotedFromObj = data.get(_aliquotedFromColInd);
+            if (aliquotedFromObj != null)
+            {
+                if (aliquotedFromObj instanceof String)
+                {
+                    aliquotedFromValue = (String) aliquotedFromObj;
+                }
+                else if (aliquotedFromObj instanceof Number)
+                {
+                    aliquotedFromValue = aliquotedFromObj.toString();
+                }
+            }
 
             // skip required field check for aliquots since aliquots properties are inherited
             if (!StringUtils.isEmpty(aliquotedFromValue))

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -16,6 +16,7 @@
 package org.labkey.experiment;
 
 import org.apache.commons.beanutils.ConvertUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
@@ -35,6 +36,8 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.UpdateableTableInfo;
+import org.labkey.api.data.validator.ColumnValidator;
+import org.labkey.api.data.validator.RequiredValidator;
 import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
@@ -44,7 +47,9 @@ import org.labkey.api.dataiterator.ExistingRecordDataIterator;
 import org.labkey.api.dataiterator.LoggingDataIterator;
 import org.labkey.api.dataiterator.Pump;
 import org.labkey.api.dataiterator.SimpleTranslator;
+import org.labkey.api.dataiterator.StandardDataIteratorBuilder;
 import org.labkey.api.dataiterator.TableInsertDataIteratorBuilder;
+import org.labkey.api.dataiterator.ValidatorIterator;
 import org.labkey.api.dataiterator.WrapperDataIterator;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.PropertyType;
@@ -189,6 +194,55 @@ public class ExpDataIterators
         }
     }
 
+    public static class ExpMaterialValidatorIterator extends ValidatorIterator
+    {
+        private Integer _aliquotedFromColInd = null;
+
+        public ExpMaterialValidatorIterator(DataIterator data, DataIteratorContext context, Container c, User user)
+        {
+            super(data, context, c, user);
+        }
+
+        @Override
+        protected String validate(ColumnValidator v, int rowNum, Object value, DataIterator data)
+        {
+            if (_aliquotedFromColInd == null)
+            {
+                Map<String, Integer> columnNameMap = ((SimpleTranslator) data).getColumnNameMap();
+                if (columnNameMap != null && columnNameMap.containsKey("AliquotedFrom"))
+                    _aliquotedFromColInd = columnNameMap.get("AliquotedFrom");
+                else
+                    _aliquotedFromColInd = -1;
+            }
+
+            if (!(v instanceof RequiredValidator) || _aliquotedFromColInd < 0)
+                return super.validate(v, rowNum, value, data);
+
+            String aliquotedFromValue = (String) data.get(_aliquotedFromColInd);
+
+            // skip required field check for aliquots since aliquots properties are inherited
+            if (!StringUtils.isEmpty(aliquotedFromValue))
+                return null;
+
+            return v.validate(rowNum, value);
+        }
+    }
+
+    public static class ExpMaterialDataIteratorBuilder extends StandardDataIteratorBuilder
+    {
+        public ExpMaterialDataIteratorBuilder(TableInfo target, @NotNull DataIteratorBuilder in, @Nullable Container c, @NotNull User user)
+        {
+            super(target, in, c, user);
+        }
+
+        @Override
+        protected ValidatorIterator getValidatorIterator(DataIterator validateInput, DataIteratorContext context, Map<String, TranslateHelper> translateHelperMap, Container c, User user)
+        {
+            ExpMaterialValidatorIterator validate = new ExpMaterialValidatorIterator(LoggingDataIterator.wrap(validateInput), context, c, user);
+            validate.setDebugName("ExpMaterialDataIteratorBuilder validate");
+            return validate;
+        }
+    }
 
     /**
      * Data iterator to handle aliases


### PR DESCRIPTION
#### Rationale
RequiredValidator fails import/creation for aliquots when the sample type has require fields. This PR modifies the import so that aliquots can bypass the required field validator

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/597
* https://github.com/LabKey/platform/pull/2524
* https://github.com/LabKey/sampleManagement/pull/653

#### Changes
*  skip RequiredValidation for sample fields that are required, if the sample is an aliquot
