### PR TITLE
Pass through container when getting old and new record maps for audit logs

### DIFF
--- a/api/src/org/labkey/api/audit/AbstractAuditHandler.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditHandler.java
@@ -119,7 +119,7 @@ public abstract class AbstractAuditHandler implements AuditHandler
                             {
                                 String newRecord = AbstractAuditTypeProvider.encodeForDataMap(c, row);
                                 if (newRecord != null)
-                                    event.setNewRecordMap(newRecord);
+                                    event.setNewRecordMap(newRecord, c);
                                 break;
                             }
                             case MERGE:
@@ -128,7 +128,7 @@ public abstract class AbstractAuditHandler implements AuditHandler
                                 {
                                     String newRecord = AbstractAuditTypeProvider.encodeForDataMap(c, row);
                                     if (newRecord != null)
-                                        event.setNewRecordMap(newRecord);
+                                        event.setNewRecordMap(newRecord, c);
                                 }
                                 else
                                 {
@@ -140,7 +140,7 @@ public abstract class AbstractAuditHandler implements AuditHandler
                             {
                                 String oldRecord = AbstractAuditTypeProvider.encodeForDataMap(c, row);
                                 if (oldRecord != null)
-                                    event.setOldRecordMap(oldRecord);
+                                    event.setOldRecordMap(oldRecord, c);
                                 break;
                             }
                             case UPDATE:

--- a/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
+++ b/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
@@ -3,6 +3,7 @@ package org.labkey.api.audit;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.qc.DataState;
 import org.labkey.api.qc.DataStateManager;
@@ -214,7 +215,7 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
     {
         if (oldRecordMap != null)
         {
-            Map<String, String> row = AbstractAuditTypeProvider.decodeFromDataMap(oldRecordMap);
+            Map<String, String> row = new CaseInsensitiveHashMap<>(AbstractAuditTypeProvider.decodeFromDataMap(oldRecordMap));
             String label = getStatusLabel(row, container);
             if (label != null)
             {
@@ -234,7 +235,7 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
     {
         if (newRecordMap != null)
         {
-            Map<String, String> row = AbstractAuditTypeProvider.decodeFromDataMap(newRecordMap);
+            Map<String, String> row = new CaseInsensitiveHashMap<>(AbstractAuditTypeProvider.decodeFromDataMap(newRecordMap));
             String label = getStatusLabel(row, container);
             if (label != null)
             {


### PR DESCRIPTION
#### Rationale
In order to record the label of the sample status when creating the audit log, we need to have the container.  We also need the map we look for this value in to be case-insensitive.  Because the insert of rows does not go through the `setOldAndNewMapsForUpdate` method, the row that comes through when inserting has not had its keys lower-cased. This is strange to me, but investigating further is beyond the scope of the current PR. 

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/759

#### Changes
* Pass through container to `setNewRecordMap` and `setOldRecordMap`.
* Use CaseInsensitiveHashMap for better checking of sampleState values.
