### PR TITLE
44123: Issue list "Estimate" lookup doesn't resolve to description in details view

### DIFF
--- a/issues/src/org/labkey/issue/model/IssuePage.java
+++ b/issues/src/org/labkey/issue/model/IssuePage.java
@@ -42,13 +42,11 @@ import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.issues.IssuesSchema;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.query.QueryDefinition;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.ValidEmail;
 import org.labkey.api.security.permissions.InsertPermission;
-import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.HtmlString;
@@ -78,6 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 import static org.labkey.api.util.PageFlowUtil.filter;
@@ -357,10 +356,12 @@ public class IssuePage implements DataRegionSelection.DataSelectionKeyForm
             // issue 27109 : need to add additional bindings to the render context so display values for lookup columns
             // don't render as broken lookups
             TableInfo table = getIssueTable(context);
-            QueryDefinition queryDefinition = table.getUserSchema().getQueryDefForTable(_issueListDef.getName());
-            if (queryDefinition != null)
+            if (table != null)
             {
-                List<ColumnInfo> selectCols = RenderContext.getSelectColumns(queryDefinition.getDisplayColumns(null, table), table);
+                List<DisplayColumn> displayColumns = table.getColumns().stream()
+                        .map(ColumnInfo::getRenderer)
+                        .collect(Collectors.toUnmodifiableList());
+                List<ColumnInfo> selectCols = RenderContext.getSelectColumns(displayColumns, table);
                 SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("IssueId"), _issue.getIssueId());
 
                 try (Results results = new TableSelector(table, selectCols, filter, null).getResults())

--- a/issues/src/org/labkey/issue/model/IssuePage.java
+++ b/issues/src/org/labkey/issue/model/IssuePage.java
@@ -346,10 +346,7 @@ public class IssuePage implements DataRegionSelection.DataSelectionKeyForm
                 Map<DomainProperty, Object> domainDefaults = DefaultValueService.get().getDefaultValues(context.getContainer(), domain, context.getUser());
                 for (Map.Entry<DomainProperty, Object> entry : domainDefaults.entrySet())
                 {
-                    if (row.get(entry.getKey()) == null)
-                    {
-                        row.put(entry.getKey().getName(), entry.getValue());
-                    }
+                    row.putIfAbsent(entry.getKey().getName(), entry.getValue());
                 }
             }
 
@@ -371,7 +368,7 @@ public class IssuePage implements DataRegionSelection.DataSelectionKeyForm
                         Map<FieldKey, Object> rowMap = results.getFieldKeyRowMap();
                         for (Map.Entry<FieldKey, Object> entry : rowMap.entrySet())
                         {
-                            row.put(entry.getKey().encode(), entry.getValue());
+                            row.putIfAbsent(entry.getKey().encode(), entry.getValue());
                         }
                     }
                 }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44123

The estimate lookup was not rendering properly because the domain property had been setup to exclude that field from the default view:

![image](https://user-images.githubusercontent.com/5741543/137817103-b1cc0525-ac12-40a9-bc2a-2c8f9c3ce0fb.png)

When we create the render context for that view we populate the context using the values from the default view, so for the lookup only the key is returned (but not the title column).

#### Changes
- When we setup the render context for the various issue views, ask for all of the fields on the table so that rendering can proceed regardless of domain property configurations.
- The domain property configurations were already being respected and were independent of the render context prep.
- I'll add the field back to the default view on labkey.org until we can deploy this fix for 21.11.