### PR TITLE
Issue 43853: Always include "children" array (even if empty) in project-getContainers API response

### DIFF
--- a/core/src/org/labkey/core/portal/ProjectController.java
+++ b/core/src/org/labkey/core/portal/ProjectController.java
@@ -1527,12 +1527,13 @@ public class ProjectController extends SpringActionController
             if (_requestedDepth > 0)
             {
                 List<Map<String, Object>> children = getVisibleChildren(container, user, propertiesToSerialize, 0);
+                resultMap.put("children", children);
+
                 if (children.size() > 0)
                 {
-                    // if use has perm to at least one child container, make sure that at least the parent name is shown
+                    // if use has permissions to at least one child container, make sure that at least the parent name is shown
                     // (even if the user doesn't have perm to that parent container)
                     resultMap.put("name", container.getName());
-                    resultMap.put("children", children);
                 }
             }
 


### PR DESCRIPTION
#### Rationale
The merge of the related PR to fix the permissions issue for the project-getContainers API action resulted in some failures in the 21.7 Daily suites. Turns out that the Study Publish Wizard relies on the "children" property being in the response object (even if it is empty) to do a container duplicate name check. This PR makes a change so that this property is once again always included.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2611

#### Changes
* Update getContainerJSON to revert back to always including the "children" property in the response object when requestedDepth > 0
