### PR TITLE
Remove reference to (deprecated) SecurityManager

### DIFF
--- a/api/src/org/labkey/api/util/JobRunner.java
+++ b/api/src/org/labkey/api/util/JobRunner.java
@@ -275,8 +275,7 @@ public class JobRunner implements Executor
 
         JobThreadFactory(int priority)
         {
-            SecurityManager s = System.getSecurityManager();
-            group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+            group = Thread.currentThread().getThreadGroup();
             namePrefix = "JobThread-" + poolNumber.getAndIncrement() + ".";
             this.priority = priority;
         }


### PR DESCRIPTION
#### Rationale
Java's `SecurityManager` has been deprecated and marked `forRemoval` in JDK 17, therefore, our single reference to SecurityManager in `JobRunner` produces a warning at compile time.

In JDK 17, `SecurityManager.getThreadGroup()` just calls `Thread.currentThread().getThreadGroup()`... so there's no reason for this code to reference SecurityManager.
