### PR TITLE
Issue 43687: UsersGridPanel update to not default to root container path for site/app admin users

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.87.0-fb-siteUsersGridPanel43687.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.87.0-fb-siteUsersGridPanel43687.0.tgz",
-      "integrity": "sha1-W3kAWEAOyMTo4y8Fv+jWd/eEC14=",
+      "version": "2.88.0-fb-siteUsersGridPanel43687.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.88.0-fb-siteUsersGridPanel43687.0.tgz",
+      "integrity": "sha1-ewrM6iVQ1S/iyloF9sWetJ5TwZ0=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -11435,9 +11435,9 @@
       "integrity": "sha512-uoVmQnZQ+BtKKDKpBdbBri5SLNyIK9ULZGOA504++VbHcwouWE+fJDIo8AuESPF9/EYSkI0v05LDEQK6stCbTA=="
     },
     "redux": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
-      "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
       "requires": {
         "@babel/runtime": "^7.9.2"
       }

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.88.0-fb-siteUsersGridPanel43687.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.88.0-fb-siteUsersGridPanel43687.0.tgz",
-      "integrity": "sha1-ewrM6iVQ1S/iyloF9sWetJ5TwZ0=",
+      "version": "2.88.1",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.88.1.tgz",
+      "integrity": "sha1-cLi5dvchwKJpAkNh3EJJ3RG4QAo=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1210,15 +1210,15 @@
       "dev": true
     },
     "@emotion/cache": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.4.0.tgz",
-      "integrity": "sha512-Zx70bjE7LErRO9OaZrhf22Qye1y4F7iDl+ITjet0J+i+B88PrAOBkKvaAWhxsZf72tDLajwCgfCjJ2dvH77C3g==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.5.0.tgz",
+      "integrity": "sha512-mAZ5QRpLriBtaj/k2qyrXwck6yeoz1V5lMt/jfj6igWU35yYlNKs2LziXVgvH81gnJZ+9QQNGelSsnuoAy6uIw==",
       "requires": {
         "@emotion/memoize": "^0.7.4",
-        "@emotion/sheet": "^1.0.0",
+        "@emotion/sheet": "^1.0.3",
         "@emotion/utils": "^1.0.0",
         "@emotion/weak-memoize": "^0.2.5",
-        "stylis": "^4.0.3"
+        "stylis": "^4.0.10"
       }
     },
     "@emotion/core": {
@@ -1344,14 +1344,14 @@
       "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
     },
     "@emotion/react": {
-      "version": "11.4.1",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.4.1.tgz",
-      "integrity": "sha512-pRegcsuGYj4FCdZN6j5vqCALkNytdrKw3TZMekTzNXixRg4wkLsU5QEaBG5LC6l01Vppxlp7FE3aTHpIG5phLg==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.5.0.tgz",
+      "integrity": "sha512-MYq/bzp3rYbee4EMBORCn4duPQfgpiEB5XzrZEBnUZAL80Qdfr7CEv/T80jwaTl/dnZmt9SnTa8NkTrwFNpLlw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@emotion/cache": "^11.4.0",
+        "@emotion/cache": "^11.5.0",
         "@emotion/serialize": "^1.0.2",
-        "@emotion/sheet": "^1.0.2",
+        "@emotion/sheet": "^1.0.3",
         "@emotion/utils": "^1.0.0",
         "@emotion/weak-memoize": "^0.2.5",
         "hoist-non-react-statics": "^3.3.1"
@@ -1370,9 +1370,9 @@
       }
     },
     "@emotion/sheet": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.2.tgz",
-      "integrity": "sha512-QQPB1B70JEVUHuNtzjHftMGv6eC3Y9wqavyarj4x4lg47RACkeSfNo5pxIOKizwS9AEFLohsqoaxGQj4p0vSIw=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.3.tgz",
+      "integrity": "sha512-YoX5GyQ4db7LpbmXHMuc8kebtBGP6nZfRC5Z13OKJMixBEwdZrJ914D6yJv/P+ZH/YY3F5s89NYX2hlZAf3SRQ=="
     },
     "@emotion/styled": {
       "version": "10.0.27",
@@ -2093,16 +2093,16 @@
       }
     },
     "@labkey/components": {
-      "version": "2.81.0",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.81.0.tgz",
-      "integrity": "sha1-zqc9GyZCbf12KW2imXzDaVDsp14=",
+      "version": "2.87.0-fb-siteUsersGridPanel43687.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.87.0-fb-siteUsersGridPanel43687.0.tgz",
+      "integrity": "sha1-W3kAWEAOyMTo4y8Fv+jWd/eEC14=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-regular-svg-icons": "5.15.4",
         "@fortawesome/free-solid-svg-icons": "5.15.4",
         "@fortawesome/react-fontawesome": "0.1.15",
-        "@labkey/api": "1.6.7",
+        "@labkey/api": "1.6.8",
         "bootstrap": "3.4.1",
         "classnames": "2.3.1",
         "font-awesome": "4.7.0",
@@ -2133,6 +2133,13 @@
         "redux-actions": "2.3.2",
         "use-immer": "0.6.0",
         "vis-network": "6.5.2"
+      },
+      "dependencies": {
+        "@labkey/api": {
+          "version": "1.6.8",
+          "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.8.tgz",
+          "integrity": "sha1-qAtCm9vx9JY+tSID1ItZaXN6GDE="
+        }
       }
     },
     "@labkey/eslint-config-base": {
@@ -2454,9 +2461,9 @@
       }
     },
     "@types/react-redux": {
-      "version": "7.1.18",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.18.tgz",
-      "integrity": "sha512-9iwAsPyJ9DLTRH+OFeIrm9cAbIj1i2ANL3sKQFATqnPWRbg+jEFXyZOKHiQK/N86pNRXbb4HRxAxo0SIX1XwzQ==",
+      "version": "7.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.20.tgz",
+      "integrity": "sha512-q42es4c8iIeTgcnB+yJgRTTzftv3eYYvCZOh1Ckn2eX/3o5TdsQYKUWpLoLuGlcY/p+VAhV9IOEZJcWk/vfkXw==",
       "requires": {
         "@types/hoist-non-react-statics": "^3.3.0",
         "@types/react": "*",
@@ -11165,16 +11172,23 @@
       }
     },
     "react-redux": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.5.tgz",
-      "integrity": "sha512-Dt29bNyBsbQaysp6s/dN0gUodcq+dVKKER8Qv82UrpeygwYeX1raTtil7O/fftw/rFqzaf6gJhDZRkkZnn6bjg==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
+      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
       "requires": {
-        "@babel/runtime": "^7.12.1",
-        "@types/react-redux": "^7.1.16",
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
         "hoist-non-react-statics": "^3.3.2",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.7.2",
-        "react-is": "^16.13.1"
+        "react-is": "^17.0.2"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        }
       }
     },
     "react-router": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.6.7",
-    "@labkey/components": "2.88.0-fb-siteUsersGridPanel43687.0",
+    "@labkey/components": "2.88.1",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.6.7",
-    "@labkey/components": "2.87.0-fb-siteUsersGridPanel43687.0",
+    "@labkey/components": "2.88.0-fb-siteUsersGridPanel43687.0",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.6.7",
-    "@labkey/components": "2.81.0",
+    "@labkey/components": "2.87.0-fb-siteUsersGridPanel43687.0",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/src/client/LabKeyUIComponentsPage/LabKeyUIComponentsPage.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/LabKeyUIComponentsPage.tsx
@@ -48,7 +48,7 @@ import { AssayImportPage } from "./AssayImportPage";
 import { LineagePage } from "./LineagePage";
 import { UserProfilePage } from "./UserProfilePage";
 import { PermissionAssignmentsPage } from "./PermissionAssignmentsPage";
-import { SiteUsersGridPanelPage } from "./SiteUsersGridPanelPage";
+import { UsersGridPanelPage } from "./UsersGridPanelPage";
 import { GridPanelPage } from './GridPanelPage';
 
 const COMPONENT_NAMES = List<string>([
@@ -78,7 +78,7 @@ const COMPONENT_NAMES = List<string>([
     {value: 'SchemaListing'},
     {value: 'SearchResultCard'},
     {value: 'SearchResultsPanel'},
-    {value: 'SiteUsersGridPanel'},
+    {value: 'UsersGridPanel'},
     {value: 'Tip'},
     {value: 'ToggleButtons'},
     {value: 'UserDetailHeader'},
@@ -421,8 +421,8 @@ export class App extends React.Component<any, State> {
                         />
                     )
                 }
-                {selected === 'SiteUsersGridPanel' &&
-                    <SiteUsersGridPanelPage/>
+                {selected === 'UsersGridPanel' &&
+                    <UsersGridPanelPage/>
                 }
                 {selected === 'Tip' &&
                     this.renderPanel('Tip',

--- a/core/src/client/LabKeyUIComponentsPage/UsersGridPanelPage.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/UsersGridPanelPage.tsx
@@ -11,7 +11,7 @@ import {
     PermissionsPageContextProvider,
     PermissionsProviderProps,
     SecurityPolicy,
-    SiteUsersGridPanel,
+    UsersGridPanel,
     fetchContainerSecurityPolicy,
     queryGridInvalidate,
     SCHEMAS,
@@ -25,7 +25,7 @@ interface State {
     message: string
 }
 
-class SiteUsersGridPanelPageImpl extends React.PureComponent<PermissionsProviderProps, State> {
+class UsersGridPanelPageImpl extends React.PureComponent<PermissionsProviderProps, State> {
 
     constructor(props: PermissionsProviderProps) {
         super(props);
@@ -95,9 +95,9 @@ class SiteUsersGridPanelPageImpl extends React.PureComponent<PermissionsProvider
 
         return (
             <>
-                <Alert bsStyle={'info'}>NOTE: if you have the proper permissions, this will actually update site users for this server.</Alert>
+                <Alert bsStyle={'info'}>NOTE: if you have the proper permissions, this will actually update users for this server.</Alert>
                 {message && <Alert bsStyle={'success'}>{message}</Alert>}
-                <SiteUsersGridPanel
+                <UsersGridPanel
                     user={user}
                     showDetailsPanel={user.isRootAdmin}
                     onCreateComplete={this.onSuccess}
@@ -110,5 +110,5 @@ class SiteUsersGridPanelPageImpl extends React.PureComponent<PermissionsProvider
     }
 }
 
-export const SiteUsersGridPanelPage = PermissionsPageContextProvider(SiteUsersGridPanelPageImpl);
+export const UsersGridPanelPage = PermissionsPageContextProvider(UsersGridPanelPageImpl);
 


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43687

In the SM app, the Administration > Users grid was showing all site users when the user logged in was a site or application admin (i.e. had root container admin permissions). This was causing some confusion in the app as the expectation was that the grid would should just users that had permissions to the given container/project. 

This PR updates that component/grid to show the core.Users table for the given container instead of the root container for the site/application admins. This is effectively the same as the LKS Project Users grid / page.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/660
* https://github.com/LabKey/sampleManagement/pull/733
* https://github.com/LabKey/platform/pull/2721

#### Changes
* update @labkey/components package
* rename SiteUsersGridPanel to UsersGridPanel
* update core.Users grid to include site and app admins assigned via the root container security policy
