### PR TITLE
43768: NullPointerException in org.labkey.study.query.StudyProperties…

### DIFF
--- a/study/src/org/labkey/study/query/StudyPropertiesUpdateService.java
+++ b/study/src/org/labkey/study/query/StudyPropertiesUpdateService.java
@@ -126,8 +126,8 @@ public class StudyPropertiesUpdateService extends AbstractQueryUpdateService
                     {
                         // Translate both values to new Date objects to avoid Timestamp/Date comparison problems - issue 40166
                         Date newDate = new Date(DateUtil.parseDateTime(container, entry.getValue().toString()));
-                        Date oldDate = new Date(study.getStartDate().getTime());
-                        recomputeStartDates = !oldDate.equals(newDate);
+                        Date oldDate = study.getStartDate() != null ? new Date(study.getStartDate().getTime()) : null;
+                        recomputeStartDates = !newDate.equals(oldDate);
 
                         if (recomputeStartDates)
                         {


### PR DESCRIPTION
#### Rationale
NPE detected on a Dataspace server:

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43768

This issue was discovered from a mothership exception report. The repro is to attempt to change a study start date from blank (null) to non-null.
