### PR TITLE
Issue 44023: Query Report created through Clinical and Assay tab of study appends comma in URL

### DIFF
--- a/query/src/org/labkey/query/reports/view/createQueryReport.jsp
+++ b/query/src/org/labkey/query/reports/view/createQueryReport.jsp
@@ -113,7 +113,7 @@
                 description : true,
                 shared      : true
             },
-            extraItems : [querySchemaPanel, {xtype: 'hiddenfield', name: 'returnUrl'}],
+            extraItems : [querySchemaPanel],
             dockedItems: [{
                 xtype: 'toolbar',
                 dock: 'bottom',


### PR DESCRIPTION
#### Rationale
Two returnURL parameters (one blank) being passed as parameters from this jsp. Binding both puts a comma in the returnURL before the blank returnURL. There has been some refactoring on this page since the original hidden returnURL field was added (2013). I don't see a use case where it is needed any longer.  I've run a lot of tests and no use cases are showing up.

#### Changes
* Remove hidden field
