### PR TITLE
Keep showing note after toggling log level

### DIFF
--- a/core/src/org/labkey/core/admin/logger/manage.jsp
+++ b/core/src/org/labkey/core/admin/logger/manage.jsp
@@ -197,7 +197,7 @@
         var inherited = logger.inherited === true || logger.inherited === "true"; // convert to boolean
 
         return "<tr class='logger-row' " + (visible ? "" : " style='display:none;'") +
-                "data-name='" + LABKEY.Utils.encodeHtml(logger.name) + "' data-level='" + logger.level + "' data-inherited='" + logger.inherited + "' data-parent='" + LABKEY.Utils.encodeHtml(logger.parent) + "'>" +
+                "data-name='" + LABKEY.Utils.encodeHtml(logger.name) + "' data-level='" + logger.level + "' data-inherited='" + logger.inherited + "' data-parent='" + LABKEY.Utils.encodeHtml(logger.parent) + "' data-notes='" + LABKEY.Utils.encodeHtml(logger.notes) + "'>" +
                 "<td class='" + (inherited ? 'level-inherited' : 'level-configured') + " level-" + logger.level + "'>" +
                 logger.level +
                 "</td>" +


### PR DESCRIPTION
#### Rationale
We now show notes for loggers in the Admin Console. But they don't survive the toggling of the log level because we're regenerating the HTML row and not populating it

#### Changes
* Keep the note as a data attribute so that we can reshow it on the new row