### PR TITLE
Item 9544: Restrict operations for selections of samples based on status

### DIFF
--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -91,6 +91,7 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -893,13 +894,16 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
                                    String role,
                                    @NotNull Set<Container> searchContainers,
                                    @Nullable ExpSampleType st,
-                                   @NotNull Map<Integer, ExpMaterial> materialCache)
+                                   @NotNull Map<Integer, ExpMaterial> materialCache) throws ExperimentException
     {
         final Container c = context.getContainer();
         final User user = context.getUser();
         ExpMaterial material = materialCache.computeIfAbsent(sampleRowId, (x) -> ExperimentService.get().getExpMaterial(c, user, sampleRowId, null));
+
         if (material != null && !resolved.containsKey(material) && searchContainers.contains(material.getContainer()))
         {
+            if (!material.isOperationPermitted(SampleTypeService.SampleOperations.AddAssayData))
+                throw new ExperimentException(SampleTypeService.get().getOperationNotPermittedMessage(Collections.singleton(material), SampleTypeService.SampleOperations.AddAssayData));
             if (st == null || st.getLSID().equals(material.getCpasType()))
                 resolved.put(material, role);
         }

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -53,7 +53,6 @@ public interface SampleTypeService
         UpdateStorageMetadata("updating storage metadata"),
         RemoveFromStorage("removing from storage"),
         AddToPicklist("adding to a picklist"),
-        RemoveFromPicklist("removing from a picklist"),
         Delete("deleting"),
         AddToWorkflow("adding to a workflow"),
         RemoveFromWorkflow("removing from a workflow"),

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -369,7 +369,7 @@ public class ExpSchema extends AbstractExpSchema
                 SampleTypeService.SampleOperations.RecallFromStudy
         )),
         Locked(Set.of(
-                SampleTypeService.SampleOperations.AddToPicklist,
+                SampleTypeService.SampleOperations.AddToPicklist
         ));
 
         Set<SampleTypeService.SampleOperations> _permittedOps;

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -361,7 +361,6 @@ public class ExpSchema extends AbstractExpSchema
                 SampleTypeService.SampleOperations.EditLineage,
                 SampleTypeService.SampleOperations.RemoveFromStorage,
                 SampleTypeService.SampleOperations.AddToPicklist,
-                SampleTypeService.SampleOperations.RemoveFromPicklist,
                 SampleTypeService.SampleOperations.Delete,
                 SampleTypeService.SampleOperations.AddToWorkflow,
                 SampleTypeService.SampleOperations.RemoveFromWorkflow,
@@ -371,7 +370,6 @@ public class ExpSchema extends AbstractExpSchema
         )),
         Locked(Set.of(
                 SampleTypeService.SampleOperations.AddToPicklist,
-                SampleTypeService.SampleOperations.RemoveFromPicklist
         ));
 
         Set<SampleTypeService.SampleOperations> _permittedOps;

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1481,7 +1481,7 @@
     },
     "@labkey/api": {
       "version": "1.6.7",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz",
       "integrity": "sha1-IL/ynYviKDi8Ik1jZUPdCazpr9I="
     },
     "@labkey/build": {

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -867,7 +867,7 @@ public class ExpDataIterators
                             continue;
 
                         if (_isSample && !((ExpMaterial) runItem).isOperationPermitted(SampleTypeService.SampleOperations.EditLineage))
-                            throw new ValidationException(String.format("Sample %s with status %s cannot be have its lineage updated.", runItem.getName(), ((ExpMaterial) runItem).getStateLabel()));
+                            throw new ValidationException(String.format("Sample %s with status %s cannot have its lineage updated.", runItem.getName(), ((ExpMaterial) runItem).getStateLabel()));
 
                         // the parent columns provided in the input are all empty and there are no existing parents not mentioned in the input that need to be retained.
                         if (_isSample && _context.getInsertOption().mergeRows && pair.first.doClear())

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4109,24 +4109,23 @@ public class ExperimentServiceImpl implements ExperimentService
         new SqlExecutor(getSchema()).execute("DELETE FROM exp.ProtocolInput WHERE ProtocolId IN (" + protocolIdsInClause + ")");
     }
 
-    public static Map<String, Collection<Map<String, Object>>> partitionRequestedDeleteObjects(List<Integer> deleteRequest, List<Integer> cannotDelete, List<? extends ExpRunItem> allData)
+    public static Map<String, Collection<Map<String, Object>>> partitionRequestedOperationObjects(Collection<Integer> requestIds, List<Integer> notPermittedIds, List<? extends ExpRunItem> allData)
     {
-        // start with all of them marked as deletable.  As we find evidence to the contrary, we will remove from the deleteRequest set.
-        deleteRequest.removeAll(cannotDelete);
-        List<Map<String, Object>> canDeleteRows = new ArrayList<>();
-        List<Map<String, Object>> cannotDeleteRows = new ArrayList<>();
+        List<Integer> permittedIds = new ArrayList<>(requestIds);
+        permittedIds.removeAll(notPermittedIds);
+        List<Map<String, Object>> allowedRows = new ArrayList<>();
+        List<Map<String, Object>> notAllowedRows = new ArrayList<>();
         allData.forEach((dataObject) -> {
             Map<String, Object> rowMap = Map.of("RowId", dataObject.getRowId(), "Name", dataObject.getName());
-            if (deleteRequest.contains(dataObject.getRowId()))
-                canDeleteRows.add(rowMap);
+            if (permittedIds.contains(dataObject.getRowId()))
+                allowedRows.add(rowMap);
             else
-                cannotDeleteRows.add(rowMap);
+                notAllowedRows.add(rowMap);
         });
 
-
         Map<String, Collection<Map<String, Object>>> partitionedIds = new HashMap<>();
-        partitionedIds.put("canDelete", canDeleteRows);
-        partitionedIds.put("cannotDelete", cannotDeleteRows);
+        partitionedIds.put("allowed", allowedRows);
+        partitionedIds.put("notAllowed", notAllowedRows);
         return partitionedIds;
     }
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -338,7 +338,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         // had a locked status before and either not updating the status or updating to a new locked status
         if (hasNonStatusChange && !oldAllowsOp && (newStatus == null || !newAllowsOp))
         {
-            throw new ValidationException(String.format("Updating sample metadata when status is '%s' is not allowed.", oldStatus.getLabel()));
+            throw new ValidationException(String.format("Updating sample data when status is '%s' is not allowed.", oldStatus.getLabel()));
         }
 
         keys = new Object[]{lsid};

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -338,7 +338,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         // had a locked status before and either not updating the status or updating to a new locked status
         if (hasNonStatusChange && !oldAllowsOp && (newStatus == null || !newAllowsOp))
         {
-            throw new ValidationException(String.format("Updating sample data when status is '%s' is not allowed.", oldStatus.getLabel()));
+            throw new ValidationException(String.format("Updating sample data when status is %s is not allowed.", oldStatus.getLabel()));
         }
 
         keys = new Object[]{lsid};

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3294,9 +3294,9 @@ public class ExperimentController extends SpringActionController
         public void validateForm(OperationConfirmationForm form, Errors errors)
         {
             if (form.getDataRegionSelectionKey() == null && form.getRowIds() == null)
-                errors.reject(ERROR_REQUIRED, "You must provide either a set of rowIds or a dataRegionSelectionKey");
+                errors.reject(ERROR_REQUIRED, "You must provide either a set of rowIds or a dataRegionSelectionKey.");
             if (form.getSampleOperation() == null)
-                errors.reject(ERROR_REQUIRED, "An operation type must be provided");
+                errors.reject(ERROR_REQUIRED, "An operation type must be provided.");
         }
 
         @Override

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3250,40 +3250,7 @@ public class ExperimentController extends SpringActionController
 
             List<Integer> cannotDelete = ExperimentServiceImpl.get().getDataUsedAsInput(deleteForm.getIds(false));
 
-            return success(ExperimentServiceImpl.partitionRequestedDeleteObjects(deleteRequest, cannotDelete, allData));
-        }
-    }
-
-
-    @Marshal(Marshaller.Jackson)
-    @RequiresPermission(DeletePermission.class)
-    public class GetMaterialDeleteConfirmationDataAction extends ReadOnlyApiAction<DeleteConfirmationForm>
-    {
-        @Override
-        public void validateForm(DeleteConfirmationForm deleteForm, Errors errors)
-        {
-            if (deleteForm.getDataRegionSelectionKey() == null && deleteForm.getRowIds() == null)
-                errors.reject(ERROR_REQUIRED, "You must provide either a set of rowIds or a dataRegionSelectionKey");
-        }
-
-        @Override
-        public Object execute(DeleteConfirmationForm deleteForm, BindException errors)
-        {
-            // start with all of them marked as deletable.  As we find evidence to the contrary, we will remove from this set.
-            Set<Integer> deletable = deleteForm.getIds(false);
-            List<Integer> deleteRequest = new ArrayList<>(deletable);
-            ExperimentServiceImpl service = ExperimentServiceImpl.get();
-            List<? extends ExpMaterial> allMaterials = service.getExpMaterials(deleteRequest);
-
-            List<Integer> cannotDelete = service.getMaterialsUsedAsInput(deleteForm.getIds(false));
-            if (SampleTypeService.isSampleStatusEnabled())
-                cannotDelete.addAll(service.findIdsNotPermittedForOperation(allMaterials, SampleTypeService.SampleOperations.Delete));
-            Map<String, Collection<Map<String, Object>>> response = ExperimentServiceImpl.partitionRequestedDeleteObjects(deleteRequest, cannotDelete, allMaterials);
-
-            // String 'associatedDatasets' must be synced to its handling in confirmDelete.js, confirmDelete()
-            response.put("associatedDatasets", ExperimentServiceImpl.includeLinkedToStudyText(allMaterials, deletable, getUser(), getContainer()));
-
-            return success(response);
+            return success(ExperimentServiceImpl.partitionRequestedOperationObjects(deleteRequest, cannotDelete, allData));
         }
     }
 
@@ -3315,6 +3282,59 @@ public class ExperimentController extends SpringActionController
         public Set<Integer> getIds(boolean clear)
         {
             return (_rowIds != null) ? _rowIds : DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
+        }
+    }
+
+
+    @Marshal(Marshaller.Jackson)
+    @RequiresPermission(ReadPermission.class)
+    public class GetMaterialOperationConfirmationDataAction extends ReadOnlyApiAction<OperationConfirmationForm>
+    {
+        @Override
+        public void validateForm(OperationConfirmationForm form, Errors errors)
+        {
+            if (form.getDataRegionSelectionKey() == null && form.getRowIds() == null)
+                errors.reject(ERROR_REQUIRED, "You must provide either a set of rowIds or a dataRegionSelectionKey");
+            if (form.getSampleOperation() == null)
+                errors.reject(ERROR_REQUIRED, "An operation type must be provided");
+        }
+
+        @Override
+        public Object execute(OperationConfirmationForm form, BindException errors)
+        {
+            Set<Integer> requestIds = form.getIds(false);
+            ExperimentServiceImpl service = ExperimentServiceImpl.get();
+            List<? extends ExpMaterial> allMaterials = service.getExpMaterials(requestIds);
+
+            List<Integer> notPermittedIds = new ArrayList<>();
+            // We prevent deletion if a sample is used as a parent or has assay data
+            if (form.getSampleOperation() == SampleTypeService.SampleOperations.Delete)
+                notPermittedIds = service.getMaterialsUsedAsInput(requestIds);
+
+            if (SampleTypeService.isSampleStatusEnabled())
+                notPermittedIds.addAll(service.findIdsNotPermittedForOperation(allMaterials, form.getSampleOperation()));
+
+            Map<String, Collection<Map<String, Object>>> response = ExperimentServiceImpl.partitionRequestedOperationObjects(requestIds, notPermittedIds, allMaterials);
+            if (form.getSampleOperation() == SampleTypeService.SampleOperations.Delete)
+                // String 'associatedDatasets' must be synced to its handling in confirmDelete.js, confirmDelete()
+                response.put("associatedDatasets", ExperimentServiceImpl.includeLinkedToStudyText(allMaterials, requestIds, getUser(), getContainer()));
+
+            return success(response);
+        }
+    }
+
+    public static class OperationConfirmationForm extends DeleteConfirmationForm
+    {
+        private SampleTypeService.SampleOperations _sampleOperation;
+
+        public SampleTypeService.SampleOperations getSampleOperation()
+        {
+            return _sampleOperation;
+        }
+
+        public void setSampleOperation(SampleTypeService.SampleOperations sampleOperation)
+        {
+            _sampleOperation = sampleOperation;
         }
     }
 

--- a/experiment/webapp/experiment/confirmDelete.js
+++ b/experiment/webapp/experiment/confirmDelete.js
@@ -90,7 +90,7 @@ LABKEY.experiment.confirmDelete = function(dataRegionName, schemaName, queryName
                             Ext4.Msg.hide();
                         }
                         else if (btn === 'ok') {
-                            const canDelete = response.data.canDelete;
+                            const canDelete = response.data.allowed;
                             Ext4.Ajax.request({
                                 url: LABKEY.ActionURL.buildURL('query', 'deleteRows'),
                                 method: 'POST',

--- a/experiment/webapp/experiment/confirmDelete.js
+++ b/experiment/webapp/experiment/confirmDelete.js
@@ -7,15 +7,16 @@ LABKEY.experiment.confirmDelete = function(dataRegionName, schemaName, queryName
         msg: "Loading ..."
     });
     Ext4.Ajax.request({
-        url: LABKEY.ActionURL.buildURL('experiment', "getMaterialDeleteConfirmationData.api", LABKEY.containerPath, {
-            dataRegionSelectionKey: selectionKey
+        url: LABKEY.ActionURL.buildURL('experiment', "getMaterialOperationConfirmationData.api", LABKEY.containerPath, {
+            dataRegionSelectionKey: selectionKey,
+            sampleOperation: 'Delete',
         }),
         method: "GET",
         success: LABKEY.Utils.getCallbackWrapper(function(response) {
             loadingMsg.hide();
             if (response.success) {
-                var numCanDelete = response.data.canDelete.length;
-                var numCannotDelete = response.data.cannotDelete.length;
+                var numCanDelete = response.data.allowed.length;
+                var numCannotDelete = response.data.notAllowed.length;
                 var associatedDatasets = response.data.associatedDatasets;
                 var associatedDatasetsLength = associatedDatasets.length;
                 var canDeleteNoun = numCanDelete === 1 ? nounSingular : nounPlural;


### PR DESCRIPTION
#### Rationale
We are adding support for samples having status values that will restrict the types of operations that can be done on the samples.  The changes here are to support restrictions and warnings when a user has selected a number of samples that  may have different statuses, so we generalize the method we previously had for confirming deletion of samples to cover other types of operations as well.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/654
* https://github.com/LabKey/biologics/pull/1030
* https://github.com/LabKey/inventory/pull/325
* https://github.com/LabKey/sampleManagement/pull/728

#### Changes
* Add status check for adding assay data for samples that are either run or batch properties
* Remove RemoveFromPicklist operation since all samples can be removed from picklists and it seems unlikely we would restrict this. 
* Generalize and rename `GetMaterialDeleteConfirmationDataAction` and its relatives to apply to all operations
