### PR TITLE
Update dataset shadowing test to match new behavior

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
@@ -300,7 +300,7 @@ public class SharedStudyTest extends BaseWebDriverTest
         assertTextPresent("over 6 visits. Data is present for 6 Pandas.");
 
         // verfiy that published study description has correct dataset
-        clickAndWait(Locator.linkWithText("1 dataset"));
+        clickAndWait(Locator.linkContainingText("dataset")); // Might be '1 dataset' or '2 datasets'
         clickAndWait(Locator.linkWithText(SHARED_DEMOGRAPHICS));
 
         // verify dataset has correct participants
@@ -500,7 +500,7 @@ public class SharedStudyTest extends BaseWebDriverTest
         _studyHelper.createCustomParticipantGroup(getProjectName(), getProjectName(), mixed_group, PARTICIPANT_NOUN_SINGULAR, ptids);
 
         clickTab("Overview");
-        clickAndWait(Locator.linkWithText("1 dataset"));
+        clickAndWait(Locator.linkContainingText("dataset")); // Might be '1 dataset' or '2 datasets'
         clickAndWait(Locator.linkWithText(SHARED_DEMOGRAPHICS));
 
         DataRegionTable dataset = new DataRegionTable("Dataset", this);
@@ -525,7 +525,7 @@ public class SharedStudyTest extends BaseWebDriverTest
             assertElementNotPresent(Locator.css("li.ptid"));
 
             clickTab("Overview");
-            clickAndWait(Locator.linkWithText("1 dataset"));
+            clickAndWait(Locator.linkContainingText("dataset")); // Might be '1 dataset' or '2 datasets'
             clickAndWait(Locator.linkWithText(SHARED_DEMOGRAPHICS));
 
             DataRegionTable dataset = new DataRegionTable("Dataset", this);
@@ -556,7 +556,7 @@ public class SharedStudyTest extends BaseWebDriverTest
 
             clickTab("Overview");
 
-            clickAndWait(Locator.linkWithText("1 dataset"));
+            clickAndWait(Locator.linkContainingText("dataset")); // Might be '1 dataset' or '2 datasets'
             clickAndWait(Locator.linkWithText(SHARED_DEMOGRAPHICS));
 
             DataRegionTable dataset = new DataRegionTable("Dataset", this);


### PR DESCRIPTION
#### Rationale
We now prevent creation of a dataset with an ID that collides with the ID of a shared dataset. This update explicitly checks for that error. We do not prevent dataset ID collisions when creating a shared dataset however, so we can verify the shadowing warnings by creating the datasets in the opposite order.

#### Related Pull Requests
* #2764 

#### Changes
* Update dataset shadowing test to match new behavior
