### PR TITLE
Add Support for WorkflowTask to ImportRunApiAction

### DIFF
--- a/api/src/org/labkey/api/assay/AssayRunDatabaseContext.java
+++ b/api/src/org/labkey/api/assay/AssayRunDatabaseContext.java
@@ -25,6 +25,7 @@ import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.api.ExpProtocolApplication;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
@@ -119,6 +120,15 @@ public class AssayRunDatabaseContext<ProviderType extends AssayProvider> impleme
     public String getName()
     {
         return _run.getName();
+    }
+
+    @Override
+    public Integer getWorkflowTask()
+    {
+        if (_run.getWorkflowTask() != null)
+            return _run.getWorkflowTask().getRowId();
+
+        return null;
     }
 
     @Override

--- a/api/src/org/labkey/api/assay/AssayRunUploadContext.java
+++ b/api/src/org/labkey/api/assay/AssayRunUploadContext.java
@@ -65,7 +65,10 @@ public interface AssayRunUploadContext<ProviderType extends AssayProvider> exten
 
     String getName();
 
-    Integer getWorkflowTask();
+    @Nullable
+    default Integer getWorkflowTask() {
+        return null;
+    };
 
     @Override
     User getUser();

--- a/api/src/org/labkey/api/assay/AssayRunUploadContext.java
+++ b/api/src/org/labkey/api/assay/AssayRunUploadContext.java
@@ -65,6 +65,8 @@ public interface AssayRunUploadContext<ProviderType extends AssayProvider> exten
 
     String getName();
 
+    Integer getWorkflowTask();
+
     @Override
     User getUser();
 
@@ -204,6 +206,7 @@ public interface AssayRunUploadContext<ProviderType extends AssayProvider> exten
         protected ViewContext _context;
         protected String _comments;
         protected String _name;
+        protected Integer _workflowTask;
         protected String _targetStudy;
         protected Integer _reRunId;
         protected Map<String, Object> _rawRunProperties;
@@ -261,6 +264,12 @@ public interface AssayRunUploadContext<ProviderType extends AssayProvider> exten
         public final FACTORY setName(String name)
         {
             _name = name;
+            return self();
+        }
+
+        public final FACTORY setWorkflowTask(Integer workflowTask)
+        {
+            _workflowTask = workflowTask;
             return self();
         }
 

--- a/api/src/org/labkey/api/assay/AssayRunUploadContextImpl.java
+++ b/api/src/org/labkey/api/assay/AssayRunUploadContextImpl.java
@@ -68,6 +68,7 @@ public class AssayRunUploadContextImpl<ProviderType extends AssayProvider> imple
     private final ViewContext _context;
     private final String _comments;
     private final String _name;
+    private final Integer _workflowTask;
     private final String _targetStudy;
     private final Integer _reRunId;
     private final Map<String, Object> _rawRunProperties;
@@ -104,6 +105,7 @@ public class AssayRunUploadContextImpl<ProviderType extends AssayProvider> imple
         _logger = factory._logger;
 
         _name = factory._name;
+        _workflowTask = factory._workflowTask;
         _comments = factory._comments;
 
         _rawRunProperties = factory._rawRunProperties == null ? emptyMap() : unmodifiableMap(factory._rawRunProperties);
@@ -266,6 +268,12 @@ public class AssayRunUploadContextImpl<ProviderType extends AssayProvider> imple
     public String getName()
     {
         return _name;
+    }
+
+    @Override
+    public Integer getWorkflowTask()
+    {
+        return _workflowTask;
     }
 
     @Override

--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -156,6 +156,7 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
             File primaryFile = context.getUploadedData().get(AssayDataCollector.PRIMARY_FILE);
             run = AssayService.get().createExperimentRun(context.getName(), context.getContainer(), protocol, primaryFile);
             run.setComments(context.getComments());
+            run.setWorkflowTaskId(context.getWorkflowTask());
 
             exp = saveExperimentRun(context, exp, run, false);
 

--- a/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
+++ b/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
@@ -92,6 +92,7 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
     protected Map<DomainProperty, String> _runProperties = null;
     private String _comments;
     private String _name;
+    private Integer _workflowTask;
     private String _dataCollectorName;
     private boolean _multiRunUpload;
     private String _uploadStep;
@@ -198,6 +199,17 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
     public void setName(String name)
     {
         _name = name;
+    }
+
+    @Override
+    public Integer getWorkflowTask()
+    {
+        return _workflowTask;
+    }
+
+    public void setWorkflowTask(Integer workflowTask)
+    {
+        _workflowTask = workflowTask;
     }
 
     public String getDataCollectorName()

--- a/api/src/org/labkey/api/assay/pipeline/AssayRunAsyncContext.java
+++ b/api/src/org/labkey/api/assay/pipeline/AssayRunAsyncContext.java
@@ -61,6 +61,7 @@ public class AssayRunAsyncContext<ProviderType extends AssayProvider> implements
     private String _containerId;
     private String _runName;
     private String _runComments;
+    private Integer _runWorkflowTask;
     private ActionURL _actionURL;
     private Map<String, File> _uploadedData;
     /** propertyId -> value */
@@ -105,6 +106,7 @@ public class AssayRunAsyncContext<ProviderType extends AssayProvider> implements
         _targetStudy = originalContext.getTargetStudy();
         _runName = originalContext.getName();
         _runComments = originalContext.getComments();
+        _runWorkflowTask = originalContext.getWorkflowTask();
         _container = originalContext.getContainer();
         if (_container != null)
             _containerId = _container.getId();
@@ -285,6 +287,12 @@ public class AssayRunAsyncContext<ProviderType extends AssayProvider> implements
     public String getName()
     {
         return _runName;
+    }
+
+    @Override
+    public Integer getWorkflowTask()
+    {
+        return _runWorkflowTask;
     }
 
     @Override

--- a/api/src/org/labkey/api/exp/api/ExperimentJSONConverter.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentJSONConverter.java
@@ -71,6 +71,7 @@ public class ExperimentJSONConverter
     public static final String MODIFIED = "modified";
     public static final String MODIFIED_BY = "modifiedBy";
     public static final String NAME = "name";
+    public static final String WORKFLOW_TASK = "workflowTask";
     public static final String LSID = "lsid";
     public static final String CPAS_TYPE = "cpasType";
     // Matches the expType parameter used in the linage api: "Data", "Material", "ExperimentRun", "Object"

--- a/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
+++ b/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
@@ -1231,6 +1231,12 @@ public class TsvDataExchangeHandler implements DataExchangeHandler
         }
 
         @Override
+        public Integer getWorkflowTask()
+        {
+            return null;
+        }
+
+        @Override
         public User getUser()
         {
             return _context.getUser();

--- a/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
+++ b/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
@@ -90,6 +90,7 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
 
         Integer batchId;
         String name;
+        Integer workflowTask;
         String comments;
         Map<String, Object> runProperties;
         Map<String, Object> batchProperties;
@@ -126,6 +127,9 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
 
             batchId = json.optInt(AssayJSONConverter.BATCH_ID);
             name = json.optString(ExperimentJSONConverter.NAME, null);
+            workflowTask = json.optInt(ExperimentJSONConverter.WORKFLOW_TASK);
+            if (workflowTask == 0)
+                workflowTask = null;
             comments = json.optString(ExperimentJSONConverter.COMMENT, null);
             forceAsync = json.optBoolean("forceAsync");
             jobDescription = json.optString("jobDescription", null);
@@ -157,6 +161,7 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
 
             batchId = form.getBatchId();
             name = form.getName();
+            workflowTask = form.getWorkflowTask();
             comments = form.getComment();
             runProperties = form.getProperties();
             batchProperties = form.getBatchProperties();
@@ -216,6 +221,7 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
         AssayRunUploadContext.Factory<? extends AssayProvider, ? extends AssayRunUploadContext.Factory> factory
                 = provider.createRunUploadFactory(protocol, getViewContext());
         factory.setName(name)
+                .setWorkflowTask(workflowTask)
                 .setComments(comments)
                 .setRunProperties(runProperties)
                 .setBatchProperties(batchProperties)
@@ -333,6 +339,7 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
         private String _comment;
         private JSONObject _json;
         private String _name;
+        private Integer _workflowTask;
         private Integer _reRunId;
         private String _targetStudy;
         private Map<String, Object> _properties = new HashMap<>();
@@ -386,6 +393,16 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
         public void setName(String name)
         {
             _name = name;
+        }
+
+        public Integer getWorkflowTask()
+        {
+            return _workflowTask;
+        }
+
+        public void setWorkflowTask(Integer workflowTask)
+        {
+            _workflowTask = workflowTask;
         }
 
         public String getComment()

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -1481,7 +1481,7 @@
     },
     "@labkey/api": {
       "version": "1.6.7",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz",
+      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.7.tgz",
       "integrity": "sha1-IL/ynYviKDi8Ik1jZUPdCazpr9I="
     },
     "@labkey/build": {


### PR DESCRIPTION
#### Rationale
Workflow Task can be set via updateRows since my last PR, however it was not properly wired up to get set during assay import, which is where it is needed. This PR adds a workflowTask param to the ImportAPIAction.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/113

#### Changes
* Add Support for WorkflowTask to ImportRunApiAction
