### PR TITLE
Issue 43850: Need a way to convert from text to JSON and JSONB in PG

### DIFF
--- a/query/src/org/labkey/query/sql/Method.java
+++ b/query/src/org/labkey/query/sql/Method.java
@@ -1481,7 +1481,7 @@ public abstract class Method
             }
         });
 
-        // Special functions to cast an argument to the JSON or JSONB data types
+        // Special functions to cast an argument to the JSON or JSONB data types without needing to support as official datatype in CAST
         postgresMethods.put("parse_json", new ParseJSONMethod("json"));
         postgresMethods.put("parse_jsonb", new ParseJSONMethod("jsonb"));
 

--- a/query/src/org/labkey/query/sql/Method.java
+++ b/query/src/org/labkey/query/sql/Method.java
@@ -1481,6 +1481,10 @@ public abstract class Method
             }
         });
 
+        // Special functions to cast an argument to the JSON or JSONB data types
+        postgresMethods.put("parse_json", new ParseJSONMethod("json"));
+        postgresMethods.put("parse_jsonb", new ParseJSONMethod("jsonb"));
+
         postgresMethods.put("to_json", new PassthroughMethod("to_json", JdbcType.OTHER, 1, 1));
         postgresMethods.put("to_jsonb", new PassthroughMethod("to_jsonb", JdbcType.OTHER, 1, 1));
         postgresMethods.put("array_to_json", new PassthroughMethod("array_to_json", JdbcType.OTHER, 1, 2));
@@ -1571,4 +1575,27 @@ public abstract class Method
         oracleMethods.put("sysdate", new PassthroughMethod("sysdate", JdbcType.DATE, 0,0));
     }
 
+    private static class ParseJSONMethod extends Method
+    {
+        private final String _targetType;
+
+        ParseJSONMethod(String targetType)
+        {
+            super(JdbcType.OTHER, 1, 1);
+            _targetType = targetType;
+        }
+
+        @Override
+        public MethodInfo getMethodInfo()
+        {
+            return new AbstractMethodInfo(JdbcType.OTHER)
+            {
+                @Override
+                public SQLFragment getSQL(SqlDialect dialect, SQLFragment[] arguments)
+                {
+                    return new SQLFragment("(").append(arguments[0]).append(")::").append(_targetType);
+                }
+            };
+        }
+    }
 }

--- a/query/src/org/labkey/query/sql/Query.java
+++ b/query/src/org/labkey/query/sql/Query.java
@@ -1801,6 +1801,9 @@ public class Query
         new SqlTest("SELECT 'similar' WHERE similar_to('abc','%(b|d)%')", 1, 1),
         new SqlTest("SELECT 'similar' WHERE similar_to('abc','(b|c)%')", 1, 0),
         new SqlTest("SELECT 'similar' WHERE similar_to('abc|','abc\\|', '\\')", 1, 1),
+        new SqlTest("SELECT parse_jsonb('{\"a\":1, \"b\":null}')", 1, 1),
+        new SqlTest("SELECT json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a')", 1, 1),
+        new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a') AS INTEGER) AS f) X WHERE f != 1", 1, 0),
     };
 
 


### PR DESCRIPTION
#### Rationale
We introduced pass throughs for Postgres JSON operators and functions but don't support casting a VARCHAR or other data type to JSON or JSONB

#### Changes
* Introduce parse_json and parse_jsonb LabKey SQL functions to do the casting