### PR TITLE
Unique names for data classes and sample types

### DIFF
--- a/api/src/org/labkey/api/dataiterator/NameExpressionDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/NameExpressionDataIterator.java
@@ -39,6 +39,7 @@ public class NameExpressionDataIterator extends WrapperDataIterator
     private Container _container;
     private Function<String, Long> _getNonConflictCountFn;
     private String _counterSeqPrefix;
+    private boolean _allowUserSpecifiedNames = true;        // whether manual names specification is allowed or only name expression generation
 
     public NameExpressionDataIterator(DataIterator di, DataIteratorContext context, @Nullable TableInfo parentTable, @Nullable Container container, Function<String, Long> getNonConflictCountFn, String counterSeqPrefix)
     {
@@ -56,6 +57,12 @@ public class NameExpressionDataIterator extends WrapperDataIterator
         _getNonConflictCountFn = getNonConflictCountFn;
         _counterSeqPrefix = counterSeqPrefix;
 
+    }
+
+    public NameExpressionDataIterator setAllowUserSpecifiedNames(boolean allowUserSpecifiedNames)
+    {
+        _allowUserSpecifiedNames = allowUserSpecifiedNames;
+        return this;
     }
 
     MapDataIterator getInput()
@@ -93,7 +100,11 @@ public class NameExpressionDataIterator extends WrapperDataIterator
                 curName = StringUtils.isEmpty((String)curName) ? null : curName;
 
             if (curName != null)
+            {
+                if (!_allowUserSpecifiedNames)
+                    getErrors().addRowError(new ValidationException("Manual entry of names has been disabled for this folder. Only naming pattern generated names are allowed."));
                 return curName;
+            }
 
             Map<String, Object> currentRow = getInput().getMap();
 

--- a/api/src/org/labkey/api/dataiterator/NameExpressionDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/NameExpressionDataIterator.java
@@ -102,7 +102,7 @@ public class NameExpressionDataIterator extends WrapperDataIterator
             if (curName != null)
             {
                 if (!_allowUserSpecifiedNames)
-                    getErrors().addRowError(new ValidationException("Manual entry of names has been disabled for this folder. Only naming pattern generated names are allowed."));
+                    getErrors().addRowError(new ValidationException("Manual entry of names has been disabled for this folder. Only naming-pattern-generated names are allowed."));
                 return curName;
             }
 

--- a/api/src/org/labkey/api/exp/api/ExpSampleType.java
+++ b/api/src/org/labkey/api/exp/api/ExpSampleType.java
@@ -109,6 +109,8 @@ public interface ExpSampleType extends ExpObject
     /** @return true if this SampleSet has an override aliquot name expression. */
     boolean hasAliquotNameExpression();
 
+    void setAliquotNameExpression(String expression);
+
     /** @return label color hex value if set. */
     @Nullable
     String getLabelColor();

--- a/api/src/org/labkey/api/exp/api/ExpSampleType.java
+++ b/api/src/org/labkey/api/exp/api/ExpSampleType.java
@@ -41,6 +41,7 @@ import java.util.function.Function;
 public interface ExpSampleType extends ExpObject
 {
     String SEQUENCE_PREFIX = "org.labkey.experiment.api.MaterialSource";
+    String ALIQUOTED_FROM_EXPRESSION = "${AliquotedFrom}";
 
     String getMaterialLSIDPrefix();
 

--- a/api/src/org/labkey/api/exp/api/ExpSampleType.java
+++ b/api/src/org/labkey/api/exp/api/ExpSampleType.java
@@ -97,6 +97,8 @@ public interface ExpSampleType extends ExpObject
     @Nullable
     String getNameExpression();
 
+    void setNameExpression(String expression);
+
     /** @return true if this SampleSet has a name expression. */
     boolean hasNameExpression();
 

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -68,7 +68,6 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
-import org.labkey.api.util.GUID;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.NotFoundException;

--- a/api/src/org/labkey/api/exp/api/NameExpressionOptionService.java
+++ b/api/src/org/labkey/api/exp/api/NameExpressionOptionService.java
@@ -85,7 +85,7 @@ public interface NameExpressionOptionService
         @Override
         public String createPrefixedExpression(Container c, String nameExpression, boolean isAliquotNameExpression)
         {
-            return null;
+            return nameExpression;
         }
     }
 }

--- a/api/src/org/labkey/api/exp/api/NameExpressionOptionService.java
+++ b/api/src/org/labkey/api/exp/api/NameExpressionOptionService.java
@@ -1,0 +1,77 @@
+package org.labkey.api.exp.api;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.Container;
+import org.labkey.api.security.User;
+import org.labkey.api.services.ServiceRegistry;
+
+import javax.annotation.Nullable;
+
+/**
+ * Service which exists to provide mostly application specific functionality around how name expressions work in
+ * data classes and sample types.
+ */
+public interface NameExpressionOptionService
+{
+    NameExpressionOptionService NO_OP_IMPL = new NoOpService();
+
+    @NotNull
+    static NameExpressionOptionService get()
+    {
+        NameExpressionOptionService impl = ServiceRegistry.get().getService(NameExpressionOptionService.class);
+        return impl != null ? impl : NO_OP_IMPL;
+    }
+
+    static void setInstance(NameExpressionOptionService impl)
+    {
+        ServiceRegistry.get().registerService(NameExpressionOptionService.class, impl);
+    }
+
+    /**
+     * Returns the optional name expression prefix configured for this container
+     */
+    @Nullable
+    String getExpressionPrefix(Container c);
+
+    /**
+     * Set the name expression prefix for the specified container. Setting the prefix to null
+     * will clear out an existing prefix.
+     */
+    void setExpressionPrefix(Container c, User user, @Nullable String prefix) throws Exception;
+
+    /**
+     * Returns whether user specified names for samples and dataclasses are permitted for this folder.
+     */
+    boolean allowUserSpecifiedNames(Container c);
+
+    /**
+     * Set whether user specified names for samples and dataclasses are allowed for this folder. If set to false
+     * it is required that all samples and dataclasses in the folder have a configured name expression.
+     */
+    void setAllowUserSpecifiedNames(Container c, User user, boolean allowNames) throws Exception;
+
+    class NoOpService implements NameExpressionOptionService
+    {
+        @Override
+        public String getExpressionPrefix(Container c)
+        {
+            return null;
+        }
+
+        @Override
+        public void setExpressionPrefix(Container c, User user, String prefix) throws Exception
+        {
+        }
+
+        @Override
+        public boolean allowUserSpecifiedNames(Container c)
+        {
+            return true;
+        }
+
+        @Override
+        public void setAllowUserSpecifiedNames(Container c, User user, boolean allowNames) throws Exception
+        {
+        }
+    }
+}

--- a/api/src/org/labkey/api/exp/api/NameExpressionOptionService.java
+++ b/api/src/org/labkey/api/exp/api/NameExpressionOptionService.java
@@ -42,12 +42,12 @@ public interface NameExpressionOptionService
     void setExpressionPrefix(Container c, User user, @Nullable String prefix) throws Exception;
 
     /**
-     * Returns whether user specified names for samples and dataclasses are permitted for this folder.
+     * Returns whether user-specified names for samples and dataclasses are permitted for this folder.
      */
     boolean allowUserSpecifiedNames(Container c);
 
     /**
-     * Set whether user specified names for samples and dataclasses are allowed for this folder. If set to false
+     * Set whether user-specified names for samples and dataclasses are allowed for this folder. If set to false
      * it is required that all samples and dataclasses in the folder have a configured name expression.
      */
     void setAllowUserSpecifiedNames(Container c, User user, boolean allowNames) throws Exception;

--- a/api/src/org/labkey/api/exp/api/NameExpressionOptionService.java
+++ b/api/src/org/labkey/api/exp/api/NameExpressionOptionService.java
@@ -13,6 +13,8 @@ import javax.annotation.Nullable;
  */
 public interface NameExpressionOptionService
 {
+    String NAME_EXPRESSION_REQUIRED_MSG = "A Naming Pattern is required because manually specifying a name has been disabled for this folder.";
+
     NameExpressionOptionService NO_OP_IMPL = new NoOpService();
 
     @NotNull
@@ -50,6 +52,12 @@ public interface NameExpressionOptionService
      */
     void setAllowUserSpecifiedNames(Container c, User user, boolean allowNames) throws Exception;
 
+    /**
+     * Creates a prefixed name expression for new data classes or sample types, if configured for the
+     * container.
+     */
+    String createPrefixedExpression(Container c, String nameExpression, boolean isAliquotNameExpression);
+
     class NoOpService implements NameExpressionOptionService
     {
         @Override
@@ -72,6 +80,12 @@ public interface NameExpressionOptionService
         @Override
         public void setAllowUserSpecifiedNames(Container c, User user, boolean allowNames) throws Exception
         {
+        }
+
+        @Override
+        public String createPrefixedExpression(Container c, String nameExpression, boolean isAliquotNameExpression)
+        {
+            return null;
         }
     }
 }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -61,6 +61,7 @@ import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.NameExpressionOptionService;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
@@ -205,6 +206,13 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 c.setNullable(nameExpression != null);
                 String desc = ExpMaterialTableImpl.appendNameExpressionDescription(c.getDescription(), nameExpression);
                 c.setDescription(desc);
+
+                // shut off this field in insert and update views if user specified names are not allowed
+                if (!NameExpressionOptionService.get().allowUserSpecifiedNames(getContainer()))
+                {
+                    c.setShownInInsertView(false);
+                    c.setShownInUpdateView(false);
+                }
                 return c;
             }
 
@@ -621,7 +629,8 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 //              TODO check if this covers all the functionality, in particular how is alternateKeyCandidates used?
                 di = LoggingDataIterator.wrap(new CoerceDataIterator(di, context, ExpDataClassDataTableImpl.this, false));
 
-                di = LoggingDataIterator.wrap(new NameExpressionDataIterator(di, context, ExpDataClassDataTableImpl.this, getContainer(), _dataClass.getMaxDataCounterFunction(), DATA_COUNTER_SEQ_PREFIX + _dataClass.getRowId() + "-"));
+                di = LoggingDataIterator.wrap(new NameExpressionDataIterator(di, context, ExpDataClassDataTableImpl.this, getContainer(), _dataClass.getMaxDataCounterFunction(), DATA_COUNTER_SEQ_PREFIX + _dataClass.getRowId() + "-")
+                        .setAllowUserSpecifiedNames(NameExpressionOptionService.get().allowUserSpecifiedNames(getContainer())));
             }
             else
             {

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -207,7 +207,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 String desc = ExpMaterialTableImpl.appendNameExpressionDescription(c.getDescription(), nameExpression);
                 c.setDescription(desc);
 
-                // shut off this field in insert and update views if user specified names are not allowed
+                // shut off this field in insert and update views if user-specified names are not allowed
                 if (!NameExpressionOptionService.get().allowUserSpecifiedNames(getContainer()))
                 {
                     c.setShownInInsertView(false);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -53,6 +53,7 @@ import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.ExperimentUrls;
+import org.labkey.api.exp.api.NameExpressionOptionService;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.Domain;
@@ -196,7 +197,14 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 return columnInfo;
             }
             case Name:
-                return wrapColumn(alias, _rootTable.getColumn("Name"));
+                var nameCol = wrapColumn(alias, _rootTable.getColumn(column.toString()));
+                // shut off this field in insert and update views if user specified names are not allowed
+                if (!NameExpressionOptionService.get().allowUserSpecifiedNames(getContainer()))
+                {
+                    nameCol.setShownInInsertView(false);
+                    nameCol.setShownInUpdateView(false);
+                }
+                return nameCol;
             case Description:
                 return wrapColumn(alias, _rootTable.getColumn("Description"));
             case SampleSet:

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -82,14 +82,12 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static org.labkey.api.data.CompareType.STARTS_WITH;
-
 public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource> implements ExpSampleType
 {
     private static final String categoryName = "materialSource";
     public static final SearchService.SearchCategory searchCategory = new SearchService.SearchCategory(categoryName, "Set of Samples");
 
-    public static final String ALIQUOT_NAME_EXPRESSION = "${${AliquotedFrom}-:withCounter}";
+    public static final String ALIQUOT_NAME_EXPRESSION = "${" + ALIQUOTED_FROM_EXPRESSION + "-:withCounter}";
     public static final String SAMPLE_COUNTER_SEQ_PREFIX = "SampleNameGenCounter-";
 
     private Domain _domain;

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -285,7 +285,7 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
         return getDomainProperty(_object.getParentCol());
     }
 
-    // NOTE: intentionally not public in ExpSampleType interface
+    @Override
     public void setNameExpression(String expression)
     {
         if (expression != null && hasIdColumns() && !hasNameAsIdCol())

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -294,6 +294,7 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
         _object.setNameExpression(expression);
     }
 
+    @Override
     public void setAliquotNameExpression(String expression)
     {
         _object.setAliquotNameExpression(expression);

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -7044,7 +7044,10 @@ public class ExperimentServiceImpl implements ExperimentService
             {
                 if (nameExpression == null)
                     throw new ExperimentException(NAME_EXPRESSION_REQUIRED_MSG);
+            }
 
+            if (svc.getExpressionPrefix(c) != null)
+            {
                 // automatically apply the configured prefix to the name expression
                 nameExpression = svc.createPrefixedExpression(c, nameExpression, false);
             }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -96,6 +96,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.SchemaKey;
+import org.labkey.api.query.SimpleValidationError;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.search.SearchService;
@@ -178,6 +179,7 @@ import static org.labkey.api.exp.OntologyManager.getTinfoObject;
 import static org.labkey.api.exp.api.ExpProtocol.ApplicationType.ExperimentRun;
 import static org.labkey.api.exp.api.ExpProtocol.ApplicationType.ExperimentRunOutput;
 import static org.labkey.api.exp.api.ExpProtocol.ApplicationType.ProtocolApplication;
+import static org.labkey.api.exp.api.NameExpressionOptionService.NAME_EXPRESSION_REQUIRED_MSG;
 import static org.labkey.api.exp.api.ProvenanceService.PROVENANCE_PROTOCOL_LSID;
 
 public class ExperimentServiceImpl implements ExperimentService
@@ -7036,8 +7038,18 @@ public class ExperimentServiceImpl implements ExperimentService
         bean.setLSID(lsid.toString());
         if (options != null)
         {
+            String nameExpression = options.getNameExpression();
+            NameExpressionOptionService svc = NameExpressionOptionService.get();
+            if (!svc.allowUserSpecifiedNames(c))
+            {
+                if (nameExpression == null)
+                    throw new ExperimentException(NAME_EXPRESSION_REQUIRED_MSG);
+
+                // automatically apply the configured prefix to the name expression
+                nameExpression = svc.createPrefixedExpression(c, nameExpression, false);
+            }
             bean.setDescription(options.getDescription());
-            bean.setNameExpression(options.getNameExpression());
+            bean.setNameExpression(nameExpression);
             bean.setMaterialSourceId(options.getSampleType());
             bean.setCategory(options.getCategory());
         }
@@ -7076,6 +7088,14 @@ public class ExperimentServiceImpl implements ExperimentService
             dataClass.setNameExpression(options.getNameExpression());
             dataClass.setSampleType(options.getSampleType());
             dataClass.setCategory(options.getCategory());
+
+            if (!NameExpressionOptionService.get().allowUserSpecifiedNames(c) && options.getNameExpression() == null)
+            {
+                ValidationException errors = new ValidationException();
+                errors.addError(new SimpleValidationError(NAME_EXPRESSION_REQUIRED_MSG));
+
+                return errors;
+            }
         }
 
         ValidationException errors;

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -635,7 +635,10 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         {
             if (nameExpression == null)
                 throw new ExperimentException(NAME_EXPRESSION_REQUIRED_MSG);
+        }
 
+        if (svc.getExpressionPrefix(c) != null)
+        {
             // automatically apply the configured prefix to the name expression
             nameExpression = svc.createPrefixedExpression(c, nameExpression, false);
             aliquotNameExpression = svc.createPrefixedExpression(c, aliquotNameExpression, true);

--- a/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
+++ b/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
@@ -878,8 +878,7 @@ public abstract class UploadSamplesHelper
                         {
                             // don't flag rows that already exist if the option is set to update existing
                             if (!rowExists(currNameObj.toString()))
-                                addRowError("Manual entry of names has been disabled for this folder. Only naming-pattern- generated names (or existing names) are allowed.");
-
+                                addRowError("Manual entry of names has been disabled for this folder. Only naming-pattern-generated names (or existing names) are allowed.");
                         }
                         else
                             addRowError("Manual entry of names has been disabled for this folder. Only naming-pattern-generated names are allowed.");

--- a/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
+++ b/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
@@ -34,6 +34,7 @@ import org.labkey.api.data.MultiValuedForeignKey;
 import org.labkey.api.data.NameGenerator;
 import org.labkey.api.data.RemapCache;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
 import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
@@ -63,9 +64,11 @@ import org.labkey.api.exp.api.SimpleRunRecord;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.exp.query.ExpSchema;
+import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryKey;
+import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.util.Pair;
@@ -792,6 +795,7 @@ public abstract class UploadSamplesHelper
         boolean first = true;
         Map<String, String> importAliasMap = null;
         boolean _allowUserSpecifiedNames = true;        // whether manual names specification is allowed or only name expression generation
+        Set<String> _existingNames = null;
 
         String generatedName = null;
         String generatedLsid = null;
@@ -869,7 +873,16 @@ public abstract class UploadSamplesHelper
                 if (currNameObj != null && !_allowUserSpecifiedNames)
                 {
                     if (StringUtils.isNotBlank(currNameObj.toString()))
-                        addRowError("Manual entry of names has been disabled for this folder. Only naming pattern generated names are allowed.");
+                    {
+                        if (_context.getInsertOption().equals(QueryUpdateService.InsertOption.MERGE))
+                        {
+                            // don't flag rows that already exist if the option is set to update existing
+                            if (!rowExists(currNameObj.toString()))
+                                addRowError("Manual entry of names has been disabled for this folder. Only naming pattern generated names (or existing names) are allowed.");
+                        }
+                        else
+                            addRowError("Manual entry of names has been disabled for this folder. Only naming pattern generated names are allowed.");
+                    }
                 }
 
                 generatedName = nameGen.generateName(nameState, map, null, null, extraPropsFn, isAliquot ? aliquotNameGen.getParsedNameExpression() : null);;
@@ -916,6 +929,18 @@ public abstract class UploadSamplesHelper
             super.close();
             if (null != nameState)
                 nameState.close();
+        }
+
+        private boolean rowExists(String name)
+        {
+            if (_existingNames == null)
+            {
+                _existingNames = new HashSet<>();
+                SamplesSchema schema = new SamplesSchema(User.getSearchUser(), _container);
+                TableSelector ts = new TableSelector(schema.getTable(sampletype, null), Set.of("Name")).setMaxRows(1_000_000);
+                ts.fillSet(_existingNames);
+            }
+            return _existingNames.contains(name);
         }
     }
 

--- a/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
+++ b/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
@@ -878,10 +878,12 @@ public abstract class UploadSamplesHelper
                         {
                             // don't flag rows that already exist if the option is set to update existing
                             if (!rowExists(currNameObj.toString()))
-                                addRowError("Manual entry of names has been disabled for this folder. Only naming pattern generated names (or existing names) are allowed.");
+                                addRowError("Manual entry of names has been disabled for this folder. Only naming-pattern- generated names (or existing names) are allowed.");
+
                         }
                         else
-                            addRowError("Manual entry of names has been disabled for this folder. Only naming pattern generated names are allowed.");
+                            addRowError("Manual entry of names has been disabled for this folder. Only naming-pattern-generated names are allowed.");
+
                     }
                 }
 


### PR DESCRIPTION
#### Rationale
For this [story ](https://docs.google.com/document/d/1N6xfULI198pbU7xYdijYi4jmEg8n1a9s5PcPc5Tb4w0/edit) we want to support an administrative ability to set an optional prefix for data classes and sample types on a per container basis. 

We also will want to give administrators the ability to disable manually inserting/updating a name for sample types and data classes. This should make is so the name field is removed from all insert/update forms for LKS, LKB, LKSM and raise an error if a name comes in through an API endpoint.

#### Related Pull Requests
- https://github.com/LabKey/sampleManagement/pull/723
- https://github.com/LabKey/labkey-ui-components/pull/652
- https://github.com/LabKey/biologics/pull/1023

#### Changes
- Define a `NameExpressionOptionService` with a default NoOp implementation. An actual implementation will be provided in the `SampleManagementModule`
- If users are not allowed to manually insert names
  - Remove the name field for insert/update views
  - Add validation in the name expression `DataIterator` to fail if detected
  - Disallow removing the name expression from the domain editors
  - For samples, if the `UpdateExisting` option is specified, fail only if a specified name doesn't exist in the database