### PR TITLE
Issue 43491: Creating study-specific datasets in a subfolder of a Dat…

### DIFF
--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -875,13 +875,16 @@ public class StudyPublishManager implements StudyPublishService
             // auto generate a dataset ID
             if (null == builder.getDatasetId())
             {
-                int id = study.isDataspaceStudy() ? 10000 : MIN_ASSAY_ID;
+                // To help avoid datasetid collisions, child studies in a dataspace project try to avoid colliding with project dataset id's.
+                // Even better would be if the project datasets also tried to avoid collisions with all other datasets in the entire project folder hierarchy
+                var sharedStudy = StudyManager.getInstance().getSharedStudy(study);
+                int id = null != sharedStudy ? 10000 : MIN_ASSAY_ID;
                 Integer mx = new SqlSelector(schema, "SELECT MAX(datasetid) FROM study.dataset WHERE container=?", study.getContainer().getId()).getObject(Integer.class);
                 if (null != mx)
                     id = Math.max(id,mx);
-                if (study.isDataspaceStudy())
+                if (null != sharedStudy)
                 {
-                    mx = new SqlSelector(schema, "SELECT MAX(datasetid) FROM study.dataset WHERE container=?", study.getContainer().getProject().getId()).getObject(Integer.class);
+                    mx = new SqlSelector(schema, "SELECT MAX(datasetid) FROM study.dataset WHERE container=?", sharedStudy.getContainer().getId()).getObject(Integer.class);
                     if (null != mx)
                        id = Math.max(id, mx);
                 }


### PR DESCRIPTION
…aSpace project stomps on shared dataset ID

#### Rationale
StudyManager.getInstance().getSharedStudy(study) returns the shared dataspace study, for a non-project study. So testing null != StudyManager.getInstance().getSharedStudy(study) is a good way to test for "am I a child of a dataspace study".


#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
