### PR TITLE
Issue 43774: Support SQL Server with case-sensitive collation as external data source

### DIFF
--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1473,7 +1473,7 @@ public abstract class SqlDialect
     public boolean isProcedureExists(DbScope scope, String schema, String name)
     {
         /* Does not handle overloaded functions for dialects that support them (Postgres) */
-        SQLFragment sqlf = new SQLFragment("SELECT 1 FROM information_schema.routines WHERE UPPER(specific_schema) = UPPER(?) AND UPPER(routine_name) = UPPER(?)");
+        SQLFragment sqlf = new SQLFragment("SELECT 1 FROM INFORMATION_SCHEMA.ROUTINES WHERE UPPER(specific_schema) = UPPER(?) AND UPPER(routine_name) = UPPER(?)");
         sqlf.add(schema);
         sqlf.add(name);
         return new SqlSelector(scope, sqlf).exists();


### PR DESCRIPTION
#### Rationale
External data sources on a SQL Server database with case-sensitive collation throw because `SqlDialect.isProcedureExists()` queries the INFORMATION_SCHEMA with lower case names.

[Issue 43774: Support SQL Server with case-sensitive collation as external data source](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43774)