### PR TITLE
43992: Support issue tracker sending HTML email notifications

### DIFF
--- a/api/src/org/labkey/api/util/emailTemplate/EmailTemplate.java
+++ b/api/src/org/labkey/api/util/emailTemplate/EmailTemplate.java
@@ -93,7 +93,7 @@ public abstract class EmailTemplate
                 {
                     return sourceValue;
                 }
-                return PageFlowUtil.filter(sourceValue, true, false);
+                return PageFlowUtil.filter(sourceValue, true, true);
             }
         };
 

--- a/issues/src/org/labkey/issue/IssueUpdateEmailTemplate.java
+++ b/issues/src/org/labkey/issue/IssueUpdateEmailTemplate.java
@@ -62,7 +62,7 @@ public class IssueUpdateEmailTemplate extends UserOriginatedEmailTemplate
 
     public IssueUpdateEmailTemplate()
     {
-        super("Issue update", "Sent to the users based on issue notification rules and settings after an issue has been edited or inserted.", DEFAULT_SUBJECT, DEFAULT_BODY, ContentType.Plain, Scope.SiteOrFolder);
+        super("Issue update", "Sent to the users based on issue notification rules and settings after an issue has been edited or inserted.", DEFAULT_SUBJECT, DEFAULT_BODY, ContentType.HTML, Scope.SiteOrFolder);
 
         Replacements replacements = new Replacements(_replacements);
 

--- a/issues/src/org/labkey/issue/actions/ChangeSummary.java
+++ b/issues/src/org/labkey/issue/actions/ChangeSummary.java
@@ -371,12 +371,15 @@ public class ChangeSummary
                     m.setSubject(template.renderSubject(container));
                     template.renderSenderToMessage(m, container);
                     m.setHeader("References", references);
-                    String body = template.renderBody(container);
 
-                    m.setTextContent(body);
+                    // support for plain text only if configured via the multipart boundary
+                    if (template.hasMultipleContentTypes())
+                        m.setTextContent(template.renderTextBody(container));
+
+                    // html body plus some additional content
                     StringBuilder html = new StringBuilder();
                     html.append("<html><head></head><body>");
-                    html.append(PageFlowUtil.filter(body,true,true));
+                    html.append(template.renderHtmlBody(container));
                     html.append(
                             "<div itemscope itemtype=\"http://schema.org/EmailMessage\">\n" +
                                     "  <div itemprop=\"action\" itemscope itemtype=\"http://schema.org/ViewAction\">\n" +


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43992

We used to HTML encode the entire email body which made it impossible to include HTML content in the email template.

#### Changes
- Change the content type of the email template to HTML so that encoding will occur on a per-replacement basis. User supplied values like comments, title etc. will still be encoded.
- Stop encoding the entire email body
- Stop automatically generating a plain text email part, instead support the multipart boundary `--text/html--boundary--` in the template which will allow more control over the formatting of plain text and html parts.
- Switch the default HTML encoding to encode links, this was the way it was previously until Tony changed it in 2014 (unsure if this was intentional)

We may see some slight formatting differences from this change. One reason is since we no longer escape newlines to `<br>` by filtering the entire body. Users can easily fix this by add the tags directly to their templates.
