### PR TITLE
Item 9533: App support for module defined sample assay results view configs to show in sample assays tabbed grid

### DIFF
--- a/api/src/org/labkey/api/action/UrlProviderOverrideHandler.java
+++ b/api/src/org/labkey/api/action/UrlProviderOverrideHandler.java
@@ -1,0 +1,64 @@
+package org.labkey.api.action;
+
+import org.labkey.api.module.Module;
+import org.labkey.api.module.ModuleDependencySorter;
+import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.util.Pair;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class UrlProviderOverrideHandler implements InvocationHandler
+{
+    private final Class<? extends UrlProvider> _inter;
+    private final UrlProvider _impl;
+
+    public UrlProviderOverrideHandler(Class<? extends UrlProvider> inter, UrlProvider impl)
+    {
+        _inter = inter;
+        _impl = impl;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method m, Object[] args) throws Throwable {
+        // check to see if the given interface has any module registered overrides
+        List<Pair<Module, Class<? extends UrlProvider>>> impls = ModuleLoader.getInstance().getUrlProviderOverrides(_inter);
+        if (impls != null)
+        {
+            // convert the pairs of module/impl to a map from module -> impl and a list of all module dependencies
+            Map<Module, Class<? extends UrlProvider>> moduleToImpl = new HashMap<>();
+            Set<Module> modulesWithDependentModules = new HashSet<>();
+            for (Pair<Module, Class<? extends UrlProvider>> impl : impls)
+            {
+                moduleToImpl.put(impl.first, impl.second);
+                modulesWithDependentModules.add(impl.first);
+                modulesWithDependentModules.addAll(impl.first.getResolvedModuleDependencies());
+            }
+
+            // sort the modules in dependency order so that we can iterate through them looking for a non-null result
+            // for the given method being invoked
+            ModuleDependencySorter sorter = new ModuleDependencySorter();
+            List<Module> orderedModules = sorter.sortModulesByDependencies(new ArrayList<>(modulesWithDependentModules));
+            Collections.reverse(orderedModules);
+            for (Module module : orderedModules)
+            {
+                if (moduleToImpl.containsKey(module))
+                {
+                    Object result = m.invoke(moduleToImpl.get(module).getDeclaredConstructor().newInstance(), args);
+                    if (result != null)
+                        return result;
+                }
+            }
+        }
+
+        // fall back to invoking the given method on the default URLProvider implementation for the interface
+        return m.invoke(_impl, args);
+    }
+}

--- a/api/src/org/labkey/api/action/UrlProviderOverrideHandler.java
+++ b/api/src/org/labkey/api/action/UrlProviderOverrideHandler.java
@@ -25,6 +25,10 @@ public class UrlProviderOverrideHandler implements InvocationHandler
         _impl = impl;
     }
 
+    /**
+     * Note that if the overriding implementation is only to be applicable when the given module is enabled in
+     * the container being checked, then it is up to that overriding implementation to make that check.
+     */
     @Override
     public Object invoke(Object proxy, Method m, Object[] args) throws Throwable {
         // check to see if the given interface has any module registered overrides

--- a/api/src/org/labkey/api/action/UrlProviderOverrideHandler.java
+++ b/api/src/org/labkey/api/action/UrlProviderOverrideHandler.java
@@ -2,7 +2,6 @@ package org.labkey.api.action;
 
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleDependencySorter;
-import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.Pair;
 
 import java.lang.reflect.InvocationHandler;
@@ -29,7 +28,7 @@ public class UrlProviderOverrideHandler implements InvocationHandler
     @Override
     public Object invoke(Object proxy, Method m, Object[] args) throws Throwable {
         // check to see if the given interface has any module registered overrides
-        List<Pair<Module, Class<? extends UrlProvider>>> impls = ModuleLoader.getInstance().getUrlProviderOverrides(_inter);
+        List<Pair<Module, Class<? extends UrlProvider>>> impls = UrlProviderService.getInstance().getUrlProviderOverrides(_inter);
         if (impls != null)
         {
             // convert the pairs of module/impl to a map from module -> impl and a list of all module dependencies

--- a/api/src/org/labkey/api/action/UrlProviderOverrideHandler.java
+++ b/api/src/org/labkey/api/action/UrlProviderOverrideHandler.java
@@ -28,13 +28,13 @@ public class UrlProviderOverrideHandler implements InvocationHandler
     @Override
     public Object invoke(Object proxy, Method m, Object[] args) throws Throwable {
         // check to see if the given interface has any module registered overrides
-        List<Pair<Module, Class<? extends UrlProvider>>> impls = UrlProviderService.getInstance().getUrlProviderOverrides(_inter);
+        List<Pair<Module, UrlProvider>> impls = UrlProviderService.getInstance().getUrlProviderOverrides(_inter);
         if (impls != null)
         {
             // convert the pairs of module/impl to a map from module -> impl and a list of all module dependencies
-            Map<Module, Class<? extends UrlProvider>> moduleToImpl = new HashMap<>();
+            Map<Module, UrlProvider> moduleToImpl = new HashMap<>();
             Set<Module> modulesWithDependentModules = new HashSet<>();
-            for (Pair<Module, Class<? extends UrlProvider>> impl : impls)
+            for (Pair<Module, UrlProvider> impl : impls)
             {
                 moduleToImpl.put(impl.first, impl.second);
                 modulesWithDependentModules.add(impl.first);
@@ -50,7 +50,7 @@ public class UrlProviderOverrideHandler implements InvocationHandler
             {
                 if (moduleToImpl.containsKey(module))
                 {
-                    Object result = m.invoke(moduleToImpl.get(module).getDeclaredConstructor().newInstance(), args);
+                    Object result = m.invoke(moduleToImpl.get(module), args);
                     if (result != null)
                         return result;
                 }

--- a/api/src/org/labkey/api/action/UrlProviderService.java
+++ b/api/src/org/labkey/api/action/UrlProviderService.java
@@ -28,7 +28,7 @@ public class UrlProviderService
 {
     private static final UrlProviderService instance = new UrlProviderService();
     private static final Map<Class, Class<? extends UrlProvider>> _urlProviderToImpl = new HashMap<>();
-    private static final Map<Class<? extends UrlProvider>, List<Pair<Module, Class<? extends UrlProvider>>>> _urlProviderToOverrideImpls = new HashMap<>();
+    private static final Map<Class<? extends UrlProvider>, List<Pair<Module, UrlProvider>>> _urlProviderToOverrideImpls = new HashMap<>();
 
     public static UrlProviderService getInstance()
     {
@@ -75,9 +75,9 @@ public class UrlProviderService
      * @param impl the override URLProvider implementation class
      * @param module the module providing the override
      */
-    public void registerUrlProviderOverride(Class<? extends UrlProvider> inter, Class<? extends UrlProvider> impl, Module module)
+    public void registerUrlProviderOverride(Class<? extends UrlProvider> inter, UrlProvider impl, Module module)
     {
-        List<Pair<Module, Class<? extends UrlProvider>>> impls = new ArrayList<>();
+        List<Pair<Module, UrlProvider>> impls = new ArrayList<>();
         if (_urlProviderToOverrideImpls.containsKey(inter))
             impls = _urlProviderToOverrideImpls.get(inter);
 
@@ -85,7 +85,7 @@ public class UrlProviderService
         _urlProviderToOverrideImpls.put(inter, impls);
     }
 
-    public List<Pair<Module, Class<? extends UrlProvider>>> getUrlProviderOverrides(Class<? extends UrlProvider> inter)
+    public List<Pair<Module, UrlProvider>> getUrlProviderOverrides(Class<? extends UrlProvider> inter)
     {
         return _urlProviderToOverrideImpls.get(inter);
     }

--- a/api/src/org/labkey/api/action/UrlProviderService.java
+++ b/api/src/org/labkey/api/action/UrlProviderService.java
@@ -70,7 +70,9 @@ public class UrlProviderService
     }
 
     /**
-     * Register an implementation class to use for overrides to a URLProvider interface.
+     * Register an implementation class to use for overrides to a URLProvider interface. Note that if the overriding
+     * implementation is only to be applicable when the given module is enabled in the container being checked, then
+     * it is up to that overriding implementation to make that check.
      * @param inter the URLProvider interface
      * @param impl the override URLProvider implementation class
      * @param module the module providing the override

--- a/api/src/org/labkey/api/action/UrlProviderService.java
+++ b/api/src/org/labkey/api/action/UrlProviderService.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2017-2018 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.api.action;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.module.Module;
+import org.labkey.api.util.Pair;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class UrlProviderService
+{
+    private static final UrlProviderService instance = new UrlProviderService();
+    private static final Map<Class, Class<? extends UrlProvider>> _urlProviderToImpl = new HashMap<>();
+    private static final Map<Class<? extends UrlProvider>, List<Pair<Module, Class<? extends UrlProvider>>>> _urlProviderToOverrideImpls = new HashMap<>();
+
+    public static UrlProviderService getInstance()
+    {
+        return instance;
+    }
+
+    public <P extends UrlProvider> void registerUrlProvider(Class<P> inter, Class innerClass)
+    {
+        _urlProviderToImpl.put(inter, innerClass);
+    }
+
+    /** @return true if the UrlProvider exists. */
+    public <P extends UrlProvider> boolean hasUrlProvider(Class<P> inter)
+    {
+        return _urlProviderToImpl.get(inter) != null;
+    }
+
+    @Nullable
+    public <P extends UrlProvider> P getUrlProvider(Class<P> inter)
+    {
+        Class<? extends UrlProvider> clazz = _urlProviderToImpl.get(inter);
+
+        if (clazz == null)
+            return null;
+
+        try
+        {
+            P impl = (P) clazz.newInstance();
+            return impl;
+        }
+        catch (InstantiationException e)
+        {
+            throw new RuntimeException("Failed to instantiate provider class " + clazz.getName() + " for " + inter.getName(), e);
+        }
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException("Illegal access of provider class " + clazz.getName() + " for " + inter.getName(), e);
+        }
+    }
+
+    /**
+     * Register an implementation class to use for overrides to a URLProvider interface.
+     * @param inter the URLProvider interface
+     * @param impl the override URLProvider implementation class
+     * @param module the module providing the override
+     */
+    public void registerUrlProviderOverride(Class<? extends UrlProvider> inter, Class<? extends UrlProvider> impl, Module module)
+    {
+        List<Pair<Module, Class<? extends UrlProvider>>> impls = new ArrayList<>();
+        if (_urlProviderToOverrideImpls.containsKey(inter))
+            impls = _urlProviderToOverrideImpls.get(inter);
+
+        impls.add(new Pair<>(module, impl));
+        _urlProviderToOverrideImpls.put(inter, impls);
+    }
+
+    public List<Pair<Module, Class<? extends UrlProvider>>> getUrlProviderOverrides(Class<? extends UrlProvider> inter)
+    {
+        return _urlProviderToOverrideImpls.get(inter);
+    }
+}

--- a/api/src/org/labkey/api/assay/sample/SampleAssayResultsConfig.java
+++ b/api/src/org/labkey/api/assay/sample/SampleAssayResultsConfig.java
@@ -4,6 +4,11 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.data.ContainerFilter;
 
+/**
+ * This class is for a module to define a configuration that will be used in the LKB/LKSM apps to display assay
+ * results for a given sample in the Assays tabbed grid view of the app. This allows for non-standard module based
+ * assays that are not part of the assay designer infrastructure to participate in the app results display.
+ */
 public class SampleAssayResultsConfig
 {
     private String _moduleName;

--- a/api/src/org/labkey/api/assay/sample/SampleAssayResultsConfig.java
+++ b/api/src/org/labkey/api/assay/sample/SampleAssayResultsConfig.java
@@ -1,0 +1,93 @@
+package org.labkey.api.assay.sample;
+
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONObject;
+import org.labkey.api.data.ContainerFilter;
+
+public class SampleAssayResultsConfig
+{
+    private String _moduleName;
+    private String _title;
+    private String _schemaName;
+    private String _queryName;
+    private String _viewName; //  optional
+    private String _sampleRowKey; // optional sample row property to use for key in baseFilter, defaults to 'RowId' on client
+    private String _filterKey; // field key of the query/view to use for the sample filter IN clause
+    private ContainerFilter.Type _containerFilter; //  optional, defaults to 'Current' on client
+
+    public SampleAssayResultsConfig(
+            String title, String schemaName, String queryName, @Nullable String viewName,
+            @Nullable String sampleRowKey, String filterKey, @Nullable ContainerFilter.Type containerFilter
+        )
+    {
+        _title = title;
+        _schemaName = schemaName;
+        _queryName = queryName;
+        _viewName = viewName;
+        _sampleRowKey = sampleRowKey;
+        _filterKey = filterKey;
+        _containerFilter = containerFilter;
+    }
+
+    public String getTitle()
+    {
+        return _title;
+    }
+
+    public String getSchemaName()
+    {
+        return _schemaName;
+    }
+
+    public String getQueryName()
+    {
+        return _queryName;
+    }
+
+    public String getViewName()
+    {
+        return _viewName;
+    }
+
+    public String getSampleRowKey()
+    {
+        return _sampleRowKey;
+    }
+
+    public String getFilterKey()
+    {
+        return _filterKey;
+    }
+
+    public ContainerFilter.Type getContainerFilter()
+    {
+        return _containerFilter;
+    }
+
+    public String getModuleName()
+    {
+        return _moduleName;
+    }
+
+    public void setModuleName(String moduleName)
+    {
+        _moduleName = moduleName;
+    }
+
+    public JSONObject toJSON()
+    {
+        JSONObject json = new JSONObject();
+        json.put("moduleName", getModuleName());
+        json.put("title", getTitle());
+        json.put("schemaName", getSchemaName());
+        json.put("queryName", getQueryName());
+        if (getViewName() != null)
+            json.put("viewName", getViewName());
+        if (getSampleRowKey() != null)
+            json.put("sampleRowKey", getSampleRowKey());
+        json.put("filterKey", getFilterKey());
+        if (getContainerFilter() != null)
+            json.put("containerFilter", getContainerFilter().name());
+        return json;
+    }
+}

--- a/api/src/org/labkey/api/assay/sample/SampleAssayResultsService.java
+++ b/api/src/org/labkey/api/assay/sample/SampleAssayResultsService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017-2018 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.api.assay.sample;
+
+import org.labkey.api.module.Module;
+import org.labkey.api.services.ServiceRegistry;
+
+import java.util.List;
+
+public interface SampleAssayResultsService
+{
+    static SampleAssayResultsService get()
+    {
+        return ServiceRegistry.get().getService(SampleAssayResultsService.class);
+    }
+
+    static void setInstance(SampleAssayResultsService impl)
+    {
+        ServiceRegistry.get().registerService(SampleAssayResultsService.class, impl);
+    }
+
+    /** @return list of module SampleAssayResultsConfig objects */
+    List<SampleAssayResultsConfig> getConfigs();
+
+    /**
+     *  Method to register a module's SampleAssayResultsConfig. Call from doStartup() / startupAfterSpringConfiguration()
+     *
+     * @param module The LK module
+     * @param config The SampleAssayResultsConfig object defining the schemaName, queryName, etc. properties to use
+     *               for showing the module's assay results in the LKSM app's sample assays tab.
+     */
+    void registerConfig(Module module, SampleAssayResultsConfig config);
+}

--- a/api/src/org/labkey/api/exp/api/ExpMaterial.java
+++ b/api/src/org/labkey/api/exp/api/ExpMaterial.java
@@ -17,9 +17,11 @@
 package org.labkey.api.exp.api;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.Container;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.qc.DataState;
 import org.labkey.api.security.User;
+import org.labkey.api.view.ActionURL;
 
 import java.util.Map;
 
@@ -55,4 +57,6 @@ public interface ExpMaterial extends ExpRunItem
     String getNameAndStatus();
 
     void setSampleStateId(Integer stateId);
+
+    ActionURL detailsURL(Container container, boolean checkForOverride);
 }

--- a/api/src/org/labkey/api/exp/api/ExperimentUrls.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentUrls.java
@@ -86,6 +86,8 @@ public interface ExperimentUrls extends UrlProvider
 
     default ActionURL getMaterialDetailsURL(Container c, int materialRowId) { return null; }
 
+    default ActionURL getMaterialDetailsBaseURL(Container c, @Nullable String materialIdFieldKey) { return null; }
+
     default ActionURL getCreateSampleTypeURL(Container c) { return null; }
 
     default ActionURL getImportSamplesURL(Container c, String sampleTypeName) { return null; }

--- a/api/src/org/labkey/api/exp/api/ExperimentUrls.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentUrls.java
@@ -38,80 +38,82 @@ public interface ExperimentUrls extends UrlProvider
         return PageFlowUtil.urlProvider(ExperimentUrls.class);
     }
 
-    ActionURL getRunGraphURL(ExpRun run);
-    ActionURL getRunGraphURL(Container c, int rowId);
+    default ActionURL getRunGraphURL(ExpRun run) { return null; }
+    default ActionURL getRunGraphURL(Container c, int rowId) { return null; }
 
-    ActionURL getRunGraphDetailURL(ExpRun run, @Nullable ExpData focus);
+    default ActionURL getRunGraphDetailURL(ExpRun run, @Nullable ExpData focus) { return null; }
 
-    ActionURL getRunTextURL(Container c, int rowId);
-    ActionURL getRunTextURL(ExpRun run);
+    default ActionURL getRunTextURL(Container c, int rowId) { return null; }
+    default ActionURL getRunTextURL(ExpRun run) { return null; }
 
-    ActionURL getDeleteProtocolURL(@NotNull ExpProtocol protocol, URLHelper returnURL);
+    default ActionURL getDeleteProtocolURL(@NotNull ExpProtocol protocol, URLHelper returnURL) { return null; }
 
-    ActionURL getDeleteExperimentsURL(Container container, URLHelper returnURL);
+    default ActionURL getDeleteExperimentsURL(Container container, URLHelper returnURL) { return null; }
 
-    ActionURL getDeleteDatasURL(Container container, URLHelper returnURL);
+    default ActionURL getDeleteDatasURL(Container container, URLHelper returnURL) { return null; }
 
-    ActionURL getExperimentDetailsURL(Container c, ExpExperiment expExperiment);
+    default ActionURL getExperimentDetailsURL(Container c, ExpExperiment expExperiment) { return null; }
 
-    ActionURL getRemoveSelectedExpRunsURL(Container container, URLHelper returnURL, ExpExperiment expExperiment);
+    default ActionURL getRemoveSelectedExpRunsURL(Container container, URLHelper returnURL, ExpExperiment expExperiment) { return null; }
 
-    ActionURL getExportProtocolURL(Container container, ExpProtocol protocol);
+    default ActionURL getExportProtocolURL(Container container, ExpProtocol protocol) { return null; }
 
-    ActionURL getProtocolDetailsURL(ExpProtocol protocol);
+    default ActionURL getProtocolDetailsURL(ExpProtocol protocol) { return null; }
 
-    ActionURL getProtocolApplicationDetailsURL(ExpProtocolApplication app);
+    default ActionURL getProtocolApplicationDetailsURL(ExpProtocolApplication app) { return null; }
 
-    ActionURL getMoveRunsLocationURL(Container container);
+    default ActionURL getMoveRunsLocationURL(Container container) { return null; }
 
-    ActionURL getDeleteSelectedExpRunsURL(Container container, URLHelper returnURL);
+    default ActionURL getDeleteSelectedExpRunsURL(Container container, URLHelper returnURL) { return null; }
 
-    ActionURL getCreateRunGroupURL(Container container, URLHelper returnURL, boolean addSelectedRuns);
+    default ActionURL getCreateRunGroupURL(Container container, URLHelper returnURL, boolean addSelectedRuns) { return null; }
 
-    ActionURL getShowRunsURL(Container c, ExperimentRunType type);
+    default ActionURL getShowRunsURL(Container c, ExperimentRunType type) { return null; }
 
-    ActionURL getAddRunsToExperimentURL(Container container, ExpExperiment expExperiment);
+    default ActionURL getAddRunsToExperimentURL(Container container, ExpExperiment expExperiment) { return null; }
 
-    ActionURL getDomainEditorURL(Container container, String domainURI, boolean createOrEdit);
+    default ActionURL getDomainEditorURL(Container container, String domainURI, boolean createOrEdit) { return null; }
 
-    ActionURL getDomainEditorURL(Container container, Domain domain);
+    default ActionURL getDomainEditorURL(Container container, Domain domain) { return null; }
 
-    ActionURL getCreateDataClassURL(Container c);
+    default ActionURL getCreateDataClassURL(Container c) { return null; }
 
-    ActionURL getShowDataClassURL(Container container, int rowId);
+    default ActionURL getShowDataClassURL(Container container, int rowId) { return null; }
 
-    ActionURL getShowFileURL(ExpData data, boolean inline);
+    default ActionURL getShowFileURL(ExpData data, boolean inline) { return null; }
 
-    ActionURL getMaterialDetailsURL(ExpMaterial material);
+    default ActionURL getMaterialDetailsURL(ExpMaterial material) { return null; }
 
-    ActionURL getMaterialDetailsURL(Container c, int materialRowId);
+    default ActionURL getMaterialDetailsURL(Container c, int materialRowId) { return null; }
 
-    ActionURL getCreateSampleTypeURL(Container c);
+    default ActionURL getCreateSampleTypeURL(Container c) { return null; }
 
-    ActionURL getImportSamplesURL(Container c, String sampleTypeName);
+    default ActionURL getImportSamplesURL(Container c, String sampleTypeName) { return null; }
 
-    ActionURL getImportDataURL(Container c, String dataClassName);
+    default ActionURL getImportDataURL(Container c, String dataClassName) { return null; }
 
-    ActionURL getDataDetailsURL(ExpData data);
+    default ActionURL getDataDetailsURL(ExpData data) { return null; }
 
-    ActionURL getShowFileURL(Container container);
+    default ActionURL getShowFileURL(Container container) { return null; }
 
-    ActionURL getSetFlagURL(Container container);
+    default ActionURL getSetFlagURL(Container container) { return null; }
 
-    ActionURL getShowSampleTypeListURL(Container container);
+    default ActionURL getShowSampleTypeListURL(Container container) { return null; }
 
-    ActionURL getShowSampleTypeURL(ExpSampleType sampleType);
+    default ActionURL getShowSampleTypeURL(ExpSampleType sampleType) { return null; }
 
-    ActionURL getDataClassListURL(Container container);
+    default ActionURL getShowSampleTypeURL(ExpSampleType sampleType, Container container) { return null; }
 
-    ActionURL getShowRunGraphURL(ExpRun run);
+    default ActionURL getDataClassListURL(Container container) { return null; }
 
-    ActionURL getUploadXARURL(Container container);
+    default ActionURL getShowRunGraphURL(ExpRun run) { return null; }
 
-    ActionURL getRepairTypeURL(Container container);
+    default ActionURL getUploadXARURL(Container container) { return null; }
 
-    ActionURL getUpdateMaterialQueryRowAction(Container c, TableInfo table);
+    default ActionURL getRepairTypeURL(Container container) { return null; }
 
-    ActionURL getInsertMaterialQueryRowAction(Container c, TableInfo table);
+    default ActionURL getUpdateMaterialQueryRowAction(Container c, TableInfo table) { return null; }
+
+    default ActionURL getInsertMaterialQueryRowAction(Container c, TableInfo table) { return null; }
 
 }

--- a/api/src/org/labkey/api/query/QueryForeignKey.java
+++ b/api/src/org/labkey/api/query/QueryForeignKey.java
@@ -54,7 +54,7 @@ public class QueryForeignKey extends AbstractForeignKey
     QuerySchema _schema;
     boolean _useRawFKValue;
     LookupColumn.JoinType _joinType = LookupColumn.JoinType.leftOuter;
-
+    DetailsURL _url;
 
     /* There are (were) way too many QueryForeignKey constructors, that's a sign we need a builder */
     public static class Builder implements org.labkey.api.data.Builder<ForeignKey>
@@ -77,6 +77,8 @@ public class QueryForeignKey extends AbstractForeignKey
         // display
         String displayField = null;
         boolean useRawFKValue = false;
+
+        DetailsURL url;
 
         // for deprecated constructors only
         private Builder()
@@ -177,6 +179,12 @@ public class QueryForeignKey extends AbstractForeignKey
             return this;
         }
 
+        public Builder url(DetailsURL url)
+        {
+            this.url = url;
+            return this;
+        }
+
 //        public Builder setLookupKey(String name)
 //        {
 //            this.lookupKey = name;
@@ -244,6 +252,7 @@ public class QueryForeignKey extends AbstractForeignKey
         _useRawFKValue = builder.useRawFKValue;
         _table = builder.table;
         _schema = builder.targetSchema;
+        _url = builder.url;
         // TODO there is an EHR usage that fails this assert (AbstractTableCustomizer)
         // assert(null == _lookupContainer || getEffectiveContainer() == getLookupContainer());
     }
@@ -400,6 +409,10 @@ public class QueryForeignKey extends AbstractForeignKey
         TableInfo table = getLookupTableInfo();
         if (table == null)
             return null;
+
+        if (_url != null)
+            return _url;
+
         return LookupForeignKey.getDetailsURL(parent, table, getLookupColumnName());
     }
 

--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -35,8 +35,6 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.property.Domain;
-import org.labkey.api.module.ModuleLoader;
-import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reports.model.ViewCategory;
 import org.labkey.api.security.User;
@@ -211,18 +209,7 @@ public interface Dataset extends StudyEntity, StudyCachable<Dataset>
                     @Override
                     public ActionURL getSourceActionURL(ExpObject sourceObject, Container container)
                     {
-                        ActionURL url;
-                        // When the sample management module is enabled in the sample type's container, we want to link into the application
-                        if (container.getActiveModules().contains(ModuleLoader.getInstance().getModule("sampleManagement")))
-                        {
-                            url = new ActionURL("sampleManager", "app", container);
-                            url.setFragment("/samples/" + sourceObject.getName());
-                        }
-                        else
-                        {
-                            url = PageFlowUtil.urlProvider(ExperimentUrls.class).getShowSampleTypeURL((ExpSampleType) sourceObject);
-                        }
-                        return url;
+                        return PageFlowUtil.urlProvider(ExperimentUrls.class, true).getShowSampleTypeURL((ExpSampleType) sourceObject, container);
                     }
                 };
 

--- a/api/src/org/labkey/api/util/ContainerContext.java
+++ b/api/src/org/labkey/api/util/ContainerContext.java
@@ -40,9 +40,17 @@ public interface ContainerContext
         @NotNull
         final FieldKey _key;
 
+        private  boolean _strictContainerContextEval;
+
         public FieldKeyContext(@NotNull FieldKey key)
         {
             _key = key;
+        }
+
+        public FieldKeyContext(@NotNull FieldKey key, boolean strictContainerContextEval)
+        {
+            _key = key;
+            _strictContainerContextEval = strictContainerContextEval;
         }
 
         public FieldKeyContext copy()
@@ -69,7 +77,7 @@ public interface ContainerContext
             // We couldn't resolve a container in the row of data we're rendering, so fall back to the current container
             // for the request in general, if available. This can happen if a custom query doesn't pull a Container
             // column from the source table to make available in the query's results.
-            if (context instanceof RenderContext)
+            if (!_strictContainerContextEval && context instanceof RenderContext)
                 return ((RenderContext)context).getViewContext().getContainer();
 
             return null;

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -35,6 +35,7 @@ import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.action.UrlProvider;
+import org.labkey.api.action.UrlProviderOverrideHandler;
 import org.labkey.api.admin.CoreUrls;
 import org.labkey.api.admin.notification.NotificationService;
 import org.labkey.api.announcements.api.Tour;
@@ -104,7 +105,6 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -121,6 +121,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.lang.reflect.Proxy;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -2691,6 +2692,30 @@ public class PageFlowUtil
     static public <P extends UrlProvider> P urlProvider(Class<P> inter)
     {
         return ModuleLoader.getInstance().getUrlProvider(inter);
+    }
+
+    /**
+     * Returns a specified <code>UrlProvider</code> interface implementation, for use
+     * in writing URLs implemented in other modules. If the user passes true for the checkForOverrides param,
+     * we will create and return a UrlProviderOverrideHandler which will take into account any module registered
+     * overrides to the given interface. If module overrides exist, they will be checked first for non-null results
+     * when a given method of the interface is invoked before falling back to the default implementation.
+     *
+     * @param inter interface extending UrlProvider
+     * @param checkForOverrides true to check for module overrides to this interface
+     * @return an implementation of the interface.
+     */
+    @Nullable
+    static public <P extends UrlProvider> P urlProvider(Class<P> inter, boolean checkForOverrides)
+    {
+        if (checkForOverrides)
+        {
+            P impl = urlProvider(inter);
+            ClassLoader cl = inter.getClassLoader();
+            return (P) Proxy.newProxyInstance(cl, new Class[]{inter}, new UrlProviderOverrideHandler(inter, impl));
+        }
+
+        return urlProvider(inter);
     }
 
     static private String h(Object o)

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -36,6 +36,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.action.UrlProvider;
 import org.labkey.api.action.UrlProviderOverrideHandler;
+import org.labkey.api.action.UrlProviderService;
 import org.labkey.api.admin.CoreUrls;
 import org.labkey.api.admin.notification.NotificationService;
 import org.labkey.api.announcements.api.Tour;
@@ -2678,7 +2679,7 @@ public class PageFlowUtil
     /** @return true if the UrlProvider exists. */
     static public <P extends UrlProvider> boolean hasUrlProvider(Class<P> inter)
     {
-        return ModuleLoader.getInstance().hasUrlProvider(inter);
+        return UrlProviderService.getInstance().hasUrlProvider(inter);
     }
 
     /**
@@ -2691,7 +2692,7 @@ public class PageFlowUtil
     @Nullable
     static public <P extends UrlProvider> P urlProvider(Class<P> inter)
     {
-        return ModuleLoader.getInstance().getUrlProvider(inter);
+        return UrlProviderService.getInstance().getUrlProvider(inter);
     }
 
     /**

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -128,6 +128,11 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
         return _object.detailsURL();
     }
 
+    @Override
+    public ActionURL detailsURL(Container container, boolean checkForOverride)
+    {
+        return _object.detailsURL(container, checkForOverride);
+    }
 
     @Override
     public @Nullable QueryRowReference getQueryRowReference()

--- a/experiment/src/org/labkey/experiment/api/Material.java
+++ b/experiment/src/org/labkey/experiment/api/Material.java
@@ -16,9 +16,11 @@
 package org.labkey.experiment.api;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.Container;
 import org.labkey.api.exp.api.ExpMaterial;
+import org.labkey.api.exp.api.ExperimentUrls;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
-import org.labkey.experiment.controllers.exp.ExperimentController;
 
 /**
  * Bean class for the exp.material table.
@@ -69,9 +71,12 @@ public class Material extends RunItem
     @Override
     public ActionURL detailsURL()
     {
-        ActionURL ret = new ActionURL(ExperimentController.ShowMaterialAction.class, getContainer());
-        ret.addParameter("rowId", Integer.toString(getRowId()));
-        return ret;
+        return detailsURL(getContainer(), false);
+    }
+
+    public ActionURL detailsURL(Container container, boolean checkForOverride)
+    {
+        return PageFlowUtil.urlProvider(ExperimentUrls.class, checkForOverride).getMaterialDetailsURL(container, getRowId());
     }
 
     public boolean equals(Object o)

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -6202,7 +6202,13 @@ public class ExperimentController extends SpringActionController
         @Override
         public ActionURL getShowSampleTypeURL(ExpSampleType sampleType)
         {
-            return new ActionURL(ShowSampleTypeAction.class, sampleType.getContainer()).addParameter("rowId", sampleType.getRowId());
+            return getShowSampleTypeURL(sampleType, sampleType.getContainer());
+        }
+
+        @Override
+        public ActionURL getShowSampleTypeURL(ExpSampleType sampleType, Container container)
+        {
+            return new ActionURL(ShowSampleTypeAction.class, container).addParameter("rowId", sampleType.getRowId());
         }
 
         public ActionURL getExperimentListURL(Container container)

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -6066,7 +6066,7 @@ public class ExperimentController extends SpringActionController
 
         public ActionURL getShowSampleURL(Container c, ExpMaterial material)
         {
-            return new ActionURL(ShowMaterialAction.class, c).addParameter("rowId", material.getRowId());
+            return getMaterialDetailsBaseURL(c, null).addParameter("rowId", material.getRowId());
         }
 
         @Override
@@ -6367,13 +6367,19 @@ public class ExperimentController extends SpringActionController
         @Override
         public ActionURL getMaterialDetailsURL(ExpMaterial material)
         {
-            return new ActionURL(ShowMaterialAction.class, material.getContainer()).addParameter("rowId", material.getRowId());
+            return getMaterialDetailsURL(material.getContainer(), material.getRowId());
         }
 
         @Override
         public ActionURL getMaterialDetailsURL(Container c, int materialRowId)
         {
-            return new ActionURL(ShowMaterialAction.class, c).addParameter("rowId", materialRowId);
+            return getMaterialDetailsBaseURL(c, null).addParameter("rowId", materialRowId);
+        }
+
+        @Override
+        public ActionURL getMaterialDetailsBaseURL(Container c, @Nullable String materialIdFieldKey)
+        {
+            return new ActionURL(ShowMaterialAction.class, c);
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
We want to allow for non-standard assays (i.e. those defined in customModules but not part of the assay designer infrastructure) to have a chance to participate in the Sample > Assays tabbed grid view within the LKB and LKSM apps. This PR adds some registries / services to allow for modules to register these SampleAssayResultsConfig objects. It also has a registry so that the LKB and LKSM apps can provider overrides for ExperimentUrl interface methods as a way for ActionURLs within LKS to opt in to generating URL that will bring the user into the relevant application based on a given context (i.e. for a sample type or for a sample Id).

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/649
* https://github.com/LabKey/platform/pull/2667
* https://github.com/LabKey/targetedms/pull/436
* https://github.com/LabKey/sampleManagement/pull/719
* https://github.com/LabKey/biologics/pull/1019
* https://github.com/LabKey/dataintegration/pull/129

#### Changes
* Add UrlProviderService to allow modules to register their UrlProvider interface overrides for generating app-based ActionURLs
* Add UrlProviderOverrideHandler to check for UrlProvider overrides based on the given interface method being invoked
* Add SampleAssayResultsService to allow for modules to register a query/view and related config information to be used within the app to show sample related assay results for that module
* Update ExperimentUrls interface to provide default "return null" implementations for all methods
* Update Dataset getSourceActionURL method to use new URLProvider overrides check