### PR TITLE
Add some debug logging to folder type and dataset importers

### DIFF
--- a/core/src/org/labkey/core/admin/importer/FolderTypeImporterFactory.java
+++ b/core/src/org/labkey/core/admin/importer/FolderTypeImporterFactory.java
@@ -38,6 +38,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * User: cnathe
@@ -70,11 +71,13 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
         {
             Container c = ctx.getContainer();
             FolderDocument.Folder folderXml = ctx.getXml();
+            ctx.getLogger().debug("[" + c.getPath() + "] Importing folder properties from: " + root.getLocation());
 
             if (folderXml.isSetDefaultDateFormat())
             {
                 try
                 {
+                    ctx.getLogger().debug("[" + c.getPath() + "] Default date format: " + folderXml.getDefaultDateFormat());
                     WriteableFolderLookAndFeelProperties.saveDefaultDateFormat(c, folderXml.getDefaultDateFormat());
                 }
                 catch (IllegalArgumentException e)
@@ -87,6 +90,7 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
             {
                 try
                 {
+                    ctx.getLogger().debug("[" + c.getPath() + "] Default date-time format: " + folderXml.getDefaultDateTimeFormat());
                     WriteableFolderLookAndFeelProperties.saveDefaultDateTimeFormat(c, folderXml.getDefaultDateTimeFormat());
                 }
                 catch (IllegalArgumentException e)
@@ -97,6 +101,7 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
 
             if (folderXml.isSetRestrictedColumnsEnabled())
             {
+                ctx.getLogger().debug("[" + c.getPath() + "] Restricted columns enabled: " + folderXml.getRestrictedColumnsEnabled());
                 WriteableFolderLookAndFeelProperties.saveRestrictedColumnsEnabled(c, folderXml.getRestrictedColumnsEnabled());
             }
 
@@ -104,6 +109,7 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
             {
                 try
                 {
+                    ctx.getLogger().debug("[" + c.getPath() + "] Default number format: " + folderXml.getDefaultNumberFormat());
                     WriteableFolderLookAndFeelProperties.saveDefaultNumberFormat(c, folderXml.getDefaultNumberFormat());
                 }
                 catch (IllegalArgumentException e)
@@ -116,6 +122,7 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
             {
                 try
                 {
+                    ctx.getLogger().debug("[" + c.getPath() + "] Extra date parsing format: " + folderXml.getExtraDateParsingPattern());
                     WriteableFolderLookAndFeelProperties.saveExtraDateParsingPattern(c, folderXml.getExtraDateParsingPattern());
                 }
                 catch (IllegalArgumentException e)
@@ -124,10 +131,11 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
                 }
             }
 
-            if (folderXml.isSetExtraDateParsingPattern())
+            if (folderXml.isSetExtraDateTimeParsingPattern())
             {
                 try
                 {
+                    ctx.getLogger().debug("[" + c.getPath() + "] Extra date-time parsing format: " + folderXml.getExtraDateTimeParsingPattern());
                     WriteableFolderLookAndFeelProperties.saveExtraDateTimeParsingPattern(c, folderXml.getExtraDateTimeParsingPattern());
                 }
                 catch (IllegalArgumentException e)
@@ -156,18 +164,14 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
 
                 if (null != folderType)
                 {
+                    ctx.getLogger().debug("[" + c.getPath() + "] Folder type: " + folderType.getName());
+                    ctx.getLogger().debug("[" + c.getPath() + "] Active modules: " + activeModules.stream().map(Module::getName).collect(Collectors.joining(", ")));
                     // It's sorta BrandNew, but not really; say it's not and SubImporter will handle container tabs correctly
                     BindException errors = new BindException(new Object(), "dummy");
                     c.setFolderType(folderType, activeModules, ctx.getUser(), errors);
-                    if (errors.hasErrors())
+                    for (ObjectError error : errors.getAllErrors())
                     {
-                        for (Object error : errors.getAllErrors())
-                        {
-                            if (error instanceof ObjectError)
-                                ctx.getLogger().error(((ObjectError)error).getDefaultMessage());
-                            else
-                                ctx.getLogger().error("Unknown error attempting to set folder type or enable modules.");
-                        }
+                        ctx.getLogger().error(error.getDefaultMessage());
                     }
                 }
                 else

--- a/study/src/org/labkey/study/importer/DatasetDefinitionImporter.java
+++ b/study/src/org/labkey/study/importer/DatasetDefinitionImporter.java
@@ -88,6 +88,7 @@ public class DatasetDefinitionImporter implements InternalStudyImporter
                     {
                         try
                         {
+                            ctx.getLogger().debug("[" + c.getPath() + "] Default date format from dataset metadata (obsolete): " + manifestDatasetsXml.getDefaultDateFormat());
                             WriteableFolderLookAndFeelProperties.saveDefaultDateFormat(c, manifestDatasetsXml.getDefaultDateFormat());
                         }
                         catch (IllegalArgumentException e)
@@ -101,6 +102,7 @@ public class DatasetDefinitionImporter implements InternalStudyImporter
                     {
                         try
                         {
+                            ctx.getLogger().debug("[" + c.getPath() + "] Default date format from dataset metadata (obsolete): " + manifestDatasetsXml.getDefaultNumberFormat());
                             WriteableFolderLookAndFeelProperties.saveDefaultNumberFormat(c, manifestDatasetsXml.getDefaultNumberFormat());
                         }
                         catch (IllegalArgumentException e)


### PR DESCRIPTION
#### Rationale
`StudySimpleExportTest` fails intermittently when validating that the default number format is imported correctly.
```
org.junit.ComparisonFailure: expected:<[#.000]> but was:<[]>
  at org.junit.Assert.assertEquals(Assert.java:117)
  at org.junit.Assert.assertEquals(Assert.java:146)
  at org.labkey.test.tests.study.StudySimpleExportTest.verifyDefaultDatasetFormats(StudySimpleExportTest.java:298)
```
The imported `folder.xml` does contain `defaultNumberFormat="#.000"` as expected. Adding debug logging will allow us to verify whether the folder importer is setting that property correctly or, maybe, getting overwritten by the dataset importer.

#### Changes
* Add debug logging to `FolderTypeImporter` and `DatasetDefinitionImporter`
* Fix condition for importing extra date-time pattern
