### PR TITLE
43992: Adjust default issue update email template

### DIFF
--- a/issues/src/org/labkey/issue/IssueUpdateEmailTemplate.java
+++ b/issues/src/org/labkey/issue/IssueUpdateEmailTemplate.java
@@ -43,11 +43,15 @@ public class IssueUpdateEmailTemplate extends UserOriginatedEmailTemplate
 {
     protected static final String DEFAULT_SUBJECT =
             "^itemName^ #^issueId^, \"^title^,\" has been ^action^";
+
+    // issue 43992 - add HTML line breaks to preserve original formatting, issue update emails no longer include
+    // a plain text version unless the --text/html--boundary-- boundary is specified in the template
+    //
     protected static final String DEFAULT_BODY =
-            "You can review this ^itemNameLowerCase^ here: ^detailsURL^\n" +
-                    "Modified by: ^user^\n" +
-                    "^modifiedFields^\n" +
-                    "^comment^\n" +
+            "You can review this ^itemNameLowerCase^ here: ^detailsURL^<br>\n" +
+                    "Modified by: ^user^<br>\n" +
+                    "^modifiedFields^<br>\n" +
+                    "^comment^<br>\n" +
                     "^attachments^";
     private final List<ReplacementParam<?>> _replacements = new ArrayList<>();
     private final List<ReplacementParam<?>> _allReplacements = new ArrayList<>();    // includes both static and dynamic custom field replacements


### PR DESCRIPTION
#### Rationale
As part of this feature to allow HTML in the issue email templates, we stopped running the template through `PageFlowUtil.filter` which would automatically translate spaces to line breaks.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43992

This introduced slight formatting differences in the generated emails. This change adds HTML line breaks to the default issue update email template to preserve the original formatting behavior. Also, since we no longer generate a plain text version of the email, this should be safe to add the tags to the template.
