### PR TITLE
Issue 43394: Sample import error handler parse error from JSON responseText

### DIFF
--- a/api/src/org/labkey/api/query/import.jsp
+++ b/api/src/org/labkey/api/query/import.jsp
@@ -233,6 +233,8 @@
                     case Ext4.form.Action.CONNECT_FAILURE:
                         if (action.result && (action.result.errors || action.result.exception))
                             serverInvalid(action.result);
+                        else if (action.response && action.response.responseText)
+                            serverInvalid(Ext4.decode(action.response.responseText));
                         else
                             Ext4.Msg.alert('Failure', 'Ajax communication failed');
                         break;


### PR DESCRIPTION
#### Rationale
Issue [43394](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43394): Bulk insert with name expression to lookup field swallows errors

The Ext4 form used for the import.jsp file in the sample import case was not correctly showing error messages for the text field import case. This PR fixes that to handle the JSON responseText in the failure case.

#### Changes
* On form failure, check for response.responseText and parse as JSON if applicable
