### PR TITLE
Issue 43672: Add referrer parameter to links to docs from within the product

### DIFF
--- a/api/src/org/labkey/api/util/HelpTopic.java
+++ b/api/src/org/labkey/api/util/HelpTopic.java
@@ -72,7 +72,22 @@ public class HelpTopic
 
     public String getHelpTopicHref()
     {
-        return HELP_LINK_PREFIX + _topic;
+        return getHelpTopicHref(Referrer.inPage);
+    }
+
+    public enum Referrer
+    {
+        /** The LabKey Documentation link under the user menu in the main page header */
+        docMenu,
+        /** Help links under the Developer header menu */
+        devMenu,
+        /** Links in the main page or its tooltips */
+        inPage
+    }
+
+    public String getHelpTopicHref(@NotNull Referrer referrer)
+    {
+        return HELP_LINK_PREFIX + _topic + "&referrer=" + referrer;
     }
 
     // Create a simple link (just an <a> tag with plain mixed case text, no graphics) to the help topic, displaying
@@ -97,7 +112,7 @@ public class HelpTopic
     // Create a NavTree for a menu item that links to the help topic, displaying the provided text, using the standard target, etc.
     public NavTree getNavTree(String displayText)
     {
-        NavTree tree = new NavTree(displayText, getHelpTopicHref());
+        NavTree tree = new NavTree(displayText, getHelpTopicHref(Referrer.docMenu));
         tree.setTarget(HelpTopic.TARGET_NAME);
 
         return tree;

--- a/api/src/org/labkey/api/view/PopupDeveloperView.java
+++ b/api/src/org/labkey/api/view/PopupDeveloperView.java
@@ -86,7 +86,7 @@ public class PopupDeveloperView extends PopupMenuView
             }
 
             items.add(DeveloperMenuNavTrees.Section.referenceDocs, new NavTree("XML Schema Reference", "https://www.labkey.org/download/schema-docs/xml-schemas"));
-            items.add(DeveloperMenuNavTrees.Section.referenceDocs, new NavTree("SQL Reference", new HelpTopic("labkeySql").getHelpTopicHref()));
+            items.add(DeveloperMenuNavTrees.Section.referenceDocs, new NavTree("SQL Reference", new HelpTopic("labkeySql").getHelpTopicHref(HelpTopic.Referrer.devMenu)));
         });
     }
 }


### PR DESCRIPTION
#### Rationale
To help understand how users navigate to our doc pages, adding a referrer parameter will let us break them into broad categories 

#### Changes
* Add parameter, defaulting to "inPage" but set to "docMenu" and "devMenu" for header menu variants