### PR TITLE
Attempted fix for intermittent DatasetImportTestCase_jsp failures

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -2332,6 +2332,11 @@ public class DbScope
             {
                 for (Lock extraLock : extraLocks)
                 {
+                    // Clear the interrupted status of this thread so a previous, lingering interrupt won't prevent us
+                    // from acquiring a new lock - perhaps we should clear this at the start of every HTTP request
+                    // or background job that's using a thread pool?
+                    //noinspection ResultOfMethodCallIgnored
+                    Thread.interrupted();
                     try
                     {
                         boolean locked = extraLock.tryLock(_lockTimeout, _lockTimeoutUnit);


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/buildConfiguration/LabKey_2111Release_Community_BvtBPostgres/1606692

#### Changes
* Clear the interrupted status before starting to acquire the lock