### PR TITLE
Fix path check

### DIFF
--- a/pipeline/src/org/labkey/pipeline/api/PipeRootImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipeRootImpl.java
@@ -356,7 +356,7 @@ public class PipeRootImpl implements PipeRoot
     @Nullable
     public Path resolveToNioPath(String path)
     {
-        if (StringUtils.isBlank(path))
+        if (path == null)
             throw new NotFoundException("Must specify a file path");
 
         try


### PR DESCRIPTION
#### Rationale
A blank path is valid. Should just check for null.

#### Related Pull Requests
* #2655 

#### Changes
* Revert back to null check instead of `StringUtils.isBlank`
