### PR TITLE
Issue 43979: Hide SSO auth links if logo is not provided

### DIFF
--- a/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
+++ b/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
@@ -1138,7 +1138,7 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
                     return HtmlString.EMPTY_STRING;
 
                 Set<HtmlString> uniqueErrorStrs = new TreeSet<>();
-                HtmlStringBuilder sb = HtmlStringBuilder.of("");
+                HtmlStringBuilder sb = HtmlStringBuilder.of();
                 StringBuilder msgBox = new StringBuilder();
                 HtmlString br = HtmlString.unsafe("<font class=\"labkey-error\">");
                 int cnt = 0;

--- a/api/src/org/labkey/api/data/RenderContext.java
+++ b/api/src/org/labkey/api/data/RenderContext.java
@@ -839,7 +839,7 @@ public class RenderContext implements Map<String, Object>, Serializable
             return HtmlString.EMPTY_STRING;
 
         Set<HtmlString> uniqueErrorStrs = new TreeSet<>();
-        HtmlStringBuilder builder = HtmlStringBuilder.of("");
+        HtmlStringBuilder builder = HtmlStringBuilder.of();
         HtmlString br = HtmlString.unsafe("<font class=\"labkey-error\">");
         for (Object m : list)
         {

--- a/api/src/org/labkey/api/reports/report/view/AjaxScriptReportView.java
+++ b/api/src/org/labkey/api/reports/report/view/AjaxScriptReportView.java
@@ -112,7 +112,7 @@ public class AjaxScriptReportView extends JspView<ScriptReportBean>
                 File f = ModuleEditorService.get().getFileForModuleResource(m, mrd.getSourceFile().getPath());
                 if (null != f)
                 {
-                    HtmlStringBuilder moduleWarning = HtmlStringBuilder.of("")
+                    HtmlStringBuilder moduleWarning = HtmlStringBuilder.of()
                             .append("This report is defined in the '" + m.getName() + "' module in directory '" + f.getParent() + "'.")
                             .append(HtmlString.BR)
                             .append("Changes to this report will be reflected in all usages across different folders on the server.")

--- a/api/src/org/labkey/api/security/AuthenticationConfiguration.java
+++ b/api/src/org/labkey/api/security/AuthenticationConfiguration.java
@@ -1,9 +1,16 @@
 package org.labkey.api.security;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.attachments.Attachment;
+import org.labkey.api.attachments.AttachmentFile;
 import org.labkey.api.attachments.AttachmentParent;
+import org.labkey.api.attachments.AttachmentService;
+import org.labkey.api.attachments.InputStreamAttachmentFile;
 import org.labkey.api.data.Container;
+import org.labkey.api.security.AuthenticationManager.AuthLogoType;
 import org.labkey.api.security.AuthenticationManager.LinkFactory;
 import org.labkey.api.security.AuthenticationProvider.LoginFormAuthenticationProvider;
 import org.labkey.api.security.AuthenticationProvider.PrimaryAuthenticationProvider;
@@ -14,13 +21,18 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
 
 import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public interface AuthenticationConfiguration<AP extends AuthenticationProvider> extends AttachmentParent
 {
+    Logger LOG = LogManager.getLogger(AuthenticationConfiguration.class);
+
     // All the AuthenticationProvider interfaces. This list is used by AuthenticationProviderCache to filter collections of providers.
     List<Class<? extends AuthenticationConfiguration>> ALL_CONFIGURATION_INTERFACES = Arrays.asList(
         AuthenticationConfiguration.class,
@@ -81,6 +93,38 @@ public interface AuthenticationConfiguration<AP extends AuthenticationProvider> 
          * @return boolean indicates if this configuration is set to autoRedirect
          */
         boolean isAutoRedirect();
+
+        void savePlaceholderLogos(User user);
+
+        default void ensureLogos(SSOAuthenticationConfiguration configuration, User user, String prefix)
+        {
+            ensureLogo(configuration, user, AuthLogoType.HEADER, prefix + "_small.png");
+            ensureLogo(configuration, user, AuthLogoType.LOGIN_PAGE, prefix + "_big.png");
+        }
+
+        default void ensureLogo(SSOAuthenticationConfiguration configuration, User user, AuthLogoType logoType, String filename)
+        {
+            AttachmentService svc = AttachmentService.get();
+            Attachment att = svc.getAttachment(configuration, logoType.getFileName());
+
+            if (null == att)
+            {
+                LOG.info("Saving a placeholder " + logoType.getLabel() + " logo for \"" + configuration.getDescription() + "\"");
+                try (InputStream is = configuration.getClass().getResourceAsStream(filename))
+                {
+                    if (null != is)
+                    {
+                        AttachmentFile file = new InputStreamAttachmentFile(is, logoType.getFileName());
+                        svc.addAttachments(configuration, Collections.singletonList(file), user);
+                        SsoSaveConfigurationAction.logLogoAction(user, configuration, logoType, "saved");
+                    }
+                }
+                catch (Exception e)
+                {
+                    LOG.warn("Error while attempting to save placeholder logo", e);
+                }
+            }
+        }
     }
 
     interface SecondaryAuthenticationConfiguration<AP extends SecondaryAuthenticationProvider<? extends SecondaryAuthenticationConfiguration<?>>> extends AuthenticationConfiguration<AP>

--- a/api/src/org/labkey/api/security/AuthenticationConfiguration.java
+++ b/api/src/org/labkey/api/security/AuthenticationConfiguration.java
@@ -21,7 +21,6 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
 
 import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
@@ -57,7 +56,7 @@ public interface AuthenticationConfiguration<AP extends AuthenticationProvider> 
     }
 
     /**
-     * @return Map of all property names and values that are updateable and appropriate for audit logging
+     * @return Map of all property names and values that are updatable and appropriate for audit logging
      */
     default @NotNull Map<String, Object> getLoggingProperties()
     {
@@ -94,6 +93,7 @@ public interface AuthenticationConfiguration<AP extends AuthenticationProvider> 
          */
         boolean isAutoRedirect();
 
+        // TODO: Delete everything below once earliest upgrade is later than 21.008. See #43979.
         void savePlaceholderLogos(User user);
 
         default void ensureLogos(SSOAuthenticationConfiguration configuration, User user, String prefix)

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -348,16 +348,21 @@ public class AuthenticationManager
         if (ssoConfigurations.isEmpty())
             return null;
 
-        HtmlStringBuilder html = HtmlStringBuilder.of("");
+        HtmlStringBuilder html = HtmlStringBuilder.of();
 
         for (SSOAuthenticationConfiguration configuration : ssoConfigurations)
         {
             if (!configuration.isAutoRedirect())
             {
                 LinkFactory factory = configuration.getLinkFactory();
-                html.startTag("li");
-                html.append(factory.getLink(currentURL, logoType));
-                html.endTag("li");
+                HtmlString link = factory.getLink(currentURL, logoType);
+
+                if (null != link)
+                {
+                    html.startTag("li");
+                    html.append(link);
+                    html.endTag("li");
+                }
             }
         }
 
@@ -1438,15 +1443,11 @@ public class AuthenticationManager
             _configuration = configuration;
         }
 
-        private @NotNull HtmlString getLink(URLHelper returnURL, AuthLogoType prefix)
+        private @Nullable HtmlString getLink(URLHelper returnURL, AuthLogoType prefix)
         {
-            String content = _configuration.getDescription();
             String img = getImg(prefix);
 
-            if (null != img)
-                content = img;
-
-            return HtmlString.unsafe("<a href=\"" + PageFlowUtil.filter(getURL(returnURL, false)) + "\">" + content + "</a>");
+            return null != img ? HtmlString.unsafe("<a href=\"" + PageFlowUtil.filter(getURL(returnURL, false)) + "\">" + img + "</a>") : null;
         }
 
         @SuppressWarnings("ConstantConditions")
@@ -1463,7 +1464,7 @@ public class AuthenticationManager
 
                 if (null != logoUrl)
                 {
-                    return "<img src=\"" + logoUrl + "\" alt=\"Sign in using " + _configuration.getDescription() + "\" height=\"" + logoType.getHeight() + "px\">";
+                    return "<img src=\"" + logoUrl + "\" alt=\"Sign in using " + PageFlowUtil.filter(_configuration.getDescription()) + "\" height=\"" + logoType.getHeight() + "px\">";
                 }
             }
             catch (RuntimeSQLException e)

--- a/api/src/org/labkey/api/security/SsoSaveConfigurationAction.java
+++ b/api/src/org/labkey/api/security/SsoSaveConfigurationAction.java
@@ -97,7 +97,8 @@ public abstract class SsoSaveConfigurationAction<F extends SsoSaveConfigurationF
         return true;
     }
 
-    private void logLogoAction(User user, SSOAuthenticationConfiguration<?> configuration, @NotNull AuthLogoType logoType, String action)
+    // TODO: restore to private and non-static once upgrade code is no longer needed
+    public static void logLogoAction(User user, SSOAuthenticationConfiguration<?> configuration, @NotNull AuthLogoType logoType, String action)
     {
         AuthSettingsAuditEvent event = new AuthSettingsAuditEvent(logoType.getLabel() + " logo for " + configuration.getAuthenticationProvider().getName() + " authentication configuration \"" + configuration.getDescription() + "\" (" + configuration.getRowId() + ") was " + action);
         event.setChanges(logoType.getLabel() + " logo " + action);

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 21.007
+SchemaVersion: 21.008
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/core-21.007-21.008.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-21.007-21.008.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('savePlaceholderLogos');

--- a/core/resources/schemas/dbscripts/sqlserver/core-21.007-21.008.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-21.007-21.008.sql
@@ -1,0 +1,1 @@
+EXEC core.executeJavaUpgradeCode 'savePlaceholderLogos';

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -8038,7 +8038,7 @@ public class AdminController extends SpringActionController
 
             ManageFilter filter = form.isManagedOnly() ? ManageFilter.ManagedOnly : (form.isUnmanagedOnly() ? ManageFilter.UnmanagedOnly : ManageFilter.All);
 
-            HtmlStringBuilder deleteInstructions = HtmlStringBuilder.of("");
+            HtmlStringBuilder deleteInstructions = HtmlStringBuilder.of();
             if (hasAdminOpsPerm)
             {
                 deleteInstructions.append(unsafe("<br><br>")).append(
@@ -8048,14 +8048,14 @@ public class AdminController extends SpringActionController
                         PageFlowUtil.link("Create new empty module").href(getCreateURL()));
             }
 
-            HtmlStringBuilder docLink = HtmlStringBuilder.of("");
+            HtmlStringBuilder docLink = HtmlStringBuilder.of();
             docLink.append(unsafe("<br><br>")).append("Additional modules available, click ").append(new HelpTopic("defaultModules").getSimpleLinkHtml("here")).append(" to learn more.");
 
-            HtmlStringBuilder knownDescription = HtmlStringBuilder.of("")
+            HtmlStringBuilder knownDescription = HtmlStringBuilder.of()
                 .append("Each of these modules is installed and has a valid module file. ").append(managedLink).append(unmanagedLink).append(deleteInstructions).append(docLink);
             HttpView known = new ModulesView(knownModules, "Known", knownDescription.getHtmlString(), null, ignoreSet, filter);
 
-            HtmlStringBuilder unknownDescription = HtmlStringBuilder.of("")
+            HtmlStringBuilder unknownDescription = HtmlStringBuilder.of()
                     .append(1 == unknownModules.size() ? "This module" : "Each of these modules").append(" has been installed on this server " +
                     "in the past but the corresponding module file is currently missing or invalid. Possible explanations: the " +
                     "module is no longer being distributed, the module has been renamed, the server location where the module " +

--- a/core/src/org/labkey/core/admin/sql/SqlScriptController.java
+++ b/core/src/org/labkey/core/admin/sql/SqlScriptController.java
@@ -16,8 +16,8 @@
 
 package org.labkey.core.admin.sql;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
@@ -1349,6 +1349,7 @@ public class SqlScriptController extends SpringActionController
     {
         private Method _method;
         private ModuleContext _ctx;
+        private UpgradeCode _code;
 
         @Override
         public void validateCommand(UpgradeCodeForm form, Errors errors)
@@ -1360,8 +1361,8 @@ public class SqlScriptController extends SpringActionController
             }
             else
             {
-                UpgradeCode code = module.getUpgradeCode();
-                if (null == code)
+                _code = module.getUpgradeCode();
+                if (null == _code)
                 {
                     errors.reject(ERROR_MSG, "Module doesn't have UpgradeCode");
                 }
@@ -1369,7 +1370,7 @@ public class SqlScriptController extends SpringActionController
                 {
                     try
                     {
-                        _method = code.getClass().getDeclaredMethod(form.getMethod(), ModuleContext.class);
+                        _method = _code.getClass().getDeclaredMethod(form.getMethod(), ModuleContext.class);
                         _ctx = ModuleLoader.getInstance().getModuleContext(form.getModule());
                         if (null == _ctx)
                             errors.reject(ERROR_MSG, "ModuleContext not found");
@@ -1392,7 +1393,7 @@ public class SqlScriptController extends SpringActionController
         public boolean handlePost(UpgradeCodeForm form, BindException errors) throws Exception
         {
             LOG.info("Executing " + _method.getDeclaringClass().getSimpleName() + "." + _method.getName() + "(ModuleContext moduleContext)");
-            _method.invoke(null, _ctx);
+            _method.invoke(_code, _ctx);
             return true;
         }
 

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -1265,7 +1265,7 @@ public class SecurityController extends SpringActionController
         private boolean _skipProfile;
         private String _provider = null;
 
-        private final HtmlStringBuilder _message = HtmlStringBuilder.of("");
+        private final HtmlStringBuilder _message = HtmlStringBuilder.of();
 
         @SuppressWarnings("unused")
         public void setProvider(String provider)

--- a/devtools/src/org/labkey/devtools/authentication/TestSsoConfiguration.java
+++ b/devtools/src/org/labkey/devtools/authentication/TestSsoConfiguration.java
@@ -3,6 +3,7 @@ package org.labkey.devtools.authentication;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.AuthenticationManager.LinkFactory;
 import org.labkey.api.security.BaseSSOAuthenticationConfiguration;
+import org.labkey.api.security.User;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
@@ -31,5 +32,11 @@ public class TestSsoConfiguration extends BaseSSOAuthenticationConfiguration<Tes
     public LinkFactory getLinkFactory()
     {
         return _linkFactory;
+    }
+
+    @Override
+    public void savePlaceholderLogos(User user)
+    {
+        // Don't bother with the test configuration
     }
 }

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -789,7 +789,7 @@ public class ReportsController extends SpringActionController
                 return new AjaxScriptReportView(null, form, Mode.create);
             else
             {
-                HtmlStringBuilder sb = HtmlStringBuilder.of("");
+                HtmlStringBuilder sb = HtmlStringBuilder.of();
 
                 for (ValidationError error : reportErrors)
                     sb.append(error.getMessage()).append(HtmlString.unsafe("<br>"));


### PR DESCRIPTION
#### Rationale
Some administrators don't want to see the SSO logos

#### Related Pull Requests
* https://github.com/LabKey/cas/pull/42
* https://github.com/LabKey/saml/pull/45

#### Changes
* Hide SSO links in header and login page if corresponding logo is not provided
* Add upgrade code that saves placeholder logos in cases where existing configurations lack a logo; these configurations have been relying on placeholder text, which is no longer being displayed
* Fix upgrade code action to work with non-static methods
