### PR TITLE
Issue 43988: Mismatch on query name in linked schema - StudyProperties take 2

### DIFF
--- a/study/src/org/labkey/study/query/StudyPropertiesTable.java
+++ b/study/src/org/labkey/study/query/StudyPropertiesTable.java
@@ -66,7 +66,6 @@ public class StudyPropertiesTable extends BaseStudyTable
     public StudyPropertiesTable(StudyQuerySchema schema, ContainerFilter cf)
     {
         super(schema, StudySchema.getInstance().getTableInfoStudy(), cf);
-        setName(StudyQuerySchema.PROPERTIES_TABLE_NAME);
 
         Container c = schema.getContainer();
 
@@ -154,6 +153,12 @@ public class StudyPropertiesTable extends BaseStudyTable
 
         // disable import data link for this table
         setImportURL(AbstractTableInfo.LINK_DISABLER);
+    }
+
+    @Override
+    public String getPublicName()
+    {
+        return StudyQuerySchema.PROPERTIES_TABLE_NAME;
     }
 
     private MutableColumnInfo addRootColumn(String columnName, boolean visible, boolean userEditable)

--- a/study/src/org/labkey/study/query/StudyPropertiesTable.java
+++ b/study/src/org/labkey/study/query/StudyPropertiesTable.java
@@ -158,6 +158,8 @@ public class StudyPropertiesTable extends BaseStudyTable
     @Override
     public String getPublicName()
     {
+        // Issue 43988 - need to use the preferred query schema name for the table to make linked schemas and other
+        // metadata-driven scenarios consistent
         return StudyQuerySchema.PROPERTIES_TABLE_NAME;
     }
 


### PR DESCRIPTION
#### Rationale
My commit last week for this issue caused test failures due to caching issues. Better to make a more targeted fix so that the public name (for purposes of the query schema) is set correctly but the name is still consistent with the underlying table in the DB.

#### Changes
* Set the public name to StudyProperties but not what's used internally for getName()