### PR TITLE
Remove support for Java 14 & 15 and PostgreSQL 9.6

### DIFF
--- a/api/src/org/labkey/api/module/JavaVersion.java
+++ b/api/src/org/labkey/api/module/JavaVersion.java
@@ -31,8 +31,6 @@ import java.util.stream.Collectors;
 public enum JavaVersion
 {
     JAVA_UNSUPPORTED(-1, true, false, null),
-    JAVA_14(14, true, true, "https://docs.oracle.com/en/java/javase/14/docs/api/java.base/"),
-    JAVA_15(15, true, true, "https://docs.oracle.com/en/java/javase/15/docs/api/java.base/"),
     JAVA_16(16, false, true, "https://docs.oracle.com/en/java/javase/16/docs/api/java.base/"),
     JAVA_17(17, false, true, "https://docs.oracle.com/en/java/javase/17/docs/api/java.base/"),
     JAVA_FUTURE(Integer.MAX_VALUE, false, false, "https://docs.oracle.com/en/java/javase/17/docs/api/java.base/");
@@ -130,10 +128,10 @@ public enum JavaVersion
             test(11, JAVA_UNSUPPORTED);
             test(12, JAVA_UNSUPPORTED);
             test(13, JAVA_UNSUPPORTED);
+            test(14, JAVA_UNSUPPORTED);
+            test(15, JAVA_UNSUPPORTED);
 
             // Good
-            test(14, JAVA_14);
-            test(15, JAVA_15);
             test(16, JAVA_16);
             test(17, JAVA_17);
 

--- a/core/src/org/labkey/core/dialect/PostgreSql96Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql96Dialect.java
@@ -18,6 +18,6 @@ package org.labkey.core.dialect;
 /**
  * Created by adam on 8/10/2016.
  */
-public class PostgreSql96Dialect extends PostgreSql95Dialect
+abstract class PostgreSql96Dialect extends PostgreSql95Dialect
 {
 }

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -64,11 +64,11 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
     @Override
     public @Nullable SqlDialect createFromDriverClassName(String driverClassName)
     {
-        return "org.postgresql.Driver".equals(driverClassName) ? new PostgreSql96Dialect() : null;
+        return "org.postgresql.Driver".equals(driverClassName) ? new PostgreSql_10_Dialect() : null;
     }
 
     final static String PRODUCT_NAME = "PostgreSQL";
-    final static String RECOMMENDED = PRODUCT_NAME + " 13.x is the recommended version.";
+    final static String RECOMMENDED = PRODUCT_NAME + " 14.x is the recommended version.";
     final static String JDBC_PREFIX = "jdbc:postgresql:";
 
     @Override
@@ -97,7 +97,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
         if (PostgreSqlVersion.POSTGRESQL_UNSUPPORTED == psv)
             throw new DatabaseNotSupportedException(PRODUCT_NAME + " version " + databaseProductVersion + " is not supported. You must upgrade your database server installation; " + RECOMMENDED);
 
-        PostgreSql96Dialect dialect = psv.getDialect();
+        PostgreSql_10_Dialect dialect = psv.getDialect();
 
         Connection conn = md.getConnection();
         Map<String, String> parameterStatuses = (conn instanceof PgConnection ? ((PgConnection) conn).getParameterStatuses() : Collections.emptyMap());
@@ -130,10 +130,10 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
     @Override
     public Collection<? extends SqlDialect> getDialectsToTest()
     {
-        // PostgreSQL dialects are nearly identical, so just test 9.6
-        PostgreSql96Dialect conforming = new PostgreSql96Dialect();
+        // PostgreSQL dialects are nearly identical, so just test 10.x
+        PostgreSql_10_Dialect conforming = new PostgreSql_10_Dialect();
         conforming.setStandardConformingStrings(true);
-        PostgreSql96Dialect nonconforming = new PostgreSql96Dialect();
+        PostgreSql_10_Dialect nonconforming = new PostgreSql_10_Dialect();
         nonconforming.setStandardConformingStrings(false);
 
         return PageFlowUtil.set(
@@ -149,14 +149,10 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
         {
             final String connectionUrl = "jdbc:postgresql:";
 
-            // < 9.6 should result in bad version number exception
-            badVersion("PostgreSQL", 0.0, 9.6, null, connectionUrl);
-
-            // 9.7, 9.8, and 9.9 are bad as well - these versions never existed
-            badVersion("PostgreSQL", 9.7, 10.0, null, connectionUrl);
+            // < 10.0 should result in bad version number exception. Note: versions 9.7, 9.8, and 9.9 never existed.
+            badVersion("PostgreSQL", 0.0, 10.0, null, connectionUrl);
 
             // Test good versions
-            good("PostgreSQL", 9.6, 9.7, "", connectionUrl, null, PostgreSql96Dialect.class);
             good("PostgreSQL", 10.0, 11.0, "", connectionUrl, null, PostgreSql_10_Dialect.class);
             good("PostgreSQL", 11.0, 12.0, "", connectionUrl, null, PostgreSql_11_Dialect.class);
             good("PostgreSQL", 12.0, 13.0, "", connectionUrl, null, PostgreSql_12_Dialect.class);
@@ -189,7 +185,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
                 "SELECT core.executeJaavUpgradeCode('upgradeCode');\n" +          // Misspell function name
                 "SELECT core.executeJavaUpgradeCode('upgradeCode')\n";            // No semicolon
 
-            SqlDialect dialect = new PostgreSql96Dialect();
+            SqlDialect dialect = new PostgreSql_10_Dialect();
             TestUpgradeCode good = new TestUpgradeCode();
             dialect.runSql(null, goodSql, good, null, null);
             assertEquals(5, good.getCounter());
@@ -210,7 +206,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
                 @Override
                 protected SqlDialect getDialect()
                 {
-                    return new PostgreSql96Dialect();
+                    return new PostgreSql_10_Dialect();
                 }
 
                 @NotNull

--- a/core/src/org/labkey/core/dialect/PostgreSqlInClauseTest.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlInClauseTest.java
@@ -17,19 +17,19 @@ import java.util.Arrays;
  */
 public class PostgreSqlInClauseTest extends Assert
 {
-    private PostgreSql96Dialect getDialect()
+    private PostgreSql_10_Dialect getDialect()
     {
         DbSchema core = CoreSchema.getInstance().getSchema();
         SqlDialect d = core.getSqlDialect();
-        if (d instanceof PostgreSql96Dialect)
-            return (PostgreSql96Dialect) d;
+        if (d instanceof PostgreSql_10_Dialect)
+            return (PostgreSql_10_Dialect) d;
         return null;
     }
 
     @Test
     public void testInClause()
     {
-        PostgreSql96Dialect d = getDialect();
+        PostgreSql_10_Dialect d = getDialect();
         if (null == d)
             return;
         DbSchema core = CoreSchema.getInstance().getSchema();

--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -17,7 +17,6 @@ import java.util.stream.Collectors;
 public enum PostgreSqlVersion
 {
     POSTGRESQL_UNSUPPORTED(-1, true, false, null),
-    POSTGRESQL_96(96, true, true, PostgreSql96Dialect::new),
     POSTGRESQL_10(100, false, true, PostgreSql_10_Dialect::new),
     POSTGRESQL_11(110, false, true, PostgreSql_11_Dialect::new),
     POSTGRESQL_12(120, false, true, PostgreSql_12_Dialect::new),
@@ -28,9 +27,9 @@ public enum PostgreSqlVersion
     private final int _version;
     private final boolean _deprecated;
     private final boolean _tested;
-    private final Supplier<? extends PostgreSql96Dialect> _dialectFactory;
+    private final Supplier<? extends PostgreSql_10_Dialect> _dialectFactory;
 
-    PostgreSqlVersion(int version, boolean deprecated, boolean tested, Supplier<? extends PostgreSql96Dialect> dialectFactory)
+    PostgreSqlVersion(int version, boolean deprecated, boolean tested, Supplier<? extends PostgreSql_10_Dialect> dialectFactory)
     {
         _version = version;
         _deprecated = deprecated;
@@ -49,7 +48,7 @@ public enum PostgreSqlVersion
         return _tested;
     }
 
-    public PostgreSql96Dialect getDialect()
+    public PostgreSql_10_Dialect getDialect()
     {
         return _dialectFactory.get();
     }
@@ -84,7 +83,6 @@ public enum PostgreSqlVersion
         public void test()
         {
             // Good
-            test(96, POSTGRESQL_96);
             test(100, POSTGRESQL_10);
             test(110, POSTGRESQL_11);
             test(120, POSTGRESQL_12);
@@ -106,6 +104,7 @@ public enum PostgreSqlVersion
             test(93, POSTGRESQL_UNSUPPORTED);
             test(94, POSTGRESQL_UNSUPPORTED);
             test(95, POSTGRESQL_UNSUPPORTED);
+            test(96, POSTGRESQL_UNSUPPORTED);
             test(97, POSTGRESQL_UNSUPPORTED);
             test(98, POSTGRESQL_UNSUPPORTED);
         }

--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -107,6 +107,7 @@ public enum PostgreSqlVersion
             test(96, POSTGRESQL_UNSUPPORTED);
             test(97, POSTGRESQL_UNSUPPORTED);
             test(98, POSTGRESQL_UNSUPPORTED);
+            test(99, POSTGRESQL_UNSUPPORTED);
         }
 
         private void test(int version, PostgreSqlVersion expectedVersion)


### PR DESCRIPTION
#### Rationale
We don't want to allow dependencies that are no longer supported by their development teams
