### PR TITLE
Issue43480: Sample timeline shows sample link to study before registration

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -1131,14 +1131,13 @@ public class ExpDataIterators
 
             // Wire up derived parent/child data and materials
             DataIteratorBuilder step5 = LoggingDataIterator.wrap(new ExpDataIterators.DerivationDataIteratorBuilder(step4, _container, _user, isSample, false));
-            DataIteratorBuilder step6 = LoggingDataIterator.wrap(new AutoLinkToStudyDataIteratorBuilder(step5, isSample, _container, _user, _expTable));
 
             // Hack: add the alias and lsid values back into the input so we can process them in the chained data iterator
-            DataIteratorBuilder step7 = step6;
+            DataIteratorBuilder step6 = step5;
             if (null != _indexFunction)
-                step7 = LoggingDataIterator.wrap(new ExpDataIterators.SearchIndexIteratorBuilder(step6, _indexFunction)); // may need to add this after the aliases are set
+                step6 = LoggingDataIterator.wrap(new ExpDataIterators.SearchIndexIteratorBuilder(step5, _indexFunction)); // may need to add this after the aliases are set
 
-            return LoggingDataIterator.wrap(step7.getDataIterator(context));
+            return LoggingDataIterator.wrap(step6.getDataIterator(context));
         }
     }
 }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -164,7 +164,11 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             ExpSampleType sampleType = ((ExpMaterialTableImpl) getQueryTable()).getSampleType();
             UserSchema userSchema = getQueryTable().getUserSchema();
             if (userSchema != null)
-                return LoggingDataIterator.wrap(InventoryService.get().getPersistStorageItemDataIteratorBuilder(dib, userSchema.getContainer(), userSchema.getUser(), sampleType.getMetricUnit()));
+            {
+                DataIteratorBuilder persistStorageItem = LoggingDataIterator.wrap(InventoryService.get().getPersistStorageItemDataIteratorBuilder(dib, userSchema.getContainer(), userSchema.getUser(), sampleType.getMetricUnit()));
+                DataIteratorBuilder autoLinkToStudy = LoggingDataIterator.wrap(new ExpDataIterators.AutoLinkToStudyDataIteratorBuilder(persistStorageItem, true, userSchema.getContainer(), userSchema.getUser(), getQueryTable()));
+                return autoLinkToStudy;
+            }
             return dib;
         }
         else

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -159,12 +159,15 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
     {
         assert _sampleType != null : "SampleType required for insert/update, but not required for read/delete";
         DataIteratorBuilder dib = super.createImportDIB(user, container, data, context);
+        LOG.warn("Temp: inside of createImportDIB");
         if (InventoryService.get() != null)
         {
+            LOG.warn("Temp: got inventory service");
             ExpSampleType sampleType = ((ExpMaterialTableImpl) getQueryTable()).getSampleType();
             UserSchema userSchema = getQueryTable().getUserSchema();
             if (userSchema != null)
             {
+                LOG.warn("Temp: got user schema");
                 DataIteratorBuilder persistStorageItem = LoggingDataIterator.wrap(InventoryService.get().getPersistStorageItemDataIteratorBuilder(dib, userSchema.getContainer(), userSchema.getUser(), sampleType.getMetricUnit()));
                 DataIteratorBuilder autoLinkToStudy = LoggingDataIterator.wrap(new ExpDataIterators.AutoLinkToStudyDataIteratorBuilder(persistStorageItem, true, userSchema.getContainer(), userSchema.getUser(), getQueryTable()));
                 return autoLinkToStudy;
@@ -208,6 +211,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         // insertRows with lineage is pretty good at deadlocking against it self, so use retry loop
 
         DbScope scope = getSchema().getDbSchema().getScope();
+        LOG.warn("Temp: inside of SampleTypeUpdateServiceDI.insertRows");
         List<Map<String, Object>> results = scope.executeWithRetry(transaction ->
                 super._insertRowsUsingDIB(user, container, rows, getDataIteratorContext(errors, InsertOption.INSERT, configParameters), extraScriptContext));
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -164,12 +164,10 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         {
             ExpSampleType sampleType = ((ExpMaterialTableImpl) getQueryTable()).getSampleType();
             dib = LoggingDataIterator.wrap(InventoryService.get().getPersistStorageItemDataIteratorBuilder(dib, userSchema.getContainer(), userSchema.getUser(), sampleType.getMetricUnit()));
-            dib = LoggingDataIterator.wrap(new ExpDataIterators.AutoLinkToStudyDataIteratorBuilder(dib, true, userSchema.getContainer(), userSchema.getUser(), getQueryTable()));
-            return dib;
         }
-
+        
         if (userSchema != null)
-            return LoggingDataIterator.wrap(new ExpDataIterators.AutoLinkToStudyDataIteratorBuilder(dib, true, userSchema.getContainer(), userSchema.getUser(), getQueryTable()));
+            dib = LoggingDataIterator.wrap(new ExpDataIterators.AutoLinkToStudyDataIteratorBuilder(dib, true, userSchema.getContainer(), userSchema.getUser(), getQueryTable()));
 
         return dib;
     }


### PR DESCRIPTION
#### Rationale
Currently, SM Timeline shows the "Sample was linked to a study" event before the "Sample was registered" event. Rearranging the order of the data iterators resolves this problem.

#### Related Pull Requests
* n/a

#### Changes
* move dataiterator
