### PR TITLE
fix export/import of concept properties in list archive

### DIFF
--- a/api/src/org/labkey/api/data/MutableColumnConceptProperties.java
+++ b/api/src/org/labkey/api/data/MutableColumnConceptProperties.java
@@ -1,0 +1,10 @@
+package org.labkey.api.data;
+
+public interface MutableColumnConceptProperties
+{
+    public void setPrincipalConceptCode(String principalConceptCode);
+    public void setConceptImportColumn(String conceptImportColumn);
+    public void setConceptLabelColumn(String conceptLabelColumn);
+    public void setSourceOntology(String sourceOntology);
+    public void setConceptSubtree(String conceptSubtree);
+}

--- a/api/src/org/labkey/api/data/MutableColumnRenderProperties.java
+++ b/api/src/org/labkey/api/data/MutableColumnRenderProperties.java
@@ -8,7 +8,7 @@ import org.labkey.api.util.StringExpression;
 
 import java.util.Set;
 
-public interface MutableColumnRenderProperties extends ColumnRenderProperties
+public interface MutableColumnRenderProperties extends ColumnRenderProperties, MutableColumnConceptProperties
 {
     void setSortDirection(Sort.SortDirection sortDirection);
 

--- a/api/src/org/labkey/api/exp/ImportTypesHelper.java
+++ b/api/src/org/labkey/api/exp/ImportTypesHelper.java
@@ -25,6 +25,7 @@ import org.labkey.api.data.ConditionalFormat;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.MutableColumnConceptProperties;
 import org.labkey.api.data.PHI;
 import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.exp.OntologyManager.ImportPropertyDescriptorsList;
@@ -33,6 +34,7 @@ import org.labkey.api.exp.property.ValidatorKind;
 import org.labkey.api.gwt.client.DefaultScaleType;
 import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.gwt.client.FacetingBehaviorType;
+import org.labkey.api.ontology.OntologyService;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpression;
@@ -188,6 +190,10 @@ public class ImportTypesHelper
                 if (columnXml.isSetDefaultValue())
                     builder.setDefaultValue(columnXml.getDefaultValue());
 
+                OntologyService os = OntologyService.get();
+                if (null != os)
+                    os.parseXml(columnXml,builder);
+
                 builders.add(builder);
             }
         }
@@ -279,7 +285,7 @@ public class ImportTypesHelper
         return ret;
     }
 
-    public static class Builder implements org.labkey.api.data.Builder<PropertyDescriptor>
+    public static class Builder implements org.labkey.api.data.Builder<PropertyDescriptor>, MutableColumnConceptProperties
     {
         private PropertyType _type;
         private Container _container;
@@ -312,6 +318,12 @@ public class ImportTypesHelper
         private boolean _excludeFromShifting;
         private int _scale;
         private DefaultValueType _defaultValueType = null;
+
+        private String _principalConceptCode = null;
+        private String _conceptImportColumn = null;
+        private String _conceptLabelColumn = null;
+        private String _sourceOntology = null;
+        private String _conceptSubtree = null;
 
         // not part of PropertyDescriptors, this class could eventually become a builder for DomainProperty
         private String _domainName;
@@ -379,6 +391,11 @@ public class ImportTypesHelper
             pd.setExcludeFromShifting(_excludeFromShifting);
             pd.setScale(_scale);
             pd.setDefaultValueTypeEnum(_defaultValueType);
+            pd.setPrincipalConceptCode(_principalConceptCode);
+            pd.setConceptImportColumn(_conceptImportColumn);
+            pd.setConceptLabelColumn(_conceptLabelColumn);
+            pd.setSourceOntology(_sourceOntology);
+            pd.setConceptSubtree(_conceptSubtree);
 
             return pd;
         }
@@ -652,6 +669,58 @@ public class ImportTypesHelper
         public void setDefaultValue(String defaultValue)
         {
             _defaultValue = defaultValue;
+        }
+
+
+        // interface MutableColumnConceptProperties
+        public String getPrincipalConceptCode()
+        {
+            return _principalConceptCode;
+        }
+
+        public void setPrincipalConceptCode(String principalConceptCode)
+        {
+            this._principalConceptCode = principalConceptCode;
+        }
+
+        public String getConceptImportColumn()
+        {
+            return _conceptImportColumn;
+        }
+
+        public void setConceptImportColumn(String conceptImportColumn)
+        {
+            this._conceptImportColumn = conceptImportColumn;
+        }
+
+        public String getConceptLabelColumn()
+        {
+            return _conceptLabelColumn;
+        }
+
+        public void setConceptLabelColumn(String conceptLabelColumn)
+        {
+            this._conceptLabelColumn = conceptLabelColumn;
+        }
+
+        public String getSourceOntology()
+        {
+            return _sourceOntology;
+        }
+
+        public void setSourceOntology(String sourceOntology)
+        {
+            this._sourceOntology = sourceOntology;
+        }
+
+        public String getConceptSubtree()
+        {
+            return _conceptSubtree;
+        }
+
+        public void setConceptSubtree(String conceptSubtree)
+        {
+            this._conceptSubtree = conceptSubtree;
         }
 
         private String convertNumberFormatChars(String format)

--- a/api/src/org/labkey/api/exp/property/DomainProperty.java
+++ b/api/src/org/labkey/api/exp/property/DomainProperty.java
@@ -22,6 +22,7 @@ import org.labkey.api.data.ConditionalFormat;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ImportAliasable;
 import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.MutableColumnConceptProperties;
 import org.labkey.api.data.PHI;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
@@ -32,7 +33,7 @@ import org.labkey.api.gwt.client.FacetingBehaviorType;
 import java.util.List;
 import java.util.Set;
 
-public interface DomainProperty extends ImportAliasable
+public interface DomainProperty extends ImportAliasable, MutableColumnConceptProperties
 {
     int getPropertyId();
     Container getContainer();
@@ -127,15 +128,20 @@ public interface DomainProperty extends ImportAliasable
      */
     void setSchemaImport(boolean isSchemaImport);
 
+    @Override
     void setPrincipalConceptCode(String code);
     String getPrincipalConceptCode();
     String getSourceOntology();
+    @Override
     void setSourceOntology(String sourceOntology);
     String getConceptSubtree();
+    @Override
     void setConceptSubtree(String path);
     String getConceptImportColumn();
+    @Override
     void setConceptImportColumn(String conceptImportColumn);
     String getConceptLabelColumn();
+    @Override
     void setConceptLabelColumn(String conceptLabelColumn);
 
     void setDerivationDataScope(String type);

--- a/api/src/org/labkey/api/ontology/OntologyService.java
+++ b/api/src/org/labkey/api/ontology/OntologyService.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnRenderProperties;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.MutableColumnRenderProperties;
+import org.labkey.api.data.MutableColumnConceptProperties;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.exp.property.DomainProperty;
@@ -48,11 +48,11 @@ public interface OntologyService
         ServiceRegistry.get().registerService(OntologyService.class, impl);
     }
 
-    void parseXml(ColumnType xmlCol, MutableColumnRenderProperties col);
+    void parseXml(ColumnType xmlCol, MutableColumnConceptProperties col);
 
     void writeXml(ColumnRenderProperties col, ColumnType colXml);
 
-    void parseXml(PropertyDescriptorType xmlProp, DomainProperty domainProp);
+    void parseXml(PropertyDescriptorType xmlProp, MutableColumnConceptProperties domainProp);
 
     void writeXml(DomainProperty domainProp, PropertyDescriptorType xProp);
 

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -535,17 +535,20 @@ public class SearchController extends SpringActionController
 
             SearchService.IndexTask task = null;
 
-            if (full)
+            try (var x = SpringActionController.ignoreSqlUpdates())
             {
-                ss.indexFull(true);
-            }
-            else if (since)
-            {
-                task = ss.indexContainer(null, getContainer(), new Date(System.currentTimeMillis()- TimeUnit.DAYS.toMillis(1)));
-            }
-            else
-            {
-                task = ss.indexContainer(null, getContainer(), null);
+                if (full)
+                {
+                    ss.indexFull(true);
+                }
+                else if (since)
+                {
+                    task = ss.indexContainer(null, getContainer(), new Date(System.currentTimeMillis()- TimeUnit.DAYS.toMillis(1)));
+                }
+                else
+                {
+                    task = ss.indexContainer(null, getContainer(), null);
+                }
             }
 
             if (wait && null != task)


### PR DESCRIPTION
#### Rationale
Fix bug reported by customer.  concept related column attributes did not round trip in list archive.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/2700
https://github.com/LabKey/ontology/pull/58

#### Changes
* Add not-set checks to export to avoid xml validation error
* Update ImportTypesHelper to support concept related attributes
* introduce MutableColumnConceptProperties to avoid repetitive code