### PR TITLE
Issue 43844: Better handling for script running failures

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -909,7 +909,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
 
     public void setFolderType(FolderType folderType, Set<Module> ensureModules, BindException errors)
     {
-        setFolderType(folderType, ensureModules,ModuleLoader.getInstance().getUpgradeUser(), errors);
+        setFolderType(folderType, ensureModules, null, errors);
     }
 
     public void setFolderType(FolderType folderType, Set<Module> ensureModules, User user, BindException errors)

--- a/api/src/org/labkey/api/data/SqlScriptManager.java
+++ b/api/src/org/labkey/api/data/SqlScriptManager.java
@@ -285,14 +285,14 @@ public abstract class SqlScriptManager
             if (null == bean)
             {
                 bean = new SchemaBean(_schema.getDisplayName(), _provider.getProviderName(), version);
-                Table.insert(ModuleLoader.getInstance().getUpgradeUser(), tinfo, bean);
+                Table.insert(null, tinfo, bean);
             }
             else
             {
                 if (version != bean.getInstalledVersion())
                 {
                     bean.setInstalledVersion(version);
-                    Table.update(ModuleLoader.getInstance().getUpgradeUser(), tinfo, bean, bean.getName());
+                    Table.update(null, tinfo, bean, bean.getName());
                 }
             }
         }

--- a/api/src/org/labkey/api/data/SqlScriptRunner.java
+++ b/api/src/org/labkey/api/data/SqlScriptRunner.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
-import org.labkey.api.security.User;
 import org.labkey.api.util.logging.LogHelper;
 
 import java.util.ArrayList;
@@ -39,7 +38,6 @@ public class SqlScriptRunner
 {
     private static final Logger _log = LogHelper.getLogger(SqlScriptRunner.class, "Schema SQL script handling during install and upgrade");
 
-    private final User _user;
     private final List<SqlScript> _remainingScripts = new ArrayList<>();
     private final Object SCRIPT_LOCK = new Object();
 
@@ -47,17 +45,6 @@ public class SqlScriptRunner
 
     public SqlScriptRunner()
     {
-        _user = null;  // Delegate to ModuleLoader.getUpgradeUser() in this case
-    }
-
-    public SqlScriptRunner(@Nullable User user)
-    {
-        _user = user;
-    }
-
-    private User getUser()
-    {
-        return null != _user ? _user : ModuleLoader.getInstance().getUpgradeUser();
     }
 
     public List<SqlScript> getRunningScripts(@Nullable String moduleName)
@@ -94,7 +81,7 @@ public class SqlScriptRunner
         for (SqlScript script : scripts)
         {
             SqlScriptManager manager = SqlScriptManager.get(script.getProvider(), script.getSchema());
-            manager.runScript(getUser(), script, ModuleLoader.getInstance().getModuleContext(module), null);
+            manager.runScript(null, script, ModuleLoader.getInstance().getModuleContext(module), null);
 
             synchronized(SCRIPT_LOCK)
             {

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -299,7 +299,7 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
     public void beforeUpdate(ModuleContext moduleContext)
     {
         if (!moduleContext.isNewInstall())
-            ModuleLoader.getInstance().runScripts(this, SchemaUpdateType.Before);
+            ModuleLoader.getInstance().runUpgradeScripts(this, SchemaUpdateType.Before);
     }
 
     /**
@@ -316,6 +316,7 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
             }
 
             SqlScriptProvider provider = new FileSqlScriptProvider(this);
+            SqlScriptRunner runner = ModuleLoader.getInstance().getUpgradeScriptRunner();
 
             for (DbSchema schema : provider.getSchemas())
             {
@@ -323,12 +324,12 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
                 List<SqlScript> scripts = manager.getRecommendedScripts(getSchemaVersion());
 
                 if (!scripts.isEmpty())
-                    SqlScriptRunner.runScripts(this, moduleContext.getUpgradeUser(), scripts);
+                    runner.runScripts(this, scripts);
 
                 SqlScript script = SchemaUpdateType.After.getScript(provider, schema);
 
                 if (null != script)
-                    SqlScriptRunner.runScripts(this, null, Collections.singletonList(script));
+                    runner.runScripts(this, Collections.singletonList(script));
             }
         }
     }

--- a/api/src/org/labkey/api/module/ModuleContext.java
+++ b/api/src/org/labkey/api/module/ModuleContext.java
@@ -175,7 +175,7 @@ public class ModuleContext implements Cloneable
 
     public User getUpgradeUser()
     {
-        return ModuleLoader.getInstance().getUpgradeUser();
+        return User.getSearchUser();
     }
 
     public boolean isAutoUninstall()

--- a/api/src/org/labkey/api/security/GroupManager.java
+++ b/api/src/org/labkey/api/security/GroupManager.java
@@ -107,6 +107,7 @@ public class GroupManager
         int gotUserId;
         if ((gotUserId = createSystemGroup(userId, name, type)) != userId)
             _log.warn(name + " group exists but has an unexpected UserId (is " + gotUserId + ", should be " + userId + ")");
+        GroupCache.uncache(userId);
     }
 
 

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -667,7 +667,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
     {
         if (moduleContext.isNewInstall())
         {
-            bootstrap(moduleContext.getUpgradeUser());
+            bootstrap();
         }
 
         // Increment on every core module upgrade to defeat browser caching of static resources.
@@ -693,7 +693,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
     }
 
 
-    private void bootstrap(User upgradeUser)
+    private void bootstrap()
     {
         // Create the initial groups
         GroupManager.bootstrapGroup(Group.groupAdministrators, "Administrators");
@@ -722,13 +722,13 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
 
         // Users & guests can read from /home
         Container home = ContainerManager.bootstrapContainer(ContainerManager.HOME_PROJECT_PATH, readerRole, readerRole, null);
-        home.setFolderType(collaborationType, upgradeUser);
+        home.setFolderType(collaborationType, (User)null);
         addWebPart("Projects", home, HttpView.BODY, 0); // Wiki module used to do this, but it's optional now. If wiki isn't present, at least we'll have the projects webpart.
 
-        ContainerManager.createDefaultSupportContainer().setFolderType(collaborationType, upgradeUser);
+        ContainerManager.createDefaultSupportContainer().setFolderType(collaborationType, (User)null);
 
         // Only users can read from /Shared
-        ContainerManager.bootstrapContainer(ContainerManager.SHARED_CONTAINER_PATH, readerRole, null, null).setFolderType(collaborationType, upgradeUser);
+        ContainerManager.bootstrapContainer(ContainerManager.SHARED_CONTAINER_PATH, readerRole, null, null).setFolderType(collaborationType, (User)null);
 
         try
         {

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -7597,7 +7597,7 @@ public class AdminController extends SpringActionController
         @Override
         public boolean handlePost(Object o, BindException errors)
         {
-            ModuleLoader.getInstance().recreateViews(getUser());
+            ModuleLoader.getInstance().recreateViews();
             return true;
         }
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -7597,7 +7597,7 @@ public class AdminController extends SpringActionController
         @Override
         public boolean handlePost(Object o, BindException errors)
         {
-            ModuleLoader.getInstance().recreateViews();
+            ModuleLoader.getInstance().recreateViews(getUser());
             return true;
         }
 

--- a/core/src/org/labkey/core/admin/sql/SqlScriptController.java
+++ b/core/src/org/labkey/core/admin/sql/SqlScriptController.java
@@ -115,7 +115,8 @@ public class SqlScriptController extends SpringActionController
             JSONObject result = new JSONObject();
             JSONArray modulesJSON = new JSONArray();
 
-            String currentlyUpgradingModule = SqlScriptRunner.getCurrentModuleName();
+            SqlScriptRunner runner = ModuleLoader.getInstance().getUpgradeScriptRunner();
+            String currentlyUpgradingModule = runner.getCurrentModuleName();
             result.put("currentlyUpgradingModule", currentlyUpgradingModule);
 
             for (Module module : ModuleLoader.getInstance().getModules())
@@ -130,7 +131,7 @@ public class SqlScriptController extends SpringActionController
                 if (module.getName().equals(currentlyUpgradingModule))
                 {
                     moduleJSON.put("currentlyUpgrading", true);
-                    List<SqlScript> sqlScripts = SqlScriptRunner.getRunningScripts(currentlyUpgradingModule);
+                    List<SqlScript> sqlScripts = runner.getRunningScripts(currentlyUpgradingModule);
                     for (SqlScript sqlScript : sqlScripts)
                     {
                         JSONObject scriptJSON = new JSONObject();

--- a/core/src/org/labkey/core/admin/sql/SqlScriptController.java
+++ b/core/src/org/labkey/core/admin/sql/SqlScriptController.java
@@ -1391,16 +1391,8 @@ public class SqlScriptController extends SpringActionController
         @Override
         public boolean handlePost(UpgradeCodeForm form, BindException errors) throws Exception
         {
-            try
-            {
-                ModuleLoader.getInstance().setUpgradeUser(getUser());
-                LOG.info("Executing " + _method.getDeclaringClass().getSimpleName() + "." + _method.getName() + "(ModuleContext moduleContext)");
-                _method.invoke(null, _ctx);
-            }
-            finally
-            {
-                ModuleLoader.getInstance().setUpgradeUser(null);
-            }
+            LOG.info("Executing " + _method.getDeclaringClass().getSimpleName() + "." + _method.getName() + "(ModuleContext moduleContext)");
+            _method.invoke(null, _ctx);
             return true;
         }
 

--- a/study/src/org/labkey/study/controllers/CreateChildStudyAction.java
+++ b/study/src/org/labkey/study/controllers/CreateChildStudyAction.java
@@ -26,7 +26,6 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.module.FolderType;
 import org.labkey.api.module.FolderTypeManager;
-import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.pipeline.PipelineUrls;
@@ -235,7 +234,7 @@ public class CreateChildStudyAction extends MutatingApiAction<ChildStudyDefiniti
 
         // Set a default folder type. Will be overridden if user has chosen to copy from source.
         FolderType folderType = FolderTypeManager.get().getFolderType(StudyFolderType.NAME);
-        _dstContainer.setFolderType(folderType, ModuleLoader.getInstance().getUpgradeUser());
+        _dstContainer.setFolderType(folderType, User.getSearchUser());
 
         return study;
     }


### PR DESCRIPTION
#### Rationale
Holding static lists of scripts makes iterative development of drop/create scripts impossible. Switch to constructing instances of `SqlScriptRunner` as needed.
