### PR TITLE
Issue 43875: Query name casing issues in schema browser cause double caching and tab loading issues

### DIFF
--- a/query/webapp/query/browser/Browser.js
+++ b/query/webapp/query/browser/Browser.js
@@ -237,7 +237,7 @@ Ext4.define('LABKEY.query.browser.Browser', {
     },
 
     buildQueryPanelId : function(schemaName, queryName) {
-        return this.qdpPrefix + encodeURIComponent('&' + schemaName.toString() + '&' + queryName.toLowerCase());
+        return this.qdpPrefix + encodeURIComponent('&' + schemaName.toString() + '&' + queryName);
     },
 
     getTree : function() {
@@ -488,15 +488,28 @@ Ext4.define('LABKEY.query.browser.Browser', {
     showPanel : function(queryId, node) {
         var tabs = this.getComponent('lk-sb-details');
         var tab = tabs.getComponent(queryId);
+
+        // Find tab by id
         if (tab) {
             tabs.setActiveTab(tab);
+            return;
         }
-        else {
-            var panel = this.tabFactory.generateTab(queryId, this, node);
-            if (panel) {
-                tabs.add(panel);
-                tabs.setActiveTab(panel);
-            }
+
+        // Check for lowercase query name
+        var idMap = this.parseQueryPanelId(queryId);
+        if (idMap.queryName)
+            tab = tabs.getComponent(this.buildQueryPanelId(idMap.schemaName, idMap.queryName.toLowerCase()));
+
+        if (tab) {
+            tabs.setActiveTab(tab);
+            return;
+        }
+
+        // Tab not found so generate it
+        var panel = this.tabFactory.generateTab(queryId, this, node);
+        if (panel) {
+            tabs.add(panel);
+            tabs.setActiveTab(panel);
         }
     },
 

--- a/query/webapp/query/browser/Browser.js
+++ b/query/webapp/query/browser/Browser.js
@@ -237,7 +237,7 @@ Ext4.define('LABKEY.query.browser.Browser', {
     },
 
     buildQueryPanelId : function(schemaName, queryName) {
-        return this.qdpPrefix + encodeURIComponent('&' + schemaName.toString() + '&' + queryName);
+        return this.qdpPrefix + encodeURIComponent('&' + schemaName.toString() + '&' + queryName.toLowerCase());
     },
 
     getTree : function() {

--- a/query/webapp/query/browser/Caches.js
+++ b/query/webapp/query/browser/Caches.js
@@ -127,7 +127,7 @@ Ext4.define('LABKEY.query.browser.cache.QueryDetails', {
     },
 
     getCacheKey : function(schemaName, queryName, fk) {
-        return schemaName + '.' + queryName + (fk ? '.' + fk : '');
+        return schemaName + '.' + queryName.toLowerCase() + (fk ? '.' + fk : '');
     },
 
     getQueryDetails : function(schemaName, queryName, fk) {
@@ -179,7 +179,7 @@ Ext4.define('LABKEY.query.browser.cache.QueryDependencies', {
     },
 
     getCacheKey : function(container, schemaName, queryName) {
-        return container + '.' + schemaName + '.' + queryName;
+        return container + '.' + schemaName + '.' + queryName.toLowerCase();
     },
 
     getDependencies : function(container, schemaName, queryName) {


### PR DESCRIPTION
#### Rationale
Queries with a name and title of the same name but different casing get double cached on the client side in the query browser.  Also causes tab loading issues of the query metadata browser depending on the query name in the URL.

#### Changes
* Use lower case query name for cache key
* Since tab query name could come from URL, look for tab id also by lower case, before creating new tab
