### PR TITLE
Introduce DbScope.getDbScopesToTest() and push capabilities bits onto PostgreSqlServerType

### DIFF
--- a/api/src/org/labkey/api/data/SchemaXmlCacheHandler.java
+++ b/api/src/org/labkey/api/data/SchemaXmlCacheHandler.java
@@ -153,7 +153,7 @@ public class SchemaXmlCacheHandler implements ModuleResourceCacheHandler<Map<Str
                     // Special case "labkey" schema, which gets added to all module data sources
                     if ("labkey".equalsIgnoreCase(fullyQualified))
                     {
-                        // Invalidate "labkey" in every scope if its meta data changes
+                        // Invalidate "labkey" in every scope if its metadata changes
                         for (DbScope scope : DbScope.getDbScopes())
                             invalidateSchema(scope, "labkey");
                     }

--- a/api/src/org/labkey/api/data/dialect/PostgreSqlServerType.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSqlServerType.java
@@ -4,8 +4,50 @@ import java.util.Map;
 
 public enum PostgreSqlServerType
 {
-    PostgreSQL,
-    LabKey;
+    PostgreSQL()
+    {
+        @Override
+        boolean shouldTest()
+        {
+            return true;
+        }
+
+        @Override
+        boolean supportsGroupConcat()
+        {
+            return true;
+        }
+
+        @Override
+        boolean supportsSpecialMetadataQueries()
+        {
+            return true;
+        }
+    },
+    LabKey
+    {
+        @Override
+        boolean shouldTest()
+        {
+            return false;
+        }
+
+        @Override
+        boolean supportsGroupConcat()
+        {
+            return false;
+        }
+
+        @Override
+        boolean supportsSpecialMetadataQueries()
+        {
+            return false;
+        }
+    };
+
+    abstract boolean shouldTest();
+    abstract boolean supportsGroupConcat();
+    abstract boolean supportsSpecialMetadataQueries();
 
     public static PostgreSqlServerType getFromParameterStatuses(Map<String, String> parameterStatuses)
     {


### PR DESCRIPTION
#### Rationale
We want to avoid invoking junit tests on PostgreSQL scopes that are connected to LabKey Server via our PostgreSQL emulation layer