### PR TITLE
Don't log an error for failed file deletion

### DIFF
--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -180,7 +180,7 @@ public class FileUtil
                 try {Thread.sleep(1000);} catch (InterruptedException x) {/* pass */}
             }
         }
-        log.error("Failed to delete file after 5 attempts: " + FileUtil.getAbsoluteCaseSensitiveFile(dir.toFile()));
+        log.warn("Failed to delete file after 5 attempts: " + FileUtil.getAbsoluteCaseSensitiveFile(dir.toFile()));
         return false;
     }
 

--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -164,6 +164,8 @@ public class FileUtil
             }
         }
 
+        IOException lastException = null;
+
         // The directory is now either a sym-link or empty, so delete it
         for (int i = 0; i < 5 ; i++)
         {
@@ -174,13 +176,14 @@ public class FileUtil
             }
             catch (IOException e)
             {
+                lastException = e;
                 // Issue 39579: Folder import sometimes fails to delete temp directory
                 // wait a little then try again
-                log.warn("Failed to delete file.  Sleep and try to delete again: " + FileUtil.getAbsoluteCaseSensitiveFile(dir.toFile()));
+                log.warn("Failed to delete file.  Sleep and try to delete again: " + FileUtil.getAbsoluteCaseSensitiveFile(dir.toFile()), e);
                 try {Thread.sleep(1000);} catch (InterruptedException x) {/* pass */}
             }
         }
-        log.warn("Failed to delete file after 5 attempts: " + FileUtil.getAbsoluteCaseSensitiveFile(dir.toFile()));
+        log.warn("Failed to delete file after 5 attempts: " + FileUtil.getAbsoluteCaseSensitiveFile(dir.toFile()), lastException);
         return false;
     }
 

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -1404,7 +1404,7 @@ public class FileContentServiceImpl implements FileContentService
                             }
                             catch (MissingRootDirectoryException e)
                             {
-                                _log.error("Unable to list files for fileset: " + rootName);
+                                _log.error("Unable to list files for fileset: " + rootName, e);
                             }
                             break;
                         }
@@ -1430,7 +1430,7 @@ public class FileContentServiceImpl implements FileContentService
             }
             catch (Exception e)
             {
-                _log.error("Error listing content of directory: " + file.getAbsolutePath());
+                _log.error("Error listing content of directory: " + file.getAbsolutePath(), e);
             }
         }
     }


### PR DESCRIPTION
#### Rationale
File deletion fails on Windows occasionally and causes failures on TeamCity. The delete is often of a temp file of some kind and isn't serious. A warning will be sufficient.

#### Changes
* Log failed deletion as a warning instead of error
