### PR TITLE
44241: Merge option for dataset file watchers not working as expected

### DIFF
--- a/study/webapp/WEB-INF/study/studyContext.xml
+++ b/study/webapp/WEB-INF/study/studyContext.xml
@@ -112,7 +112,7 @@
                                     <list>
                                         <bean class="org.labkey.api.formSchema.Option">
                                             <constructor-arg index="0" value="append"/>
-                                            <constructor-arg index="1" value="Merge"/>
+                                            <constructor-arg index="1" value="Append"/>
                                         </bean>
                                         <bean class="org.labkey.api.formSchema.Option">
                                             <constructor-arg index="0" value="replace"/>
@@ -120,7 +120,7 @@
                                         </bean>
                                     </list>
                                 </constructor-arg>
-                                <constructor-arg index="5" value="Choose Merge to merge values in file with existing list, Replace to replace existing values."/>
+                                <constructor-arg index="5" value="Choose Append to add new records to an existing dataset (uniqueness rules apply), Replace to replace existing values."/>
                             </bean>
 
                             <bean class="org.labkey.api.formSchema.CheckboxField">


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44241

Updating the option name (and help text) to align with the actual parameter that is being passed to the file watcher.
