### PR TITLE
Issue 44126: CommandTasks fail on remote pipeline servers

### DIFF
--- a/api/src/org/labkey/api/assay/DefaultDataTransformer.java
+++ b/api/src/org/labkey/api/assay/DefaultDataTransformer.java
@@ -202,7 +202,7 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
         return result;
     }
 
-    public static void addStandardParameters(@Nullable HttpServletRequest request, Container container, @Nullable File scriptFile, String apiKey, @NotNull Map<String, String> paramMap)
+    public static void addStandardParameters(@Nullable HttpServletRequest request, @Nullable Container container, @Nullable File scriptFile, @Nullable String apiKey, @NotNull Map<String, String> paramMap)
     {
         if (scriptFile != null)
         {
@@ -216,7 +216,7 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
         paramMap.put(SecurityManager.API_KEY, apiKey);
         paramMap.put(BASE_SERVER_URL_REPLACEMENT, AppProps.getInstance().getBaseServerUrl()
                                                     + AppProps.getInstance().getContextPath());
-        paramMap.put(CONTAINER_PATH, container.getPath());
+        paramMap.put(CONTAINER_PATH, container == null ? null : container.getPath());
     }
 
     @Deprecated

--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -1651,23 +1651,33 @@ abstract public class PipelineJob extends Job implements Serializable
 
     /**
      * Gets the <code>User</code> instance from the <code>ViewBackgroundInfo</code>.
-     * WARNING: Not supported if job is not running in the LabKey Server.
+     * WARNING: Not supported if job is not running in the LabKey web server.
      *
      * @return the user who started the job
+     * @throws IllegalStateException if invoked on a remote pipeline server
      */
     public User getUser()
     {
+        if (!PipelineJobService.get().isWebServer())
+        {
+            throw new IllegalStateException("User lookup not available on remote pipeline servers");
+        }
         return getInfo().getUser();
     }
 
     /**
      * Gets the <code>Container</code> instance from the <code>ViewBackgroundInfo</code>.
-     * WARNING: Not supported if job is not running in the LabKey Server.
+     * WARNING: Not supported if job is not running in the LabKey web server.
      *
      * @return the container in which the job was started
+     * @throws IllegalStateException if invoked on a remote pipeline server
      */
     public Container getContainer()
     {
+        if (!PipelineJobService.get().isWebServer())
+        {
+            throw new IllegalStateException("User lookup not available on remote pipeline servers");
+        }
         return getInfo().getContainer();
     }
 

--- a/api/src/org/labkey/api/pipeline/PipelineJobService.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJobService.java
@@ -175,5 +175,10 @@ public interface PipelineJobService extends TaskPipelineRegistry
         RemoteExecutionEngine
     }
 
-    public FormSchema getFormSchema(Container container);
+    FormSchema getFormSchema(Container container);
+
+    /** @return true if the current instance is the web server, which has access to more resources including the
+     * primary database, or false if we're on a remote server
+     */
+    boolean isWebServer();
 }

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -646,6 +646,9 @@ public class SecurityManager
         {
             return _apikey;
         }
+
+        @Override
+        public abstract void close();
     }
 
     private static final class HttpSessionTransformSession extends TransformSession
@@ -657,7 +660,7 @@ public class SecurityManager
         }
 
         @Override
-        public void close() throws IOException
+        public void close()
         {
             SessionApiKeyManager.get().invalidateKey(getApiKey());
         }
@@ -672,7 +675,7 @@ public class SecurityManager
         }
 
         @Override
-        public void close() throws IOException
+        public void close()
         {
             ApiKeyManager.get().deleteKey(getApiKey());
         }

--- a/pipeline/src/org/labkey/pipeline/analysis/CommandTaskImpl.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/CommandTaskImpl.java
@@ -28,13 +28,11 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.TSVMapWriter;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.module.Module;
-import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.AbstractTaskFactory;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.PipelineJobService;
-import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.pipeline.RecordedAction;
 import org.labkey.api.pipeline.RecordedActionSet;
 import org.labkey.api.pipeline.TaskId;
@@ -51,7 +49,6 @@ import org.labkey.api.resource.FileResource;
 import org.labkey.api.resource.Resource;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityManager.TransformSession;
-import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.NetworkDrive;
@@ -682,8 +679,10 @@ public class CommandTaskImpl extends WorkDirectoryTask<CommandTaskImpl.Factory> 
     {
         TransformSession session = null;
         Container container = null;
-        if (ModuleLoader.getServletContext() != null)
+        if (PipelineJobService.get().isWebServer())
         {
+            // We're inside of the web server so we have access to the DB and can set up a transform session, among
+            // other resources
             session = SecurityManager.createTransformSession(getJob().getUser());
             container = getJob().getContainer();
         }
@@ -747,14 +746,7 @@ public class CommandTaskImpl extends WorkDirectoryTask<CommandTaskImpl.Factory> 
             _wd = null;
             if (session != null)
             {
-                try
-                {
-                    session.close();
-                }
-                catch (IOException e)
-                {
-                    throw new PipelineJobException(e);
-                }
+                session.close();
             }
         }
     }

--- a/pipeline/src/org/labkey/pipeline/analysis/ConvertTaskFactory.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/ConvertTaskFactory.java
@@ -113,34 +113,34 @@ public class ConvertTaskFactory extends AbstractTaskFactory<ConvertTaskFactorySe
         // If this job is not actually running a conversion, then no
         // converter command can be determined.
         List<File> files = job.getJobSupport(FileAnalysisJobSupport.class).getInputFiles();
-        LOG.info("Checking " + files + " for possible converters");
+        LOG.debug("Checking " + files + " for possible converters");
         if (files == null || files.size() != 1)
             return null;
 
         // Otherwise, find the appropriate converter.
         File fileInput = getInputFile(job);
-        LOG.info("Checking " + fileInput + " against " + _commands.length + " possible converters");
+        LOG.debug("Checking " + fileInput + " against up to " + _commands.length + " possible converters");
         for (TaskId tid : _commands)
         {
-            LOG.info("Checking " + fileInput + " against " + tid);
+            LOG.debug("Checking " + fileInput + " against " + tid);
             TaskFactory<? extends TaskFactorySettings> factory = PipelineJobService.get().getTaskFactory(tid);
             for (FileType ft : factory.getInputTypes())
             {
-                LOG.info("Checking " + fileInput + " against " + tid + ": " + ft);
+                LOG.debug("Checking " + fileInput + " against " + tid + ": " + ft);
                 try
                 {
                     // If we have a match based on the file type and the factory says that it's a participant based
                     // on the search protocol parameters, use it
                     if (ft.isType(fileInput) && factory.isParticipant(job))
                     {
-                        LOG.info("Matched");
+                        LOG.debug("Matched");
                         return factory;
                     }
-                    LOG.info("No match");
+                    LOG.debug("No match");
                 }
-                catch (IOException ignored)
+                catch (IOException e)
                 {
-                    LOG.warn("Exception when checking " + fileInput, ignored);
+                    LOG.debug("Exception when checking " + fileInput + ", reporting that " + tid + " is not available", e);
                     // Consider this command out of the running, caller will report an error if there are no other options
                 }
             }

--- a/pipeline/src/org/labkey/pipeline/analysis/ConvertTaskFactory.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/ConvertTaskFactory.java
@@ -113,25 +113,34 @@ public class ConvertTaskFactory extends AbstractTaskFactory<ConvertTaskFactorySe
         // If this job is not actually running a conversion, then no
         // converter command can be determined.
         List<File> files = job.getJobSupport(FileAnalysisJobSupport.class).getInputFiles();
+        LOG.info("Checking " + files + " for possible converters");
         if (files == null || files.size() != 1)
             return null;
 
         // Otherwise, find the appropriate converter.
         File fileInput = getInputFile(job);
+        LOG.info("Checking " + fileInput + " against " + _commands.length + " possible converters");
         for (TaskId tid : _commands)
         {
+            LOG.info("Checking " + fileInput + " against " + tid);
             TaskFactory<? extends TaskFactorySettings> factory = PipelineJobService.get().getTaskFactory(tid);
             for (FileType ft : factory.getInputTypes())
             {
+                LOG.info("Checking " + fileInput + " against " + tid + ": " + ft);
                 try
                 {
                     // If we have a match based on the file type and the factory says that it's a participant based
                     // on the search protocol parameters, use it
                     if (ft.isType(fileInput) && factory.isParticipant(job))
+                    {
+                        LOG.info("Matched");
                         return factory;
+                    }
+                    LOG.info("No match");
                 }
                 catch (IOException ignored)
                 {
+                    LOG.warn("Exception when checking " + fileInput, ignored);
                     // Consider this command out of the running, caller will report an error if there are no other options
                 }
             }

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -589,6 +589,12 @@ public class PipelineJobServiceImpl implements PipelineJobService
         return new FormSchema(fields);
     }
 
+    @Override
+    public boolean isWebServer()
+    {
+        return ModuleLoader.getServletContext() != null;
+    }
+
     public void setJobStore(PipelineStatusFile.JobStore jobStore)
     {
         _jobStore = jobStore;

--- a/pipeline/src/org/labkey/pipeline/api/ScriptTaskImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/ScriptTaskImpl.java
@@ -82,7 +82,7 @@ public class ScriptTaskImpl extends CommandTaskImpl
     // TODO: Rhino engine.  A non-ExternalScriptEngine won't use the PARAM_REPLACEMENT_MAP binding.
     // CONSIDER: Use ScriptEngineReport to generate a script prolog
     @Override
-    protected boolean runCommand(RecordedAction action, String apiKey) throws IOException, PipelineJobException
+    protected boolean runCommand(RecordedAction action, @Nullable String apiKey, @Nullable Container container) throws IOException, PipelineJobException
     {
         // Get the script engine
         LabKeyScriptEngineManager mgr = LabKeyScriptEngineManager.get();
@@ -160,7 +160,7 @@ public class ScriptTaskImpl extends CommandTaskImpl
             if (_factory.getTimeout() != null && _factory.getTimeout() > 0)
                 bindings.put(ExternalScriptEngine.TIMEOUT, _factory.getTimeout());
 
-            Map<String, String> replacements = createReplacements(scriptFile, apiKey);
+            Map<String, String> replacements = createReplacements(scriptFile, apiKey, container);
             bindings.put(ExternalScriptEngine.PARAM_REPLACEMENT_MAP, replacements);
 
             // Write task properties file into the work directory


### PR DESCRIPTION
#### Rationale
Remote pipeline servers fail to run CommandTasks because we've introduced code that only works when invoked on the web server where we have the DB connection available

#### Changes
* Check if we're on the web server before setting up script replacement tokens and auto-creating an API key
* Debug logging to help track down future problems in finding MS2 conversion tools
* Improve error messages when invoking methods that don't work on remote servers