### PR TITLE
Issue 44151: Let admins know when there's a websocket connection issue - help link

### DIFF
--- a/api/src/org/labkey/api/data/LoggingResultSetWrapper.java
+++ b/api/src/org/labkey/api/data/LoggingResultSetWrapper.java
@@ -133,7 +133,7 @@ public class LoggingResultSetWrapper extends ResultSetWrapper
             {
                 Object obj = getObject(dataLoggingColumn.getAlias());
                 if (null == obj)
-                    throw new UnauthorizedException("Unable to read expected data logging column.");
+                    throw new UnauthorizedException("Unable to read expected data logging column for " + dataLoggingColumn.getFieldKey() + " with alias " + dataLoggingColumn.getAlias());
                 _dataLoggingValues.add(obj);
             }
         }

--- a/api/src/org/labkey/api/data/validator/LengthValidator.java
+++ b/api/src/org/labkey/api/data/validator/LengthValidator.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.api.data.validator;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Validate that a string value is not longer than the column's scale.
  */
@@ -35,7 +37,7 @@ public class LengthValidator extends AbstractColumnValidator
         {
             String s = (String)value;
             if (s.length() > scale)
-                return "Value is too long for column '" + _columnName + "', a maximum length of " + scale + " is allowed. Supplied value was " + s.length() + " characters long.";
+                return "Value is too long for column '" + _columnName + "', a maximum length of " + scale + " is allowed. The supplied value, '" + StringUtils.abbreviateMiddle(s, "...", 50) + "', was " + s.length() + " characters long.";
         }
 
         return null;

--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -962,7 +962,7 @@ abstract public class PipelineJob extends Job implements Serializable
     private boolean findRunnableTask(TaskId[] progression, int i)
     {
         // Search for next task that is not already complete
-        TaskFactory factory = null;
+        TaskFactory<?> factory = null;
         while (i < progression.length)
         {
             try

--- a/api/src/org/labkey/api/util/HelpTopic.java
+++ b/api/src/org/labkey/api/util/HelpTopic.java
@@ -17,6 +17,7 @@
 package org.labkey.api.util;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.Constants;
@@ -43,6 +44,7 @@ public class HelpTopic
     public static final HelpTopic DEFAULT_HELP_TOPIC = new HelpTopic("default");
 
     private final String _topic;
+    private final String _fragment;
 
     public String getTopic()
     {
@@ -51,7 +53,13 @@ public class HelpTopic
 
     public HelpTopic(@NotNull String topic)
     {
+        this(topic.contains("#") ? topic.split("#")[0] : topic, topic.contains("#") ? topic.split("#")[1] : null);
+    }
+
+    public HelpTopic(@NotNull String topic, @Nullable String fragment)
+    {
         _topic = topic;
+        _fragment = fragment;
     }
 
     @Override
@@ -87,7 +95,7 @@ public class HelpTopic
 
     public String getHelpTopicHref(@NotNull Referrer referrer)
     {
-        return HELP_LINK_PREFIX + _topic + "&referrer=" + referrer;
+        return HELP_LINK_PREFIX + _topic + "&referrer=" + referrer + (_fragment == null ? "" : ("#" + _fragment));
     }
 
     // Create a simple link (just an <a> tag with plain mixed case text, no graphics) to the help topic, displaying

--- a/api/src/org/labkey/api/util/MothershipReport.java
+++ b/api/src/org/labkey/api/util/MothershipReport.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbSchema;
@@ -29,6 +30,7 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.reader.Readers;
 import org.labkey.api.settings.AppProps;
+import org.labkey.api.util.logging.LogHelper;
 
 import javax.mail.internet.ContentType;
 import javax.net.ssl.HttpsURLConnection;
@@ -59,6 +61,7 @@ import java.util.stream.Collectors;
  */
 public class MothershipReport implements Runnable
 {
+    private final static Logger LOG = LogHelper.getLogger(MothershipReport.class, "Exception reporting and usage statistics submissions");
     private final URL _url;
     private final Map<String, String> _params = new LinkedHashMap<>();
     private final String _errorCode;
@@ -313,6 +316,7 @@ public class MothershipReport implements Runnable
         catch (Exception ignored)
         {
             // Don't bother the client if this report fails
+            LOG.debug("Failed to submit report to " + this._target + " at " + _url, ignored);
         }
     }
 

--- a/core/src/org/labkey/core/portal/ProjectController.java
+++ b/core/src/org/labkey/core/portal/ProjectController.java
@@ -340,7 +340,10 @@ public class ProjectController extends SpringActionController
             }
 
             PageConfig page = getPageConfig();
-            page.setHelpTopic(folderType.getHelpTopic());
+            if (folderType.getHelpTopic() != null)
+            {
+                page.setHelpTopic(folderType.getHelpTopic());
+            }
             page.setNavTrail(Collections.emptyList());
 
             Template t = isPrint() ? Template.Print : Template.Home;


### PR DESCRIPTION
#### Rationale
When a help link is targeting a fragment within the doc page, we're mangling the URL by appending a "referrer=inPage" or similar GET parameter after the #

Also, we can improve our logging and error messages to help users zero in on problems

#### Changes
* Correctly assemble help links that target a fragment
* Include string value when in error message about values being too long, truncating to keep the output manageable
* Debug-level logging to help diagnose failure to report exceptions/usage metrics
* Be specific about column that failed to return a value when we can't do query logging