### PR TITLE
43716: Sample types with name expression values don't round trip via folder archive as expected for SM app

### DIFF
--- a/experiment/src/org/labkey/experiment/XarExporter.java
+++ b/experiment/src/org/labkey/experiment/XarExporter.java
@@ -605,7 +605,8 @@ public class XarExporter
         {
             xSampleSet.setNameExpression(sampleType.getNameExpression());
         }
-        else if (sampleType.hasNameAsIdCol())
+
+        if (sampleType.hasNameAsIdCol())
         {
             xSampleSet.addKeyField(ExpMaterialTable.Column.Name.name());
         }

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -470,7 +470,8 @@ public class XarReader extends AbstractXarImporter
         {
             materialSource.setNameExpression(sampleSet.getNameExpression());
         }
-        else if (keyFields.size() == 1 && keyFields.get(0).equals(ExpMaterialTable.Column.Name.name()))
+
+        if (keyFields.size() == 1 && keyFields.get(0).equals(ExpMaterialTable.Column.Name.name()))
         {
             // We can use Name as the idCol1 without requiring it to be a domain property
             materialSource.setIdCol1(ExpMaterialTable.Column.Name.name());


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43716

This seems to be a long standing bug with XAR export/import but we weren't properly setting up the idcol1 field in materialSource when a name expression was provided. 

#### Changes
This change aligns the XAR export/import code with the code which creates a sample type in the `SampleTypeService` with respect to name expressions and the idCol1 field. This ensures that a name expression will work only if idCol1 is set to "name".
