### PR TITLE
Issue 44092: Deadlock between DatasetDomainKind.updateDomain() and afterLoadTable()

### DIFF
--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -140,6 +140,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static org.labkey.api.query.QueryService.AuditAction.DELETE;
@@ -1211,6 +1212,12 @@ public class DatasetDefinition extends AbstractStudyEntity<DatasetDefinition> im
     public String getResourceDescription()
     {
         return null == _description ? "The study dataset " + getName() : _description;
+    }
+
+    /** @return the lock object used to synchronize domain loading */
+    public Lock getDomainLoadingLock()
+    {
+        return _lock;
     }
 
     private static class AutoCompleteDisplayColumnFactory implements DisplayColumnFactory


### PR DESCRIPTION
#### Rationale
Servers under load can deadlock when a dataset's domain is updated while other requests are actively using the same dataset

#### Changes
* Acquire Java lock object before starting the transaction that locks the domain and property tables in the DB