### PR TITLE
TNPRC Issue 290: Method to edit legacy data via query module update row

### DIFF
--- a/api/src/org/labkey/api/ldk/buttons/ShowEditUIButton.java
+++ b/api/src/org/labkey/api/ldk/buttons/ShowEditUIButton.java
@@ -84,7 +84,7 @@ public class ShowEditUIButton extends SimpleButtonConfigFactory
     @Override
     protected String getJsHandler(TableInfo ti)
     {
-        String ret = getHandlerName() + "(" + PageFlowUtil.jsString(_schemaName) + "," + PageFlowUtil.jsString(_queryName) + ",dataRegionName, {";
+        String ret = getHandlerName() + "(" + PageFlowUtil.jsString(ti.getPublicSchemaName()) + "," + PageFlowUtil.jsString(ti.getPublicName()) + ",dataRegionName, {";
 
         String delim = "";
         if (_urlParamMap != null)


### PR DESCRIPTION
#### Rationale
In rare cases, users need to navigate to the "raw" data entry page to edit records that were ETL'd instead of being entered into a LabKey EHR data entry form

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/260

#### Changes
* Use the TableInfo's schema and query, making it easy to reuse the same button declaration for many tables
