### PR TITLE
Update Constants.getDocumentationVersion to 21.11

### DIFF
--- a/api/src/org/labkey/api/Constants.java
+++ b/api/src/org/labkey/api/Constants.java
@@ -49,7 +49,7 @@ public class Constants
      */
     public static String getDocumentationVersion()
     {
-        return "21.7";
+        return "21.11";
     }
 
     /**


### PR DESCRIPTION
#### Rationale
We're on 21.11 now. Point at appropriate documentation version

#### Related Pull Requests
* https://github.com/LabKey/server/pull/129

#### Changes
* Update Constants.getDocumentationVersion to 21.11
