### PR TITLE
Postgres 9.6 doesn't support direct casting from JSONB to numeric

### DIFF
--- a/query/src/org/labkey/query/sql/Query.java
+++ b/query/src/org/labkey/query/sql/Query.java
@@ -1803,7 +1803,11 @@ public class Query
         new SqlTest("SELECT 'similar' WHERE similar_to('abc|','abc\\|', '\\')", 1, 1),
         new SqlTest("SELECT parse_jsonb('{\"a\":1, \"b\":null}')", 1, 1),
         new SqlTest("SELECT json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a')", 1, 1),
-        new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a') AS INTEGER) AS f) X WHERE f != 1", 1, 0),
+        // Postgres 9.6 doesn't support direct JSONB and JSON to INTEGER casting, so use VARCHAR for our simple purposes
+        new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f != '1'", 1, 0),
+        new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f = '1'", 1, 1),
+        new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_json('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f != '1'", 1, 0),
+        new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_json('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f = '1'", 1, 1),
     };
 
 


### PR DESCRIPTION
#### Rationale
TeamCity has informed us that Postgres 9.6 doesn't support directly casting from JSONB and JSON to INTEGER and other numeric types. We're deprecating support for 9.6 so this isn't really an important functional difference but this will clean up test failures.

https://teamcity.labkey.org/buildConfiguration/LabKey_217Release_Internal_InternalSuites_OldDependenciesPostgres/1530613?expandedTest=build%3A%28id%3A1530613%29%2Cid%3A14693

#### Changes
* Do a VARCHAR-based validation instead
* Fill in JSON variant that was intended for original merge