### PR TITLE
Issue 44141: Move test-csrf.api to login-csrf.api

### DIFF
--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -2754,6 +2754,26 @@ public class LoginController extends SpringActionController
         }
     }
 
+
+    /**
+     * Simple action for verifying proper CSRF token handling from external scripts and programs. Referenced in the
+     * HTTP Interface docs: https://www.labkey.org/Documentation/wiki-page.view?name=remoteAPIs
+     */
+    @SuppressWarnings("unused")
+    @RequiresNoPermission
+    @CSRF(CSRF.Method.ALL)
+    public static class CsrfAction extends ReadOnlyApiAction
+    {
+        @Override
+        public ApiResponse execute(Object o, BindException errors)
+        {
+            ApiSimpleResponse res = new ApiSimpleResponse();
+            res.put("success", true);
+            return res;
+        }
+    }
+
+
     public static class TestCase extends AbstractActionPermissionTest
     {
         @Override


### PR DESCRIPTION
#### Rationale
see Issue 44141: Move test-csrf.api to login-csrf.api 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
