### PR TITLE
Issue 43984: Replace curly quotes with regular quotes in name expressions

### DIFF
--- a/api/src/org/labkey/api/util/StringUtilsLabKey.java
+++ b/api/src/org/labkey/api/util/StringUtilsLabKey.java
@@ -379,8 +379,36 @@ public class StringUtilsLabKey
         return s.length() > maxLength ? s.substring(0, maxLength - 3) + "..." : s;
     }
 
+    /**
+     * Replaces known bad characters (currently curly quotes) with reasonable replacements (non-curly quotes).
+     * @param original The string to be sanitized
+     * @return the sanitized string
+     */
+    public static String replaceBadCharacters(String original)
+    {
+        if (original == null)
+            return null;
+
+        return original.replaceAll("[\\u2018\\u2019]", "'")
+                        .replaceAll("[\\u201C\\u201D]", "\"");
+
+    }
+
     public static class TestCase extends Assert
     {
+        @Test
+        public void testReplaceBadCharacters()
+        {
+            assertNull(replaceBadCharacters(null));
+            assertEquals("", replaceBadCharacters(""));
+            assertEquals("It's all good", replaceBadCharacters("It's all good"));
+            assertEquals("She said \"yes\"", replaceBadCharacters("She said \"yes\""));
+            assertEquals("'It's bad'", replaceBadCharacters("\u2018It\u2018s bad\u2018"));
+            assertEquals("It's bad", replaceBadCharacters("It\u2019s bad"));
+            assertEquals("\"Stuff\"", replaceBadCharacters("\u201CStuff\u201D"));
+            assertEquals("\"It's 'My' Stuff\"", replaceBadCharacters("\u201CIt\u2018s \u2019My\u2019 Stuff\u201D"));
+        }
+
         @Test
         public void testFindCommonPrefix()
         {

--- a/api/src/org/labkey/api/util/StringUtilsLabKey.java
+++ b/api/src/org/labkey/api/util/StringUtilsLabKey.java
@@ -384,7 +384,7 @@ public class StringUtilsLabKey
      * @param original The string to be sanitized
      * @return the sanitized string
      */
-    public static String replaceBadCharacters(String original)
+    public static @Nullable String replaceBadCharacters(@Nullable String original)
     {
         if (original == null)
             return null;

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -114,6 +114,7 @@ import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.util.logging.LogHelper;
@@ -6996,7 +6997,7 @@ public class ExperimentServiceImpl implements ExperimentService
     {
         DataClassDomainKindProperties options = new DataClassDomainKindProperties();
         options.setDescription(description);
-        options.setNameExpression(nameExpression);
+        options.setNameExpression(StringUtilsLabKey.replaceBadCharacters(nameExpression));
         options.setSampleType(sampleTypeId);
         options.setCategory(category);
         return createDataClass(c, u, name, options, properties, indices, templateInfo);
@@ -7069,7 +7070,7 @@ public class ExperimentServiceImpl implements ExperimentService
                 nameExpression = svc.createPrefixedExpression(c, nameExpression, false);
             }
             bean.setDescription(options.getDescription());
-            bean.setNameExpression(nameExpression);
+            bean.setNameExpression(StringUtilsLabKey.replaceBadCharacters(nameExpression));
             bean.setMaterialSourceId(options.getSampleType());
             bean.setCategory(options.getCategory());
         }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -89,6 +89,7 @@ import org.labkey.api.study.publish.StudyPublishService;
 import org.labkey.api.util.CPUTimer;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.experiment.samples.UploadSamplesHelper;
 
 import java.time.LocalDateTime;
@@ -915,7 +916,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
         if (options != null)
         {
-            String sampleIdPattern = StringUtils.trimToNull(options.getNameExpression());
+            String sampleIdPattern = StringUtils.trimToNull(StringUtilsLabKey.replaceBadCharacters(options.getNameExpression()));
             String oldPattern = st.getNameExpression();
             if (oldPattern == null || !oldPattern.equals(sampleIdPattern))
             {

--- a/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
+++ b/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
@@ -59,6 +59,7 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DesignSampleTypePermission;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.writer.ContainerUser;
@@ -459,8 +460,8 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
             idCol3 = idCols.size() > 2 ? idCols.get(2) : -1;
             parentCol = arguments.getParentCol() != null ? arguments.getParentCol() : -1;
 
-            nameExpression = StringUtils.trimToNull(arguments.getNameExpression());
-            aliquotNameExpression = StringUtils.trimToNull(arguments.getAliquotNameExpression());
+            nameExpression = StringUtils.trimToNull(StringUtilsLabKey.replaceBadCharacters(arguments.getNameExpression()));
+            aliquotNameExpression = StringUtils.trimToNull(StringUtilsLabKey.replaceBadCharacters(arguments.getAliquotNameExpression()));
             labelColor = StringUtils.trimToNull(arguments.getLabelColor());
             metricUnit = StringUtils.trimToNull(arguments.getMetricUnit());
             autoLinkTargetContainer = ContainerManager.getForId(arguments.getAutoLinkTargetContainerId());


### PR DESCRIPTION
#### Rationale
When naming patterns are constructed via cut and paste and Microsoft somehow gets into the mix, curly quotes can get introduced.  We don't recognize these when parsing naming patterns and they generally just cause problems.  (See the [issue ](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43984) for more details.)

The implementation here is not sophisticated and is targeted to naming patterns.  This is deliberate so as not to introduce unnecessary processing in places where these characters a merely annoying and don't result in errors. If there's a more general place to include this that doesn't incur lots of overhead, please let me know.

#### Changes
* Add utility method for removing bad characters and apply that method before saving naming patterns.
