### PR TITLE
Fix sample status import when sample type has required and MV fields

### DIFF
--- a/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
@@ -98,7 +98,7 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
 
     /*
      * This is a way to indicate that SDIB should ignore the required constraint on a column.
-     * This can be used if the required column will provided by a later step in the DI.
+     * This can be used if the required column will be provided by a later step in the DI.
      */
     public void addDoNotRequireColumn(String name)
     {

--- a/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
@@ -67,9 +67,7 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
     boolean _builtInColumns = true;
     boolean _validate = true;
 
-
-
-    public static StandardDataIteratorBuilder forInsert(TableInfo target, @NotNull DataIteratorBuilder in, @Nullable Container c, @NotNull User user, DataIteratorContext unused)
+    public static StandardDataIteratorBuilder forInsert(TableInfo target, @NotNull DataIteratorBuilder in, @Nullable Container c, @NotNull User user, DataIteratorContext context)
     {
         return new StandardDataIteratorBuilder(target, in, c, user);
     }
@@ -239,7 +237,7 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
         //
         // check for unbound columns that are required
         //
-        if (_validate)
+        if (_validate && !context.getConfigParameterBoolean(QueryUpdateService.ConfigParameters.SkipRequiredFieldValidation))
         {
             for (TranslateHelper pair : unusedCols.values())
             {

--- a/api/src/org/labkey/api/query/QueryUpdateService.java
+++ b/api/src/org/labkey/api/query/QueryUpdateService.java
@@ -92,7 +92,8 @@ public interface QueryUpdateService extends HasPermission
         PreserveEmptyString, // (Bool) When source field is an empty string, insert it instead of replacing with null
         // used by Dataspace currently
         TargetMultipleContainers,    // (Bool) allow multi container import
-        SkipTriggers        // (Bool) skip setup and firing of trigger scripts
+        SkipTriggers,         // (Bool) skip setup and firing of trigger scripts
+        SkipRequiredFieldValidation        // (Bool) skip validation of required fields, used during import when the import of data happens in two hitches (e.g., samples in one file and sample statuses in a second)
     }
 
 

--- a/experiment/src/org/labkey/experiment/samples/SampleStatusFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleStatusFolderImporter.java
@@ -6,8 +6,6 @@ import org.labkey.api.admin.FolderImporter;
 import org.labkey.api.admin.FolderImporterFactory;
 import org.labkey.api.admin.ImportContext;
 import org.labkey.api.data.DbScope;
-import org.labkey.api.exp.CompressedInputStreamXarSource;
-import org.labkey.api.exp.XarSource;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.pipeline.PipelineJob;
@@ -15,7 +13,6 @@ import org.labkey.api.util.FileUtil;
 import org.labkey.api.writer.VirtualFile;
 import org.labkey.experiment.XarReader;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -83,7 +80,7 @@ public class SampleStatusFolderImporter extends SampleTypeAndDataClassFolderImpo
                     XarReader typesReader = getXarReader(job, ctx, root, typesXarFile);
 
                     // process any sample status data files
-                    importTsvData(ctx, SamplesSchema.SCHEMA_NAME, typesReader.getSampleTypeNames(), sampleStatusDataFiles, xarDir, false);
+                    importTsvData(ctx, SamplesSchema.SCHEMA_NAME, typesReader.getSampleTypeNames(), sampleStatusDataFiles, xarDir, false, true);
                 }
                 else
                     log.info("No sample types XAR file to process.");

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
@@ -301,22 +301,12 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
     {
         List<ColumnInfo> columns = new ArrayList<>();
 
-        // Need to include all required fields and their missing-value indicators
-        tinfo.getColumns().stream().filter(colInfo -> colInfo.isRequired() && colInfo.isUserEditable() && !colInfo.isHidden() && !colInfo.isReadOnly() ).forEach(required -> {
-            MutableColumnInfo wCol = WrappedColumnInfo.wrap(required);
-            wCol.setDisplayColumnFactory(ExportDataColumn::new);
-            columns.add(wCol);
-
-            // If the column is MV enabled, export the data in the indicator column as well
-            if (required.isMvEnabled())
-            {
-                ColumnInfo mvIndicator = tinfo.getColumn(required.getMvColumnName());
-                if (null == mvIndicator)
-                    ExceptionUtil.logExceptionToMothership(null, new IllegalStateException("MV indicator column not found: " + tinfo.getName() + "|" + required.getMvColumnName()));
-                else
-                    columns.add(mvIndicator);
-            }
-        });
+        // Name
+        FieldKey nameFieldKey = FieldKey.fromParts(ExpMaterialTable.Column.Name.name());
+        ColumnInfo col = tinfo.getColumn(nameFieldKey);
+        MutableColumnInfo wrappedCol = WrappedColumnInfo.wrap(col);
+        wrappedCol.setDisplayColumnFactory(ExportDataColumn::new);
+        columns.add(wrappedCol);
 
         // SampleState
         // substitute the Label value for the RowId lookup value


### PR DESCRIPTION
#### Rationale
During a folder import, the sample TSV files are imported use the MERGE option for insert.  Normally, this means that we check for the presence of required fields and the missing value indicators, if applicable.  We've recently split the sample type import into two files, one containing just the fields needed for adding status to the samples after all other data in the import has been registered.  We do not need to check for the required fields in this second TSV file, so we add a new data iterator config parameter to allow us to skip those checks.

#### Related Pull Requests
* #2760 

#### Changes
* Indicate that checks for required fields should be skipped during status TSV import.
