### PR TITLE
Fix for productNavigation loadApp error when call to loadApp() is made before requiresScript() has finished

### DIFF
--- a/core/webapp/core/ProductNavigationHeader.js
+++ b/core/webapp/core/ProductNavigationHeader.js
@@ -11,7 +11,6 @@
 
             LABKEY.requiresScript('gen/productNavigation', loadProductNav);
             // LABKEY.requiresScript('http://localhost:3001/productNavigation.js', loadProductNav);
-            productNavLoaded = true;
         } else {
             loadProductNav();
         }
@@ -20,6 +19,7 @@
     var loadProductNav = function() {
         LABKEY.App.loadApp('productNavigation', HEADER_CONTENT_ID, { show: true });
         $(document).on('click', addProductNavClickHandler);
+        productNavLoaded = true;
     };
 
     // stop the product navigation menu from closing when click within the menu div


### PR DESCRIPTION
#### Rationale
A few people have reported seeing a JS error like below when interacting with the LKS header icons. This can happen if a user has a slow network connection (or really fast mouse movements) and hovers over the product nav header icon a second time before the requiresScript of the JS file has completed loading. This second hover triggers a call to loadApp(), but that app JS file hasn't loaded yet.
<img width="1073" alt="Screen Shot 2021-08-30 at 5 05 59 PM" src="https://user-images.githubusercontent.com/6411206/131411996-09bf3744-295e-4b5d-a56d-c5eb1d6da7fc.png">

#### Changes
* Move `productNavLoaded` update to the `loadProductNav()` so that `App.loadApp()` won't be called before ready
