### PR TITLE
Add InvalidDocumentException to DocumentProvider interface

### DIFF
--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -429,6 +429,28 @@ public interface SearchService
          * any stored lastIndexed values.
          */
         void indexDeleted() throws SQLException;
+
+        /**
+         * Thrown for a document that is an illegal/invalid state that should not be indexed, but can be safely ignored.
+         * May be caused by the document's subject being queued for indexing, but being deleted prior to processing.
+         */
+        class InvalidDocumentException extends IllegalStateException
+        {
+            public InvalidDocumentException(String message)
+            {
+                super(message);
+            }
+
+            public InvalidDocumentException(Throwable e)
+            {
+                super(e);
+            }
+
+            public InvalidDocumentException(String message, Throwable e)
+            {
+                super(message, e);
+            }
+        }
     }
 
 


### PR DESCRIPTION
Add indexing exception that can be thrown for an index document that is in a bad state and can be used to either ignore the document or cancel the indexing task.

#### Rationale
While working on https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43144 the [TC tests failed](https://teamcity.labkey.org/repository/download/LabKey_Trunk_LabkeyPremiumTrunk_GitModules_OntologyPostgres/1602085:id/ConceptColumnImportTest.tar.gz!/202111101119ConceptColumnImportTest%23ConceptColumnImportTestAfterClass.png) because of an error indexing the ontology during test cleanup.

#### Related Pull Requests
* https://github.com/LabKey/ontology/pull/61

#### Changes
* Added exception to search DocumentProvider interface that can be used to indicate a resource document in a bad state.
