### PR TITLE
Update JDK 17 JavaDoc link

### DIFF
--- a/api/src/org/labkey/api/module/JavaVersion.java
+++ b/api/src/org/labkey/api/module/JavaVersion.java
@@ -34,8 +34,8 @@ public enum JavaVersion
     JAVA_14(14, true, true, "https://docs.oracle.com/en/java/javase/14/docs/api/java.base/"),
     JAVA_15(15, true, true, "https://docs.oracle.com/en/java/javase/15/docs/api/java.base/"),
     JAVA_16(16, false, true, "https://docs.oracle.com/en/java/javase/16/docs/api/java.base/"),
-    JAVA_17(17, false, true, "https://download.java.net/java/early_access/jdk17/docs/api/java.base/"), // TODO: Update to final location, once published
-    JAVA_FUTURE(Integer.MAX_VALUE, false, false, "https://docs.oracle.com/en/java/javase/16/docs/api/java.base/"); // TODO: Update
+    JAVA_17(17, false, true, "https://docs.oracle.com/en/java/javase/17/docs/api/java.base/"),
+    JAVA_FUTURE(Integer.MAX_VALUE, false, false, "https://docs.oracle.com/en/java/javase/17/docs/api/java.base/");
 
     private final int _version;
     private final boolean _deprecated;

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -1475,7 +1475,6 @@ public class AuthenticationManager
         }
     }
 
-    // In most cases, callers will want to add a "revision" parameter with the look & feel revision value to defeat browser caching
     public static @Nullable String generateLogoUrl(SSOAuthenticationConfiguration<?> configuration, AuthLogoType logoType)
     {
         Attachment logo = AttachmentService.get().getAttachment(configuration, logoType.getFileName());

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -837,7 +837,7 @@ validNum:       {
     }
 
 
-    public static long parseDateTime(String s, MonthDayOption md)
+    private static long parseDateTime(String s, MonthDayOption md)
     {
         return parseDateTime(s, md, true);
     }


### PR DESCRIPTION
#### Rationale
With JDK 17's release last week, the 17 JavaDocs have been published to a new location; need to update our base URL to match.

#### Changes
* Update JDK 17 JavaDocs base URL
* Remove obsolete comment (the method adds the `revision` parameter, so callers shouldn't)