### PR TITLE
Fix importFolderFromZip-related test outages

### DIFF
--- a/api/src/org/labkey/api/reports/model/ViewCategoryManager.java
+++ b/api/src/org/labkey/api/reports/model/ViewCategoryManager.java
@@ -181,6 +181,7 @@ public class ViewCategoryManager extends ContainerManager.AbstractContainerListe
                         throw new IllegalArgumentException("There is already a category in this folder with the name: " + category.getLabel());
                 }
                 category.beforeInsert(user, c.getId());
+                ViewCategoryCache.get().clear(c);
 
                 ret = Table.insert(user, getTableInfoCategories(), category);
 
@@ -195,6 +196,7 @@ public class ViewCategoryManager extends ContainerManager.AbstractContainerListe
                     existing.setDisplayOrder(category.getDisplayOrder());
 
                     ret = Table.update(user, getTableInfoCategories(), existing, existing.getRowId());
+                    ViewCategoryCache.get().clear(c);
 
                     errors = fireUpdateCategory(user, ret);
                 }


### PR DESCRIPTION
#### Rationale
In a previous commit, a change was made to avoid deadlocks in ViewCategoryManager.ensureViewCategory(). However, this broke scenarios in which studies (and view categories) are imported from zip files. We are reverting these changes in order to fix the test outages on a branch.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2616

#### Changes
* Revert changes
