### PR TITLE
Look up from Panorama to sample type if we find matching sample IDs

### DIFF
--- a/api/src/org/labkey/api/data/LazyForeignKey.java
+++ b/api/src/org/labkey/api/data/LazyForeignKey.java
@@ -1,0 +1,105 @@
+package org.labkey.api.data;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.NamedObjectList;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.StringExpression;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * A foreign key implementation that waits until it's asked for something and then uses the Supplier to create the
+ * real foreign key. This lets us postpone potentially expensive initialization of the lookup, and in many cases
+ * avoid needing to do it at all if the lookup isn't being actively used in a given codepath.
+ */
+public class LazyForeignKey implements ForeignKey
+{
+    private final Supplier<ForeignKey> _supplier;
+
+    private boolean _delegateCreationAttempted = false;
+    private ForeignKey _delegate;
+
+    public LazyForeignKey(Supplier<ForeignKey> supplier)
+    {
+        _supplier = supplier;
+    }
+
+    private ForeignKey getDelegate()
+    {
+        if (!_delegateCreationAttempted)
+        {
+            _delegate = _supplier.get();
+            _delegateCreationAttempted = true;
+        }
+        return _delegate;
+    }
+
+    @Override
+    public @Nullable ColumnInfo createLookupColumn(ColumnInfo parent, String displayField)
+    {
+        return getDelegate() == null ? null : getDelegate().createLookupColumn(parent, displayField);
+    }
+
+    @Override
+    public @Nullable TableInfo getLookupTableInfo()
+    {
+        return getDelegate() == null ? null : getDelegate().getLookupTableInfo();
+    }
+
+    @Override
+    public StringExpression getURL(ColumnInfo parent)
+    {
+        return getDelegate() == null ? null : getDelegate().getURL(parent);
+    }
+
+    @Override
+    public @NotNull NamedObjectList getSelectList(RenderContext ctx)
+    {
+        return getDelegate() == null ? new NamedObjectList() : getDelegate().getSelectList(ctx);
+    }
+
+    @Override
+    public Container getLookupContainer()
+    {
+        return getDelegate() == null ? null : getDelegate().getLookupContainer();
+    }
+
+    @Override
+    public String getLookupTableName()
+    {
+        return getDelegate() == null ? null : getDelegate().getLookupTableName();
+    }
+
+    @Override
+    public String getLookupSchemaName()
+    {
+        return getDelegate() == null ? null : getDelegate().getLookupSchemaName();
+    }
+
+    @Override
+    public String getLookupColumnName()
+    {
+        return getDelegate() == null ? null : getDelegate().getLookupColumnName();
+    }
+
+    @Override
+    public String getLookupDisplayName()
+    {
+        return getDelegate() == null ? null : getDelegate().getLookupDisplayName();
+    }
+
+    @Override
+    public @Nullable ForeignKey remapFieldKeys(@Nullable FieldKey parent, @Nullable Map<FieldKey, FieldKey> mapping)
+    {
+        return getDelegate() == null ? null : getDelegate().remapFieldKeys(parent, mapping);
+    }
+
+    @Override
+    public @Nullable Set<FieldKey> getSuggestedColumns()
+    {
+        return getDelegate() == null ? null : getDelegate().getSuggestedColumns();
+    }
+}

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -291,7 +291,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
     /**
      * Looks in all the sample types visible from the given container for a single match with the specified name
      */
-    @NotNull List<? extends ExpMaterial> getExpMaterialsByName(String name, Container container, User user);
+    @NotNull List<? extends ExpMaterial> getExpMaterialsByName(String name, @Nullable Container container, User user);
 
     @Nullable ExpData findExpData(Container c, User user,
                                   @NotNull ExpDataClass dataClass,

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -83,6 +83,7 @@ import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpression;
+import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
 import org.labkey.experiment.ExpDataIterators;
@@ -102,6 +103,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
+import static org.labkey.api.util.StringExpressionFactory.AbstractStringExpression.NullValueBehavior.NullResult;
+import static org.labkey.api.util.StringExpressionFactory.AbstractStringExpression.NullValueBehavior.ReplaceNullWithBlank;
 
 public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.Column> implements ExpMaterialTable
 {
@@ -111,7 +114,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     public ExpMaterialTableImpl(String name, UserSchema schema, ContainerFilter cf)
     {
         super(name, ExperimentServiceImpl.get().getTinfoMaterial(), schema, cf);
-        setDetailsURL(new DetailsURL(new ActionURL(ExperimentController.ShowMaterialAction.class, schema.getContainer()), Collections.singletonMap("rowId", "rowId")));
+        setDetailsURL(new DetailsURL(new ActionURL(ExperimentController.ShowMaterialAction.class, schema.getContainer()), Collections.singletonMap("rowId", "rowId"), NullResult));
         setName(ExpSchema.TableType.Materials.name());
         setPublicSchemaName(ExpSchema.SCHEMA_NAME);
         addAllowablePermission(InsertPermission.class);
@@ -604,7 +607,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
 
         ActionURL detailsUrl = new ActionURL(ExperimentController.ShowMaterialAction.class, getContainer());
-        DetailsURL url = new DetailsURL(detailsUrl, Collections.singletonMap("rowId", "RowId"));
+        DetailsURL url = new DetailsURL(detailsUrl, Collections.singletonMap("rowId", "RowId"), NullResult);
         nameCol.setURL(url);
         rowIdCol.setURL(url);
         setDetailsURL(url);


### PR DESCRIPTION
#### Rationale
Users want to link data from their Skyline documents to sample metadata, especially in LKSM

#### Changes
* Make it possible to search for materials by name across containers
* Create LazyForeignKey to make it easy to avoid expensive initialization when it's not required
* Avoid rendering sample URLs when we don't have a matching RowId to use as a parameter