### PR TITLE
Issue 44065: Change PropertyColumn SQL cast to use NVARCHAR intead of VARCHAR for MSSQL

### DIFF
--- a/api/src/org/labkey/api/exp/PropertyColumn.java
+++ b/api/src/org/labkey/api/exp/PropertyColumn.java
@@ -228,7 +228,7 @@ public class PropertyColumn extends LookupColumn
         else if (PropertyType.BOOLEAN == pt)
             return getParentTable().getSqlDialect().getBooleanDataType();
         else
-            return "VARCHAR(" + PropertyStorageSpec.DEFAULT_SIZE + ")";
+            return getParentTable().getSqlDialect().getSqlTypeName(JdbcType.VARCHAR) + "(" + PropertyStorageSpec.DEFAULT_SIZE + ")";
     }
 
 


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44065

FMFreezerConfigurationTest.testSaveProperties test failure found that freezer properties (i.e. custom columns on an extensible table) can't round trip extended ASCII characters in MSSQL because they were being cast to VARCHAR instead of NVARCHAR. This also exposed that the inventory.box Name column in MSSQL was created as type VARCHAR instead of NVARCHAR

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/320

#### Changes
* Change PropertyColumn SQL cast to use dialect based varchar type (i.e. NVARCHAR instead of VARCHAR for MSSQL)
