### PR TITLE
Issue 43935: EHR test failures due to linked schema's queries parsing

### DIFF
--- a/query/src/org/labkey/query/LinkedSchemaQueryDefinition.java
+++ b/query/src/org/labkey/query/LinkedSchemaQueryDefinition.java
@@ -106,6 +106,17 @@ public class LinkedSchemaQueryDefinition extends QueryDefinitionImpl
     {
         // Parse/resolve the wrapped query in the context of the original source schema
         UserSchema sourceSchema = getSchema().getSourceSchema();
+
+        if (_sourceQueryErrors != null && !_sourceQueryErrors.isEmpty())
+        {
+            if (errors != null)
+                errors.addAll(_sourceQueryErrors);
+            Query q = new Query(schema, getName(), parent);
+            q.setDebugName(getSchemaName() + "." + getName());
+            q.getParseErrors().addAll(_sourceQueryErrors);
+            return q;
+        }
+
         return super.getQuery(sourceSchema, errors, parent, includeMetadata, skipSuggestedColumns);
     }
 


### PR DESCRIPTION
#### Rationale
The recent change in #2601 didn't propagate source query errors when getting a TableInfo from a wrapping linked schema query.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2601

#### Changes
* propagate source query parse errors to linked schema wrapping query

