### PR TITLE
Fix testLinkedColumnNotDisplayedCase

### DIFF
--- a/api/src/org/labkey/api/study/publish/publishChooseStudy.jsp
+++ b/api/src/org/labkey/api/study/publish/publishChooseStudy.jsp
@@ -128,7 +128,7 @@
         };
 
         handleNext = function(){
-            if ($("#autoLinkCategory").val().length > 200) {
+            if ($("#autoLinkCategory").val() !== undefined && $("#autoLinkCategory").val().length > 200) {
                 let errorMessageDiv = $('#chooseStudyError');
                 errorMessageDiv.text("Linked Dataset Category name must be shorter than 200 characters.");
                 return;


### PR DESCRIPTION
#### Rationale
Neglected to add nullcheck while implementing new code for link to study dataset category assignment.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2596

#### Changes
* Add nullcheck for if sought-after selector is not on page
