### PR TITLE
Issue 44151: Add site warning message for failed WebSocket connection

### DIFF
--- a/api/webapp/clientapi/dom/Utils.js
+++ b/api/webapp/clientapi/dom/Utils.js
@@ -70,7 +70,7 @@ LABKEY.Utils = new function(impl, $) {
         }
         var html = [
             '<div class="modal-header">',
-                (!disableCloseBtn ? '<button type="button" class="close" data-dismiss="modal">&times;</button>' : ''),
+                (!disableCloseBtn && supportsModal() ? '<button type="button" class="close" data-dismiss="modal">&times;</button>' : ''),
                 '<h4 class="modal-title">' + LABKEY.Utils.encodeHtml(title) + '</h4>',
             '</div>',
             '<div class="modal-body">'
@@ -93,12 +93,17 @@ LABKEY.Utils = new function(impl, $) {
             modal.modal({backdrop: 'static'});
         }
 
-        showModal('lk-utils-modal')
+        showModal()
     };
 
-    var showModal = function(divId) {
-        var modal = $('#' + divId);
-        if (LABKEY.Utils.isFunction(modal.modal)) {
+    var supportsModal = function() {
+        var modal = $('#lk-utils-modal');
+        return LABKEY.Utils.isFunction(modal.modal);
+    }
+
+    var showModal = function() {
+        var modal = $('#lk-utils-modal');
+        if (supportsModal()) {
             modal.modal('show');
         } else {
             $('body').append('<div id="lk-utils-modal-backdrop" class="fade modal-backdrop in"></div>');

--- a/api/webapp/clientapi/dom/WebSocket.js
+++ b/api/webapp/clientapi/dom/WebSocket.js
@@ -40,16 +40,15 @@ LABKEY.WebSocket = new function ()
         _websocket = new WebSocket((window.location.protocol==="http:"?"ws:":"wss:") + "//" + window.location.host + LABKEY.contextPath + "/_websocket/notifications");
         _websocket.onmessage = websocketOnMessage;
         _websocket.onclose = websocketOnClose;
-        _websocket.onopen = function() { websocketConnectionStatus(true); }
-        _websocket.onerror = function() { websocketConnectionStatus(false); }
+        _websocket.onerror = websocketConnectionFailure;
     }
 
-    function websocketConnectionStatus(connected) {
+    function websocketConnectionFailure() {
         if (!LABKEY.user.isGuest) {
             LABKEY.Ajax.request({
                 url: LABKEY.ActionURL.buildURL("core", "webSocketConnection.api"),
                 method: 'POST',
-                params: { connected: connected }
+                params: { connected: false }
             });
         }
     }

--- a/api/webapp/clientapi/dom/WebSocket.js
+++ b/api/webapp/clientapi/dom/WebSocket.js
@@ -40,6 +40,23 @@ LABKEY.WebSocket = new function ()
         _websocket = new WebSocket((window.location.protocol==="http:"?"ws:":"wss:") + "//" + window.location.host + LABKEY.contextPath + "/_websocket/notifications");
         _websocket.onmessage = websocketOnMessage;
         _websocket.onclose = websocketOnClose;
+        _websocket.onerror = websocketConnectionUpdate;
+    }
+
+    function websocketConnectionUpdate() {
+        if (!LABKEY.user.isGuest) {
+            LABKEY.Ajax.request({
+                url: LABKEY.ActionURL.buildURL("core", "webSocketConnection.api"),
+                method: 'POST',
+                params: { connected: false },
+                success: LABKEY.Utils.getCallbackWrapper(function(response) {
+                    if (response.warningsHtml) {
+                        $('.lk-dismissable-alert-ct').html(response.warningsHtml);
+                        $('#headerWarningIcon').hide();
+                    }
+                })
+            });
+        }
     }
 
     function websocketOnMessage(evt) {

--- a/api/webapp/clientapi/dom/WebSocket.js
+++ b/api/webapp/clientapi/dom/WebSocket.js
@@ -40,21 +40,16 @@ LABKEY.WebSocket = new function ()
         _websocket = new WebSocket((window.location.protocol==="http:"?"ws:":"wss:") + "//" + window.location.host + LABKEY.contextPath + "/_websocket/notifications");
         _websocket.onmessage = websocketOnMessage;
         _websocket.onclose = websocketOnClose;
-        _websocket.onerror = websocketConnectionUpdate;
+        _websocket.onopen = function() { websocketConnectionStatus(true); }
+        _websocket.onerror = function() { websocketConnectionStatus(false); }
     }
 
-    function websocketConnectionUpdate() {
+    function websocketConnectionStatus(connected) {
         if (!LABKEY.user.isGuest) {
             LABKEY.Ajax.request({
                 url: LABKEY.ActionURL.buildURL("core", "webSocketConnection.api"),
                 method: 'POST',
-                params: { connected: false },
-                success: LABKEY.Utils.getCallbackWrapper(function(response) {
-                    if (response.warningsHtml) {
-                        $('.lk-dismissable-alert-ct').html(response.warningsHtml);
-                        $('#headerWarningIcon').hide();
-                    }
-                })
+                params: { connected: connected }
             });
         }
     }

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -162,6 +162,7 @@ import org.labkey.api.writer.VirtualFile;
 import org.labkey.api.writer.Writer;
 import org.labkey.api.writer.ZipUtil;
 import org.labkey.core.metrics.ClientSideMetricManager;
+import org.labkey.core.metrics.WebSocketConnectionManager;
 import org.labkey.core.portal.ProjectController;
 import org.labkey.core.qc.CoreQCStateHandler;
 import org.labkey.core.reports.ExternalScriptEngineDefinitionImpl;
@@ -203,7 +204,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static org.labkey.api.view.template.WarningService.SESSION_WARNINGS_BANNER_KEY;
-import static org.labkey.core.view.template.bootstrap.CoreWarningProvider.WEBSOCKET_CONNECTION_KEY;
 
 /**
  * User: jeckels
@@ -2420,38 +2420,17 @@ public class CoreController extends SpringActionController
     }
 
     @RequiresLogin
-    public class WebSocketConnectionAction extends MutatingApiAction<WebSocketWarningForm>
+    public class WebSocketConnectionAction extends MutatingApiAction<WebSocketConnectionForm>
     {
         @Override
-        public ApiResponse execute(WebSocketWarningForm form, BindException errors)
+        public Object execute(WebSocketConnectionForm form, BindException errors)
         {
-            // update session attribute so warnings will display via CoreWarningProvider.java
-            ViewContext context = getViewContext();
-            HttpSession session = context.getRequest().getSession(true);
-            Object previousValue = session.getAttribute(WEBSOCKET_CONNECTION_KEY);
-            session.setAttribute(WEBSOCKET_CONNECTION_KEY, form.isConnected());
-
-            JSONObject json = new JSONObject();
-            json.put("success", true);
-
-            // if the value has changed, recheck for warning messages
-            Object updatedValue = session.getAttribute(WEBSOCKET_CONNECTION_KEY);
-            if (previousValue == null || !previousValue.equals(updatedValue))
-            {
-                Warnings warnings = WarningService.get().getWarnings(context);
-                if (!warnings.isEmpty())
-                    json.put("warningsHtml", WarningService.get().getWarningsHtml(warnings, context).toString());
-
-                // if the value changed to "not connected", set client side metric
-                if (updatedValue != null && !(boolean) updatedValue)
-                    ClientSideMetricManager.get().setFlag("Core", "webSocketConnectionFailed", true);
-            }
-
-            return new ApiSimpleResponse(json);
+            WebSocketConnectionManager.getInstance().incrementCounter(form.isConnected());
+            return success();
         }
     }
 
-    public static class WebSocketWarningForm
+    public static class WebSocketConnectionForm
     {
         private boolean _connected;
 

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -190,6 +190,7 @@ import org.labkey.core.junit.JunitController;
 import org.labkey.core.login.DbLoginAuthenticationProvider;
 import org.labkey.core.login.LoginController;
 import org.labkey.core.metrics.ClientSideMetricManager;
+import org.labkey.core.metrics.WebSocketConnectionManager;
 import org.labkey.core.notification.EmailPreferenceConfigServiceImpl;
 import org.labkey.core.notification.EmailPreferenceContainerListener;
 import org.labkey.core.notification.EmailPreferenceUserListener;
@@ -975,6 +976,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         });
 
         ClientSideMetricManager.get().registerUsageMetrics(getName());
+        UsageMetricsService.get().registerUsageMetrics(getName(), WebSocketConnectionManager.getInstance());
 
         if (AppProps.getInstance().isDevMode())
             PremiumService.get().registerAntiVirusProvider(new DummyAntiVirusService.Provider());

--- a/core/src/org/labkey/core/metrics/ClientSideMetricManager.java
+++ b/core/src/org/labkey/core/metrics/ClientSideMetricManager.java
@@ -12,7 +12,6 @@ public class ClientSideMetricManager
 {
     private static final ClientSideMetricManager instance = new ClientSideMetricManager();
     private static final Map<String, Map<String, AtomicInteger>> FEATURE_AREA_METRIC_COUNTS = new ConcurrentHashMap<>();
-    private static final Map<String, Map<String, Boolean>> FEATURE_AREA_METRIC_FLAGS = new ConcurrentHashMap<>();
 
     public static ClientSideMetricManager get()
     {
@@ -25,19 +24,12 @@ public class ClientSideMetricManager
         return FEATURE_AREA_METRIC_COUNTS.get(featureArea).computeIfAbsent(metricName, s -> new AtomicInteger(0)).incrementAndGet();
     }
 
-    public void setFlag(String featureArea, String metricName, Boolean value)
-    {
-        FEATURE_AREA_METRIC_FLAGS.computeIfAbsent(featureArea, k -> new HashMap<>());
-        FEATURE_AREA_METRIC_FLAGS.get(featureArea).computeIfAbsent(metricName, s -> value);
-    }
-
     public void registerUsageMetrics(String moduleName)
     {
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {
             svc.registerUsageMetrics(moduleName, () -> Collections.singletonMap("clientSideMetricCounts", FEATURE_AREA_METRIC_COUNTS));
-            svc.registerUsageMetrics(moduleName, () -> Collections.singletonMap("clientSideMetricFlags", FEATURE_AREA_METRIC_FLAGS));
         }
     }
 }

--- a/core/src/org/labkey/core/metrics/ClientSideMetricManager.java
+++ b/core/src/org/labkey/core/metrics/ClientSideMetricManager.java
@@ -12,6 +12,7 @@ public class ClientSideMetricManager
 {
     private static final ClientSideMetricManager instance = new ClientSideMetricManager();
     private static final Map<String, Map<String, AtomicInteger>> FEATURE_AREA_METRIC_COUNTS = new ConcurrentHashMap<>();
+    private static final Map<String, Map<String, Boolean>> FEATURE_AREA_METRIC_FLAGS = new ConcurrentHashMap<>();
 
     public static ClientSideMetricManager get()
     {
@@ -24,12 +25,19 @@ public class ClientSideMetricManager
         return FEATURE_AREA_METRIC_COUNTS.get(featureArea).computeIfAbsent(metricName, s -> new AtomicInteger(0)).incrementAndGet();
     }
 
+    public void setFlag(String featureArea, String metricName, Boolean value)
+    {
+        FEATURE_AREA_METRIC_FLAGS.computeIfAbsent(featureArea, k -> new HashMap<>());
+        FEATURE_AREA_METRIC_FLAGS.get(featureArea).computeIfAbsent(metricName, s -> value);
+    }
+
     public void registerUsageMetrics(String moduleName)
     {
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {
             svc.registerUsageMetrics(moduleName, () -> Collections.singletonMap("clientSideMetricCounts", FEATURE_AREA_METRIC_COUNTS));
+            svc.registerUsageMetrics(moduleName, () -> Collections.singletonMap("clientSideMetricFlags", FEATURE_AREA_METRIC_FLAGS));
         }
     }
 }

--- a/core/src/org/labkey/core/metrics/WebSocketConnectionManager.java
+++ b/core/src/org/labkey/core/metrics/WebSocketConnectionManager.java
@@ -3,13 +3,14 @@ package org.labkey.core.metrics;
 import org.labkey.api.usageMetrics.UsageMetricsProvider;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class WebSocketConnectionManager implements UsageMetricsProvider
 {
     private static final WebSocketConnectionManager _instance = new WebSocketConnectionManager();
 
-    private int successCounter = 0;
-    private int failureCounter = 0;
+    final private AtomicInteger successCounter = new AtomicInteger();
+    final private AtomicInteger failureCounter = new AtomicInteger();
 
     private WebSocketConnectionManager()
     {
@@ -23,14 +24,14 @@ public class WebSocketConnectionManager implements UsageMetricsProvider
     public void incrementCounter(boolean success)
     {
         if (success)
-            successCounter++;
+            successCounter.incrementAndGet();
         else
-            failureCounter++;
+            failureCounter.incrementAndGet();
     }
 
     public boolean showWarning()
     {
-        return successCounter == 0 && failureCounter > 0;
+        return successCounter.get() == 0 && failureCounter.get() > 0;
     }
 
     @Override
@@ -38,8 +39,8 @@ public class WebSocketConnectionManager implements UsageMetricsProvider
     {
         return Map.of(
             "webSocketConnections", Map.of(
-                    "success", successCounter,
-                    "failure", failureCounter
+                    "success", successCounter.get(),
+                    "failure", failureCounter.get()
                 )
         );
     }

--- a/core/src/org/labkey/core/metrics/WebSocketConnectionManager.java
+++ b/core/src/org/labkey/core/metrics/WebSocketConnectionManager.java
@@ -1,0 +1,46 @@
+package org.labkey.core.metrics;
+
+import org.labkey.api.usageMetrics.UsageMetricsProvider;
+
+import java.util.Map;
+
+public class WebSocketConnectionManager implements UsageMetricsProvider
+{
+    private static final WebSocketConnectionManager _instance = new WebSocketConnectionManager();
+
+    private int successCounter = 0;
+    private int failureCounter = 0;
+
+    private WebSocketConnectionManager()
+    {
+    }
+
+    public static WebSocketConnectionManager getInstance()
+    {
+        return _instance;
+    }
+
+    public void incrementCounter(boolean success)
+    {
+        if (success)
+            successCounter++;
+        else
+            failureCounter++;
+    }
+
+    public boolean showWarning()
+    {
+        return successCounter == 0 && failureCounter > 0;
+    }
+
+    @Override
+    public Map<String, Object> getUsageMetrics()
+    {
+        return Map.of(
+            "webSocketConnections", Map.of(
+                    "success", successCounter,
+                    "failure", failureCounter
+                )
+        );
+    }
+}

--- a/core/src/org/labkey/core/notification/NotificationEndpoint.java
+++ b/core/src/org/labkey/core/notification/NotificationEndpoint.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.security.User;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.security.SecurityManager;
+import org.labkey.core.metrics.WebSocketConnectionManager;
 
 import javax.servlet.http.HttpSession;
 import javax.websocket.CloseReason;
@@ -78,6 +79,7 @@ public class NotificationEndpoint extends Endpoint
             if (this.userId > 0)
             {
                 endpointsMap.put(this.userId, this);
+                WebSocketConnectionManager.getInstance().incrementCounter(true);
                 MemTracker.get().put(this);
             }
         }

--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -177,7 +177,7 @@ public class CoreWarningProvider implements WarningProvider
         HttpSession session = context.getRequest().getSession(true);
         Object connected = session.getAttribute(WEBSOCKET_CONNECTION_KEY);
         if (SHOW_ALL_WARNINGS || (connected != null && !(boolean) connected))
-            addStandardWarning(warnings, "The WebSocket connection failed.", "configTomcat#websocket", "Tomcat Configuration");
+            addStandardWarning(warnings, "The WebSocket connection failed. LabKey Server uses WebSockets to send notifications and alert users when their session ends.", "configTomcat#websocket", "Tomcat Configuration");
     }
 
     private void getUserRequestedAdminOnlyModeWarnings(Warnings warnings)

--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -36,8 +36,8 @@ import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.template.WarningProvider;
 import org.labkey.api.view.template.WarningService;
 import org.labkey.api.view.template.Warnings;
+import org.labkey.core.metrics.WebSocketConnectionManager;
 
-import javax.servlet.http.HttpSession;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.util.Map;
@@ -47,7 +47,6 @@ import static org.labkey.api.view.template.WarningService.SESSION_WARNINGS_BANNE
 public class CoreWarningProvider implements WarningProvider
 {
     private static final boolean SHOW_ALL_WARNINGS = WarningService.get().showAllWarnings();
-    public static final String WEBSOCKET_CONNECTION_KEY = "PAGE_CONFIG$WEBSOCKET_CONNECTION_KEY";
 
     public CoreWarningProvider()
     {
@@ -81,7 +80,7 @@ public class CoreWarningProvider implements WarningProvider
 
             getProbableLeakCountWarnings(warnings);
 
-            getWebSocketConnectionWarnings(warnings, context);
+            getWebSocketConnectionWarnings(warnings);
 
             //upgrade message--show to admins
             HtmlString upgradeMessage = UsageReportingLevel.getUpgradeMessage();
@@ -172,11 +171,9 @@ public class CoreWarningProvider implements WarningProvider
         }
     }
 
-    private void getWebSocketConnectionWarnings(Warnings warnings, ViewContext context)
+    private void getWebSocketConnectionWarnings(Warnings warnings)
     {
-        HttpSession session = context.getRequest().getSession(true);
-        Object connected = session.getAttribute(WEBSOCKET_CONNECTION_KEY);
-        if (SHOW_ALL_WARNINGS || (connected != null && !(boolean) connected))
+        if (SHOW_ALL_WARNINGS || WebSocketConnectionManager.getInstance().showWarning())
             addStandardWarning(warnings, "The WebSocket connection failed. LabKey Server uses WebSockets to send notifications and alert users when their session ends.", "configTomcat#websocket", "Tomcat Configuration");
     }
 

--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -37,6 +37,7 @@ import org.labkey.api.view.template.WarningProvider;
 import org.labkey.api.view.template.WarningService;
 import org.labkey.api.view.template.Warnings;
 
+import javax.servlet.http.HttpSession;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.util.Map;
@@ -46,6 +47,7 @@ import static org.labkey.api.view.template.WarningService.SESSION_WARNINGS_BANNE
 public class CoreWarningProvider implements WarningProvider
 {
     private static final boolean SHOW_ALL_WARNINGS = WarningService.get().showAllWarnings();
+    public static final String WEBSOCKET_CONNECTION_KEY = "PAGE_CONFIG$WEBSOCKET_CONNECTION_KEY";
 
     public CoreWarningProvider()
     {
@@ -78,6 +80,8 @@ public class CoreWarningProvider implements WarningProvider
             getModuleErrorWarnings(warnings, context);
 
             getProbableLeakCountWarnings(warnings);
+
+            getWebSocketConnectionWarnings(warnings, context);
 
             //upgrade message--show to admins
             HtmlString upgradeMessage = UsageReportingLevel.getUpgradeMessage();
@@ -166,6 +170,14 @@ public class CoreWarningProvider implements WarningProvider
             }
             addStandardWarning(warnings, "The following modules experienced errors during startup:", moduleFailures.keySet().toString(), PageFlowUtil.urlProvider(AdminUrls.class).getModuleErrorsURL(context.getContainer()));
         }
+    }
+
+    private void getWebSocketConnectionWarnings(Warnings warnings, ViewContext context)
+    {
+        HttpSession session = context.getRequest().getSession(true);
+        Object connected = session.getAttribute(WEBSOCKET_CONNECTION_KEY);
+        if (SHOW_ALL_WARNINGS || (connected != null && !(boolean) connected))
+            addStandardWarning(warnings, "The WebSocket connection failed.", "configTomcat#websocket", "Tomcat Configuration");
     }
 
     private void getUserRequestedAdminOnlyModeWarnings(Warnings warnings)


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44151

As we make increasing use of websocket connections for notifications, it's more important to make sure that they're working as expected. This PR adds a site warning message for admin users to see when the WebSocket Connection Failed. This is checked on the client side and in the failure case, calls the server API to track the failure, add a metric flag, and display the warning accordingly (similar to warnings for locked projects, downgraded modules, etc.).

<img width="1335" alt="Screen Shot 2021-10-29 at 9 47 16 AM" src="https://user-images.githubusercontent.com/6411206/139469349-60cbd027-5aff-46b6-b3dc-62179e0f44a5.png">

#### Related Pull Requests
* n/a

#### Changes
* add websocket connection success/failure metric tracking
* core controller WebSocketConnectionAction to set session attribute for a failed connection and add metric
* CoreWarningProvider update to add site warning message based on the websocket connection metrics
* WebSocket.js client side check to catch failed connection and call API action to notify the server
* fix for LABKEY.Utils.modal close button in LKSM app use-case
