### PR TITLE
Remove isStatic() requirement from upgrade code filter

### DIFF
--- a/core/src/org/labkey/core/admin/view/upgradeCode.jsp
+++ b/core/src/org/labkey/core/admin/view/upgradeCode.jsp
@@ -18,7 +18,7 @@
         if (null != code)
         {
             Arrays.stream(code.getClass().getDeclaredMethods())
-                .filter(method -> Modifier.isPublic(method.getModifiers()) && Modifier.isStatic(method.getModifiers()))
+                .filter(method -> Modifier.isPublic(method.getModifiers()))
                 .filter(method -> Arrays.equals(method.getParameterTypes(), params))
                 .forEach(method -> {
                     String key = module.getName() + ": " + method.getName();


### PR DESCRIPTION
#### Rationale
The upgrade code action was blissfully unaware of a bunch of upgrade code methods because it filtered out all non-static methods. Turns out upgrade code can be implemented as either static or instance methods.
