### PR TITLE
Show error message if study/folder/list export-to-zip process fails

### DIFF
--- a/api/src/org/labkey/api/writer/ZipFile.java
+++ b/api/src/org/labkey/api/writer/ZipFile.java
@@ -93,7 +93,7 @@ public class ZipFile extends AbstractVirtualFile
         return new BufferedOutputStream(fos);
     }
 
-    private static OutputStream getOutputStream(HttpServletResponse response, String name) throws IOException
+    public static OutputStream getOutputStream(HttpServletResponse response, String name) throws IOException
     {
         response.setContentType("application/zip");
         response.setHeader("Content-Disposition", "attachment; filename=\"" + _makeLegalName(name) + "\";");

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -4371,7 +4371,7 @@ public class AdminController extends SpringActionController
                     {
                         ContainerManager.checkContainerValidity(container); // TODO: Why isn't this called in the other two cases?
 
-                        // Export to a temporary file first so any exceptions are displayed by the standard error page, Issue #44152
+                        // Export to a temporary file first so exceptions are displayed by the standard error page, Issue #44152
                         // Same pattern as ExportListArchiveAction
                         Path tempDir = FileUtil.getTempDirectory().toPath();
                         Path tempZipFile = exportFolderToFile(tempDir, container, writer, ctx, errors);

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -4329,10 +4329,9 @@ public class AdminController extends SpringActionController
                     form.getFormat(), form.isIncludeSubfolders(), form.getExportPhiLevel(), form.isShiftDates(),
                     form.isAlternateIds(), form.isMaskClinic(), new StaticLoggerGetter(LogManager.getLogger(FolderWriterImpl.class)));
 
-            switch(form.getLocation())
+            switch (form.getLocation())
             {
-                case 0:
-                {
+                case 0 -> {
                     PipeRoot root = PipelineService.get().findPipelineRoot(container);
                     if (root == null || !root.isValid())
                     {
@@ -4349,16 +4348,14 @@ public class AdminController extends SpringActionController
                         {
                             writer.write(container, ctx, new FileSystemFile(exportDir));
                         }
-                        catch (Container.ContainerException e)
+                        catch (ContainerException e)
                         {
                             errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
                         }
                         _successURL = urlProvider(PipelineUrls.class).urlBrowse(container);
                     }
-                    break;
                 }
-                case 1:
-                {
+                case 1 -> {
                     PipeRoot root = PipelineService.get().findPipelineRoot(container);
                     if (root == null || !root.isValid())
                     {
@@ -4368,31 +4365,31 @@ public class AdminController extends SpringActionController
                     Files.createDirectories(exportDir);
                     exportFolderToFile(exportDir, container, writer, ctx, errors);
                     _successURL = urlProvider(PipelineUrls.class).urlBrowse(container);
-                    break;
                 }
-                case 2:
-                {
+                case 2 -> {
                     try
                     {
                         ContainerManager.checkContainerValidity(container); // TODO: Why isn't this called in the other two cases?
 
-                        // Export to a temporary file first so any exceptions can be displayed to the user, Issue #44152
+                        // Export to a temporary file first so any exceptions are displayed by the standard error page, Issue #44152
+                        // Same pattern as ExportListArchiveAction
                         Path tempDir = FileUtil.getTempDirectory().toPath();
                         Path tempZipFile = exportFolderToFile(tempDir, container, writer, ctx, errors);
 
-                        // No exceptions, so stream the resulting zip file to the browser
+                        // No exceptions, so stream the resulting zip file to the browser and delete it
                         try (OutputStream os = ZipFile.getOutputStream(getViewContext().getResponse(), tempZipFile.getFileName().toString()))
                         {
                             Files.copy(tempZipFile, os);
                         }
-
-                        Files.delete(tempZipFile);
+                        finally
+                        {
+                            Files.delete(tempZipFile);
+                        }
                     }
-                    catch (Container.ContainerException e)
+                    catch (ContainerException e)
                     {
                         errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
                     }
-                    break;
                 }
             }
 
@@ -4402,6 +4399,7 @@ public class AdminController extends SpringActionController
         private Path exportFolderToFile(Path exportDir, Container container, FolderWriterImpl writer, FolderExportContext ctx, BindException errors) throws Exception
         {
             String filename = FileUtil.makeFileNameWithTimestamp(container.getName(), "folder.zip");
+
             try (ZipFile zip = new ZipFile(exportDir, filename))
             {
                 writer.write(container, ctx, zip);

--- a/core/src/org/labkey/core/admin/view/upgradeCode.jsp
+++ b/core/src/org/labkey/core/admin/view/upgradeCode.jsp
@@ -12,7 +12,7 @@
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     Class<?>[] params = new Class[]{ModuleContext.class};
-    Map<String, String> methodMap = new TreeMap<>();
+    Map<String, String> methodMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     ModuleLoader.getInstance().getModules().forEach(module -> {
         UpgradeCode code = module.getUpgradeCode();
         if (null != code)

--- a/devtools/src/org/labkey/devtools/ToolsController.java
+++ b/devtools/src/org/labkey/devtools/ToolsController.java
@@ -434,7 +434,7 @@ public class ToolsController extends SpringActionController
                                         public boolean string(int beginIndex, int endIndex)
                                         {
                                             String s = code.substring(beginIndex + 1, endIndex - 1);
-                                            if (s.length() > 4 && s.endsWith(".jsp"))
+                                            if (s.length() > 4 && s.contains("/") && s.endsWith(".jsp"))
                                                 ret.add(s);
                                             return true;
                                         }

--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -976,7 +976,7 @@ public class ListController extends SpringActionController
             ctx.setListIds(IDs);
             ListWriter writer = new ListWriter();
 
-            // Export to a temporary file first so any exceptions are displayed by the standard error page, Issue #44152
+            // Export to a temporary file first so exceptions are displayed by the standard error page, Issue #44152
             // Same pattern as ExportFolderAction
             Path tempDir = FileUtil.getTempDirectory().toPath();
             String filename = FileUtil.makeFileNameWithTimestamp(c.getName(), "lists.zip");

--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -130,6 +130,9 @@ import org.springframework.web.servlet.ModelAndView;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -973,9 +976,26 @@ public class ListController extends SpringActionController
             ctx.setListIds(IDs);
             ListWriter writer = new ListWriter();
 
-            try (ZipFile zip = new ZipFile(response, FileUtil.makeFileNameWithTimestamp(c.getName(), "lists.zip")))
+            // Export to a temporary file first so any exceptions are displayed by the standard error page, Issue #44152
+            // Same pattern as ExportFolderAction
+            Path tempDir = FileUtil.getTempDirectory().toPath();
+            String filename = FileUtil.makeFileNameWithTimestamp(c.getName(), "lists.zip");
+
+            try (ZipFile zip = new ZipFile(tempDir, filename))
             {
                 writer.write(c, getUser(), zip, ctx);
+            }
+
+            Path tempZipFile = tempDir.resolve(filename);
+
+            // No exceptions, so stream the resulting zip file to the browser and delete it
+            try (OutputStream os = ZipFile.getOutputStream(getViewContext().getResponse(), filename))
+            {
+                Files.copy(tempZipFile, os);
+            }
+            finally
+            {
+                Files.delete(tempZipFile);
             }
         }
     }


### PR DESCRIPTION
#### Rationale
As discussed in [Issue 44152: Stop exporting corrupted archives](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44152), the two "pipeline" options on the folder/study export page will show the error page if an exception occurs during the export process. The "Browser as zip file" option does not show an error page, because it proactively configures the response to stream a zip file; the end result is a corrupted zip file with no warning (other than an exception stack trace in the log).

This change makes the "Browser as zip file" option behave like the pipeline options; if an error occurs during export the user will see a standard error page and the archive won't be sent to the browser. The downside is potential delay between clicking the Export button and seeing the file downloading in the browser. In Chrome, I see a spinner on the browser tab and a "Waiting for cache..." message below where downloads appear, but this may not be enough feedback for some users. We could consider client-side changes to provide better feedback (e.g., disable the Submit button as we do with the pipeline options or display some kind of modal spinny thing). This PR does none of that.

Current commits handle the folder/study export case. Once reviewed and approved, I'll make a similar change for the export list archive case.

#### Changes
* Export folder/study archives to a temporary file before streaming to the browser so export exceptions are presented by our normal error page