### PR TITLE
Issue 43757: Add metric for number of aliquots and update field label from "Assay Id" to "Assay ID"

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -388,7 +388,7 @@ public abstract class AssayProtocolSchema extends AssaySchema
         addQCFlagColumn(runTable);
 
         var dataLinkColumn = runTable.getMutableColumn(ExpRunTable.Column.Name);
-        dataLinkColumn.setLabel("Assay Id");
+        dataLinkColumn.setLabel("Assay ID");
         dataLinkColumn.setDescription("The assay/experiment ID that uniquely identifies this assay run.");
         dataLinkColumn.setURL(new DetailsURL(new ActionURL(AssayDetailRedirectAction.class, getContainer()), Collections.singletonMap("runId", "rowId")));
 

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -470,6 +470,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
 
                 results.put("sampleSetCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.materialsource").getObject(Long.class));
                 results.put("sampleCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.material").getObject(Long.class));
+                results.put("aliquotCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.material where aliquotedfromlsid IS NOT NULL").getObject(Long.class));
 
                 results.put("dataClassCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.dataclass").getObject(Long.class));
                 results.put("dataClassRowCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.data WHERE classid IN (SELECT rowid FROM exp.dataclass)").getObject(Long.class));


### PR DESCRIPTION
#### Rationale
Tracking whether users are creating aliquots will help us know whether to make it easier to do or if it is useful.


#### Changes
* Add `aliquotCount` as a companion to `sampleCount` metric.
