### PR TITLE
Add Workflow Task column to Exp Run table

### DIFF
--- a/api/schemas/expTypes.xsd
+++ b/api/schemas/expTypes.xsd
@@ -96,6 +96,7 @@
 			<xs:element name="Comments" type="string" minOccurs="0"/>
             <xs:element name="ExperimentLSID" type="string" minOccurs="0" maxOccurs="1" />
 			<xs:element name="Properties" type="exp:PropertyCollectionType" minOccurs="0"/>
+            <xs:element name="WorkflowTaskLSID" type="string" minOccurs="0" maxOccurs="1" />
 			<xs:element name="ExperimentLog" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>

--- a/api/src/org/labkey/api/exp/api/ExpRun.java
+++ b/api/src/org/labkey/api/exp/api/ExpRun.java
@@ -118,6 +118,8 @@ public interface ExpRun extends ExpObject, Identifiable
     void setCreated(Date created);
     void setCreatedBy(User user);
 
+    void setWorkflowTaskId(@Nullable Integer workflowTaskId);
+
     void setWorkflowTask(@Nullable ExpProtocolApplication workflowTask);
 
     @Nullable ExpProtocolApplication getWorkflowTask();

--- a/api/src/org/labkey/api/exp/api/ExpRun.java
+++ b/api/src/org/labkey/api/exp/api/ExpRun.java
@@ -118,4 +118,7 @@ public interface ExpRun extends ExpObject, Identifiable
     void setCreated(Date created);
     void setCreatedBy(User user);
 
+    void setWorkflowTask(@Nullable ExpProtocolApplication workflowTask);
+
+    @Nullable ExpProtocolApplication getWorkflowTask();
 }

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -68,7 +68,6 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
-import org.labkey.api.util.GUID;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.NotFoundException;
@@ -686,6 +685,9 @@ public interface ExperimentService extends ExperimentRunTypeSource
     @Nullable ExpProtocolApplication getExpProtocolApplication(int rowId);
 
     @Nullable ExpProtocolApplication getExpProtocolApplicationFromEntityId(String entityId);
+
+    @NotNull
+    List<? extends ExpProtocolApplication> getExpProtocolApplicationsByObjectId(Container container, String objectId);
 
     List<? extends ExpProtocolApplication> getExpProtocolApplicationsForRun(int runId);
 

--- a/api/src/org/labkey/api/exp/query/ExpRunTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpRunTable.java
@@ -54,7 +54,8 @@ public interface ExpRunTable extends ExpTable<ExpRunTable.Column>
         ReplacedByRun,
         ReplacesRun,
         Batch,
-        Properties
+        Properties,
+        WorkflowTask
     }
 
     /**

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-21.015-21.016.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-21.015-21.016.sql
@@ -1,3 +1,3 @@
 ALTER TABLE exp.ExperimentRun ADD COLUMN WorkflowTask INT;
 
-ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_Run_WorfklowTask FOREIGN KEY (WorkflowTask) REFERENCES exp.ProtocolApplication (RowId);
+ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_Run_WorfklowTask FOREIGN KEY (WorkflowTask) REFERENCES exp.ProtocolApplication (RowId) MATCH SIMPLE ON DELETE SET NULL;

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-21.015-21.016.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-21.015-21.016.sql
@@ -1,0 +1,3 @@
+ALTER TABLE exp.ExperimentRun ADD COLUMN WorkflowTask INT;
+
+ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_Run_WorfklowTask FOREIGN KEY (WorkflowTask) REFERENCES exp.ProtocolApplication (RowId);

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-21.015-21.016.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-21.015-21.016.sql
@@ -1,3 +1,3 @@
 ALTER TABLE exp.ExperimentRun ADD WorkflowTask INT;
 GO
-ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_Run_WorfklowTask FOREIGN KEY (WorkflowTask) REFERENCES exp.ProtocolApplication (RowId);
+ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_Run_WorfklowTask FOREIGN KEY (WorkflowTask) REFERENCES exp.ProtocolApplication (RowId) ON DELETE SET NULL;

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-21.015-21.016.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-21.015-21.016.sql
@@ -1,3 +1,3 @@
-ALTER TABLE exp.ExperimentRun ADD COLUMN WorkflowTask INT;
+ALTER TABLE exp.ExperimentRun ADD WorkflowTask INT;
 GO
 ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_Run_WorfklowTask FOREIGN KEY (WorkflowTask) REFERENCES exp.ProtocolApplication (RowId);

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-21.015-21.016.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-21.015-21.016.sql
@@ -1,0 +1,3 @@
+ALTER TABLE exp.ExperimentRun ADD COLUMN WorkflowTask INT;
+GO
+ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_Run_WorfklowTask FOREIGN KEY (WorkflowTask) REFERENCES exp.ProtocolApplication (RowId);

--- a/experiment/resources/schemas/exp.xml
+++ b/experiment/resources/schemas/exp.xml
@@ -183,6 +183,9 @@
       </column>
       <column columnName="ObjectId"/>
       <column columnName="LastIndexed"/>
+      <column columnName="WorkflowTask">
+        <description>The Workflow Task this run is associated with.</description>
+      </column>
     </columns>
     <description>Contains a row per experiment run in this folder.</description>
   </table>

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -161,7 +161,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     public Double getSchemaVersion()
     {
-        return 21.015;
+        return 21.016;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/XarExporter.java
+++ b/experiment/src/org/labkey/experiment/XarExporter.java
@@ -122,17 +122,17 @@ public class XarExporter
      * As we export objects to XML, we may transform the LSID so we need to remember the
      * original LSIDs
      */
-    private Map<String, Set<String>> _experimentLSIDToRunLSIDs = new HashMap<>();
-    private Set<String> _experimentRunLSIDs = new HashSet<>();
-    private Set<String> _protocolLSIDs = new HashSet<>();
-    private Set<String> _inputDataLSIDs = new HashSet<>();
-    private Set<String> _inputMaterialLSIDs = new HashSet<>();
+    private final Map<String, Set<String>> _experimentLSIDToRunLSIDs = new HashMap<>();
+    private final Set<String> _experimentRunLSIDs = new HashSet<>();
+    private final Set<String> _protocolLSIDs = new HashSet<>();
+    private final Set<String> _inputDataLSIDs = new HashSet<>();
+    private final Set<String> _inputMaterialLSIDs = new HashSet<>();
 
-    private Set<String> _sampleSetLSIDs = new HashSet<>();
+    private final Set<String> _sampleSetLSIDs = new HashSet<>();
     /** Use a TreeMap so that we order domains by their RowIds, see issue 22459 */
-    private Map<Integer, Domain> _domainsToAdd = new TreeMap<>();
-    private Set<String> _domainLSIDs = new HashSet<>();
-    private Set<Integer> _expDataIDs = new HashSet<>();
+    private final Map<Integer, Domain> _domainsToAdd = new TreeMap<>();
+    private final Set<String> _domainLSIDs = new HashSet<>();
+    private final Set<Integer> _expDataIDs = new HashSet<>();
 
     private final LSIDRelativizer.RelativizedLSIDs _relativizedLSIDs;
     private Logger _log;
@@ -302,6 +302,16 @@ public class XarExporter
         for (ExpProtocolApplication application : ExperimentService.get().getExpProtocolApplicationsForRun(run.getRowId()))
         {
             addProtocolApplication(application, run, xApplications);
+        }
+
+        ExpProtocolApplication workflowTask = run.getWorkflowTask();
+
+        if (workflowTask != null)
+        {
+            // Due to the way ProtocolApplication LSIDs are generated we can't actually round trip them the normal way
+            // via the LSIDRelativizer. Instead we construct an LSID out of the object ID with a custom prefix.
+            String workflowObjectId = Lsid.parse(workflowTask.getLSID()).getObjectId();
+            xRun.setWorkflowTaskLSID("${WorkflowTaskReference}:" + workflowObjectId);
         }
 
         // get AssayService.get().getProvider(run).getXarCallbacks().beforeXarExportRun() with simple attempt at caching for common case

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -1070,6 +1070,8 @@ public class XarReader extends AbstractXarImporter
                     {
                         throw new ExperimentException(e);
                     }
+                } else {
+                    getLog().warn("Could not find ProtocolApplication with LSID containing: " + lsidPart);
                 }
             }
         }

--- a/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
@@ -58,7 +58,6 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryRowReference;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DeletePermission;
-import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.view.ActionURL;
@@ -1013,9 +1012,15 @@ public class ExpRunImpl extends ExpIdentifiableEntityImpl<ExperimentRun> impleme
     }
 
     @Override
+    public void setWorkflowTaskId(@Nullable Integer workflowTaskId)
+    {
+        _object.setWorkflowTask(workflowTaskId);
+    }
+
+    @Override
     public ExpProtocolApplication getWorkflowTask()
     {
-        Integer id = _object.getWorkflowTaskId();
+        Integer id = _object.getWorkflowTask();
 
         if (id == null) {
             return null;
@@ -1035,8 +1040,8 @@ public class ExpRunImpl extends ExpIdentifiableEntityImpl<ExperimentRun> impleme
         ensureUnlocked();
 
         if (workflowTask == null)
-            _object.setWorkflowTaskId(null);
+            _object.setWorkflowTask(null);
         else
-            _object.setWorkflowTaskId(workflowTask.getRowId());
+            _object.setWorkflowTask(workflowTask.getRowId());
     }
 }

--- a/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
@@ -91,6 +91,7 @@ public class ExpRunImpl extends ExpIdentifiableEntityImpl<ExperimentRun> impleme
     private ExpRunImpl _replacedByRun;
     private Integer _maxOutputActionSequence = null;
     private static final Logger LOG = LogManager.getLogger(ExpRunImpl.class);
+    private ExpProtocolApplication _workflowTask;
 
     static public List<ExpRunImpl> fromRuns(List<ExperimentRun> runs)
     {
@@ -1009,5 +1010,33 @@ public class ExpRunImpl extends ExpIdentifiableEntityImpl<ExperimentRun> impleme
             }
         }
         return false;
+    }
+
+    @Override
+    public ExpProtocolApplication getWorkflowTask()
+    {
+        Integer id = _object.getWorkflowTaskId();
+
+        if (id == null) {
+            return null;
+        }
+
+        if (_workflowTask == null || _workflowTask.getRowId() != id.intValue())
+        {
+            _workflowTask = ExperimentServiceImpl.get().getExpProtocolApplication(id);
+        }
+
+        return _workflowTask;
+    }
+
+    @Override
+    public void setWorkflowTask(ExpProtocolApplication workflowTask)
+    {
+        ensureUnlocked();
+
+        if (workflowTask == null)
+            _object.setWorkflowTaskId(null);
+        else
+            _object.setWorkflowTaskId(workflowTask.getRowId());
     }
 }

--- a/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
@@ -387,8 +387,8 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
                 return createPropertiesColumn(alias);
             case WorkflowTask:
                 var workflowTaskCol = wrapColumn(alias, _rootTable.getColumn("WorkflowTask"));
-                workflowTaskCol.setShownInInsertView(false);
-                workflowTaskCol.setShownInUpdateView(false);
+                workflowTaskCol.setShownInInsertView(true);
+                workflowTaskCol.setShownInUpdateView(true);
                 workflowTaskCol.setFk(getExpSchema().getProtocolApplicationForeignKey(getContainerFilter()));
                 workflowTaskCol.setLabel("Workflow Task");
                 return workflowTaskCol;
@@ -909,6 +909,11 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
                             String newFlag = value == null ? null : (String)ConvertUtils.convert(value.toString(), String.class);
                             appendPropertyIfChanged(sb, "Flag", run.getComment(), newFlag);
                             run.setComment(user, newFlag);
+                        }
+                        else if (entry.getKey().equalsIgnoreCase(Column.WorkflowTask.toString()))
+                        {
+                            Integer newWorkflowTaskId = value == null ? null : (Integer)ConvertUtils.convert(value.toString(), Integer.class);
+                            run.setWorkflowTaskId(newWorkflowTaskId);
                         }
 
                         // Also check for properties

--- a/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
@@ -385,6 +385,13 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
                 return batchIdCol;
             case Properties:
                 return createPropertiesColumn(alias);
+            case WorkflowTask:
+                var workflowTaskCol = wrapColumn(alias, _rootTable.getColumn("WorkflowTask"));
+                workflowTaskCol.setShownInInsertView(false);
+                workflowTaskCol.setShownInUpdateView(false);
+                workflowTaskCol.setFk(getExpSchema().getProtocolApplicationForeignKey(getContainerFilter()));
+                workflowTaskCol.setLabel("Workflow Task");
+                return workflowTaskCol;
             default:
                 throw new IllegalArgumentException("Unknown column " + column);
         }
@@ -547,8 +554,8 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
         addColumn(Column.Output);
         addColumn(Column.DataInputs);
         addColumn(Column.DataOutputs);
-
         addColumn(Column.Properties);
+        addColumn(Column.WorkflowTask);
         addVocabularyDomains();
 
         ActionURL urlDetails = new ActionURL(ExperimentController.ShowRunTextAction.class, schema.getContainer());
@@ -565,6 +572,7 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
         defaultVisibleColumns.remove(FieldKey.fromParts(Column.DataOutputs));
         defaultVisibleColumns.remove(FieldKey.fromParts(Column.Modified));
         defaultVisibleColumns.remove(FieldKey.fromParts(Column.ModifiedBy));
+        defaultVisibleColumns.remove(FieldKey.fromParts(Column.WorkflowTask));
         setDefaultVisibleColumns(defaultVisibleColumns);
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
@@ -387,8 +387,8 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
                 return createPropertiesColumn(alias);
             case WorkflowTask:
                 var workflowTaskCol = wrapColumn(alias, _rootTable.getColumn("WorkflowTask"));
-                workflowTaskCol.setShownInInsertView(true);
-                workflowTaskCol.setShownInUpdateView(true);
+                workflowTaskCol.setShownInInsertView(false);
+                workflowTaskCol.setShownInUpdateView(false);
                 workflowTaskCol.setFk(getExpSchema().getProtocolApplicationForeignKey(getContainerFilter()));
                 workflowTaskCol.setLabel("Workflow Task");
                 return workflowTaskCol;

--- a/experiment/src/org/labkey/experiment/api/ExperimentRun.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentRun.java
@@ -35,6 +35,7 @@ public class ExperimentRun extends IdentifiableEntity
     private Integer jobId;
     private Integer _replacedByRunId;
     private Integer _batchId;
+    private Integer _workflowTaskId;
 
     public String getProtocolLSID()
     {
@@ -105,6 +106,16 @@ public class ExperimentRun extends IdentifiableEntity
     public void setBatchId(Integer batchId)
     {
         _batchId = batchId;
+    }
+
+    public Integer getWorkflowTaskId()
+    {
+        return _workflowTaskId;
+    }
+
+    public void setWorkflowTaskId(Integer workflowTaskId)
+    {
+        _workflowTaskId = workflowTaskId;
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExperimentRun.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentRun.java
@@ -17,7 +17,6 @@ package org.labkey.experiment.api;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
-import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.view.ActionURL;
 import org.labkey.experiment.controllers.exp.ExperimentController;
@@ -35,7 +34,7 @@ public class ExperimentRun extends IdentifiableEntity
     private Integer jobId;
     private Integer _replacedByRunId;
     private Integer _batchId;
-    private Integer _workflowTaskId;
+    private Integer _workflowTask;
 
     public String getProtocolLSID()
     {
@@ -108,14 +107,14 @@ public class ExperimentRun extends IdentifiableEntity
         _batchId = batchId;
     }
 
-    public Integer getWorkflowTaskId()
+    public Integer getWorkflowTask()
     {
-        return _workflowTaskId;
+        return _workflowTask;
     }
 
-    public void setWorkflowTaskId(Integer workflowTaskId)
+    public void setWorkflowTask(Integer workflowTaskId)
     {
-        _workflowTaskId = workflowTaskId;
+        _workflowTask = workflowTaskId;
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -3597,6 +3597,22 @@ public class ExperimentServiceImpl implements ExperimentService
         return new TableSelector(getTinfoProtocolApplication(), new SimpleFilter(FieldKey.fromParts("LSID"), lsid), null).getObject(ProtocolApplication.class);
     }
 
+    @Override
+    @NotNull
+    public List<? extends ExpProtocolApplication> getExpProtocolApplicationsByObjectId(Container container, String objectId)
+    {
+        String likeFilter = "%:" + objectId;
+        final SQLFragment sql = new SQLFragment("SELECT * FROM ");
+        sql.append(getTinfoProtocolApplication(), "pa");
+        sql.append(" WHERE LSID LIKE ? AND RunId IN (SELECT RowId FROM ");
+        sql.append(getTinfoExperimentRun(), "er");
+        sql.append(" WHERE Container = ?)");
+        sql.add(likeFilter);
+        sql.add(container);
+        List<ProtocolApplication> apps = new SqlSelector(getExpSchema(), sql).getArrayList(org.labkey.experiment.api.ProtocolApplication.class);
+        return ExpProtocolApplicationImpl.fromProtocolApplications(apps);
+    }
+
     public List<ProtocolAction> getProtocolActions(int parentProtocolRowId)
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("ParentProtocolId"), parentProtocolRowId);

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -3599,7 +3599,7 @@ public class ExperimentServiceImpl implements ExperimentService
 
     @Override
     @NotNull
-    public List<? extends ExpProtocolApplication> getExpProtocolApplicationsByObjectId(Container container, String objectId)
+    public List<ExpProtocolApplicationImpl> getExpProtocolApplicationsByObjectId(Container container, String objectId)
     {
         String likeFilter = "%:" + objectId;
         final SQLFragment sql = new SQLFragment("SELECT * FROM ");


### PR DESCRIPTION
#### Rationale
We need a Workflow Task column (FK to Exp ProtocolApplication) on the Exp Run table in order to associate Workflow Tasks with Assay Runs.

#### Related Pull Requests
* n/a

#### Changes
* DB Scripts to add WorkflowTask column to exp.ExperimentRun
* Add WorkflowTask column to ExpRunTableImpl
* Add getter/setter for workflowTaskId to ExperimentRun
* Add getter/setter for WorkflowTask to ExpRunImpl
* Roundtrip WorkflowTask during export/import