### PR TITLE
43669: R report option groupings won't expand on Safari

### DIFF
--- a/api/webapp/ext-4.2.1/ext-patches.js
+++ b/api/webapp/ext-4.2.1/ext-patches.js
@@ -1104,12 +1104,6 @@ if (Ext4.isSafari || Ext4.isGecko) {
     });
 }
 
-/**
- * Issue 43669: R report option groupings won't expand on Safari
- * This is a bit of a work around because I was never able to pinpoint exactly why this was failing but the DOM rendering
- * on Safari was causing the expand/title divs to not receive the click event. The work around is to render the container
- * as a div and apply styling directly instead of rendering the legend element.
- */
 Ext4.override(Ext4.form.FieldSet, {
 
     createLegendCt: function () {
@@ -1125,6 +1119,12 @@ Ext4.override(Ext4.form.FieldSet, {
                     ownerLayout: me.componentLayout
                 };
 
+        // Issue 43669: R report option groupings won't expand on Safari
+        // For Safari, don't render the container element as legend and instead render it as a div
+        // and apply styling directly. If this causes problems, the alternative would be to either don't use
+        // collapsible fieldSets on Safari (or maybe not at all). Currently, there are very few instances of
+        // collapsible fieldSets.
+        //
         if (Ext4.isSafari && me.collapsible) {
             legend.style = {'background-color' :'#999', border: '1px solid #999', 'margin-top' : '8px', 'margin-bottom': '20px'};
         }
@@ -1144,6 +1144,6 @@ Ext4.override(Ext4.form.FieldSet, {
         items.push(me.createTitleCmp());
 
         return legend;
-    },
+    }
 });
 

--- a/api/webapp/ext-4.2.1/ext-patches.js
+++ b/api/webapp/ext-4.2.1/ext-patches.js
@@ -1103,3 +1103,47 @@ if (Ext4.isSafari || Ext4.isGecko) {
         }
     });
 }
+
+/**
+ * Issue 43669: R report option groupings won't expand on Safari
+ * This is a bit of a work around because I was never able to pinpoint exactly why this was failing but the DOM rendering
+ * on Safari was causing the expand/title divs to not receive the click event. The work around is to render the container
+ * as a div and apply styling directly instead of rendering the legend element.
+ */
+Ext4.override(Ext4.form.FieldSet, {
+
+    createLegendCt: function () {
+        var me = this,
+                items = [],
+                legend = {
+                    xtype: 'container',
+                    baseCls: me.baseCls + '-header',
+                    id: me.id + '-legend',
+                    items: items,
+                    ownerCt: me,
+                    shrinkWrap: true,
+                    ownerLayout: me.componentLayout
+                };
+
+        if (Ext4.isSafari && me.collapsible) {
+            legend.style = {'background-color' :'#999', border: '1px solid #999', 'margin-top' : '8px', 'margin-bottom': '20px'};
+        }
+        else {
+            legend.autoEl = 'legend';
+        }
+
+        // Checkbox
+        if (me.checkboxToggle) {
+            items.push(me.createCheckboxCmp());
+        } else if (me.collapsible) {
+            // Toggle button
+            items.push(me.createToggleCmp());
+        }
+
+        // Title
+        items.push(me.createTitleCmp());
+
+        return legend;
+    },
+});
+


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43669

#### Changes
- override `FieldSet.createLegendCt` which creates the fieldset expand/collapse and title components, so that for Safari we render a div instead of a legend element.