### PR TITLE
Issue 43572: Display fields on lookups to issues

### DIFF
--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -364,7 +364,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
             cols = Arrays.asList(firstColumn, titleColumnInfo);
             titleIndex = 2;
         }
-        else if (firstColumn == titleColumn)
+        else if (firstColumn == titleColumn || firstColumn.equals(titleColumnInfo))
         {
             cols = Arrays.asList(firstColumn);
             titleIndex = 1;


### PR DESCRIPTION
#### Rationale
Previously, after creating a lookup field to issueslistdef with a DisplayColumnName of issueid (or, in general, creating a lookup field where the DisplayColumnName is the PK), upon attempting to insert a new row into the data structure or update a row within it, the dropdown on the lookup field did not show the DisplayColumnName. 
Now, in the above example, when updating a row or inserting a row, the dropdown correctly shows text from issueid, not the title column.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/487

#### Changes
* Catch case in which display column is the same as PK column
