### PR TITLE
Issue 44306: Run order in imported folders is not always preserved

### DIFF
--- a/experiment/src/org/labkey/experiment/xar/XarExportSelection.java
+++ b/experiment/src/org/labkey/experiment/xar/XarExportSelection.java
@@ -66,7 +66,8 @@ public class XarExportSelection implements Serializable
 
     public void addRuns(Collection<? extends ExpRun> runs)
     {
-        _runIds.addAll(runs.stream().map(ExpObject::getRowId).collect(Collectors.toSet()));
+        // Issue 44306 - be sure to retain the ordering of the runs as passed in the collection
+        _runIds.addAll(runs.stream().map(ExpObject::getRowId).collect(Collectors.toList()));
     }
 
     public void addDataIds(int... dataIds)


### PR DESCRIPTION
#### Rationale
For a more full fidelity export/import we want to present runs in the same order in which they appear in the original order. This was broken by https://github.com/LabKey/platform/pull/2568 which collected the RowIds in a regular set before adding to a LinkedHashSet

#### Changes
* Use a list to retain ordering