### PR TITLE
Substitute server properties into short name

### DIFF
--- a/api/src/org/labkey/api/admin/AdminBean.java
+++ b/api/src/org/labkey/api/admin/AdminBean.java
@@ -17,22 +17,29 @@
 package org.labkey.api.admin;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
-import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
 
 import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 public class AdminBean
@@ -47,38 +54,86 @@ public class AdminBean
             this.minutes = null==minutes ? 0 : minutes.longValue();
         }
     }
-    public final String javaVendor = System.getProperty("java.vendor");
-    public final String javaRuntimeName = System.getProperty("java.runtime.name");
-    public final String javaVersion = System.getProperty("java.runtime.version");
-    public final String javaHome = System.getProperty("java.home");
-    public final String userName = System.getProperty("user.name");
-    public final String userHomeDir = System.getProperty("user.home");
-    public final String webappDir = ModuleLoader.getServletContext().getRealPath("");
-    public final String workingDir = new File("file").getAbsoluteFile().getParent();
-    public final String osName = System.getProperty("os.name");
-    public final @Nullable String releaseVersion = ModuleLoader.getInstance().getCoreModule().getReleaseVersion();
-    public final String mode = AppProps.getInstance().isDevMode() ? "Development" : "Production";
-    public final String serverGuid = AppProps.getInstance().getServerGUID();
-    public final String serverSessionGuid = AppProps.getInstance().getServerSessionGUID();
-    public final String servletContainer = ModuleLoader.getServletContext().getServerInfo();
-    @JsonIgnore
-    public final DbScope scope = CoreSchema.getInstance().getSchema().getScope();
+
+    public static final String javaVendor = System.getProperty("java.vendor");
+    public static final String javaRuntimeName = System.getProperty("java.runtime.name");
+    public static final String javaVersion = System.getProperty("java.runtime.version");
+    public static final String javaHome = System.getProperty("java.home");
+    public static final String userName = System.getProperty("user.name");
+    public static final String userHomeDir = System.getProperty("user.home");
+    public static final String webappDir = ModuleLoader.getServletContext().getRealPath("");
+    public static final String workingDir = new File("file").getAbsoluteFile().getParent();
+    public static final String osName = System.getProperty("os.name");
+    public static final @Nullable String releaseVersion = ModuleLoader.getInstance().getCoreModule().getReleaseVersion();
+    public static final String mode = AppProps.getInstance().isDevMode() ? "Development" : "Production";
+    public static final String serverGuid = AppProps.getInstance().getServerGUID();
+    public static final String serverSessionGuid = AppProps.getInstance().getServerSessionGUID();
+    public static final String servletContainer = ModuleLoader.getServletContext().getServerInfo();
+    public static final List<Module> modules;
+
+    public static String asserts = "disabled";
+
     public final List<ActiveUser> active;
 
-    public final String userEmail;
-    public final List<Module> modules;
+    @JsonIgnore
+    public static final DbScope scope = CoreSchema.getInstance().getSchema().getScope();
 
-    public String asserts = "disabled";
+    private final static Map<String, String> propertyMap = new TreeMap<>();
 
-    public AdminBean(User user)
+    static
     {
+        Arrays.stream(AdminBean.class.getDeclaredFields())
+            .filter(f -> Modifier.isStatic(f.getModifiers()))
+            .filter(f -> f.getType().equals(String.class))
+            .forEach(f -> propertyMap.put(f.getName(), getValue(f)));
+
+        Arrays.stream(scope.getClass().getMethods())
+            .filter(m -> m.getReturnType().equals(String.class))
+            .filter(m -> m.getName().startsWith("get"))
+            .forEach(m -> {
+                String key = StringUtils.uncapitalize(m.getName().substring(3));
+                propertyMap.put(key, getValue(m));
+            });
+
+        // TODO: Remove -- for testing only
+        propertyMap.entrySet().stream()
+            .forEach(e -> System.out.println(e.getKey() + ": " + e.getValue()));
+
         //noinspection ConstantConditions,AssertWithSideEffects
         assert null != (asserts = "enabled");
-        userEmail = user.getEmail();
+
         modules = new ArrayList<>(ModuleLoader.getInstance().getModules());
         modules.sort(Comparator.comparing(Module::getName, String.CASE_INSENSITIVE_ORDER));
+    }
+
+    static @Nullable String getValue(Field field)
+    {
+        try
+        {
+            return (String)field.get(null);
+        }
+        catch (IllegalAccessException e)
+        {
+            return null;
+        }
+    }
+
+    static @Nullable String getValue(Method method)
+    {
+        try
+        {
+            return (String)method.invoke(scope);
+        }
+        catch (IllegalAccessException | InvocationTargetException e)
+        {
+            return null;
+        }
+    }
+
+    public AdminBean()
+    {
         active = UserManager.getRecentUsers(System.currentTimeMillis() - DateUtils.MILLIS_PER_HOUR).stream()
-                 .map(p -> new ActiveUser(p.first, p.second)).collect(Collectors.toList());
+            .map(p -> new ActiveUser(p.first, p.second)).collect(Collectors.toList());
     }
 
     public List<NavTree> getLinks(ViewContext ctx)
@@ -89,5 +144,10 @@ public class AdminBean
             links.addAll(headerLinkProvider.getLinks(ctx));
         }
         return links;
+    }
+
+    public static Map<String, String> getPropertyMap()
+    {
+        return propertyMap;
     }
 }

--- a/api/src/org/labkey/api/admin/AdminBean.java
+++ b/api/src/org/labkey/api/admin/AdminBean.java
@@ -129,7 +129,7 @@ public class AdminBean
     {
     }
 
-    public List<NavTree> getLinks(ViewContext ctx)
+    public static List<NavTree> getLinks(ViewContext ctx)
     {
         List<NavTree> links = new ArrayList<>();
         for (AdminConsoleHeaderLinkProvider headerLinkProvider : AdminConsoleService.get().getAdminConsoleHeaderProviders())

--- a/api/src/org/labkey/api/admin/AdminBean.java
+++ b/api/src/org/labkey/api/admin/AdminBean.java
@@ -73,8 +73,6 @@ public class AdminBean
 
     public static String asserts = "disabled";
 
-    public final List<ActiveUser> active;
-
     @JsonIgnore
     public static final DbScope scope = CoreSchema.getInstance().getSchema().getScope();
 
@@ -95,10 +93,6 @@ public class AdminBean
                 propertyMap.put(key, getValue(m));
             });
 
-        // TODO: Remove -- for testing only
-        propertyMap.entrySet().stream()
-            .forEach(e -> System.out.println(e.getKey() + ": " + e.getValue()));
-
         //noinspection ConstantConditions,AssertWithSideEffects
         assert null != (asserts = "enabled");
 
@@ -106,7 +100,7 @@ public class AdminBean
         modules.sort(Comparator.comparing(Module::getName, String.CASE_INSENSITIVE_ORDER));
     }
 
-    static @Nullable String getValue(Field field)
+    private static @Nullable String getValue(Field field)
     {
         try
         {
@@ -118,7 +112,7 @@ public class AdminBean
         }
     }
 
-    static @Nullable String getValue(Method method)
+    private static @Nullable String getValue(Method method)
     {
         try
         {
@@ -130,10 +124,9 @@ public class AdminBean
         }
     }
 
-    public AdminBean()
+    // No constructing for you!
+    private AdminBean()
     {
-        active = UserManager.getRecentUsers(System.currentTimeMillis() - DateUtils.MILLIS_PER_HOUR).stream()
-            .map(p -> new ActiveUser(p.first, p.second)).collect(Collectors.toList());
     }
 
     public List<NavTree> getLinks(ViewContext ctx)
@@ -144,6 +137,13 @@ public class AdminBean
             links.addAll(headerLinkProvider.getLinks(ctx));
         }
         return links;
+    }
+
+    public static List<ActiveUser> getActiveUsers()
+    {
+        return UserManager.getRecentUsers(System.currentTimeMillis() - DateUtils.MILLIS_PER_HOUR).stream()
+            .map(p -> new ActiveUser(p.first, p.second))
+            .collect(Collectors.toList());
     }
 
     public static Map<String, String> getPropertyMap()

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -126,6 +126,7 @@ public class DbScope
     private final String _databaseProductVersion;
     private final String _driverName;
     private final String _driverVersion;
+    private final String _driverLocation;
     private final DbSchemaCache _schemaCache;
     private final SchemaTableInfoCache _tableCache;
     private final Map<Thread, List<TransactionImpl>> _transaction = new WeakHashMap<>();
@@ -251,6 +252,7 @@ public class DbScope
         _databaseProductVersion = null;
         _driverName = null;
         _driverVersion = null;
+        _driverLocation = null;
         _schemaCache = null;
         _tableCache = null;
         _rds = false;
@@ -343,10 +345,23 @@ public class DbScope
             _databaseProductName = dbmd.getDatabaseProductName();
             _driverName = dbmd.getDriverName();
             _driverVersion = dbmd.getDriverVersion();
+            _driverLocation = determineDriverLocation();
             _schemaCache = new DbSchemaCache(this);
             _tableCache = new SchemaTableInfoCache(this);
             _rds = _dialect.isRds(this);
             _escape = dbmd.getSearchStringEscape();
+        }
+    }
+
+    private String determineDriverLocation()
+    {
+        try
+        {
+            return getDelegateClass().getProtectionDomain().getCodeSource().getLocation().toString();
+        }
+        catch (Exception ignored)
+        {
+            return "UNKNOWN";
         }
     }
 
@@ -381,7 +396,7 @@ public class DbScope
         return _databaseName;
     }
 
-    public String getURL()
+    public String getDatabaseUrl()
     {
         try
         {
@@ -412,6 +427,11 @@ public class DbScope
     public String getDriverVersion()
     {
         return _driverVersion;
+    }
+
+    public String getDriverLocation()
+    {
+        return _driverLocation;
     }
 
     public LabKeyDataSourceProperties getLabKeyProps()

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1479,7 +1479,7 @@ public class DbScope
         return _rds;
     }
 
-    public String getSearchStringEscape()
+    public String getDatabaseSearchStringEscape()
     {
         return _escape;
     }

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1210,17 +1210,14 @@ public abstract class SqlDialect
                 return null;
             }
         }
-
     }
 
-
-    // All statement creation passes through these two methods.  We return our standard statement wrappers in most
+    // All statement creation passes through these two methods. We return our standard statement wrappers in most
     // cases, but dialects can return their own subclasses of StatementWrapper to work around JDBC driver bugs.
     public StatementWrapper getStatementWrapper(ConnectionWrapper conn, Statement stmt)
     {
         return new StatementWrapper(conn, stmt);
     }
-
 
     public StatementWrapper getStatementWrapper(ConnectionWrapper conn, Statement stmt, String sql)
     {
@@ -1511,7 +1508,7 @@ public abstract class SqlDialect
     // Simple check. Subclasses can override to provide better checks.
     public boolean isRds(DbScope scope)
     {
-        return StringUtils.containsIgnoreCase(scope.getURL(), "rds.amazonaws.com");
+        return StringUtils.containsIgnoreCase(scope.getDatabaseUrl(), "rds.amazonaws.com");
     }
 
     public static final class MetadataParameterInfo

--- a/api/src/org/labkey/api/data/dialect/StandardTableResolver.java
+++ b/api/src/org/labkey/api/data/dialect/StandardTableResolver.java
@@ -77,7 +77,7 @@ public class StandardTableResolver implements TableResolver
     // parameter, see #43821
     public static String escapeName(DbScope scope, @NotNull String name)
     {
-        String escape = scope.getSearchStringEscape();
+        String escape = scope.getDatabaseSearchStringEscape();
 
         String ret = name.replace(escape, escape + escape);
         ret = ret.replace("_", escape + "_");

--- a/api/src/org/labkey/api/settings/FolderSettingsCache.java
+++ b/api/src/org/labkey/api/settings/FolderSettingsCache.java
@@ -16,6 +16,7 @@
 package org.labkey.api.settings;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.Constants;
 import org.labkey.api.cache.BlockingCache;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.Container;
@@ -37,7 +38,7 @@ import java.util.Collections;
 // properties on a per-container basis and clear the entire cache on every change of look and feel settings.
 public class FolderSettingsCache
 {
-    private static final BlockingCache<Container, FolderSettings> CACHE = CacheManager.getBlockingCache(10000, CacheManager.DAY, "Folder Settings", (c, argument) -> new FolderSettings(c));
+    private static final BlockingCache<Container, FolderSettings> CACHE = CacheManager.getBlockingCache(Constants.getMaxContainers(), CacheManager.DAY, "Folder Settings", (c, argument) -> new FolderSettings(c));
 
     public static String getDefaultDateFormat(Container c)
     {

--- a/api/src/org/labkey/api/settings/LookAndFeelFolderProperties.java
+++ b/api/src/org/labkey/api/settings/LookAndFeelFolderProperties.java
@@ -55,13 +55,11 @@ public class LookAndFeelFolderProperties extends AbstractWriteableSettingsGroup
         return LOOK_AND_FEEL_SET_NAME;
     }
 
-
     public boolean isPropertyInherited(Container c, String name)
     {
         String value = super.lookupStringValue(c, name, null);
         return null == value;
     }
-
 
     @Override
     protected String lookupStringValue(String name, @Nullable String defaultValue)

--- a/api/src/org/labkey/api/settings/WriteableLookAndFeelProperties.java
+++ b/api/src/org/labkey/api/settings/WriteableLookAndFeelProperties.java
@@ -52,7 +52,8 @@ import static org.labkey.api.settings.LookAndFeelProperties.THEME_NAME_PROP;
 // Handles all the properties that can be set at the project or site level
 public class WriteableLookAndFeelProperties extends WriteableFolderLookAndFeelProperties
 {
-    boolean isRoot;
+    private final boolean isRoot;
+
     WriteableLookAndFeelProperties(Container c)
     {
         super(c);
@@ -92,8 +93,8 @@ public class WriteableLookAndFeelProperties extends WriteableFolderLookAndFeelPr
     public void setHelpMenuEnabled(boolean enabled)
     {
         storeBooleanValue(HELP_MENU_ENABLED_PROP, enabled);
-
     }
+
     public void setDiscussionEnabled(boolean enabled)
     {
         storeBooleanValue(DISCUSSION_ENABLED_PROP, enabled);
@@ -186,5 +187,12 @@ public class WriteableLookAndFeelProperties extends WriteableFolderLookAndFeelPr
         startupProps
                 .forEach(prop -> writeable.storeStringValue(prop.getName(), prop.getValue()));
         writeable.save();
+    }
+
+    @Override
+    public void save()
+    {
+        super.save();
+        LookAndFeelProperties.clearCaches();
     }
 }

--- a/api/src/org/labkey/api/util/ErrorRenderer.java
+++ b/api/src/org/labkey/api/util/ErrorRenderer.java
@@ -187,7 +187,7 @@ public class ErrorRenderer
 
                     out.println("<br><table>\n");
                     out.println("<tr><td colspan=2><b>core schema database configuration</b></td></tr>\n");
-                    out.println("<tr><td>Server URL</td><td>" + PageFlowUtil.filter(scope.getURL()) + "</td></tr>\n");
+                    out.println("<tr><td>Server URL</td><td>" + PageFlowUtil.filter(scope.getDatabaseUrl()) + "</td></tr>\n");
                     out.println("<tr><td>Product Name</td><td>" + PageFlowUtil.filter(scope.getDatabaseProductName()) + "</td></tr>\n");
                     out.println("<tr><td>Product Version</td><td>" + PageFlowUtil.filter(scope.getDatabaseProductVersion()) + "</td></tr>\n");
                     out.println("<tr><td>Driver Name</td><td>" + PageFlowUtil.filter(scope.getDriverName()) + "</td></tr>\n");

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -431,7 +431,7 @@ public class AdminController extends SpringActionController
         @Override
         public ModelAndView getView(Object o, BindException errors)
         {
-            return new JspView<>("/org/labkey/core/admin/admin.jsp", new AdminBean());
+            return new JspView<>("/org/labkey/core/admin/admin.jsp");
         }
 
         @Override
@@ -10037,8 +10037,7 @@ public class AdminController extends SpringActionController
     {
         JSONObject res = new JSONObject();
 
-        AdminBean admin = new AdminBean();
-        res.put("server", admin);
+        res.put("server", AdminBean.getPropertyMap());
 
         final Map<String,Map<String,Object>> sets = new TreeMap<>();
         new SqlSelector(CoreSchema.getInstance().getScope(),

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -431,7 +431,7 @@ public class AdminController extends SpringActionController
         @Override
         public ModelAndView getView(Object o, BindException errors)
         {
-            return new JspView<>("/org/labkey/core/admin/admin.jsp", new AdminBean(getUser()));
+            return new JspView<>("/org/labkey/core/admin/admin.jsp", new AdminBean());
         }
 
         @Override
@@ -10037,7 +10037,7 @@ public class AdminController extends SpringActionController
     {
         JSONObject res = new JSONObject();
 
-        AdminBean admin = new AdminBean(getUser());
+        AdminBean admin = new AdminBean();
         res.put("server", admin);
 
         final Map<String,Map<String,Object>> sets = new TreeMap<>();

--- a/core/src/org/labkey/core/admin/admin.jsp
+++ b/core/src/org/labkey/core/admin/admin.jsp
@@ -27,18 +27,15 @@
 <%@ page import="org.labkey.api.settings.AppProps" %>
 <%@ page import="org.labkey.api.util.GUID" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
-<%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.NavTree" %>
-<%@ page import="org.labkey.core.admin.AdminController"%>
-<%@ page import="java.util.Collection" %>
+<%@ page import="org.labkey.core.admin.AdminController" %>
+<%@ page import="java.util.Collection"%>
 <%@ page import="java.util.Date" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.TreeMap" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
-    HttpView<AdminBean> me = (HttpView<AdminBean>) HttpView.currentView();
-    AdminBean bean = me.getModelBean();
     boolean devMode = AppProps.getInstance().isDevMode();
     int row = 0;
 %>
@@ -60,7 +57,7 @@
     <div class="col-sm-12 col-md-9">
         <labkey:panel id="info" className="lk-admin-section">
             <h3 class="header-title labkey-page-section-header">LabKey Server <%=h(ObjectUtils.defaultIfNull(AdminBean.releaseVersion, "Information"))%></h3>
-            <% for (NavTree link : bean.getLinks(getViewContext())) { %>
+            <% for (NavTree link : AdminBean.getLinks(getViewContext())) { %>
             <div class="header-link">
                 <a href="<%=h(link.getHref())%>"><%=h(link.getText())%></a>
             </div>
@@ -217,7 +214,7 @@
                 <tr><td class="labkey-column-header">User</td><td class="labkey-column-header">Last Activity</td></tr>
                 <%
                     int count = 0;
-                    for (var activeUser : bean.active)
+                    for (var activeUser : AdminBean.getActiveUsers())
                     {
                 %>
                 <tr class="<%=getShadeRowClass(count)%>"><td><%=h(activeUser.email)%></td><td><%=activeUser.minutes%> minutes ago</td></tr>

--- a/core/src/org/labkey/core/admin/admin.jsp
+++ b/core/src/org/labkey/core/admin/admin.jsp
@@ -18,7 +18,6 @@
 <%@ page import="org.apache.commons.lang3.ObjectUtils" %>
 <%@ page import="org.apache.commons.lang3.StringUtils" %>
 <%@ page import="org.labkey.api.admin.AdminBean" %>
-<%@ page import="org.labkey.api.data.CoreSchema" %>
 <%@ page import="org.labkey.api.module.DefaultModule" %>
 <%@ page import="org.labkey.api.module.Module" %>
 <%@ page import="org.labkey.api.moduleeditor.api.ModuleEditorService" %>
@@ -29,8 +28,8 @@
 <%@ page import="org.labkey.api.util.GUID" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
-<%@ page import="org.labkey.api.view.NavTree"%>
-<%@ page import="org.labkey.core.admin.AdminController" %>
+<%@ page import="org.labkey.api.view.NavTree" %>
+<%@ page import="org.labkey.core.admin.AdminController"%>
 <%@ page import="java.util.Collection" %>
 <%@ page import="java.util.Date" %>
 <%@ page import="java.util.Map" %>
@@ -41,16 +40,6 @@
     HttpView<AdminBean> me = (HttpView<AdminBean>) HttpView.currentView();
     AdminBean bean = me.getModelBean();
     boolean devMode = AppProps.getInstance().isDevMode();
-
-    String location = null;
-    try
-    {
-        Class cls = CoreSchema.getInstance().getSchema().getScope().getDelegateClass();
-        location = cls.getProtectionDomain().getCodeSource().getLocation().toString();
-    }
-    catch (Exception ignored)
-    {}
-
     int row = 0;
 %>
 <style type="text/css">
@@ -70,7 +59,7 @@
     </div>
     <div class="col-sm-12 col-md-9">
         <labkey:panel id="info" className="lk-admin-section">
-            <h3 class="header-title labkey-page-section-header">LabKey Server <%=h(ObjectUtils.defaultIfNull(bean.releaseVersion, "Information"))%></h3>
+            <h3 class="header-title labkey-page-section-header">LabKey Server <%=h(ObjectUtils.defaultIfNull(AdminBean.releaseVersion, "Information"))%></h3>
             <% for (NavTree link : bean.getLinks(getViewContext())) { %>
             <div class="header-link">
                 <a href="<%=h(link.getHref())%>"><%=h(link.getText())%></a>
@@ -79,20 +68,17 @@
             <h4>Core Database Configuration</h4>
             <table class="labkey-data-region-legacy labkey-show-borders">
                 <tr><td class="labkey-column-header">Property</td><td class="labkey-column-header">Value</td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Database Server URL</td><td id="databaseServerURL"><%=h(bean.scope.getURL())%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Database Name</td><td id="databaseName"><%=h(bean.scope.getDatabaseName())%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Database Product Name</td><td id="databaseProductName"><%=h(bean.scope.getDatabaseProductName())%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Database Product Version</td><td id="databaseProductVersion"><%=h(bean.scope.getDatabaseProductVersion())%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>JDBC Driver Name</td><td id="databaseDriverName"><%=h(bean.scope.getDriverName())%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>JDBC Driver Version</td><td id="databaseDriverVersion"><%=h(bean.scope.getDriverVersion())%></td></tr><%
-                if (null != location)
-                { %>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>JDBC Driver Location</td><td id="databaseDriverLocation"><%=h(location)%></td></tr><%
-                } %>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Pool Max Size</td><td id="connectionPoolSize"><%=h(bean.scope.getDataSourceProperties().getMaxTotal())%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Pool Active</td><td id="connectionPoolActive"><%=h(bean.scope.getDataSourceProperties().getNumActive())%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Pool Idle</td><td id="connectionPoolIdle"><%=h(bean.scope.getDataSourceProperties().getNumIdle())%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Max Wait (ms)</td><td id="connectionPoolMaxWait"><%=h(bean.scope.getDataSourceProperties().getMaxWaitMillis())%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Database Server URL</td><td id="databaseServerURL"><%=h(AdminBean.scope.getDatabaseUrl())%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Database Name</td><td id="databaseName"><%=h(AdminBean.scope.getDatabaseName())%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Database Product Name</td><td id="databaseProductName"><%=h(AdminBean.scope.getDatabaseProductName())%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Database Product Version</td><td id="databaseProductVersion"><%=h(AdminBean.scope.getDatabaseProductVersion())%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>JDBC Driver Name</td><td id="databaseDriverName"><%=h(AdminBean.scope.getDriverName())%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>JDBC Driver Version</td><td id="databaseDriverVersion"><%=h(AdminBean.scope.getDriverVersion())%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>JDBC Driver Location</td><td id="databaseDriverLocation"><%=h(AdminBean.scope.getDriverLocation())%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Pool Max Size</td><td id="connectionPoolSize"><%=h(AdminBean.scope.getDataSourceProperties().getMaxTotal())%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Pool Active</td><td id="connectionPoolActive"><%=h(AdminBean.scope.getDataSourceProperties().getNumActive())%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Pool Idle</td><td id="connectionPoolIdle"><%=h(AdminBean.scope.getDataSourceProperties().getNumIdle())%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Connection Max Wait (ms)</td><td id="connectionPoolMaxWait"><%=h(AdminBean.scope.getDataSourceProperties().getMaxWaitMillis())%></td></tr>
             </table>
             <br/>
 <%
@@ -101,20 +87,20 @@
             <h4>Runtime Information</h4>
             <table class="labkey-data-region-legacy labkey-show-borders">
                 <tr><td class="labkey-column-header">Property</td><td class="labkey-column-header">Value</td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Mode</td><td><%=h(bean.mode)%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Asserts</td><td><%=h(bean.asserts)%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Servlet Container</td><td><%=h(bean.servletContainer)%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Java Runtime Vendor</td><td><%=h(bean.javaVendor)%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Java Runtime Name</td><td><%=h(bean.javaRuntimeName)%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Java Runtime Version</td><td><%=h(bean.javaVersion)%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Java Home</td><td><%=h(bean.javaHome)%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Username</td><td><%=h(bean.userName)%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>User Home Dir</td><td><%=h(bean.userHomeDir)%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Webapp Dir</td><td><%=h(bean.webappDir)%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>OS</td><td><%=h(bean.osName)%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Working Dir</td><td><%=h(bean.workingDir)%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Server GUID</td><td style="font-family:monospace"><%=h(bean.serverGuid)%></td></tr>
-                <tr class="<%=getShadeRowClass(row++)%>"><td>Server Session GUID</td><td style="font-family:monospace"><%=h(bean.serverSessionGuid)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Mode</td><td><%=h(AdminBean.mode)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Asserts</td><td><%=h(AdminBean.asserts)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Servlet Container</td><td><%=h(AdminBean.servletContainer)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Java Runtime Vendor</td><td><%=h(AdminBean.javaVendor)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Java Runtime Name</td><td><%=h(AdminBean.javaRuntimeName)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Java Runtime Version</td><td><%=h(AdminBean.javaVersion)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Java Home</td><td><%=h(AdminBean.javaHome)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Username</td><td><%=h(AdminBean.userName)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>User Home Dir</td><td><%=h(AdminBean.userHomeDir)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Webapp Dir</td><td><%=h(AdminBean.webappDir)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>OS</td><td><%=h(AdminBean.osName)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Working Dir</td><td><%=h(AdminBean.workingDir)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Server GUID</td><td style="font-family:monospace"><%=h(AdminBean.serverGuid)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Server Session GUID</td><td style="font-family:monospace"><%=h(AdminBean.serverSessionGuid)%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Server Time</td><td><%=formatDateTime(new Date())%></td></tr>
             </table>
         </labkey:panel>
@@ -144,7 +130,7 @@
             <br/><br/>
             <table><%
 
-                for (Module module : bean.modules)
+                for (Module module : AdminBean.modules)
                 {
                     String guid = GUID.makeGUID();
             %>

--- a/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
+++ b/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
@@ -84,7 +84,7 @@
 </tr>
 <tr>
     <td class="labkey-form-label">Header short name (appears in every page header and in emails)</td>
-    <td><input type="text" name="systemShortName" size="50" value="<%= h(laf.getShortName()) %>"></td>
+    <td><input type="text" name="systemShortName" size="50" value="<%= h(laf.getUnsubstitutedShortName()) %>"></td>
 </tr>
 <tr>
     <td class="labkey-form-label">Theme</td>

--- a/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
+++ b/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
@@ -15,9 +15,11 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.labkey.api.admin.AdminUrls"%>
+<%@ page import="org.labkey.api.admin.AdminBean" %>
+<%@ page import="org.labkey.api.admin.AdminUrls" %>
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.data.ContainerManager" %>
+<%@ page import="org.labkey.api.module.ModuleLoader" %>
 <%@ page import="org.labkey.api.security.SecurityManager" %>
 <%@ page import="org.labkey.api.security.permissions.AdminOperationsPermission" %>
 <%@ page import="org.labkey.api.security.permissions.ApplicationAdminPermission" %>
@@ -29,10 +31,10 @@
 <%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
-<%@ page import="org.labkey.api.module.ModuleLoader" %>
 <%@ page import="org.labkey.core.admin.AdminController" %>
 <%@ page import="org.labkey.core.admin.AdminController.AdminUrlsImpl" %>
 <%@ page import="java.util.Arrays" %>
+<%@ page import="java.util.stream.Collectors" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
@@ -57,7 +59,10 @@
 <tr>
     <td colspan=2>&nbsp;</td>
 </tr>
-<% if (c.isProject()) {%>
+<%
+    if (c.isProject())
+    {
+%>
 <tr>
     <td colspan=2>Security defaults</td>
 </tr>
@@ -69,11 +74,22 @@
     <td colspan=2>&nbsp;</td>
 </tr>
 <%
-   }
+    }
 
-   // If this is a folder then skip everything except default date & number formats
-   if (!folder)
-   {
+    // If this is a folder then skip everything except default date & number formats
+    if (!folder)
+    {
+        String shortNameHelp = "The header short name supports string substitution of specific server properties. For example, " +
+            "the value:<br><br><code>&nbsp;&nbsp;LabKey ${releaseVersion}</code><br><br>will currently result in this header text:<br><br><code>&nbsp;&nbsp;LabKey " + AdminBean.releaseVersion + "</code><br><br>" +
+            "The supported properties and their current values are listed in the table below.<br><br>" +
+            "<table class=\"labkey-data-region-legacy labkey-show-borders\">" +
+            "<tr class=\"labkey-frame\"><th>Property</th><th>Current Value</th></tr>" +
+
+            AdminBean.getPropertyMap().entrySet().stream()
+                .map(e -> "<tr valign=top class=\"labkey-row\"><td>" + h(e.getKey()) + "</td><td>" + h(e.getValue()) + "</td></tr>\n")
+                .collect(Collectors.joining()) +
+
+            "</table>";
 %>
 <tr>
     <td colspan=2>Customize the look and feel of <%=h(c.isRoot() ? "your LabKey Server installation" : "the '" + c.getProject().getName() + "' project")%> (<%=bean.helpLink%>)</td>
@@ -83,7 +99,7 @@
     <td><input type="text" name="systemDescription" size="50" value="<%= h(laf.getDescription()) %>"></td>
 </tr>
 <tr>
-    <td class="labkey-form-label">Header short name (appears in every page header and in emails)</td>
+    <td class="labkey-form-label">Header short name (appears in every page header and in emails)<%=helpPopup("Header short name", shortNameHelp, true, 350)%></td>
     <td><input type="text" name="systemShortName" size="50" value="<%= h(laf.getUnsubstitutedShortName()) %>"></td>
 </tr>
 <tr>

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -590,7 +590,7 @@ public class QueryController extends SpringActionController
 
                 sb.append(status);
                 sb.append("</td><td>");
-                sb.append(PageFlowUtil.filter(scope.getURL()));
+                sb.append(PageFlowUtil.filter(scope.getDatabaseUrl()));
                 sb.append("</td><td>");
                 sb.append(PageFlowUtil.filter(scope.getDatabaseName()));
                 sb.append("</td><td>");
@@ -1549,7 +1549,7 @@ public class QueryController extends SpringActionController
 
             sb.append("<tr><td class=\"labkey-form-label\">Scope</td><td>").append(_scope.getDisplayName()).append("</td></tr>\n");
             sb.append("<tr><td class=\"labkey-form-label\">Dialect</td><td>").append(_scope.getSqlDialect().getClass().getSimpleName()).append("</td></tr>\n");
-            sb.append("<tr><td class=\"labkey-form-label\">URL</td><td>").append(_scope.getURL()).append("</td></tr>\n");
+            sb.append("<tr><td class=\"labkey-form-label\">URL</td><td>").append(_scope.getDatabaseUrl()).append("</td></tr>\n");
             sb.append("</table>\n");
 
             out.print(sb);


### PR DESCRIPTION
#### Rationale
The ability to substitute key server properties, like primary database name & product name, LabKey release version, etc., into the short name displayed at the top of every page could be handy for development & test deployments.

For example, setting this as the short name:

`LabKey ${releaseVersion} running on ${databaseProductName}:${databaseName}`

Results in a header caption like:

`LabKey 21.12-SNAPSHOT running on PostgreSQL:labkey22.3`

#### Related Pull Requests
* https://github.com/LabKey/premium/pull/291

#### Changes
* Switch nearly all `AdminBean` properties to static, since they never change
* Create map of properties and values; substitute it into short name
* Lil bit o' caching
