### PR TITLE
Update @labkey/components package version for 21.11 patch release changes

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -1210,12 +1210,12 @@
       "dev": true
     },
     "@emotion/cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.5.0.tgz",
-      "integrity": "sha512-mAZ5QRpLriBtaj/k2qyrXwck6yeoz1V5lMt/jfj6igWU35yYlNKs2LziXVgvH81gnJZ+9QQNGelSsnuoAy6uIw==",
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.6.0.tgz",
+      "integrity": "sha512-ElbsWY1KMwEowkv42vGo0UPuLgtPYfIs9BxxVrmvsaJVvktknsHYYlx5NQ5g6zLDcOTyamlDc7FkRg2TAcQDKQ==",
       "requires": {
         "@emotion/memoize": "^0.7.4",
-        "@emotion/sheet": "^1.0.3",
+        "@emotion/sheet": "^1.1.0",
         "@emotion/utils": "^1.0.0",
         "@emotion/weak-memoize": "^0.2.5",
         "stylis": "^4.0.10"
@@ -1344,14 +1344,14 @@
       "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
     },
     "@emotion/react": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.5.0.tgz",
-      "integrity": "sha512-MYq/bzp3rYbee4EMBORCn4duPQfgpiEB5XzrZEBnUZAL80Qdfr7CEv/T80jwaTl/dnZmt9SnTa8NkTrwFNpLlw==",
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.6.0.tgz",
+      "integrity": "sha512-23MnRZFBN9+D1lHXC5pD6z4X9yhPxxtHr6f+iTGz6Fv6Rda0GdefPrsHL7otsEf+//7uqCdT5QtHeRxHCERzuw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@emotion/cache": "^11.5.0",
+        "@emotion/cache": "^11.6.0",
         "@emotion/serialize": "^1.0.2",
-        "@emotion/sheet": "^1.0.3",
+        "@emotion/sheet": "^1.1.0",
         "@emotion/utils": "^1.0.0",
         "@emotion/weak-memoize": "^0.2.5",
         "hoist-non-react-statics": "^3.3.1"
@@ -1370,9 +1370,9 @@
       }
     },
     "@emotion/sheet": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.3.tgz",
-      "integrity": "sha512-YoX5GyQ4db7LpbmXHMuc8kebtBGP6nZfRC5Z13OKJMixBEwdZrJ914D6yJv/P+ZH/YY3F5s89NYX2hlZAf3SRQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+      "integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
     },
     "@emotion/styled": {
       "version": "10.0.27",
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.91.1-fb-mergeFrom2111.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.91.1-fb-mergeFrom2111.0.tgz",
-      "integrity": "sha1-uEnrbPuTv7vVExYygL+dXG1tfO4=",
+      "version": "2.91.2",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.91.2.tgz",
+      "integrity": "sha1-z2RCPFgboiGLmtk4laCPx6XjP28=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2042,9 +2042,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.6.8",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.8.tgz",
-      "integrity": "sha1-qAtCm9vx9JY+tSID1ItZaXN6GDE="
+      "version": "1.6.9",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.9.tgz",
+      "integrity": "sha1-fwVHUDWDV9Zn46bv13yBc0Vu7Xc="
     },
     "@labkey/build": {
       "version": "4.0.1",
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.91.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.91.1.tgz",
-      "integrity": "sha1-afDZGR5jjRyvxqZYeEsuMv/uYyc=",
+      "version": "2.91.1-fb-mergeFrom2111.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.91.1-fb-mergeFrom2111.0.tgz",
+      "integrity": "sha1-uEnrbPuTv7vVExYygL+dXG1tfO4=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -2133,18 +2133,11 @@
         "redux-actions": "2.3.2",
         "use-immer": "0.6.0",
         "vis-network": "6.5.2"
-      },
-      "dependencies": {
-        "@labkey/api": {
-          "version": "1.6.9",
-          "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.6.9.tgz",
-          "integrity": "sha1-fwVHUDWDV9Zn46bv13yBc0Vu7Xc="
-        }
       }
     },
     "@labkey/eslint-config-base": {
       "version": "0.0.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/eslint-config-base/-/@labkey/eslint-config-base-0.0.8.tgz",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/eslint-config-base/-/@labkey/eslint-config-base-0.0.8.tgz",
       "integrity": "sha1-zGBA9a8jgwSAh3TpyWRFaqfFN0s=",
       "dev": true,
       "requires": {
@@ -2193,7 +2186,7 @@
     },
     "@labkey/eslint-config-react": {
       "version": "0.0.8",
-      "resolved": "https://artifactory.labkey.com/artifactory/api/npm/libs-client/@labkey/eslint-config-react/-/@labkey/eslint-config-react-0.0.8.tgz",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/eslint-config-react/-/@labkey/eslint-config-react-0.0.8.tgz",
       "integrity": "sha1-5326T0G33/fxDhByI4d3BxwBIrE=",
       "dev": true,
       "requires": {

--- a/core/package.json
+++ b/core/package.json
@@ -51,8 +51,8 @@
     "testResultsProcessor": "jest-teamcity-reporter"
   },
   "dependencies": {
-    "@labkey/api": "1.6.8",
-    "@labkey/components": "2.91.1",
+    "@labkey/api": "1.6.9",
+    "@labkey/components": "2.91.1-fb-mergeFrom2111.0",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.6.9",
-    "@labkey/components": "2.91.1-fb-mergeFrom2111.0",
+    "@labkey/components": "2.91.2",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Rationale
Including changes from version [2.90.2](https://github.com/LabKey/labkey-ui-components/pull/667) and [2.90.3](https://github.com/LabKey/labkey-ui-components/pull/669)

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/672
* https://github.com/LabKey/platform/pull/2775
* https://github.com/LabKey/biologics/pull/1057
* https://github.com/LabKey/sampleManagement/pull/747
