### PR TITLE
Item 9500: Improve Sample display when spanning types

### DIFF
--- a/list/src/org/labkey/list/ListModule.java
+++ b/list/src/org/labkey/list/ListModule.java
@@ -35,6 +35,7 @@ import org.labkey.api.lists.permissions.ManagePicklistsPermission;
 import org.labkey.api.module.AdminLinkManager;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.module.SpringModule;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
@@ -121,6 +122,8 @@ public class ListModule extends SpringModule
 
         AttachmentService.get().registerAttachmentType(ListItemType.get());
         ExperimentService.get().addExperimentListener(new PicklistMaterialListener());
+
+        QueryService.get().addCompareType(new PicklistSampleCompareType());
     }
 
     @Override

--- a/list/src/org/labkey/list/PicklistSampleCompareType.java
+++ b/list/src/org/labkey/list/PicklistSampleCompareType.java
@@ -1,0 +1,40 @@
+package org.labkey.list;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.CompareType;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.exp.list.ListDefinition;
+import org.labkey.api.exp.list.ListService;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QueryService;
+import org.labkey.api.security.User;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class PicklistSampleCompareType extends CompareType
+{
+    public PicklistSampleCompareType()
+    {
+        super("Samples for picklist", "picklistsamples", "PICKLIST_SAMPLES", true, " matches picklist ", null);
+    }
+
+    @Override
+    public SimpleFilter.FilterClause createFilterClause(@NotNull FieldKey fieldKey, Object value)
+    {
+        final Integer listId = Integer.parseInt(value.toString());
+        final User user = (User) QueryService.get().getEnvironment(QueryService.Environment.USER);
+        final Container container = (Container) QueryService.get().getEnvironment(QueryService.Environment.CONTAINER);
+
+        ListDefinition listDef = ListService.get().getList(container, listId);
+        if (listDef == null || !listDef.isPicklist())
+            return new SimpleFilter.FalseClause();
+
+        TableInfo listTable = listDef.getTable(user, container);
+        Integer[] sampleIds = new TableSelector(listTable, Collections.singleton("SampleID")).getArray(Integer.class);
+        return new SimpleFilter.InClause(fieldKey, Arrays.asList(sampleIds));
+    }
+}


### PR DESCRIPTION
#### Rationale
In the places of the apps (LKSM and LKB) that showed grids of samples for a given object (i.e. Job, Picklist, Source), we were always showing the grid of samples across all of the sample types. This worked well for some operations on those samples but it did mean that users had to go to the given sample type grids to see and edit the sample type specific metadata. 

This PR adds a PicklistSampleCompareType so that a sample type grid can use the picklist ID to filter for those samples in that picklist.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/671
* https://github.com/LabKey/sampleManagement/pull/744
* https://github.com/LabKey/biologics/pull/1053
* https://github.com/LabKey/inventory/pull/328
* https://github.com/LabKey/platform/pull/2781

#### Changes
* add/register PicklistSampleCompareType to use in picklist per-sample type grid filtering