### PR TITLE
Issue 43898: Study dataset with subject column name set to "SubjectID" has issues when a field of that same name is also added to the dataset

### DIFF
--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -69,6 +69,7 @@ import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.module.ModuleHtmlView;
 import org.labkey.api.module.ModuleLoader;
@@ -1562,6 +1563,35 @@ public class StudyController extends BaseStudyController
             setHelpTopic("manageStudy");
             _addManageStudy(root);
             root.addChild("Study Properties");
+        }
+
+        @Override
+        public void validateForm(TableViewForm form, Errors errors)
+        {
+            // Validate that the subject column name is not a user defined field in one of the datasets
+            String subjectColName = form.get("SubjectColumnName");
+            if (null != subjectColName)
+            {
+                Study study = StudyService.get().getStudy(getContainer());
+                if (null != study)
+                {
+                    for (Dataset dataset : study.getDatasets())
+                    {
+                        Domain domain = dataset.getDomain();
+                        if (null != domain)
+                        {
+                            for (DomainProperty property : domain.getProperties())
+                            {
+                                if (property.getName().equalsIgnoreCase(subjectColName))
+                                {
+                                    errors.reject(ERROR_MSG, "Cannot set Subject Column Name to a user defined dataset field. " + subjectColName + " is already defined in " + dataset.getName() + ". ");
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         @Override

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -1568,7 +1568,7 @@ public class StudyController extends BaseStudyController
         @Override
         public void validateForm(TableViewForm form, Errors errors)
         {
-            // Validate that the subject column name is not a user defined field in one of the datasets
+            // Issue 43898: Validate that the subject column name is not a user defined field in one of the datasets
             String subjectColName = form.get("SubjectColumnName");
             if (null != subjectColName)
             {

--- a/study/src/org/labkey/study/model/ContinuousDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/ContinuousDatasetDomainKind.java
@@ -19,6 +19,7 @@ import org.labkey.api.exp.property.Domain;
 import org.labkey.api.study.TimepointType;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -55,6 +56,9 @@ public class ContinuousDatasetDomainKind extends DatasetDomainKind
     @Override
     public Set<String> getReservedPropertyNames(Domain domain)
     {
-        return Collections.unmodifiableSet(DatasetDefinition.DEFAULT_ABSOLUTE_DATE_FIELDS);
+        HashSet<String> fields = new HashSet<>(getStudySubjectReservedName(domain));
+        fields.addAll(DatasetDefinition.DEFAULT_ABSOLUTE_DATE_FIELDS);
+
+        return Collections.unmodifiableSet(fields);
     }
 }

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -60,11 +60,11 @@ import org.labkey.study.StudySchema;
 import org.labkey.study.assay.StudyPublishManager;
 import org.labkey.study.controllers.StudyController;
 import org.labkey.study.query.DatasetFactory;
-import org.labkey.study.query.DatasetTableImpl;
 import org.labkey.study.query.StudyQuerySchema;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -261,6 +261,21 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
     DatasetDefinition getDatasetDefinition(String domainURI)
     {
         return StudyManager.getInstance().getDatasetDefinition(domainURI);
+    }
+
+    protected Set<String> getStudySubjectReservedName(Domain domain)
+    {
+        HashSet<String> fields = new HashSet<>();
+        if (null != domain)
+        {
+            Study study = StudyManager.getInstance().getStudy(domain.getContainer());
+            if (null != study)
+            {
+                String participantIdField = study.getSubjectColumnName();
+                fields.add(participantIdField);
+            }
+        }
+        return Collections.unmodifiableSet(fields);
     }
 
     @Override

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -263,6 +263,7 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
         return StudyManager.getInstance().getDatasetDefinition(domainURI);
     }
 
+    // Issue 43898: Add the study subject name column to reserved fields
     protected Set<String> getStudySubjectReservedName(Domain domain)
     {
         HashSet<String> fields = new HashSet<>();

--- a/study/src/org/labkey/study/model/DateDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DateDatasetDomainKind.java
@@ -19,6 +19,7 @@ import org.labkey.api.exp.property.Domain;
 import org.labkey.api.study.TimepointType;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -57,6 +58,9 @@ public class DateDatasetDomainKind extends DatasetDomainKind
     @Override
     public Set<String> getReservedPropertyNames(Domain domain)
     {
-        return Collections.unmodifiableSet(DatasetDefinition.DEFAULT_RELATIVE_DATE_FIELDS);
+        HashSet<String> fields = new HashSet<>(getStudySubjectReservedName(domain));
+        fields.addAll(DatasetDefinition.DEFAULT_RELATIVE_DATE_FIELDS);
+
+        return Collections.unmodifiableSet(fields);
     }
 }

--- a/study/src/org/labkey/study/model/VisitDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/VisitDatasetDomainKind.java
@@ -58,18 +58,8 @@ public class VisitDatasetDomainKind extends DatasetDomainKind
     @Override
     public Set<String> getReservedPropertyNames(Domain domain)
     {
-        HashSet<String> fields = new HashSet<>(DatasetDefinition.DEFAULT_VISIT_FIELDS);
-
-        // Add the study Subject Column Name to reserved fields
-        if (null != domain)
-        {
-            Study study = StudyManager.getInstance().getStudy(domain.getContainer());
-            if (null != study)
-            {
-                String participantIdField = study.getSubjectColumnName();
-                fields.add(participantIdField);
-            }
-        }
+        HashSet<String> fields = new HashSet<>(getStudySubjectReservedName(domain));
+        fields.addAll(DatasetDefinition.DEFAULT_VISIT_FIELDS);
 
         return Collections.unmodifiableSet(fields);
     }

--- a/study/src/org/labkey/study/model/VisitDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/VisitDatasetDomainKind.java
@@ -61,11 +61,14 @@ public class VisitDatasetDomainKind extends DatasetDomainKind
         HashSet<String> fields = new HashSet<>(DatasetDefinition.DEFAULT_VISIT_FIELDS);
 
         // Add the study Subject Column Name to reserved fields
-        Study study = StudyManager.getInstance().getStudy(domain.getContainer());
-        if (null != study)
+        if (null != domain)
         {
-            String participantIdField = study.getSubjectColumnName();
-            fields.add(participantIdField);
+            Study study = StudyManager.getInstance().getStudy(domain.getContainer());
+            if (null != study)
+            {
+                String participantIdField = study.getSubjectColumnName();
+                fields.add(participantIdField);
+            }
         }
 
         return Collections.unmodifiableSet(fields);

--- a/study/src/org/labkey/study/model/VisitDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/VisitDatasetDomainKind.java
@@ -58,7 +58,17 @@ public class VisitDatasetDomainKind extends DatasetDomainKind
     @Override
     public Set<String> getReservedPropertyNames(Domain domain)
     {
-        return Collections.unmodifiableSet(DatasetDefinition.DEFAULT_VISIT_FIELDS);
+        HashSet<String> fields = new HashSet<>(DatasetDefinition.DEFAULT_VISIT_FIELDS);
+
+        // Add the study Subject Column Name to reserved fields
+        Study study = StudyManager.getInstance().getStudy(domain.getContainer());
+        if (null != study)
+        {
+            String participantIdField = study.getSubjectColumnName();
+            fields.add(participantIdField);
+        }
+
+        return Collections.unmodifiableSet(fields);
     }
 
     @Override

--- a/study/src/org/labkey/study/view/manageStudyPropertiesExt.jsp
+++ b/study/src/org/labkey/study/view/manageStudyPropertiesExt.jsp
@@ -203,7 +203,10 @@ function onSaveFailure_formSubmit(form, action)
             if (action.result.errors)
             {
                 for (var prop in action.result.errors)
-                    msg += action.result.errors[prop] + "<br/>";
+
+                    // Don't double print form and general exception if the same
+                    if (action.result.errors[prop] !== msg)
+                        msg += action.result.errors[prop] + "<br/>";
             }
 
             Ext4.Msg.show({title: 'Failure', msg: msg, buttons: Ext4.Msg.OK, icon: Ext4.Msg.ERROR});

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
@@ -199,6 +199,8 @@ public class StudyDatasetsTest extends BaseWebDriverTest
 
         waitForText("Cannot set Subject Column Name to a user defined dataset field. " + mySubjectId + " is already defined in " + subjectIdDataset + ".");
         click(findButton("Ok"));
+        clickButton("Cancel");
+        clickTab("Overview");
     }
 
     @LogMethod

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
@@ -162,6 +162,45 @@ public class StudyDatasetsTest extends BaseWebDriverTest
         checkDataElementsPresent("B", DATASET_B_MERGE.split("\t|\n"));
     }
 
+    @Test
+    public void testDatasetSubjectId()
+    {
+        final String mySubjectId = "MySubjectId";
+        final String subjectIdDataset = "SubjectIdTest";
+
+        // Check the number of server errors.
+        int errorCountBefore = getServerErrorCount();
+
+        goToManageStudy();
+        waitAndClickAndWait(Locator.linkWithText("Change Study Properties"));
+        waitForElement(Locator.name("SubjectColumnName"), WAIT_FOR_JAVASCRIPT);
+        String subjectName = getFormElement(Locator.name("SubjectColumnName"));
+        clickButton("Cancel");
+        clickTab("Overview");
+
+        DatasetDesignerPage designerPage = _studyHelper.goToManageDatasets()
+                .clickCreateNewDataset()
+                .setName(subjectIdDataset);
+
+        DomainFormPanel fieldsPanel = designerPage.getFieldsPanel();
+        fieldsPanel.manuallyDefineFields(subjectName);
+        designerPage.saveExpectFail("Property: " + subjectName + " is reserved or exists in the current domain.");
+
+        fieldsPanel.removeField(subjectName);
+        fieldsPanel.manuallyDefineFields(mySubjectId);
+        designerPage.clickSave();
+        checkExpectedErrors(errorCountBefore + 2);
+
+        goToManageStudy();
+        waitAndClickAndWait(Locator.linkWithText("Change Study Properties"));
+        waitForElement(Locator.name("SubjectColumnName"), WAIT_FOR_JAVASCRIPT);
+        setFormElement(Locator.name("SubjectColumnName"), mySubjectId);
+        click(findButton("Submit"));
+
+        waitForText("Cannot set Subject Column Name to a user defined dataset field. " + mySubjectId + " is already defined in " + subjectIdDataset + ".");
+        click(findButton("Ok"));
+    }
+
     @LogMethod
     protected void createDataset(@LoggedParam String name)
     {


### PR DESCRIPTION
#### Rationale
Don't allow a dataset to have a user defined field that matches the Study Subject Column in study properties. Validated when creating/updating dataset designs and when updating study properties.  Applied to all dataset types.

#### Changes
* Update reserved names for datasets
* Validation on ManageStudyPropertiesAction
* Add automated test
