### PR TITLE
Remove search tests from daily suite

### DIFF
--- a/study/test/src/org/labkey/test/tests/search/DataClassSearchTest.java
+++ b/study/test/src/org/labkey/test/tests/search/DataClassSearchTest.java
@@ -32,7 +32,6 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Search;
 import org.labkey.test.util.SearchHelper;
 import org.labkey.test.util.search.SearchAdminAPIHelper;
@@ -44,7 +43,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@Category({Daily.class, Search.class})
+@Category({Search.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class DataClassSearchTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/search/SearchTestDefault.java
+++ b/study/test/src/org/labkey/test/tests/search/SearchTestDefault.java
@@ -16,11 +16,10 @@
 package org.labkey.test.tests.search;
 
 import org.junit.experimental.categories.Category;
-import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Search;
 import org.labkey.test.util.search.SearchAdminAPIHelper;
 
-@Category({Search.class, Daily.class})
+@Category({Search.class})
 public class SearchTestDefault extends SearchTest
 {
     @Override

--- a/study/test/src/org/labkey/test/tests/search/SearchTestDefault.java
+++ b/study/test/src/org/labkey/test/tests/search/SearchTestDefault.java
@@ -16,10 +16,14 @@
 package org.labkey.test.tests.search;
 
 import org.junit.experimental.categories.Category;
-import org.labkey.test.categories.Search;
+import org.labkey.test.categories.Disabled;
 import org.labkey.test.util.search.SearchAdminAPIHelper;
 
-@Category({Search.class})
+/**
+ * 'Default' is redundant with whatever the default is (MMapDirectory).
+ * Don't include in any suite by default. Retain to allow running manually.
+ */
+@Category({Disabled.class})
 public class SearchTestDefault extends SearchTest
 {
     @Override


### PR DESCRIPTION
#### Rationale
Search tests are very sensitive to data left on the server by unrelated tests. We will run them in a more isolated environment on TeamCity to avoid such collisions.

#### Changes
* Remove `SearchTestDefault` and `DataClassSearchTest` from daily suite
