### PR TITLE
Restore direct use of LocalDate

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1682,26 +1682,13 @@ public class Container implements Serializable, Comparable<Container>, Securable
         _lockState = lockState;
     }
 
-    @Deprecated @JsonIgnore
-    public @Nullable LocalDate getExpirationDateLD()
+    public @Nullable LocalDate getExpirationDate()
     {
         return _expirationDate;
     }
 
-    @Deprecated
-    public void setExpirationDateLD(LocalDate expirationDate)
+    public void setExpirationDate(LocalDate expirationDate)
     {
         _expirationDate = expirationDate;
-    }
-
-    // TODO: Convert to LocalDate once we fix Jackson serialization of LocalDate
-    public java.sql.Date getExpirationDate()
-    {
-        return java.sql.Date.valueOf(_expirationDate);
-    }
-
-    public void setExpirationDate(java.sql.Date expirationDate)
-    {
-        _expirationDate = expirationDate.toLocalDate();
     }
 }

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -2780,7 +2780,7 @@ public class ContainerManager
             d.setType(type);
             d.setTitle(title);
             d.setLockState(lockState);
-            d.setExpirationDateLD(expirationDate);
+            d.setExpirationDate(expirationDate);
             return d;
         }
 


### PR DESCRIPTION
#### Rationale
After upgrading to Jackson 2.13.0, `LocalDate` should serialize correctly, allowing us to use this type directly on Container

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2758
