### PR TITLE
Time out when acquiring locks during transaction setup instead of deadlocking

### DIFF
--- a/api/src/org/labkey/api/cache/BlockingCache.java
+++ b/api/src/org/labkey/api/cache/BlockingCache.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.labkey.api.util.DeadlockPreventingException;
 import org.labkey.api.util.Filter;
 
 import java.util.HashMap;
@@ -127,7 +128,7 @@ public class BlockingCache<K, V> implements Cache<K, V>
             {
                 if (System.currentTimeMillis() > endTime)
                 {
-                    throw new RuntimeException("Cache timeout for " + getTrackingCache().getDebugName() + ", exceeding " + _timeout + "ms limit");
+                    throw new DeadlockPreventingException("Cache timeout for " + getTrackingCache().getDebugName() + ", exceeding " + _timeout + "ms limit");
                 }
                 try
                 {

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -61,6 +60,7 @@ import org.labkey.api.util.GUID;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.FolderTab;
 import org.labkey.api.view.ForbiddenProjectException;
@@ -98,7 +98,7 @@ import java.util.function.BooleanSupplier;
  */
 public class Container implements Serializable, Comparable<Container>, SecurableResource, ContainerContext, HasPermission, Parameter.JdbcParameterValue
 {
-    private static final Logger LOG = LogManager.getLogger(Container.class);
+    private static final Logger LOG = LogHelper.getLogger(Container.class, "Information about projects and folders");
 
     private GUID _id;
     private Path _path;

--- a/api/src/org/labkey/api/data/ServerPrimaryKeyLock.java
+++ b/api/src/org/labkey/api/data/ServerPrimaryKeyLock.java
@@ -82,7 +82,9 @@ public class ServerPrimaryKeyLock implements DbScope.ServerLock
     @Override
     public boolean tryLock(long time, @NotNull TimeUnit unit)
     {
-        throw new UnsupportedOperationException("ServerRowLock does not support tryLock()");
+        // We don't really support the timeout but pretend we do to participate in DbScope.Transaction's deadlock prevention
+        lock();
+        return true;
     }
 
     @Override

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -128,7 +128,7 @@ public abstract class SqlDialect
 
     protected abstract @NotNull Set<String> getReservedWords();
 
-    protected String getOtherDatabaseThreads()
+    public String getOtherDatabaseThreads()
     {
         StringBuilder sb = new StringBuilder();
 

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -128,6 +128,8 @@ public abstract class SqlDialect
 
     protected abstract @NotNull Set<String> getReservedWords();
 
+    public static final String SEPARATOR_BANNER = "******** Other thread info *********";
+
     public String getOtherDatabaseThreads()
     {
         StringBuilder sb = new StringBuilder();
@@ -187,6 +189,12 @@ public abstract class SqlDialect
                 }
             }
         }
+
+        if (sb.length() > 0)
+        {
+            sb.insert(0, SEPARATOR_BANNER + "\n\n");
+        }
+
         return sb.toString();
     }
 

--- a/api/src/org/labkey/api/util/DeadlockPreventingException.java
+++ b/api/src/org/labkey/api/util/DeadlockPreventingException.java
@@ -1,0 +1,17 @@
+package org.labkey.api.util;
+
+/**
+ * Thrown after a resource doesn't become available after a timeout in an attempt to avoid deadlocking the whole server.
+ */
+public class DeadlockPreventingException extends RuntimeException
+{
+    public DeadlockPreventingException(String message)
+    {
+        super(message);
+    }
+
+    public DeadlockPreventingException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -263,6 +263,15 @@ public class ExceptionUtil
                 }
             }
 
+            if (t instanceof DeadlockPreventingException)
+            {
+                String extraSqlInfo = CoreSchema.getInstance().getSqlDialect().getOtherDatabaseThreads();
+                if (extraSqlInfo != null)
+                {
+                    extraInfo = extraSqlInfo;
+                }
+            }
+
             if (sqlState != null)
                 break;
         }


### PR DESCRIPTION
#### Rationale
Deadlocking the server is really bad. Similar to how we switched to timing out with an exception when DB connections aren't available from the pool, we can time out when trying to acquire (most) lock objects passed to DbScope.ensureTransaction()

#### Changes
* Time out after 2 minutes of failing to get a lock
* Unwind already acquired locks when one fails
* New test coverage
* Enable test that now seems to pass
* More descriptions for loggers