### PR TITLE
Handle `InvalidPathException` in `PipeRootImpl.resolveToNioPath`

### DIFF
--- a/pipeline/src/org/labkey/pipeline/api/PipeRootImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipeRootImpl.java
@@ -356,7 +356,7 @@ public class PipeRootImpl implements PipeRoot
     @Nullable
     public Path resolveToNioPath(String path)
     {
-        if (null == path)
+        if (StringUtils.isBlank(path))
             throw new NotFoundException("Must specify a file path");
 
         try

--- a/pipeline/src/org/labkey/pipeline/api/PipeRootImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipeRootImpl.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -358,23 +359,30 @@ public class PipeRootImpl implements PipeRoot
         if (null == path)
             throw new NotFoundException("Must specify a file path");
 
-        if (ROOT_BASE.cloud.equals(_defaultRoot))
+        try
         {
-            // Remove leading "./" sometimes added by the client side FileBrowser
-            if (path.startsWith("./"))
-                path = path.substring(2);
+            if (ROOT_BASE.cloud.equals(_defaultRoot))
+            {
+                // Remove leading "./" sometimes added by the client side FileBrowser
+                if (path.startsWith("./"))
+                    path = path.substring(2);
 
-            // Return the path to the default location
-            org.labkey.api.util.Path combinedPath = StringUtils.isNotBlank(_uris.get(0).getPath()) ?
-                    new org.labkey.api.util.Path(_uris.get(0).getPath(), path) :
-                    new org.labkey.api.util.Path(path);
-            return CloudStoreService.get().getPath(getContainer(), _cloudStoreName, combinedPath);
-            // TODO: Do we need? Check that it's under the root to protect against ../../ type paths
+                // Return the path to the default location
+                org.labkey.api.util.Path combinedPath = StringUtils.isNotBlank(_uris.get(0).getPath()) ?
+                        new org.labkey.api.util.Path(_uris.get(0).getPath(), path) :
+                        new org.labkey.api.util.Path(path);
+                return CloudStoreService.get().getPath(getContainer(), _cloudStoreName, combinedPath);
+                // TODO: Do we need? Check that it's under the root to protect against ../../ type paths
+            }
+            else
+            {
+                File file = resolvePath(path);
+                return null != file ? file.toPath() : null;
+            }
         }
-        else
+        catch (InvalidPathException e)
         {
-            File  file = resolvePath(path);
-            return null != file ? file.toPath() : null;
+            throw new NotFoundException("Must specify a valid file path", e);
         }
     }
 


### PR DESCRIPTION
#### Rationale
Should prevent errors such as this one triggered by the crawler:
```
java.nio.file.InvalidPathException: Illegal char <>> at index 68: D:\teamcity\work\c86b103d373f4c06\server\testAutomation\data\flow\-->">'>'"<\script><img src="xss" onerror="alert('8(')">
	[...]
	at org.labkey.pipeline.api.PipeRootImpl.resolveToNioPath(PipeRootImpl.java:377) ~[pipeline-21.10-SNAPSHOT.jar:?]
	at org.labkey.api.pipeline.browse.PipelinePathForm.getValidatedPaths(PipelinePathForm.java:155) ~[api-21.10-SNAPSHOT.jar:?]
	at org.labkey.api.pipeline.browse.PipelinePathForm.getValidatedSinglePath(PipelinePathForm.java:223) ~[api-21.10-SNAPSHOT.jar:?]
	at org.labkey.api.pipeline.browse.PipelinePathForm.getValidatedSingleFile(PipelinePathForm.java:217) ~[api-21.10-SNAPSHOT.jar:?]
	at org.labkey.flow.controllers.executescript.AnalysisScriptController$ImportAnalysisFromPipelineAction.getView(AnalysisScriptController.java:524) ~[flow-21.10-SNAPSHOT.jar:?]
	at org.labkey.flow.controllers.executescript.AnalysisScriptController$ImportAnalysisFromPipelineAction.getView(AnalysisScriptController.java:518) ~[flow-21.10-SNAPSHOT.jar:?]
```

#### Related Pull Requests
* #2541 

#### Changes
* Handle `InvalidPathException` in `PipeRootImpl.resolveToNioPath`