### PR TITLE
Issue 43523: MetadataUnavailableException - multiple document elements on table name rename

### DIFF
--- a/query/src/org/labkey/query/MetadataTableJSON.java
+++ b/query/src/org/labkey/query/MetadataTableJSON.java
@@ -123,6 +123,12 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
                 throw new MetadataUnavailableException(e.getMessage());
             }
             xmlTable = getTableType(this.getName(), doc);
+            // when there is a queryDef but xmlTable is null it means the xmlMetaData contains tableName which does not
+            // match with actual queryName then reconstruct the xml table metadata : See Issue 43523
+            if (xmlTable == null)
+            {
+                doc = null;
+            }
         }
         else
         {

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1056,7 +1056,8 @@ public class QueryController extends SpringActionController
                                 {
                                     if (!Objects.equals(tableType.getTableName(), form.getQueryName()))
                                     {
-                                        errors.reject(ERROR_MSG, "Table name must not be modified");
+                                        errors.reject(ERROR_MSG, "Table name in the XML metadata must match the table/query name: " + form.getQueryName());
+
                                     }
 
                                     TableType.Columns tableColumns = tableType.getColumns();

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1054,6 +1054,11 @@ public class QueryController extends SpringActionController
                             {
                                 if (null != tableType)
                                 {
+                                    if (!Objects.equals(tableType.getTableName(), form.getQueryName()))
+                                    {
+                                        errors.reject(ERROR_MSG, "Table name must not be modified");
+                                    }
+
                                     TableType.Columns tableColumns = tableType.getColumns();
                                     if (null != tableColumns)
                                     {


### PR DESCRIPTION
#### Rationale
Query metadata editor allows the user to edit the tableName i.e. the queryName or tableName which causes problems when editing columns metadata through visual editor as multiple XML docs get generated one with old table name and one with new table name along with changed column's metadata.

#### Changes
* add error message when tableName attribute is changed in text metadata editor

![Screen Shot 2021-10-25 at 5 58 03 PM](https://user-images.githubusercontent.com/11548616/138791315-286e130e-356e-4c76-b505-cb90381667ae.png)

