### PR TITLE
Core components page update to use QueryModel based details panel components

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1550,9 +1550,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.69.1-fb-finalDetailQueryModel.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.1.tgz",
-      "integrity": "sha1-g9JoNK9uXDY8tNQxxM99hbKBtuU=",
+      "version": "2.70.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.70.0.tgz",
+      "integrity": "sha1-kbw7GjNmYMFTTsrqwZwWmdKhOfU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",
@@ -1684,9 +1684,9 @@
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/react": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.19.tgz",
-      "integrity": "sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.20.tgz",
+      "integrity": "sha512-wWZrPlihslrPpcKyCSlmIlruakxr57/buQN1RjlIeaaTWDLtJkTtRW429MoQJergvVKc4IWBpRhWw7YNh/7GVA==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -6746,9 +6746,9 @@
       }
     },
     "react-redux": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz",
-      "integrity": "sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.5.tgz",
+      "integrity": "sha512-Dt29bNyBsbQaysp6s/dN0gUodcq+dVKKER8Qv82UrpeygwYeX1raTtil7O/fftw/rFqzaf6gJhDZRkkZnn6bjg==",
       "requires": {
         "@babel/runtime": "^7.12.1",
         "@types/react-redux": "^7.1.16",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1124,9 +1124,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.15.3.tgz",
-      "integrity": "sha512-iG7ypZmrdoKP1ckFurS8z97TR+Bqd6KaDsLQ9DiC/Rdxmrvy1nsCDlgfLNKfalbg9sFWdmIdNf+Hg+19XysSFg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.15.4.tgz",
+      "integrity": "sha512-TmuTI+n5HsMesW6Ah2WjvBwix9fBMXwbMxQV3c0ETLAzlmwN4OeRVbYMYwp9P4LEOlAxwGKdd9e8pMiLMAg/Mg==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -1500,7 +1500,7 @@
     },
     "@labkey/api": {
       "version": "1.6.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz",
       "integrity": "sha1-IL/ynYviKDi8Ik1jZUPdCazpr9I="
     },
     "@labkey/build": {
@@ -1550,9 +1550,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.68.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.68.0.tgz",
-      "integrity": "sha1-hvg9RrZ/faV0RfhDpWRkQaNWDYY=",
+      "version": "2.69.1-fb-finalDetailQueryModel.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.0.tgz",
+      "integrity": "sha1-yXj+XvcJSda16GyD0hztdgQvnwU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -1550,9 +1550,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.69.1-fb-finalDetailQueryModel.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.0.tgz",
-      "integrity": "sha1-yXj+XvcJSda16GyD0hztdgQvnwU=",
+      "version": "2.69.1-fb-finalDetailQueryModel.1",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.1.tgz",
+      "integrity": "sha1-g9JoNK9uXDY8tNQxxM99hbKBtuU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.68.0"
+    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.0"
   },
   "devDependencies": {
     "@labkey/build": "4.0.1"

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.0"
+    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.1"
   },
   "devDependencies": {
     "@labkey/build": "4.0.1"

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.1"
+    "@labkey/components": "2.70.0"
   },
   "devDependencies": {
     "@labkey/build": "4.0.1"

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2492,9 +2492,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.69.1-fb-finalDetailQueryModel.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.1.tgz",
-      "integrity": "sha1-g9JoNK9uXDY8tNQxxM99hbKBtuU=",
+      "version": "2.70.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.70.0.tgz",
+      "integrity": "sha1-kbw7GjNmYMFTTsrqwZwWmdKhOfU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",
@@ -12902,9 +12902,9 @@
       }
     },
     "react-redux": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz",
-      "integrity": "sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.5.tgz",
+      "integrity": "sha512-Dt29bNyBsbQaysp6s/dN0gUodcq+dVKKER8Qv82UrpeygwYeX1raTtil7O/fftw/rFqzaf6gJhDZRkkZnn6bjg==",
       "requires": {
         "@babel/runtime": "^7.12.1",
         "@types/react-redux": "^7.1.16",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2492,9 +2492,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.69.1-fb-finalDetailQueryModel.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.0.tgz",
-      "integrity": "sha1-yXj+XvcJSda16GyD0hztdgQvnwU=",
+      "version": "2.69.1-fb-finalDetailQueryModel.1",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.1.tgz",
+      "integrity": "sha1-g9JoNK9uXDY8tNQxxM99hbKBtuU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1142,9 +1142,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.15.3.tgz",
-      "integrity": "sha512-iG7ypZmrdoKP1ckFurS8z97TR+Bqd6KaDsLQ9DiC/Rdxmrvy1nsCDlgfLNKfalbg9sFWdmIdNf+Hg+19XysSFg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.15.4.tgz",
+      "integrity": "sha512-TmuTI+n5HsMesW6Ah2WjvBwix9fBMXwbMxQV3c0ETLAzlmwN4OeRVbYMYwp9P4LEOlAxwGKdd9e8pMiLMAg/Mg==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -2492,9 +2492,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.68.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.68.0.tgz",
-      "integrity": "sha1-hvg9RrZ/faV0RfhDpWRkQaNWDYY=",
+      "version": "2.69.1-fb-finalDetailQueryModel.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.0.tgz",
+      "integrity": "sha1-yXj+XvcJSda16GyD0hztdgQvnwU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.6.7",
-    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.1",
+    "@labkey/components": "2.70.0",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.6.7",
-    "@labkey/components": "2.68.0",
+    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.0",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.6.7",
-    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.0",
+    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.1",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/src/client/LabKeyUIComponentsPage/DetailPage.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/DetailPage.tsx
@@ -2,117 +2,112 @@
  * Copyright (c) 2019 LabKey Corporation. All rights reserved. No portion of this work may be reproduced in
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
-import React from 'react'
+import React, { FC, memo, useCallback, useState, useMemo } from 'react';
 import { Col, FormControl, Row, Button } from "react-bootstrap";
 import {
-    SchemaQuery,
     Alert,
-    QueryGridModel,
-    Detail,
-    getQueryGridModel,
-    getStateQueryGridModel,
-    gridInit,
-    DetailEditing,
-    gridInvalidate
-} from "@labkey/components";
-import { getServerContext } from "@labkey/api";
+    DetailPanel,
+    EditableDetailPanel,
+    InjectedQueryModels,
+    LoadingSpinner,
+    withQueryModels,
+    QueryConfigMap,
+    useServerContext,
+    SchemaQuery,
+} from '@labkey/components';
 
 interface Props {
     editable: boolean
 }
 
-interface State {
-    schemaName: string
-    queryName: string
-    keyValue: string,
-    model: QueryGridModel,
-    error: string
-}
+const DetailPageBody: FC<Props & InjectedQueryModels> = memo(props => {
+    const { actions, queryModels: { model }, editable } = props;
+    const { user } = useServerContext();
 
-export class DetailPage extends React.Component<Props, State> {
+    const onUpdate = useCallback(() => {
+        actions.loadModel(model.id);
+    }, [actions, model]);
 
-    constructor(props: Props) {
-        super(props);
-
-        this.state = {
-            schemaName: undefined,
-            queryName: undefined,
-            keyValue: undefined,
-            model: undefined,
-            error: undefined
-        };
+    if (!model) {
+        return;
+    }
+    if (model.queryInfoError || model.rowsError) {
+        return <Alert>{model.queryInfoError || model.rowsError}</Alert>;
+    }
+    if (model.isLoading) {
+        return <LoadingSpinner/>;
+    }
+    if (!model.queryInfo.isAppEditable()) {
+        return <Alert>This schema/query is not set as editable on this page.</Alert>;
     }
 
-    onSchemaNameChange = (evt) => {
+    return (
+        <>
+            {!editable && <DetailPanel asPanel actions={actions} model={model} />}
+            {editable && <EditableDetailPanel onUpdate={onUpdate} canUpdate={user.canUpdate} actions={actions} model={model} />}
+        </>
+    )
+});
+
+const DetailPageWithModels = withQueryModels<Props>(DetailPageBody);
+
+export const DetailPage: FC<Props> = memo(props => {
+    const [error, setError] = useState<string>();
+    const [queryConfigs, setQueryConfigs] = useState<QueryConfigMap>({});
+
+    const [schemaName, setSchemaName] = useState<string>();
+    const onSchemaNameChange = useCallback((evt) => {
         const value = evt.target.value;
-        this.setState(() => ({schemaName: value}));
-    };
+        setSchemaName(value);
+    }, []);
 
-    onQueryNameChange = (evt) => {
+    const [queryName, setQueryName] = useState<string>();
+    const onQueryNameChange = useCallback((evt) => {
         const value = evt.target.value;
-        this.setState(() => ({queryName: value}));
-    };
+        setQueryName(value);
+    }, []);
 
-    onKeyValueChange = (evt) => {
+    const [keyValue, setKeyValue] = useState<string>();
+    const onKeyValueChange = useCallback((evt) => {
         const value = evt.target.value;
-        this.setState(() => ({keyValue: value}));
-    };
+        setKeyValue(value);
+    }, []);
 
-    onApply = () => {
-        const { schemaName, queryName, keyValue } = this.state;
-        let error;
-        let model;
-
+    const onApply = useCallback(() => {
         if (!schemaName || !queryName || !keyValue) {
-            error = 'You must enter a schema/query/key to view the detail form.'
+            setError('You must enter a schema/query/key to view the detail form.');
         }
         else {
-            model = getStateQueryGridModel('detail', SchemaQuery.create(schemaName, queryName), {}, keyValue);
-            const stateModel = getQueryGridModel(model.getId()) || model;
-            gridInit(stateModel, true, this);
+            setError(undefined);
+            setQueryConfigs({
+                model: {
+                    keyValue: keyValue,
+                    schemaQuery: SchemaQuery.create(schemaName, queryName),
+                }
+            });
         }
+    }, [schemaName, queryName, keyValue]);
 
-        this.setState(() => ({model, error}));
-    };
-
-    getQueryGridModel(): QueryGridModel {
-        const { model } = this.state;
-        return model ? getQueryGridModel(model.getId()) || model : undefined;
-    }
-
-    onUpdate = () => {
-        gridInvalidate(this.getQueryGridModel(), true, this);
-    };
-
-    render() {
-        const { editable } = this.props;
-        const { error } = this.state;
-        const queryModel = this.getQueryGridModel();
-
-        let message = error;
-        if (queryModel) {
-            if (queryModel.message) {
-                message = queryModel.message;
-            }
-            else if (queryModel.isLoaded && queryModel.queryInfo && !queryModel.queryInfo.isAppEditable()) {
-                message = 'This schema/query is not set as editable on this page.'
-            }
+    const key = useMemo(() => {
+        if (queryConfigs.model) {
+            const { schemaName, queryName } = queryConfigs.model.schemaQuery;
+            return [schemaName, queryName, queryConfigs.model.keyValue].join('|');
+        } else {
+            return undefined;
         }
+    }, [queryConfigs]);
 
-        return (
-            <>
-                <Row>
-                    <Col xs={4}>Schema: <FormControl name={'schemaNameField'} type="text" onChange={this.onSchemaNameChange}/></Col>
-                    <Col xs={4}>Query: <FormControl name={'queryNameField'} type="text" onChange={this.onQueryNameChange}/></Col>
-                    <Col xs={3}>Row Key: <FormControl name={'keyValueField'} type="text" onChange={this.onKeyValueChange}/></Col>
-                    <Col xs={1}><Button onClick={this.onApply}>Apply</Button></Col>
-                </Row>
-                <br/>
-                {message && <Alert>{message}</Alert>}
-                {queryModel && !editable && <Detail queryModel={queryModel} asPanel={true}/>}
-                {queryModel && editable && <DetailEditing queryModel={queryModel} canUpdate={getServerContext().user.canUpdate} onUpdate={this.onUpdate}/>}
-            </>
-        )
-    }
-}
-
+    return (
+        <>
+            <Row>
+                <Col xs={4}>Schema: <FormControl name={'schemaNameField'} type="text" onChange={onSchemaNameChange}/></Col>
+                <Col xs={4}>Query: <FormControl name={'queryNameField'} type="text" onChange={onQueryNameChange}/></Col>
+                <Col xs={3}>Row Key: <FormControl name={'keyValueField'} type="text" onChange={onKeyValueChange}/></Col>
+                <Col xs={1}><Button onClick={onApply}>Apply</Button></Col>
+            </Row>
+            <br/>
+            {error && <Alert>{error}</Alert>}
+            {!error && <DetailPageWithModels autoLoad key={key} queryConfigs={queryConfigs} {...props} />}
+        </>
+    );
+});

--- a/core/src/client/LabKeyUIComponentsPage/LabKeyUIComponentsPage.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/LabKeyUIComponentsPage.tsx
@@ -58,8 +58,8 @@ const COMPONENT_NAMES = List<string>([
     {value: 'BreadcrumbCreate'},
     {value: 'Cards'},
     {value: 'ConfirmModal'},
-    {value: 'Detail'},
-    {value: 'DetailEditing'},
+    {value: 'DetailPanel'},
+    {value: 'EditableDetailPanel'},
     {value: 'EditableGridPanel'},
     {value: 'EntityInsertPanel'},
     {value: 'FileAttachmentForm'},
@@ -261,10 +261,10 @@ export class App extends React.Component<any, State> {
                         </>
                     )
                 }
-                {selected === 'Detail' &&
+                {selected === 'DetailPanel' &&
                     <DetailPage editable={false}/>
                 }
-                {selected === 'DetailEditing' &&
+                {selected === 'EditableDetailPanel' &&
                     <DetailPage editable={true}/>
                 }
                 {selected === 'EditableGridPanel' &&

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1550,9 +1550,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.69.1-fb-finalDetailQueryModel.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.1.tgz",
-      "integrity": "sha1-g9JoNK9uXDY8tNQxxM99hbKBtuU=",
+      "version": "2.70.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.70.0.tgz",
+      "integrity": "sha1-kbw7GjNmYMFTTsrqwZwWmdKhOfU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",
@@ -1684,9 +1684,9 @@
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/react": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.19.tgz",
-      "integrity": "sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.20.tgz",
+      "integrity": "sha512-wWZrPlihslrPpcKyCSlmIlruakxr57/buQN1RjlIeaaTWDLtJkTtRW429MoQJergvVKc4IWBpRhWw7YNh/7GVA==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -6746,9 +6746,9 @@
       }
     },
     "react-redux": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz",
-      "integrity": "sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.5.tgz",
+      "integrity": "sha512-Dt29bNyBsbQaysp6s/dN0gUodcq+dVKKER8Qv82UrpeygwYeX1raTtil7O/fftw/rFqzaf6gJhDZRkkZnn6bjg==",
       "requires": {
         "@babel/runtime": "^7.12.1",
         "@types/react-redux": "^7.1.16",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1124,9 +1124,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.15.3.tgz",
-      "integrity": "sha512-iG7ypZmrdoKP1ckFurS8z97TR+Bqd6KaDsLQ9DiC/Rdxmrvy1nsCDlgfLNKfalbg9sFWdmIdNf+Hg+19XysSFg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.15.4.tgz",
+      "integrity": "sha512-TmuTI+n5HsMesW6Ah2WjvBwix9fBMXwbMxQV3c0ETLAzlmwN4OeRVbYMYwp9P4LEOlAxwGKdd9e8pMiLMAg/Mg==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -1500,7 +1500,7 @@
     },
     "@labkey/api": {
       "version": "1.6.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz",
       "integrity": "sha1-IL/ynYviKDi8Ik1jZUPdCazpr9I="
     },
     "@labkey/build": {
@@ -1550,9 +1550,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.68.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.68.0.tgz",
-      "integrity": "sha1-hvg9RrZ/faV0RfhDpWRkQaNWDYY=",
+      "version": "2.69.1-fb-finalDetailQueryModel.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.0.tgz",
+      "integrity": "sha1-yXj+XvcJSda16GyD0hztdgQvnwU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1550,9 +1550,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.69.1-fb-finalDetailQueryModel.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.0.tgz",
-      "integrity": "sha1-yXj+XvcJSda16GyD0hztdgQvnwU=",
+      "version": "2.69.1-fb-finalDetailQueryModel.1",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.1.tgz",
+      "integrity": "sha1-g9JoNK9uXDY8tNQxxM99hbKBtuU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.68.0"
+    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.0"
   },
   "devDependencies": {
     "@labkey/build": "4.0.1"

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.0"
+    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.1"
   },
   "devDependencies": {
     "@labkey/build": "4.0.1"

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.1"
+    "@labkey/components": "2.70.0"
   },
   "devDependencies": {
     "@labkey/build": "4.0.1"

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -1560,9 +1560,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.69.1-fb-finalDetailQueryModel.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.1.tgz",
-      "integrity": "sha1-g9JoNK9uXDY8tNQxxM99hbKBtuU=",
+      "version": "2.70.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.70.0.tgz",
+      "integrity": "sha1-kbw7GjNmYMFTTsrqwZwWmdKhOfU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",
@@ -1727,9 +1727,9 @@
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/react": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.19.tgz",
-      "integrity": "sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.20.tgz",
+      "integrity": "sha512-wWZrPlihslrPpcKyCSlmIlruakxr57/buQN1RjlIeaaTWDLtJkTtRW429MoQJergvVKc4IWBpRhWw7YNh/7GVA==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -7953,9 +7953,9 @@
       }
     },
     "react-redux": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz",
-      "integrity": "sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.5.tgz",
+      "integrity": "sha512-Dt29bNyBsbQaysp6s/dN0gUodcq+dVKKER8Qv82UrpeygwYeX1raTtil7O/fftw/rFqzaf6gJhDZRkkZnn6bjg==",
       "requires": {
         "@babel/runtime": "^7.12.1",
         "@types/react-redux": "^7.1.16",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -1124,9 +1124,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.15.3.tgz",
-      "integrity": "sha512-iG7ypZmrdoKP1ckFurS8z97TR+Bqd6KaDsLQ9DiC/Rdxmrvy1nsCDlgfLNKfalbg9sFWdmIdNf+Hg+19XysSFg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.15.4.tgz",
+      "integrity": "sha512-TmuTI+n5HsMesW6Ah2WjvBwix9fBMXwbMxQV3c0ETLAzlmwN4OeRVbYMYwp9P4LEOlAxwGKdd9e8pMiLMAg/Mg==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -1510,7 +1510,7 @@
     },
     "@labkey/api": {
       "version": "1.6.7",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz",
       "integrity": "sha1-IL/ynYviKDi8Ik1jZUPdCazpr9I="
     },
     "@labkey/build": {
@@ -1560,9 +1560,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.68.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.68.0.tgz",
-      "integrity": "sha1-hvg9RrZ/faV0RfhDpWRkQaNWDYY=",
+      "version": "2.69.1-fb-finalDetailQueryModel.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.0.tgz",
+      "integrity": "sha1-yXj+XvcJSda16GyD0hztdgQvnwU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -1560,9 +1560,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.69.1-fb-finalDetailQueryModel.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.0.tgz",
-      "integrity": "sha1-yXj+XvcJSda16GyD0hztdgQvnwU=",
+      "version": "2.69.1-fb-finalDetailQueryModel.1",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.69.1-fb-finalDetailQueryModel.1.tgz",
+      "integrity": "sha1-g9JoNK9uXDY8tNQxxM99hbKBtuU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.3",
         "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "2.68.0"
+    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.0"
   },
   "devDependencies": {
     "@labkey/build": "4.0.1",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.1"
+    "@labkey/components": "2.70.0"
   },
   "devDependencies": {
     "@labkey/build": "4.0.1",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.0"
+    "@labkey/components": "2.69.1-fb-finalDetailQueryModel.1"
   },
   "devDependencies": {
     "@labkey/build": "4.0.1",


### PR DESCRIPTION
#### Rationale
The core-components page was still using the QueryGridModel based details panel (i.e. Detail and DetailEditing). This PR updates that usage to the QueryModel based components (i.e. DetailPanel and EditableDetailPanel). 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/624
* https://github.com/LabKey/platform/pull/2602
* https://github.com/LabKey/biologics/pull/988
* https://github.com/LabKey/sampleManagement/pull/685

#### Changes
* Core components page usage of QueryModel based DetailPanel and EditableDetailPanel
* Update @labkey/components package version
