### PR TITLE
Issue 44038: Important blank lines removed from R reports when opened in RStudio, breaking the report

### DIFF
--- a/api/src/org/labkey/api/reports/report/RReport.java
+++ b/api/src/org/labkey/api/reports/report/RReport.java
@@ -987,6 +987,7 @@ public class RReport extends ExternalScriptEngineReport
             assertTrue( post.contains(">8") );
             String strip = report.stripScriptProlog(post);
             assertEquals(pre, strip);
+
             int[] expected = new int[]{3, 17, 0, 2, 25, 646};
             assertArrayEquals(expected, report.getPrologAnchors(post));
         }

--- a/api/src/org/labkey/api/reports/report/RReport.java
+++ b/api/src/org/labkey/api/reports/report/RReport.java
@@ -931,7 +931,7 @@ public class RReport extends ExternalScriptEngineReport
             assertEquals(pre, strip);
             assertTrue( post.endsWith(pre) );
             boolean isRStudioEnabled = RStudioService.get() != null;
-            int[] expected = isRStudioEnabled ? new int[]{0, 12, -1, -1, 0, 584} : new int[]{0, 7, -1, -1, 0, 437};
+            int[] expected = isRStudioEnabled ? new int[]{0, 12, -1, -1, 0, 584} : new int[]{0, 7, -1, -1, 0, post.indexOf("# >8")};
             assertArrayEquals(expected, report.getPrologAnchors(post));
         }
 
@@ -959,7 +959,7 @@ public class RReport extends ExternalScriptEngineReport
             assertTrue( post.endsWith("<b>hello world</b>\n") );
 
             boolean isRStudioEnabled = RStudioService.get() != null;
-            int[] expected = isRStudioEnabled ? new int[]{0, 14, -1, -1, 0, 639} : new int[]{0, 9, -1, -1, 0, 492};
+            int[] expected = isRStudioEnabled ? new int[]{0, 14, -1, -1, 0, 639} : new int[]{0, 9, -1, -1, 0, post.indexOf("<!-- >8 -->")};
             assertArrayEquals(expected, report.getPrologAnchors(post));
         }
 
@@ -992,7 +992,7 @@ public class RReport extends ExternalScriptEngineReport
             assertEquals(pre, strip);
 
             boolean isRStudioEnabled = RStudioService.get() != null;
-            int[] expected = isRStudioEnabled ? new int[]{3, 17, 0, 2, 25, 646} : new int[]{3, 12, 0, 2, 25, 499};
+            int[] expected = isRStudioEnabled ? new int[]{3, 17, 0, 2, 25, 646} : new int[]{3, 12, 0, 2, 25, post.indexOf("<!-- >8 -->")};
             assertArrayEquals(expected, report.getPrologAnchors(post));
         }
     }

--- a/api/src/org/labkey/api/reports/report/RReport.java
+++ b/api/src/org/labkey/api/reports/report/RReport.java
@@ -930,7 +930,6 @@ public class RReport extends ExternalScriptEngineReport
             String strip = report.stripScriptProlog(post);
             assertEquals(pre, strip);
             assertTrue( post.endsWith(pre) );
-
             int[] expected = new int[]{0, 12, -1, -1, 0, 584};
             assertArrayEquals(expected, report.getPrologAnchors(post));
         }
@@ -957,7 +956,6 @@ public class RReport extends ExternalScriptEngineReport
             String strip = report.stripScriptProlog(post);
             assertEquals(pre, strip);
             assertTrue( post.endsWith("<b>hello world</b>\n") );
-
             int[] expected = new int[]{0, 14, -1, -1, 0, 639};
             assertArrayEquals(expected, report.getPrologAnchors(post));
         }
@@ -989,7 +987,6 @@ public class RReport extends ExternalScriptEngineReport
             assertTrue( post.contains(">8") );
             String strip = report.stripScriptProlog(post);
             assertEquals(pre, strip);
-
             int[] expected = new int[]{3, 17, 0, 2, 25, 646};
             assertArrayEquals(expected, report.getPrologAnchors(post));
         }

--- a/api/src/org/labkey/api/reports/report/RReport.java
+++ b/api/src/org/labkey/api/reports/report/RReport.java
@@ -930,7 +930,8 @@ public class RReport extends ExternalScriptEngineReport
             String strip = report.stripScriptProlog(post);
             assertEquals(pre, strip);
             assertTrue( post.endsWith(pre) );
-            int[] expected = new int[]{0, 12, -1, -1, 0, 584};
+            boolean isRStudioEnabled = RStudioService.get() != null;
+            int[] expected = isRStudioEnabled ? new int[]{0, 12, -1, -1, 0, 584} : new int[]{0, 7, -1, -1, 0, 437};
             assertArrayEquals(expected, report.getPrologAnchors(post));
         }
 
@@ -956,7 +957,9 @@ public class RReport extends ExternalScriptEngineReport
             String strip = report.stripScriptProlog(post);
             assertEquals(pre, strip);
             assertTrue( post.endsWith("<b>hello world</b>\n") );
-            int[] expected = new int[]{0, 14, -1, -1, 0, 639};
+
+            boolean isRStudioEnabled = RStudioService.get() != null;
+            int[] expected = isRStudioEnabled ? new int[]{0, 14, -1, -1, 0, 639} : new int[]{0, 9, -1, -1, 0, 492};
             assertArrayEquals(expected, report.getPrologAnchors(post));
         }
 
@@ -988,7 +991,8 @@ public class RReport extends ExternalScriptEngineReport
             String strip = report.stripScriptProlog(post);
             assertEquals(pre, strip);
 
-            int[] expected = new int[]{3, 17, 0, 2, 25, 646};
+            boolean isRStudioEnabled = RStudioService.get() != null;
+            int[] expected = isRStudioEnabled ? new int[]{3, 17, 0, 2, 25, 646} : new int[]{3, 12, 0, 2, 25, 499};
             assertArrayEquals(expected, report.getPrologAnchors(post));
         }
     }


### PR DESCRIPTION
#### Rationale
Newline characters are important in certain cases for R markdown. During prolog processing for preparing RStudio report, extra newline characters are removed from the source code, which result in unexpected report source when Edit in RStudio.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2688
* https://github.com/LabKey/rstudio/pull/92

#### Changes
* Determine cutStartCharInd, cutEndCharInd so RStudio can better strip prolog.
