### PR TITLE
Deprecate old dependencies

### DIFF
--- a/api/src/org/labkey/api/module/JavaVersion.java
+++ b/api/src/org/labkey/api/module/JavaVersion.java
@@ -31,8 +31,8 @@ import java.util.stream.Collectors;
 public enum JavaVersion
 {
     JAVA_UNSUPPORTED(-1, true, false, null),
-    JAVA_14(14, false, true, "https://docs.oracle.com/en/java/javase/14/docs/api/java.base/"),
-    JAVA_15(15, false, true, "https://docs.oracle.com/en/java/javase/15/docs/api/java.base/"),
+    JAVA_14(14, true, true, "https://docs.oracle.com/en/java/javase/14/docs/api/java.base/"),
+    JAVA_15(15, true, true, "https://docs.oracle.com/en/java/javase/15/docs/api/java.base/"),
     JAVA_16(16, false, true, "https://docs.oracle.com/en/java/javase/16/docs/api/java.base/"),
     JAVA_17(17, false, false, "https://docs.oracle.com/en/java/javase/16/docs/api/java.base/"), // TODO: No JDK 17 docs yet
     JAVA_FUTURE(Integer.MAX_VALUE, false, false, "https://docs.oracle.com/en/java/javase/16/docs/api/java.base/");

--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 public enum PostgreSqlVersion
 {
     POSTGRESQL_UNSUPPORTED(-1, true, false, null),
-    POSTGRESQL_96(96, false, true, PostgreSql96Dialect::new),
+    POSTGRESQL_96(96, true, true, PostgreSql96Dialect::new),
     POSTGRESQL_10(100, false, true, PostgreSql_10_Dialect::new),
     POSTGRESQL_11(110, false, true, PostgreSql_11_Dialect::new),
     POSTGRESQL_12(120, false, true, PostgreSql_12_Dialect::new),

--- a/core/src/org/labkey/core/junit/JunitRunner.java
+++ b/core/src/org/labkey/core/junit/JunitRunner.java
@@ -68,14 +68,10 @@ public class JunitRunner
     {
         Runner runner = request.getRunner();
         Description desc = runner.getDescription();
-        String description = desc.toString();
-
-        if ("null".equals(description))
-        {
-            StringBuilder sb = new StringBuilder();
-            ArrayList<Description> children = desc.getChildren();
-            description = children.stream().map(Description::toString).collect(Collectors.joining(", "));
-        }
+        ArrayList<Description> children = desc.getChildren();
+        String description = children.stream()
+            .map(Description::toString)
+            .collect(Collectors.joining(", "));
 
         try
         {
@@ -88,14 +84,14 @@ public class JunitRunner
             JUnitCore core = new JUnitCore();
             core.addListener(new RunListener() {
                 @Override
-                public void testStarted(Description description) throws Exception
+                public void testStarted(Description description)
                 {
                     LOG.debug("Starting test: " + description);
                     TestContext.get().clearPerfResults();
                 }
 
                 @Override
-                public void testFinished(Description description) throws Exception
+                public void testFinished(Description description)
                 {
                     LOG.debug("Finished test: " + description);
                     ArrayList<CPUTimer> timers = TestContext.get().getPerfResults();
@@ -104,7 +100,7 @@ public class JunitRunner
                 }
 
                 @Override
-                public void testFailure(Failure failure) throws Exception
+                public void testFailure(Failure failure)
                 {
                     Throwable t = failure.getException();
                     LOG.error("Test failed: " + failure.getDescription() + ":\n" + JunitController.renderTrace(t));
@@ -126,5 +122,4 @@ public class JunitRunner
                 LOG.info("Completed suite: " + description);
         }
     }
-
 }


### PR DESCRIPTION
#### Rationale
We are deprecating support for Java 14 & 15 and PostgreSQL 9.6 for 21.11.

Separately, I noticed that the junit runner always logs "classes" instead of the name of each junit suite. Maybe the junit upgrade caused this?
