### PR TITLE
Issue 43988: Mismatch on query name in linked schema - StudyProperties vs Study

### DIFF
--- a/study/src/org/labkey/study/query/StudyPropertiesTable.java
+++ b/study/src/org/labkey/study/query/StudyPropertiesTable.java
@@ -66,6 +66,7 @@ public class StudyPropertiesTable extends BaseStudyTable
     public StudyPropertiesTable(StudyQuerySchema schema, ContainerFilter cf)
     {
         super(schema, StudySchema.getInstance().getTableInfoStudy(), cf);
+        setName(StudyQuerySchema.PROPERTIES_TABLE_NAME);
 
         Container c = schema.getContainer();
 


### PR DESCRIPTION
#### Rationale
The study schema thinks the proper name for this table is StudyProperties, but the table think it's simply called Study.

#### Changes
* Have the table report the advertised name so that everything lines up