### PR TITLE
Avoid double-counting jobs that might still be in the pending queue

### DIFF
--- a/pipeline/src/org/labkey/pipeline/api/PipelineQueueImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineQueueImpl.java
@@ -278,7 +278,10 @@ public class PipelineQueueImpl extends AbstractPipelineQueue
         {
             for (PipelineJob pipelineJob : _pending)
             {
-                result.put(pipelineJob.getJobGUID(), ++position);
+                if (!result.containsKey(pipelineJob.getJobGUID()))
+                {
+                    result.put(pipelineJob.getJobGUID(), ++position);
+                }
             }
         }
         return result;


### PR DESCRIPTION
#### Rationale
We've seen a few cases on customer servers where the new queue position column double-counts the running job

#### Changes
* De-deduplicate the running and pending queues when using the in-memory job queue