### PR TITLE
Add option to hide SSO login links from header area

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -197,7 +197,7 @@ public class AuthenticationManager
             .forEach(cp-> {
                 switch(cp.getName())
                 {
-                    case SELF_REGISTRATION_KEY, AUTO_CREATE_ACCOUNTS_KEY, SELF_SERVICE_EMAIL_CHANGES_KEY -> saveAuthSetting(null, cp.getName(), Boolean.parseBoolean(cp.getValue()));
+                    case SELF_REGISTRATION_KEY, AUTO_CREATE_ACCOUNTS_KEY, SELF_SERVICE_EMAIL_CHANGES_KEY, DISABLE_HEADER_AUTH_LINKS_KEY -> saveAuthSetting(null, cp.getName(), Boolean.parseBoolean(cp.getValue()));
                     case DEFAULT_DOMAIN -> setDefaultDomain(null, cp.getValue());
                     default -> _log.warn("Property '" + cp.getName() + "' does not map to a known authentication property");
                 }
@@ -246,6 +246,11 @@ public class AuthenticationManager
     }
 
     public static boolean isSelfServiceEmailChangesEnabled() { return getAuthSetting(SELF_SERVICE_EMAIL_CHANGES_KEY, false);}
+
+    public static boolean isDisableHeaderAuthLinks()
+    {
+        return getAuthSetting(DISABLE_HEADER_AUTH_LINKS_KEY, false);
+    }
 
     public static String getDefaultDomain()
     {
@@ -347,6 +352,11 @@ public class AuthenticationManager
 
         if (ssoConfigurations.isEmpty())
             return null;
+
+        if (AuthenticationManager.isDisableHeaderAuthLinks() && logoType == AuthLogoType.HEADER)
+        {
+            return null;
+        }
 
         HtmlStringBuilder html = HtmlStringBuilder.of("");
 
@@ -554,6 +564,7 @@ public class AuthenticationManager
     public static final String DEFAULT_DOMAIN = "DefaultDomain";
     public static final String SELF_SERVICE_EMAIL_CHANGES_KEY = "SelfServiceEmailChanges";
     public static final String ACCEPT_ONLY_FICAM_PROVIDERS_KEY = "AcceptOnlyFicamProviders";
+    public static final String DISABLE_HEADER_AUTH_LINKS_KEY = "DisableHeaderAuthLinks";
 
     /**
      * Return the first SSOAuthenticationConfiguration that is set to auto redirect from the login page.

--- a/core/src/client/components/GlobalSettings.tsx
+++ b/core/src/client/components/GlobalSettings.tsx
@@ -18,6 +18,11 @@ const ROW_TEXTS = [
         tip: 'Users can change their own email address if their password is managed by LabKey Server.',
     },
     {
+        id: 'DisableHeaderAuthLinks',
+        text: 'Do not show header links for SSO auth providers',
+        tip: 'By default, each SSO will have a login link in the header area. If checked, these links will not be shown.',
+    },
+    {
         id: 'AutoCreateAccounts',
         text: 'Auto-create authenticated users',
         tip: 'Accounts are created automatically when new users authenticate via LDAP or SSO.',

--- a/core/src/client/components/models.ts
+++ b/core/src/client/components/models.ts
@@ -33,6 +33,7 @@ export interface GlobalSettingsOptions {
     SelfRegistration?: boolean;
     SelfServiceEmailChanges?: boolean;
     AutoCreateAccounts?: boolean;
+    DisableHeaderAuthLinks?: boolean;
     DefaultDomain?: string;
 }
 

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -118,6 +118,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.labkey.api.security.AuthenticationManager.AUTO_CREATE_ACCOUNTS_KEY;
 import static org.labkey.api.security.AuthenticationManager.AuthenticationStatus.Success;
 import static org.labkey.api.security.AuthenticationManager.DEFAULT_DOMAIN;
+import static org.labkey.api.security.AuthenticationManager.DISABLE_HEADER_AUTH_LINKS_KEY;
 import static org.labkey.api.security.AuthenticationManager.SELF_REGISTRATION_KEY;
 import static org.labkey.api.security.AuthenticationManager.SELF_SERVICE_EMAIL_CHANGES_KEY;
 
@@ -2394,6 +2395,7 @@ public class LoginController extends SpringActionController
             AuthenticationManager.saveAuthSettings(getUser(), Map.of(
                 SELF_REGISTRATION_KEY, form.isSelfRegistration(),
                 SELF_SERVICE_EMAIL_CHANGES_KEY, form.isSelfServiceEmailChanges(),
+                DISABLE_HEADER_AUTH_LINKS_KEY, form.isDisableHeaderAuthLinks(),
                 AUTO_CREATE_ACCOUNTS_KEY, form.isAutoCreateAccounts()
             ));
 
@@ -2413,6 +2415,7 @@ public class LoginController extends SpringActionController
         private boolean _selfRegistration;
         private boolean _selfServiceEmailChanges;
         private boolean _autoCreateAccounts;
+        private boolean _disableHeaderAuthLinks;
         private String _defaultDomain;
         private int[] _formConfigurations;
         private int[] _ssoConfigurations;
@@ -2432,6 +2435,17 @@ public class LoginController extends SpringActionController
         public boolean isSelfServiceEmailChanges()
         {
             return _selfServiceEmailChanges;
+        }
+
+        public boolean isDisableHeaderAuthLinks()
+        {
+            return _disableHeaderAuthLinks;
+        }
+
+        @SuppressWarnings("unused")
+        public void setDisableHeaderAuthLinks(boolean disableHeaderAuthLinks)
+        {
+            _disableHeaderAuthLinks = disableHeaderAuthLinks;
         }
 
         @SuppressWarnings("unused")
@@ -2656,6 +2670,7 @@ public class LoginController extends SpringActionController
             Map<String, Object> globalSettings = Map.of(
                 SELF_REGISTRATION_KEY, AuthenticationManager.isRegistrationEnabled(),
                 SELF_SERVICE_EMAIL_CHANGES_KEY, AuthenticationManager.isSelfServiceEmailChangesEnabled(),
+                DISABLE_HEADER_AUTH_LINKS_KEY, AuthenticationManager.isDisableHeaderAuthLinks(),
                 AUTO_CREATE_ACCOUNTS_KEY, AuthenticationManager.isAutoCreateAccountsEnabled(),
                 DEFAULT_DOMAIN, AuthenticationManager.getDefaultDomain()
             );


### PR DESCRIPTION
This is related to:

https://www.labkey.org/ONPRC/Support%20Tickets/issues-details.view?issueId=43965
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43979

The proposal here is to create one global setting that toggles whether header icons are shown for SSO providers or not. 