### PR TITLE
Issue 43802: Export runs to XAR via "Write to ... pipeline" fails

### DIFF
--- a/api/src/org/labkey/api/pipeline/PipelineJobNotificationProvider.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJobNotificationProvider.java
@@ -112,7 +112,7 @@ public interface PipelineJobNotificationProvider
                 Integer jobId = PipelineService.get().getJobId(user, job.getContainer(), job.getJobGUID());
                 if (jobId != null)
                 {
-                    n.setActionLinkURL(PageFlowUtil.urlProvider(PipelineUrls.class).statusDetails(job.getContainer()).addParameter("rowId", jobId).getLocalURIString());
+                    n.setActionLinkURL(PageFlowUtil.urlProvider(PipelineUrls.class).statusDetails(job.getContainer(), jobId).getLocalURIString());
                     n.setActionLinkText("view");
                 }
                 else

--- a/api/src/org/labkey/api/pipeline/PipelineUrls.java
+++ b/api/src/org/labkey/api/pipeline/PipelineUrls.java
@@ -45,7 +45,7 @@ public interface PipelineUrls extends UrlProvider
 
     ActionURL urlCreatePipelineTrigger(Container container, String pipelineId, @Nullable ActionURL returnUrl);
 
-    ActionURL statusDetails(Container container);
+    ActionURL statusDetails(Container container, int jobRowId);
 
     ActionURL statusList(Container container);
 }

--- a/experiment/src/org/labkey/experiment/XarExporter.java
+++ b/experiment/src/org/labkey/experiment/XarExporter.java
@@ -1325,7 +1325,7 @@ public class XarExporter
                 sb.append(error.getCursorLocation().xmlText());
                 sb.append("\n");
             }
-            throw new ExperimentException("Failed to create a valid XML file\n" + sb.toString());
+            throw new ExperimentException("Failed to create a valid XML file\n" + sb);
         }
 
         XmlOptions options = new XmlOptions();
@@ -1370,14 +1370,8 @@ public class XarExporter
         }
     }
 
-    @Deprecated
-    public void write(OutputStream out) throws IOException
-    {
-        writeAsArchive(out);
-    }
-
     /** TODO use VFS so we can void two impl */
-    public void writeAsArchive(OutputStream out) throws IOException
+    public void writeAsArchive(OutputStream out) throws IOException, ExperimentException
     {
         try (ZipOutputStream zOut = new ZipOutputStream(out))
         {
@@ -1405,7 +1399,7 @@ public class XarExporter
                     }
                 }
             }
-            catch (Exception e)
+            catch (IOException | RuntimeException e)
             {
                 // insert the stack trace into the zip file
                 ZipEntry errorEntry = new ZipEntry("error.log");
@@ -1415,6 +1409,7 @@ public class XarExporter
                 ps.println("Failed to complete export of the XAR file: ");
                 e.printStackTrace(ps);
                 zOut.closeEntry();
+                throw e;
             }
         }
     }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -91,6 +91,7 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineRootContainerTree;
 import org.labkey.api.pipeline.PipelineService;
+import org.labkey.api.pipeline.PipelineStatusFile;
 import org.labkey.api.pipeline.PipelineUrls;
 import org.labkey.api.pipeline.PipelineValidationException;
 import org.labkey.api.query.AbstractQueryImportAction;
@@ -4143,7 +4144,7 @@ public class ExperimentController extends SpringActionController
                 getViewContext().getResponse().setHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
                 ResponseHelper.setPrivate(getViewContext().getResponse());
 
-                exporter.write(getViewContext().getResponse().getOutputStream());
+                exporter.writeAsArchive(getViewContext().getResponse().getOutputStream());
                 return null;
             case PIPELINE_FILE:
                 if (!PipelineService.get().hasValidPipelineRoot(getContainer()))
@@ -4153,7 +4154,8 @@ public class ExperimentController extends SpringActionController
                 PipeRoot pipeRoot = PipelineService.get().findPipelineRoot(getContainer());
                 XarExportPipelineJob job = new XarExportPipelineJob(getViewBackgroundInfo(), pipeRoot, fileName, lsidRelativizer, selection, xarXmlFileName);
                 PipelineService.get().queueJob(job);
-                return getContainer().getStartURL(getUser());
+                PipelineStatusFile status = PipelineService.get().getStatusFile(job.getJobGUID());
+                return PageFlowUtil.urlProvider(PipelineUrls.class).statusDetails(getContainer(), status.getRowId());
             default:
                 throw new IllegalArgumentException("Unknown export type: " + exportType);
         }

--- a/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
@@ -134,7 +134,7 @@ public class FolderXarWriterFactory implements FolderWriterFactory
 
             try (OutputStream fOut = xarDir.getOutputStream(XAR_FILE_NAME))
             {
-                exporter.write(fOut);
+                exporter.writeAsArchive(fOut);
             }
         }
 

--- a/experiment/src/org/labkey/experiment/xar/XarExportSelection.java
+++ b/experiment/src/org/labkey/experiment/xar/XarExportSelection.java
@@ -18,6 +18,7 @@ package org.labkey.experiment.xar;
 
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpDataClass;
+import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExpSampleType;
@@ -36,6 +37,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * User: jeckels
@@ -43,8 +45,9 @@ import java.util.Set;
  */
 public class XarExportSelection implements Serializable
 {
+    // Store ids instead of experiment objects so that it's easily serializable
     private final List<Integer> _expIds = new ArrayList<>();
-    private final Set<ExpRun> _runs = new LinkedHashSet<>();
+    private final Set<Integer> _runIds = new LinkedHashSet<>();
     private final List<Integer> _dataIds = new ArrayList<>();
     private final List<Integer> _sampleTypeIds = new ArrayList<>();
     private final List<Integer> _protocolIds = new ArrayList<>();
@@ -63,7 +66,7 @@ public class XarExportSelection implements Serializable
 
     public void addRuns(Collection<? extends ExpRun> runs)
     {
-        _runs.addAll(runs);
+        _runIds.addAll(runs.stream().map(ExpObject::getRowId).collect(Collectors.toSet()));
     }
 
     public void addDataIds(int... dataIds)
@@ -122,9 +125,9 @@ public class XarExportSelection implements Serializable
             exporter.addExperiment(ExperimentServiceImpl.get().getExpExperiment(expId));
         }
 
-        for (ExpRun run : _runs)
+        for (int runId : _runIds)
         {
-            exporter.addExperimentRun(run);
+            exporter.addExperimentRun(ExperimentService.get().getExpRun(runId));
         }
 
         for (int protocolId : _protocolIds)

--- a/pipeline/src/org/labkey/pipeline/PipelineController.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineController.java
@@ -1772,9 +1772,9 @@ public class PipelineController extends SpringActionController
         }
 
         @Override
-        public ActionURL statusDetails(Container container)
+        public ActionURL statusDetails(Container container, int jobRowId)
         {
-            return new ActionURL(StatusController.DetailsAction.class, container);
+            return new ActionURL(StatusController.DetailsAction.class, container).addParameter("rowId", jobRowId);
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
We've clearly not been testing the ability to export XARs to the pipeline directory, and want it to be a viable option

#### Changes
* Fix serialization error for pipeline job by storing run RowIds instead of full ExpRun objects
* Fix problem when trying to write TSV of assay data in background thread due to lack of active ViewContext
* Redirect to job status page instead of folder home page to monitor progress
* Fail job when export fails, and log errors