### PR TITLE
Dataset "Delete All Rows" fix for confirm dialog so it doesn't truncate message text

### DIFF
--- a/study/src/org/labkey/study/view/datasetDetails.jsp
+++ b/study/src/org/labkey/study/view/datasetDetails.jsp
@@ -260,9 +260,17 @@ if (!pipelineSet)
                 %>msg +="<b>This will delete data in sub-folders that use this dataset.</b><br>";<%
         } %>
         msg += "This action cannot be undone and will result in an empty dataset.";
-        Ext4.Msg.confirm("Confirm Deletion", msg, function(button){
-            if (button === 'yes') {
-                truncate();
+
+        Ext4.Msg.show({
+            title: "Confirm Deletion",
+            msg: msg,
+            width: 450,
+            buttons: Ext4.MessageBox.YESNO,
+            icon: Ext4.MessageBox.QUESTION,
+            fn : function(buttonId) {
+                if (buttonId === 'yes') {
+                    truncate();
+                }
             }
         });
 


### PR DESCRIPTION
#### Rationale
I noticed that for a manage dataset page the confirm dialog truncates the message in the display when you click the "Delete All Rows" button. This PR fixes that by making the dialog wider.

BEFORE
<img width="621" alt="Screen Shot 2021-09-16 at 5 48 15 PM" src="https://user-images.githubusercontent.com/6411206/133695534-5fdbda9e-9b0b-4a13-9a5b-85123f8cba91.png">

AFTER
<img width="611" alt="Screen Shot 2021-09-16 at 5 48 33 PM" src="https://user-images.githubusercontent.com/6411206/133695543-f8745f32-af29-4608-bfeb-927c7ffca57c.png">

#### Changes
* convert from Ext4.Msg.confirm() to Ext.Msg.show() which allows for control over the width of the dialog
