### PR TITLE
Fix EHR test failures in trigger scripts after refactor to use loadRows()

### DIFF
--- a/api/src/org/labkey/api/data/ConvertHelper.java
+++ b/api/src/org/labkey/api/data/ConvertHelper.java
@@ -159,8 +159,8 @@ public class ConvertHelper implements PropertyEditorRegistrar
         _register(new NullSafeConverter(new SqlTimeConverter()), java.sql.Time.class);
         _register(new LenientTimestampConverter(), java.sql.Timestamp.class);
         _register(new LenientDateConverter(), java.util.Date.class);
-        _register(new NullSafeConverter(new LongConverter()), Long.class);
-        _register(new LongConverter(), Long.TYPE);
+        _register(new NullSafeConverter(new _LongConverter()), Long.class);
+        _register(new _LongConverter(), Long.TYPE);
         _register(new NullSafeConverter(new LongArrayConverter()), long[].class);
         _register(new ReportIdentifierConverter(), ReportIdentifier.class);
         _register(new RoleConverter(), Role.class);
@@ -599,8 +599,14 @@ public class ConvertHelper implements PropertyEditorRegistrar
             }
             else if (value instanceof Number)
             {
-                // NOTE: Inconsistent with String case which disallows non-zero fractional part
-                return ((Number) value).intValue();
+                try
+                {
+                    return BigDecimal.valueOf(((Number) value).doubleValue()).intValueExact();
+                }
+                catch (Exception e)
+                {
+                    throw new ConversionException("Could not convert '" + value + "' to an integer", e);
+                }
             }
 
             String s = value.toString();
@@ -624,6 +630,111 @@ public class ConvertHelper implements PropertyEditorRegistrar
                 else
                 {
                     throw new ConversionException("Could not convert '" + s + "' to an integer", e);
+                }
+            }
+        }
+    }
+
+    public static final class _LongConverter implements Converter
+    {
+
+        // ----------------------------------------------------------- Constructors
+        /**
+         * Create a {@link Converter} that will throw a {@link ConversionException}
+         * if a conversion error occurs.
+         */
+        public _LongConverter()
+        {
+            this.defaultValue = null;
+            this.useDefault = false;
+        }
+
+        /**
+         * Create a {@link Converter} that will return the specified default value
+         * if a conversion error occurs.
+         *
+         * @param defaultValue The default value to be returned
+         */
+        public _LongConverter(Object defaultValue)
+        {
+            this.defaultValue = defaultValue;
+            this.useDefault = true;
+        }
+
+        // ----------------------------------------------------- Instance Variables
+        /**
+         * The default value specified to our Constructor, if any.
+         */
+        private final Object defaultValue;
+
+        /**
+         * Should we return the default value on conversion errors?
+         */
+        private final boolean useDefault;
+
+        // --------------------------------------------------------- Public Methods
+
+        /**
+         * Convert the specified input object into an output object of the
+         * specified type.
+         *
+         * @param type  Data type to which this value should be converted
+         * @param value The input value to be converted
+         * @throws ConversionException if conversion cannot be performed
+         *                             successfully
+         */
+        @Override
+        public Object convert(Class type, Object value)
+        {
+            if (value == null)
+            {
+                if (useDefault)
+                {
+                    return (defaultValue);
+                }
+                else
+                {
+                    throw new ConversionException("No value specified");
+                }
+            }
+
+            if (value instanceof Long)
+            {
+                return value;
+            }
+            else if (value instanceof Number)
+            {
+                try
+                {
+                    return BigDecimal.valueOf(((Number) value).doubleValue()).longValueExact();
+                }
+                catch (Exception e)
+                {
+                    throw new ConversionException("Could not convert '" + value + "' to a long", e);
+                }
+            }
+
+            String s = value.toString();
+            try
+            {
+                try
+                {
+                    return Long.parseLong(s);
+                }
+                catch (NumberFormatException x)
+                {
+                    return (new BigDecimal(s)).longValueExact();
+                }
+            }
+            catch (Exception e)
+            {
+                if (useDefault)
+                {
+                    return (defaultValue);
+                }
+                else
+                {
+                    throw new ConversionException("Could not convert '" + s + "' to a long", e);
                 }
             }
         }

--- a/api/src/org/labkey/api/data/ConvertHelper.java
+++ b/api/src/org/labkey/api/data/ConvertHelper.java
@@ -35,7 +35,6 @@ import org.apache.commons.beanutils.converters.FloatArrayConverter;
 import org.apache.commons.beanutils.converters.FloatConverter;
 import org.apache.commons.beanutils.converters.IntegerArrayConverter;
 import org.apache.commons.beanutils.converters.LongArrayConverter;
-import org.apache.commons.beanutils.converters.LongConverter;
 import org.apache.commons.beanutils.converters.ShortArrayConverter;
 import org.apache.commons.beanutils.converters.ShortConverter;
 import org.apache.commons.beanutils.converters.SqlTimeConverter;

--- a/api/src/org/labkey/api/data/JdbcType.java
+++ b/api/src/org/labkey/api/data/JdbcType.java
@@ -55,7 +55,8 @@ public enum JdbcType
         @Override
         protected Object _fromString(String s)
         {
-            return Long.valueOf(s);
+            // Be tolerant of trailing decimal zeros like "39.0", which Long.parseLong() is not
+            return new BigDecimal(s).longValueExact();
         }
     },
 
@@ -139,7 +140,8 @@ public enum JdbcType
         @Override
         protected Object _fromString(String s)
         {
-            return Integer.valueOf(s);
+            // Be tolerant of trailing decimal zeros like "39.0", which Integer.parseInt() is not
+            return new BigDecimal(s).intValueExact();
         }
     },
 
@@ -533,7 +535,7 @@ public enum JdbcType
             if (null != r)
                 return r;
         }
-        catch (NumberFormatException x)
+        catch (NumberFormatException | ArithmeticException x)
         {
             throw new ConversionException("Expected decimal value", x);
         }

--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -37,6 +37,7 @@ import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.ValidationException;
 import org.labkey.api.reports.model.ViewCategory;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
@@ -396,7 +397,7 @@ public interface Dataset extends StudyEntity, StudyCachable<Dataset>
      * @param data the data to be updated
      * @param errors any errors during update will be added to this object
      */
-    String updateDatasetRow(User u, String lsid, Map<String,Object> data, BatchValidationException errors);
+    String updateDatasetRow(User u, String lsid, Map<String,Object> data) throws ValidationException;
 
     /**
      * Fetches a single row from a dataset given an LSID

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -2650,7 +2650,9 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
         if (getKeyType() == Dataset.KeyType.SUBJECT_VISIT_OTHER && getKeyManagementType() != Dataset.KeyManagementType.None)
             managedKey = getKeyPropertyName();
 
-        try (Transaction transaction = StudySchema.getInstance().getSchema().getScope().ensureTransaction())
+        DbScope scope = StudySchema.getInstance().getSchema().getScope();
+
+        try (Transaction transaction = scope.isTransactionActive() ? DbScope.NO_OP_TRANSACTION : scope.ensureTransaction())
         {
             Map<String, Object> oldData = getDatasetRow(u, lsid);
 

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -442,19 +442,12 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
         // Update will delete old and insert, so covering aliases, like insert, is needed
         aliasColumns(_columnMapping, row);
 
-        BatchValidationException errors = new BatchValidationException();
         String lsid = keyFromMap(oldRow);
         // Make sure we've found the original participant before doing the update
         String oldParticipant = getParticipant(oldRow, user, container);
-        String newLsid = _dataset.updateDatasetRow(user, lsid, row, errors);
+        String newLsid = _dataset.updateDatasetRow(user, lsid, row);
         //update the lsid and return
         row.put("lsid", newLsid);
-        if(errors.hasErrors())
-        {
-            ValidationException error = new ValidationException();
-            errors.getRowErrors().forEach(e -> error.addError(new SimpleValidationError(e.getMessage())));
-            throw error;
-        }
 
         row = getRow(user, container, row);
 


### PR DESCRIPTION
#### Rationale
Two categories of problems post-refactor:
- Transaction boundary issues in DatasetDefinition when it hit a problematic row but the calling code wanted to continue gathering additional row errors
- Numeric values being added to the row map in the JS trigger code were coming through as Doubles and not converting to Longs even though they were whole numbers

#### Changes
* Don't push into the transaction stack is one is already active, allowing callers to keep processing without having the connection closed out from under them
* Convert values like "6.0" to Integer and Long without error. Strings or floating points that include decimal values will still error out
* Be more consistent in rejecting decimal values during conversions