### PR TITLE
Issue 44307: ReplacedByRun not getting set in folder export/import

### DIFF
--- a/api/schemas/expTypes.xsd
+++ b/api/schemas/expTypes.xsd
@@ -97,6 +97,11 @@
             <xs:element name="ExperimentLSID" type="string" minOccurs="0" maxOccurs="1" />
 			<xs:element name="Properties" type="exp:PropertyCollectionType" minOccurs="0"/>
             <xs:element name="WorkflowTaskLSID" type="string" minOccurs="0" maxOccurs="1" />
+            <xs:element name="ReplacedByRunLSID" type="string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reference to another run that defines an updated version of this data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="ExperimentLog" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence>

--- a/experiment/src/org/labkey/experiment/XarExporter.java
+++ b/experiment/src/org/labkey/experiment/XarExporter.java
@@ -264,6 +264,12 @@ public class XarExporter
 
         addProtocol(protocol, true);
 
+        ExpRun replacedByRun = run.getReplacedByRun();
+        if (replacedByRun != null)
+        {
+            xRun.setReplacedByRunLSID(_relativizedLSIDs.relativize(replacedByRun.getLSID()));
+        }
+
         Set<Map.Entry<ExpData, String>> inputData = run.getDataInputs().entrySet();
         ExperimentArchiveType.StartingInputDefinitions inputDefs = _archive.getStartingInputDefinitions();
         if (inputData.size() > 0 && inputDefs == null)


### PR DESCRIPTION
#### Rationale
We want to include run versioning info in the export/import process

#### Changes
* Include replacement info in XAR schema
* Write during export
* Retain during import and resolve references when possible after all runs have been created