### PR TITLE
Issue 43754: SampleTypeDomainKind.hasNullValues override to filter out aliquot rows in "can field be made required" check

### DIFF
--- a/internal/src/org/labkey/api/exp/property/AbstractDomainKind.java
+++ b/internal/src/org/labkey/api/exp/property/AbstractDomainKind.java
@@ -185,7 +185,7 @@ public abstract class AbstractDomainKind<T> extends DomainKind<T>
         }
     }
 
-    private boolean getTotalAndNonBlankSql(Domain domain, DomainProperty prop, SQLFragment allRowsSQL, SQLFragment nonBlankRowsSQL)
+    protected boolean getTotalAndNonBlankSql(Domain domain, DomainProperty prop, SQLFragment allRowsSQL, SQLFragment nonBlankRowsSQL)
     {
         if (getStorageSchemaName() == null)
         {

--- a/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
+++ b/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
@@ -530,11 +530,11 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
         {
             // Issue 43754: Don't include aliquot rows in the null value check (see ExpMaterialTableImpl.createColumn for IsAliquot)
             String table = domain.getStorageTableName();
-            allRowsSQL = new SQLFragment("SELECT * FROM exp.material WHERE LSID IN (")
+            SQLFragment nonAliquotRowsSQL = new SQLFragment("SELECT * FROM exp.material WHERE LSID IN (")
                     .append("SELECT LSID FROM " + getStorageSchemaName() + "." + table)
                     .append(") AND RootMaterialLSID IS NULL");
 
-            long totalRows = new SqlSelector(ExperimentService.get().getSchema(), allRowsSQL).getRowCount();
+            long totalRows = new SqlSelector(ExperimentService.get().getSchema(), nonAliquotRowsSQL).getRowCount();
             long nonBlankRows = new SqlSelector(ExperimentService.get().getSchema(), nonBlankRowsSQL).getRowCount();
             return totalRows != nonBlankRows;
         }


### PR DESCRIPTION
### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43754

If a sample type has aliquots, those rows inherit the field values from the parent sample. However in the check that determines if a field can be set as "required" it compares the total sample/row count agains the non-nulls. Since field values in the DB for aliquot samples will always be null, this results in all fields for that sample type not being able to be set as required, even if all parent samples have values for that field. This PR takes aliquot sample rows into account when getting the total row count (i.e. filtering out aliquots).

#### Changes
* Override hasNullValues in SampleTypeDomainKind to add where clause filtering out aliquot sample rows from total row count query
