### PR TITLE
Adjust candidate keywords to accommodate PostgreSQL 14

### DIFF
--- a/api/src/org/labkey/api/data/dialect/sqlKeywords.txt
+++ b/api/src/org/labkey/api/data/dialect/sqlKeywords.txt
@@ -350,6 +350,7 @@ file_block_size
 fillfactor
 filter
 final
+finalize
 first
 first_value
 fixed
@@ -395,9 +396,9 @@ granted
 grants
 greatest
 group
-groups
 group_replication
 grouping
+groups
 handler
 hash
 having
@@ -750,6 +751,8 @@ percentile_disc
 perm
 permanent
 permission
+persist
+persist_only
 phase
 pivot
 placing
@@ -887,10 +890,10 @@ rollback
 rollup
 rotate
 routine
-routines
 routine_catalog
 routine_name
 routine_schema
+routines
 row
 row_count
 row_format

--- a/bigiron/src/org/labkey/bigiron/mysql/MySql80Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySql80Dialect.java
@@ -30,9 +30,9 @@ public class MySql80Dialect extends MySql57Dialect
         Set<String> words = super.getReservedWords();
 
         words.remove("sql_cache");
-        words.addAll(new CsvSet("admin, columns, cube, cume_dist, dense_rank, empty, events, except, first_value, function, " +
-                "grouping, groups, indexes, json_table, lag, last_value, lateral, lead, nth_value, ntile, of, over, parameters, " +
-                "percent_rank, rank, recursive, routines, row, row_number, rows, system, tables, triggers, window"));
+        words.addAll(new CsvSet("columns, cube, cume_dist, dense_rank, empty, events, except, first_value, function, " +
+            "grouping, groups, indexes, json_table, lag, last_value, lateral, lead, nth_value, ntile, of, over, parameters, " +
+            "percent_rank, rank, recursive, routines, row, row_number, rows, system, tables, triggers, window"));
 
         return words;
     }


### PR DESCRIPTION
#### Rationale
Junit test that verifies reserved words on all supported databases started failing when run against PostgreSQL 14.

While we're at it, make a few keyword changes for recent MySQL releases.
