### PR TITLE
Item 9587: Remove FM Biologics experimental flag

### DIFF
--- a/api/src/org/labkey/api/inventory/InventoryService.java
+++ b/api/src/org/labkey/api/inventory/InventoryService.java
@@ -59,8 +59,6 @@ public interface InventoryService
             "StorageComment"
     );
 
-    String EXPERIMENTAL_FM_BIOLOGICS = "experimental-freezermanager-biologics";
-
     static void setInstance(InventoryService impl)
     {
         ServiceRegistry.get().registerService(InventoryService.class, impl);
@@ -87,9 +85,7 @@ public interface InventoryService
     static boolean isFreezerManagementEnabled(Container c)
     {
         Set<Module> moduleSet = c.getActiveModules();
-        return (moduleSet.contains(ModuleLoader.getInstance().getModule("Inventory"))
-                && (!moduleSet.contains(ModuleLoader.getInstance().getModule("Biologics"))
-                || ExperimentalFeatureService.get().isFeatureEnabled(InventoryService.EXPERIMENTAL_FM_BIOLOGICS)));
+        return moduleSet.contains(ModuleLoader.getInstance().getModule("Inventory"));
     }
 
 }


### PR DESCRIPTION
#### Rationale
FreezerManager as well as picklist functions were enabled for LKB under experimental flag. We are now ready to enable those features and remove the experimental flag.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2789
* https://github.com/LabKey/labkey-ui-components/pull/675
* https://github.com/LabKey/inventory/pull/331
* https://github.com/LabKey/sampleManagement/pull/755
* https://github.com/LabKey/biologics/pull/1064

#### Changes
* Remove check for EXPERIMENTAL_FM_BIOLOGICS