### PR TITLE
Update `testShadowingSharedDataset` to set dataset ID

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
@@ -406,6 +406,9 @@ public class SharedStudyTest extends BaseWebDriverTest
         assertElementPresent(Locator.linkContainingText(SHARED_DEMOGRAPHICS));
         datasetsPage.clickCreateNewDataset()
             .setName(datasetName)
+            .openAdvancedDatasetSettings()
+            .setDatasetId(SHARED_DEMOGRAPHICS_ID)
+            .clickApply()
             .clickSave();
 
         // Default dataset ID will overlap shared demographics (5001)


### PR DESCRIPTION
#### Rationale
A server fix caught another path where overlapping dataset IDs were getting generated. This test wants that overlap though, so we need to set the ID explicitly.

#### Related Pull Requests
* #2734
* #2756

#### Changes
* Update `testShadowingSharedDataset` to set dataset ID
