### PR TITLE
Avoid 'AccessDeniedException' importing folder on Windows

### DIFF
--- a/api/src/org/labkey/api/pipeline/PipelineService.java
+++ b/api/src/org/labkey/api/pipeline/PipelineService.java
@@ -51,9 +51,9 @@ import java.util.Map;
 public interface PipelineService extends PipelineStatusFile.StatusReader, PipelineStatusFile.StatusWriter
 {
     String MODULE_NAME = "Pipeline";
-    String UNZIP_DIR = "unzip";
+    String UNZIP_DIR = ".unzip"; // '.' prefix prevents search indexing
     String EXPORT_DIR = "export";
-    String CACHE_DIR = "cache";
+    String CACHE_DIR = ".cache";
 
     String PRIMARY_ROOT = "PRIMARY";
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -4693,46 +4693,7 @@ public class AdminController extends SpringActionController
             try
             {
                 Path pipelineUnzipFile = pipelineUnzipDir.resolve(zipFile.getOriginalFilename());
-
-                if (Files.exists(pipelineUnzipDir))
-                {
-                    errors.reject("folderImport", "Pipeline import directory already exists.");
-                    return null;
-                }
-
-                if (!Files.isDirectory(pipelineUnzipDir.getParent()))
-                {
-                    errors.reject("folderImport", "Pipeline root is not a directory.");
-                    return null;
-                }
-                if (!Files.isWritable(pipelineUnzipDir.getParent()))
-                {
-                    errors.reject("folderImport", "Pipeline root is not writable.");
-                    return null;
-                }
-
-                IOException lastException = null;
-
-                // Directory creation sometimes fails on Windows. Retry for a couple of seconds.
-                for (int i = 0; i < 20; i++)
-                {
-                    try
-                    {
-                        Files.createDirectories(pipelineUnzipDir);
-                        lastException = null; // clear last exception
-                        break;
-                    }
-                    catch (IOException e)
-                    {
-                        lastException = e;
-                        LOG.warn("Failed to create pipeline import directory. Sleep and try to delete again. " + e.getMessage());
-                        try {Thread.sleep(500);} catch (InterruptedException x) {/* pass */}
-                    }
-                }
-                if (lastException != null)
-                {
-                    throw lastException;
-                }
+                Files.createDirectories(pipelineUnzipFile.getParent()); // Non-pipeline import sometimes fails here on Windows (shrug)
                 Files.createFile(pipelineUnzipFile);
                 try (OutputStream os = Files.newOutputStream(pipelineUnzipFile))
                 {

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -4714,7 +4714,7 @@ public class AdminController extends SpringActionController
                 IOException lastException = null;
 
                 // Directory creation sometimes fails on Windows. Retry for a couple of seconds.
-                for (int i = 0; i < 4; i++)
+                for (int i = 0; i < 20; i++)
                 {
                     try
                     {

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -4694,6 +4694,23 @@ public class AdminController extends SpringActionController
             {
                 Path pipelineUnzipFile = pipelineUnzipDir.resolve(zipFile.getOriginalFilename());
 
+                if (Files.exists(pipelineUnzipDir))
+                {
+                    errors.reject("folderImport", "Pipeline import directory already exists.");
+                    return null;
+                }
+
+                if (!Files.isDirectory(pipelineUnzipDir.getParent()))
+                {
+                    errors.reject("folderImport", "Pipeline root is not a directory.");
+                    return null;
+                }
+                if (!Files.isWritable(pipelineUnzipDir.getParent()))
+                {
+                    errors.reject("folderImport", "Pipeline root is not writable.");
+                    return null;
+                }
+
                 IOException lastException = null;
 
                 // Directory creation sometimes fails on Windows. Retry for a couple of seconds.
@@ -4701,7 +4718,7 @@ public class AdminController extends SpringActionController
                 {
                     try
                     {
-                        Files.createDirectories(pipelineUnzipFile.getParent());
+                        Files.createDirectories(pipelineUnzipDir);
                         lastException = null; // clear last exception
                         break;
                     }

--- a/study/test/src/org/labkey/test/tests/study/StudyCheckForReloadTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyCheckForReloadTest.java
@@ -44,9 +44,9 @@ public class StudyCheckForReloadTest extends StudyBaseTest
     @LogMethod
     protected void doVerifySteps() throws IOException
     {
-        log("Copy files from \"unzip\" folder into parent folder");
+        log("Copy files from \".unzip\" folder into parent folder");
         File fileRoot = TestFileUtils.getDefaultFileRoot(getProjectName() + "/" + getFolderName());
-        File unzipDir = new File(fileRoot, "unzip");
+        File unzipDir = new File(fileRoot, ".unzip");
         FileUtils.copyDirectory(unzipDir, fileRoot);
 
         log("Create studyload.txt file");

--- a/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
@@ -32,7 +32,6 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.TestFileUtils;
-import org.labkey.test.categories.BVT;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Study;
 import org.labkey.test.pages.StartImportPage;
@@ -57,7 +56,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Category({Daily.class, Study.class, BVT.class}) // TODO: remove BVT
+@Category({Daily.class, Study.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class StudyVisitManagementTest extends BaseWebDriverTest
 {
@@ -95,7 +94,7 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
     }
 
     @Test
-    public void testDeleteMultipleVisits() throws Exception
+    public void testDeleteMultipleVisits()
     {
         _containerHelper.createSubfolder(getProjectName(), "testDeleteMultipleVisits");
         importFolderArchiveWithFailureFlag(INITIAL_FOLDER_ARCHIVE, true, 1, false);
@@ -169,20 +168,20 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
     }
 
     @Test
-    public void testFailForUndefinedVisitsSpecimen() throws Exception
+    public void testFailForUndefinedVisitsSpecimen()
     {
         _containerHelper.createSubfolder(getProjectName(), "testFailForUndefinedVisitsSpecimen");
         testFailForUndefinedVisits(SPECIMENS_ONLY_FOLDER_ARCHIVE, SPECIMEN_UNDEFINED_VISIT_MSG, 3);
     }
 
     @Test
-    public void testFailForUndefinedVisitsDataset() throws Exception
+    public void testFailForUndefinedVisitsDataset()
     {
         _containerHelper.createSubfolder(getProjectName(), "testFailForUndefinedVisitsDataset");
         testFailForUndefinedVisits(DATASETS_ONLY_FOLDER_ARCHIVE, DATASET_UNDEFINED_VISIT_MSG, 11);
     }
 
-    private void testFailForUndefinedVisits(File archive, String errorMsgPrefix, int numExpectedErrors) throws IOException
+    private void testFailForUndefinedVisits(File archive, String errorMsgPrefix, int numExpectedErrors)
     {
         // first try importing the datasets only archive, expecting this to give an error
         importFolderArchiveWithFailureFlag(archive, true, 1, true);
@@ -315,7 +314,7 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
         }
     }
 
-    private void importFolderArchiveWithFailureFlag(File archive, boolean failForUndefinedVisits, int expectedCompleted, boolean expectedError) throws IOException
+    private void importFolderArchiveWithFailureFlag(File archive, boolean failForUndefinedVisits, int expectedCompleted, boolean expectedError)
     {
         goToModule("FileContent");
         _fileBrowserHelper.uploadFile(archive, null, null, _fileBrowserHelper.fileIsPresent(archive.getName()));

--- a/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
@@ -33,6 +33,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.TestFileUtils;
+import org.labkey.test.categories.BVT;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Study;
 import org.labkey.test.pages.StartImportPage;
@@ -59,7 +60,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Category({Daily.class, Study.class})
+@Category({Daily.class, Study.class, BVT.class}) // TODO: remove BVT
 @BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class StudyVisitManagementTest extends BaseWebDriverTest
 {

--- a/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
@@ -36,11 +36,13 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Study;
 import org.labkey.test.pages.StartImportPage;
+import org.labkey.test.pages.core.admin.logger.ManagerPage;
 import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.labkey.test.pages.query.ExecuteQueryPage;
 import org.labkey.test.pages.study.DeleteMultipleVisitsPage;
 import org.labkey.test.pages.study.ManageVisitPage;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.Log4jUtils;
 import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.core.webdav.WebDavUploadHelper;
 import org.labkey.test.util.core.webdav.WebDavUrlFactory;
@@ -75,6 +77,8 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
     {
         StudyVisitManagementTest init = (StudyVisitManagementTest) getCurrentTest();
         init.doSetup();
+        Log4jUtils.setLogLevel("org.labkey.core.admin.AdminController", ManagerPage.LoggingLevel.DEBUG);
+        Log4jUtils.setLogLevel("org.labkey.search", ManagerPage.LoggingLevel.DEBUG);
     }
 
     private void doSetup()
@@ -315,7 +319,7 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
         // Delete temporary folder to avoid 'AccessDeniedException' trying to unzip folder archive on Windows
         final Sardine webDav = WebDavUtils.beginSardine(PasswordUtil.getUsername());
         final WebDavUrlFactory urlFactory = WebDavUrlFactory.webDavUrlFactory(getCurrentContainerPath());
-        final String unzipFolder = urlFactory.getPath("unzip");
+        final String unzipFolder = urlFactory.getPath(".unzip");
         if(webDav.exists(unzipFolder))
         {
             webDav.delete(unzipFolder);

--- a/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.test.tests.study;
 
-import com.github.sardine.Sardine;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
@@ -44,10 +43,7 @@ import org.labkey.test.pages.study.DeleteMultipleVisitsPage;
 import org.labkey.test.pages.study.ManageVisitPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Log4jUtils;
-import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.core.webdav.WebDavUploadHelper;
-import org.labkey.test.util.core.webdav.WebDavUrlFactory;
-import org.labkey.test.util.core.webdav.WebDavUtils;
 import org.labkey.test.util.search.SearchAdminAPIHelper;
 
 import java.io.File;
@@ -321,16 +317,11 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
 
     private void importFolderArchiveWithFailureFlag(File archive, boolean failForUndefinedVisits, int expectedCompleted, boolean expectedError) throws IOException
     {
-        // Delete temporary folder to avoid 'AccessDeniedException' trying to unzip folder archive on Windows
-        final Sardine webDav = WebDavUtils.beginSardine(PasswordUtil.getUsername());
-        final WebDavUrlFactory urlFactory = WebDavUrlFactory.webDavUrlFactory(getCurrentContainerPath());
-        final String unzipFolder = urlFactory.getPath(".unzip");
-        if(webDav.exists(unzipFolder))
-        {
-            webDav.delete(unzipFolder);
-        }
-        SearchAdminAPIHelper.waitForIndexer();
-        StartImportPage importPage = StartImportPage.startImportFromFile(this, archive, false);
+        goToModule("FileContent");
+        _fileBrowserHelper.uploadFile(archive, null, null, _fileBrowserHelper.fileIsPresent(archive.getName()));
+        _fileBrowserHelper.importFile(archive.getName(), "Import Folder");
+
+        StartImportPage importPage = new StartImportPage(getDriver());
         importPage.setFailForUndefinedVisitsCheckBox(failForUndefinedVisits);
         importPage.clickStartImport();
         waitForElement(Locators.bodyTitle("Data Pipeline"));

--- a/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
@@ -35,15 +35,12 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.categories.Study;
 import org.labkey.test.pages.StartImportPage;
-import org.labkey.test.pages.core.admin.logger.ManagerPage;
 import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.labkey.test.pages.query.ExecuteQueryPage;
 import org.labkey.test.pages.study.DeleteMultipleVisitsPage;
 import org.labkey.test.pages.study.ManageVisitPage;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.Log4jUtils;
 import org.labkey.test.util.core.webdav.WebDavUploadHelper;
-import org.labkey.test.util.search.SearchAdminAPIHelper;
 
 import java.io.File;
 import java.io.IOException;
@@ -78,11 +75,6 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
 
     private void doSetup()
     {
-        Log4jUtils.setLogLevel("org.labkey.core.admin.AdminController", ManagerPage.LoggingLevel.DEBUG);
-        Log4jUtils.setLogLevel("org.labkey.search", ManagerPage.LoggingLevel.DEBUG);
-        SearchAdminAPIHelper.pauseCrawler(getDriver());
-        SearchAdminAPIHelper.waitForIndexerBackground();
-
         _containerHelper.createProject(getProjectName(), null);
     }
 
@@ -316,6 +308,8 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
 
     private void importFolderArchiveWithFailureFlag(File archive, boolean failForUndefinedVisits, int expectedCompleted, boolean expectedError)
     {
+        // Importing from folder management triggers sometimes triggers 'AccessDeniedException' on Windows
+        // Import from pipeline instead
         goToModule("FileContent");
         _fileBrowserHelper.uploadFile(archive, null, null, _fileBrowserHelper.fileIsPresent(archive.getName()));
         _fileBrowserHelper.importFile(archive.getName(), "Import Folder");

--- a/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
@@ -48,6 +48,7 @@ import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.core.webdav.WebDavUploadHelper;
 import org.labkey.test.util.core.webdav.WebDavUrlFactory;
 import org.labkey.test.util.core.webdav.WebDavUtils;
+import org.labkey.test.util.search.SearchAdminAPIHelper;
 
 import java.io.File;
 import java.io.IOException;
@@ -80,6 +81,7 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
         init.doSetup();
         Log4jUtils.setLogLevel("org.labkey.core.admin.AdminController", ManagerPage.LoggingLevel.DEBUG);
         Log4jUtils.setLogLevel("org.labkey.search", ManagerPage.LoggingLevel.DEBUG);
+
     }
 
     private void doSetup()
@@ -325,7 +327,7 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
         {
             webDav.delete(unzipFolder);
         }
-
+        SearchAdminAPIHelper.waitForIndexer();
         StartImportPage importPage = StartImportPage.startImportFromFile(this, archive, false);
         importPage.setFailForUndefinedVisitsCheckBox(failForUndefinedVisits);
         importPage.clickStartImport();

--- a/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java
@@ -79,13 +79,15 @@ public class StudyVisitManagementTest extends BaseWebDriverTest
     {
         StudyVisitManagementTest init = (StudyVisitManagementTest) getCurrentTest();
         init.doSetup();
-        Log4jUtils.setLogLevel("org.labkey.core.admin.AdminController", ManagerPage.LoggingLevel.DEBUG);
-        Log4jUtils.setLogLevel("org.labkey.search", ManagerPage.LoggingLevel.DEBUG);
-
     }
 
     private void doSetup()
     {
+        Log4jUtils.setLogLevel("org.labkey.core.admin.AdminController", ManagerPage.LoggingLevel.DEBUG);
+        Log4jUtils.setLogLevel("org.labkey.search", ManagerPage.LoggingLevel.DEBUG);
+        SearchAdminAPIHelper.pauseCrawler(getDriver());
+        SearchAdminAPIHelper.waitForIndexerBackground();
+
         _containerHelper.createProject(getProjectName(), null);
     }
 


### PR DESCRIPTION
#### Rationale
`StudyVisitManagementTest` fails frequently on Windows. Trying to prevent that.
```
DEBUG AdminController          2021-11-08T23:07:01,821     http-nio-8111-exec-8 : Failed to import 'StudyVisitManagement.folder.zip'.
java.nio.file.AccessDeniedException: D:\teamcity\work\2206cbdfe9ba02a3\build\deploy\files\StudyVisitManagementTest Project\testFailForUndefinedVisitsSpecimen\@files\unzip
	at sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:89) ~[?:?]
	at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103) ~[?:?]
	at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:108) ~[?:?]
	at sun.nio.fs.WindowsFileSystemProvider.createDirectory(WindowsFileSystemProvider.java:521) ~[?:?]
	at java.nio.file.Files.createDirectory(Files.java:700) ~[?:?]
	at java.nio.file.Files.createAndCheckIsDirectory(Files.java:807) ~[?:?]
	at java.nio.file.Files.createDirectories(Files.java:793) ~[?:?]
	at org.labkey.core.admin.AdminController$ImportFolderAction.getFolderFromZipArchive(AdminController.java:4696) [core-21.11-SNAPSHOT.jar:?]
	at org.labkey.core.admin.AdminController$ImportFolderAction.handlePost(AdminController.java:4628) [core-21.11-SNAPSHOT.jar:?]
	at org.labkey.core.admin.AdminController$ImportFolderAction.handlePost(AdminController.java:4549) [core-21.11-SNAPSHOT.jar:?]
	at org.labkey.api.action.FormViewAction.handleRequest(FormViewAction.java:96) [api-21.11-SNAPSHOT.jar:?]
	at org.labkey.api.view.FolderManagement$ManagementViewPostAction.handleRequest(FolderManagement.java:236) [api-21.11-SNAPSHOT.jar:?]
	at org.labkey.api.view.FolderManagement$FolderManagementViewPostAction.handleRequest(FolderManagement.java:319) [api-21.11-SNAPSHOT.jar:?]
```

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
