### PR TITLE
Dataset trigger script fix

### DIFF
--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -300,18 +300,25 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
             context.setDataSource((String) extraScriptContext.get(DataIteratorUtil.DATA_SOURCE));
         }
 
-        in = preTriggerDataIterator(in, context);
-
+        boolean skipTriggers = context.getConfigParameterBoolean(ConfigParameters.SkipTriggers);
         boolean hasTableScript = hasTableScript(container);
         TriggerDataBuilderHelper helper = new TriggerDataBuilderHelper(getQueryTable(), container, user, extraScriptContext, context.getInsertOption().useImportAliases);
-        if (hasTableScript)
-            in = helper.before(in);
+        if (!skipTriggers)
+        {
+            in = preTriggerDataIterator(in, context);
+            if (hasTableScript)
+                in = helper.before(in);
+        }
         DataIteratorBuilder importDIB = createImportDIB(user, container, in, context);
         DataIteratorBuilder out = importDIB;
-        if (hasTableScript)
-            out = helper.after(importDIB);
 
-        out = postTriggerDataIterator(out, context);
+        if (!skipTriggers)
+        {
+            if (hasTableScript)
+                out = helper.after(importDIB);
+
+            out = postTriggerDataIterator(out, context);
+        }
 
         if (hasTableScript)
         {

--- a/api/src/org/labkey/api/query/QueryUpdateService.java
+++ b/api/src/org/labkey/api/query/QueryUpdateService.java
@@ -91,7 +91,8 @@ public interface QueryUpdateService extends HasPermission
         TrimStringRight,     // (Bool) TrimRight strings on insert
         PreserveEmptyString, // (Bool) When source field is an empty string, insert it instead of replacing with null
         // used by Dataspace currently
-        TargetMultipleContainers    // (Bool) allow multi container import
+        TargetMultipleContainers,    // (Bool) allow multi container import
+        SkipTriggers        // (Bool) skip setup and firing of trigger scripts
     }
 
 

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -458,7 +458,7 @@ public class StudyPublishManager implements StudyPublishService
                 contextualRoles.add(RoleManager.getRole(FolderAdminRole.class));
                 user = new LimitedUser(user, user.getGroups(), contextualRoles, false);
             }
-            datasetLsids = StudyManager.getInstance().importDatasetData(user, dataset, convertedDataMaps, validationException, DatasetDefinition.CheckForDuplicates.sourceAndDestination, defaultQCState, null, false);
+            datasetLsids = StudyManager.getInstance().importDatasetData(user, dataset, convertedDataMaps, validationException, DatasetDefinition.CheckForDuplicates.sourceAndDestination, defaultQCState, null, false, false);
             StudyManager.getInstance().batchValidateExceptionToList(validationException, errors);
 
             final ExpObject source = publishSource.first.resolvePublishSource(publishSource.second);

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -3506,7 +3506,7 @@ public class StudyManager
                                           @Nullable QCState defaultQCState,
                                           Logger logger,
                                           boolean allowImportManagedKey,
-                                          boolean calledFromQUS) throws IOException
+                                          boolean skipTriggers) throws IOException
     {
         if (data.isEmpty())
             return Collections.emptyList();
@@ -3519,7 +3519,7 @@ public class StudyManager
         if (defaultQCState != null)
             options.put(DatasetUpdateService.Config.DefaultQCState, defaultQCState);
         options.put(DatasetUpdateService.Config.CheckForDuplicates, checkDuplicates);
-        options.put(DatasetUpdateService.Config.CalledFromQUS, calledFromQUS);
+        options.put(QueryUpdateService.ConfigParameters.SkipTriggers, skipTriggers);
         context.setConfigParameters(options);
 
         DataLoader loader = new MapLoader(data);

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -3505,7 +3505,8 @@ public class StudyManager
                                           DatasetDefinition.CheckForDuplicates checkDuplicates,
                                           @Nullable QCState defaultQCState,
                                           Logger logger,
-                                          boolean allowImportManagedKey) throws IOException
+                                          boolean allowImportManagedKey,
+                                          boolean calledFromQUS) throws IOException
     {
         if (data.isEmpty())
             return Collections.emptyList();
@@ -3518,6 +3519,7 @@ public class StudyManager
         if (defaultQCState != null)
             options.put(DatasetUpdateService.Config.DefaultQCState, defaultQCState);
         options.put(DatasetUpdateService.Config.CheckForDuplicates, checkDuplicates);
+        options.put(DatasetUpdateService.Config.CalledFromQUS, calledFromQUS);
         context.setConfigParameters(options);
 
         DataLoader loader = new MapLoader(data);

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -98,7 +98,8 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
         StudyImportMaps,        // expected: Map<String,Map<Object,Object>>
 
         KeyList,                // expected: List<String>
-        AllowImportManagedKey   // expected: Boolean
+        AllowImportManagedKey,  // expected: Boolean
+        CalledFromQUS           // expected: Boolean - is set to true if we are already in an QUS call
     }
 
     private static final Logger LOG = LogManager.getLogger(DatasetUpdateService.class);

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -98,8 +98,7 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
         StudyImportMaps,        // expected: Map<String,Map<Object,Object>>
 
         KeyList,                // expected: List<String>
-        AllowImportManagedKey,  // expected: Boolean
-        CalledFromQUS           // expected: Boolean - is set to true if we are already in an QUS call
+        AllowImportManagedKey   // expected: Boolean
     }
 
     private static final Logger LOG = LogManager.getLogger(DatasetUpdateService.class);


### PR DESCRIPTION
#### Rationale
Since the refactor to support trigger scripts for bulk dataset actions, some EHR tests have been failing regularly. Josh has investigated a failure in the ONPRC_EHRTest2.testBirthStatusApi test and the cause of the failure is that the triggers are firing twice from a saveRows() update API call. The first is a beforeUpdate and the second is a beforeInsert.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43946

#### Changes
`AbstractQueryUpdateService.updateRows` invokes the abstract method `updateRow`. For datasets, as has always been the case, we eventually call into `StudyManager.importDatasetData`. The previous refactor consolidated all of the bulk update code to use the QUS so that the trigger script data iterator will get set up. The problem is that `AbstractQueryUpdateService.updateRows:666` fires the row triggers directly and then we see the triggers again getting fired from the `TriggerDataIterator`.

This is somewhat of an un-elegant solution that basically threads a setting into `DatasetDefinition.insertData` to indicate whether the row triggers have been fired and if so, just grab the dataset dataiterator and invoke it directly which is what the code used to do prior to the refactor.

Another approach that I thought about was to conditionally support the trigger scripts at a lower level in `_importRowsUsingDIB`, but would obviously have a larger footprint outside of datasets.

