### PR TITLE
Issue 43914: Option to provide custom date parsing patterns

### DIFF
--- a/api/schemas/folder.xsd
+++ b/api/schemas/folder.xsd
@@ -122,6 +122,22 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="extraDateParsingFormat" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation xmlns="http://www.w3.org/1999/xhtml">
+                        Indicates the extra date parsing format. See
+                        <a href="https://www.labkey.org/Documentation/wiki-page.view?name=dateFormats" target="_top">Date and Number Formats</a>.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="extraDateTimeParsingFormat" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation xmlns="http://www.w3.org/1999/xhtml">
+                        Indicates the extra date-time parsing format. See
+                        <a href="https://www.labkey.org/Documentation/wiki-page.view?name=dateFormats" target="_top">Date and Number Formats</a>.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
     <xs:complexType name="exportDirType">

--- a/api/src/org/labkey/api/admin/FolderWriterImpl.java
+++ b/api/src/org/labkey/api/admin/FolderWriterImpl.java
@@ -126,10 +126,18 @@ public class FolderWriterImpl extends BaseFolderWriter
         if (null != defaultNumberFormat)
             folderXml.setDefaultNumberFormat(defaultNumberFormat);
 
+        String extraDateParsingFormat = props.getExtraDateParsingFormatStored();
+        if (null != extraDateParsingFormat)
+            folderXml.setExtraDateParsingFormat(extraDateParsingFormat);
+
+        String extraDateTimeParsingFormat = props.getExtraDateTimeParsingFormatStored();
+        if (null != extraDateTimeParsingFormat)
+            folderXml.setExtraDateTimeParsingFormat(extraDateTimeParsingFormat);
+
         if (props.areRestrictedColumnsEnabled())
             folderXml.setRestrictedColumnsEnabled(true);
 
-        // Save the folder.xml file.  This gets called last, after all other writers have populated the other sections.
+        // Save the folder.xml file. This gets called last, after all other writers have populated the other sections.
         vf.saveXmlBean("folder.xml", ctx.getDocument());
 
         ctx.lockDocument();

--- a/api/src/org/labkey/api/admin/FolderWriterImpl.java
+++ b/api/src/org/labkey/api/admin/FolderWriterImpl.java
@@ -93,7 +93,7 @@ public class FolderWriterImpl extends BaseFolderWriter
         LOG.info("Done exporting folder to " + vf.getLocation());
     }
 
-    // This writer is responsible for folder.xml.  It writes the top-level folder attributes and saves out the bean when it's complete.
+    // This writer is responsible for folder.xml. It writes the top-level folder attributes and saves out the bean when it's complete.
     private void writeFolderXml(Container c, FolderExportContext ctx, VirtualFile vf) throws Exception
     {
         FolderDocument.Folder folderXml = ctx.getXml();

--- a/api/src/org/labkey/api/data/ConvertHelper.java
+++ b/api/src/org/labkey/api/data/ConvertHelper.java
@@ -324,7 +324,7 @@ public class ConvertHelper implements PropertyEditorRegistrar
     }
 
     /**
-     * This format accepts dates in the form MM/dd/yy
+     * This converter accepts dates in a variety of standard formats
      */
     public static class LenientDateConverter implements Converter
     {

--- a/api/src/org/labkey/api/settings/FolderSettingsCache.java
+++ b/api/src/org/labkey/api/settings/FolderSettingsCache.java
@@ -16,9 +16,7 @@
 package org.labkey.api.settings;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.BlockingCache;
-import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -34,19 +32,12 @@ import java.util.Collections;
  * Time: 10:31 AM
  */
 
-// Folder settings inherit all the way up the folder tree. All the property sets involved should be cached, but the walk up the tree
-// is a potentially expensive operation to perform just to format a date or number. So, we cache the set of resolved properties
-// on a per-container basis and clear the entire cache on every change of look and feel settings.
+// Folder settings inherit all the way up the folder tree. All the property sets involved should be cached, but the walk
+// up the tree is a potentially expensive operation just to format a date or number. So, we cache the set of resolved
+// properties on a per-container basis and clear the entire cache on every change of look and feel settings.
 public class FolderSettingsCache
 {
-    private static final BlockingCache<Container, FolderSettings> CACHE = CacheManager.getBlockingCache(10000, CacheManager.DAY, "Folder Settings", new CacheLoader<Container, FolderSettings>()
-    {
-        @Override
-        public FolderSettings load(Container c, @Nullable Object argument)
-        {
-            return new FolderSettings(c);
-        }
-    });
+    private static final BlockingCache<Container, FolderSettings> CACHE = CacheManager.getBlockingCache(10000, CacheManager.DAY, "Folder Settings", (c, argument) -> new FolderSettings(c));
 
     public static String getDefaultDateFormat(Container c)
     {
@@ -61,6 +52,16 @@ public class FolderSettingsCache
     public static String getDefaultNumberFormat(Container c)
     {
         return CACHE.get(c).getDefaultNumberFormat();
+    }
+
+    public static String getExtraDateParsingFormat(Container c)
+    {
+        return CACHE.get(c).getExtraDateParsingFormat();
+    }
+
+    public static String getExtraDateTimeParsingFormat(Container c)
+    {
+        return CACHE.get(c).getExtraDateTimeParsingFormat();
     }
 
     public static boolean areRestrictedColumnsEnabled(Container c)
@@ -83,6 +84,8 @@ public class FolderSettingsCache
         private final String _defaultDateFormat;
         private final String _defaultDateTimeFormat;
         private final String _defaultNumberFormat;
+        private final String _extraDateParsingFormat;
+        private final String _extraDateTimeParsingFormat;
         private final boolean _restrictedColumnsEnabled;
 
         FolderSettings(Container c)
@@ -91,6 +94,8 @@ public class FolderSettingsCache
             _defaultDateFormat = props.getDefaultDateFormat();
             _defaultDateTimeFormat = props.getDefaultDateTimeFormat();
             _defaultNumberFormat = props.getDefaultNumberFormat();
+            _extraDateParsingFormat = props.getExtraDateParsingFormat();
+            _extraDateTimeParsingFormat = props.getExtraDateTimeParsingFormat();
             _restrictedColumnsEnabled = props.areRestrictedColumnsEnabled();
         }
 
@@ -107,6 +112,16 @@ public class FolderSettingsCache
         public String getDefaultDateTimeFormat()
         {
             return _defaultDateTimeFormat;
+        }
+
+        public String getExtraDateParsingFormat()
+        {
+            return _extraDateParsingFormat;
+        }
+
+        public String getExtraDateTimeParsingFormat()
+        {
+            return _extraDateTimeParsingFormat;
         }
 
         public boolean areRestrictedColumnsEnabled()

--- a/api/src/org/labkey/api/settings/LookAndFeelFolderProperties.java
+++ b/api/src/org/labkey/api/settings/LookAndFeelFolderProperties.java
@@ -33,6 +33,8 @@ public class LookAndFeelFolderProperties extends AbstractWriteableSettingsGroup
     protected static final String DEFAULT_DATE_TIME_FORMAT = "defaultDateTimeFormatString";
     protected static final String RESTRICTED_COLUMNS_ENABLED = "restrictedColumnsEnabled";
     protected static final String DEFAULT_NUMBER_FORMAT = "defaultNumberFormatString";
+    protected static final String EXTRA_DATE_PARSING_FORMAT = "extraDateParsingFormat";
+    protected static final String EXTRA_DATE_TIME_PARSING_FORMAT = "extraDateTimeParsingFormat";
 
     protected final Container _c;
 
@@ -90,25 +92,37 @@ public class LookAndFeelFolderProperties extends AbstractWriteableSettingsGroup
 
     public String getDefaultDateFormat()
     {
-        // Look up this value starting from the current container (unlike all the other look & feel settings)
+        // Look up this value starting from the current container (unlike most look & feel settings)
         return lookupStringValue(_c, DEFAULT_DATE_FORMAT, DateUtil.getStandardDateFormatString());
     }
 
     public String getDefaultDateTimeFormat()
     {
-        // Look up this value starting from the current container (unlike all the other look & feel settings)
+        // Look up this value starting from the current container (unlike most look & feel settings)
         return lookupStringValue(_c, DEFAULT_DATE_TIME_FORMAT, DateUtil.getStandardDateTimeFormatString());
+    }
+
+    public String getDefaultNumberFormat()
+    {
+        // Look up this value starting from the current container (unlike most look & feel settings)
+        return lookupStringValue(_c, DEFAULT_NUMBER_FORMAT, null);
+    }
+
+    public String getExtraDateParsingFormat()
+    {
+        // Look up this value starting from the current container (unlike most look & feel settings)
+        return lookupStringValue(_c, EXTRA_DATE_PARSING_FORMAT, null);
+    }
+
+    public String getExtraDateTimeParsingFormat()
+    {
+        // Look up this value starting from the current container (unlike most look & feel settings)
+        return lookupStringValue(_c, EXTRA_DATE_TIME_PARSING_FORMAT, null);
     }
 
     public boolean areRestrictedColumnsEnabled()
     {
         return lookupBooleanValue(_c, RESTRICTED_COLUMNS_ENABLED, false);
-    }
-
-    public String getDefaultNumberFormat()
-    {
-        // Look up this value starting from the current container (unlike all the other look & feel settings)
-        return lookupStringValue(_c, DEFAULT_NUMBER_FORMAT, null);
     }
 
     // Get the value that's actually stored in this container; don't look up the hierarchy. This is useful only for export.
@@ -127,5 +141,17 @@ public class LookAndFeelFolderProperties extends AbstractWriteableSettingsGroup
     public String getDefaultNumberFormatStored()
     {
         return super.lookupStringValue(_c, DEFAULT_NUMBER_FORMAT, null);
+    }
+
+    // Get the value that's actually stored in this container; don't look up the hierarchy. This is useful only for export.
+    public String getExtraDateParsingFormatStored()
+    {
+        return super.lookupStringValue(_c, EXTRA_DATE_PARSING_FORMAT, null);
+    }
+
+    // Get the value that's actually stored in this container; don't look up the hierarchy. This is useful only for export.
+    public String getExtraDateTimeParsingFormatStored()
+    {
+        return super.lookupStringValue(_c, EXTRA_DATE_TIME_PARSING_FORMAT, null);
     }
 }

--- a/api/src/org/labkey/api/settings/WriteableFolderLookAndFeelProperties.java
+++ b/api/src/org/labkey/api/settings/WriteableFolderLookAndFeelProperties.java
@@ -23,6 +23,8 @@ import java.text.DecimalFormat;
 import static org.labkey.api.settings.LookAndFeelFolderProperties.DEFAULT_DATE_FORMAT;
 import static org.labkey.api.settings.LookAndFeelFolderProperties.DEFAULT_DATE_TIME_FORMAT;
 import static org.labkey.api.settings.LookAndFeelFolderProperties.DEFAULT_NUMBER_FORMAT;
+import static org.labkey.api.settings.LookAndFeelFolderProperties.EXTRA_DATE_PARSING_FORMAT;
+import static org.labkey.api.settings.LookAndFeelFolderProperties.EXTRA_DATE_TIME_PARSING_FORMAT;
 import static org.labkey.api.settings.LookAndFeelFolderProperties.RESTRICTED_COLUMNS_ENABLED;
 import static org.labkey.api.settings.LookAndFeelProperties.LOOK_AND_FEEL_SET_NAME;
 
@@ -127,6 +129,50 @@ public class WriteableFolderLookAndFeelProperties extends AbstractWriteableSetti
     {
         WriteableFolderLookAndFeelProperties props = LookAndFeelProperties.getWriteableFolderInstance(c);
         props.setDefaultNumberFormat(defaultNumberFormat);
+        props.save();
+    }
+
+    // Validate inside the set method, since this is called from multiple places
+    public void setExtraDateParsingFormat(String extraDateParsingFormat) throws IllegalArgumentException
+    {
+        // Check for legal format
+        FastDateFormat.getInstance(extraDateParsingFormat);
+        storeStringValue(EXTRA_DATE_PARSING_FORMAT, extraDateParsingFormat);
+    }
+
+    // Validate inside the set method, since this is called from multiple places
+    public void setExtraDateTimeParsingFormat(String extraDateTimeParsingFormat) throws IllegalArgumentException
+    {
+        // Check for legal format
+        FastDateFormat.getInstance(extraDateTimeParsingFormat);
+        storeStringValue(EXTRA_DATE_TIME_PARSING_FORMAT, extraDateTimeParsingFormat);
+    }
+
+    // Allows clearing the property to allow inheriting of this property alone. Should make this more obvious and universal, via "inherit/override" checkboxes and highlighting in the UI
+    public void clearExtraDateParsingFormat()
+    {
+        remove(EXTRA_DATE_PARSING_FORMAT);
+    }
+
+    // Allows clearing the property to allow inheriting of this property alone. Should make this more obvious and universal, via "inherit/override" checkboxes and highlighting in the UI
+    public void clearExtraDateTimeParsingFormat()
+    {
+        remove(EXTRA_DATE_TIME_PARSING_FORMAT);
+    }
+
+    // Convenience method to support import: validate and save just this property
+    public static void saveExtraDateParsingFormat(Container c, String extraDateParsingFormat) throws IllegalArgumentException
+    {
+        WriteableFolderLookAndFeelProperties props = LookAndFeelProperties.getWriteableFolderInstance(c);
+        props.setExtraDateParsingFormat(extraDateParsingFormat);
+        props.save();
+    }
+
+    // Convenience method to support import: validate and save just this property
+    public static void saveExtraDateTimeParsingFormat(Container c, String extraDateTimeParsingFormat) throws IllegalArgumentException
+    {
+        WriteableFolderLookAndFeelProperties props = LookAndFeelProperties.getWriteableFolderInstance(c);
+        props.setDefaultDateTimeFormat(extraDateTimeParsingFormat);
         props.save();
     }
 

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -820,7 +820,7 @@ validNum:       {
                 PipelineJobService.get().getLocationType() != PipelineJobService.LocationType.WebServer;
         if (isNotRunningOnWebServer)
         {
-            return parseDateTime(s, MonthDayOption.MONTH_DAY, true);
+            return parseDateTime(s, MonthDayOption.MONTH_DAY, true, null);
         }
 
         return parseDateTime(ContainerManager.getRoot(), s);
@@ -830,20 +830,31 @@ validNum:       {
     // Lenient parsing using a variety of standard formats
     public static long parseDateTime(Container c, String s)
     {
-        String displayFormat = getDateTimeFormatString(c);  // TODO: Pass this into parseDate() as a bonus format?
+        @Nullable String extraDateTimeParsingFormat = FolderSettingsCache.getExtraDateTimeParsingFormat(c);
         MonthDayOption monthDayOption = LookAndFeelProperties.getInstance(c).getDateParsingMode().getDayMonth();
 
-        return parseDateTime(s, monthDayOption);
+        return parseDateTime(s, monthDayOption, true, extraDateTimeParsingFormat);
     }
 
-
-    public static long parseDateTime(String s, MonthDayOption md)
+    private static long parseDateTime(String s, MonthDayOption md)
     {
-        return parseDateTime(s, md, true);
+        return parseDateTime(s, md, true, null);
     }
 
-    public static long parseDateTime(String s, MonthDayOption md, boolean strict)
+    public static long parseDateTime(String s, MonthDayOption md, boolean strict, @Nullable String extraParsingFormat)
     {
+        // If provided, try the extra parsing format first
+        if (null != extraParsingFormat)
+        {
+            try
+            {
+                return parseDateTime(s, extraParsingFormat).getTime();
+            }
+            catch (ParseException ignored)
+            {
+            }
+        }
+
         try
         {
             return parseDateTimeEN(s, DateTimeOption.DateTime, md, strict);
@@ -865,15 +876,28 @@ validNum:       {
     // Lenient parsing using a variety of standard formats
     public static long parseDate(Container c, String s)
     {
-        String displayFormat = getDateFormatString(c);  // TODO: Pass this into parseDate() as a bonus format
+        @Nullable String extraDateParsingFormat = FolderSettingsCache.getExtraDateParsingFormat(c);
         MonthDayOption monthDayOption = LookAndFeelProperties.getInstance(c).getDateParsingMode().getDayMonth();
 
-        return parseDate(s, monthDayOption);
+        return parseDate(s, monthDayOption, extraDateParsingFormat);
     }
 
 
-    private static long parseDate(String s, MonthDayOption md)
+    private static long parseDate(String s, MonthDayOption md, @Nullable String extraParsingFormat)
     {
+        // If provided, try the extra parsing format first
+        if (null != extraParsingFormat)
+        {
+            try
+            {
+                Date parsed = parseDateTime(s, extraParsingFormat);
+                return DateUtils.truncate(parsed, Calendar.DAY_OF_MONTH).getTime(); // Truncate to days... should this throw instead?
+            }
+            catch (ParseException ignored)
+            {
+            }
+        }
+
         try
         {
             // quick check for JDBC/ISO date
@@ -1494,7 +1518,7 @@ Parse:
             try
             {
                 parseDate(s);
-                fail("Not a legal date: " + s);
+                fail("Should not have successfully parsed: " + s);
             }
             catch (ConversionException x)
             {
@@ -1506,7 +1530,7 @@ Parse:
             try
             {
                 parseDateTime(s);
-                fail("Not a legal datetime: " + s);
+                fail("Should not have successfully parsed: " + s);
             }
             catch (ConversionException x)
             {
@@ -1567,9 +1591,9 @@ Parse:
             assertIllegalDateTime("03-FEB-2001 04:05:06:61");
             assertIllegalDateTime("03-FEB-2001 04:05:06:91");
             // invalid fractional seconds > 59, but allowed to overflow when strict=false
-            assertEquals(datetimeExpected+1000, DateUtil.parseDateTime("03-FEB-2001 4:05:06:60", MonthDayOption.MONTH_DAY, false));
-            assertEquals(datetimeExpected+1017, DateUtil.parseDateTime("03-FEB-2001 4:05:06:61", MonthDayOption.MONTH_DAY, false));
-            assertEquals(datetimeExpected+1517, DateUtil.parseDateTime("03-FEB-2001 4:05:06:91", MonthDayOption.MONTH_DAY, false));
+            assertEquals(datetimeExpected+1000, DateUtil.parseDateTime("03-FEB-2001 4:05:06:60", MonthDayOption.MONTH_DAY, false, null));
+            assertEquals(datetimeExpected+1017, DateUtil.parseDateTime("03-FEB-2001 4:05:06:61", MonthDayOption.MONTH_DAY, false, null));
+            assertEquals(datetimeExpected+1517, DateUtil.parseDateTime("03-FEB-2001 4:05:06:91", MonthDayOption.MONTH_DAY, false, null));
 
 
             // Test parseXMLDate() handling of time and date time values
@@ -1660,6 +1684,16 @@ Parse:
             assertEquals(datetimeUTC + 213, parseDateTimeUS("2001-02-03T04:05:06.213Z", DateTimeOption.DateTime, true));
 
             assertIllegalDateTime("20131113_Guide Set plate 1.xls");
+
+            // Test extra date-time parsing format
+            assertIllegalDateTime("03FEB2001:04:05:06"); // Should fail... not a standard format
+            assertEquals(datetimeLocal, DateUtil.parseDateTime("2001-02-03 04:05:06", MonthDayOption.MONTH_DAY, true, "ddMMMyyyy:HH:mm:ss")); // Standard parsing formats still work
+            assertEquals(datetimeLocal, DateUtil.parseDateTime("03FEB2001:04:05:06", MonthDayOption.MONTH_DAY, true, "ddMMMyyyy:HH:mm:ss"));
+
+            // Test extra date parsing format
+            assertIllegalDateTime("03$FEB$2001"); // Should fail... not a standard format
+            assertEquals(dateExpected, DateUtil.parseDate("2001-02-03", MonthDayOption.MONTH_DAY, "dd$MMM$yyyy")); // Standard parsing formats still work
+            assertEquals(dateExpected, DateUtil.parseDate("03$FEB$2001", MonthDayOption.MONTH_DAY, "dd$MMM$yyyy"));
         }
 
 
@@ -1734,8 +1768,8 @@ Parse:
             assertIllegalDateTime("23000101");
 
             // Test XML date format
-            assertXmlDateMatches(DateUtil.parseDate("2001-02-03+01:00", MonthDayOption.DAY_MONTH));
-            assertXmlDateMatches(DateUtil.parseDate("2001-02-03Z", MonthDayOption.DAY_MONTH));
+            assertXmlDateMatches(DateUtil.parseDate("2001-02-03+01:00", MonthDayOption.DAY_MONTH, null));
+            assertXmlDateMatches(DateUtil.parseDate("2001-02-03Z", MonthDayOption.DAY_MONTH, null));
             assertIllegalDateTime("115468001");
 
             // some zero testing

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -823,7 +823,12 @@ validNum:       {
             return parseDateTime(s, MonthDayOption.MONTH_DAY, true, null);
         }
 
-        return parseDateTime(ContainerManager.getRoot(), s);
+        // Yes, this approach is unfortunate, but some code paths have no way to pass a Container through to the parsing
+        // methods (e.g., TableViewForm -> ConvertUtils and DataIterator -> JdbcType -> ConvertUtils)
+        ViewContext ctx = HttpView.currentContext();
+        Container c = null != ctx ? ctx.getContainer() : ContainerManager.getRoot();
+
+        return parseDateTime(c, s);
     }
 
 
@@ -869,7 +874,12 @@ validNum:       {
     @Deprecated  // Use version that takes a Container instead
     public static long parseDate(String s)
     {
-        return parseDate(ContainerManager.getRoot(), s);
+        // Yes, this approach is unfortunate, but some code paths have no way to pass a Container through to the parsing
+        // methods (e.g., TableViewForm -> ConvertUtils and DataIterator -> JdbcType -> ConvertUtils)
+        ViewContext ctx = HttpView.currentContext();
+        Container c = null != ctx ? ctx.getContainer() : ContainerManager.getRoot();
+
+        return parseDate(c, s);
     }
 
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1537,6 +1537,16 @@ public class AdminController extends SpringActionController
         @SuppressWarnings("UnusedDeclaration")
         void setDefaultNumberFormat(String defaultNumberFormat);
 
+        String getExtraDateParsingFormat();
+
+        @SuppressWarnings("UnusedDeclaration")
+        void setExtraDateParsingFormat(String extraDateParsingFormat);
+
+        String getExtraDateTimeParsingFormat();
+
+        @SuppressWarnings("UnusedDeclaration")
+        void setExtraDateTimeParsingFormat(String extraDateTimeParsingFormat);
+
         boolean areRestrictedColumnsEnabled();
 
         @SuppressWarnings("UnusedDeclaration")
@@ -1590,6 +1600,8 @@ public class AdminController extends SpringActionController
         private String _defaultDateFormat;
         private String _defaultDateTimeFormat;
         private String _defaultNumberFormat;
+        private String _extraDateParsingFormat;
+        private String _extraDateTimeParsingFormat;
         private boolean _restrictedColumnsEnabled;
         private String _customLogin;
         private String _customWelcome;
@@ -1820,6 +1832,30 @@ public class AdminController extends SpringActionController
         public void setDefaultNumberFormat(String defaultNumberFormat)
         {
             _defaultNumberFormat = defaultNumberFormat;
+        }
+
+        @Override
+        public String getExtraDateParsingFormat()
+        {
+            return _extraDateParsingFormat;
+        }
+
+        @Override
+        public void setExtraDateParsingFormat(String extraDateParsingFormat)
+        {
+            _extraDateParsingFormat = extraDateParsingFormat;
+        }
+
+        @Override
+        public String getExtraDateTimeParsingFormat()
+        {
+            return _extraDateTimeParsingFormat;
+        }
+
+        @Override
+        public void setExtraDateTimeParsingFormat(String extraDateTimeParsingFormat)
+        {
+            _extraDateTimeParsingFormat = extraDateTimeParsingFormat;
         }
 
         @Override
@@ -4722,6 +4758,8 @@ public class AdminController extends SpringActionController
         private String _defaultDateFormat;
         private String _defaultDateTimeFormat;
         private String _defaultNumberFormat;
+        private String _extraDateParsingFormat;
+        private String _extraDateTimeParsingFormat;
         private boolean _restrictedColumnsEnabled;
 
         @Override
@@ -4758,6 +4796,30 @@ public class AdminController extends SpringActionController
         public void setDefaultNumberFormat(String defaultNumberFormat)
         {
             _defaultNumberFormat = defaultNumberFormat;
+        }
+
+        @Override
+        public String getExtraDateParsingFormat()
+        {
+            return _extraDateParsingFormat;
+        }
+
+        @Override
+        public void setExtraDateParsingFormat(String extraDateParsingFormat)
+        {
+            _extraDateParsingFormat = extraDateParsingFormat;
+        }
+
+        @Override
+        public String getExtraDateTimeParsingFormat()
+        {
+            return _extraDateTimeParsingFormat;
+        }
+
+        @Override
+        public void setExtraDateTimeParsingFormat(String extraDateTimeParsingFormat)
+        {
+            _extraDateTimeParsingFormat = extraDateTimeParsingFormat;
         }
 
         @Override
@@ -10208,59 +10270,16 @@ public class AdminController extends SpringActionController
     // Validate and populate the folder settings; save & log all changes
     private static boolean saveFolderSettings(Container c, SettingsForm form, WriteableFolderLookAndFeelProperties props, User user, BindException errors)
     {
-        String defaultDateFormat = StringUtils.trimToNull(form.getDefaultDateFormat());
-        if (null == defaultDateFormat)
-        {
-            props.clearDefaultDateFormat();
-        }
-        else
-        {
-            try
-            {
-                props.setDefaultDateFormat(defaultDateFormat);
-            }
-            catch (IllegalArgumentException e)
-            {
-                errors.reject(ERROR_MSG, "Invalid date format: " + e.getMessage());
-                return false;
-            }
-        }
-
-        String defaultDateTimeFormat = StringUtils.trimToNull(form.getDefaultDateTimeFormat());
-        if (null == defaultDateTimeFormat)
-        {
-            props.clearDefaultDateTimeFormat();
-        }
-        else
-        {
-            try
-            {
-                props.setDefaultDateTimeFormat(defaultDateTimeFormat);
-            }
-            catch (IllegalArgumentException e)
-            {
-                errors.reject(ERROR_MSG, "Invalid date time format: " + e.getMessage());
-                return false;
-            }
-        }
-
-        String defaultNumberFormat = StringUtils.trimToNull(form.getDefaultNumberFormat());
-        if (null == defaultNumberFormat)
-        {
-            props.clearDefaultNumberFormat();
-        }
-        else
-        {
-            try
-            {
-                props.setDefaultNumberFormat(defaultNumberFormat);
-            }
-            catch (IllegalArgumentException e)
-            {
-                errors.reject(ERROR_MSG, "Invalid number format: " + e.getMessage());
-                return false;
-            }
-        }
+        if (!validateAndSaveFormat(form.getDefaultDateFormat(), props::clearDefaultDateFormat, props::setDefaultDateFormat, errors, "date"))
+            return false;
+        if (!validateAndSaveFormat(form.getDefaultDateTimeFormat(), props::clearDefaultDateTimeFormat, props::setDefaultDateTimeFormat, errors, "date-time"))
+            return false;
+        if (!validateAndSaveFormat(form.getDefaultNumberFormat(), props::clearDefaultNumberFormat, props::setDefaultNumberFormat, errors, "number"))
+            return false;
+        if (!validateAndSaveFormat(form.getExtraDateParsingFormat(), props::clearExtraDateParsingFormat, props::setExtraDateParsingFormat, errors, "date"))
+            return false;
+        if (!validateAndSaveFormat(form.getExtraDateTimeParsingFormat(), props::clearExtraDateTimeParsingFormat, props::setExtraDateTimeParsingFormat, errors, "date-time"))
+            return false;
 
         try
         {
@@ -10280,6 +10299,33 @@ public class AdminController extends SpringActionController
         return true;
     }
 
+    private interface FormatSaver
+    {
+        void save(String format) throws IllegalArgumentException;
+    }
+
+    private static boolean validateAndSaveFormat(String format, Runnable clearer, FormatSaver saver, BindException errors, String what)
+    {
+        String defaultFormat = StringUtils.trimToNull(format);
+        if (null == defaultFormat)
+        {
+            clearer.run();
+        }
+        else
+        {
+            try
+            {
+                saver.save(defaultFormat);
+            }
+            catch (IllegalArgumentException e)
+            {
+                errors.reject(ERROR_MSG, "Invalid " + what + " format: " + e.getMessage());
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     public static class LookAndFeelView extends JspView<LookAndFeelBean>
     {

--- a/core/src/org/labkey/core/admin/importer/FolderTypeImporterFactory.java
+++ b/core/src/org/labkey/core/admin/importer/FolderTypeImporterFactory.java
@@ -112,6 +112,30 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
                 }
             }
 
+            if (folderXml.isSetExtraDateParsingFormat())
+            {
+                try
+                {
+                    WriteableFolderLookAndFeelProperties.saveExtraDateParsingFormat(c, folderXml.getExtraDateParsingFormat());
+                }
+                catch (IllegalArgumentException e)
+                {
+                    ctx.getLogger().warn("Illegal default date format specified: " + e.getMessage());
+                }
+            }
+
+            if (folderXml.isSetExtraDateTimeParsingFormat())
+            {
+                try
+                {
+                    WriteableFolderLookAndFeelProperties.saveExtraDateTimeParsingFormat(c, folderXml.getExtraDateTimeParsingFormat());
+                }
+                catch (IllegalArgumentException e)
+                {
+                    ctx.getLogger().warn("Illegal default date-time format specified: " + e.getMessage());
+                }
+            }
+
             if (folderXml.isSetFolderType())
             {
                 if (null != job)

--- a/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
+++ b/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
@@ -216,31 +216,15 @@
             "<tr class=\"labkey-alternate-row\"><td><code>s</code><td>Second in minute<td><code>55</code></tr>" +
             "<tr class=\"labkey-row\"><td><code>S</code><td>Millisecond<td><code>978</code></tr>" +
             "</table>";
-    String dateFormatHelp = "This format is applied when displaying columns that are defined with a date-only data type or annotated with the \"Date\" meta type. Most standard LabKey columns use date-time data types (see below)." + simpleDateFormatDocs;
-    String dateTimeFormatHelp = "This format is applied when displaying columns that are defined with a date-time data type or annotated with the \"DateTime\" meta type. Most standard LabKey columns use this format." + simpleDateFormatDocs;
+    String dateFormatHelp = "This format is applied when displaying a column that is defined with a date-only data type or annotated with the \"Date\" meta type. Most standard LabKey columns use date-time data types (see below)." + simpleDateFormatDocs;
+    String dateTimeFormatHelp = "This format is applied when displaying a column that is defined with a date-time data type or annotated with the \"DateTime\" meta type. Most standard LabKey columns use this format." + simpleDateFormatDocs;
+
+    String dateParsingHelp = "This format is attempted first when parsing text input for a column that is designated with a date-only data type or annotated with the \"Date\" meta type. Most standard LabKey columns use date-time data types (see below)." + simpleDateFormatDocs;
+    String dateTimeParsingHelp = "This format is attempted first when parsing text input for a column that is designated with a date-time data type or annotated with the \"DateTime\" meta type. Most standard LabKey columns use this format." + simpleDateFormatDocs;
 %>
 <tr>
-    <td colspan=2>Customize date and number formats (<%=bean.helpLink%>)</td>
+    <td colspan=2>Customize date and number display formats (<%=bean.helpLink%>)</td>
 </tr>
-<%
-    // TODO: This check is temporary and should switch to "if (!folder) {}" once the date parsing methods pass Container consistently
-    if (c.isRoot())
-    {
-        DateParsingMode dateParsingMode = laf.getDateParsingMode();
-        String dateParsingHelp = "LabKey needs to understand how to interpret (parse) dates that users enter into input forms. " +
-                "For example, if a user enters the date \"10/4/2013\" does that person mean October 4, 2013 (typical interpretation " +
-                "in the United States) or April 10, 2013 (typical interpretation in most other countries)? Choose the " +
-                "parsing mode that matches your users' expectations.";
-%>
-<tr>
-    <td class="labkey-form-label">Date parsing mode<%=helpPopup("Date parsing", dateParsingHelp, false)%></td>
-    <td>
-        <label><input type="radio" name="dateParsingMode" value="<%=h(DateParsingMode.US.toString())%>"<%=checked(dateParsingMode == DateParsingMode.US)%>> <%=h(DateParsingMode.US.getDisplayString())%> </label><br>
-        <label><input type="radio" name="dateParsingMode" value="<%=h(DateParsingMode.NON_US.toString())%>"<%=checked(dateParsingMode == DateParsingMode.NON_US)%>> <%=h(DateParsingMode.NON_US.getDisplayString())%> </label><br>
-    </td>
-</tr><%
-    }
-%>
 <tr>
     <td class="labkey-form-label">Default display format for dates<%=helpPopup("Date format", dateFormatHelp, true, 300)%></td>
     <td><input type="text" name="defaultDateFormat" size="50" value="<%= h(laf.getDefaultDateFormat()) %>"></td>
@@ -252,6 +236,40 @@
 <tr>
     <td class="labkey-form-label">Default display format for numbers<%=helpPopup("Number format", decimalFormatHelp, true, 350)%></td>
     <td><input type="text" name="defaultNumberFormat" size="50" value="<%= h(laf.getDefaultNumberFormat()) %>"></td>
+</tr>
+<tr>
+    <td>&nbsp;</td>
+</tr>
+
+<tr>
+    <td colspan=2>Customize date parsing behavior (<%=bean.helpLink%>)</td>
+</tr>
+<%
+    // TODO: This check is temporary and should switch to "if (!folder) {}" once the date parsing methods pass Container consistently
+    if (c.isRoot())
+    {
+        DateParsingMode dateParsingMode = laf.getDateParsingMode();
+        String dateParsingModeHelp = "LabKey needs to understand how to interpret (parse) dates that users enter into input forms. " +
+                "For example, if a user enters the date \"10/4/2013\" does that person mean October 4, 2013 (typical interpretation " +
+                "in the United States) or April 10, 2013 (typical interpretation in most other countries)? Choose the " +
+                "parsing mode that matches your users' expectations.";
+%>
+<tr>
+    <td class="labkey-form-label">Date parsing mode<%=helpPopup("Date parsing mode", dateParsingModeHelp, false)%></td>
+    <td>
+        <label><input type="radio" name="dateParsingMode" value="<%=h(DateParsingMode.US.toString())%>"<%=checked(dateParsingMode == DateParsingMode.US)%>> <%=h(DateParsingMode.US.getDisplayString())%> </label><br>
+        <label><input type="radio" name="dateParsingMode" value="<%=h(DateParsingMode.NON_US.toString())%>"<%=checked(dateParsingMode == DateParsingMode.NON_US)%>> <%=h(DateParsingMode.NON_US.getDisplayString())%> </label><br>
+    </td>
+</tr><%
+    }
+%>
+<tr>
+    <td class="labkey-form-label">Additional parsing format for dates<%=helpPopup("Extra date parsing format", dateParsingHelp, true, 300)%></td>
+    <td><input type="text" name="extraDateParsingFormat" size="50" value="<%= h(laf.getExtraDateParsingFormat()) %>"></td>
+</tr>
+<tr>
+    <td class="labkey-form-label">Additional parsing format for date-times<%=helpPopup("Extra date-time parsing format", dateTimeParsingHelp, true, 300)%></td>
+    <td><input type="text" name="extraDateTimeParsingFormat" size="50" value="<%= h(laf.getExtraDateTimeParsingFormat()) %>"></td>
 </tr>
 <tr>
     <td>&nbsp;</td>


### PR DESCRIPTION
#### Rationale
Give administrators a way to provide custom date parsing patterns

#### Changes
* Display, input, persist, cache, inherit, import, and export two new look & feel properties that provide extra date and date-time parsing patterns
* Use the extra parsing patterns in public `DateUtils` helper methods. Add unit tests for same.
* If not passed in, use `HttpView.currentContext()` to retrieve current `Container` and associated parsing patterns
