### PR TITLE
Support additional configuration for exporting subfolders

### DIFF
--- a/api/src/org/labkey/api/admin/ImportContext.java
+++ b/api/src/org/labkey/api/admin/ImportContext.java
@@ -62,7 +62,7 @@ public interface ImportContext<XmlType extends XmlObject> extends ContainerUser
     }
 
     // Used to determine the level of permissions the user needs to have in order to export a subfolder.
-    default Class<? extends Permission> getSubfolderPermission()
+    default Class<? extends Permission> getSubfolderExportPermission()
     {
         return FolderExportPermission.class;
     }

--- a/api/src/org/labkey/api/admin/ImportContext.java
+++ b/api/src/org/labkey/api/admin/ImportContext.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Activity;
 import org.labkey.api.data.PHI;
 import org.labkey.api.gwt.client.AuditBehaviorType;
+import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.api.writer.VirtualFile;
 
@@ -58,6 +59,12 @@ public interface ImportContext<XmlType extends XmlObject> extends ContainerUser
     default AuditBehaviorType getAuditBehaviorType() throws Exception
     {
         return null;
+    }
+
+    // Used to determine the level of permissions the user needs to have in order to export a subfolder.
+    default Class<? extends Permission> getSubfolderPermission()
+    {
+        return FolderExportPermission.class;
     }
 
     // These methods let writers add and get module-specific context information

--- a/api/src/org/labkey/api/admin/SubfolderWriter.java
+++ b/api/src/org/labkey/api/admin/SubfolderWriter.java
@@ -22,6 +22,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.TabContainerType;
 import org.labkey.api.data.WorkbookContainerType;
+import org.labkey.api.exp.XarExportContext;
 import org.labkey.api.writer.VirtualFile;
 import org.labkey.folder.xml.FolderDocument;
 import org.labkey.folder.xml.SubfolderType;
@@ -46,7 +47,7 @@ public class SubfolderWriter extends BaseFolderWriter
     public void write(Container container, ImportContext<FolderDocument.Folder> ctx, VirtualFile vf) throws Exception
     {
         // start with just those child containers that the user has permissions to export.
-        List<Container> allChildren = ContainerManager.getChildren(container, ctx.getUser(), FolderExportPermission.class);
+        List<Container> allChildren = ContainerManager.getChildren(container, ctx.getUser(), ctx.getSubfolderPermission());
         List<Container> childrenToExport = new ArrayList<>();
         getChildrenToExport(ctx, allChildren, childrenToExport);
 
@@ -72,6 +73,11 @@ public class SubfolderWriter extends BaseFolderWriter
                 FolderExportContext childCtx = new FolderExportContext(ctx.getUser(), child, ctx.getDataTypes(), ctx.getFormat(),
                         ctx.isIncludeSubfolders(), ctx.getPhiLevel(), ctx.isShiftDates(), ctx.isAlternateIds(), ctx.isMaskClinic(), ctx.getLoggerGetter());
                 childCtx.setAddExportComment(ctx.isAddExportComment());
+
+                // pass the export context to each subfolder
+                var parentXarCtx = ctx.getContext(XarExportContext.class);
+                if (parentXarCtx != null)
+                    childCtx.addContext(XarExportContext.class, parentXarCtx);
 
                 FolderWriterImpl childFolderWriter = new FolderWriterImpl();
                 childFolderWriter.write(child, childCtx, childDir);

--- a/api/src/org/labkey/api/admin/SubfolderWriter.java
+++ b/api/src/org/labkey/api/admin/SubfolderWriter.java
@@ -47,7 +47,7 @@ public class SubfolderWriter extends BaseFolderWriter
     public void write(Container container, ImportContext<FolderDocument.Folder> ctx, VirtualFile vf) throws Exception
     {
         // start with just those child containers that the user has permissions to export.
-        List<Container> allChildren = ContainerManager.getChildren(container, ctx.getUser(), ctx.getSubfolderPermission());
+        List<Container> allChildren = ContainerManager.getChildren(container, ctx.getUser(), ctx.getSubfolderExportPermission());
         List<Container> childrenToExport = new ArrayList<>();
         getChildrenToExport(ctx, allChildren, childrenToExport);
 

--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -237,7 +237,9 @@ public class DataIteratorUtil
                 var vocabProperties = PropertyService.get().findVocabularyProperties(container, Collections.singleton(from.getColumnName()));
                 if (vocabProperties.size() > 0)
                 {
-                    to = Pair.of(target.getColumn(from.getColumnName()), MatchType.propertyuri);
+                    var propCol = target.getColumn(from.getColumnName());
+                    if (null != propCol)
+                        to = Pair.of(propCol, MatchType.propertyuri);
                 }
             }
             if (null != to && null == to.first)

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -1303,11 +1303,17 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
     }
 
 
-    public int addCoaleseColumn(String name, int fromIndex, Supplier second)
+    public int addCoaleseColumn(String name, int firstIndex, Supplier second)
     {
-        var col = new BaseColumnInfo(_data.getColumnInfo(fromIndex));
+        var col = new BaseColumnInfo(_data.getColumnInfo(firstIndex));
         col.setName(name);
-        return addColumn(col, new CoalesceColumn(fromIndex, second));
+        return addColumn(col, new CoalesceColumn(firstIndex, second));
+    }
+
+
+    public int addCoaleseColumn(String name, int firstIndex, int secondIndex)
+    {
+        return addCoaleseColumn(name, firstIndex, _data.getSupplier(secondIndex));
     }
 
 


### PR DESCRIPTION
#### Rationale
Adds additional configuration for exporting folders in support of what is needed for creating cross-folder ELN data snapshots.

#### Related Pull Requests
* https://github.com/LabKey/labbook/pull/118
* https://github.com/LabKey/biologics/pull/1031
* https://github.com/LabKey/labkey-ui-components/pull/655
* https://github.com/LabKey/platform/pull/2714

#### Changes
* Allow implementors of `ImportContext` to specify the necessary permissions needed to export subfolders. Defaults to `FolderExportPermission`.
* Pass through any `XarExportContext` to subfolders being exported.
* Bug. Prevent `null` being placed into the collection for resolved `ColumnInfo` models coming from Vocabulary properties.
