### PR TITLE
Hide sample status column for a sample type display/insert/update when container doesn't have statuses defined

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -332,7 +332,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 return (BaseColumnInfo) createPropertiesColumn(alias);
 
             case SampleState:
-                boolean statusEnabled = SampleStatusService.get().supportsSampleStatus();
+                boolean statusEnabled = SampleStatusService.get().supportsSampleStatus() && SampleStatusService.get().getStates(getContainer()).size() > 0;
                 var ret = wrapColumn(alias, _rootTable.getColumn(column.name()));
                 ret.setLabel("Status");
                 ret.setHidden(!statusEnabled);
@@ -587,7 +587,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         addColumn(ExpMaterialTable.Column.Flag);
 
         var statusColInfo = addColumn(ExpMaterialTable.Column.SampleState);
-        boolean statusEnabled = SampleStatusService.get().supportsSampleStatus();
+        boolean statusEnabled = SampleStatusService.get().supportsSampleStatus() && SampleStatusService.get().getStates(getContainer()).size() > 0;
         statusColInfo.setShownInDetailsView(statusEnabled);
         statusColInfo.setShownInInsertView(statusEnabled);
         statusColInfo.setShownInUpdateView(statusEnabled);


### PR DESCRIPTION
#### Rationale
After merging the final set of changes for the Sample Status feature, I noticed that in LKS if you have a sample type but the container does not have any sample statuses defined, the status input / dropdown for the insert and update forms is empty. Also the column in the default sample type grid is shown but is always empty. This PR checks for defined sample statuses in the given container when decided to show/hide the status column for the sample type display/insert/update views.

#### Related Pull Requests
* https://github.com/LabKey/premium/pull/282

#### Changes
* ExpMaterialTableImpl update to include "does this container have sample statuses defined" in check to hide/show the sample status column
