### PR TITLE
Issue 43924: Assure samples that are deleted are removed from all picklists

### DIFF
--- a/list/src/org/labkey/list/ListModule.java
+++ b/list/src/org/labkey/list/ListModule.java
@@ -26,6 +26,7 @@ import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.UpgradeCode;
+import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.list.ListDefinition;
 import org.labkey.api.exp.list.ListService;
 import org.labkey.api.exp.property.PropertyService;
@@ -119,6 +120,7 @@ public class ListModule extends SpringModule
         RoleManager.registerPermission(new ManagePicklistsPermission());
 
         AttachmentService.get().registerAttachmentType(ListItemType.get());
+        ExperimentService.get().addExperimentListener(new PicklistMaterialListener());
     }
 
     @Override

--- a/list/src/org/labkey/list/PicklistMaterialListener.java
+++ b/list/src/org/labkey/list/PicklistMaterialListener.java
@@ -1,11 +1,12 @@
 package org.labkey.list;
 
 import org.labkey.api.data.Container;
-import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.SqlExecutor;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExperimentListener;
+import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.security.User;
 import org.labkey.list.model.ListDef;
@@ -26,13 +27,13 @@ public class PicklistMaterialListener implements ExperimentListener
         picklists.forEach(picklist -> {
             ListQuerySchema listQuerySchema = new ListQuerySchema(user, container);
             TableInfo table = listQuerySchema.getTable(picklist.getName());
+
             if (table != null)
             {
-                SQLFragment sql = new SQLFragment("DELETE FROM ")
-                        .append(((FilteredTable) table).getRealTable(), "")
-                        .append(" WHERE SampleID ").appendInClause(materialIds, table.getSqlDialect());
-                new SqlExecutor(table.getSchema()).execute(sql);
+                SimpleFilter filter = new SimpleFilter();
+                filter.addInClause(FieldKey.fromParts("SampleID"), materialIds);
 
+                Table.delete(((FilteredTable) table).getRealTable(), filter);
             }
         });
     }

--- a/list/src/org/labkey/list/PicklistMaterialListener.java
+++ b/list/src/org/labkey/list/PicklistMaterialListener.java
@@ -1,0 +1,40 @@
+package org.labkey.list;
+
+import org.labkey.api.data.Container;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SqlExecutor;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.exp.api.ExpMaterial;
+import org.labkey.api.exp.api.ExperimentListener;
+import org.labkey.api.query.FilteredTable;
+import org.labkey.api.security.User;
+import org.labkey.list.model.ListDef;
+import org.labkey.list.model.ListManager;
+import org.labkey.list.model.ListQuerySchema;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PicklistMaterialListener implements ExperimentListener
+{
+    @Override
+    public void beforeMaterialDelete(List<? extends ExpMaterial> materials, Container container, User user)
+    {
+        Collection<ListDef> picklists = ListManager.get().getPicklists(container);
+        List<Integer> materialIds = materials.stream().map(ExpMaterial::getRowId).collect(Collectors.toList());
+        picklists.forEach(picklist -> {
+            ListQuerySchema listQuerySchema = new ListQuerySchema(user, container);
+            TableInfo table = listQuerySchema.getTable(picklist.getName());
+            if (table != null)
+            {
+                SQLFragment sql = new SQLFragment("DELETE FROM ")
+                        .append(((FilteredTable) table).getRealTable(), "")
+                        .append(" WHERE SampleID ").appendInClause(materialIds, table.getSqlDialect());
+                new SqlExecutor(table.getSchema()).execute(sql);
+
+            }
+        });
+    }
+
+}

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -128,6 +128,13 @@ public class ListManager implements SearchService.DocumentProvider
         return getListMetadataSchema().getTable("list");
     }
 
+    public Collection<ListDef> getPicklists(Container container)
+    {
+        List<ListDef> ownLists = _listDefCache.get(container.getId());
+        Collection<ListDef> scopedLists = getAllScopedLists(ownLists, container);
+        return scopedLists.stream().filter(ListDef::isPicklist).collect(Collectors.toList());
+    }
+
     public Collection<ListDef> getLists(Container container)
     {
         return getLists(container, null, false, true);


### PR DESCRIPTION
#### Rationale
When samples are deleted, they currently leave holes in the picklists that had included them.  While functionally this doesn't seem to cause a problem it does make for a somewhat odd user experience.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/735

#### Changes
* Add ExperimentListener for Picklists to samples that are about to be deleted can also be removed from picklists
