### PR TITLE
Fix many study import tests

### DIFF
--- a/api/src/org/labkey/api/view/HttpView.java
+++ b/api/src/org/labkey/api/view/HttpView.java
@@ -612,13 +612,15 @@ public abstract class HttpView<ModelBean> extends DefaultModelAndView<ModelBean>
     /**
      * Current view context. Dangerous because some views do not use a ViewContext
      * object for their model and can cause a class cast exception.
+     * @return the current context, or null if the current thread isn't rendering a view (like a background
+     * pipeline thread)
      */
     @Nullable
     public static ViewContext currentContext()
     {
         // CONSIDER: if we ever have something besides HttpView on stack
         // we may need to iterate til we find the top most HttpView
-        return HttpView.currentView().getViewContext();
+        return hasCurrentView() ? currentView().getViewContext() : null;
     }
 
 


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/platform/pull/2649 broke study import because it's asking for the current ViewContext from a background thread in an attempt to determine if there's a custom date pattern for parsing

#### Changes
* Return null as advertised via annotation instead of throwing an exception when we don't have a ViewContext