### PR TITLE
Clear caches again and log imports for intermittent folder import issue

### DIFF
--- a/api/src/org/labkey/api/admin/FolderImporterFactory.java
+++ b/api/src/org/labkey/api/admin/FolderImporterFactory.java
@@ -23,7 +23,7 @@ public interface FolderImporterFactory
 {
     int DEFAULT_PRIORITY = 50;
 
-    FolderImporter create();
+    FolderImporter<?> create();
 
     /* priority allows importers to be ordered relative to each other in ascending order. 0 would be the highest priority */
     int getPriority();

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -248,6 +248,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
 
     ServletContext _servletContext = null;
 
+    @Nullable
     public static ServletContext getServletContext()
     {
         return getInstance() == null ? null : getInstance()._servletContext;

--- a/api/src/org/labkey/api/module/SimpleModule.java
+++ b/api/src/org/labkey/api/module/SimpleModule.java
@@ -16,8 +16,6 @@
 package org.labkey.api.module;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
@@ -62,8 +60,6 @@ import java.util.regex.Pattern;
  */
 public class SimpleModule extends SpringModule
 {
-    private static final Logger _log = LogManager.getLogger(ModuleUpgrader.class);
-
     public static String NAMESPACE_PREFIX = "ExtensibleTable";
     public static String DOMAIN_NAMESPACE_PREFIX_TEMPLATE = NAMESPACE_PREFIX + "-${SchemaName}";
     public static String DOMAIN_LSID_TEMPLATE = "${FolderLSIDBase}:${TableName}";
@@ -143,7 +139,7 @@ public class SimpleModule extends SpringModule
     }
 
     @Override
-    public Controller getController(@Nullable HttpServletRequest request, Class controllerClass)
+    public Controller getController(@Nullable HttpServletRequest request, Class<? extends Controller> controllerClass)
     {
         return new SimpleController(getName().toLowerCase());
     }

--- a/api/src/org/labkey/api/view/Portal.java
+++ b/api/src/org/labkey/api/view/Portal.java
@@ -802,12 +802,12 @@ public class Portal implements ModuleChangeListener
 
     public static void saveParts(Container c, Collection<WebPart> newParts)
     {
-        saveParts(c, DEFAULT_PORTAL_PAGE_ID, newParts.toArray(new WebPart[newParts.size()]));
+        saveParts(c, DEFAULT_PORTAL_PAGE_ID, newParts.toArray(new WebPart[0]));
     }
 
     public static void saveParts(Container c, String pageId, Collection<WebPart> newParts)
     {
-        saveParts(c, pageId, newParts.toArray(new WebPart[newParts.size()]));
+        saveParts(c, pageId, newParts.toArray(new WebPart[0]));
     }
 
 

--- a/api/src/org/labkey/api/view/WebPartCache.java
+++ b/api/src/org/labkey/api/view/WebPartCache.java
@@ -146,7 +146,7 @@ public class WebPartCache
         return CACHE.get(c.getId(), c, _webpartLoader);
     }
 
-    static void remove(Container c)
+    public static void remove(Container c)
     {
         CoreSchema.getInstance().getSchema().getScope().addCommitTask(
                 () -> CACHE.remove(c.getId()),


### PR DESCRIPTION
#### Rationale
We see intermittent test failures where the imported portal layout hasn't been applied as expected.

Also, we received a good suggestion from a customer on simple generics cleanup for registering controllers

#### Changes
* Clear cache after all webpart config has been imported
* Log the number of pages and webparts created
* Improve generics on SimpleModule and SpringModule
* Misc cleanup