### PR TITLE
Remove previously added timestamp to job log filename

### DIFF
--- a/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
+++ b/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
@@ -156,8 +156,7 @@ abstract public class AbstractFileAnalysisJob extends PipelineJob implements Fil
             _baseName = protocol.getBaseName(_filesInput.get(0));
         }
 
-        setupLocalDirectoryAndJobLog(getPipeRoot(), "FileAnalysis", FileUtil.makeFileNameWithTimestamp(_baseName));
-
+        setupLocalDirectoryAndJobLog(getPipeRoot(), "FileAnalysis", _baseName);
 
         // CONSIDER: Remove writing out jobInfo file completely
 //        // Write out job information


### PR DESCRIPTION
#### Rationale
Time stamp causes some retried jobs to fail finding the original log file, so they can't append to it.

#### Related Pull Requests
* https://github.com/LabKey/premium/pull/279

#### Changes
* Remove recently added timestamp to log file's name.