### PR TITLE
Rotate labkey-errors.log (43686), show logger info in Admin console (43787)

### DIFF
--- a/api/src/org/labkey/api/data/ConnectionWrapper.java
+++ b/api/src/org/labkey/api/data/ConnectionWrapper.java
@@ -31,6 +31,7 @@ import org.labkey.api.util.LoggerWriter;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.SimpleLoggerWriter;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ViewServlet;
 
 import java.lang.reflect.Method;
@@ -68,7 +69,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class ConnectionWrapper implements java.sql.Connection
 {
-    private static final Logger LOG = LogManager.getLogger(ConnectionWrapper.class);
+    private static final Logger LOG = LogHelper.getLogger(ConnectionWrapper.class, "All JDBC meta data and SQL execution calls being made");
     private static final Map<ConnectionWrapper, Pair<Thread, Throwable>> _openConnections = Collections.synchronizedMap(new IdentityHashMap<>());
     private static final Set<ConnectionWrapper> _loggedLeaks = new HashSet<>();
     private static final Logger _logDefault = LogManager.getLogger(ConnectionWrapper.class);

--- a/api/src/org/labkey/api/data/ConnectionWrapper.java
+++ b/api/src/org/labkey/api/data/ConnectionWrapper.java
@@ -69,7 +69,8 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class ConnectionWrapper implements java.sql.Connection
 {
-    private static final Logger LOG = LogHelper.getLogger(ConnectionWrapper.class, "All JDBC meta data and SQL execution calls being made");
+    private static final Logger LOG = LogHelper.getLogger(ConnectionWrapper.class, "All JDBC metadata and SQL execution calls being made");
+
     private static final Map<ConnectionWrapper, Pair<Thread, Throwable>> _openConnections = Collections.synchronizedMap(new IdentityHashMap<>());
     private static final Set<ConnectionWrapper> _loggedLeaks = new HashSet<>();
     private static final Logger _logDefault = LogManager.getLogger(ConnectionWrapper.class);

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -81,6 +81,7 @@ import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.TestContext;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.FolderTab;
 import org.labkey.api.view.NavTree;
@@ -136,7 +137,7 @@ import java.util.stream.Collectors;
  */
 public class ContainerManager
 {
-    private static final Logger LOG = LogManager.getLogger(ContainerManager.class);
+    private static final Logger LOG = LogHelper.getLogger(ContainerManager.class, "Container (projects, folders, and workbooks) retrieval and management");
     private static final CoreSchema CORE = CoreSchema.getInstance();
 
     private static final String CONTAINER_PREFIX = ContainerManager.class.getName() + "/";

--- a/api/src/org/labkey/api/data/SchemaTableInfoCache.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfoCache.java
@@ -16,7 +16,6 @@
 
 package org.labkey.api.data;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.cache.BlockingCache;
@@ -26,6 +25,7 @@ import org.labkey.api.cache.CacheManager;
 import org.labkey.api.cache.CacheTimeChooser;
 import org.labkey.api.cache.Wrapper;
 import org.labkey.api.util.ExceptionUtil;
+import org.labkey.api.util.logging.LogHelper;
 
 /*
 * User: adam
@@ -34,7 +34,7 @@ import org.labkey.api.util.ExceptionUtil;
 */
 public class SchemaTableInfoCache
 {
-    private static final Logger LOG = LogManager.getLogger(SchemaTableInfoCache.class);
+    private static final Logger LOG = LogHelper.getLogger(SchemaTableInfoCache.class, "See loading of schema and table metadata from database schemas");
 
     private final BlockingCache<String, SchemaTableInfo> _blockingCache;
 

--- a/api/src/org/labkey/api/data/SqlScriptRunner.java
+++ b/api/src/org/labkey/api/data/SqlScriptRunner.java
@@ -16,7 +16,6 @@
 
 package org.labkey.api.data;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -24,6 +23,7 @@ import org.labkey.api.cache.CacheManager;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.User;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public class SqlScriptRunner
 {
-    private static final Logger _log = LogManager.getLogger(SqlScriptRunner.class);
+    private static final Logger _log = LogHelper.getLogger(SqlScriptRunner.class, "Schema SQL script handling during install and upgrade");
     private static final List<SqlScript> _remainingScripts = new ArrayList<>();
     private static final Object SCRIPT_LOCK = new Object();
 

--- a/api/src/org/labkey/api/data/Table.java
+++ b/api/src/org/labkey/api/data/Table.java
@@ -89,7 +89,7 @@ public class Table
     public static final int ERROR_DELETED = 10002;
     public static final int ERROR_TABLEDELETED = 10003;
 
-    private static final Logger _log = LogHelper.getLogger(Table.class, "SQL generation and execution, some TableInfo-scoped DB scoped operations");
+    private static final Logger _log = LogHelper.getLogger(Table.class, "SQL generation and execution, some TableInfo-scoped DB operations");
 
     // Return all rows instead of limiting to the top n
     public static final int ALL_ROWS = -1;

--- a/api/src/org/labkey/api/data/Table.java
+++ b/api/src/org/labkey/api/data/Table.java
@@ -20,7 +20,6 @@ import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -55,6 +54,7 @@ import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.TestContext;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.sql.BatchUpdateException;
 import java.sql.Connection;
@@ -89,7 +89,7 @@ public class Table
     public static final int ERROR_DELETED = 10002;
     public static final int ERROR_TABLEDELETED = 10003;
 
-    private static final Logger _log = LogManager.getLogger(Table.class);
+    private static final Logger _log = LogHelper.getLogger(Table.class, "SQL generation and execution, some TableInfo-scoped DB scoped operations");
 
     // Return all rows instead of limiting to the top n
     public static final int ALL_ROWS = -1;

--- a/api/src/org/labkey/api/dataiterator/LoggingDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/LoggingDataIterator.java
@@ -16,11 +16,11 @@
 package org.labkey.api.dataiterator;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.io.IOException;
 import java.util.Formatter;
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
  */
 public class LoggingDataIterator extends AbstractDataIterator implements ScrollableDataIterator, MapDataIterator
 {
-    static Logger _staticLog = LogManager.getLogger(LoggingDataIterator.class);
+    static Logger _staticLog = LogHelper.getLogger(LoggingDataIterator.class, "Shows transformations and mappings during many types of data imports and ETLs");
     Logger _log = _staticLog;
     Level _pri = Level.DEBUG;
 

--- a/api/src/org/labkey/api/dataiterator/LoggingDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/LoggingDataIterator.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
  */
 public class LoggingDataIterator extends AbstractDataIterator implements ScrollableDataIterator, MapDataIterator
 {
-    static Logger _staticLog = LogHelper.getLogger(LoggingDataIterator.class, "Shows transformations and mappings during many types of data imports and ETLs");
+    static Logger _staticLog = LogHelper.getLogger(LoggingDataIterator.class, "Transformations and mappings during many types of data imports and ETLs");
     Logger _log = _staticLog;
     Level _pri = Level.DEBUG;
 

--- a/api/src/org/labkey/api/files/FileSystemWatcherImpl.java
+++ b/api/src/org/labkey/api/files/FileSystemWatcherImpl.java
@@ -16,7 +16,6 @@
 package org.labkey.api.files;
 
 import org.apache.commons.lang3.SystemUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.imca_cat.pollingwatchservice.PathWatchService;
 import org.imca_cat.pollingwatchservice.PollingWatchService;
@@ -29,6 +28,7 @@ import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.ShutdownListener;
 import org.labkey.api.util.StringUtilsLabKey;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.writer.PrintWriters;
 
 import java.io.File;
@@ -74,7 +74,7 @@ import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
  */
 public class FileSystemWatcherImpl implements FileSystemWatcher
 {
-    private static final Logger LOG = LogManager.getLogger(FileSystemWatcherImpl.class);
+    private static final Logger LOG = LogHelper.getLogger(FileSystemWatcherImpl.class, "Open file system handlers and listeners");
 
     private final WatchService _watcher;
     private final ConcurrentMap<Path, PathListenerManager> _listenerMap = new ConcurrentHashMap<>(1000);

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -70,10 +70,10 @@ import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.MemTrackerListener;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.UnexpectedException;
+import org.labkey.api.util.logging.ErrorLogRotator;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.ViewServlet;
@@ -100,7 +100,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -430,6 +429,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
     private void doInit(ServletContext servletCtx, Execution execution) throws Exception
     {
         _log.info(BANNER);
+        ErrorLogRotator.init();
 
         _servletContext = servletCtx;
 

--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -48,6 +48,7 @@ import org.labkey.api.util.GUID;
 import org.labkey.api.util.Job;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.URLHelper;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.api.writer.PrintWriters;
@@ -100,7 +101,7 @@ abstract public class PipelineJob extends Job implements Serializable
     public static final String PIPELINE_TASK_INFO_PARAM = "pipeline, taskInfo";
     public static final String PIPELINE_TASK_OUTPUT_PARAMS_PARAM = "pipeline, taskOutputParams";
 
-    protected static Logger _log = LogManager.getLogger(PipelineJob.class);
+    protected static Logger _log = LogHelper.getLogger(PipelineJob.class, "Execution and queuing of pipeline jobs");
     // Send start/stop messages to a separate logger because the default logger for this class is set to
     // only write ERROR level events to the system log
     private static final Logger _logJobStopStart = LogManager.getLogger(Job.class);

--- a/api/src/org/labkey/api/reader/TabLoader.java
+++ b/api/src/org/labkey/api/reader/TabLoader.java
@@ -98,7 +98,7 @@ public class TabLoader extends DataLoader
     public static class CsvFactory extends AbstractDataLoaderFactory
     {
         @NotNull @Override
-        public DataLoader createLoader(File file, boolean hasColumnHeaders, Container mvIndicatorContainer) throws IOException
+        public TabLoader createLoader(File file, boolean hasColumnHeaders, Container mvIndicatorContainer) throws IOException
         {
             TabLoader loader = new TabLoader(file, hasColumnHeaders, mvIndicatorContainer);
             loader.parseAsCSV();
@@ -107,7 +107,7 @@ public class TabLoader extends DataLoader
 
         @NotNull @Override
         // A DataLoader created with this constructor does NOT close the reader
-        public DataLoader createLoader(InputStream is, boolean hasColumnHeaders, Container mvIndicatorContainer) throws IOException
+        public TabLoader createLoader(InputStream is, boolean hasColumnHeaders, Container mvIndicatorContainer) throws IOException
         {
             TabLoader loader = new TabLoader(new InputStreamReader(is, StandardCharsets.UTF_8), hasColumnHeaders, mvIndicatorContainer);
             loader.parseAsCSV();
@@ -121,21 +121,26 @@ public class TabLoader extends DataLoader
     public static class CsvFactoryNoConversions extends CsvFactory
     {
         @NotNull @Override
-        public DataLoader createLoader(File file, boolean hasColumnHeaders, Container mvIndicatorContainer) throws IOException
+        public TabLoader createLoader(File file, boolean hasColumnHeaders, Container mvIndicatorContainer) throws IOException
         {
+            TabLoader loader = super.createLoader(file, hasColumnHeaders, mvIndicatorContainer);
+            return configParsing(loader);
+        }
 
-            DataLoader loader = super.createLoader(file, hasColumnHeaders, mvIndicatorContainer);
+        private TabLoader configParsing(TabLoader loader)
+        {
             loader.setInferTypes(false);
+            // Issue 43661 - Excessive logging when indexing a .log file containing backslash followed by "u" that confuses TabLoader
+            loader.setUnescapeBackslashes(false);
             return loader;
         }
 
         @NotNull @Override
         // A DataLoader created with this constructor does NOT close the reader
-        public DataLoader createLoader(InputStream is, boolean hasColumnHeaders, Container mvIndicatorContainer) throws IOException
+        public TabLoader createLoader(InputStream is, boolean hasColumnHeaders, Container mvIndicatorContainer) throws IOException
         {
-            DataLoader loader = super.createLoader(is, hasColumnHeaders, mvIndicatorContainer);
-            loader.setInferTypes(false);
-            return loader;
+            TabLoader loader = super.createLoader(is, hasColumnHeaders, mvIndicatorContainer);
+            return configParsing(loader);
         }
 
         @NotNull @Override
@@ -180,7 +185,7 @@ public class TabLoader extends DataLoader
     private TabBufferedReader _reader = null;
     private int _commentLines = 0;
     private char _chDelimiter = '\t';
-    private String _strDelimiter = new String(new char[]{_chDelimiter});
+    private String _strDelimiter = String.valueOf(_chDelimiter);
     private String _lineDelimiter = null;
 
     private String _strQuote = null;
@@ -417,7 +422,7 @@ public class TabLoader extends DataLoader
             {
                 if (_strQuote == null)
                 {
-                    _strQuote = new String(new char[] {chQuote});
+                    _strQuote = String.valueOf(chQuote);
                     _strQuoteQuote = new String(new char[] {chQuote, chQuote});
                     _replaceDoubleQuotes = Pattern.compile("\\" + chQuote + "\\" + chQuote);
                 }
@@ -502,7 +507,7 @@ public class TabLoader extends DataLoader
             start = end;
         }
 
-        return listParse.toArray(new String[listParse.size()]);
+        return listParse.toArray(new String[0]);
     }
 
     @Deprecated // Just use a CloseableFilteredIterator.  TODO: Remove
@@ -547,7 +552,7 @@ public class TabLoader extends DataLoader
     public void setDelimiterCharacter(char delimiter)
     {
         _chDelimiter = delimiter;
-        _strDelimiter = new String(new char[]{_chDelimiter});
+        _strDelimiter = String.valueOf(_chDelimiter);
     }
 
     public void setDelimiters(@NotNull String field, @Nullable String line)

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -21,7 +21,6 @@ import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -97,6 +96,7 @@ import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.emailTemplate.EmailTemplate;
 import org.labkey.api.util.emailTemplate.EmailTemplateService;
 import org.labkey.api.util.emailTemplate.UserOriginatedEmailTemplate;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HasHttpRequest;
 import org.labkey.api.view.HttpView;
@@ -116,7 +116,6 @@ import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
-import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.Closeable;
 import java.io.IOException;
@@ -145,7 +144,7 @@ import static org.labkey.api.action.SpringActionController.ERROR_MSG;
 
 public class SecurityManager
 {
-    private static final Logger _log = LogManager.getLogger(SecurityManager.class);
+    private static final Logger _log = LogHelper.getLogger(SecurityManager.class, "User and group creation and management");
     private static final CoreSchema core = CoreSchema.getInstance();
     private static final List<ViewFactory> VIEW_FACTORIES = new CopyOnWriteArrayList<>();
     private static final List<TermsOfUseProvider> TERMS_OF_USE_PROVIDERS = new CopyOnWriteArrayList<>();

--- a/api/src/org/labkey/api/util/logging/ErrorLogRotator.java
+++ b/api/src/org/labkey/api/util/logging/ErrorLogRotator.java
@@ -1,0 +1,88 @@
+package org.labkey.api.util.logging;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.appender.rolling.action.PathWithAttributes;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Helper class to retain labkey-errors.log file content if it's danger of rotating out and potentially losing
+ * the root cause of a problem.
+ *
+ * We will retain up to three log files of 100 MB (as configured in log4j2.xml). We'll keep the first log from a given
+ * webapp startup, moving it to labkey-errors-yyyy-MM-dd.log for archive purposes.
+ *
+ * See issue 43686.
+ */
+public class ErrorLogRotator
+{
+    public static final int MAX_RETAINED = 3;
+    /** Don't retain more than one file per session */
+    private static boolean _copiedOriginal = false;
+
+    /** Remember when we started up so we can compare file timestamps against it */
+    private static final Date _startup = new Date();
+
+    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+    private static final Logger LOG = LogHelper.getLogger(ErrorLogRotator.class, "Retains original set of errors from labkey-errors.log when rotating");
+
+    public static void init()
+    {
+
+    }
+
+    public List<PathWithAttributes> filter(List<PathWithAttributes> paths)
+    {
+        // Narrow to just the error log files
+        paths = paths.stream().filter(p -> p.getPath().toString().contains("labkey-errors.log")).collect(Collectors.toList());
+
+        List<PathWithAttributes> result = new ArrayList<>();
+
+        // Look for the first file from the current set of logging to move it away instead of rotating it
+        PathWithAttributes logToRetain = null;
+        long bestTimeVersusStartup = Long.MAX_VALUE;
+
+        for (int i = MAX_RETAINED; i < paths.size(); i++)
+        {
+            PathWithAttributes path = paths.get(i);
+            long timeVersusStartup = Math.abs(path.getAttributes().creationTime().toMillis() - _startup.getTime());
+            // Look for a file that's the closest to the time we started up, and within 20 seconds of startup
+            if (timeVersusStartup < bestTimeVersusStartup && timeVersusStartup < 20_000)
+            {
+                bestTimeVersusStartup = timeVersusStartup;
+                logToRetain = path;
+            }
+
+            result.add(path);
+        }
+
+        if (logToRetain != null && !_copiedOriginal && logToRetain.getAttributes().size() > 0)
+        {
+            Path target = logToRetain.getPath().getParent().resolve("labkey-errors-" + DATE_FORMAT.format(new Date()) + ".log");
+            LOG.info("Retaining labkey-errors.log file before it gets deleted by rotation. Copying to " + target);
+
+            try
+            {
+                Files.move(logToRetain.getPath(), target);
+                // Don't need to mark it for deletion, as it's already been moved
+                result.remove(logToRetain);
+            }
+            catch (IOException e)
+            {
+                LOG.warn("Failed to retain labkey-errors.log file", e);
+            }
+            _copiedOriginal = true;
+        }
+
+        return result;
+    }
+}

--- a/api/src/org/labkey/api/util/logging/ErrorLogRotator.java
+++ b/api/src/org/labkey/api/util/logging/ErrorLogRotator.java
@@ -51,6 +51,7 @@ public class ErrorLogRotator
         PathWithAttributes logToRetain = null;
         long bestTimeVersusStartup = Long.MAX_VALUE;
 
+        // Per Log4J specs, paths are sorted with most recently modified files first
         for (int i = MAX_RETAINED; i < paths.size(); i++)
         {
             PathWithAttributes path = paths.get(i);
@@ -78,7 +79,7 @@ public class ErrorLogRotator
             }
             catch (IOException e)
             {
-                LOG.warn("Failed to retain labkey-errors.log file", e);
+                LOG.warn("Failed to retain error log file " + logToRetain.getPath(), e);
             }
             _copiedOriginal = true;
         }

--- a/api/src/org/labkey/api/util/logging/ErrorLogRotator.java
+++ b/api/src/org/labkey/api/util/logging/ErrorLogRotator.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Helper class to retain labkey-errors.log file content if it's danger of rotating out and potentially losing
+ * Helper class to retain labkey-errors.log file content if it's in danger of rotating out and potentially losing
  * the root cause of a problem.
  *
  * We will retain up to three log files of 100 MB (as configured in log4j2.xml). We'll keep the first log from a given

--- a/api/src/org/labkey/api/util/logging/LogHelper.java
+++ b/api/src/org/labkey/api/util/logging/LogHelper.java
@@ -1,0 +1,28 @@
+package org.labkey.api.util.logging;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Keep a short note about what a given class will log to help admins enable/disable logging of interest via the
+ * Loggers page in the Admin Console.
+ */
+public class LogHelper
+{
+    private static final Map<String, String> LOGGER_NOTES = new ConcurrentHashMap<>();
+
+    public static Logger getLogger(Class<?> c, String note)
+    {
+        LOGGER_NOTES.put(c.getName(), note);
+        //noinspection SSBasedInspection
+        return LogManager.getLogger(c);
+    }
+
+    public static String getNote(String className)
+    {
+        return LOGGER_NOTES.get(className);
+    }
+}

--- a/api/src/org/labkey/api/view/ViewServlet.java
+++ b/api/src/org/labkey/api/view/ViewServlet.java
@@ -16,7 +16,6 @@
 package org.labkey.api.view;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
@@ -46,6 +45,7 @@ import org.labkey.api.util.ShuttingDownException;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.UniqueID;
+import org.labkey.api.util.logging.LogHelper;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.servlet.mvc.Controller;
@@ -80,7 +80,7 @@ import static org.apache.commons.lang3.StringUtils.trimToEmpty;
  */
 public class ViewServlet extends HttpServlet
 {
-    private static final Logger _log = LogManager.getLogger(ViewServlet.class);
+    private static final Logger _log = LogHelper.getLogger(ViewServlet.class, "HTTP request processing details, including failed authentication");
 
     public static final String ORIGINAL_URL_STRING = "LABKEY.OriginalURL";           // String
     public static final String ORIGINAL_URL_URLHELPER = "LABKEY.OriginalURLHelper";  // URLHelper

--- a/api/src/org/labkey/api/websocket/BrowserEndpoint.java
+++ b/api/src/org/labkey/api/websocket/BrowserEndpoint.java
@@ -15,12 +15,12 @@
  */
 package org.labkey.api.websocket;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.labkey.api.security.AuthenticationManager;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.util.UnexpectedException;
+import org.labkey.api.util.logging.LogHelper;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpSession;
@@ -33,9 +33,6 @@ import javax.websocket.Endpoint;
 import javax.websocket.EndpointConfig;
 import javax.websocket.HandshakeResponse;
 import javax.websocket.MessageHandler;
-import javax.websocket.OnClose;
-import javax.websocket.OnError;
-import javax.websocket.OnOpen;
 import javax.websocket.PongMessage;
 import javax.websocket.Session;
 import javax.websocket.WebSocketContainer;
@@ -53,7 +50,7 @@ import java.util.Map;
 
 public abstract class BrowserEndpoint extends Endpoint
 {
-    static Logger LOG = LogManager.getLogger(BrowserEndpoint.class);
+    static final Logger LOG = LogHelper.getLogger(BrowserEndpoint.class, "Server side websocket communication status");
 
     protected Session browserSession;
     ServerEndpoint serverEndpoint = null;

--- a/core/src/org/labkey/core/admin/logger/LoggerController.java
+++ b/core/src/org/labkey/core/admin/logger/LoggerController.java
@@ -41,6 +41,7 @@ import org.labkey.api.security.permissions.AdminOperationsPermission;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.util.URLHelper;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
@@ -84,6 +85,7 @@ public class LoggerController extends SpringActionController
         private String parent;
         private String level;
         private boolean inherited;
+        private String notes;
 
         public static LoggerLevel fromLoggerConfig(LoggerConfig log)
         {
@@ -109,6 +111,7 @@ public class LoggerController extends SpringActionController
             loggerLevel.setLevel(level.toString());
             boolean inherited = parent != null && !parent.equalsIgnoreCase(name);
             loggerLevel.setInherited(inherited);
+            loggerLevel.setNotes(LogHelper.getNote(name));
             return loggerLevel;
         }
 
@@ -152,6 +155,16 @@ public class LoggerController extends SpringActionController
             this.inherited = inherited;
         }
 
+        public String getNotes()
+        {
+            return notes;
+        }
+
+        public void setNotes(String notes)
+        {
+            this.notes = notes;
+        }
+
         @Override
         public boolean equals(Object o)
         {
@@ -161,13 +174,14 @@ public class LoggerController extends SpringActionController
             return inherited == that.inherited &&
                     name.equals(that.name) &&
                     Objects.equals(parent, that.parent) &&
+                    Objects.equals(notes, that.notes) &&
                     level.equals(that.level);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(name, parent, level, inherited);
+            return Objects.hash(name, parent, level, inherited, notes);
         }
     }
 

--- a/core/src/org/labkey/core/admin/logger/manage.jsp
+++ b/core/src/org/labkey/core/admin/logger/manage.jsp
@@ -64,8 +64,11 @@
 
 </style>
 
-<input id="search" type="text" size="120">
 
+<p style='padding-left:0.75em; margin:0.5em;'>
+    <label for="showLevel">Filter by name:</label>
+    <input id="search" type="text" size="50">
+</p>
 <p style='padding-left:0.75em; margin:0.5em;'>
 <label for="showLevel">Show Level:</label>
 <select id="showLevel" value="">
@@ -94,9 +97,10 @@
 <table id='loggerTable' class='labkey-data-region-legacy labkey-show-borders' style='margin-left:0.75em;'>
   <thead>
     <tr>
-      <td width=80 class='labkey-column-header'>Level</td>
-      <td width=500 class='labkey-column-header'>Name</td>
-      <td width=100 class='labkey-column-header'>Parent</td>
+      <td style="width: 80px" class='labkey-column-header'>Level</td>
+      <td style="width: 500px" class='labkey-column-header'>Name</td>
+      <td style="width: 100px" class='labkey-column-header'>Parent</td>
+      <td style="width: 400px" class='labkey-column-header'>Notes</td>
     </tr>
     <tr>
       <td colspan=3 id='loggerTableMessage' class='labkey-message'></td>
@@ -164,7 +168,7 @@
         {
             return a.name.localeCompare(b.name);
         });
-        if (loggers.length == 0)
+        if (loggers.length === 0)
         {
             loggerTableMessage.innerHTML = 'No loggers in response';
             loggerTableMessage.style.display = '';
@@ -193,12 +197,13 @@
         var inherited = logger.inherited === true || logger.inherited === "true"; // convert to boolean
 
         return "<tr class='logger-row' " + (visible ? "" : " style='display:none;'") +
-                "data-name='" + logger.name + "' data-level='" + logger.level + "' data-inherited='" + logger.inherited + "' data-parent='" + logger.parent + "'>" +
+                "data-name='" + LABKEY.Utils.encodeHtml(logger.name) + "' data-level='" + logger.level + "' data-inherited='" + logger.inherited + "' data-parent='" + LABKEY.Utils.encodeHtml(logger.parent) + "'>" +
                 "<td class='" + (inherited ? 'level-inherited' : 'level-configured') + " level-" + logger.level + "'>" +
                 logger.level +
                 "</td>" +
-                "<td>" + (logger.name == 'null' ? '&lt;root&gt;' : logger.name) + "</td>" +
-                "<td>" + logger.parent + "</td>" +
+                "<td>" + (logger.name == 'null' ? '&lt;root&gt;' : LABKEY.Utils.encodeHtml(logger.name)) + "</td>" +
+                "<td>" + LABKEY.Utils.encodeHtml(logger.parent) + "</td>" +
+                "<td>" + LABKEY.Utils.encodeHtml(logger.notes ? logger.notes : '') + "</td>" +
                 "</tr>";
     }
 

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -25,7 +25,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -49,7 +48,6 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.Sort;
-import org.labkey.api.exp.api.DataType;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.files.FileContentService;
@@ -73,6 +71,7 @@ import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.test.TestWhen;
 import org.labkey.api.util.*;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DefaultModelAndView;
 import org.labkey.api.view.JspView;
@@ -191,7 +190,7 @@ import static org.labkey.api.files.FileContentService.UPLOADED_FILE;
  */
 public class DavController extends SpringActionController
 {
-    private static final Logger _log = LogManager.getLogger(DavController.class);
+    private static final Logger _log = LogHelper.getLogger(DavController.class, "WebDAV request handling");
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(DavController.class);
 
     public static final String name = "_dav_";

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -113,6 +113,7 @@ import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.util.UnexpectedException;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.JspTemplate;
@@ -153,7 +154,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -181,7 +181,7 @@ import static org.labkey.api.exp.api.ProvenanceService.PROVENANCE_PROTOCOL_LSID;
 
 public class ExperimentServiceImpl implements ExperimentService
 {
-    private static final Logger LOG = LogManager.getLogger(ExperimentServiceImpl.class);
+    private static final Logger LOG = LogHelper.getLogger(ExperimentServiceImpl.class, "Experiment infrastructure including maintaining runs and lineage");
 
     private Cache<String, ExpProtocolImpl> protocolCache;
 

--- a/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
@@ -19,7 +19,6 @@ package org.labkey.pipeline.api;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -65,6 +64,7 @@ import org.labkey.api.trigger.TriggerConfiguration;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.TestContext;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.JspView;
@@ -113,7 +113,7 @@ import static org.labkey.api.pipeline.file.AbstractFileAnalysisJob.ANALYSIS_PARA
 
 public class PipelineServiceImpl implements PipelineService
 {
-    private static final Logger LOG = LogManager.getLogger(PipelineService.class);
+    private static final Logger LOG = LogHelper.getLogger(PipelineService.class, "Pipeline initialization and job requeuing during server startup");
 
     private static final String PREF_LASTPROTOCOL = "lastprotocol";
     private static final String PREF_LASTSEQUENCEDB = "lastsequencedb";

--- a/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
@@ -16,7 +16,6 @@
 package org.labkey.study.dataset;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.NullSafeBindException;
@@ -64,6 +63,7 @@ import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.ShutdownListener;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
@@ -111,7 +111,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements QuerySnapshotService.AutoUpdateable, DatasetManager.DatasetListener, ParticipantCategoryListener
 {
     private static final DatasetSnapshotProvider INSTANCE = new DatasetSnapshotProvider();
-    private static final Logger LOG = LogManager.getLogger(DatasetSnapshotProvider.class);
+    private static final Logger LOG = LogHelper.getLogger(DatasetSnapshotProvider.class, "Query snapshot refresh details");
     private static final BlockingQueue<SnapshotDependency.SourceDataType> QUEUE = new LinkedBlockingQueue<>(1000);
     private static final QuerySnapshotDependencyThread DEPENDENCY_THREAD = new QuerySnapshotDependencyThread();
 


### PR DESCRIPTION
#### Rationale
* Runaway error logging can fill the disk via labkey-errors.log, further compounding server problems
* Users like to know what loggers may have debug logging of interest. They can currently find some guidance at https://www.labkey.org/Documentation/wiki-page.view?name=loggers
* Issue 43787: Add use-case guidance to Loggers page of admin console
* Issue 43686: Improve log rotation on labkey-errors.log to avoid filling disk

#### Changes
* Rotate labkey-errors.log at 100MB
* Retain last 3 files, plus ensure that we archive the error log with the first error logging from the current startup in a separate dated file
* Let code include a short note about a logger's usage
* Show the note in the Admin Console's Loggers page
* Add various logger notes