### PR TITLE
Issue44091: Race condition prevents study dataset loading 

### DIFF
--- a/internal/webapp/labkey.js
+++ b/internal/webapp/labkey.js
@@ -151,8 +151,6 @@ if (typeof LABKEY == "undefined")
                 elem.innerHTML = html;
                 document.body.appendChild(elem.firstChild);
             }
-            else
-                document.write(html);
         };
 
         //private. used to append additional module context objects for AJAXd views

--- a/internal/webapp/util.js
+++ b/internal/webapp/util.js
@@ -32,9 +32,12 @@ function getHelpDiv()
                 '  </table>'+
                 '</div>'
         );
-        _helpDiv = document.getElementById("helpDiv");
-        document.addEventListener('keyup', helpDivHideHandler);
-        document.addEventListener('click', helpDivHideHandler);
+        const helpDiv = document.getElementById("helpDiv");
+        if (helpDiv) {
+            _helpDiv = helpDiv;
+            document.addEventListener('keyup', helpDivHideHandler);
+            document.addEventListener('click', helpDivHideHandler);
+        }
     }
     return _helpDiv;
 }
@@ -64,7 +67,11 @@ function showHelpDiv(elem, titleText, bodyText, width)
 
     posTop += elem.offsetHeight;
 
-    var div = getHelpDiv();
+    // helpDiv can potentially not render if the web page is in a loading state
+    const div = getHelpDiv();
+    if (!div) {
+        return false;
+    }
     div.anchorElem = elem;
 
     document.getElementById("helpDivTitle").innerHTML = titleText;
@@ -102,8 +109,13 @@ function showHelpDiv(elem, titleText, bodyText, width)
 
 function hideHelpDiv(force)
 {
-    if (force || !_mouseInHelpDiv)
-        getHelpDiv().style.display = "none";
+    if (force || !_mouseInHelpDiv) {
+        // helpDiv can potentially not render if the web page is in a loading state
+        const helpDiv = getHelpDiv();
+        if (helpDiv) {
+            helpDiv.style.display = "none";
+        }
+    }
     return false;
 }
 


### PR DESCRIPTION
#### Rationale
If a user, upon loading a page to view a dataset, hovered rapidly over the still-loading icons that generate helpDivs, it was possible for the page to blank-out indefinitely. 
This is because a call to document.write() while the document was assumed to be open, but was actually closed was replacing the contents of the page's <body/> with the contents of the helpDiv. (This being a known behavior of document.write() when a document is closed.)
As it is an edge case to be creating and hiding helpDivs while actively loading a page, a solution is to not render helpDivs until the page is fully loaded.

#### Related Pull Requests
* N/A

#### Changes
* Remove clause that uses `document.write()` when document is open
