### PR TITLE
Mark PostgreSQL 14 as tested

### DIFF
--- a/api/src/org/labkey/api/data/dialect/StandardJdbcMetaDataLocator.java
+++ b/api/src/org/labkey/api/data/dialect/StandardJdbcMetaDataLocator.java
@@ -83,7 +83,7 @@ public class StandardJdbcMetaDataLocator implements JdbcMetaDataLocator
     public String getSchemaName()
     {
         if (null == _schemaName)
-            throw new IllegalStateException("Schema setting method has not been called");
+            throw new IllegalStateException("Schema name has not been initialized!");
         return _schemaName;
     }
 
@@ -91,7 +91,7 @@ public class StandardJdbcMetaDataLocator implements JdbcMetaDataLocator
     public String getSchemaNamePattern()
     {
         if (null == _schemaNamePattern)
-            throw new IllegalStateException("Schema setting method has not been called");
+            throw new IllegalStateException("Schema name pattern has not been initialized!");
         return _schemaNamePattern;
     }
 
@@ -99,7 +99,7 @@ public class StandardJdbcMetaDataLocator implements JdbcMetaDataLocator
     public String getTableName()
     {
         if (null == _tableName)
-            throw new IllegalStateException("Table setting method has not been called");
+            throw new IllegalStateException("Table name has not been initialized!");
         return _tableName;
     }
 
@@ -107,7 +107,7 @@ public class StandardJdbcMetaDataLocator implements JdbcMetaDataLocator
     public String getTableNamePattern()
     {
         if (null == _tableNamePattern)
-            throw new IllegalStateException("Table setting method has not been called");
+            throw new IllegalStateException("Table name pattern has not been initialized!");
         return _tableNamePattern;
     }
 

--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -22,7 +22,7 @@ public enum PostgreSqlVersion
     POSTGRESQL_11(110, false, true, PostgreSql_11_Dialect::new),
     POSTGRESQL_12(120, false, true, PostgreSql_12_Dialect::new),
     POSTGRESQL_13(130, false, true, PostgreSql_13_Dialect::new),
-    POSTGRESQL_14(140, false, false, PostgreSql_14_Dialect::new),
+    POSTGRESQL_14(140, false, true, PostgreSql_14_Dialect::new),
     POSTGRESQL_FUTURE(Integer.MAX_VALUE, true, false, PostgreSql_14_Dialect::new);
 
     private final int _version;


### PR DESCRIPTION
#### Rationale
PostgreSQL 14 is in release candidate mode and our testing has shown no problems with it

#### Changes
* Mark PostgreSQL 14 as tested
* Correct some exception messages to match reality (schema- and table-setting methods were removed)
