### PR TITLE
Stop warning about JDK 17. Add preliminary JDK 17 JavaDoc link.

### DIFF
--- a/api/src/org/labkey/api/module/JavaVersion.java
+++ b/api/src/org/labkey/api/module/JavaVersion.java
@@ -34,8 +34,8 @@ public enum JavaVersion
     JAVA_14(14, true, true, "https://docs.oracle.com/en/java/javase/14/docs/api/java.base/"),
     JAVA_15(15, true, true, "https://docs.oracle.com/en/java/javase/15/docs/api/java.base/"),
     JAVA_16(16, false, true, "https://docs.oracle.com/en/java/javase/16/docs/api/java.base/"),
-    JAVA_17(17, false, false, "https://docs.oracle.com/en/java/javase/16/docs/api/java.base/"), // TODO: No JDK 17 docs yet
-    JAVA_FUTURE(Integer.MAX_VALUE, false, false, "https://docs.oracle.com/en/java/javase/16/docs/api/java.base/");
+    JAVA_17(17, false, true, "https://download.java.net/java/early_access/jdk17/docs/api/java.base/"), // TODO: Update to final location, once published
+    JAVA_FUTURE(Integer.MAX_VALUE, false, false, "https://docs.oracle.com/en/java/javase/16/docs/api/java.base/"); // TODO: Update
 
     private final int _version;
     private final boolean _deprecated;


### PR DESCRIPTION
#### Rationale
JDK 17 will be released in a couple weeks and we've done enough testing that we can claim to support it
