### PR TITLE
Issue 43670: Default rmarkdownOutputOptions not applying "css=NULL, theme=NULL" 

### DIFF
--- a/api/src/org/labkey/api/reports/RScriptEngine.java
+++ b/api/src/org/labkey/api/reports/RScriptEngine.java
@@ -248,8 +248,9 @@ public class RScriptEngine extends ExternalScriptEngine
                 sb.append("render(run_pandoc=TRUE, ");
                 if (useDefaultOutputFormat(context))
                 {
-                    sb.append("html_document(keep_md=TRUE, self_contained=FALSE, fig_caption=TRUE, " +
-                            "theme=NULL, css=NULL, smart=TRUE, highlight=\"default\"), ");
+                    sb.append("html_document(")
+                            .append(PANDOC_DEFAULT_OUTPUT_OPTIONS_LIST)
+                            .append("), ");
                 }
                 else
                 {

--- a/api/src/org/labkey/api/reports/RScriptEngine.java
+++ b/api/src/org/labkey/api/reports/RScriptEngine.java
@@ -248,7 +248,7 @@ public class RScriptEngine extends ExternalScriptEngine
                 sb.append("render(run_pandoc=TRUE, ");
                 if (useDefaultOutputFormat(context))
                 {
-                    sb.append("output_format=html_document_base(keep_md=TRUE, self_contained=FALSE, fig_caption=TRUE, " +
+                    sb.append("html_document(keep_md=TRUE, self_contained=FALSE, fig_caption=TRUE, " +
                             "theme=NULL, css=NULL, smart=TRUE, highlight=\"default\"), ");
                 }
                 else


### PR DESCRIPTION
#### Rationale
The arguments passed in to output_format=html_document_base is no longer doing the right thing (skipping adding css and theme) for a newer version of pandoc (v2.11.4).  The old command worked for pandoc v2.2.1. The updated command works for both v2.2.1 and v2.11.4.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* change output_format=html_document_base to html_document