### PR TITLE
Study schema contextual roles

### DIFF
--- a/announcements/src/org/labkey/announcements/query/AbstractSubscriptionTable.java
+++ b/announcements/src/org/labkey/announcements/query/AbstractSubscriptionTable.java
@@ -56,6 +56,7 @@ public class AbstractSubscriptionTable extends FilteredTable<AnnouncementSchema>
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
+        checkedPermissions.add(perm);
         return hasPermission(user, perm, getContainer());
     }
 

--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -67,6 +67,7 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.SchemaKey;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.reports.report.view.ReportUtil;
 import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.User;
@@ -110,7 +111,7 @@ import java.util.Set;
  * User: kevink
  * Date: 9/15/12
  */
-public abstract class AssayProtocolSchema extends AssaySchema
+public abstract class AssayProtocolSchema extends AssaySchema implements UserSchema.HasContextualRoles
 {
     public static final String RUNS_TABLE_NAME = "Runs";
     public static final String DATA_TABLE_NAME = "Data";
@@ -128,6 +129,8 @@ public abstract class AssayProtocolSchema extends AssaySchema
     private final ExpProtocol _protocol;
     private final AssayProvider _provider;
 
+    private Set<Role> _contextualRoles = new HashSet<>();
+
     public static SchemaKey schemaName(@NotNull AssayProvider provider, @NotNull ExpProtocol protocol)
     {
         return SchemaKey.fromParts(AssaySchema.NAME, provider.getResourceName(), protocol.getName());
@@ -144,6 +147,22 @@ public abstract class AssayProtocolSchema extends AssaySchema
         if (provider == null)
             throw new NotFoundException("Assay provider for assay protocol '" + protocol.getName() + "' not found");
         _provider = provider;
+    }
+
+    /** NOTE: this method should not be used for schemas created via QuerySchema.getSchema() (e.g. DefaultSchema.getSchema())
+     * as those might be cached.
+     * This should only be used for locally created Schema.
+     */
+    public void addContextualRole(@NotNull Role role)
+    {
+        assert role == RoleManager.getRole(role.getClass());
+        _contextualRoles.add(role);
+    }
+
+    @Override
+    public @NotNull Set<Role> getContextualRoles()
+    {
+        return _contextualRoles;
     }
 
     private static String descr(ExpProtocol protocol)

--- a/api/src/org/labkey/api/assay/AssaySchema.java
+++ b/api/src/org/labkey/api/assay/AssaySchema.java
@@ -70,7 +70,7 @@ public abstract class AssaySchema extends UserSchema
 
     // UNDONE: need to check permissions here 8449
     @Override
-    protected boolean canReadSchema()
+    public boolean canReadSchema()
     {
         return true;
     }

--- a/api/src/org/labkey/api/assay/AssaySchema.java
+++ b/api/src/org/labkey/api/assay/AssaySchema.java
@@ -69,7 +69,7 @@ public abstract class AssaySchema extends UserSchema
     }
 
     @Override
-    protected boolean canReadSchema()
+    public boolean canReadSchema()
     {
         return true;
     }

--- a/api/src/org/labkey/api/assay/AssaySchema.java
+++ b/api/src/org/labkey/api/assay/AssaySchema.java
@@ -68,9 +68,8 @@ public abstract class AssaySchema extends UserSchema
         return protocol.getName() + " " + tableType;
     }
 
-    // UNDONE: need to check permissions here 8449
     @Override
-    public boolean canReadSchema()
+    protected boolean canReadSchema()
     {
         return true;
     }

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -54,6 +54,7 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.query.column.ColumnInfoTransformer;
 import org.labkey.api.security.SecurityLogger;
+import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
@@ -889,6 +890,9 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
         SecurityLogger.log("AbstractTableInfo.hasPermission " + getName(), user, null, false);
+        UserSchema s = getUserSchema();
+        if (perm.equals(ReadPermission.class) && null != s)
+            return s.canReadSchema() && s.getContainer().hasPermission(user, perm);
         return false;
     }
 

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -446,9 +446,14 @@ public class Container implements Serializable, Comparable<Container>, Securable
     }
 
 
-    public boolean hasPermissions(@NotNull User user, @NotNull Set<Class<? extends Permission>> permissions)
+    public boolean hasPermissions(@NotNull UserPrincipal user, @NotNull Set<Class<? extends Permission>> permissions)
     {
         return SecurityManager.hasAllPermissions(null, getPolicy(), user, permissions, Set.of());
+    }
+
+    public boolean hasPermissions(@NotNull UserPrincipal user, @NotNull Set<Class<? extends Permission>> permissions, @Nullable Set<Role> contextualRoles)
+    {
+        return SecurityManager.hasAllPermissions(null, getPolicy(), user, permissions, contextualRoles);
     }
 
 

--- a/api/src/org/labkey/api/data/CrosstabTable.java
+++ b/api/src/org/labkey/api/data/CrosstabTable.java
@@ -80,7 +80,7 @@ public class CrosstabTable extends VirtualTable implements CrosstabTableInfo
      */
     public CrosstabTable(CrosstabSettings settings, List<CrosstabMember> colMembers)
     {
-        super(settings.getSourceTable().getSchema(), ALIAS);
+        super(settings.getSourceTable().getSchema(), ALIAS, settings.getSourceTable().getUserSchema());
 
         assert null != settings.getRowAxis() && null != settings.getColumnAxis() && null != settings.getMeasures();
         assert !settings.getRowAxis().getDimensions().isEmpty() && ! settings.getColumnAxis().getDimensions().isEmpty();

--- a/api/src/org/labkey/api/data/CrosstabTable.java
+++ b/api/src/org/labkey/api/data/CrosstabTable.java
@@ -522,6 +522,7 @@ public class CrosstabTable extends VirtualTable implements CrosstabTableInfo
     @Override @NotNull
     public SQLFragment getFromSQL()
     {
+        checkReadBeforeExecute();
         assert null != getColMembers();
 
         SQLFragment sql = new SQLFragment();

--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -2007,7 +2007,7 @@ public class DataRegion extends DisplayElement
                     throw new UnauthorizedException();
 
                 TableInfo tinfoMain = getTable();
-                Collection<Map<String, Object>> maps = new TableSelector(tinfoMain, selectKeyMap.values(), new PkFilter(getTable(), viewForm.getPkVals()), null).getMapCollection();
+                Collection<Map<String, Object>> maps = new TableSelector(tinfoMain, selectKeyMap.values(), new PkFilter(tinfoMain, viewForm.getPkVals()), null).getMapCollection();
                 if (!maps.isEmpty())
                     valueMap = maps.iterator().next();
             }

--- a/api/src/org/labkey/api/data/EnumTableInfo.java
+++ b/api/src/org/labkey/api/data/EnumTableInfo.java
@@ -128,6 +128,7 @@ public class EnumTableInfo<EnumType extends Enum<EnumType>> extends VirtualTable
     @Override @NotNull
     public SQLFragment getFromSQL()
     {
+        checkReadBeforeExecute();
         SQLFragment sql = new SQLFragment();
         String separator = "";
         EnumSet<EnumType> enumSet = EnumSet.allOf(_enum);

--- a/api/src/org/labkey/api/data/GroupTableInfo.java
+++ b/api/src/org/labkey/api/data/GroupTableInfo.java
@@ -43,7 +43,7 @@ public class GroupTableInfo extends VirtualTable
 
     public GroupTableInfo(TableInfo source, SimpleFilter sourceFilter, List<ColumnInfo> groupByCols, List<CrosstabMeasure> measures)
     {
-        super(source.getSchema(), ALIAS);
+        super(source.getSchema(), ALIAS, source.getUserSchema());
 
         assert null != groupByCols && groupByCols.size() > 0 : "No group by columns passed to GroupTableInfo constructor!";
         assert null != measures && measures.size() > 0 : "No measures passed to GroupTableInfo constructor!";

--- a/api/src/org/labkey/api/data/GroupTableInfo.java
+++ b/api/src/org/labkey/api/data/GroupTableInfo.java
@@ -68,6 +68,7 @@ public class GroupTableInfo extends VirtualTable
     @Override @NotNull
     public SQLFragment getFromSQL()
     {
+        checkReadBeforeExecute();
         SQLFragment sql = new SQLFragment("SELECT ");
         String sep = "";
         

--- a/api/src/org/labkey/api/data/NestedRenderContext.java
+++ b/api/src/org/labkey/api/data/NestedRenderContext.java
@@ -166,7 +166,7 @@ public class NestedRenderContext extends RenderContext
         fromSQL.append(groupColumn.getAlias());
 
         // Create a TableInfo that wraps the GROUP BY query
-        VirtualTable aggTableInfo = new VirtualTable(tinfo.getSchema(), "AggTable")
+        VirtualTable aggTableInfo = new VirtualTable(tinfo.getSchema(), "AggTable", tinfo.getUserSchema())
         {
             @NotNull
             @Override

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -38,11 +38,13 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.HasPermission;
 import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.ContainerContext;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.view.ActionURL;
+import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewContext;
 import org.labkey.data.xml.TableType;
 import org.labkey.data.xml.queryCustomView.FilterType;
@@ -725,4 +727,17 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
         return getMaxPhiLevel().isLevelAllowed(getUserMaxAllowedPhiLevel());
     }
 
+    /**
+     * Useful helper to combine permission check/throw.  This is especially useful for tables where permissions can
+     * differ from the containing schema/container.
+     *
+     * TableInfo users should still always check hasPermission() as early as possible for best error handling, and
+     * to fail-fast (or degrade gracefully).
+     */
+    default void checkReadBeforeExecute()
+    {
+        assert null != getUserSchema(); // this is only for tables in UserSchema
+        if (null != getUserSchema() && !hasPermission(getUserSchema().getUser(), ReadPermission.class))
+            throw new UnauthorizedException(getUserSchema().getSchemaName() + "." + getName());
+    }
 }

--- a/api/src/org/labkey/api/data/VirtualTable.java
+++ b/api/src/org/labkey/api/data/VirtualTable.java
@@ -20,6 +20,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.query.AbstractContainerFilterable;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.SecurityLogger;
+import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 
 /**
  * A {@link org.labkey.api.data.TableInfo} implementation that is not backed directly by a real table in the database,
@@ -56,6 +60,14 @@ public class VirtualTable<SchemaType extends UserSchema> extends AbstractContain
     public VirtualTable(DbSchema schema, String name)
     {
         this(schema, name, null);
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
+    {
+        boolean result = perm.equals(ReadPermission.class) && getUserSchema().getContainer().hasPermission(getUserSchema().getUser(), perm);
+        SecurityLogger.log("VirtualTable.hasPermission " + getName(), user, null, result);
+        return result;
     }
 
     @Override

--- a/api/src/org/labkey/api/data/VirtualTable.java
+++ b/api/src/org/labkey/api/data/VirtualTable.java
@@ -53,19 +53,14 @@ public class VirtualTable<SchemaType extends UserSchema> extends AbstractContain
         _setContainerFilter(cf);
     }
 
-    /**
-     * @deprecated Use constructor with SchemaType parameter instead
-     */
-    @Deprecated
-    public VirtualTable(DbSchema schema, String name)
-    {
-        this(schema, name, null);
-    }
 
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        boolean result = perm.equals(ReadPermission.class) && getUserSchema().getContainer().hasPermission(getUserSchema().getUser(), perm);
+        var us = getUserSchema();
+        if (null == us)
+            return false;
+        boolean result = perm.equals(ReadPermission.class) && us.getContainer().hasPermission(user, perm);
         SecurityLogger.log("VirtualTable.hasPermission " + getName(), user, null, result);
         return result;
     }

--- a/api/src/org/labkey/api/query/DefaultSchema.java
+++ b/api/src/org/labkey/api/query/DefaultSchema.java
@@ -236,11 +236,15 @@ final public class DefaultSchema extends AbstractSchema implements QuerySchema.C
         SchemaKey skey = new SchemaKey(null, name);
         QuerySchema ret = cache.get(skey);
         if (ret != null)
+        {
+            assert !(ret instanceof UserSchema.HasContextualRoles) || ((UserSchema.HasContextualRoles)ret).getContextualRoles().isEmpty();
             return ret;
+        }
         ret = _getSchema(name);
         if (null != ret)
         {
             // If QuerySchema had getSchemaKey(), it would be nice to cache under a canonical name
+            assert !(ret instanceof UserSchema.HasContextualRoles) || ((UserSchema.HasContextualRoles)ret).getContextualRoles().isEmpty();
             cache.put(skey,ret);
             if (ret.getContainer().equals(getContainer()))
             {

--- a/api/src/org/labkey/api/query/FilteredTable.java
+++ b/api/src/org/labkey/api/query/FilteredTable.java
@@ -47,6 +47,7 @@ import org.labkey.api.util.ContainerContext;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.view.ActionURL;
+import org.labkey.api.view.UnauthorizedException;
 import org.labkey.data.xml.TableCustomizerType;
 import org.labkey.data.xml.TableType;
 
@@ -83,6 +84,22 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
     private final @NotNull TableRules _rules;
     private Set<FieldKey> _rulesOmittedColumns = null;
     private Set<FieldKey> _rulesTransformedColumns = null;
+
+    // for debugging/validation only
+    protected Set<Class<? extends Permission>> checkedPermissions = new HashSet<>();
+
+    private static boolean assertCheckedPermissions = false; // for fail fast (developers only)
+
+    @Override
+    public void checkReadBeforeExecute()
+    {
+        // strongest (can't leave on until every subclass uses checkedPermissions.add()
+        assert !assertCheckedPermissions || checkedPermissions.contains(ReadPermission.class) : "caller should call TableInfo.hasPermission()";
+        // strong
+        assert !assertCheckedPermissions || hasPermission(getUserSchema().getUser(), ReadPermission.class) : "Caller should check TableInfo.hasPermission()";
+        if (!hasPermission(getUserSchema().getUser(), ReadPermission.class))
+            throw new UnauthorizedException(getUserSchema().getSchemaName() + "." + getName());
+    }
 
     public FilteredTable(@NotNull TableInfo table, @NotNull SchemaType userSchema)
     {
@@ -473,11 +490,13 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
     @Override
     public SQLFragment getFromSQL(String alias)
     {
+        checkReadBeforeExecute();
         return getFromSQL(alias, false);
     }
 
     public SQLFragment getFromSQL(String alias, boolean skipTransform)
     {
+        checkReadBeforeExecute();
         SimpleFilter filter = getFilter();
         SQLFragment where = filter.getSQLFragment(_rootTable.getSqlDialect());
         if (where.isEmpty())
@@ -819,6 +838,7 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
+        checkedPermissions.add(perm);
         if (ReadPermission.class.isAssignableFrom(perm))
         {
             return _userSchema.getContainer().hasPermission(user, perm);

--- a/api/src/org/labkey/api/query/FilteredTable.java
+++ b/api/src/org/labkey/api/query/FilteredTable.java
@@ -43,6 +43,7 @@ import org.labkey.api.data.WrappedColumnInfo;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.roles.Role;
 import org.labkey.api.util.ContainerContext;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpression;
@@ -841,7 +842,13 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
         checkedPermissions.add(perm);
         if (ReadPermission.class.isAssignableFrom(perm))
         {
-            return _userSchema.getContainer().hasPermission(user, perm);
+            // Not sure the historical reason why this code did not just call AbstractTable.hasPermission()
+            // however this is a useful place to handle UserSchema.HasContextualRoles()
+            Set<Role> roles = null;
+            if (_userSchema instanceof UserSchema.HasContextualRoles)
+                roles = ((UserSchema.HasContextualRoles) _userSchema).getContextualRoles();
+            if (_userSchema.getContainer().hasPermission(user, perm, roles))
+                return true;
         }
         return super.hasPermission(user, perm);
     }

--- a/api/src/org/labkey/api/query/PropertyForeignKey.java
+++ b/api/src/org/labkey/api/query/PropertyForeignKey.java
@@ -173,7 +173,7 @@ public class PropertyForeignKey extends AbstractForeignKey implements PropertyCo
     @Override
     public TableInfo getLookupTableInfo()
     {
-        VirtualTable ret = new VirtualTable(ExperimentService.get().getSchema(), null);
+        VirtualTable ret = new VirtualTable(ExperimentService.get().getSchema(), null, (UserSchema)_sourceSchema);
         for (Map.Entry<String, PropertyDescriptor> entry : _pdMap.entrySet())
         {
             BaseColumnInfo column = constructColumnInfo(null, new FieldKey(null,entry.getKey()), entry.getValue());

--- a/api/src/org/labkey/api/query/QueryForeignKey.java
+++ b/api/src/org/labkey/api/query/QueryForeignKey.java
@@ -27,6 +27,7 @@ import org.labkey.api.data.ForeignKey;
 import org.labkey.api.data.LookupColumn;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.StringExpression;
 
 import java.util.Map;
@@ -384,7 +385,10 @@ public class QueryForeignKey extends AbstractForeignKey
     {
         if (_table == null && getSchema() != null)
         {
-            _table = getSchema().getTable(_tableName, getLookupContainerFilter());
+            TableInfo t = getSchema().getTable(_tableName, getLookupContainerFilter());
+            if (null != t && !t.hasPermission(getLookupUser(), ReadPermission.class))
+                t = null;
+            _table = t;
         }
         return _table;
     }

--- a/api/src/org/labkey/api/query/QueryForm.java
+++ b/api/src/org/labkey/api/query/QueryForm.java
@@ -71,7 +71,7 @@ public class QueryForm extends ReturnUrlForm implements HasViewContext, HasBindP
     private boolean _bindQueryName = true;
     private boolean _bindSchemaName = true;
     private boolean _bindViewName = true;
-    private BindState _bindState = BindState.UNBOUND;
+    protected BindState _bindState = BindState.UNBOUND;
     private QueryUpdateService.InsertOption _insertOption = QueryUpdateService.InsertOption.IMPORT;
 
 
@@ -104,7 +104,7 @@ public class QueryForm extends ReturnUrlForm implements HasViewContext, HasBindP
         return _queryView;
     }
 
-    private enum BindState { UNBOUND, BINDING, BOUND }
+    protected enum BindState { UNBOUND, BINDING, BOUND }
 
     protected PropertyValues _initParameters = null;
 

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -115,7 +115,7 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
         _restricted = restricted;
     }
 
-    public boolean canReadSchema()
+    protected boolean canReadSchema()
     {
         User user = getUser();
         if (user == null)

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -113,7 +113,7 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
         _restricted = restricted;
     }
 
-    protected boolean canReadSchema()
+    public boolean canReadSchema()
     {
         User user = getUser();
         if (user == null)

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -37,6 +37,7 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.security.roles.Role;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.MemTrackable;
 import org.labkey.api.util.MemTracker;
@@ -882,5 +883,11 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
             tableInfoCache.put(key,ret);
         }
         return ret;
+    }
+
+
+    public interface HasContextualRoles
+    {
+        @NotNull Set<Role> getContextualRoles();
     }
 }

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -115,7 +115,7 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
         _restricted = restricted;
     }
 
-    protected boolean canReadSchema()
+    public boolean canReadSchema()
     {
         User user = getUser();
         if (user == null)

--- a/api/src/org/labkey/api/reports/report/AbstractReport.java
+++ b/api/src/org/labkey/api/reports/report/AbstractReport.java
@@ -610,29 +610,27 @@ public abstract class AbstractReport implements Report, Cloneable // TODO: Remov
         if (view != null)
         {
             QueryDefinition def = view.getQueryDef();
-            if (def != null)
-            {
-                List<QueryException> errors = new ArrayList<>();
-                TableInfo table = def.getTable(errors, false);
-
-                if (!errors.isEmpty())
-                {
-                    StringBuilder sb = new StringBuilder();
-                    String delim = "";
-
-                    for (QueryException error : errors)
-                    {
-                        sb.append(delim).append(error.getMessage());
-                        delim = "\n";
-                    }
-                    throw new ValidationException("Unable to get table or query: " + sb.toString());
-                }
-
-                if (table == null)
-                    throw new ValidationException("Table or query not found: " + view.getSettings().getQueryName());
-            }
-            else
+            if (def == null)
                 throw new ValidationException("Unable to get a query definition from table or query: " + view.getSettings().getQueryName());
+
+            List<QueryException> errors = new ArrayList<>();
+            TableInfo table = def.getTable(errors, false);
+
+            if (!errors.isEmpty())
+            {
+                StringBuilder sb = new StringBuilder();
+                String delim = "";
+
+                for (QueryException error : errors)
+                {
+                    sb.append(delim).append(error.getMessage());
+                    delim = "\n";
+                }
+                throw new ValidationException("Unable to get table or query: " + sb.toString());
+            }
+
+            if (table == null)
+                throw new ValidationException("Table or query not found: " + view.getSettings().getQueryName());
         }
     }
 

--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -320,22 +320,30 @@ public interface Dataset extends StudyEntity, StudyCachable<Dataset>
 
     /**
      * @return whether the user has permission to read rows from this dataset
+     * @deprecated use DatasetTableImpl.hasPermission()
      */
+    @Deprecated
     boolean canRead(UserPrincipal user);
 
     /**
      * @return whether the user has permission to update the dataset
+     * @deprecated use DatasetTableImpl.hasPermission()
      */
+    @Deprecated
     boolean canUpdate(UserPrincipal user);
 
     /**
      * @return whether the user has permission to delete from the dataset
+     * @deprecated use DatasetTableImpl.hasPermission()
      */
+    @Deprecated
     boolean canDelete(UserPrincipal user);
 
     /**
      * @return whether the user has permission to insert rows into the dataset
+     * @deprecated use DatasetTableImpl.hasPermission()
      */
+    @Deprecated
     boolean canInsert(UserPrincipal user);
 
     /**

--- a/api/src/org/labkey/api/study/assay/RunDatasetContextualRoles.java
+++ b/api/src/org/labkey/api/study/assay/RunDatasetContextualRoles.java
@@ -113,7 +113,8 @@ public class RunDatasetContextualRoles implements HasContextualRoles
         if (provider == null)
             return null;
 
-        AssayProtocolSchema schema = provider.createProtocolSchema(user, container, protocol, null);
+        // use a user with elevated permissions to do the query to figure out permissions
+        AssayProtocolSchema schema = provider.createProtocolSchema(User.getSearchUser(), container, protocol, null);
         if (schema == null)
             return null;
 

--- a/api/src/org/labkey/api/study/assay/SampleParticipantVisitResolver.java
+++ b/api/src/org/labkey/api/study/assay/SampleParticipantVisitResolver.java
@@ -76,7 +76,7 @@ public class SampleParticipantVisitResolver extends StudyParticipantVisitResolve
                     {
                         if (dataset.getContainer() == targetStudyContainer)
                         {
-                            TableInfo tableInfo = dataset.getTableInfo(getUser(), false);
+                            TableInfo tableInfo = dataset.getTableInfo(getUser());
                             Filter datasetFilter = new SimpleFilter(FieldKey.fromParts(dataset.getKeyPropertyName()), id);
                             Map<String, Object> row = new TableSelector(tableInfo, datasetFilter, null).getMap();
                             if (row != null && !row.isEmpty())

--- a/api/src/org/labkey/api/study/assay/SampleParticipantVisitResolver.java
+++ b/api/src/org/labkey/api/study/assay/SampleParticipantVisitResolver.java
@@ -76,7 +76,7 @@ public class SampleParticipantVisitResolver extends StudyParticipantVisitResolve
                     {
                         if (dataset.getContainer() == targetStudyContainer)
                         {
-                            TableInfo tableInfo = dataset.getTableInfo(getUser());
+                            TableInfo tableInfo = dataset.getTableInfo(getUser(), false);
                             Filter datasetFilter = new SimpleFilter(FieldKey.fromParts(dataset.getKeyPropertyName()), id);
                             Map<String, Object> row = new TableSelector(tableInfo, datasetFilter, null).getMap();
                             if (row != null && !row.isEmpty())

--- a/api/webapp/clientapi/dom/Utils.js
+++ b/api/webapp/clientapi/dom/Utils.js
@@ -70,7 +70,7 @@ LABKEY.Utils = new function(impl, $) {
         }
         var html = [
             '<div class="modal-header">',
-                (!disableCloseBtn ? '<button type="button" class="close" data-dismiss="modal">&times;</button>' : ''),
+                (!disableCloseBtn && supportsModal() ? '<button type="button" class="close" data-dismiss="modal">&times;</button>' : ''),
                 '<h4 class="modal-title">' + LABKEY.Utils.encodeHtml(title) + '</h4>',
             '</div>',
             '<div class="modal-body">'
@@ -93,12 +93,17 @@ LABKEY.Utils = new function(impl, $) {
             modal.modal({backdrop: 'static'});
         }
 
-        showModal('lk-utils-modal')
+        showModal()
     };
 
-    var showModal = function(divId) {
-        var modal = $('#' + divId);
-        if (LABKEY.Utils.isFunction(modal.modal)) {
+    var supportsModal = function() {
+        var modal = $('#lk-utils-modal');
+        return LABKEY.Utils.isFunction(modal.modal);
+    }
+
+    var showModal = function() {
+        var modal = $('#lk-utils-modal');
+        if (supportsModal()) {
             modal.modal('show');
         } else {
             $('body').append('<div id="lk-utils-modal-backdrop" class="fade modal-backdrop in"></div>');

--- a/api/webapp/clientapi/dom/WebSocket.js
+++ b/api/webapp/clientapi/dom/WebSocket.js
@@ -40,6 +40,17 @@ LABKEY.WebSocket = new function ()
         _websocket = new WebSocket((window.location.protocol==="http:"?"ws:":"wss:") + "//" + window.location.host + LABKEY.contextPath + "/_websocket/notifications");
         _websocket.onmessage = websocketOnMessage;
         _websocket.onclose = websocketOnClose;
+        _websocket.onerror = websocketConnectionFailure;
+    }
+
+    function websocketConnectionFailure() {
+        if (!LABKEY.user.isGuest) {
+            LABKEY.Ajax.request({
+                url: LABKEY.ActionURL.buildURL("core", "webSocketConnection.api"),
+                method: 'POST',
+                params: { connected: false }
+            });
+        }
     }
 
     function websocketOnMessage(evt) {

--- a/assay/api-src/org/labkey/api/assay/plate/AbstractPlateBasedAssayProvider.java
+++ b/assay/api-src/org/labkey/api/assay/plate/AbstractPlateBasedAssayProvider.java
@@ -397,6 +397,7 @@ public abstract class AbstractPlateBasedAssayProvider extends AbstractTsvAssayPr
         @Override
         public @NotNull SQLFragment getFromSQL()
         {
+            checkReadBeforeExecute();
             SQLFragment sql = new SQLFragment();
             String separator = "";
             EnumSet<StatsService.CurveFitType> enumSet = EnumSet.allOf(_enum);

--- a/assay/src/org/labkey/assay/query/AssayProviderTable.java
+++ b/assay/src/org/labkey/assay/query/AssayProviderTable.java
@@ -55,6 +55,7 @@ public class AssayProviderTable extends VirtualTable<AssaySchema>
     @Override @NotNull
     public SQLFragment getFromSQL()
     {
+        checkReadBeforeExecute();
         SQLFragment sql = new SQLFragment();
         String separator = "";
 

--- a/audit/src/org/labkey/audit/query/AuditQuerySchema.java
+++ b/audit/src/org/labkey/audit/query/AuditQuerySchema.java
@@ -110,7 +110,7 @@ public class AuditQuerySchema extends UserSchema
     }
 
     @Override
-    protected boolean canReadSchema()
+    public boolean canReadSchema()
     {
         return true;
     }

--- a/audit/src/org/labkey/audit/query/AuditQuerySchema.java
+++ b/audit/src/org/labkey/audit/query/AuditQuerySchema.java
@@ -110,7 +110,7 @@ public class AuditQuerySchema extends UserSchema
     }
 
     @Override
-    public boolean canReadSchema()
+    protected boolean canReadSchema()
     {
         return true;
     }

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -162,6 +162,7 @@ import org.labkey.api.writer.VirtualFile;
 import org.labkey.api.writer.Writer;
 import org.labkey.api.writer.ZipUtil;
 import org.labkey.core.metrics.ClientSideMetricManager;
+import org.labkey.core.metrics.WebSocketConnectionManager;
 import org.labkey.core.portal.ProjectController;
 import org.labkey.core.qc.CoreQCStateHandler;
 import org.labkey.core.reports.ExternalScriptEngineDefinitionImpl;
@@ -2415,6 +2416,32 @@ public class CoreController extends SpringActionController
             }
 
             return new ApiSimpleResponse(json);
+        }
+    }
+
+    @RequiresLogin
+    public class WebSocketConnectionAction extends MutatingApiAction<WebSocketConnectionForm>
+    {
+        @Override
+        public Object execute(WebSocketConnectionForm form, BindException errors)
+        {
+            WebSocketConnectionManager.getInstance().incrementCounter(form.isConnected());
+            return success();
+        }
+    }
+
+    public static class WebSocketConnectionForm
+    {
+        private boolean _connected;
+
+        public boolean isConnected()
+        {
+            return _connected;
+        }
+
+        public void setConnected(boolean connected)
+        {
+            _connected = connected;
         }
     }
 

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -190,6 +190,7 @@ import org.labkey.core.junit.JunitController;
 import org.labkey.core.login.DbLoginAuthenticationProvider;
 import org.labkey.core.login.LoginController;
 import org.labkey.core.metrics.ClientSideMetricManager;
+import org.labkey.core.metrics.WebSocketConnectionManager;
 import org.labkey.core.notification.EmailPreferenceConfigServiceImpl;
 import org.labkey.core.notification.EmailPreferenceContainerListener;
 import org.labkey.core.notification.EmailPreferenceUserListener;
@@ -975,6 +976,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         });
 
         ClientSideMetricManager.get().registerUsageMetrics(getName());
+        UsageMetricsService.get().registerUsageMetrics(getName(), WebSocketConnectionManager.getInstance());
 
         if (AppProps.getInstance().isDevMode())
             PremiumService.get().registerAntiVirusProvider(new DummyAntiVirusService.Provider());

--- a/core/src/org/labkey/core/metrics/WebSocketConnectionManager.java
+++ b/core/src/org/labkey/core/metrics/WebSocketConnectionManager.java
@@ -1,0 +1,47 @@
+package org.labkey.core.metrics;
+
+import org.labkey.api.usageMetrics.UsageMetricsProvider;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class WebSocketConnectionManager implements UsageMetricsProvider
+{
+    private static final WebSocketConnectionManager _instance = new WebSocketConnectionManager();
+
+    final private AtomicInteger successCounter = new AtomicInteger();
+    final private AtomicInteger failureCounter = new AtomicInteger();
+
+    private WebSocketConnectionManager()
+    {
+    }
+
+    public static WebSocketConnectionManager getInstance()
+    {
+        return _instance;
+    }
+
+    public void incrementCounter(boolean success)
+    {
+        if (success)
+            successCounter.incrementAndGet();
+        else
+            failureCounter.incrementAndGet();
+    }
+
+    public boolean showWarning()
+    {
+        return successCounter.get() == 0 && failureCounter.get() > 0;
+    }
+
+    @Override
+    public Map<String, Object> getUsageMetrics()
+    {
+        return Map.of(
+            "webSocketConnections", Map.of(
+                    "success", successCounter.get(),
+                    "failure", failureCounter.get()
+                )
+        );
+    }
+}

--- a/core/src/org/labkey/core/notification/NotificationEndpoint.java
+++ b/core/src/org/labkey/core/notification/NotificationEndpoint.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.security.User;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.security.SecurityManager;
+import org.labkey.core.metrics.WebSocketConnectionManager;
 
 import javax.servlet.http.HttpSession;
 import javax.websocket.CloseReason;
@@ -78,6 +79,7 @@ public class NotificationEndpoint extends Endpoint
             if (this.userId > 0)
             {
                 endpointsMap.put(this.userId, this);
+                WebSocketConnectionManager.getInstance().incrementCounter(true);
                 MemTracker.get().put(this);
             }
         }

--- a/core/src/org/labkey/core/query/ApiKeysTableInfo.java
+++ b/core/src/org/labkey/core/query/ApiKeysTableInfo.java
@@ -20,9 +20,12 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.query.DefaultQueryUpdateService;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.permissions.UserManagementPermission;
 
 public class ApiKeysTableInfo extends FilteredTable<CoreQuerySchema>
 {
@@ -46,7 +49,8 @@ public class ApiKeysTableInfo extends FilteredTable<CoreQuerySchema>
     {
         // We only allow delete on this table. No need for permission check, since we already know user has
         // UserManagementPermission at the root.
-        return perm.equals(DeletePermission.class);
+        assert((User)user).hasRootPermission(UserManagementPermission.class);
+        return perm.equals(ReadPermission.class) || perm.equals(DeletePermission.class);
     }
 
     @Override

--- a/core/src/org/labkey/core/query/CoreQuerySchema.java
+++ b/core/src/org/labkey/core/query/CoreQuerySchema.java
@@ -658,7 +658,7 @@ public class CoreQuerySchema extends UserSchema
     }
 
     @Override
-    protected boolean canReadSchema()
+    public boolean canReadSchema()
     {
         SecurityLogger.indent("CoreQuerySchema.canReadSchema()");
         try

--- a/core/src/org/labkey/core/query/CoreQuerySchema.java
+++ b/core/src/org/labkey/core/query/CoreQuerySchema.java
@@ -685,7 +685,7 @@ public class CoreQuerySchema extends UserSchema
     }
 
     @Override
-    public boolean canReadSchema()
+    protected boolean canReadSchema()
     {
         SecurityLogger.indent("CoreQuerySchema.canReadSchema()");
         try

--- a/core/src/org/labkey/core/query/CoreQuerySchema.java
+++ b/core/src/org/labkey/core/query/CoreQuerySchema.java
@@ -685,7 +685,7 @@ public class CoreQuerySchema extends UserSchema
     }
 
     @Override
-    protected boolean canReadSchema()
+    public boolean canReadSchema()
     {
         SecurityLogger.indent("CoreQuerySchema.canReadSchema()");
         try

--- a/core/src/org/labkey/core/query/ModulesTableInfo.java
+++ b/core/src/org/labkey/core/query/ModulesTableInfo.java
@@ -33,7 +33,9 @@ import org.labkey.api.module.ModuleContext;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.SimpleUserSchema;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.StringExpressionFactory;
+import org.labkey.api.view.UnauthorizedException;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -150,6 +152,7 @@ public class ModulesTableInfo extends SimpleUserSchema.SimpleTable<CoreQuerySche
     @Override
     public SQLFragment getFromSQL(String alias)
     {
+        checkReadBeforeExecute();
         var h = getSqlDialect().getStringHandler();
         SQLFragment ret = new SQLFragment();
 

--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -36,6 +36,7 @@ import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.template.WarningProvider;
 import org.labkey.api.view.template.WarningService;
 import org.labkey.api.view.template.Warnings;
+import org.labkey.core.metrics.WebSocketConnectionManager;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
@@ -78,6 +79,8 @@ public class CoreWarningProvider implements WarningProvider
             getModuleErrorWarnings(warnings, context);
 
             getProbableLeakCountWarnings(warnings);
+
+            getWebSocketConnectionWarnings(warnings);
 
             //upgrade message--show to admins
             HtmlString upgradeMessage = UsageReportingLevel.getUpgradeMessage();
@@ -166,6 +169,12 @@ public class CoreWarningProvider implements WarningProvider
             }
             addStandardWarning(warnings, "The following modules experienced errors during startup:", moduleFailures.keySet().toString(), PageFlowUtil.urlProvider(AdminUrls.class).getModuleErrorsURL(context.getContainer()));
         }
+    }
+
+    private void getWebSocketConnectionWarnings(Warnings warnings)
+    {
+        if (SHOW_ALL_WARNINGS || WebSocketConnectionManager.getInstance().showWarning())
+            addStandardWarning(warnings, "The WebSocket connection failed. LabKey Server uses WebSockets to send notifications and alert users when their session ends.", "configTomcat#websocket", "Tomcat Configuration");
     }
 
     private void getUserRequestedAdminOnlyModeWarnings(Warnings warnings)

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -84,6 +84,7 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.study.assay.FileLinkDisplayColumn;
 import org.labkey.api.util.Pair;
@@ -91,6 +92,7 @@ import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
+import org.labkey.api.view.UnauthorizedException;
 import org.labkey.experiment.ExpDataIterators;
 import org.labkey.experiment.ExpDataIterators.AliasDataIteratorBuilder;
 import org.labkey.experiment.ExpDataIterators.PersistDataIteratorBuilder;
@@ -437,6 +439,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
     @Override
     public SQLFragment getFromSQL(String alias)
     {
+        checkReadBeforeExecute();
         TableInfo provisioned = _dataClass.getTinfo();
 
         // all columns from exp.data except lsid

--- a/experiment/src/org/labkey/experiment/api/ExpRunGroupMapTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunGroupMapTableImpl.java
@@ -108,6 +108,7 @@ public class ExpRunGroupMapTableImpl extends ExpTableImpl<ExpRunGroupMapTable.Co
     @Override
     public SQLFragment getFromSQL(String alias)
     {
+        checkReadBeforeExecute();
         SQLFragment ret = new SQLFragment("(SELECT * FROM (SELECT rl.* FROM ");
         ret.append(ExperimentServiceImpl.get().getTinfoRunList(), "rl");
         ret.append(", ");

--- a/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
@@ -271,7 +271,7 @@ abstract public class ExpTableImpl<C extends Enum>
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        if (getUpdateService() != null)
+        if (perm == ReadPermission.class || getUpdateService() != null)
             return isAllowedPermission(perm) && _userSchema.getContainer().hasPermission(user, perm);
         return false;
     }

--- a/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
@@ -47,6 +47,7 @@ import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.roles.Role;
 import org.labkey.api.util.URIUtil;
 import org.labkey.api.view.ActionURL;
 
@@ -272,7 +273,12 @@ abstract public class ExpTableImpl<C extends Enum>
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
         if (perm == ReadPermission.class || getUpdateService() != null)
-            return isAllowedPermission(perm) && _userSchema.getContainer().hasPermission(user, perm);
+        {
+            Set<Role> roles = null;
+            if (_userSchema instanceof UserSchema.HasContextualRoles)
+                roles = ((UserSchema.HasContextualRoles)_userSchema).getContextualRoles();
+            return isAllowedPermission(perm) && _userSchema.getContainer().hasPermission(user, perm, roles);
+        }
         return false;
     }
 

--- a/experiment/src/org/labkey/experiment/api/LineageTableInfo.java
+++ b/experiment/src/org/labkey/experiment/api/LineageTableInfo.java
@@ -266,6 +266,7 @@ public class LineageTableInfo extends VirtualTable
     @Override
     public SQLFragment getFromSQL()
     {
+        checkReadBeforeExecute();
         ExpLineageOptions options = new ExpLineageOptions();
         options.setForLookup(true);
         options.setParents(_parents);
@@ -329,7 +330,7 @@ public class LineageTableInfo extends VirtualTable
         @Override
         public SQLFragment getFromSQL()
         {
-            // giant union query
+            checkReadBeforeExecute();
             SQLFragment sql = new SQLFragment();
             sql.append(
                     "SELECT container, CAST('Data' AS VARCHAR(50)) AS exptype, CAST(cpastype AS VARCHAR(200)) AS cpastype, name, lsid, rowid, CAST(NULL AS VARCHAR(200)) AS RunProtocolLsid\n" +

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -627,7 +627,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
 
         _VirtualTable(DbSchema schema, String name, SchemaTableInfo inner, Map<String,String> map)
         {
-            super(schema, name);
+            super(schema, name, null);
             _inner = inner;
             _map.putAll(map);
         }

--- a/internal/src/org/labkey/api/query/PropertiesDisplayColumn.java
+++ b/internal/src/org/labkey/api/query/PropertiesDisplayColumn.java
@@ -21,7 +21,6 @@ import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyColumn;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.security.UserPrincipal;
-import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.JsonUtil;
 import org.labkey.api.util.Pair;
@@ -335,12 +334,6 @@ public class PropertiesDisplayColumn extends DataColumn implements NestedPropert
         public UserSchema getUserSchema()
         {
             return this.schema;
-        }
-
-        @Override
-        public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
-        {
-            return ReadPermission.class.isAssignableFrom(perm) && getUserSchema().getContainer().hasPermission(user, perm);
         }
     }
 }

--- a/internal/src/org/labkey/api/query/PropertiesDisplayColumn.java
+++ b/internal/src/org/labkey/api/query/PropertiesDisplayColumn.java
@@ -305,7 +305,7 @@ public class PropertiesDisplayColumn extends DataColumn implements NestedPropert
 
         public PropsTable(UserSchema schema)
         {
-            super(schema.getDbSchema(), "props");
+            super(schema.getDbSchema(), "props", schema);
             this.schema = schema;
             SqlDialect d = schema.getDbSchema().getSqlDialect();
 

--- a/issues/src/org/labkey/issue/query/IssuesTable.java
+++ b/issues/src/org/labkey/issue/query/IssuesTable.java
@@ -75,6 +75,7 @@ import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.Tuple3;
 import org.labkey.api.view.ActionURL;
+import org.labkey.api.view.UnauthorizedException;
 import org.labkey.issue.IssuesController;
 import org.labkey.issue.model.Issue;
 import org.labkey.issue.model.IssueListDef;
@@ -185,12 +186,17 @@ public class IssuesTable extends FilteredTable<IssuesQuerySchema> implements Upd
                 if (_table == null && getSchema() != null)
                 {
                     // TODO use forWrite==true because of setFk() below
-                    _table = getUserSchema().getTable(_tableName, getLookupContainerFilter(), true, true);
-
-                    var lookupColumn = (BaseColumnInfo)_table.getColumn(getLookupColumnName());
-                    lookupColumn.setFk( QueryForeignKey.from(getUserSchema(), getLookupContainerFilter()).to(IssuesQuerySchema.ALL_ISSUE_TABLE, "issueid", null) );
-                    var junctionColumn = (BaseColumnInfo)_table.getColumn("RelatedIssueId");
-                    junctionColumn.setFk( QueryForeignKey.from(getUserSchema(), getLookupContainerFilter()).to(IssuesQuerySchema.ALL_ISSUE_TABLE, "issueid", null) );
+                    TableInfo t = getUserSchema().getTable(_tableName, getLookupContainerFilter(), true, true);
+                    if (null != t && !t.hasPermission(getLookupUser(), ReadPermission.class))
+                        t = null;
+                    if (null != t)
+                    {
+                        var lookupColumn = (BaseColumnInfo)t.getColumn(getLookupColumnName());
+                        lookupColumn.setFk( QueryForeignKey.from(getUserSchema(), getLookupContainerFilter()).to(IssuesQuerySchema.ALL_ISSUE_TABLE, "issueid", null) );
+                        var junctionColumn = (BaseColumnInfo)t.getColumn("RelatedIssueId");
+                        junctionColumn.setFk( QueryForeignKey.from(getUserSchema(), getLookupContainerFilter()).to(IssuesQuerySchema.ALL_ISSUE_TABLE, "issueid", null) );
+                        _table = t;
+                    }
                 }
 
                 return _table;
@@ -364,6 +370,7 @@ public class IssuesTable extends FilteredTable<IssuesQuerySchema> implements Upd
     @Override
     public SQLFragment getFromSQL(String alias)
     {
+        checkReadBeforeExecute();
         TableInfo provisioned = _issueDef.createTable(getUserSchema().getUser());
 
         SQLFragment sql = new SQLFragment();

--- a/query/src/org/labkey/query/LinkedTableInfo.java
+++ b/query/src/org/labkey/query/LinkedTableInfo.java
@@ -207,6 +207,7 @@ public class LinkedTableInfo extends SimpleUserSchema.SimpleTable<UserSchema>
     @Override
     public SQLFragment getFromSQL(String alias)
     {
+        checkReadBeforeExecute();
         SQLFragment frag = super.getFromSQL(alias);
 
         // Bind named parameters added to the generated LinkedSchema.createQueryDef() query. .. looks like these are bound second after URL parameters.

--- a/query/src/org/labkey/query/MetadataTableJSON.java
+++ b/query/src/org/labkey/query/MetadataTableJSON.java
@@ -123,6 +123,12 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
                 throw new MetadataUnavailableException(e.getMessage());
             }
             xmlTable = getTableType(this.getName(), doc);
+            // when there is a queryDef but xmlTable is null it means the xmlMetaData contains tableName which does not
+            // match with actual queryName then reconstruct the xml table metadata : See Issue 43523
+            if (xmlTable == null)
+            {
+                doc = null;
+            }
         }
         else
         {

--- a/query/src/org/labkey/query/TableQueryDefinition.java
+++ b/query/src/org/labkey/query/TableQueryDefinition.java
@@ -37,6 +37,7 @@ import org.labkey.api.query.QueryParseException;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.view.ActionURL;
@@ -118,7 +119,7 @@ public class TableQueryDefinition extends QueryDefinitionImpl
     {
         List<QueryException> errors = new ArrayList<>();
         TableInfo table = getTable(errors, true);
-        if (table != null)
+        if (table != null && table.hasPermission(getUser(), ReadPermission.class))
         {
             if (action == QueryAction.detailsQueryRow)
             {

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1054,6 +1054,12 @@ public class QueryController extends SpringActionController
                             {
                                 if (null != tableType)
                                 {
+                                    if (!Objects.equals(tableType.getTableName(), form.getQueryName()))
+                                    {
+                                        errors.reject(ERROR_MSG, "Table name in the XML metadata must match the table/query name: " + form.getQueryName());
+
+                                    }
+
                                     TableType.Columns tableColumns = tableType.getColumns();
                                     if (null != tableColumns)
                                     {

--- a/query/src/org/labkey/query/sql/Query.java
+++ b/query/src/org/labkey/query/sql/Query.java
@@ -73,6 +73,7 @@ import org.labkey.api.reader.DataLoader;
 import org.labkey.api.reader.DataLoaderService;
 import org.labkey.api.reader.JSONDataLoader;
 import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.test.TestWhen;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.DateUtil;
@@ -943,6 +944,9 @@ public class Query
                 ActionURL url = new QueryController.QueryUrlsImpl().urlSchemaBrowser(resolvedSchema.getContainer(), resolvedSchema.getName(), name);
                 addDependency(QueryService.DependencyType.Table, resolvedSchema.getContainer(), ((UserSchema)resolvedSchema).getSchemaPath(), name, url);
             }
+
+            if (!tableInfo.hasPermission(getSchema().getUser(), ReadPermission.class))
+                throw new UnauthorizedException(tableInfo.getPublicSchemaName() + "." + tableInfo.getName());
 
             return new QueryTable(this, resolvedSchema, tableInfo, alias);
         }

--- a/study/api-src/org/labkey/api/specimen/SpecimenManagerNew.java
+++ b/study/api-src/org/labkey/api/specimen/SpecimenManagerNew.java
@@ -186,7 +186,7 @@ public class SpecimenManagerNew
         SQLFragment sqlPtidFilter = new SQLFragment();
         if (study.isAncillaryStudy())
         {
-/*            StudyQuerySchema sourceStudySchema = StudyQuerySchema.createSchema(study.getSourceStudy(), null, false);
+/*            StudyQuerySchema sourceStudySchema = StudyQuerySchema.createSchema(study.getSourceStudy());
             SpecimenWrapTable sourceStudyTableInfo = (SpecimenWrapTable)sourceStudySchema.getTable(StudyQuerySchema.SPECIMEN_WRAP_TABLE_NAME);
             tableInfoSpecimenWrap.setUnionTable(sourceStudyTableInfo);
 

--- a/study/api-src/org/labkey/api/specimen/model/SpecimenTablesProvider.java
+++ b/study/api-src/org/labkey/api/specimen/model/SpecimenTablesProvider.java
@@ -45,6 +45,9 @@ public class SpecimenTablesProvider
     public static final String PRIMARYTYPE_TABLENAME = "SpecimenPrimaryType";
     public static final String DERIVATIVETYPE_TABLENAME = "SpecimenDerivative";
     public static final String ADDITIVETYPE_TABLENAME = "SpecimenAdditive";
+    public static  final String SPECIMENVIALCOUNT_TABLENAME = "SpecimenVialCount";
+    public static final String SPECIMENREQUEST_TABLENAME = "SpecimenRequest";
+    public static final String VIALREQUEST_TABLENAME = "VialRequest";
 
     private final Container _container;
     private final User _user;

--- a/study/api-src/org/labkey/api/specimen/query/BaseSpecimenPivotTable.java
+++ b/study/api-src/org/labkey/api/specimen/query/BaseSpecimenPivotTable.java
@@ -16,6 +16,7 @@
 package org.labkey.api.specimen.query;
 
 import org.apache.logging.log4j.LogManager;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
@@ -28,6 +29,9 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.AliasedColumn;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.specimen.SpecimenManagerNew;
 import org.labkey.api.specimen.location.LocationImpl;
 import org.labkey.api.specimen.location.LocationManager;
@@ -355,5 +359,11 @@ public abstract class BaseSpecimenPivotTable extends FilteredTable<UserSchema>
     protected void applyContainerFilter(ContainerFilter filter)
     {
         // Because these Pivot tables pull from tables that have already been filtered, don't apply any such filter here
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
+    {
+        return perm.equals(ReadPermission.class) && getContainer().hasPermission(user, perm);
     }
 }

--- a/study/api-src/org/labkey/api/specimen/query/SpecimenPivotByDerivativeType.java
+++ b/study/api-src/org/labkey/api/specimen/query/SpecimenPivotByDerivativeType.java
@@ -36,6 +36,7 @@ public class SpecimenPivotByDerivativeType extends BaseSpecimenPivotTable
     public SpecimenPivotByDerivativeType(final SpecimenQuerySchema schema, ContainerFilter cf)
     {
         super(SpecimenReportQuery.getPivotByDerivativeType(schema, cf), schema);
+        setName(PIVOT_BY_DERIVATIVE_TYPE);
         setDescription("Contains up to one row of Specimen Primary/Derivative Type totals for each " + StudyService.get().getSubjectNounSingular(getContainer()) +
             "/visit combination.");
 

--- a/study/api-src/org/labkey/api/specimen/query/SpecimenPivotByPrimaryType.java
+++ b/study/api-src/org/labkey/api/specimen/query/SpecimenPivotByPrimaryType.java
@@ -36,6 +36,7 @@ public class SpecimenPivotByPrimaryType extends BaseSpecimenPivotTable
     public SpecimenPivotByPrimaryType(final SpecimenQuerySchema schema, ContainerFilter cf)
     {
         super(SpecimenReportQuery.getPivotByPrimaryType(schema, cf), schema);
+        setName(PIVOT_BY_PRIMARY_TYPE);
         setDescription("Contains up to one row of Specimen Primary Type totals for each " + StudyService.get().getSubjectNounSingular(getContainer()) +
             "/visit combination.");
 

--- a/study/api-src/org/labkey/api/specimen/query/SpecimenPivotByRequestingLocation.java
+++ b/study/api-src/org/labkey/api/specimen/query/SpecimenPivotByRequestingLocation.java
@@ -36,6 +36,7 @@ public class SpecimenPivotByRequestingLocation extends BaseSpecimenPivotTable
     public SpecimenPivotByRequestingLocation(final SpecimenQuerySchema schema, ContainerFilter cf)
     {
         super(SpecimenReportQuery.getPivotByRequestingLocation(schema, cf), schema);
+        setName(PIVOT_BY_REQUESTING_LOCATION);
         setDescription("Contains up to one row of Specimen Derivative Type totals by Requesting Location for each " + StudyService.get().getSubjectNounSingular(getContainer()) +
             "/visit combination.");
 

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -68,6 +68,7 @@ import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.settings.AdminConsole;
@@ -481,7 +482,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
                 MutableInt hasLocations = new MutableInt(0);
 
                 allStudies.stream()
-                    .map(study->StudyQuerySchema.createSchema(study, User.getSearchUser(), false))
+                    .map(study->StudyQuerySchema.createSchema(study, User.getSearchUser(), RoleManager.getRole(ReaderRole.class)))
                     .forEach(schema->{
                         RepositorySettings settings = SettingsManager.get().getRepositorySettings(schema.getContainer());
 

--- a/study/src/org/labkey/study/StudyServiceImpl.java
+++ b/study/src/org/labkey/study/StudyServiceImpl.java
@@ -59,6 +59,8 @@ import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.roles.ReaderRole;
+import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.specimen.SpecimenSchema;
 import org.labkey.api.specimen.location.LocationManager;
 import org.labkey.api.specimen.model.SpecimenDomainKind;
@@ -389,7 +391,7 @@ public class StudyServiceImpl implements StudyService
     @Override
     public UserSchema getStudyQuerySchema(Study study, User user)
     {
-        return StudyQuerySchema.createSchema((StudyImpl)study, user, true);
+        return StudyQuerySchema.createSchema((StudyImpl)study, user);
     }
 
     @Override
@@ -665,7 +667,7 @@ public class StudyServiceImpl implements StudyService
             Study s = StudyManager.getInstance().getStudy(c);
             if (null != s)
             {
-                StudyQuerySchema schema = StudyQuerySchema.createSchema((StudyImpl) s, user, false);
+                StudyQuerySchema schema = StudyQuerySchema.createSchema((StudyImpl) s, user, RoleManager.getRole(ReaderRole.class));
                 BaseStudyTable t = constructStudyTable(tableClass, schema);
                 t.setPublic(false);
                 tables.put(c, t);
@@ -851,7 +853,7 @@ public class StudyServiceImpl implements StudyService
             Study s = StudyManager.getInstance().getStudy(c);
             if (null != s)
             {
-                StudyQuerySchema schema = StudyQuerySchema.createSchema((StudyImpl) s, user, false);
+                StudyQuerySchema schema = StudyQuerySchema.createSchema((StudyImpl) s, user, RoleManager.getRole(ReaderRole.class));
                 BaseStudyTable t = constructStudyTable(tableClass, schema);
                 t.setPublic(false);
                 tables.put(c, t);

--- a/study/src/org/labkey/study/StudyUnionTableInfo.java
+++ b/study/src/org/labkey/study/StudyUnionTableInfo.java
@@ -75,7 +75,7 @@ public class StudyUnionTableInfo extends VirtualTable
 
     public StudyUnionTableInfo(StudyImpl study, Collection<DatasetDefinition> defs, User user, boolean crossContainer)
     {
-        super(StudySchema.getInstance().getSchema(), "StudyData");
+        super(StudySchema.getInstance().getSchema(), "StudyData", null);
         _study = study;
         _user = user;
         _crossContainer = crossContainer;

--- a/study/src/org/labkey/study/StudyUnionTableInfo.java
+++ b/study/src/org/labkey/study/StudyUnionTableInfo.java
@@ -236,6 +236,7 @@ public class StudyUnionTableInfo extends VirtualTable
     @Override
     public SQLFragment getFromSQL(String alias, Set<FieldKey> cols)
     {
+        checkReadBeforeExecute();
         return _getFromSQL(alias, cols, false);
     }
 

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -96,6 +96,7 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.roles.FolderAdminRole;
+import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.study.Dataset;
@@ -240,7 +241,7 @@ public class StudyPublishManager implements StudyPublishService
                         dataset.getKeyPropertyName() != null)
                 {
                     // Check to see if it already has the data rows that are being linked
-                    TableInfo tableInfo = dataset.getTableInfo(user);
+                    TableInfo tableInfo = dataset.getTableInfo(user, false);
                     Filter datasetFilter = new SimpleFilter(new SimpleFilter.InClause(FieldKey.fromParts(dataset.getKeyPropertyName()), entry.getValue()));
                     long existingRowCount = new TableSelector(tableInfo, datasetFilter, null).getRowCount();
                     if (existingRowCount > 0)
@@ -1394,7 +1395,7 @@ public class StudyPublishManager implements StudyPublishService
             {
                 // Don't enforce permissions for the current user - we still want to tell them if the data
                 // has been linked even if they can't see the dataset.
-                UserSchema schema = StudyQuerySchema.createSchema(dataset.getStudy(), user);
+                UserSchema schema = StudyQuerySchema.createSchema(dataset.getStudy(), user, RoleManager.getRole(ReaderRole.class));
                 TableInfo tableInfo = schema.getTable(dataset.getName());
                 AssayProvider provider = AssayService.get().getProvider(entry.getKey());
                 if (provider != null)

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -1382,7 +1382,7 @@ public class StudyPublishManager implements StudyPublishService
             {
                 // Don't enforce permissions for the current user - we still want to tell them if the data
                 // has been linked even if they can't see the dataset.
-                UserSchema schema = StudyQuerySchema.createSchema(dataset.getStudy(), user, false);
+                UserSchema schema = StudyQuerySchema.createSchema(dataset.getStudy(), user);
                 TableInfo tableInfo = schema.getTable(dataset.getName());
                 AssayProvider provider = AssayService.get().getProvider(entry.getKey());
                 if (provider != null)

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -240,7 +240,7 @@ public class StudyPublishManager implements StudyPublishService
                         dataset.getKeyPropertyName() != null)
                 {
                     // Check to see if it already has the data rows that are being linked
-                    TableInfo tableInfo = dataset.getTableInfo(user, false);
+                    TableInfo tableInfo = dataset.getTableInfo(user);
                     Filter datasetFilter = new SimpleFilter(new SimpleFilter.InClause(FieldKey.fromParts(dataset.getKeyPropertyName()), entry.getValue()));
                     long existingRowCount = new TableSelector(tableInfo, datasetFilter, null).getRowCount();
                     if (existingRowCount > 0)

--- a/study/src/org/labkey/study/controllers/CohortController.java
+++ b/study/src/org/labkey/study/controllers/CohortController.java
@@ -311,7 +311,7 @@ public class CohortController extends BaseStudyController
         protected CohortTable getTableInfo()
         {
             StudyImpl study = getStudyThrowIfNull();
-            StudyQuerySchema schema = StudyQuerySchema.createSchema(study, getUser(), true);
+            StudyQuerySchema schema = StudyQuerySchema.createSchema(study, getUser());
             return new CohortTable(schema, null);
         }
 

--- a/study/src/org/labkey/study/controllers/ParticipantGroupController.java
+++ b/study/src/org/labkey/study/controllers/ParticipantGroupController.java
@@ -1519,7 +1519,7 @@ public class ParticipantGroupController extends BaseStudyController
     {
         if (!getStudy().isDataspaceStudy())
             return null;
-        DataspaceQuerySchema dqs = new DataspaceQuerySchema(getStudy(), getUser(), true);
+        DataspaceQuerySchema dqs = new DataspaceQuerySchema(getStudy(), getUser());
         return dqs.getDefaultContainerFilter();
     }
 

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -965,7 +965,7 @@ public class StudyController extends BaseStudyController
             {
                 return new HtmlView("User does not have read permission on this report.");
             }
-            else if (report == null && !def.canRead(getUser()))
+            else if (report == null && !table.hasPermission(getUser(),ReadPermission.class))
             {
                 return new HtmlView("User does not have read permission on this dataset.");
             }
@@ -2448,7 +2448,7 @@ public class StudyController extends BaseStudyController
 
             User user = getUser();
             // Go through normal getTable() codepath to be sure all metadata is applied
-            TableInfo t = StudyQuerySchema.createSchema(_study, user, true).getTable(_def.getName(), null);
+            TableInfo t = StudyQuerySchema.createSchema(_study, user).getTable(_def.getName(), null);
             if (t == null)
                 throw new NotFoundException("Dataset not found");
             setTarget(t);
@@ -2797,13 +2797,13 @@ public class StudyController extends BaseStudyController
 
             if (def != null)
             {
-                final StudyQuerySchema querySchema = StudyQuerySchema.createSchema(study, getUser(), true);
+                final StudyQuerySchema querySchema = StudyQuerySchema.createSchema(study, getUser());
                 DatasetQuerySettings qs = (DatasetQuerySettings)querySchema.getSettings(getViewContext(), DatasetQueryView.DATAREGION, def.getName());
 
                 if (!def.canRead(getUser()))
                 {
                     //requiresLogin();
-                    view.addView(new HtmlView("User does not have read permission on this dataset."));
+                    view.addView(new HtmlView(HtmlString.of("User does not have read permission on this dataset.")));
                 }
                 else
                 {
@@ -3004,7 +3004,7 @@ public class StudyController extends BaseStudyController
                 for (String lsid : lsids)
                     keys.add(Collections.singletonMap("lsid", lsid));
 
-                StudyQuerySchema schema = StudyQuerySchema.createSchema(study, getUser(), true);
+                StudyQuerySchema schema = StudyQuerySchema.createSchema(study, getUser());
                 TableInfo datasetTable = schema.createDatasetTableInternal((DatasetDefinition) dataset, null);
 
                 QueryUpdateService qus = datasetTable.getUpdateService();
@@ -3280,7 +3280,7 @@ public class StudyController extends BaseStudyController
                     return Collections.emptyList();
             }
 
-            StudyQuerySchema querySchema = StudyQuerySchema.createSchema(study, context.getUser(), true);
+            StudyQuerySchema querySchema = StudyQuerySchema.createSchema(study, context.getUser());
             QuerySettings qs = querySchema.getSettings(context, DatasetQueryView.DATAREGION, def.getName());
             qs.setViewName(viewName);
 
@@ -3636,7 +3636,7 @@ public class StudyController extends BaseStudyController
             if (lsids == null || lsids.isEmpty())
                 return new HtmlView("No data rows selected.  " + PageFlowUtil.link("back").href("javascript:back()"));
 
-            StudyQuerySchema querySchema = StudyQuerySchema.createSchema(study, getUser(), true);
+            StudyQuerySchema querySchema = StudyQuerySchema.createSchema(study, getUser());
             DatasetQuerySettings qs = new DatasetQuerySettings(getViewContext().getBindPropertyValues(), DatasetQueryView.DATAREGION);
 
             qs.setSchemaName(querySchema.getSchemaName());
@@ -6134,7 +6134,7 @@ public class StudyController extends BaseStudyController
                 throw new NotFoundException("No LSID specified");
             }
 
-            StudyQuerySchema schema = StudyQuerySchema.createSchema(study, getUser(), true);
+            StudyQuerySchema schema = StudyQuerySchema.createSchema(study, getUser());
 
             QueryDefinition queryDef = QueryService.get().createQueryDefForTable(schema, dataset.getName());
             assert queryDef != null : "Dataset was found but couldn't get a corresponding TableInfo";

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -965,7 +965,7 @@ public class StudyController extends BaseStudyController
             {
                 return new HtmlView("User does not have read permission on this report.");
             }
-            else if (report == null && !table.hasPermission(getUser(),ReadPermission.class))
+            else if (report == null && (null==table || !table.hasPermission(getUser(),ReadPermission.class)))
             {
                 return new HtmlView("User does not have read permission on this dataset.");
             }

--- a/study/src/org/labkey/study/controllers/StudyPropertiesController.java
+++ b/study/src/org/labkey/study/controllers/StudyPropertiesController.java
@@ -143,7 +143,7 @@ public class StudyPropertiesController extends BaseStudyController
         protected StudyPropertiesTable getTableInfo()
         {
             StudyImpl study = getStudyThrowIfNull();
-            StudyQuerySchema schema = StudyQuerySchema.createSchema(study, getUser(), true);
+            StudyQuerySchema schema = StudyQuerySchema.createSchema(study, getUser());
             return new StudyPropertiesTable(schema, null);
         }
     }

--- a/study/src/org/labkey/study/controllers/reports/ReportsController.java
+++ b/study/src/org/labkey/study/controllers/reports/ReportsController.java
@@ -720,7 +720,7 @@ public class ReportsController extends BaseStudyController
         private List<String> getTableAndQueryNames(ViewContext context) throws IllegalStateException
         {
             StudyImpl study = getStudyThrowIfNull(context.getContainer());
-            StudyQuerySchema studySchema = StudyQuerySchema.createSchema(study, context.getUser(), true);
+            StudyQuerySchema studySchema = StudyQuerySchema.createSchema(study, context.getUser());
             return studySchema.getTableAndQueryNames(true);
         }
 

--- a/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
@@ -220,7 +220,7 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
 
                 if (view != null && !errors.hasErrors())
                 {
-                    StudyQuerySchema studySchema = StudyQuerySchema.createSchema(study, context.getUser(), false);
+                    StudyQuerySchema studySchema = StudyQuerySchema.createSchema(study, context.getUser());
                     view.setContainerFilter(studySchema.getDefaultContainerFilter());
                     if (null != view.getTable())
                     {
@@ -448,7 +448,7 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
 
                     if (view != null && !errors.hasErrors())
                     {
-                        StudyQuerySchema studySchema = StudyQuerySchema.createSchema(study, form.getViewContext().getUser(), false);
+                        StudyQuerySchema studySchema = StudyQuerySchema.createSchema(study, form.getViewContext().getUser());
                         view.setContainerFilter(studySchema.getDefaultContainerFilter());
                         if (view.getTable() == null)
                         {

--- a/study/src/org/labkey/study/importer/AssayScheduleImporter.java
+++ b/study/src/org/labkey/study/importer/AssayScheduleImporter.java
@@ -77,7 +77,7 @@ public class AssayScheduleImporter extends DefaultStudyDesignImporter implements
                 try (DbScope.Transaction transaction = scope.ensureTransaction())
                 {
                     // import project-level tables first, since study-level may reference them
-                    StudyQuerySchema schema = StudyQuerySchema.createSchema(ctx.getStudyImpl(), ctx.getUser(), true);
+                    StudyQuerySchema schema = StudyQuerySchema.createSchema(ctx.getStudyImpl(), ctx.getUser());
 
                     // study design tables
                     List<String> studyDesignTableNames = new ArrayList<>();
@@ -86,7 +86,7 @@ public class AssayScheduleImporter extends DefaultStudyDesignImporter implements
                     studyDesignTableNames.add(StudyQuerySchema.STUDY_DESIGN_SAMPLE_TYPES_TABLE_NAME);
                     studyDesignTableNames.add(StudyQuerySchema.STUDY_DESIGN_UNITS_TABLE_NAME);
 
-                    StudyQuerySchema projectSchema = ctx.isDataspaceProject() ? new StudyQuerySchema(StudyManager.getInstance().getStudy(ctx.getProject()), ctx.getUser(), true) : schema;
+                    StudyQuerySchema projectSchema = ctx.isDataspaceProject() ? StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getProject()), ctx.getUser()) : schema;
                     for (String studyDesignTableName : studyDesignTableNames)
                     {
                         StudyQuerySchema.TablePackage tablePackage = schema.getTablePackage(ctx, projectSchema, studyDesignTableName, null);

--- a/study/src/org/labkey/study/importer/CreateChildStudyPipelineJob.java
+++ b/study/src/org/labkey/study/importer/CreateChildStudyPipelineJob.java
@@ -525,7 +525,7 @@ public class CreateChildStudyPipelineJob extends AbstractStudyPipelineJob
             for (DatasetDefinition def : datasets)
             {
                 BindException datasetErrors = new NullSafeBindException(def, "dataset");
-                StudyQuerySchema schema = StudyQuerySchema.createSchema(sourceStudy, user, true);
+                StudyQuerySchema schema = StudyQuerySchema.createSchema(sourceStudy, user);
                 TableInfo table = def.getTableInfo(user);
                 QueryDefinition queryDef = QueryService.get().createQueryDefForTable(schema, table.getName());
 

--- a/study/src/org/labkey/study/importer/DefaultStudyDesignImporter.java
+++ b/study/src/org/labkey/study/importer/DefaultStudyDesignImporter.java
@@ -417,7 +417,7 @@ public class DefaultStudyDesignImporter
                 ContainerFilter currentFilter = null;
                 try {
 
-                    if (_tableInfo instanceof ContainerFilterable)
+                    if (_tableInfo instanceof ContainerFilterable && _tableInfo.supportsContainerFilter())
                     {
                         currentFilter = _tableInfo.getContainerFilter();
                         ((ContainerFilterable)_tableInfo).setContainerFilter(ContainerFilter.Type.Project.create(_tableInfo.getUserSchema()));

--- a/study/src/org/labkey/study/importer/DefaultStudyDesignImporter.java
+++ b/study/src/org/labkey/study/importer/DefaultStudyDesignImporter.java
@@ -112,7 +112,7 @@ public class DefaultStudyDesignImporter
             final String tableName = tableXml.getTableName();
 
             // get the domain of the table we are updating
-            StudyQuerySchema schema = StudyQuerySchema.createSchema(ctx.getStudyImpl(), ctx.getUser(), true);
+            StudyQuerySchema schema = StudyQuerySchema.createSchema(ctx.getStudyImpl(), ctx.getUser());
             TableInfo table = schema.getTable(tableName);
 
             if (table != null)

--- a/study/src/org/labkey/study/importer/StudyImportInitialTask.java
+++ b/study/src/org/labkey/study/importer/StudyImportInitialTask.java
@@ -138,6 +138,9 @@ public class StudyImportInitialTask extends PipelineJob.Task<StudyImportInitialT
                     studyForm.setSecurityType(SecurityType.valueOf(studyXml.getSecurityType().toString()));
 
                 StudyController.createStudy(null, ctx.getContainer(), ctx.getUser(), studyForm);
+
+                if (null == StudyManager.getInstance().getStudy(ctx.getContainer()))
+                    throw new IllegalStateException("Where's my study!");
             }
             else
             {

--- a/study/src/org/labkey/study/importer/StudyPropertiesImporter.java
+++ b/study/src/org/labkey/study/importer/StudyPropertiesImporter.java
@@ -78,8 +78,8 @@ public class StudyPropertiesImporter extends DefaultStudyDesignImporter
                     importTableinfo(ctx, vf, StudyPropertiesWriter.SCHEMA_FILENAME);
 
                     // import the objective and personnel tables
-                    StudyQuerySchema schema = StudyQuerySchema.createSchema(ctx.getStudyImpl(), ctx.getUser(), true);
-                    StudyQuerySchema projectSchema = isDataspaceProject ? new StudyQuerySchema(StudyManager.getInstance().getStudy(ctx.getProject()), ctx.getUser(), true) : schema;
+                    StudyQuerySchema schema = StudyQuerySchema.createSchema(ctx.getStudyImpl(), ctx.getUser());
+                    StudyQuerySchema projectSchema = isDataspaceProject ? StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getProject()), ctx.getUser()) : schema;
 
                     if (!isDataspaceProject)
                     {

--- a/study/src/org/labkey/study/importer/TreatmentDataImporter.java
+++ b/study/src/org/labkey/study/importer/TreatmentDataImporter.java
@@ -99,8 +99,8 @@ public class TreatmentDataImporter extends DefaultStudyDesignImporter implements
                     importTableinfo(ctx, vf, TreatmentDataWriter.SCHEMA_FILENAME);
 
                     // import project-level tables first, since study-level may reference them
-                    StudyQuerySchema schema = StudyQuerySchema.createSchema(ctx.getStudyImpl(), ctx.getUser(), true);
-                    StudyQuerySchema projectSchema = ctx.isDataspaceProject() ? new StudyQuerySchema(StudyManager.getInstance().getStudy(ctx.getProject()), ctx.getUser(), true) : schema;
+                    StudyQuerySchema schema = StudyQuerySchema.createSchema(ctx.getStudyImpl(), ctx.getUser());
+                    StudyQuerySchema projectSchema = ctx.isDataspaceProject() ? StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getProject()), ctx.getUser()) : schema;
 
                     // study design tables
                     List<String> studyDesignTableNames = new ArrayList<>();

--- a/study/src/org/labkey/study/importer/TreatmentVisitMapImporter.java
+++ b/study/src/org/labkey/study/importer/TreatmentVisitMapImporter.java
@@ -79,8 +79,8 @@ public class TreatmentVisitMapImporter extends DefaultStudyDesignImporter implem
                 DbScope scope = StudySchema.getInstance().getSchema().getScope();
                 try (DbScope.Transaction transaction = scope.ensureTransaction())
                 {
-                    StudyQuerySchema schema = StudyQuerySchema.createSchema(ctx.getStudyImpl(), ctx.getUser(), true);
-                    StudyQuerySchema projectSchema = ctx.isDataspaceProject() ? new StudyQuerySchema(StudyManager.getInstance().getStudy(ctx.getProject()), ctx.getUser(), true) : schema;
+                    StudyQuerySchema schema = StudyQuerySchema.createSchema(ctx.getStudyImpl(), ctx.getUser());
+                    StudyQuerySchema projectSchema = ctx.isDataspaceProject() ? StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getProject()), ctx.getUser()) : schema;
 
                     // Note: TreatmentVisitMap info needs to import after cohorts are loaded (issue 19947).
                     StudyQuerySchema.TablePackage treatmentVisitMapTablePackage = schema.getTablePackage(ctx, projectSchema, StudyQuerySchema.TREATMENT_VISIT_MAP_TABLE_NAME, null);

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1500,7 +1500,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
                 @Override
                 public TableInfo getLookupTableInfo()
                 {
-                    StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(_container), user, true);
+                    StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(_container), user);
                     return schema.getTable("Datasets");
                 }
             };
@@ -2599,7 +2599,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
     {
         // Unfortunately we need to use two tableinfos: one to get the column names with correct casing,
         // and one to get the data.  We should eventually be able to convert to using Query completely.
-        StudyQuerySchema querySchema = StudyQuerySchema.createSchema(getStudy(), u, true);
+        StudyQuerySchema querySchema = StudyQuerySchema.createSchema(getStudy(), u);
         TableInfo queryTableInfo = querySchema.createDatasetTableInternal(this, null);
 
         TableInfo tInfo = getTableInfo(u, true);

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -96,6 +96,7 @@ import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.ReadSomePermission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.security.roles.Role;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.study.CompletionType;
 import org.labkey.api.study.Dataset;
@@ -655,6 +656,8 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
      * Get table info representing dataset.  This relies on the DatasetDefinition being removed from
      * the cache if the dataset type changes.
      * see StudyManager.importDatasetTSV()
+     *
+     * TODO convert usages of DatasetDefinition.getTableInfo() to use StudyQuerySchema.getTable()
      */
     @Override
     public DatasetSchemaTableInfo getTableInfo(User user) throws UnauthorizedException
@@ -677,7 +680,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
         if (user == null && checkPermission)
             throw new IllegalArgumentException("user cannot be null");
 
-        if (checkPermission && !canRead(user))
+        if (checkPermission && !canReadInternal(user))
         {
             throw new UnauthorizedException();
         }
@@ -918,6 +921,11 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
     @Override
     public Set<Class<? extends Permission>> getPermissions(UserPrincipal user)
     {
+        return getPermissions(user, null);
+    }
+
+    public Set<Class<? extends Permission>> getPermissions(UserPrincipal user, @Nullable Set<Role> contextualRoles)
+    {
         Set<Class<? extends Permission>> result = new HashSet<>();
 
         //if the study security type is basic read or basic write, use the container's policy instead of the
@@ -927,18 +935,20 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
         SecurityPolicy studyPolicy = (securityType == SecurityType.BASIC_READ || securityType == SecurityType.BASIC_WRITE) ?
                 SecurityPolicyManager.getPolicy(getContainer()) : SecurityPolicyManager.getPolicy(getStudy());
 
+        Set<Class<? extends Permission>> studyPermissions = SecurityManager.getPermissions(studyPolicy, user, contextualRoles);
+
         //need to check both the study's policy and the dataset's policy
         //users that have read permission on the study can read all datasets
         //users that have read-some permission on the study must also have read permission on this dataset
-        if (studyPolicy.hasPermission(user, ReadPermission.class) ||
-            (studyPolicy.hasPermission(user, ReadSomePermission.class) && SecurityPolicyManager.getPolicy(this).hasPermission(user, ReadPermission.class)))
+        copyReadPerms(studyPermissions, result);
+        if (studyPermissions.contains(ReadSomePermission.class))
         {
-            result.add(ReadPermission.class);
+            Set<Class<? extends Permission>> datasetPermissions = SecurityPolicyManager.getPolicy(this).getOwnPermissions(user);
+            copyReadPerms(datasetPermissions, result);
+        }
 
-            // a dataspace study always has read-only datasets, you cannot edit no matter who you are
-            if (_study.isDataspaceStudy())
-                return result;
-
+        if (result.contains(ReadPermission.class))
+        {
             // Now check if they can write
             if (securityType == SecurityType.BASIC_WRITE)
             {
@@ -951,7 +961,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
                 copyEditPerms(studyPolicy, user, result);
                 // A user can be part of multiple groups, which are set to both Edit All and Per Dataset permissions
                 // so check for a custom security policy even if they have UpdatePermission on the study's policy
-                if (studyPolicy.hasPermission(user, ReadSomePermission.class))
+                if (studyPermissions.contains(ReadSomePermission.class))
                 {
                     // Advanced write grants dataset permissions based on the policy stored directly on the dataset
                     // In this case, we return all permissions, important for EHR-specific per-dataset role assignments
@@ -960,7 +970,17 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
             }
         }
 
+        if (isEditProhibited(user, result))
+            result.retainAll(READ_PERMS);
         return result;
+    }
+
+
+    private static final Collection<Class<? extends Permission>> READ_PERMS = List.of(ReadPermission.class);
+
+    private void copyReadPerms(Set<Class<? extends Permission>> granted, Set<Class<? extends Permission>> result)
+    {
+        READ_PERMS.stream().filter(granted::contains).forEach(result::add);
     }
 
     private static final Collection<Class<? extends Permission>> EDIT_PERMS = List.of(InsertPermission.class, UpdatePermission.class, DeletePermission.class);
@@ -971,43 +991,73 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
         EDIT_PERMS.stream().filter(granted::contains).forEach(result::add);
     }
 
+    /* use  DatasetTableImpl.hasPermission()! */
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        if (perm != ReadPermission.class && isEditProhibited(user))
+        if (!perm.equals(ReadPermission.class))
+            throw new UnsupportedOperationException("use DatasetTableImpl.hasPermission()");
+        return hasPermission(user, perm, null);
+    }
+
+    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm, @Nullable Set<Role> contextualRoles)
+    {
+        Set<Class<? extends Permission>> granted = getPermissions(user, contextualRoles);
+        if (perm != ReadPermission.class && isEditProhibited(user, granted))
             return false;
         if (getContainer().hasPermission(user, AdminPermission.class))
             return true;
-        return getPermissions(user).contains(perm);
+        return granted.contains(perm);
     }
 
-    private boolean isEditProhibited(UserPrincipal user)
+    private boolean isEditProhibited(UserPrincipal user, Set<Class<? extends Permission>> perms)
     {
-        return getStudy().isDataspaceStudy() || (user instanceof User && !canAccessPhi((User) user));
+        return getStudy().isDataspaceStudy() || (user instanceof User && !canAccessPhi((User) user, perms));
     }
 
     @Override
+    @Deprecated
     public boolean canRead(UserPrincipal user)
     {
-        return hasPermission(user, ReadPermission.class);
+        var t = StudyQuerySchema.createSchema(getStudy(),(User)user,null).getTable(this.getName());
+        if (null == t || !(t instanceof DatasetTableImpl))
+            return false;
+        return t.hasPermission(user, ReadPermission.class);
+    }
+
+    public boolean canReadInternal(UserPrincipal user)
+    {
+        return hasPermission(user, ReadPermission.class, null);
     }
 
     @Override
+    @Deprecated
     public boolean canUpdate(UserPrincipal user)
     {
-        return hasPermission(user, UpdatePermission.class);
+        var t = StudyQuerySchema.createSchema(getStudy(),(User)user,null).getTable(this.getName());
+        if (null == t || !(t instanceof DatasetTableImpl))
+            return false;
+        return t.hasPermission(user, UpdatePermission.class);
     }
 
     @Override
+    @Deprecated
     public boolean canDelete(UserPrincipal user)
     {
-        return hasPermission(user, DeletePermission.class);
+        var t = StudyQuerySchema.createSchema(getStudy(),(User)user,null).getTable(this.getName());
+        if (null == t || !(t instanceof DatasetTableImpl))
+            return false;
+        return t.hasPermission(user, DeletePermission.class);
     }
 
     @Override
+    @Deprecated
     public boolean canInsert(UserPrincipal user)
     {
-        return hasPermission(user, InsertPermission.class);
+        var t = StudyQuerySchema.createSchema(getStudy(),(User)user,null).getTable(this.getName());
+        if (null == t || !(t instanceof DatasetTableImpl))
+            return false;
+        return t.hasPermission(user, InsertPermission.class);
     }
 
     @Override
@@ -1025,11 +1075,11 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
         return getContainer().hasPermission(user, AdminPermission.class) && getDefinitionContainer().getId().equals(getContainer().getId());
     }
 
-    public boolean canAccessPhi(User user)
+    public boolean canAccessPhi(User user, Set<Class<? extends Permission>> perms)
     {
-        if (canRead(user))
+        if (perms.contains(ReadPermission.class))
         {
-            DatasetSchemaTableInfo table = getTableInfo(user);
+            DatasetSchemaTableInfo table = getTableInfo(user, false);
             if (null != table)
                 return table.canUserAccessPhi();
         }

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1019,10 +1019,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
     @Deprecated
     public boolean canRead(UserPrincipal user)
     {
-        var t = StudyQuerySchema.createSchema(getStudy(),(User)user,null).getTable(this.getName());
-        if (null == t || !(t instanceof DatasetTableImpl))
-            return false;
-        return t.hasPermission(user, ReadPermission.class);
+        return hasPermission(user, ReadPermission.class, null);
     }
 
     public boolean canReadInternal(UserPrincipal user)
@@ -1034,30 +1031,21 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
     @Deprecated
     public boolean canUpdate(UserPrincipal user)
     {
-        var t = StudyQuerySchema.createSchema(getStudy(),(User)user,null).getTable(this.getName());
-        if (null == t || !(t instanceof DatasetTableImpl))
-            return false;
-        return t.hasPermission(user, UpdatePermission.class);
+        return hasPermission(user, UpdatePermission.class, null);
     }
 
     @Override
     @Deprecated
     public boolean canDelete(UserPrincipal user)
     {
-        var t = StudyQuerySchema.createSchema(getStudy(),(User)user,null).getTable(this.getName());
-        if (null == t || !(t instanceof DatasetTableImpl))
-            return false;
-        return t.hasPermission(user, DeletePermission.class);
+        return hasPermission(user, DeletePermission.class, null);
     }
 
     @Override
     @Deprecated
     public boolean canInsert(UserPrincipal user)
     {
-        var t = StudyQuerySchema.createSchema(getStudy(),(User)user,null).getTable(this.getName());
-        if (null == t || !(t instanceof DatasetTableImpl))
-            return false;
-        return t.hasPermission(user, InsertPermission.class);
+        return hasPermission(user, InsertPermission.class, null);
     }
 
     @Override

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -991,12 +991,11 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
         EDIT_PERMS.stream().filter(granted::contains).forEach(result::add);
     }
 
-    /* use  DatasetTableImpl.hasPermission()! */
+    /** @deprecated use DatasetTableImpl.hasPermission()! */
     @Override
+    @Deprecated
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        if (!perm.equals(ReadPermission.class))
-            throw new UnsupportedOperationException("use DatasetTableImpl.hasPermission()");
         return hasPermission(user, perm, null);
     }
 

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -757,7 +757,7 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
         StudyImpl study = StudyManager.getInstance().getStudy(container);
         if (null == study)
             return null;
-        StudyQuerySchema schema = StudyQuerySchema.createSchema(study, user, true);
+        StudyQuerySchema schema = StudyQuerySchema.createSchema(study, user);
         DatasetDefinition dsd = schema.getDatasetDefinitionByName(name);
         if (null == dsd)
             return null;

--- a/study/src/org/labkey/study/model/DatasetImportTestCase.jsp
+++ b/study/src/org/labkey/study/model/DatasetImportTestCase.jsp
@@ -278,7 +278,7 @@ public void test() throws Throwable
 
 private void _testDatasetUpdateService(StudyImpl study) throws Throwable
 {
-    StudyQuerySchema ss = StudyQuerySchema.createSchema(study, _context.getUser(), false);
+    StudyQuerySchema ss = StudyQuerySchema.createSchema(study, _context.getUser());
     Dataset def = createDataset(study, "A", false);
     TableInfo tt = ss.getTable(def.getName());
     QueryUpdateService qus = tt.getUpdateService();
@@ -440,7 +440,7 @@ private void _testDatasetDetailedLogging(StudyImpl study) throws Throwable
             .getObject(Integer.class);
     int rowid = null==RowId ? 0 : RowId.intValue();
 
-    StudyQuerySchema ss = StudyQuerySchema.createSchema(study, _context.getUser(), true);
+    StudyQuerySchema ss = StudyQuerySchema.createSchema(study, _context.getUser());
     Dataset def = createDataset(study, "DL", true);
     TableInfo tt = ss.getTable(def.getName());
     QueryUpdateService qus = tt.getUpdateService();
@@ -522,7 +522,7 @@ private void _testImportDatasetDataAllowImportGuid(Study study) throws Throwable
 {
     int sequenceNum = 0;
 
-    StudyQuerySchema ss = StudyQuerySchema.createSchema((StudyImpl) study, _context.getUser(), false);
+    StudyQuerySchema ss = StudyQuerySchema.createSchema((StudyImpl) study, _context.getUser());
     Dataset def = createDataset(study, "GU", DatasetType.OPTIONAL_GUID);
     TableInfo tt = def.getTableInfo(_context.getUser());
 
@@ -558,7 +558,7 @@ private void _testImportDatasetData(Study study) throws Throwable
 {
     int sequenceNum = 0;
 
-    StudyQuerySchema ss = StudyQuerySchema.createSchema((StudyImpl) study, _context.getUser(), false);
+    StudyQuerySchema ss = StudyQuerySchema.createSchema((StudyImpl) study, _context.getUser());
     Dataset def = createDataset(study, "B", false);
     TableInfo tt = def.getTableInfo(_context.getUser());
 
@@ -713,7 +713,7 @@ private void importRow(Dataset def, Map map, @Nullable Logger logger, String... 
 
 private void _testImportDemographicDatasetData(Study study) throws Throwable
 {
-    StudyQuerySchema ss = StudyQuerySchema.createSchema((StudyImpl) study, _context.getUser(), false);
+    StudyQuerySchema ss = StudyQuerySchema.createSchema((StudyImpl) study, _context.getUser());
     Dataset def = createDataset(study, "Dem", true);
     TableInfo tt = def.getTableInfo(_context.getUser());
 
@@ -781,7 +781,7 @@ private void _testImportDemographicDatasetData(Study study) throws Throwable
  */
 private void _testDaysSinceStartCalculation(Study study) throws Throwable
 {
-    StudyQuerySchema ss = StudyQuerySchema.createSchema((StudyImpl) study, _context.getUser(), false);
+    StudyQuerySchema ss = StudyQuerySchema.createSchema((StudyImpl) study, _context.getUser());
     Dataset dem = createDataset(study, "Dem", true);
     Dataset ds = createDataset(study, "DS", false);
 
@@ -838,7 +838,7 @@ private void _testDaysSinceStartCalculation(Study study) throws Throwable
 private void  _testDatasetTransformExport(Study study) throws Throwable
 {
     // create a dataset
-    StudyQuerySchema ss = StudyQuerySchema.createSchema((StudyImpl) study, _context.getUser(), false);
+    StudyQuerySchema ss = StudyQuerySchema.createSchema((StudyImpl) study, _context.getUser());
     Dataset def = createDataset(study, "DS", false);
     TableInfo datasetTI = ss.getTable(def.getName());
     QueryUpdateService qus = datasetTI.getUpdateService();

--- a/study/src/org/labkey/study/model/ParticipantIdImportHelper.java
+++ b/study/src/org/labkey/study/model/ParticipantIdImportHelper.java
@@ -125,7 +125,7 @@ public class ParticipantIdImportHelper implements ParticipantIdTranslator
     protected HashSet<String> generatePtidHashSet(StudyImpl studyImpl)
     {
         HashSet<String> ptids = new HashSet<>();
-        StudyQuerySchema studySchema = StudyQuerySchema.createSchema(studyImpl, _user, true);
+        StudyQuerySchema studySchema = StudyQuerySchema.createSchema(studyImpl, _user);
         TableInfo ptidTableInfo = studySchema.getTable(studyImpl.getSubjectNounSingular());
         Map<String, Object>[] tmp_rows = new TableSelector(ptidTableInfo, ImmutableSet.of(studyImpl.getSubjectColumnName()), null, null).getMapArray();
         for (Map<String, Object> row : tmp_rows)

--- a/study/src/org/labkey/study/model/StudyImpl.java
+++ b/study/src/org/labkey/study/model/StudyImpl.java
@@ -39,6 +39,7 @@ import org.labkey.api.data.MvUtil;
 import org.labkey.api.data.ObjectFactory;
 import org.labkey.api.data.Results;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.Transient;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.property.Domain;
@@ -51,6 +52,8 @@ import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.roles.ReaderRole;
+import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.specimen.location.LocationImpl;
 import org.labkey.api.specimen.location.LocationManager;
 import org.labkey.api.study.Location;
@@ -173,6 +176,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     }
 
     @Override
+    @Transient
     public SecurableResource getParentResource()
     {
         //overridden to return the container
@@ -196,6 +200,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
 
     @NotNull
     @Override
+    @Transient
     public String getResourceDescription()
     {
         return "The study " + _label;
@@ -218,6 +223,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
 
     // TODO: Make short name admin editable, persist, and display. For now, just use the first "word" of the label.
     @Override
+    @Transient
     public String getShortName()
     {
         String label = _label == null ? "Study" : _label;
@@ -233,6 +239,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     }
 
     @Override
+    @Transient
     public Map<String, BigDecimal> getVisitAliases()
     {
         return StudyManager.getInstance().getCustomVisitImportMapping(this)
@@ -259,6 +266,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     }
 
     @Override
+    @Transient
     public List<DatasetDefinition> getDatasets()
     {
         return StudyManager.getInstance().getDatasetDefinitions(this);
@@ -270,12 +278,14 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
         return StudyManager.getInstance().getDatasetDefinitions(this, null, types);
     }
 
+    @Transient
     public Set<PropertyDescriptor> getSharedProperties()
     {
         return StudyManager.getInstance().getSharedProperties(this);
     }
 
     @Override
+    @Transient
     public List<LocationImpl> getLocations()
     {
         return LocationManager.get().getLocations(getContainer());
@@ -313,6 +323,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     }
 
     @Override
+    @Transient
     public List<VisitImpl> getVisitsForAssaySchedule()
     {
         return StudyManager.getInstance().getVisitsForAssaySchedule(getContainer());
@@ -337,6 +348,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     }
 
     @Override
+    @Transient
     public List<VisitImpl> getVisitsForTreatmentSchedule()
     {
         return TreatmentManager.getInstance().getVisitsForTreatmentSchedule(getContainer());
@@ -351,7 +363,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     @Override
     public Object getPrimaryKey()
     {
-        return getContainer();
+        return getContainer().getId();
     }
 
     public int getRowId()
@@ -551,7 +563,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
 
     public int getNumExtendedProperties(User user)
     {
-        StudyQuerySchema schema = StudyQuerySchema.createSchema(this, user, true);
+        StudyQuerySchema schema = StudyQuerySchema.createSchema(this, user);
         String domainURI = DOMAIN_INFO.getDomainURI(schema.getContainer());
         Domain domain = PropertyService.get().getDomain(schema.getContainer(), domainURI);
 
@@ -680,6 +692,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     }
 
     @Override
+    @Transient
     public HtmlString getDescriptionHtml()
     {
         String description = getDescription();
@@ -705,6 +718,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
         }
     }
 
+    @Transient
     public WikiRendererType getDescriptionWikiRendererType()
     {
         try
@@ -759,6 +773,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     }
 
     @Override
+    @Transient
     public List<Attachment> getProtocolDocuments()
     {
         return new ArrayList<>(AttachmentService.get().getAttachments(getProtocolDocumentAttachmentParent()));
@@ -798,6 +813,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
 
     @Override
     @Nullable
+    @Transient
     public StudyImpl getSourceStudy()
     {
         if (getSourceStudyContainerId() == null)
@@ -963,6 +979,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     }
 
 
+    @Transient
     public AttachmentParent getProtocolDocumentAttachmentParent()
     {
         return new ProtocolDocumentAttachmentParent(this);
@@ -970,6 +987,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
 
 
     @Override
+    @Transient
     public String getSearchDisplayTitle()
     {
         return "Study -- " + getLabel();
@@ -984,11 +1002,12 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     }
 
     @Override
+    @Transient
     public String getSearchKeywords()
     {
         StringBuilder sb = new StringBuilder();
 
-        StudyQuerySchema sqs = StudyQuerySchema.createSchema(this, User.getSearchUser(), false);
+        StudyQuerySchema sqs = StudyQuerySchema.createSchema(this, User.getSearchUser(), RoleManager.getRole(ReaderRole.class));
         TableInfo sp = sqs.getTable("StudyProperties");
         if (null != sp)
         {
@@ -1021,6 +1040,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
 
 
     @Override
+    @Transient
     public String getSearchBody()
     {
         Container c = getContainer();
@@ -1139,6 +1159,7 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
 
     @Override
     @NotNull
+    @Transient
     public Boolean getShareDatasetDefinitions()
     {
         return _shareDatasetDefinitions && getContainer().isProject();

--- a/study/src/org/labkey/study/model/StudyImpl.java
+++ b/study/src/org/labkey/study/model/StudyImpl.java
@@ -1159,7 +1159,6 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
 
     @Override
     @NotNull
-    @Transient
     public Boolean getShareDatasetDefinitions()
     {
         return _shareDatasetDefinitions && getContainer().isProject();

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -107,6 +107,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.security.roles.RestrictedReaderRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
@@ -4168,7 +4169,7 @@ public class StudyManager
     // Return a source->alias map for the specified participant
     public Map<String, String> getAliasMap(StudyImpl study, User user, String ptid)
     {
-        @Nullable final TableInfo aliasTable = StudyQuerySchema.createSchema(study, user, true).getParticipantAliasesTable();
+        @Nullable final TableInfo aliasTable = StudyQuerySchema.createSchema(study, user).getParticipantAliasesTable();
 
         if (null == aliasTable)
             return Collections.emptyMap();
@@ -4259,7 +4260,7 @@ public class StudyManager
 
         body.append(keywords).append("\n");
 
-        StudyQuerySchema schema = StudyQuerySchema.createSchema(dsd.getStudy(), User.getSearchUser(), false);
+        StudyQuerySchema schema = StudyQuerySchema.createSchema(dsd.getStudy(), User.getSearchUser(), RoleManager.getRole(ReaderRole.class));
         TableInfo tableInfo = schema.createDatasetTableInternal(dsd, null);
         Map<FieldKey, ColumnInfo> columns = QueryService.get().getColumns(tableInfo, tableInfo.getDefaultVisibleColumns());
         String sep = "";
@@ -4329,7 +4330,7 @@ public class StudyManager
         if (!lastIndexedFragment.isEmpty())
             f.append(" AND ").append(lastIndexedFragment);
 
-        @Nullable final TableInfo aliasTable = StudyQuerySchema.createSchema(study, User.getSearchUser(), true).getParticipantAliasesTable();
+        @Nullable final TableInfo aliasTable = StudyQuerySchema.createSchema(study, User.getSearchUser()).getParticipantAliasesTable();
 
         if (null != aliasTable)
         {

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -480,7 +480,6 @@ public class StudyManager
         return _instance;
     }
 
-
     @Nullable
     public StudyImpl getStudy(@NotNull Container c)
     {
@@ -599,6 +598,7 @@ public class StudyManager
         {
             SpecimenSchema.get().getTableInfoLocation(container, user);    // This provisioned table is needed for creating the study
             study = _studyHelper.create(user, study);
+            clearCaches(container,false);
 
             //note: we no longer copy the container's policy to the study upon creation
             //instead, we let it inherit the container's policy until the security type
@@ -2048,7 +2048,7 @@ public class StudyManager
         DatasetDefinition def = getDatasetDefinition(study, cohortDatasetId);
 
         if (def != null)
-            return def.canRead(user);
+            return def.canReadInternal(user);
 
         return false;
     }

--- a/study/src/org/labkey/study/query/AbstractSpecimenTable.java
+++ b/study/src/org/labkey/study/query/AbstractSpecimenTable.java
@@ -25,9 +25,9 @@ import org.labkey.api.data.TableInfo;
  */
 public abstract class AbstractSpecimenTable extends BaseStudyTable
 {
-    public AbstractSpecimenTable(StudyQuerySchema schema, TableInfo realTable, ContainerFilter cf, boolean skipPermissionChecks, boolean isProvisioned)
+    public AbstractSpecimenTable(StudyQuerySchema schema, TableInfo realTable, ContainerFilter cf, boolean isProvisioned)
     {
-        super(schema, realTable, cf, true, skipPermissionChecks);
+        super(schema, realTable, cf, true);
 
         var rowIdColumn = addWrapColumn(_rootTable.getColumn("RowId"));
         rowIdColumn.setKeyField(true);

--- a/study/src/org/labkey/study/query/AssayDatasetTable.java
+++ b/study/src/org/labkey/study/query/AssayDatasetTable.java
@@ -125,7 +125,13 @@ public class AssayDatasetTable extends DatasetTableImpl
     @Override
     protected ColumnInfo resolveColumn(String name)
     {
-        var result = super.resolveColumn(name);
+        ColumnInfo result = null;
+
+        // NOTE: calling QueryService.get().getColumns() can cause recursion because it may call resolveColumn()!
+        // should probably handle our cases first then call super.resolveColumn()
+        if ("Properties".equalsIgnoreCase(name))
+            result = super.resolveColumn(name);
+
         if (result != null)
             return result;
 

--- a/study/src/org/labkey/study/query/AssayDatasetTable.java
+++ b/study/src/org/labkey/study/query/AssayDatasetTable.java
@@ -19,6 +19,8 @@ import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.QueryService;
+import org.labkey.api.security.roles.ReaderRole;
+import org.labkey.api.security.roles.RoleManager;
 import org.labkey.study.model.DatasetDefinition;
 
 import java.util.ArrayList;
@@ -293,6 +295,7 @@ public class AssayDatasetTable extends DatasetTableImpl
                 return null;
             }
             AssayProtocolSchema schema = provider.createProtocolSchema(_userSchema.getUser(), protocol.getContainer(), protocol, getContainer());
+            schema.addContextualRole(RoleManager.getRole(ReaderRole.class));
             _assayResultTable = schema.createDataTable(ContainerFilter.EVERYTHING, false);
         }
         return _assayResultTable;

--- a/study/src/org/labkey/study/query/AssayDatasetTable.java
+++ b/study/src/org/labkey/study/query/AssayDatasetTable.java
@@ -40,7 +40,7 @@ public class AssayDatasetTable extends DatasetTableImpl
     private List<FieldKey> _defaultVisibleColumns = null;
     private TableInfo _assayResultTable;
 
-    public AssayDatasetTable(@NotNull StudyQuerySchema schema, ContainerFilter cf, @NotNull DatasetDefinition dsd)
+    AssayDatasetTable(@NotNull StudyQuerySchema schema, ContainerFilter cf, @NotNull DatasetDefinition dsd)
     {
         super(schema, cf, dsd);
 
@@ -153,7 +153,7 @@ public class AssayDatasetTable extends DatasetTableImpl
                         @Override
                         public TableInfo getLookupTableInfo()
                         {
-                            return new DatasetTableImpl(getUserSchema(), getLookupContainerFilter(), _dsd);
+                            return getUserSchema().getTable(_dsd.getName(), getLookupContainerFilter());
                         }
 
                         @Override

--- a/study/src/org/labkey/study/query/AssaySpecimenTable.java
+++ b/study/src/org/labkey/study/query/AssaySpecimenTable.java
@@ -21,7 +21,6 @@ import org.labkey.api.query.AliasedColumn;
 import org.labkey.api.query.DefaultQueryUpdateService;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.query.QueryUpdateService;
-import org.labkey.api.query.UserIdQueryForeignKey;
 import org.labkey.api.query.column.BuiltInColumnTypes;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
@@ -97,5 +96,12 @@ public class AssaySpecimenTable extends BaseStudyTable
     public QueryUpdateService getUpdateService()
     {
         return new DefaultQueryUpdateService(this, this.getRealTable());
+    }
+
+    @Override
+    protected boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
+    {
+        // see StudyDesignController.UpdateAssayScheduleAction @RequiresPermission(UpdatePermission.class)
+        return checkContainerPermission(user, perm);
     }
 }

--- a/study/src/org/labkey/study/query/AssaySpecimenTable.java
+++ b/study/src/org/labkey/study/query/AssaySpecimenTable.java
@@ -94,12 +94,6 @@ public class AssaySpecimenTable extends BaseStudyTable
     }
 
     @Override
-    public boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
-    {
-        return getContainer().hasPermission(user, perm);
-    }
-
-    @Override
     public QueryUpdateService getUpdateService()
     {
         return new DefaultQueryUpdateService(this, this.getRealTable());

--- a/study/src/org/labkey/study/query/AssaySpecimenVisitTable.java
+++ b/study/src/org/labkey/study/query/AssaySpecimenVisitTable.java
@@ -77,7 +77,8 @@ public class AssaySpecimenVisitTable extends BaseStudyTable
     @Override
     public boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
     {
-        return getContainer().hasPermission(user, perm);
+        // see StudyDesignController.UpdateAssayScheduleAction @RequiresPermission(UpdatePermission.class)
+        return checkContainerPermission(user, perm);
     }
 
     @Override

--- a/study/src/org/labkey/study/query/BaseStudyTable.java
+++ b/study/src/org/labkey/study/query/BaseStudyTable.java
@@ -88,7 +88,10 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
         super(realTable, schema);
 
         if (includeSourceStudyData && null != schema._study && !schema._study.isDataspaceStudy())
-            _setContainerFilter(new ContainerFilter.StudyAndSourceStudy(schema.getContainer(), schema.getUser(), schema.hasContextualReadRole()));
+        {
+            boolean hasReaderRole = getContextualRoles().contains(RoleManager.getRole(ReaderRole.class));
+            _setContainerFilter(new ContainerFilter.StudyAndSourceStudy(schema.getContainer(), schema.getUser(), hasReaderRole));
+        }
         else if (null != cf && supportsContainerFilter())
             _setContainerFilter(cf);
         else

--- a/study/src/org/labkey/study/query/CohortTable.java
+++ b/study/src/org/labkey/study/query/CohortTable.java
@@ -124,6 +124,6 @@ public class CohortTable extends BaseStudyTable
     {
         if (!(user instanceof User) || !StudyManager.getInstance().showCohorts(_userSchema.getContainer(), (User)user))
             return false;
-        return canReadOrIsAdminPermission(user, perm);
+        return checkReadOrIsAdminPermission(user, perm);
     }
 }

--- a/study/src/org/labkey/study/query/CohortUpdateService.java
+++ b/study/src/org/labkey/study/query/CohortUpdateService.java
@@ -71,7 +71,7 @@ public class CohortUpdateService extends AbstractQueryUpdateService
             throws InvalidKeyException
     {
         StudyImpl study = StudyManager.getInstance().getStudy(container);
-        StudyQuerySchema querySchema = StudyQuerySchema.createSchema(study, user, true);
+        StudyQuerySchema querySchema = StudyQuerySchema.createSchema(study, user);
         TableInfo queryTableInfo = querySchema.getTable("Cohort");
         Map<String, Object> result = new TableSelector(queryTableInfo).getObject(keyFromMap(keys), Map.class);
         return result;

--- a/study/src/org/labkey/study/query/DatasetAutoJoinTable.java
+++ b/study/src/org/labkey/study/query/DatasetAutoJoinTable.java
@@ -72,7 +72,7 @@ public class DatasetAutoJoinTable extends VirtualTable
                                 @Nullable FieldKey sequenceNumFieldKey,
                                 @Nullable FieldKey keyFieldKey)
     {
-        super(StudySchema.getInstance().getSchema(), "DataSets");
+        super(StudySchema.getInstance().getSchema(), "DataSets", schema);
         _schema = schema;
         _source = source;
         _keyPropertyName = _source.getKeyPropertyName();

--- a/study/src/org/labkey/study/query/DatasetColumnsTable.java
+++ b/study/src/org/labkey/study/query/DatasetColumnsTable.java
@@ -73,6 +73,7 @@ public class DatasetColumnsTable extends FilteredTable<StudyQuerySchema>
     @Override @NotNull
     public SQLFragment getFromSQL(String alias)
     {
+        checkReadBeforeExecute();
         SQLFragment result = new SQLFragment();
         result.appendComment("<DataSetColumnsTable>", getSqlDialect());
         result.append("(SELECT DataSet.DataSetId, PropertyDescriptor.* FROM ");
@@ -98,7 +99,7 @@ public class DatasetColumnsTable extends FilteredTable<StudyQuerySchema>
     @Override
     protected void applyContainerFilter(ContainerFilter filter)
     {
-        assert null == filter || filter.getType() == ContainerFilter.Type.Current;
+        assert null == filter || filter.getType() == ContainerFilter.Type.Current || filter.getType() == ContainerFilter.Type.CurrentWithUser;
     }
 
     @Override

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -179,7 +179,7 @@ public class DatasetQueryView extends StudyQueryView
     private DatasetFilterForm getForm(ViewContext context)
     {
         DatasetFilterForm form = new DatasetFilterForm();
-
+        form.setViewContext(context);
         form.bindParameters(context.getBindPropertyValues());
         return form;
     }
@@ -553,7 +553,11 @@ public class DatasetQueryView extends StudyQueryView
         @Override
         public @NotNull BindException bindParameters(PropertyValues params)
         {
-            return BaseViewAction.springBindParameters(this, "form", params);
+            assert _bindState == BindState.UNBOUND;
+            _bindState = BindState.BINDING;
+            var ret = BaseViewAction.springBindParameters(this, "form", params);
+            _bindState = BindState.BOUND;
+            return ret;
         }
 
         public String getCohortFilterType()

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -173,7 +173,17 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
             String name = baseColumn.getName();
             if (subjectColName.equalsIgnoreCase(name))
             {
-                var column = new AliasedColumn(this, subjectColName, baseColumn);
+                var column = new AliasedColumn(this, subjectColName, baseColumn)
+                {
+                    @Override
+                    public StringExpression getURL()
+                    {
+                        // delay constructing Participant table
+                        if (null == _url && null != getFk())
+                            _url = getFk().getURL(this);
+                        return _url;
+                    }
+                };
                 column.setInputType("text");
                 // TODO, need a way for a lookup to have a "text" input
                 column.setDisplayColumnFactory(colInfo -> {
@@ -183,9 +193,6 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
                 });
 
                 column.setFk(new ParticipantForeignKey(cf));
-// I don't think we need to do this?  This is what getEffectiveURL() is for?
-//                if (null == column.getURL())
-//                    column.setURL(column.getFk().getURL(column));
 
                 if (DemoMode.isDemoMode(schema.getContainer(), schema.getUser()))
                 {

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -80,7 +80,6 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.view.ActionURL;
-import org.labkey.api.view.UnauthorizedException;
 import org.labkey.data.xml.TableType;
 import org.labkey.study.StudySchema;
 import org.labkey.study.controllers.DatasetController;
@@ -184,8 +183,9 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
                 });
 
                 column.setFk(new ParticipantForeignKey(cf));
-                if (null == column.getURL())
-                    column.setURL(column.getFk().getURL(column));
+// I don't think we need to do this?  This is what getEffectiveURL() is for?
+//                if (null == column.getURL())
+//                    column.setURL(column.getFk().getURL(column));
 
                 if (DemoMode.isDemoMode(schema.getContainer(), schema.getUser()))
                 {
@@ -888,8 +888,15 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        // OK to edit these in Dataspace project and in any folder
-        return getDatasetDefinition().hasPermission(user, perm);
+        if (!perm.equals(ReadPermission.class) && !canUserAccessPhi())
+            return false;
+        return getDatasetDefinition().hasPermission(user, perm, getContextualRoles());
+    }
+
+    @Override
+    protected boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
+    {
+        throw new IllegalStateException();
     }
 
     @Override

--- a/study/src/org/labkey/study/query/DataspaceQuerySchema.java
+++ b/study/src/org/labkey/study/query/DataspaceQuerySchema.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.security.User;
+import org.labkey.api.security.roles.Role;
 import org.labkey.api.study.DataspaceContainerFilter;
 import org.labkey.api.util.GUID;
 import org.labkey.api.view.HttpView;
@@ -43,9 +44,14 @@ public class DataspaceQuerySchema extends StudyQuerySchema
 
     private List<GUID> _sharedStudyContainerFilter;
 
-    public DataspaceQuerySchema(@NotNull StudyImpl study, User user, boolean mustCheckPermissions)
+    public DataspaceQuerySchema(@NotNull StudyImpl study, User user)
     {
-        super(study, user, mustCheckPermissions);
+        this(study, user, null);
+    }
+
+    public DataspaceQuerySchema(@NotNull StudyImpl study, User user, @Nullable Role contextualRole)
+    {
+        super(study, user, contextualRole);
 
         Container project = study.getContainer().getProject();
         List<GUID> containerIds = null;

--- a/study/src/org/labkey/study/query/ExtensibleObjectQueryView.java
+++ b/study/src/org/labkey/study/query/ExtensibleObjectQueryView.java
@@ -44,7 +44,7 @@ public class ExtensibleObjectQueryView extends QueryView
         ViewContext context,
         boolean allowEditing)
     {
-        super(StudyQuerySchema.createSchema(study, user, true));
+        super(StudyQuerySchema.createSchema(study, user));
         this.allowEditing = allowEditing;
         setShadeAlternatingRows(true);
         setShowBorders(true);

--- a/study/src/org/labkey/study/query/LocationTable.java
+++ b/study/src/org/labkey/study/query/LocationTable.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.ContainerForeignKey;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.ForeignKey;
@@ -41,7 +40,6 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.specimen.SpecimenSchema;
 import org.labkey.api.specimen.location.LocationCache;
 import org.labkey.api.specimen.location.LocationImpl;
@@ -112,7 +110,7 @@ public class LocationTable extends BaseStudyTable
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return canReadOrIsAdminPermission(user, perm);
+        return checkReadOrIsAdminPermission(user, perm);
     }
 
     @Override
@@ -321,5 +319,11 @@ public class LocationTable extends BaseStudyTable
     public boolean hasUnionTable()
     {
         return true;
+    }
+
+    @Override
+    protected boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
+    {
+        return checkSpecimenEditPermissions(user, perm);
     }
 }

--- a/study/src/org/labkey/study/query/LocationTable.java
+++ b/study/src/org/labkey/study/query/LocationTable.java
@@ -41,6 +41,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.specimen.SpecimenSchema;
 import org.labkey.api.specimen.location.LocationCache;
 import org.labkey.api.specimen.location.LocationImpl;
@@ -111,7 +112,7 @@ public class LocationTable extends BaseStudyTable
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return _userSchema.getContainer().hasPermission(this.getClass().getName() + " " + getName(), user, AdminPermission.class);
+        return canReadOrIsAdminPermission(user, perm);
     }
 
     @Override

--- a/study/src/org/labkey/study/query/ParticipantCategoryTable.java
+++ b/study/src/org/labkey/study/query/ParticipantCategoryTable.java
@@ -84,8 +84,9 @@ public class ParticipantCategoryTable extends BaseStudyTable
     @Override
     public boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
     {
+        // see ParticipantGroupController, note most actions only require ReadPermission
         if (perm.equals(ReadPermission.class) || perm.equals(DeletePermission.class))
-            return getContainer().hasPermission(user, perm);
+            return checkContainerPermission(user, perm);
         else
             return false;
     }

--- a/study/src/org/labkey/study/query/ParticipantCategoryTable.java
+++ b/study/src/org/labkey/study/query/ParticipantCategoryTable.java
@@ -30,6 +30,7 @@ import org.labkey.api.query.UserIdRenderer;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.study.DataspaceContainerFilter;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.view.ActionURL;
@@ -83,7 +84,7 @@ public class ParticipantCategoryTable extends BaseStudyTable
     @Override
     public boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
     {
-        if (perm.equals(DeletePermission.class))
+        if (perm.equals(ReadPermission.class) || perm.equals(DeletePermission.class))
             return getContainer().hasPermission(user, perm);
         else
             return false;

--- a/study/src/org/labkey/study/query/ParticipantGroupTable.java
+++ b/study/src/org/labkey/study/query/ParticipantGroupTable.java
@@ -28,6 +28,7 @@ import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.study.DataspaceContainerFilter;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.view.ActionURL;
@@ -74,7 +75,8 @@ public class ParticipantGroupTable extends BaseStudyTable
     @Override
     public boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
     {
-        if (perm.equals(DeletePermission.class))
+        checkedPermissions.add(perm);
+        if (perm.equals(ReadPermission.class) || perm.equals(DeletePermission.class))
             return getContainer().hasPermission(user, perm);
         else
             return false;

--- a/study/src/org/labkey/study/query/ParticipantGroupTable.java
+++ b/study/src/org/labkey/study/query/ParticipantGroupTable.java
@@ -77,7 +77,7 @@ public class ParticipantGroupTable extends BaseStudyTable
     {
         checkedPermissions.add(perm);
         if (perm.equals(ReadPermission.class) || perm.equals(DeletePermission.class))
-            return getContainer().hasPermission(user, perm);
+            return checkContainerPermission(user, perm);
         else
             return false;
     }

--- a/study/src/org/labkey/study/query/ParticipantTable.java
+++ b/study/src/org/labkey/study/query/ParticipantTable.java
@@ -408,14 +408,4 @@ public class ParticipantTable extends BaseStudyTable
         ret.addClause(new ParticipantGroupFilterClause(participantFieldKey, group));
         return ret;
     }
-
-
-    @NotNull
-    @Override
-    public SQLFragment getFromSQL(String alias)
-    {
-        SQLFragment ret;
-        ret = super.getFromSQL(alias);
-        return ret;
-    }
 }

--- a/study/src/org/labkey/study/query/ParticipantTable.java
+++ b/study/src/org/labkey/study/query/ParticipantTable.java
@@ -41,6 +41,7 @@ import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.TitleForeignKey;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
@@ -375,7 +376,7 @@ public class ParticipantTable extends BaseStudyTable
         public TableInfo getLookupTableInfo()
         {
             // Create a simple virtual table so that we can expose one column per alias source
-            VirtualTable result = new VirtualTable(getSchema(), null);
+            VirtualTable result = new VirtualTable(getSchema(), null, (UserSchema)_sourceSchema);
             for (String source : getParticipantAliasSources(_datasetTable, _sourceColumn))
             {
                 var column = new BaseColumnInfo(source, JdbcType.VARCHAR);

--- a/study/src/org/labkey/study/query/ParticipantTable.java
+++ b/study/src/org/labkey/study/query/ParticipantTable.java
@@ -42,6 +42,8 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.TitleForeignKey;
 import org.labkey.api.security.User;
+import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.model.ParticipantGroup;
@@ -174,7 +176,11 @@ public class ParticipantTable extends BaseStudyTable
         {
             DatasetDefinition dataset = _study.getDataset(_study.getParticipantAliasDatasetId());
             User user = getUserSchema().getUser();
-            if (dataset != null && dataset.canRead(user))
+            /* NOTE We are probably in the middle of constructing a dataset that contains a ParticipantForeignKey.
+             * Calling dataset.canRead() will try to construct a dataset tableInfo and we'll end up with a StackOverflow.
+             * Use the study permission directly (no contextual roles, etc).
+             */
+            if (dataset != null && dataset.canReadInternal(user))
             {
                 // Get the table and the two admin-configured columns
                 final DatasetDefinition.DatasetSchemaTableInfo datasetTable = dataset.getTableInfo(user, true);

--- a/study/src/org/labkey/study/query/ParticipantVisitTable.java
+++ b/study/src/org/labkey/study/query/ParticipantVisitTable.java
@@ -128,7 +128,7 @@ public class ParticipantVisitTable extends BaseStudyTable
         {
             // verify that the current user has permission to read this dataset (they may not if
             // advanced study security is enabled).
-            if (!dataset.canRead(schema.getUser()))
+            if (!dataset.canReadInternal(schema.getUser()))
                 continue;
 
             String name = _userSchema.decideTableName(dataset);

--- a/study/src/org/labkey/study/query/SampleDatasetTable.java
+++ b/study/src/org/labkey/study/query/SampleDatasetTable.java
@@ -26,7 +26,7 @@ public class SampleDatasetTable extends DatasetTableImpl
     private TableInfo _sampleTable;
     private List<FieldKey> _defaultVisibleColumns = null;
 
-    public SampleDatasetTable(@NotNull StudyQuerySchema schema, ContainerFilter cf, @NotNull DatasetDefinition dsd)
+    SampleDatasetTable(@NotNull StudyQuerySchema schema, ContainerFilter cf, @NotNull DatasetDefinition dsd)
     {
         super(schema, cf, dsd);
 

--- a/study/src/org/labkey/study/query/SimpleSpecimenTable.java
+++ b/study/src/org/labkey/study/query/SimpleSpecimenTable.java
@@ -24,12 +24,7 @@ public class SimpleSpecimenTable extends AbstractSpecimenTable
 {
     public SimpleSpecimenTable(StudyQuerySchema schema, ContainerFilter cf)
     {
-        this(schema, cf, false);
-    }
-
-    public SimpleSpecimenTable(StudyQuerySchema schema, ContainerFilter cf, boolean skipPermissionChecks)
-    {
-        super(schema, SpecimenSchema.get().getTableInfoSpecimen(schema.getContainer()), cf, skipPermissionChecks, true);
+        super(schema, SpecimenSchema.get().getTableInfoSpecimen(schema.getContainer()), cf, true);
         setName("SimpleSpecimen");
 
         getMutableColumn(StudyService.get().getSubjectColumnName(getContainer())).clearFk();

--- a/study/src/org/labkey/study/query/SpecimenDetailTable.java
+++ b/study/src/org/labkey/study/query/SpecimenDetailTable.java
@@ -356,8 +356,7 @@ public class SpecimenDetailTable extends AbstractSpecimenTable
     @Override
     public boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
     {
-        return getContainer().hasPermission(user, perm) &&
-                (perm.equals(ReadPermission.class) || getContainer().hasPermission(user, EditSpecimenDataPermission.class));
+        return checkSpecimenEditPermissions(user, perm);
     }
 
     @Override

--- a/study/src/org/labkey/study/query/SpecimenDetailTable.java
+++ b/study/src/org/labkey/study/query/SpecimenDetailTable.java
@@ -39,6 +39,7 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.specimen.SpecimenSchema;
 import org.labkey.api.specimen.importer.RollupHelper;
 import org.labkey.api.specimen.model.SpecimenTablesProvider;
@@ -46,6 +47,7 @@ import org.labkey.api.specimen.query.SpecimenUpdateService;
 import org.labkey.api.specimen.security.permissions.EditSpecimenDataPermission;
 import org.labkey.api.specimen.settings.SettingsManager;
 import org.labkey.api.study.StudyService;
+import org.labkey.api.view.UnauthorizedException;
 import org.labkey.study.CohortForeignKey;
 import org.labkey.study.StudySchema;
 import org.labkey.study.model.StudyManager;
@@ -67,7 +69,7 @@ public class SpecimenDetailTable extends AbstractSpecimenTable
 
     public SpecimenDetailTable(StudyQuerySchema schema, ContainerFilter cf)
     {
-        super(schema, SpecimenSchema.get().getTableInfoSpecimenDetail(schema.getContainer()), cf, false, true);
+        super(schema, SpecimenSchema.get().getTableInfoSpecimenDetail(schema.getContainer()), cf,  true);
 
         var guid = addWrapColumn(_rootTable.getColumn(GLOBAL_UNIQUE_ID_COLUMN_NAME));
         guid.setDisplayColumnFactory(ColumnInfo.NOWRAP_FACTORY);
@@ -355,7 +357,7 @@ public class SpecimenDetailTable extends AbstractSpecimenTable
     public boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
     {
         return getContainer().hasPermission(user, perm) &&
-               getContainer().hasPermission(user, EditSpecimenDataPermission.class);
+                (perm.equals(ReadPermission.class) || getContainer().hasPermission(user, EditSpecimenDataPermission.class));
     }
 
     @Override
@@ -371,6 +373,7 @@ public class SpecimenDetailTable extends AbstractSpecimenTable
     @Override
     public SQLFragment getFromSQL(String alias)
     {
+        checkReadBeforeExecute();
         return getSpecimenAndVialFromSQL(alias, getSchema(), getContainer(), _optionalSpecimenProperties, _optionalVialProperties);
     }
 

--- a/study/src/org/labkey/study/query/SpecimenRequestTable.java
+++ b/study/src/org/labkey/study/query/SpecimenRequestTable.java
@@ -26,6 +26,8 @@ import org.labkey.api.specimen.SpecimenSchema;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMENREQUEST_TABLENAME;
+
 /**
  * User: brittp
  * Date: Apr 20, 2007
@@ -36,6 +38,7 @@ public class SpecimenRequestTable extends BaseStudyTable
     public SpecimenRequestTable(StudyQuerySchema schema, ContainerFilter cf)
     {
         super(schema, SpecimenSchema.get().getTableInfoSampleRequest(), cf);
+        setName(SPECIMENREQUEST_TABLENAME);
 
         AliasedColumn rowIdColumn = new AliasedColumn(this, "RequestId", _rootTable.getColumn("RowId"));
         rowIdColumn.setKeyField(true);

--- a/study/src/org/labkey/study/query/SpecimenSchema.java
+++ b/study/src/org/labkey/study/query/SpecimenSchema.java
@@ -11,13 +11,16 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMENVIALCOUNT_TABLENAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.VIALREQUEST_TABLENAME;
+
 class SpecimenSchema extends StudyQuerySchema
 {
     private final StudyQuerySchema _parentSchema;
 
     SpecimenSchema(StudyQuerySchema parent)
     {
-        super(new SchemaKey(parent.getSchemaPath(), "Specimens"), "Specimen repository", parent.getStudy(), parent.getContainer(), parent.getUser(), parent._mustCheckPermissions);
+        super(new SchemaKey(parent.getSchemaPath(), "Specimens"), "Specimen repository", parent.getStudy(), parent.getContainer(), parent.getUser(), parent._contextualRole);
         _parentSchema = parent;
         setSessionParticipantGroup(parent.getSessionParticipantGroup());
     }
@@ -51,11 +54,11 @@ class SpecimenSchema extends StudyQuerySchema
                 names.add(SPECIMEN_EVENT_TABLE_NAME);
                 names.add(SPECIMEN_DETAIL_TABLE_NAME);
                 names.add(SPECIMEN_SUMMARY_TABLE_NAME);
-                names.add("SpecimenVialCount");
+                names.add(SPECIMENVIALCOUNT_TABLENAME);
                 names.add(SIMPLE_SPECIMEN_TABLE_NAME);
                 names.add("SpecimenRequest");
                 names.add("SpecimenRequestStatus");
-                names.add("VialRequest");
+                names.add(VIALREQUEST_TABLENAME);
                 names.add(SPECIMEN_ADDITIVE_TABLE_NAME);
                 names.add(SPECIMEN_DERIVATIVE_TABLE_NAME);
                 names.add(SPECIMEN_PRIMARY_TYPE_TABLE_NAME);

--- a/study/src/org/labkey/study/query/SpecimenSummaryTable.java
+++ b/study/src/org/labkey/study/query/SpecimenSummaryTable.java
@@ -54,6 +54,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
+import static org.labkey.study.query.StudyQuerySchema.SPECIMEN_SUMMARY_TABLE_NAME;
+
 public class SpecimenSummaryTable extends BaseStudyTable
 {
     final ColumnInfo _participantidColumn;
@@ -63,7 +65,7 @@ public class SpecimenSummaryTable extends BaseStudyTable
     public SpecimenSummaryTable(StudyQuerySchema schema, ContainerFilter cf)
     {
         super(schema, SpecimenSchema.get().getTableInfoSpecimen(schema.getContainer()), cf,true);
-        setName("SpecimenSummary");
+        setName(SPECIMEN_SUMMARY_TABLE_NAME);
 
         _participantidColumn = addWrapParticipantColumn("PTID");
         addContainerColumn(true);

--- a/study/src/org/labkey/study/query/SpecimenTable.java
+++ b/study/src/org/labkey/study/query/SpecimenTable.java
@@ -35,9 +35,9 @@ public class SpecimenTable extends AbstractSpecimenTable
 {
     private List<SpecimenTable> _studySpecimenTables = null;
 
-    public SpecimenTable(StudyQuerySchema schema, ContainerFilter cf, boolean skipPermissionChecks, boolean allStudies)
+    public SpecimenTable(StudyQuerySchema schema, ContainerFilter cf, boolean allStudies)
     {
-        super(schema, SpecimenSchema.get().getTableInfoSpecimen(schema.getContainer()), cf, skipPermissionChecks, true);
+        super(schema, SpecimenSchema.get().getTableInfoSpecimen(schema.getContainer()), cf, true);
 
         var ptidColumn = getMutableColumn(StudyService.get().getSubjectColumnName(getContainer()));
 //        addWrapColumn(getRealTable().getColumn("RowId"));
@@ -72,8 +72,8 @@ public class SpecimenTable extends AbstractSpecimenTable
 //                if (study.getContainer().hasPermission(user, ReadPermission.class))
                 if (study.getContainer().hasPermission(user, ReadPermission.class) && study.getContainer().getId() != getContainer().getId())
                 {
-                    StudyQuerySchema studyQuerySchema = StudyQuerySchema.createSchema((StudyImpl)study, user, false);
-                    SpecimenTable table = new SpecimenTable(studyQuerySchema, null, skipPermissionChecks, false);
+                    StudyQuerySchema studyQuerySchema = StudyQuerySchema.createSchema((StudyImpl)study, user);
+                    SpecimenTable table = new SpecimenTable(studyQuerySchema, null, false);
                     _studySpecimenTables.add(table);
                 }
             }
@@ -85,6 +85,7 @@ public class SpecimenTable extends AbstractSpecimenTable
     @Override
     public SQLFragment getFromSQL(String alias)
     {
+        checkReadBeforeExecute();
         SQLFragment sql = new SQLFragment();
         if (null != _studySpecimenTables)
         {

--- a/study/src/org/labkey/study/query/SpecimenVialCountTable.java
+++ b/study/src/org/labkey/study/query/SpecimenVialCountTable.java
@@ -25,6 +25,8 @@ import org.labkey.api.query.ExprColumn;
 import org.labkey.api.specimen.SpecimenSchema;
 import org.labkey.api.specimen.settings.SettingsManager;
 
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMENVIALCOUNT_TABLENAME;
+
 /**
  * User: klum
  * Date: Jun 2, 2009
@@ -48,6 +50,7 @@ public class SpecimenVialCountTable extends BaseStudyTable
         addColumn(new AliasedColumn(this, "ExpectedAvailable", _rootTable.getColumn("ExpectedAvailableCount"))).setHidden(!enableSpecimenRequest);
 */
         super(schema, SpecimenSchema.get().getTableInfoVial(schema.getContainer()), cf);
+        setName(SPECIMENVIALCOUNT_TABLENAME);
         setTitle("VialCounts");
 
         addContainerColumn(true).setHidden(true);
@@ -67,6 +70,7 @@ public class SpecimenVialCountTable extends BaseStudyTable
     @Override
     public SQLFragment getFromSQL(String alias)
     {
+        checkReadBeforeExecute();
         TableInfo tableInfoVial = SpecimenSchema.get().getTableInfoVial(getContainer());
         if (null == tableInfoVial)
             throw new IllegalStateException("Vial table not found.");

--- a/study/src/org/labkey/study/query/SpecimenWrapTable.java
+++ b/study/src/org/labkey/study/query/SpecimenWrapTable.java
@@ -37,7 +37,7 @@ public class SpecimenWrapTable extends BaseStudyTable
 
     public SpecimenWrapTable(StudyQuerySchema schema, ContainerFilter cf)
     {
-        super(schema, SpecimenSchema.get().getTableInfoSpecimenDetail(schema.getContainer()), cf, true, true);
+        super(schema, SpecimenSchema.get().getTableInfoSpecimenDetail(schema.getContainer()), cf, true);
 
         addWrapTypeColumn("PrimaryTypeId", "PrimaryTypeId");
         addWrapTypeColumn("DerivativeTypeId", "DerivativeTypeId");
@@ -65,6 +65,7 @@ public class SpecimenWrapTable extends BaseStudyTable
     @Override
     public SQLFragment getFromSQL(String alias)
     {
+        checkReadBeforeExecute();
         return SpecimenDetailTable.getSpecimenAndVialFromSQL(alias, getSchema(), getContainer(), _optionalSpecimenProperties, _optionalVialProperties);
     }
 

--- a/study/src/org/labkey/study/query/StudyDataTable.java
+++ b/study/src/org/labkey/study/query/StudyDataTable.java
@@ -24,6 +24,8 @@ import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.QueryForeignKey;
+import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.view.ActionURL;
 import org.labkey.study.StudySchema;

--- a/study/src/org/labkey/study/query/StudyObjectiveTable.java
+++ b/study/src/org/labkey/study/query/StudyObjectiveTable.java
@@ -87,13 +87,6 @@ public class StudyObjectiveTable extends BaseStudyTable
         modifiedBy.setHidden(true);
     }
 
-
-    @Override
-    public boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
-    {
-        return getContainer().hasPermission(user, perm);
-    }
-
     @Override
     public QueryUpdateService getUpdateService()
     {

--- a/study/src/org/labkey/study/query/StudyObjectiveTable.java
+++ b/study/src/org/labkey/study/query/StudyObjectiveTable.java
@@ -16,13 +16,11 @@
 package org.labkey.study.query;
 
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.ContainerForeignKey;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.DefaultQueryUpdateService;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.QueryUpdateService;
-import org.labkey.api.query.UserIdForeignKey;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.wiki.WikiRendererDisplayColumn;
@@ -97,5 +95,11 @@ public class StudyObjectiveTable extends BaseStudyTable
     public boolean supportsContainerFilter()
     {
         return true;
+    }
+
+    @Override
+    protected boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
+    {
+        return checkReadOrIsAdminPermission(user, perm);
     }
 }

--- a/study/src/org/labkey/study/query/StudyPersonnelTable.java
+++ b/study/src/org/labkey/study/query/StudyPersonnelTable.java
@@ -36,7 +36,7 @@ import java.util.List;
 /**
  * Created by klum on 12/17/13.
  */
-public class StudyPersonnelTable extends DefaultStudyDesignTable
+public class StudyPersonnelTable extends DefaultStudyDesignTable<StudyQuerySchema>
 {
     static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
 
@@ -50,7 +50,7 @@ public class StudyPersonnelTable extends DefaultStudyDesignTable
     }
 
 
-    public static StudyPersonnelTable create(Domain domain, UserSchema schema, @Nullable ContainerFilter containerFilter)
+    public static StudyPersonnelTable create(Domain domain, StudyQuerySchema schema, @Nullable ContainerFilter containerFilter)
     {
         TableInfo storageTableInfo = StorageProvisioner.createTableInfo(domain);
         if (null == storageTableInfo)
@@ -60,7 +60,7 @@ public class StudyPersonnelTable extends DefaultStudyDesignTable
         return new StudyPersonnelTable(domain, storageTableInfo, schema, containerFilter);
     }
 
-    private StudyPersonnelTable(Domain domain, TableInfo storageTableInfo, UserSchema schema, @Nullable ContainerFilter containerFilter)
+    private StudyPersonnelTable(Domain domain, TableInfo storageTableInfo, StudyQuerySchema schema, @Nullable ContainerFilter containerFilter)
     {
         super(domain, storageTableInfo, schema, containerFilter);
 

--- a/study/src/org/labkey/study/query/StudyPersonnelTable.java
+++ b/study/src/org/labkey/study/query/StudyPersonnelTable.java
@@ -28,6 +28,7 @@ import org.labkey.api.query.UserIdForeignKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.study.query.studydesign.DefaultStudyDesignTable;
 
 import java.util.ArrayList;
@@ -86,6 +87,8 @@ public class StudyPersonnelTable extends DefaultStudyDesignTable<StudyQuerySchem
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
+        if (perm.equals(ReadPermission.class))
+            return hasPermissionOverridable(user, perm);
         // This is editable in Dataspace, but not in a folder within a Dataspace
         if (getContainer().getProject().isDataspace() && !getContainer().isDataspace())
             return false;

--- a/study/src/org/labkey/study/query/StudyPropertiesTable.java
+++ b/study/src/org/labkey/study/query/StudyPropertiesTable.java
@@ -66,7 +66,8 @@ public class StudyPropertiesTable extends BaseStudyTable
     public StudyPropertiesTable(StudyQuerySchema schema, ContainerFilter cf)
     {
         super(schema, StudySchema.getInstance().getTableInfoStudy(), cf);
-        setName(StudyQuerySchema.PROPERTIES_TABLE_NAME);
+        // use STUDY_TABLE_NAME because that's what's returned in StudyQuerySchema.getTableNames()
+        setName(StudyQuerySchema.STUDY_TABLE_NAME);
 
         Container c = schema.getContainer();
 
@@ -189,7 +190,7 @@ public class StudyPropertiesTable extends BaseStudyTable
     public boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
     {
         if (UpdatePermission.class == perm || InsertPermission.class == perm || ReadPermission.class.equals(perm))
-            return canReadOrIsAdminPermission(user, perm);
+            return checkReadOrIsAdminPermission(user, perm);
         return false;
     }
 

--- a/study/src/org/labkey/study/query/StudyPropertiesTable.java
+++ b/study/src/org/labkey/study/query/StudyPropertiesTable.java
@@ -66,6 +66,7 @@ public class StudyPropertiesTable extends BaseStudyTable
     public StudyPropertiesTable(StudyQuerySchema schema, ContainerFilter cf)
     {
         super(schema, StudySchema.getInstance().getTableInfoStudy(), cf);
+        setName(StudyQuerySchema.PROPERTIES_TABLE_NAME);
 
         Container c = schema.getContainer();
 

--- a/study/src/org/labkey/study/query/StudyPropertiesUpdateService.java
+++ b/study/src/org/labkey/study/query/StudyPropertiesUpdateService.java
@@ -58,7 +58,7 @@ public class StudyPropertiesUpdateService extends AbstractQueryUpdateService
         StudyImpl study = StudyManager.getInstance().getStudy(container);
         if (null == study)
             throw new QueryUpdateServiceException("No study found.");
-        StudyQuerySchema querySchema = StudyQuerySchema.createSchema(study, user, true);
+        StudyQuerySchema querySchema = StudyQuerySchema.createSchema(study, user);
         TableInfo queryTableInfo = querySchema.getTable("StudyProperties", null);
         if (null == queryTableInfo)
             throw new QueryUpdateServiceException("StudyProperties table not found.");

--- a/study/src/org/labkey/study/query/StudyQuerySchema.java
+++ b/study/src/org/labkey/study/query/StudyQuerySchema.java
@@ -276,7 +276,7 @@ public class StudyQuerySchema extends UserSchema
 
 
     @Override
-    protected boolean canReadSchema()
+    public boolean canReadSchema()
     {
         SecurityLogger.indent("StudyQuerySchema.canReadSchema()");
         try

--- a/study/src/org/labkey/study/query/StudyQuerySchema.java
+++ b/study/src/org/labkey/study/query/StudyQuerySchema.java
@@ -55,9 +55,7 @@ import org.labkey.api.study.StudyService;
 import org.labkey.api.study.TimepointType;
 import org.labkey.api.study.model.ParticipantGroup;
 import org.labkey.api.study.writer.AbstractContext;
-import org.labkey.api.util.HtmlString;
 import org.labkey.api.view.ActionURL;
-import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
@@ -111,7 +109,7 @@ import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMENREQUE
 import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMENVIALCOUNT_TABLENAME;
 import static org.labkey.api.specimen.model.SpecimenTablesProvider.VIALREQUEST_TABLENAME;
 
-public class StudyQuerySchema extends UserSchema
+public class StudyQuerySchema extends UserSchema implements UserSchema.HasContextualRoles
 {
     public static final String EXPERIMENTAL_STUDY_SUBSCHEMAS = "StudySubSchemas";
 

--- a/study/src/org/labkey/study/query/StudyQuerySchema.java
+++ b/study/src/org/labkey/study/query/StudyQuerySchema.java
@@ -50,6 +50,7 @@ import org.labkey.api.specimen.query.SpecimenPivotByRequestingLocation;
 import org.labkey.api.specimen.query.SpecimenQueryView;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.DatasetTable;
+import org.labkey.api.study.SpecimenService;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.TimepointType;
@@ -248,7 +249,7 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
     {
         if (!AppProps.getInstance().isExperimentalFeatureEnabled(EXPERIMENTAL_STUDY_SUBSCHEMAS))
             return Collections.emptySet();
-        if (null != ModuleLoader.getInstance().getModule("Specimen"))
+        if (null != SpecimenService.get())
             return new LinkedHashSet<>(Arrays.asList("Datasets", "Design", "Specimens"));
         return new LinkedHashSet<>(Arrays.asList("Datasets", "Design"));
     }

--- a/study/src/org/labkey/study/query/StudyQuerySchema.java
+++ b/study/src/org/labkey/study/query/StudyQuerySchema.java
@@ -40,6 +40,7 @@ import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.security.roles.Role;
+import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.specimen.SpecimenManager;
 import org.labkey.api.specimen.SpecimenQuerySchema;
@@ -275,14 +276,14 @@ public class StudyQuerySchema extends UserSchema
 
 
     @Override
-    public boolean canReadSchema()
+    protected boolean canReadSchema()
     {
         SecurityLogger.indent("StudyQuerySchema.canReadSchema()");
         try
         {
-            if (!hasContextualReadRole())
+            if (getContextualRoles().contains(RoleManager.getRole(ReaderRole.class)))
             {
-                SecurityLogger.log("hasContextualReadRole()==true", getUser(), null, true);
+                SecurityLogger.log("hasContextualReadRole==true", getUser(), null, true);
                 return true;
             }
             return super.canReadSchema();
@@ -1024,12 +1025,7 @@ public class StudyQuerySchema extends UserSchema
         return visit.getLabel();
     }
 
-    public boolean hasContextualReadRole()
-    {
-        return null != _contextualRole && _contextualRole.getClass() == ReaderRole.class;
-    }
-
-    public Set<Role> getContextualRoles()
+    public @NotNull Set<Role> getContextualRoles()
     {
         return null != _contextualRole ? Set.of(_contextualRole) : Set.of();
     }

--- a/study/src/org/labkey/study/query/StudyQuerySchema.java
+++ b/study/src/org/labkey/study/query/StudyQuerySchema.java
@@ -377,7 +377,7 @@ public class StudyQuerySchema extends UserSchema
                 User user = getUser();
                 for (DatasetDefinition dsd : _study.getDatasets())
                 {
-                    boolean canRead = dsd.canRead(user);
+                    boolean canRead = dsd.canReadInternal(user);
                     if (dsd.getName() == null || !canRead)
                         continue;
                     names.add(dsd.getName());
@@ -1047,7 +1047,7 @@ public class StudyQuerySchema extends UserSchema
         DatasetDefinition def = getDatasetDefinitionByQueryName(queryName);
         if (def != null)
         {
-            if (def.canRead(getUser()))
+            if (def.canReadInternal(getUser()))
                 return def.getTypeURI();
             else
                 throw new RuntimeException("User does not have permission to read that dataset");

--- a/study/src/org/labkey/study/query/StudySchemaProvider.java
+++ b/study/src/org/labkey/study/query/StudySchemaProvider.java
@@ -46,6 +46,6 @@ public class StudySchemaProvider extends DefaultSchema.SchemaProvider
         {
             return StudyQuerySchema.createSchemaWithoutStudy(container, schema.getUser());
         }
-        return StudyQuerySchema.createSchema(study, schema.getUser(), true);
+        return StudyQuerySchema.createSchema(study, schema.getUser());
     }
 }

--- a/study/src/org/labkey/study/query/VialRequestTable.java
+++ b/study/src/org/labkey/study/query/VialRequestTable.java
@@ -26,6 +26,8 @@ import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.specimen.SpecimenSchema;
 
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.VIALREQUEST_TABLENAME;
+
 /**
  * User: brittp
  * Created: July 15, 2008 11:13:43 AM
@@ -35,6 +37,8 @@ public class VialRequestTable extends FilteredTable<StudyQuerySchema>
     public VialRequestTable(final StudyQuerySchema schema, ContainerFilter cf)
     {
         super(SpecimenSchema.get().getTableInfoSampleRequestSpecimen(), schema, cf);
+        setName(VIALREQUEST_TABLENAME);
+
         for (ColumnInfo baseColumn : _rootTable.getColumns())
         {
             String name = baseColumn.getName();

--- a/study/src/org/labkey/study/query/VialTable.java
+++ b/study/src/org/labkey/study/query/VialTable.java
@@ -72,6 +72,7 @@ public class VialTable extends BaseStudyTable
     @Override @NotNull
     public SQLFragment getFromSQL(String alias)
     {
+        checkReadBeforeExecute();
         SQLFragment ret = new SQLFragment();
         ret.appendComment("<org.labkey.study.query.VialTable>",getSqlDialect());
         ret.append("(SELECT ");

--- a/study/src/org/labkey/study/query/VisitTable.java
+++ b/study/src/org/labkey/study/query/VisitTable.java
@@ -104,4 +104,12 @@ public class VisitTable extends BaseStudyTable
     {
         return hasPermissionOverridable(user, perm);
     }
+
+    @Override
+    protected boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
+    {
+        // see Study.CreateVisitAction @RequiresPermission(AdminPermission.class
+        // see StudyDesignController @RequiresPermission(UpdatePermission.class)
+        return checkReadOrIsAdminPermission(user, perm);
+    }
 }

--- a/study/src/org/labkey/study/query/VisitTable.java
+++ b/study/src/org/labkey/study/query/VisitTable.java
@@ -104,10 +104,4 @@ public class VisitTable extends BaseStudyTable
     {
         return hasPermissionOverridable(user, perm);
     }
-
-    @Override
-    protected boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
-    {
-        return getContainer().hasPermission(user, perm);
-    }
 }

--- a/study/src/org/labkey/study/query/VisitTagMapTable.java
+++ b/study/src/org/labkey/study/query/VisitTagMapTable.java
@@ -27,9 +27,7 @@ import org.labkey.api.query.AliasedColumn;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.security.UserPrincipal;
-import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.study.CohortForeignKey;
 import org.labkey.study.StudySchema;
 import org.labkey.study.model.StudyManager;
@@ -92,7 +90,7 @@ public class VisitTagMapTable extends BaseStudyTable
     public boolean hasPermissionOverridable(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
         // Only allow admins to edit directly.
-        return canReadOrIsAdminPermission(user, perm);
+        return checkReadOrIsAdminPermission(user, perm);
     }
 
     private static Map<String, String> _columnMappings = new HashMap<>();

--- a/study/src/org/labkey/study/query/VisitTagMapTable.java
+++ b/study/src/org/labkey/study/query/VisitTagMapTable.java
@@ -29,6 +29,7 @@ import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.study.CohortForeignKey;
 import org.labkey.study.StudySchema;
 import org.labkey.study.model.StudyManager;
@@ -91,7 +92,7 @@ public class VisitTagMapTable extends BaseStudyTable
     public boolean hasPermissionOverridable(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
         // Only allow admins to edit directly.
-        return getContainer().hasPermission(user, AdminPermission.class) && getContainer().hasPermission(user, perm);
+        return canReadOrIsAdminPermission(user, perm);
     }
 
     private static Map<String, String> _columnMappings = new HashMap<>();

--- a/study/src/org/labkey/study/query/VisitTagTable.java
+++ b/study/src/org/labkey/study/query/VisitTagTable.java
@@ -26,6 +26,7 @@ import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.UserIdForeignKey;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.study.StudySchema;
 
 /**
@@ -76,6 +77,8 @@ public class VisitTagTable extends BaseStudyTable
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
+        if (perm.equals(ReadPermission.class))
+            return hasPermissionOverridable(user, perm);
         // This is editable in Dataspace, but not in a folder within a Dataspace
         if (getContainer().getProject().isDataspace() && !getContainer().isDataspace())
             return false;

--- a/study/src/org/labkey/study/query/VisitTagTable.java
+++ b/study/src/org/labkey/study/query/VisitTagTable.java
@@ -94,4 +94,10 @@ public class VisitTagTable extends BaseStudyTable
     {
         super._setContainerFilter(filter);
     }
+
+    @Override
+    protected boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
+    {
+        return checkReadOrIsAdminPermission(user, perm);
+    }
 }

--- a/study/src/org/labkey/study/query/VisitTagTable.java
+++ b/study/src/org/labkey/study/query/VisitTagTable.java
@@ -83,12 +83,6 @@ public class VisitTagTable extends BaseStudyTable
     }
 
     @Override
-    public boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
-    {
-        return getContainer().hasPermission(user, perm);
-    }
-
-    @Override
     public QueryUpdateService getUpdateService()
     {
         return new DefaultQueryUpdateService(this, this.getRealTable());
@@ -99,11 +93,5 @@ public class VisitTagTable extends BaseStudyTable
     protected void _setContainerFilter(@NotNull ContainerFilter filter)
     {
         super._setContainerFilter(filter);
-    }
-
-    @Override
-    public @NotNull SQLFragment getFromSQL(String alias, boolean skip)
-    {
-        return super.getFromSQL(alias, skip);
     }
 }

--- a/study/src/org/labkey/study/query/VisualizationVisitTagTable.java
+++ b/study/src/org/labkey/study/query/VisualizationVisitTagTable.java
@@ -60,6 +60,7 @@ public class VisualizationVisitTagTable extends VirtualTable
     @Override
     public SQLFragment getFromSQL(String alias)
     {
+        checkReadBeforeExecute();
         if (_altQueryName == null)
         {
             String innerAlias = alias + "_SP";

--- a/study/src/org/labkey/study/query/studydesign/DefaultStudyDesignTable.java
+++ b/study/src/org/labkey/study/query/studydesign/DefaultStudyDesignTable.java
@@ -43,6 +43,7 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.study.StudySchema;
 
 import java.util.ArrayList;
@@ -171,7 +172,7 @@ public class DefaultStudyDesignTable extends FilteredTable<UserSchema>
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
         // Most tables should not editable in Dataspace
-        if (getContainer().isDataspace())
+        if (!perm.equals(ReadPermission.class) && getContainer().isDataspace())
             return false;
         return hasPermissionOverridable(user, perm);
     }

--- a/study/src/org/labkey/study/query/studydesign/DefaultStudyDesignTable.java
+++ b/study/src/org/labkey/study/query/studydesign/DefaultStudyDesignTable.java
@@ -44,21 +44,24 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.roles.Role;
 import org.labkey.study.StudySchema;
+import org.labkey.study.query.StudyQuerySchema;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Created by klum on 12/12/13.
  */
-public class DefaultStudyDesignTable extends FilteredTable<UserSchema>
+public class DefaultStudyDesignTable<SchemaType extends StudyQuerySchema> extends FilteredTable<SchemaType>
 {
     protected List<FieldKey> _defaultVisibleColumns = new ArrayList<>();
     private Domain _domain;
 
 
-    protected DefaultStudyDesignTable(Domain domain, TableInfo storageTableInfo,  UserSchema schema)
+    protected DefaultStudyDesignTable(Domain domain, TableInfo storageTableInfo, SchemaType schema)
     {
         super(storageTableInfo, schema);
         _domain = domain;
@@ -90,7 +93,7 @@ public class DefaultStudyDesignTable extends FilteredTable<UserSchema>
                                 return dc;
                             });
                         }
-                        col.setFieldKey(new FieldKey(null,pd.getName()));
+                        col.setFieldKey(new FieldKey(null, pd.getName()));
                     }
                 }
             }
@@ -120,7 +123,7 @@ public class DefaultStudyDesignTable extends FilteredTable<UserSchema>
     }
 
 
-    protected DefaultStudyDesignTable(Domain domain, TableInfo storageTableInfo,  UserSchema schema, @Nullable ContainerFilter containerFilter)
+    protected DefaultStudyDesignTable(Domain domain, TableInfo storageTableInfo, SchemaType schema, @Nullable ContainerFilter containerFilter)
     {
         this(domain, storageTableInfo, schema);
         if (null != containerFilter)
@@ -128,10 +131,16 @@ public class DefaultStudyDesignTable extends FilteredTable<UserSchema>
     }
 
 
-    public static DefaultStudyDesignTable create(Domain domain, UserSchema schema, @Nullable ContainerFilter containerFilter)
+    public static <SchemaType extends StudyQuerySchema> DefaultStudyDesignTable create(Domain domain, SchemaType schema, @Nullable ContainerFilter containerFilter)
     {
         TableInfo storageTableInfo = StorageProvisioner.createTableInfo(domain);
         return new DefaultStudyDesignTable(domain, storageTableInfo, schema, containerFilter);
+    }
+
+
+    protected Set<Role> getContextualRoles()
+    {
+        return getUserSchema().getContextualRoles();
     }
 
 
@@ -179,7 +188,7 @@ public class DefaultStudyDesignTable extends FilteredTable<UserSchema>
 
     public boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
     {
-        return getContainer().hasPermission(user, perm);
+        return getContainer().hasPermission(user, perm, getContextualRoles());
     }
 
     /**

--- a/study/src/org/labkey/study/query/studydesign/StudyDesignLookupBaseTable.java
+++ b/study/src/org/labkey/study/query/studydesign/StudyDesignLookupBaseTable.java
@@ -36,6 +36,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.study.query.BaseStudyTable;
 import org.labkey.study.query.StudyQuerySchema;
 
@@ -151,6 +152,8 @@ public class StudyDesignLookupBaseTable extends BaseStudyTable
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
+        if (perm.equals(ReadPermission.class))
+            return hasPermissionOverridable(user, perm);
         // These are editable in Dataspace, but not in a folder within a Dataspace
         if (null == getContainer() || null == getContainer().getProject() || (getContainer().getProject().isDataspace() && !getContainer().isDataspace()))
             return false;

--- a/study/src/org/labkey/study/query/studydesign/StudyDesignLookupBaseTable.java
+++ b/study/src/org/labkey/study/query/studydesign/StudyDesignLookupBaseTable.java
@@ -30,7 +30,6 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
-import org.labkey.api.query.UserIdQueryForeignKey;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.query.column.BuiltInColumnTypes;
 import org.labkey.api.security.User;
@@ -96,9 +95,9 @@ public class StudyDesignLookupBaseTable extends BaseStudyTable
     {
         // Only admins are allowed to insert into these tables at the project level
         if (getContainer().isProject())
-            return canReadOrIsAdminPermission(user, perm);
+            return checkReadOrIsAdminPermission(user, perm);
         else
-            return getContainer().hasPermission(user, perm);
+            return checkContainerPermission(user, perm);
     }
 
     private class StudyDesignLookupsQueryUpdateService extends DefaultQueryUpdateService

--- a/study/src/org/labkey/study/query/studydesign/StudyProductAntigenTable.java
+++ b/study/src/org/labkey/study/query/studydesign/StudyProductAntigenTable.java
@@ -37,7 +37,7 @@ import java.util.List;
 /**
  * Created by klum on 12/13/13.
  */
-public class StudyProductAntigenTable extends DefaultStudyDesignTable
+public class StudyProductAntigenTable extends DefaultStudyDesignTable<StudyQuerySchema>
 {
     static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
 
@@ -52,7 +52,7 @@ public class StudyProductAntigenTable extends DefaultStudyDesignTable
     }
 
 
-    public static StudyProductAntigenTable create(Domain domain, UserSchema schema, @Nullable ContainerFilter filter)
+    public static StudyProductAntigenTable create(Domain domain, StudyQuerySchema schema, @Nullable ContainerFilter filter)
     {
         TableInfo storageTableInfo = StorageProvisioner.createTableInfo(domain);
         if (null == storageTableInfo)
@@ -63,7 +63,7 @@ public class StudyProductAntigenTable extends DefaultStudyDesignTable
     }
 
 
-    private StudyProductAntigenTable(Domain domain, TableInfo storageTableInfo, UserSchema schema, @Nullable ContainerFilter containerFilter)
+    private StudyProductAntigenTable(Domain domain, TableInfo storageTableInfo, StudyQuerySchema schema, @Nullable ContainerFilter containerFilter)
     {
         super(domain, storageTableInfo, schema, containerFilter);
 

--- a/study/src/org/labkey/study/query/studydesign/StudyProductAntigenTable.java
+++ b/study/src/org/labkey/study/query/studydesign/StudyProductAntigenTable.java
@@ -29,6 +29,7 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.study.query.StudyQuerySchema;
 
 import java.util.ArrayList;
@@ -119,6 +120,8 @@ public class StudyProductAntigenTable extends DefaultStudyDesignTable<StudyQuery
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
+        if (perm.equals(ReadPermission.class))
+            return hasPermissionOverridable(user, perm);
         // This is editable in Dataspace, but not in a folder within a Dataspace
         if (getContainer().getProject().isDataspace() && !getContainer().isDataspace())
             return false;

--- a/study/src/org/labkey/study/query/studydesign/StudyProductTable.java
+++ b/study/src/org/labkey/study/query/studydesign/StudyProductTable.java
@@ -92,8 +92,10 @@ public class StudyProductTable extends DefaultStudyDesignTable<StudyQuerySchema>
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
+        if (perm.equals(ReadPermission.class))
+            return hasPermissionOverridable(user, perm);
         // This is editable in Dataspace, but not in a folder within a Dataspace
-        if (!perm.equals(ReadPermission.class) && getContainer().getProject().isDataspace() && !getContainer().isDataspace())
+        if (getContainer().getProject().isDataspace() && !getContainer().isDataspace())
             return false;
         return hasPermissionOverridable(user, perm);
     }

--- a/study/src/org/labkey/study/query/studydesign/StudyProductTable.java
+++ b/study/src/org/labkey/study/query/studydesign/StudyProductTable.java
@@ -29,6 +29,7 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.study.query.StudyQuerySchema;
 
 import java.util.ArrayList;
@@ -93,7 +94,7 @@ public class StudyProductTable extends DefaultStudyDesignTable
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
         // This is editable in Dataspace, but not in a folder within a Dataspace
-        if (getContainer().getProject().isDataspace() && !getContainer().isDataspace())
+        if (!perm.equals(ReadPermission.class) && getContainer().getProject().isDataspace() && !getContainer().isDataspace())
             return false;
         return hasPermissionOverridable(user, perm);
     }

--- a/study/src/org/labkey/study/query/studydesign/StudyProductTable.java
+++ b/study/src/org/labkey/study/query/studydesign/StudyProductTable.java
@@ -17,7 +17,6 @@ package org.labkey.study.query.studydesign;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.TableInfo;
@@ -38,7 +37,7 @@ import java.util.List;
 /**
  * Created by klum on 12/12/13.
  */
-public class StudyProductTable extends DefaultStudyDesignTable
+public class StudyProductTable extends DefaultStudyDesignTable<StudyQuerySchema>
 {
     static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
 
@@ -50,7 +49,7 @@ public class StudyProductTable extends DefaultStudyDesignTable
         defaultVisibleColumns.add(FieldKey.fromParts("Type"));
     }
 
-    public static StudyProductTable create(Domain domain, UserSchema schema, @Nullable ContainerFilter containerFilter)
+    public static StudyProductTable create(Domain domain, StudyQuerySchema schema, @Nullable ContainerFilter containerFilter)
     {
         TableInfo storageTableInfo = StorageProvisioner.createTableInfo(domain);
         if (null == storageTableInfo)
@@ -60,7 +59,7 @@ public class StudyProductTable extends DefaultStudyDesignTable
         return new StudyProductTable(domain, storageTableInfo, schema, containerFilter);
     }
 
-    private StudyProductTable(Domain domain, TableInfo storageTableInfo, UserSchema schema, @Nullable ContainerFilter containerFilter)
+    private StudyProductTable(Domain domain, TableInfo storageTableInfo, StudyQuerySchema schema, @Nullable ContainerFilter containerFilter)
     {
          super(domain, storageTableInfo, schema, containerFilter);
 

--- a/study/src/org/labkey/study/query/studydesign/StudyTreatmentProductTable.java
+++ b/study/src/org/labkey/study/query/studydesign/StudyTreatmentProductTable.java
@@ -47,7 +47,7 @@ public class StudyTreatmentProductTable extends DefaultStudyDesignTable
         defaultVisibleColumns.add(FieldKey.fromParts("Route"));
     }
 
-    public static StudyTreatmentProductTable create(Domain domain, UserSchema schema, @Nullable ContainerFilter filter)
+    public static StudyTreatmentProductTable create(Domain domain, StudyQuerySchema schema, @Nullable ContainerFilter filter)
     {
         TableInfo storageTableInfo = StorageProvisioner.createTableInfo(domain);
         if (null == storageTableInfo)
@@ -57,7 +57,7 @@ public class StudyTreatmentProductTable extends DefaultStudyDesignTable
         return new StudyTreatmentProductTable(domain, storageTableInfo, schema, filter);
     }
 
-    private StudyTreatmentProductTable(Domain domain, TableInfo storageTableInfo, UserSchema schema, @Nullable ContainerFilter filter)
+    private StudyTreatmentProductTable(Domain domain, TableInfo storageTableInfo, StudyQuerySchema schema, @Nullable ContainerFilter filter)
     {
          super(domain, storageTableInfo, schema, filter);
 

--- a/study/src/org/labkey/study/query/studydesign/StudyTreatmentTable.java
+++ b/study/src/org/labkey/study/query/studydesign/StudyTreatmentTable.java
@@ -49,7 +49,7 @@ public class StudyTreatmentTable extends DefaultStudyDesignTable
         defaultVisibleColumns.add(FieldKey.fromParts("DescriptionRendererType"));
     }
 
-    public static StudyTreatmentTable create(Domain domain, UserSchema schema, @Nullable ContainerFilter filter)
+    public static StudyTreatmentTable create(Domain domain, StudyQuerySchema schema, @Nullable ContainerFilter filter)
     {
         TableInfo storageTableInfo = StorageProvisioner.createTableInfo(domain);
         if (null == storageTableInfo)
@@ -60,7 +60,7 @@ public class StudyTreatmentTable extends DefaultStudyDesignTable
     }
 
 
-    private StudyTreatmentTable(Domain domain, TableInfo storageTableInfo, UserSchema schema, @Nullable ContainerFilter filter)
+    private StudyTreatmentTable(Domain domain, TableInfo storageTableInfo, StudyQuerySchema schema, @Nullable ContainerFilter filter)
     {
         super(domain, storageTableInfo, schema, filter);
 

--- a/study/src/org/labkey/study/query/studydesign/StudyTreatmentVisitMapTable.java
+++ b/study/src/org/labkey/study/query/studydesign/StudyTreatmentVisitMapTable.java
@@ -83,4 +83,11 @@ public class StudyTreatmentVisitMapTable extends BaseStudyTable
     {
         return new DefaultQueryUpdateService(this, this.getRealTable());
     }
+
+    @Override
+    protected boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
+    {
+        // see StudyDesignController.UpdateTreatmentScheduleAction    @RequiresPermission(UpdatePermission.class)
+        return checkContainerPermission(user, perm);
+    }
 }

--- a/study/src/org/labkey/study/query/studydesign/StudyTreatmentVisitMapTable.java
+++ b/study/src/org/labkey/study/query/studydesign/StudyTreatmentVisitMapTable.java
@@ -79,12 +79,6 @@ public class StudyTreatmentVisitMapTable extends BaseStudyTable
     }
 
     @Override
-    public boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
-    {
-        return getContainer().hasPermission(user, perm);
-    }
-
-    @Override
     public QueryUpdateService getUpdateService()
     {
         return new DefaultQueryUpdateService(this, this.getRealTable());

--- a/study/src/org/labkey/study/reports/ExternalReport.java
+++ b/study/src/org/labkey/study/reports/ExternalReport.java
@@ -306,8 +306,7 @@ public class ExternalReport extends AbstractReport
         if (perm != ReadPermission.class)
             throw new IllegalArgumentException("only ReadPermission supported");
         StudyImpl study = StudyManager.getInstance().getStudy(context.getContainer());
-        //boolean mustCheckUserPermissions = mustCheckDatasetPermissions(user, perm);
-        return StudyQuerySchema.createSchema(study, user, false);
+        return StudyQuerySchema.createSchema(study, user);
     }
 
     private String getFilePrefix()

--- a/study/src/org/labkey/study/view/dataspace_studyfilter.jsp
+++ b/study/src/org/labkey/study/view/dataspace_studyfilter.jsp
@@ -57,7 +57,7 @@
     List<Study> studies = new ArrayList<>();
     if (hasStudy)
     {
-        DataspaceQuerySchema schema = new DataspaceQuerySchema((StudyImpl)study, getUser(), true);
+        DataspaceQuerySchema schema = new DataspaceQuerySchema((StudyImpl)study, getUser());
         ContainerFilter cf = schema.getDefaultContainerFilter();
         Collection<GUID> containerIds = cf.getIds();
         if (null != containerIds)

--- a/study/src/org/labkey/study/view/subjects.jsp
+++ b/study/src/org/labkey/study/view/subjects.jsp
@@ -63,7 +63,7 @@
     Container container  = getContainer();
     User user            = getUser();
     Study study = StudyService.get().getStudy(container);
-    StudyQuerySchema schema = StudyQuerySchema.createSchema((StudyImpl)study, user, true);
+    StudyQuerySchema schema = StudyQuerySchema.createSchema((StudyImpl)study, user);
     String subjectTableName = StudyService.get().getSubjectTableName(container);
     String subjectColumnname = StudyService.get().getSubjectColumnName(container);
 

--- a/study/src/org/labkey/study/visitmanager/VisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/VisitManager.java
@@ -642,7 +642,7 @@ public abstract class VisitManager
         // reasons.
         if (study.isAncillaryStudy() && null != user)
         {
-            StudyQuerySchema studyQuerySchema = StudyQuerySchema.createSchema(study, user, false);
+            StudyQuerySchema studyQuerySchema = StudyQuerySchema.createSchema(study, user);
             studyQuerySchema.setDontAliasColumns(true);
             return studyQuerySchema.getTable(StudyQuerySchema.SIMPLE_SPECIMEN_TABLE_NAME);
         }

--- a/study/src/org/labkey/study/writer/AssayScheduleWriter.java
+++ b/study/src/org/labkey/study/writer/AssayScheduleWriter.java
@@ -61,8 +61,8 @@ public class AssayScheduleWriter extends DefaultStudyDesignWriter implements Int
 
         VirtualFile vf = root.getDir(DEFAULT_DIRECTORY);
 
-        StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getContainer()), ctx.getUser(), true);
-        StudyQuerySchema projectSchema = ctx.isDataspaceProject() ? new StudyQuerySchema(StudyManager.getInstance().getStudy(ctx.getProject()), ctx.getUser(), true) : schema;
+        StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getContainer()), ctx.getUser());
+        StudyQuerySchema projectSchema = ctx.isDataspaceProject() ? StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getProject()), ctx.getUser()) : schema;
 
         // add the assay schedule specific tables
         TableInfo assaySpecimenTable = schema.getTable(StudyQuerySchema.ASSAY_SPECIMEN_TABLE_NAME, null);
@@ -85,7 +85,7 @@ public class AssayScheduleWriter extends DefaultStudyDesignWriter implements Int
 
     private void writeAssaySpecimenVisitMap(StudyExportContext ctx, VirtualFile vf) throws Exception
     {
-        StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getContainer()), ctx.getUser(), true);
+        StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getContainer()), ctx.getUser());
         TableInfo tableInfo = schema.getTable(StudyQuerySchema.ASSAY_SPECIMEN_VISIT_TABLE_NAME);
 
         List<FieldKey> fields = new ArrayList<>(tableInfo.getDefaultVisibleColumns());

--- a/study/src/org/labkey/study/writer/DatasetDataWriter.java
+++ b/study/src/org/labkey/study/writer/DatasetDataWriter.java
@@ -94,7 +94,7 @@ public class DatasetDataWriter implements InternalStudyWriter
 
         VirtualFile vf = root.getDir(DatasetDefinitionWriter.DEFAULT_DIRECTORY);
 
-        StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getContainer()), ctx.getUser(), true);
+        StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getContainer()), ctx.getUser());
 
         // Write out all the dataset .tsv files
         for (DatasetDefinition def : datasets)

--- a/study/src/org/labkey/study/writer/SchemaXmlWriter.java
+++ b/study/src/org/labkey/study/writer/SchemaXmlWriter.java
@@ -80,7 +80,7 @@ public class SchemaXmlWriter implements Writer<List<DatasetDefinition>, ImportCo
         TablesDocument tablesDoc = TablesDocument.Factory.newInstance();
         TablesType tablesXml = tablesDoc.addNewTables();
 
-        StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getContainer()), ctx.getUser(), true);
+        StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getContainer()), ctx.getUser());
 
         for (DatasetDefinition def : definitions)
         {

--- a/study/src/org/labkey/study/writer/StudyPropertiesWriter.java
+++ b/study/src/org/labkey/study/writer/StudyPropertiesWriter.java
@@ -43,8 +43,8 @@ public class StudyPropertiesWriter extends DefaultStudyDesignWriter
     public void write(StudyImpl study, StudyExportContext ctx, VirtualFile dir) throws Exception
     {
         Set<String> studyTableNames = new HashSet<>();
-        StudyQuerySchema schema = StudyQuerySchema.createSchema(study, ctx.getUser(), true);
-        StudyQuerySchema projectSchema = ctx.isDataspaceProject() ? new StudyQuerySchema(StudyManager.getInstance().getStudy(ctx.getProject()), ctx.getUser(), true) : schema;
+        StudyQuerySchema schema = StudyQuerySchema.createSchema(study, ctx.getUser());
+        StudyQuerySchema projectSchema = ctx.isDataspaceProject() ? StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getProject()), ctx.getUser()) : schema;
 
         studyTableNames.add(StudyQuerySchema.PERSONNEL_TABLE_NAME);
         studyTableNames.add(StudyQuerySchema.PROPERTIES_TABLE_NAME);
@@ -58,7 +58,7 @@ public class StudyPropertiesWriter extends DefaultStudyDesignWriter
 
     private void writePersonnelData(StudyExportContext ctx, VirtualFile vf) throws Exception
     {
-        StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getContainer()), ctx.getUser(), true);
+        StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getContainer()), ctx.getUser());
         TableInfo tableInfo = schema.getTable(StudyQuerySchema.PERSONNEL_TABLE_NAME);
 
         // we want to include the user display name so we can resolve during import

--- a/study/src/org/labkey/study/writer/TreatmentDataWriter.java
+++ b/study/src/org/labkey/study/writer/TreatmentDataWriter.java
@@ -59,8 +59,8 @@ public class TreatmentDataWriter extends DefaultStudyDesignWriter implements Int
 
         VirtualFile vf = root.getDir(DEFAULT_DIRECTORY);
         Set<String> treatmentTableNames = new HashSet<>();
-        StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getContainer()), ctx.getUser(), true);
-        StudyQuerySchema projectSchema = ctx.isDataspaceProject() ? new StudyQuerySchema(StudyManager.getInstance().getStudy(ctx.getProject()), ctx.getUser(), true) : schema;
+        StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getContainer()), ctx.getUser());
+        StudyQuerySchema projectSchema = ctx.isDataspaceProject() ? StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getProject()), ctx.getUser()) : schema;
 
         // add the treatment specific tables
         treatmentTableNames.add(StudyQuerySchema.PRODUCT_TABLE_NAME);
@@ -93,7 +93,7 @@ public class TreatmentDataWriter extends DefaultStudyDesignWriter implements Int
 
     private void writeTreatmentVisitMap(StudyExportContext ctx, VirtualFile vf) throws Exception
     {
-        StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getContainer()), ctx.getUser(), true);
+        StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(ctx.getContainer()), ctx.getUser());
         TableInfo tableInfo = schema.getTable(StudyQuerySchema.TREATMENT_VISIT_MAP_TABLE_NAME);
 
         List<FieldKey> fields = new ArrayList<>(tableInfo.getDefaultVisibleColumns());


### PR DESCRIPTION
#### Rationale
Flush out TableInfo.hasPermission(ReadPermission) implementations
use contextual roles for permission elevation (study schema)

Also, back-port WebSocket warning change so @cnathe doesn't have to

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->