### PR TITLE
Issue 44079: Perf regression with large domain create/update operations

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1827,7 +1827,7 @@ public class DbScope
         PRECOMMIT
         {
             @Override
-            protected Set<Runnable> getRunnables(TransactionImpl transaction)
+            protected Map<Runnable, Runnable> getRunnables(TransactionImpl transaction)
             {
                 return transaction._preCommitTasks;
             }
@@ -1836,7 +1836,7 @@ public class DbScope
         POSTCOMMIT
         {
             @Override
-            protected Set<Runnable> getRunnables(TransactionImpl transaction)
+            protected Map<Runnable, Runnable> getRunnables(TransactionImpl transaction)
             {
                 return transaction._postCommitTasks;
             }
@@ -1845,7 +1845,7 @@ public class DbScope
         POSTROLLBACK
         {
             @Override
-            protected Set<Runnable> getRunnables(TransactionImpl transaction)
+            protected Map<Runnable, Runnable> getRunnables(TransactionImpl transaction)
             {
                 return transaction._postRollbackTasks;
             }
@@ -1854,7 +1854,7 @@ public class DbScope
         IMMEDIATE
         {
             @Override
-            protected Set<Runnable> getRunnables(TransactionImpl transaction)
+            protected Map<Runnable, Runnable> getRunnables(TransactionImpl transaction)
             {
                 throw new UnsupportedOperationException();
             }
@@ -1867,12 +1867,12 @@ public class DbScope
             }
         };
 
-        protected abstract Set<Runnable> getRunnables(TransactionImpl transaction);
+        protected abstract Map<Runnable, Runnable> getRunnables(TransactionImpl transaction);
 
         public void run(TransactionImpl transaction)
         {
-            // Copy to avoid ConcurrentModificationExceptions, need to retain original order from LinkedHashSet
-            List<Runnable> tasks = new ArrayList<>(getRunnables(transaction));
+            // Copy to avoid ConcurrentModificationExceptions, need to retain original order from LinkedHashMap
+            List<Runnable> tasks = new ArrayList<>(getRunnables(transaction).keySet());
 
             for (Runnable task : tasks)
             {
@@ -1884,21 +1884,18 @@ public class DbScope
 
         public <T extends Runnable> T add(TransactionImpl transaction, T task)
         {
-            T addedObj = task;
-            boolean added = getRunnables(transaction).add(task);
-            for(Runnable r : getRunnables(transaction))
+            Map<Runnable, Runnable> runnables = getRunnables(transaction);
+            T result = (T)runnables.get(task);
+            if (result == null)
             {
-                if (r.equals(task))
-                {
-                    addedObj = (T) r;
-                    break;
-                }
+                result = task;
+                runnables.put(task, task);
             }
-            if (!added)
+            else
             {
                 LOG.debug("Skipping duplicate runnable: " + task.toString());
             }
-            return addedObj;
+            return result;
         }
     }
 
@@ -2033,10 +2030,11 @@ public class DbScope
         private final ConnectionWrapper _conn;
         private final Map<DatabaseCache<?, ?>, Cache<?, ?>> _caches = new HashMap<>(20);
 
-        // Sets so that we can coalesce identical tasks and avoid duplicating the effort
-        private final Set<Runnable> _preCommitTasks = new LinkedHashSet<>();
-        private final Set<Runnable> _postCommitTasks = new LinkedHashSet<>();
-        private final Set<Runnable> _postRollbackTasks = new LinkedHashSet<>();
+        // Maps so that we can coalesce identical tasks and avoid duplicating the effort, and efficiently find the
+        // originally added task
+        private final Map<Runnable, Runnable> _preCommitTasks = new LinkedHashMap<>();
+        private final Map<Runnable, Runnable> _postCommitTasks = new LinkedHashMap<>();
+        private final Map<Runnable, Runnable> _postRollbackTasks = new LinkedHashMap<>();
 
         private final List<List<Lock>> _locks = new ArrayList<>();
         private final Throwable _creation = new Throwable();

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1885,17 +1885,13 @@ public class DbScope
         public <T extends Runnable> T add(TransactionImpl transaction, T task)
         {
             Map<Runnable, Runnable> runnables = getRunnables(transaction);
-            T result = (T)runnables.get(task);
-            if (result == null)
-            {
-                result = task;
-                runnables.put(task, task);
-            }
-            else
+            @SuppressWarnings("unchecked")
+            T existing = (T)runnables.putIfAbsent(task, task);
+            if (existing != null)
             {
                 LOG.debug("Skipping duplicate runnable: " + task.toString());
             }
-            return result;
+            return existing == null ? task : existing;
         }
     }
 

--- a/api/src/org/labkey/api/exp/PropertyDescriptor.java
+++ b/api/src/org/labkey/api/exp/PropertyDescriptor.java
@@ -30,6 +30,7 @@ import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.ObjectFactory;
 import org.labkey.api.data.ParameterDescription;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.Transient;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.IPropertyValidator;
@@ -436,7 +437,7 @@ public class PropertyDescriptor extends ColumnRenderPropertiesImpl implements Pa
     static
     {
         ObjectFactory.Registry.register(PropertyDescriptor.class,
-            new BeanObjectFactory<PropertyDescriptor>(PropertyDescriptor.class)
+            new BeanObjectFactory<>(PropertyDescriptor.class)
             {
                 @Override
                 public @NotNull Map<String, Object> toMap(PropertyDescriptor bean, @Nullable Map<String, Object> m)
@@ -467,11 +468,13 @@ public class PropertyDescriptor extends ColumnRenderPropertiesImpl implements Pa
         return false;
     }
 
+    @Transient
     public @NotNull Collection<? extends IPropertyValidator> getValidators()
     {
         return PropertyService.get().getPropertyValidators(this);
     }
 
+    @Transient
     public @NotNull Collection<ConditionalFormat> getConditionalFormats()
     {
         return PropertyService.get().getConditionalFormats(this);
@@ -498,7 +501,8 @@ public class PropertyDescriptor extends ColumnRenderPropertiesImpl implements Pa
 
     Boolean _vocabulary = null;
 
-    // returns true if this property is a member of a VocabularyDomainKind
+    /** @return true if this property is a member of a VocabularyDomainKind */
+    @Transient
     public boolean isVocabulary()
     {
         if (_vocabulary == null)


### PR DESCRIPTION
#### Rationale
We're accidentally doing too much work when persisting exp.PropertyDescriptors. We're also being inefficient in how we manage large collections of commit tasks. This regressed as part of https://github.com/LabKey/platform/pull/2295

#### Changes
* Annotate as @Transient PropertyDescriptors.isVocabulary() and other getter methods that take significant work but don't correspond to columns on the exp.PropertyDescriptor table
* Use maps instead of sets to track commit tasks, making it fast to find an existing matching task