### PR TITLE
DataStatesTableInfo QUS fix for validate label check in updateRows case

### DIFF
--- a/core/src/org/labkey/core/query/DataStatesTableInfo.java
+++ b/core/src/org/labkey/core/query/DataStatesTableInfo.java
@@ -105,16 +105,16 @@ public class DataStatesTableInfo extends FilteredTable<CoreQuerySchema>
             return null;
         }
 
-        private boolean validateLabel(Map<String, Object> row)
+        private boolean validateLabel(Map<String, Object> row, boolean allowMissing)
         {
             String label = (String) row.get("label");
-            return !StringUtils.isBlank(label);
+            return (allowMissing && !row.containsKey("label")) || !StringUtils.isBlank(label);
         }
 
         @Override
         protected Map<String, Object> updateRow(User user, Container container, Map<String, Object> row, @NotNull Map<String, Object> oldRow, boolean allowOwner, boolean retainCreation) throws InvalidKeyException, ValidationException, QueryUpdateServiceException, SQLException
         {
-            if (!validateLabel(row))
+            if (!validateLabel(row, true))
                 throw new QueryUpdateServiceException("Label cannot be blank.");
 
             String errorMsg = validateQCStateChangeAllowed(row, container);
@@ -134,7 +134,7 @@ public class DataStatesTableInfo extends FilteredTable<CoreQuerySchema>
         @Override
         protected Map<String, Object> insertRow(User user, Container container, Map<String, Object> row) throws DuplicateKeyException, ValidationException, QueryUpdateServiceException, SQLException
         {
-            if (!validateLabel(row))
+            if (!validateLabel(row, false))
                 throw new QueryUpdateServiceException("Label cannot be blank.");
 
             Map<String, Object> rowToInsert;
@@ -151,7 +151,7 @@ public class DataStatesTableInfo extends FilteredTable<CoreQuerySchema>
         protected Map<String, Object> deleteRow(User user, Container container, Map<String, Object> oldRowMap) throws InvalidKeyException, QueryUpdateServiceException, SQLException
         {
             if (!validateQCStateNotInUse(oldRowMap, container))
-                throw new QueryUpdateServiceException("State '" + oldRowMap.get("label") + "' cannot be deleted because it is currently in use.");
+                throw new QueryUpdateServiceException("State '" + oldRowMap.get("label") + "' cannot be deleted as it is currently in use.");
 
             Map<String, Object> rowToDelete;
             try (DbScope.Transaction transaction = CoreSchema.getInstance().getSchema().getScope().ensureTransaction())


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44244

This issue was hit by the python API integration tests. If the API makes a call to update rows for the core.DataStates table and is only updating the state's description, the QUS validation check was saying that "Label cannot be blank". This fix is so that the validate label check doesn't apply in the updateRows case when the label is not being changed.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2722

#### Changes
* DataStatesTableInfo validateLabel() param for `allowMissing` in the updateRows case