### PR TITLE
Show connection pool maxWaitMillis property when describing DbScope

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -977,7 +977,8 @@ public class DbScope
             log.info("Data source " + this +
                     ". Max connections: " + getDbScopeLoader().getDsProps().getMaxTotal() +
                     ", active: " + getDbScopeLoader().getDsProps().getNumActive() +
-                    ", idle: " + getDbScopeLoader().getDsProps().getNumIdle());
+                    ", idle: " + getDbScopeLoader().getDsProps().getNumIdle() +
+                    ", maxWaitMillis: " + getDbScopeLoader().getDsProps().getMaxWaitMillis());
 
             if (_transaction.isEmpty())
             {

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1197,6 +1197,20 @@ public abstract class SqlDialect
                 return null;
             }
         }
+
+        public Long getMaxWaitMillis()
+        {
+            try
+            {
+                return callGetter("getMaxWaitMillis");
+            }
+            catch (ServletException e)
+            {
+                LOG.error("Could not extract connection pool max wait (ms) from data source \"" + _dsName + "\"");
+                return null;
+            }
+        }
+
     }
 
 

--- a/core/src/org/labkey/core/admin/admin.jsp
+++ b/core/src/org/labkey/core/admin/admin.jsp
@@ -92,6 +92,7 @@
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Pool Max Size</td><td id="connectionPoolSize"><%=h(bean.scope.getDataSourceProperties().getMaxTotal())%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Pool Active</td><td id="connectionPoolActive"><%=h(bean.scope.getDataSourceProperties().getNumActive())%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Pool Idle</td><td id="connectionPoolIdle"><%=h(bean.scope.getDataSourceProperties().getNumIdle())%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Max Wait (ms)</td><td id="connectionPoolMaxWait"><%=h(bean.scope.getDataSourceProperties().getMaxWaitMillis())%></td></tr>
             </table>
             <br/>
 <%

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -555,7 +555,8 @@ public class QueryController extends SpringActionController
             sb.append("  <td class=\"labkey-column-header\">Product Version</td>");
             sb.append("  <td class=\"labkey-column-header\">Max Connections</td>");
             sb.append("  <td class=\"labkey-column-header\">Active Connections</td>");
-            sb.append("  <td class=\"labkey-column-header\">Idle Connections</td></tr>\n");
+            sb.append("  <td class=\"labkey-column-header\">Idle Connections</td>\n");
+            sb.append("  <td class=\"labkey-column-header\">Max Wait (ms)</td></tr>\n");
 
             int rowCount = 0;
             for (DbScope scope : DbScope.getDbScopes())
@@ -602,12 +603,14 @@ public class QueryController extends SpringActionController
                 sb.append(scope.getDataSourceProperties().getNumActive());
                 sb.append("</td><td>");
                 sb.append(scope.getDataSourceProperties().getNumIdle());
+                sb.append("</td><td>");
+                sb.append(scope.getDataSourceProperties().getMaxWaitMillis());
                 sb.append("</td></tr>\n");
 
                 Collection<ExternalSchemaDef> dsDefs = byDataSourceName.get(scope.getDataSourceName());
 
                 sb.append("<tr class=\"").append(rowCount % 2 == 0 ? "labkey-alternate-row" : "labkey-row").append("\">\n");
-                sb.append("  <td colspan=9>\n");
+                sb.append("  <td colspan=\"10\">\n");
                 sb.append("    <table>\n");
 
                 if (null != dsDefs)


### PR DESCRIPTION
#### Rationale
I've worked with a number of deployments on deadlocks that involved troubleshooting this setting. It's handy to expose in the admin UI.

#### Changes
* Show the property along with the max/active/idle connection counts