### PR TITLE
Issue 43720: Connecting to Oracle database should allow username and …

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1534,8 +1534,14 @@ public class DbScope
             Class<Driver> driverClass = (Class<Driver>)Class.forName(props.getDriverClassName());
             driver = driverClass.getConstructor().newInstance();
             info = new Properties();
-            info.put("user", props.getUsername());
-            info.put("password", props.getPassword());
+            if (props.getUsername() != null)
+            {
+                info.put("user", props.getUsername());
+            }
+            if (props.getPassword() != null)
+            {
+                info.put("password", props.getPassword());
+            }
         }
         catch (Exception e)
         {


### PR DESCRIPTION
…password to be embedded in the URL

#### Rationale
The Oracle JDBC driver allows the username and password to be embedded in the URL (note that we log the URL in various messages), which means that they may not be present as separate properties.
 
#### Changes
* Don't assume we always have a discrete username and password property