### PR TITLE
remove Dataset.canInsert()/canUpdate()/canDelete()

### DIFF
--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -321,26 +321,6 @@ public interface Dataset extends StudyEntity, StudyCachable<Dataset>
     @Deprecated
     boolean canRead(UserPrincipal user);
 
-    /**
-     * @return whether the user has permission to update the dataset
-     * @deprecated use DatasetTableImpl.hasPermission()
-     */
-    @Deprecated
-    boolean canUpdate(UserPrincipal user);
-
-    /**
-     * @return whether the user has permission to delete from the dataset
-     * @deprecated use DatasetTableImpl.hasPermission()
-     */
-    @Deprecated
-    boolean canDelete(UserPrincipal user);
-
-    /**
-     * @return whether the user has permission to insert rows into the dataset
-     * @deprecated use DatasetTableImpl.hasPermission()
-     */
-    @Deprecated
-    boolean canInsert(UserPrincipal user);
 
     /**
      * @return whether the user has permission to delete the entire dataset. Use canWrite() to check if user can delete

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -3789,6 +3789,8 @@ public class ExperimentServiceImpl implements ExperimentService
         if (selectedRunIds.isEmpty())
             return;
 
+        UserSchema schema = QueryService.get().getUserSchema(user, container, "study");
+
         for (Integer runId : selectedRunIds)
         {
             try (DbScope.Transaction transaction = ensureTransaction())
@@ -3813,12 +3815,11 @@ public class ExperimentServiceImpl implements ExperimentService
 
                             for (Dataset dataset : publishService.getDatasetsForAssayRuns(Collections.singletonList(run), user))
                             {
-                                if (!dataset.canDelete(user))
+                                TableInfo tableInfo = schema.getTable(dataset.getName());
+                                if (null == tableInfo || !dataset.hasPermission(user, DeletePermission.class))
                                 {
                                     throw new UnauthorizedException("Cannot delete rows from dataset " + dataset);
                                 }
-                                UserSchema schema = QueryService.get().getUserSchema(user, dataset.getContainer(), "study");
-                                TableInfo tableInfo = schema.getTable(dataset.getName());
 
                                 AssayProvider provider = AssayService.get().getProvider(protocol);
                                 if (provider != null)

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -2954,7 +2954,8 @@ public class ExperimentController extends SpringActionController
                 for (Dataset dataset : StudyPublishService.get().getDatasetsForAssayRuns(runs, getUser()))
                 {
                     ActionURL url = urlProvider(StudyUrls.class).getDatasetURL(dataset.getContainer(), dataset.getDatasetId());
-                    if (dataset.canDelete(getUser()))
+                    TableInfo t = dataset.getTableInfo(getUser());
+                    if (null != t && t.hasPermission(getUser(),DeletePermission.class))
                     {
                         permissionDatasetRows.add(new Pair<>(dataset, url));
                     }

--- a/specimen/src/org/labkey/specimen/actions/SpecimenController.java
+++ b/specimen/src/org/labkey/specimen/actions/SpecimenController.java
@@ -52,6 +52,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.ValidEmail;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.specimen.AmbiguousLocationException;
 import org.labkey.api.specimen.RequestEventType;
 import org.labkey.api.specimen.RequestedSpecimens;
@@ -459,7 +460,7 @@ public class SpecimenController extends SpringActionController
                 if (participantCommentDatasetId != null && participantCommentDatasetId != -1)
                 {
                     Dataset ds = StudyService.get().getDataset(study.getContainer(), participantCommentDatasetId);
-                    if (ds != null && ds.canUpdate(getUser()))
+                    if (ds != null && ds.getTableInfo(getUser()).hasPermission(getUser(), UpdatePermission.class))
                     {
                         if (addSep)
                         {
@@ -477,7 +478,8 @@ public class SpecimenController extends SpringActionController
                 if (participantVisitCommentDatasetId != null && participantVisitCommentDatasetId != -1)
                 {
                     Dataset ds = StudyService.get().getDataset(study.getContainer(), participantVisitCommentDatasetId);
-                    if (ds != null && ds.canUpdate(getUser()))
+                    TableInfo table = null==ds ? null : ds.getTableInfo(getUser());
+                    if (null != table && table.hasPermission(getUser(), UpdatePermission.class))
                     {
                         if (addSep)
                         {

--- a/specimen/src/org/labkey/specimen/view/updateComments.jsp
+++ b/specimen/src/org/labkey/specimen/view/updateComments.jsp
@@ -34,6 +34,8 @@
 <%@ page import="org.labkey.specimen.actions.SpecimenController.UpdateCommentsAction" %>
 <%@ page import="org.labkey.specimen.actions.UpdateSpecimenCommentsBean" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="org.labkey.api.data.TableInfo" %>
+<%@ page import="org.labkey.api.security.permissions.UpdatePermission" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
@@ -160,13 +162,15 @@
         if (hasParticipantMenu)
         {
             Dataset ds = StudyService.get().getDataset(study.getContainer(), participantCommentDatasetId);
-            hasParticipantMenu = ds != null && ds.canUpdate(user);
+            TableInfo t = null==ds ? null : ds.getTableInfo(user);
+            hasParticipantMenu = t != null && t.hasPermission(user, UpdatePermission.class);
         }
 
         if (hasParticipantVisitMenu)
         {
             Dataset ds = StudyService.get().getDataset(study.getContainer(), participantVisitCommentDatasetId);
-            hasParticipantVisitMenu = ds != null && ds.canUpdate(user);
+            TableInfo t = null==ds ? null : ds.getTableInfo(user);
+            hasParticipantVisitMenu = t != null && t.hasPermission(user, UpdatePermission.class);
         }
 
         if (hasParticipantMenu || hasParticipantVisitMenu)

--- a/study/src/org/labkey/study/assay/ExperimentListenerImpl.java
+++ b/study/src/org/labkey/study/assay/ExperimentListenerImpl.java
@@ -32,6 +32,7 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.publish.StudyPublishService;
 import org.labkey.api.view.UnauthorizedException;
@@ -75,7 +76,8 @@ public class ExperimentListenerImpl implements ExperimentListener
             {
                 for (Dataset dataset: StudyPublishService.get().getDatasetsForPublishSource(sampleType.getRowId(), Dataset.PublishSource.SampleType))
                 {
-                    if (!dataset.canDelete(user))
+                    TableInfo t = dataset.getTableInfo(user);
+                    if (null == t || !t.hasPermission(user, DeletePermission.class))
                     {
                         throw new UnauthorizedException("Cannot delete rows from dataset " + dataset);
                     }

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -2427,6 +2427,7 @@ public class StudyController extends BaseStudyController
         private ImportDatasetForm _form = null;
         private StudyImpl _study = null;
         private DatasetDefinition _def = null;
+        private TableInfo _table = null;
 
         @Override
         protected void initRequest(ImportDatasetForm form) throws ServletException
@@ -2447,27 +2448,28 @@ public class StudyController extends BaseStudyController
             if (null == _def.getTypeURI())
                 return;
 
+
             User user = getUser();
             // Go through normal getTable() codepath to be sure all metadata is applied
-            TableInfo t = StudyQuerySchema.createSchema(_study, user).getTable(_def.getName(), null);
-            if (t == null)
+            _table = StudyQuerySchema.createSchema(_study, user).getDatasetTable(_def, null);
+            if (_table == null)
                 throw new NotFoundException("Dataset not found");
-            setTarget(t);
+            setTarget(_table);
 
-            if (!t.hasPermission(user, InsertPermission.class) && getUser().isGuest())
+            if (!_table.hasPermission(user, InsertPermission.class) && getUser().isGuest())
                 throw new UnauthorizedException();
         }
 
         @Override
         protected boolean canInsert(User user)
         {
-            return _def.canInsert(user);
+            return _table.hasPermission(user, InsertPermission.class);
         }
 
         @Override
         protected boolean canUpdate(User user)
         {
-            return _def.canUpdate(user);
+            return _table.hasPermission(user, UpdatePermission.class);
         }
 
         @Override
@@ -2988,11 +2990,14 @@ public class StudyController extends BaseStudyController
         {
             int datasetId = form.getDatasetId();
             StudyImpl study = getStudyThrowIfNull();
+            StudyQuerySchema schema = StudyQuerySchema.createSchema(study, getUser());
             DatasetDefinition dataset = StudyManager.getInstance().getDatasetDefinition(study, datasetId);
-            if (null == dataset)
+            TableInfo datasetTable = null==dataset ? null : schema.getDatasetTable(dataset, null);
+
+            if (null == dataset || null == datasetTable)
                 throw new NotFoundException();
 
-            if (!dataset.canDelete(getUser()))
+            if (!datasetTable.hasPermission(getUser(), DeletePermission.class))
                 throw new UnauthorizedException("User does not have permission to delete rows from this dataset");
 
             // Operate on each individually for audit logging purposes, but transact the whole thing
@@ -3004,9 +3009,6 @@ public class StudyController extends BaseStudyController
                 List<Map<String, Object>> keys = new ArrayList<>(lsids.size());
                 for (String lsid : lsids)
                     keys.add(Collections.singletonMap("lsid", lsid));
-
-                StudyQuerySchema schema = StudyQuerySchema.createSchema(study, getUser());
-                TableInfo datasetTable = schema.getDatasetTable(dataset, null);
 
                 QueryUpdateService qus = datasetTable.getUpdateService();
                 assert qus != null;

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1051,26 +1051,6 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
         return hasPermission(user, ReadPermission.class, null);
     }
 
-    @Override
-    @Deprecated
-    public boolean canUpdate(UserPrincipal user)
-    {
-        return hasPermission(user, UpdatePermission.class, null);
-    }
-
-    @Override
-    @Deprecated
-    public boolean canDelete(UserPrincipal user)
-    {
-        return hasPermission(user, DeletePermission.class, null);
-    }
-
-    @Override
-    @Deprecated
-    public boolean canInsert(UserPrincipal user)
-    {
-        return hasPermission(user, InsertPermission.class, null);
-    }
 
     @Override
     public boolean canDeleteDefinition(UserPrincipal user)

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -54,9 +54,11 @@ import org.labkey.api.reports.report.QueryReport;
 import org.labkey.api.reports.report.ReportUrls;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.QCAnalystPermission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.specimen.SpecimenManager;
 import org.labkey.api.specimen.SpecimenMigrationService;
 import org.labkey.api.study.CohortFilter;
@@ -136,7 +138,8 @@ public class DatasetQueryView extends StudyQueryView
         _showSourceLinks = settings.isShowSourceLinks();
 
         // Only show link to edit if permission allows it
-        setShowUpdateColumn(settings.isShowEditLinks() && !isExportView() && _dataset.canUpdate(getUser()));
+        var table = getTable();
+        setShowUpdateColumn(settings.isShowEditLinks() && !isExportView() && null != table && table.hasPermission(getUser(), UpdatePermission.class));
 
         if (form.getVisitRowId() != 0)
         {
@@ -405,8 +408,9 @@ public class DatasetQueryView extends StudyQueryView
         }
 
         User user = getUser();
-        boolean canInsert = _dataset.canInsert(user);
-        boolean canDelete = _dataset.canDelete(user);
+        var table = getTable();
+        boolean canInsert = null != table && table.hasPermission(user, InsertPermission.class);
+        boolean canDelete = null != table && table.hasPermission(user, DeletePermission.class);
         boolean canManage = user.hasRootAdminPermission() || _dataset.getContainer().hasPermission(user, AdminPermission.class);
         boolean isSnapshot = QueryService.get().isQuerySnapshot(getContainer(), StudySchema.getInstance().getSchemaName(), _dataset.getName());
         ExpObject publishSource = _dataset.resolvePublishSource();

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -63,6 +63,7 @@ import org.labkey.api.query.UserIdQueryForeignKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.RestrictedReadPermission;
@@ -940,7 +941,7 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
     {
         User user = _userSchema.getUser();
         Dataset def = getDatasetDefinition();
-        if (!user.hasRootAdminPermission() && !def.canInsert(user))
+        if (!user.hasRootAdminPermission() && !hasPermission(user, InsertPermission.class))
             return null;
         return new DatasetUpdateService(this);
     }

--- a/study/src/org/labkey/study/view/datasetDetails.jsp
+++ b/study/src/org/labkey/study/view/datasetDetails.jsp
@@ -47,6 +47,8 @@
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Set" %>
 <%@ page import="static org.labkey.study.model.DatasetDomainKindProperties.TIME_KEY_FIELD_DISPLAY" %>
+<%@ page import="org.labkey.api.data.TableInfo" %>
+<%@ page import="org.labkey.api.security.permissions.DeletePermission" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -63,8 +65,9 @@
     Container c = getContainer();
     User user = getUser();
 
-    String queryName = dataset.getTableInfo(user).getName();
-    String schemaName = dataset.getTableInfo(user).getSchema().getQuerySchemaName();
+    TableInfo datasetTable = dataset.getTableInfo(user);
+    String queryName = datasetTable.getName();
+    String schemaName = datasetTable.getSchema().getQuerySchemaName();
 
     StudyImpl study = StudyManager.getInstance().getStudy(c);
     Set<Class<? extends Permission>> permissions = SecurityManager.getPermissions(c.getPolicy(), user, Set.of());
@@ -122,7 +125,7 @@ if (permissions.contains(AdminPermission.class))
             .href(deleteDatasetURL)
             .usePost("Are you sure you want to delete this dataset? All related data and visitmap entries will also be deleted."));
     }
-    if (user.hasRootAdminPermission() || dataset.canDelete(user))
+    if (user.hasRootAdminPermission() || datasetTable.hasPermission(user, DeletePermission.class))
     {
         buttons.add(button("Delete All Rows").onClick("truncateTable();"));
     }

--- a/study/src/org/labkey/study/view/participantCharacteristics.jsp
+++ b/study/src/org/labkey/study/view/participantCharacteristics.jsp
@@ -47,6 +47,7 @@
 <%@ page import="org.labkey.study.model.StudyImpl" %>
 <%@ page import="org.labkey.api.security.permissions.ReadPermission" %>
 <%@ page import="org.labkey.api.security.permissions.UpdatePermission" %>
+<%@ page import="org.labkey.api.security.permissions.InsertPermission" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     ViewContext context = getViewContext();
@@ -145,7 +146,7 @@
 
         if (datasetRow == null)
         {
-            if (dataset.canInsert(user))
+            if (datasetTable.hasPermission(user, InsertPermission.class))
             {
                 ActionURL addAction = new ActionURL(DatasetController.InsertAction.class, getContainer());
                 addAction.addParameter("datasetId", datasetId);


### PR DESCRIPTION
#### Rationale
Remove DatasetDefinition.canInsert(), canUpdate, and canDelete() to help ensure consistency in permission checking.  Use DataswetTableImpl.hasPermission() instead.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
