### PR TITLE
44297: email links to announcements aren't properly encoded

### DIFF
--- a/api/src/org/labkey/api/util/emailTemplate/EmailTemplate.java
+++ b/api/src/org/labkey/api/util/emailTemplate/EmailTemplate.java
@@ -93,7 +93,7 @@ public abstract class EmailTemplate
                 {
                     return sourceValue;
                 }
-                return PageFlowUtil.filter(sourceValue, true, true);
+                return PageFlowUtil.filter(sourceValue, true, false);
             }
         };
 

--- a/issues/src/org/labkey/issue/IssueUpdateEmailTemplate.java
+++ b/issues/src/org/labkey/issue/IssueUpdateEmailTemplate.java
@@ -22,6 +22,7 @@ import org.labkey.api.collections.LabKeyCollectors;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.emailTemplate.UserOriginatedEmailTemplate;
 import org.labkey.api.view.ActionURL;
 import org.labkey.issue.model.Issue;
@@ -71,7 +72,7 @@ public class IssueUpdateEmailTemplate extends UserOriginatedEmailTemplate
         Replacements replacements = new Replacements(_replacements);
 
         replacements.add("issueId", Integer.class, "Unique id for the issue", ContentType.Plain, c -> _newIssue == null ? null : _newIssue.getIssueId());
-        replacements.add("detailsURL", String.class, "URL to get the details view for the issue", ContentType.Plain, c -> _detailsURL == null ? null : _detailsURL.getURIString());
+        replacements.add("detailsURL", String.class, "URL to get the details view for the issue", ContentType.HTML, c -> _detailsURL == null ? null : PageFlowUtil.filter(_detailsURL.getURIString(), true, true));
         replacements.add("action", String.class, "Description of the type of action, like 'opened' or 'resolved'", ContentType.Plain, c -> _change);
         replacements.add("itemName", String.class, "Potentially customized singular item name, typically 'Issue'", ContentType.Plain, c -> getEntryTypeName(c, _newIssue).singularName);
         replacements.add("itemNameLowerCase", String.class, "Potentially customized singular item name in lower case, typically 'issue'", ContentType.Plain, c -> getEntryTypeName(c, _newIssue).singularName.toLowerCase());


### PR DESCRIPTION
#### Rationale
This change addresses the encoding issue found in the Biologics/announcements email notification:

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44297

#### Changes
Instead of the original, more general change, to encode links. The issue detail link is encoded specifically in the issue update template and marked as an HTML content type so it won't get escaped later.
