### PR TITLE
43776: Definition text for default Missing Value Indicator 'N' is misleading

### DIFF
--- a/api/src/org/labkey/api/data/MvUtil.java
+++ b/api/src/org/labkey/api/data/MvUtil.java
@@ -212,7 +212,7 @@ public class MvUtil
     {
         Map<String, String> mvMap = new HashMap<>();
         mvMap.put("Q", "Data currently under quality control review.");
-        mvMap.put("N", "Required field marked by site as 'data not available'.");
+        mvMap.put("N", "Data in this field has been marked as not usable.");
 
         return mvMap;
     }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43776

#### Changes
- Update the default MV indicator description but new installations.