### PR TITLE
Issue 43252: List import: unable to re-select and submit a file after getting the "could not convert value..." error

### DIFF
--- a/api/src/org/labkey/api/query/import.jsp
+++ b/api/src/org/labkey/api/query/import.jsp
@@ -233,8 +233,16 @@
                     case Ext4.form.Action.CONNECT_FAILURE:
                         if (action.result && (action.result.errors || action.result.exception))
                             serverInvalid(action.result);
-                        else if (action.response && action.response.responseText)
-                            serverInvalid(Ext4.decode(action.response.responseText));
+                        else if (action.response && action.response.responseText) {
+                            var msg;
+                            try {
+                                msg = JSON.parse(action.response.responseText)
+                            }
+                            catch (e) {
+                                msg = {exception: "Server Error: " + action.response.responseText}
+                            }
+                            serverInvalid(msg);
+                        }
                         else
                             Ext4.Msg.alert('Failure', 'Ajax communication failed');
                         break;
@@ -474,7 +482,7 @@
                         name: 'file',
                         buttonText: 'Browse',
                         emptyText: 'Select a file to upload',
-                        clearOnSubmit: false
+                        clearOnSubmit: true
                     },
                     {
                         hideEmptyLabel: false,


### PR DESCRIPTION
#### Rationale
This is getting an IFrame CORS issue when trying to resubmit a file. Not sure if this is new behavior due to updated security by LabKey or browsers, but the fix seems to just be to clear the field after submitting the form. Also updated error message handling for the failure case here.

#### Changes
* Set clearOnSubmit to true for the file field
* Provide alternate if error is not valid JSON
