### PR TITLE
Item 9413: Update some display elements for Sample Status columns

### DIFF
--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -53,6 +53,7 @@ public interface SampleTypeService
         UpdateStorageMetadata("updating storage metadata"),
         RemoveFromStorage("removing from storage"),
         AddToPicklist("adding to a picklist"),
+        RemoveFromPicklist("removing from a picklist"),
         Delete("deleting"),
         AddToWorkflow("adding to a workflow"),
         RemoveFromWorkflow("removing from a workflow"),

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -369,7 +369,10 @@ public class ExpSchema extends AbstractExpSchema
                 SampleTypeService.SampleOperations.LinkToStudy,
                 SampleTypeService.SampleOperations.RecallFromStudy
         )),
-        Locked(Set.of(SampleTypeService.SampleOperations.AddToPicklist, SampleTypeService.SampleOperations.RemoveFromPicklist));
+        Locked(Set.of(
+                SampleTypeService.SampleOperations.AddToPicklist,
+                SampleTypeService.SampleOperations.RemoveFromPicklist
+        ));
 
         Set<SampleTypeService.SampleOperations> _permittedOps;
 

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -354,6 +354,7 @@ public class ExpSchema extends AbstractExpSchema
                 SampleTypeService.SampleOperations.EditLineage,
                 SampleTypeService.SampleOperations.RemoveFromStorage,
                 SampleTypeService.SampleOperations.AddToPicklist,
+                SampleTypeService.SampleOperations.RemoveFromPicklist,
                 SampleTypeService.SampleOperations.Delete,
                 SampleTypeService.SampleOperations.AddToWorkflow,
                 SampleTypeService.SampleOperations.RemoveFromWorkflow,
@@ -361,7 +362,7 @@ public class ExpSchema extends AbstractExpSchema
                 SampleTypeService.SampleOperations.LinkToStudy,
                 SampleTypeService.SampleOperations.RecallFromStudy
         )),
-        Locked(Set.of(SampleTypeService.SampleOperations.AddToPicklist));
+        Locked(Set.of(SampleTypeService.SampleOperations.AddToPicklist, SampleTypeService.SampleOperations.RemoveFromPicklist));
 
         Set<SampleTypeService.SampleOperations> _permittedOps;
 

--- a/api/src/org/labkey/api/exp/query/SampleStatusTable.java
+++ b/api/src/org/labkey/api/exp/query/SampleStatusTable.java
@@ -24,6 +24,6 @@ public class SampleStatusTable extends FilteredTable<ExpSchema>
         addWrapColumn(getRealTable().getColumn("Label"));
         addWrapColumn(getRealTable().getColumn("Description"));
         addWrapColumn(getRealTable().getColumn("Container"));
-        addWrapColumn("Status Type", getRealTable().getColumn("StateType"));
+        addWrapColumn("StatusType", getRealTable().getColumn("StateType"));
     }
 }

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -579,7 +579,8 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         statusColInfo.setShownInDetailsView(true);
         statusColInfo.setShownInInsertView(true);
         statusColInfo.setHidden(!SampleTypeService.isSampleStatusEnabled());
-        defaultCols.add(FieldKey.fromParts(ExpMaterialTable.Column.SampleState));
+        if (SampleTypeService.isSampleStatusEnabled())
+            defaultCols.add(FieldKey.fromParts(ExpMaterialTable.Column.SampleState));
         statusColInfo.setFk(new LookupForeignKey(getContainerFilter(), null, null, ExpSchema.SCHEMA_NAME, CoreSchema.DATA_STATES_TABLE_NAME, "RowId", "Label")
         {
             @Override

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -327,8 +327,9 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 ret.setLabel("Status");
                 boolean statusEnabled = SampleTypeService.isSampleStatusEnabled();
                 ret.setHidden(!statusEnabled);
-                ret.setShownInDetailsView(!statusEnabled);
-                ret.setShownInInsertView(!statusEnabled);
+                ret.setShownInDetailsView(statusEnabled);
+                ret.setShownInInsertView(statusEnabled);
+                ret.setShownInUpdateView(statusEnabled);
                 ret.setFk(new LookupForeignKey(getContainerFilter(), null, null, ExpSchema.SCHEMA_NAME, "datastates", "RowId", "Label")
                 {
                     @Override
@@ -580,6 +581,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         boolean statusEnabled = SampleTypeService.isSampleStatusEnabled();
         statusColInfo.setShownInDetailsView(statusEnabled);
         statusColInfo.setShownInInsertView(statusEnabled);
+        statusColInfo.setShownInUpdateView(statusEnabled);
         statusColInfo.setHidden(!statusEnabled);
         if (statusEnabled)
             defaultCols.add(FieldKey.fromParts(ExpMaterialTable.Column.SampleState));

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -575,21 +575,20 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
         addColumn(ExpMaterialTable.Column.Flag);
 
-        if (SampleTypeService.isSampleStatusEnabled())
+        var statusColInfo = addColumn(ExpMaterialTable.Column.SampleState);
+        statusColInfo.setShownInDetailsView(true);
+        statusColInfo.setShownInInsertView(true);
+        statusColInfo.setHidden(!SampleTypeService.isSampleStatusEnabled());
+        defaultCols.add(FieldKey.fromParts(ExpMaterialTable.Column.SampleState));
+        statusColInfo.setFk(new LookupForeignKey(getContainerFilter(), null, null, ExpSchema.SCHEMA_NAME, CoreSchema.DATA_STATES_TABLE_NAME, "RowId", "Label")
         {
-            var statusColInfo = addColumn(ExpMaterialTable.Column.SampleState);
-            statusColInfo.setShownInDetailsView(true);
-            statusColInfo.setShownInInsertView(true);
-            defaultCols.add(FieldKey.fromParts(ExpMaterialTable.Column.SampleState));
-            statusColInfo.setFk(new LookupForeignKey(getContainerFilter(), null, null, ExpSchema.SCHEMA_NAME, CoreSchema.DATA_STATES_TABLE_NAME, "RowId", "Label")
+            @Override
+            public TableInfo getLookupTableInfo()
             {
-                @Override
-                public TableInfo getLookupTableInfo()
-                {
-                    return ExperimentService.get().createSampleStatusTable(getExpSchema(), getContainerFilter());
-                }
-            });
-        }
+                return ExperimentService.get().createSampleStatusTable(getExpSchema(), getContainerFilter());
+            }
+        });
+
         // TODO is this a real Domain???
         if (st != null && !"urn:lsid:labkey.com:SampleSource:Default".equals(st.getDomain().getTypeURI()))
         {

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -577,10 +577,11 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         addColumn(ExpMaterialTable.Column.Flag);
 
         var statusColInfo = addColumn(ExpMaterialTable.Column.SampleState);
-        statusColInfo.setShownInDetailsView(true);
-        statusColInfo.setShownInInsertView(true);
-        statusColInfo.setHidden(!SampleTypeService.isSampleStatusEnabled());
-        if (SampleTypeService.isSampleStatusEnabled())
+        boolean statusEnabled = SampleTypeService.isSampleStatusEnabled();
+        statusColInfo.setShownInDetailsView(statusEnabled);
+        statusColInfo.setShownInInsertView(statusEnabled);
+        statusColInfo.setHidden(!statusEnabled);
+        if (statusEnabled)
             defaultCols.add(FieldKey.fromParts(ExpMaterialTable.Column.SampleState));
         statusColInfo.setFk(new LookupForeignKey(getContainerFilter(), null, null, ExpSchema.SCHEMA_NAME, CoreSchema.DATA_STATES_TABLE_NAME, "RowId", "Label")
         {


### PR DESCRIPTION
#### Rationale
Column names without spaces are easier to deal with.  We want to add the Status column so we can work with it in custom queries, just not show it unless the experimental feature is on

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/319
* https://github.com/LabKey/labkey-ui-components/pull/650
* https://github.com/LabKey/sampleManagement/pull/722
* https://github.com/LabKey/biologics/pull/1021

#### Changes
* Improve label for StatusType column
* Make Status column available (but hidden) even when feature flag is off
* Added SampleOperation for removing from picklist (not strictly necessary since all samples can be added or removed from picklists, but likely needed later).
