### PR TITLE
44132: Export List Archive button bug

### DIFF
--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -962,7 +962,7 @@ public class ListController extends SpringActionController
         @Override
         public void export(ListDefinitionForm form, HttpServletResponse response, BindException errors) throws Exception
         {
-            Set<String> listIDs = DataRegionSelection.getSelected(form.getViewContext(), true);
+            Set<String> listIDs = DataRegionSelection.getSelected(form.getViewContext(), false);
             Integer[] IDs = new Integer[listIDs.size()];
             int i = 0;
             for(String s : listIDs)


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44132

#### Changes
- We don't want to clear the data region selection from the `ExportListArchiveAction` because we never refresh the view after the export so the data region things there are no selections even though the UI still shows the original selection, hence the mismatch.