### PR TITLE
Explicitly set dataset ID to test dataset shadowing

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
@@ -59,7 +59,7 @@ public class SharedStudyTest extends BaseWebDriverTest
     private static final String STUDY1 = "Study001";
     private static final String STUDY2 = "Study002";
     private static final String SHARED_DEMOGRAPHICS = "P_One_Shared";
-    private static final String SHARED_DEMOGRAPHICS_ID = "10001";
+    private static final String SHARED_DEMOGRAPHICS_ID = "5001";
     private static final String STUDY2_DATASET = "Extra Dataset";
     private static final String STUDY2_DATASET_ID = "999";
     private static final String[] STUDY1_PTIDS = {"1000", "1001", "1002", "1003"};
@@ -109,7 +109,10 @@ public class SharedStudyTest extends BaseWebDriverTest
 
         DatasetDesignerPage datasetDesignerPage = _studyHelper.defineDataset(SHARED_DEMOGRAPHICS, getProjectName());
         datasetDesignerPage.setIsDemographicData(true);
-        datasetDesignerPage.shareDemographics("Share by PandaId");
+        datasetDesignerPage.openAdvancedDatasetSettings()
+                .setDatasetId(SHARED_DEMOGRAPHICS_ID)
+                .shareDemographics("Share by PandaId")
+                .clickApply();
         datasetDesignerPage.getFieldsPanel().setInferFieldFile(new File(STUDY_DIR, "study/datasets/dataset5001.tsv"));
         // leave the 'visits' column unmapped, make sure it doesn't have a value/only has a placeholder
         // (this dataset doesn't have a meaningful visit field)


### PR DESCRIPTION
#### Rationale
Automatically generated dataset IDs start at 10001 to avoid collisions but some test cases depend on that collision. Explicitly setting the ID should get the test back to passing.

#### Related Pull Requests
* #2707 
* #2727 

#### Changes
* Explicitly set dataset ID to test dataset shadowing
