### PR TITLE
Issue 43860: propagate errors from source query to the wrapped query

### DIFF
--- a/query/src/org/labkey/query/LinkedSchema.java
+++ b/query/src/org/labkey/query/LinkedSchema.java
@@ -259,7 +259,8 @@ public class LinkedSchema extends ExternalSchema
             if (_availableQueries.contains(key) && (nameFilter == null || nameFilter.equalsIgnoreCase(key)))
             {
                 QueryDefinition queryDef = queries.get(key);
-                TableInfo table = queryDef.getTable(new ArrayList<>(), true);
+                var sourceErrors = new ArrayList<QueryException>();
+                TableInfo table = queryDef.getTable(sourceErrors, true);
                 if (table != null)
                 {
                     // Apply any filters that might have been specified in the schema linking process
@@ -277,6 +278,12 @@ public class LinkedSchema extends ExternalSchema
 
                     // Create a wrapper that knows how to apply the rest of the metadata correctly
                     LinkedSchemaQueryDefinition wrappedQueryDef = new LinkedSchemaQueryDefinition(this, filteredQueryDef, extraMetadata);
+                    ret.put(key, wrappedQueryDef);
+                }
+                else if (!sourceErrors.isEmpty())
+                {
+                    // Issue 43860: Stash the source query errors to report them later
+                    LinkedSchemaQueryDefinition wrappedQueryDef = new LinkedSchemaQueryDefinition(this, sourceErrors, key);
                     ret.put(key, wrappedQueryDef);
                 }
             }


### PR DESCRIPTION
#### Rationale
Errors from the source query were not exposed in the linked schema's wrapping query.

#### Changes
* Stash the errors from the source query and return them when asked to construct the table in the wrapping linked schema query.
