### PR TITLE
Issue 43821: Escape all pattern parameters in JDBC metadata APIs

### DIFF
--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -1609,9 +1609,9 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
         DbScope scope = parentTable.getSchema().getScope();
         Map<String, ImportedKey> importedKeys = new HashMap<>();    // Use map to handle multiple FKs with multiple fields from same table referencing same PK
 
-        try (JdbcMetaDataLocator locator = dialect.getJdbcMetaDataLocator(scope, schemaName, parentTable.getMetaDataName()))
+        try (JdbcMetaDataLocator locator = dialect.getJdbcMetaDataLocator(scope).singleSchema(schemaName).singleTable(parentTable))
         {
-            JdbcMetaDataSelector columnSelector = new JdbcMetaDataSelector(locator, (dbmd, loc) -> dbmd.getColumns(loc.getCatalogName(), loc.getSchemaName(), loc.getTableName(), columnNamePattern));
+            JdbcMetaDataSelector columnSelector = new JdbcMetaDataSelector(locator, (dbmd, loc) -> dbmd.getColumns(loc.getCatalogName(), loc.getSchemaNamePattern(), loc.getTableNamePattern(), columnNamePattern));
 
             try (ResultSet rsCols = columnSelector.getResultSet())
             {

--- a/api/src/org/labkey/api/data/DbSchema.java
+++ b/api/src/org/labkey/api/data/DbSchema.java
@@ -198,7 +198,7 @@ public class DbSchema
     {
         final Map<String, SchemaTableInfoFactory> schemaTableInfoFactoryMap = new CaseInsensitiveHashMap<>();
 
-        try (JdbcMetaDataLocator locator = scope.getSqlDialect().getJdbcMetaDataLocator(scope, schemaName, "%"))
+        try (JdbcMetaDataLocator locator = scope.getSqlDialect().getJdbcMetaDataLocator(scope).singleSchema(schemaName).allTables())
         {
             new TableMetaDataLoader(locator, ignoreTemp)
             {
@@ -240,7 +240,7 @@ public class DbSchema
         {
             final SqlDialect dialect = _locator.getScope().getSqlDialect();
 
-            JdbcMetaDataSelector selector = new JdbcMetaDataSelector(_locator, (dbmd, locator) -> dbmd.getTables(locator.getCatalogName(), locator.getSchemaName(), locator.getTableName(), locator.getTableTypes()));
+            JdbcMetaDataSelector selector = new JdbcMetaDataSelector(_locator, (dbmd, locator) -> dbmd.getTables(locator.getCatalogName(), locator.getSchemaNamePattern(), locator.getTableNamePattern(), locator.getTableTypes()));
 
             selector.forEach(rs -> {
                 String tableName = rs.getString("TABLE_NAME").trim();

--- a/api/src/org/labkey/api/data/SchemaColumnMetaData.java
+++ b/api/src/org/labkey/api/data/SchemaColumnMetaData.java
@@ -58,7 +58,8 @@ public class SchemaColumnMetaData
     private boolean _hasDefaultTitleColumn = true;
     private Map<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> _uniqueIndices;
     private Map<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> _allIndices;
-    private static Logger _log = LogManager.getLogger(SchemaColumnMetaData.class);
+
+    private static final Logger _log = LogManager.getLogger(SchemaColumnMetaData.class);
 
     SchemaColumnMetaData(SchemaTableInfo tinfo, boolean load) throws SQLException
     {
@@ -181,7 +182,7 @@ public class SchemaColumnMetaData
         // Use TreeMap to order columns by keySeq
         Map<Integer, String> pkMap = new TreeMap<>();
 
-        try (JdbcMetaDataLocator locator = scope.getSqlDialect().getJdbcMetaDataLocator(scope, schemaName, ti.getMetaDataName()))
+        try (JdbcMetaDataLocator locator = scope.getSqlDialect().getJdbcMetaDataLocator(scope).singleSchema(schemaName).singleTable(ti))
         {
             JdbcMetaDataSelector pkSelector = new JdbcMetaDataSelector(locator,
                 (dbmd, locator1) -> dbmd.getPrimaryKeys(locator1.getCatalogName(), locator1.getSchemaName(), locator1.getTableName()));
@@ -238,7 +239,7 @@ public class SchemaColumnMetaData
         }
         else
         {
-            try (JdbcMetaDataLocator locator = scope.getSqlDialect().getJdbcMetaDataLocator(scope, schemaName, ti.getMetaDataName()))
+            try (JdbcMetaDataLocator locator = scope.getSqlDialect().getJdbcMetaDataLocator(scope).singleSchema(schemaName).singleTable(ti))
             {
                 JdbcMetaDataSelector uqSelector = new JdbcMetaDataSelector(locator,
                         ((dbmd, l) -> {

--- a/api/src/org/labkey/api/data/SchemaNameCache.java
+++ b/api/src/org/labkey/api/data/SchemaNameCache.java
@@ -35,21 +35,16 @@ public class SchemaNameCache
 {
     private static final SchemaNameCache INSTANCE = new SchemaNameCache();
 
-    private final BlockingCache<String, Map<String, String>> _cache = CacheManager.getBlockingStringKeyCache(50, CacheManager.YEAR, "Schema names in each scope", new CacheLoader<String, Map<String, String>>()
-    {
-        @Override
-        public Map<String, String> load(String dsName, @Nullable Object argument)
-        {
-            DbScope scope = DbScope.getDbScope(dsName);
+    private final BlockingCache<String, Map<String, String>> _cache = CacheManager.getBlockingStringKeyCache(50, CacheManager.YEAR, "Schema names in each scope", (dsName, argument) -> {
+        DbScope scope = DbScope.getDbScope(dsName);
 
-            try
-            {
-                return loadSchemaNameMap(scope);
-            }
-            catch (SQLException e)
-            {
-                throw new RuntimeSQLException(e);
-            }
+        try
+        {
+            return loadSchemaNameMap(scope);
+        }
+        catch (SQLException e)
+        {
+            throw new RuntimeSQLException(e);
         }
     });
 
@@ -75,7 +70,7 @@ public class SchemaNameCache
     {
         final Map<String, String> schemaNameMap = new CaseInsensitiveTreeMap<>();
 
-        try (JdbcMetaDataLocator locator = scope.getSqlDialect().getJdbcMetaDataLocator(scope, null, null))
+        try (JdbcMetaDataLocator locator = scope.getSqlDialect().getJdbcMetaDataLocator(scope).allSchemas().allTables())
         {
             JdbcMetaDataSelector selector = new JdbcMetaDataSelector(locator, (dbmd, locator1) -> {
                 // Most dialects support schemas, but MySQL treats them as catalogs

--- a/api/src/org/labkey/api/data/dialect/BaseJdbcMetaDataLocator.java
+++ b/api/src/org/labkey/api/data/dialect/BaseJdbcMetaDataLocator.java
@@ -15,9 +15,10 @@
  */
 package org.labkey.api.data.dialect;
 
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ColumnInfo.ImportedKey;
 import org.labkey.api.data.DbScope;
+import org.labkey.api.data.TableInfo;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -32,20 +33,59 @@ import java.sql.SQLException;
 public class BaseJdbcMetaDataLocator implements JdbcMetaDataLocator
 {
     private final DbScope _scope;
-    private final String _schemaName;
-    private final String _tableNamePattern;
     private final ConnectionHandler _connectionHandler;
     private final Connection _connection;
     private final DatabaseMetaData _dbmd;
 
-    public BaseJdbcMetaDataLocator(DbScope scope, String schemaName, @Nullable String tableNamePattern, ConnectionHandler connectionHandler) throws SQLException
+    private String _schemaName;
+    private String _schemaNamePattern;
+    private String _tableName;
+    private String _tableNamePattern;
+
+    public BaseJdbcMetaDataLocator(DbScope scope, ConnectionHandler connectionHandler) throws SQLException
     {
         _scope = scope;
-        _schemaName = schemaName;
-        _tableNamePattern = tableNamePattern;
         _connectionHandler = connectionHandler;
         _connection = connectionHandler.getConnection();
         _dbmd = _connection.getMetaData();
+    }
+
+    @Override
+    public JdbcMetaDataLocator singleSchema(@NotNull String schemaName)
+    {
+        _schemaName = schemaName;
+        _schemaNamePattern = escapeName(schemaName);
+        return this;
+    }
+
+    @Override
+    public JdbcMetaDataLocator allSchemas()
+    {
+        _schemaName = null;
+        _schemaNamePattern = "%";
+        return this;
+    }
+
+    @Override
+    public JdbcMetaDataLocator singleTable(@NotNull String tableName) throws SQLException
+    {
+        _tableName = tableName;
+        _tableNamePattern = escapeName(tableName);
+        return this;
+    }
+
+    @Override
+    public JdbcMetaDataLocator singleTable(@NotNull TableInfo tableInfo) throws SQLException
+    {
+        return singleTable(tableInfo.getMetaDataName());
+    }
+
+    @Override
+    public JdbcMetaDataLocator allTables()
+    {
+        _tableName = null;
+        _tableNamePattern = "%";
+        return this;
     }
 
     @Override
@@ -75,12 +115,28 @@ public class BaseJdbcMetaDataLocator implements JdbcMetaDataLocator
     @Override
     public String getSchemaName()
     {
+        assert null != _schemaName;
         return _schemaName;
+    }
+
+    @Override
+    public String getSchemaNamePattern()
+    {
+        assert null != _schemaNamePattern;
+        return _schemaNamePattern;
     }
 
     @Override
     public String getTableName()
     {
+        assert null != _tableName;
+        return _tableName;
+    }
+
+    @Override
+    public String getTableNamePattern()
+    {
+        assert null != _tableNamePattern;
         return _tableNamePattern;
     }
 
@@ -100,5 +156,15 @@ public class BaseJdbcMetaDataLocator implements JdbcMetaDataLocator
     public boolean supportsSchemas()
     {
         return true;
+    }
+
+    // We must escape LIKE wild card characters in cases where we're passing a table or schema name as a pattern parameter, #43821
+    private static String escapeName(@NotNull String name)
+    {
+        String ret = name.replace("\\", "\\\\");
+        ret = ret.replace("_", "\\_");
+        ret = ret.replace("%", "\\%");
+
+        return ret;
     }
 }

--- a/api/src/org/labkey/api/data/dialect/JdbcMetaDataLocator.java
+++ b/api/src/org/labkey/api/data/dialect/JdbcMetaDataLocator.java
@@ -15,25 +15,44 @@
  */
 package org.labkey.api.data.dialect;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.DbScope;
+import org.labkey.api.data.TableInfo;
 
 import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
 
 /**
  * User: adam
  * Date: 2/8/2015
  * Time: 7:45 AM
+ *
+ * JDBC metadata methods are inconsistent with their parameters. The schema and table parameters are sometimes patterns
+ * and sometimes simple strings. Callers must be very careful to review the method JavaDocs and use the appropriate
+ * methods: *NamePattern() methods for the former and the *Name() methods for the latter. This will ensure correct
+ * escaping of special characters; see #43821.
  */
 public interface JdbcMetaDataLocator extends AutoCloseable, ForeignKeyResolver
 {
     @Override
     void close();
 
+    // Once the implementation is constructed, one of these schema methods must be called...
+    JdbcMetaDataLocator singleSchema(@NotNull String schemaName);
+    JdbcMetaDataLocator allSchemas();
+
+    // ...followed by one of these table methods.
+    JdbcMetaDataLocator singleTable(@NotNull String tableName) throws SQLException;
+    JdbcMetaDataLocator singleTable(@NotNull TableInfo tableInfo) throws SQLException;
+    JdbcMetaDataLocator allTables();
+
     DbScope getScope();
     DatabaseMetaData getDatabaseMetaData();
     String getCatalogName();
     String getSchemaName();
+    String getSchemaNamePattern();
     String getTableName();
+    String getTableNamePattern();
     String[] getTableTypes();
     boolean supportsSchemas();
 }

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -920,9 +920,9 @@ public abstract class SqlDialect
         getTableResolver().addTableInfoFactories(map, scope, schemaName);
     }
 
-    public final JdbcMetaDataLocator getJdbcMetaDataLocator(DbScope scope, @Nullable String schemaName, @Nullable String requestedTableName) throws SQLException
+    public final JdbcMetaDataLocator getJdbcMetaDataLocator(DbScope scope) throws SQLException
     {
-        return getTableResolver().getJdbcMetaDataLocator(scope, schemaName, requestedTableName);
+        return getTableResolver().getJdbcMetaDataLocator(scope);
     }
 
     public final ForeignKeyResolver getForeignKeyResolver(DbScope scope, @Nullable String schemaName, @Nullable String tableName)

--- a/api/src/org/labkey/api/data/dialect/StandardTableResolver.java
+++ b/api/src/org/labkey/api/data/dialect/StandardTableResolver.java
@@ -34,9 +34,9 @@ public class StandardTableResolver implements TableResolver
     }
 
     @Override
-    public JdbcMetaDataLocator getJdbcMetaDataLocator(DbScope scope, @Nullable String schemaName, @Nullable String tableName) throws SQLException
+    public JdbcMetaDataLocator getJdbcMetaDataLocator(DbScope scope) throws SQLException
     {
-        return new StandardJdbcMetaDataLocator(scope, schemaName, tableName);
+        return new StandardJdbcMetaDataLocator(scope);
     }
 
     private static final ForeignKeyResolver STANDARD_RESOLVER = new StandardForeignKeyResolver();

--- a/api/src/org/labkey/api/data/dialect/TableResolver.java
+++ b/api/src/org/labkey/api/data/dialect/TableResolver.java
@@ -28,6 +28,6 @@ import java.util.Map;
 public interface TableResolver
 {
     void addTableInfoFactories(Map<String, SchemaTableInfoFactory> map, DbScope scope, String schemaName) throws SQLException;
-    JdbcMetaDataLocator getJdbcMetaDataLocator(DbScope scope, @Nullable String schemaName, @Nullable String requestedTableName) throws SQLException;
+    JdbcMetaDataLocator getJdbcMetaDataLocator(DbScope scope) throws SQLException;
     ForeignKeyResolver getForeignKeyResolver(DbScope scope, @Nullable String schemaName, @Nullable String tableName);
 }

--- a/api/src/org/labkey/api/exp/api/ProvisionedDbSchema.java
+++ b/api/src/org/labkey/api/exp/api/ProvisionedDbSchema.java
@@ -50,7 +50,7 @@ public class ProvisionedDbSchema extends DbSchema
     @Override
     public SchemaTableInfo createTableFromDatabaseMetaData(String requestedTableName) throws SQLException
     {
-        try (JdbcMetaDataLocator locator = getSqlDialect().getJdbcMetaDataLocator(getScope(), getName(), requestedTableName))
+        try (JdbcMetaDataLocator locator = getSqlDialect().getJdbcMetaDataLocator(getScope()).singleSchema(getName()).singleTable(requestedTableName))
         {
             return new SingleTableMetaDataLoader(this, locator, DbSchema.getTemp() != this).load();
         }

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -2144,7 +2144,7 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
             "            (\n" +
             "                t.user_type_id = c.user_type_id\n" +
             "            ) \n" +
-            " WHERE s.name = ? AND o.name = ?";
+            " WHERE s.name = ? AND o.name LIKE ? ESCAPE '\\'";
 
     @Override
     public DatabaseMetaData wrapDatabaseMetaData(DatabaseMetaData md, DbScope scope)
@@ -2160,7 +2160,7 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
 
                 if (null != tableNamePattern && !"%".equals(tableNamePattern))
                 {
-                    sql.append(" AND TABLE_NAME = ?");
+                    sql.append(" AND TABLE_NAME LIKE ? ESCAPE '\\'");
                     sql.add(tableNamePattern);
                 }
 
@@ -2178,9 +2178,9 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
                 sql.add(schemaPattern);
                 sql.add(tableNamePattern);
 
-                if (null != columnNamePattern && !"%".equals(tableNamePattern))
+                if (null != columnNamePattern && !"%".equals(columnNamePattern))
                 {
-                    sql.append(" AND c.name = ?");
+                    sql.append(" AND c.name LIKE ? ESCAPE '\\'");
                     sql.add(columnNamePattern);
                 }
 

--- a/bigiron/src/org/labkey/bigiron/mysql/MySqlDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySqlDialect.java
@@ -17,7 +17,6 @@ package org.labkey.bigiron.mysql;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CsvSet;
 import org.labkey.api.collections.Sets;
 import org.labkey.api.data.DatabaseTableType;
@@ -123,15 +122,21 @@ public class MySqlDialect extends SimpleSqlDialect
 
     private static final TableResolver TABLE_RESOLVER = new StandardTableResolver() {
         @Override
-        public JdbcMetaDataLocator getJdbcMetaDataLocator(DbScope scope, @Nullable String schemaName, @Nullable String tableName) throws SQLException
+        public JdbcMetaDataLocator getJdbcMetaDataLocator(DbScope scope) throws SQLException
         {
             // MySQL treats catalogs as schemas... i.e., getSchemaName() needs to return null and getCatalogName() needs to return the schema name
-            return new StandardJdbcMetaDataLocator(scope, null, tableName)
+            return new StandardJdbcMetaDataLocator(scope)
             {
+                @Override
+                public String getSchemaName()
+                {
+                    return null;
+                }
+
                 @Override
                 public String getCatalogName()
                 {
-                    return schemaName;
+                    return super.getSchemaName();
                 }
 
                 @Override

--- a/bigiron/src/org/labkey/bigiron/oracle/OracleDialect.java
+++ b/bigiron/src/org/labkey/bigiron/oracle/OracleDialect.java
@@ -18,7 +18,6 @@ package org.labkey.bigiron.oracle;
 
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ConnectionPool;
 import org.labkey.api.data.ConnectionWrapper;
 import org.labkey.api.data.DbScope;
@@ -64,9 +63,9 @@ abstract class OracleDialect extends SimpleSqlDialect
     private static final Map<DbScope, ConnectionPool> META_DATA_CONNECTION_POOLS = new ConcurrentHashMap<>();
     private static final TableResolver TABLE_RESOLVER = new StandardTableResolver() {
         @Override
-        public JdbcMetaDataLocator getJdbcMetaDataLocator(DbScope scope, @Nullable String schemaName, @Nullable String tableName) throws SQLException
+        public JdbcMetaDataLocator getJdbcMetaDataLocator(DbScope scope) throws SQLException
         {
-            return new BaseJdbcMetaDataLocator(scope, schemaName, tableName, new ConnectionHandler()
+            return new BaseJdbcMetaDataLocator(scope, new ConnectionHandler()
             {
                 @Override
                 public Connection getConnection()

--- a/bigiron/src/org/labkey/bigiron/sas/SasDialect.java
+++ b/bigiron/src/org/labkey/bigiron/sas/SasDialect.java
@@ -423,15 +423,14 @@ public abstract class SasDialect extends SimpleSqlDialect
 
     private static final TableResolver TABLE_RESOLVER = new StandardTableResolver() {
         @Override
-        public JdbcMetaDataLocator getJdbcMetaDataLocator(DbScope scope, @Nullable String schemaName, @Nullable String tableName) throws SQLException
+        public JdbcMetaDataLocator getJdbcMetaDataLocator(DbScope scope) throws SQLException
         {
-            // Issue 36340 - SAS doesn't support transactions, so use a no-op variant
-            return new StandardJdbcMetaDataLocator(scope, schemaName, tableName, new SasTransaction(scope))
+            return new StandardJdbcMetaDataLocator(scope)
             {
                 @Override
                 public String getCatalogName()
                 {
-                    return schemaName;
+                    return getSchemaName();
                 }
             };
         }

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1410,10 +1410,10 @@ public class QueryController extends SpringActionController
 
                 result.addView(scopeInfo);
 
-                try (JdbcMetaDataLocator locator = dialect.getJdbcMetaDataLocator(scope, _dbSchemaName, _dbTableName))
+                try (JdbcMetaDataLocator locator = dialect.getJdbcMetaDataLocator(scope).singleSchema(_dbSchemaName).singleTable(_dbTableName))
                 {
                     JdbcMetaDataSelector columnSelector = new JdbcMetaDataSelector(locator,
-                            (dbmd, l) -> dbmd.getColumns(l.getCatalogName(), l.getSchemaName(), l.getTableName(), null));
+                            (dbmd, l) -> dbmd.getColumns(l.getCatalogName(), l.getSchemaNamePattern(), l.getTableNamePattern(), null));
                     result.addView(new ResultSetView(CachedResultSets.create(columnSelector.getResultSet(), true, Table.ALL_ROWS), "Table Meta Data"));
 
                     JdbcMetaDataSelector pkSelector = new JdbcMetaDataSelector(locator,
@@ -1477,10 +1477,10 @@ public class QueryController extends SpringActionController
 
             ModelAndView tablesView;
 
-            try (JdbcMetaDataLocator locator = dialect.getJdbcMetaDataLocator(scope, dbSchemaName, null))
+            try (JdbcMetaDataLocator locator = dialect.getJdbcMetaDataLocator(scope).singleSchema(dbSchemaName).allTables())
             {
                 JdbcMetaDataSelector selector = new JdbcMetaDataSelector(locator,
-                    (dbmd, locator1) -> dbmd.getTables(locator1.getCatalogName(), locator1.getSchemaName(), locator1.getTableName(), null));
+                    (dbmd, locator1) -> dbmd.getTables(locator1.getCatalogName(), locator1.getSchemaNamePattern(), locator1.getTableNamePattern(), null));
 
                 ActionURL url = new ActionURL(RawTableMetaDataAction.class, getContainer());
                 url.addParameter("schemaName", _schemaName);


### PR DESCRIPTION
#### Rationale
JDBC metadata methods are inconsistent with their parameters. The schema and table parameters are sometimes LIKE patterns and sometimes simple strings. When a table name containing LIKE wild cards ("_" or "%") is passed to a pattern parameter, the metadata call can return results for multiple tables, leading to broken queries. See [43821](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43821) for details.

#### Related Pull Requests
* https://github.com/LabKey/synonym/pull/8

#### Changes
* Adjust `JdbcMetaDataLocator` so callers explicitly indicate:
   * Their filtering intent: multiple schemas vs. single schema, multiple tables vs. single table
   * Whether the metadata call expects a pattern or a simple string
   * Understanding these intents allows the code to escape wild card characters appropriately
* Stop using a transaction to share the connection since we now share connections per thread by default
* Update our custom SQL Server `getTables()` and `getColumns()` implementations to correctly handle pattern parameters (and therefore the escaping we're introducing)