### PR TITLE
Upgrade PostgreSQL JDBC driver 42.3.0 -> 42.3.1

### DIFF
--- a/api/resources/credits/jars.txt
+++ b/api/resources/credits/jars.txt
@@ -44,7 +44,7 @@ pdfbox-2.0.23.jar|Apache PDFBox®|2.0.23|{link:PDFBox|https://pdfbox.apache.org/
 poi-4.1.2.jar|Apache POI|4.1.2|{link:Apache|https://poi.apache.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|adam|Extracting text from and exporting to Microsoft document formats (Excel, Word, PowerPoint, etc.)
 poi-ooxml-4.1.2.jar|Apache POI OOXML|4.1.2|{link:Apache|https://poi.apache.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|adam|POI support for OOXML formats
 pollingwatchservice-0.2.0.jar|Polling Watch Service|0.2.0|{link:imca|https://www.imca.aps.anl.gov/~jlmuir/sw/pollingwatchservice.html}|{link:BSD 2-Clause license|https://www.imca.aps.anl.gov/~jlmuir/repo/bsd-2-clause-license.txt}|klum|Provide polling file watcher for cifs file systems
-postgresql-42.3.0.jar|PostgreSQL JDBC Driver|42.3.0|{link:jdbc.postgresql.org|http://jdbc.postgresql.org/index.html}|{link:BSD|https://jdbc.postgresql.org/about/license.html}|adam|Connect with PostgreSQL database servers
+postgresql-42.3.1.jar|PostgreSQL JDBC Driver|42.3.1|{link:jdbc.postgresql.org|http://jdbc.postgresql.org/index.html}|{link:BSD|https://jdbc.postgresql.org/about/license.html}|adam|Connect with PostgreSQL database servers
 quartz-2.1.7.jar|quartz|2.1.7|{link:quartz|http://quartz-scheduler.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|jeckels|Scheduling
 rengine-0.6-8.jar|Rengine|0.6-8|{link:Rserve|http://www.rforge.net/Rserve}|{link:LGPL|http://www.gnu.org/licenses/lgpl.html}|cnathe|R client classes
 rserve-0.6-8.jar|Rserve|0.6-8|{link:Rserve|http://www.rforge.net/Rserve}|{link:LGPL|http://www.gnu.org/licenses/lgpl.html}|cnathe|Library to connect to an R Server


### PR DESCRIPTION
#### Rationale
PostgreSQL JDBC driver 42.3.1 fixes a regression introduced in 42.3.0.

[Issue 44252: Upgrade PostgreSQL JDBC driver 42.3.0 -> 42.3.1](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44252)

#### Related Pull Requests[
* https://github.com/LabKey/server/pull/146