### PR TITLE
Improve error feedback when truncating ETL tables

### DIFF
--- a/api/src/org/labkey/api/di/DataIntegrationService.java
+++ b/api/src/org/labkey/api/di/DataIntegrationService.java
@@ -5,6 +5,7 @@
 package org.labkey.api.di;
 
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
@@ -47,6 +48,8 @@ public interface DataIntegrationService
 
     void registerStepProviders();
     @Nullable Integer runTransformNow(Container c, User u, String transformId) throws PipelineJobException, NotFoundException;
+
+    boolean resetTransformState(Container c, User user, @NotNull String transformId);
 
     /** @return a pair with the total number of rows that were deleted across all tables in the ETL, and any error messages */
     Pair<Long, String> truncateTargets(Container c, User user, String transformId);

--- a/api/src/org/labkey/api/di/DataIntegrationService.java
+++ b/api/src/org/labkey/api/di/DataIntegrationService.java
@@ -16,6 +16,7 @@ import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
+import org.labkey.api.util.Pair;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.remoteapi.Connection;
 
@@ -47,7 +48,8 @@ public interface DataIntegrationService
     void registerStepProviders();
     @Nullable Integer runTransformNow(Container c, User u, String transformId) throws PipelineJobException, NotFoundException;
 
-    Map<String, String> truncateTargets(Container c, User user, String transformId);
+    /** @return a pair with the total number of rows that were deleted across all tables in the ETL, and any error messages */
+    Pair<Long, String> truncateTargets(Container c, User user, String transformId);
 
     RemoteConnection getRemoteConnection(String name, Container c, @Nullable Logger log);
 

--- a/bigiron/src/org/labkey/bigiron/oracle/OracleDialect.java
+++ b/bigiron/src/org/labkey/bigiron/oracle/OracleDialect.java
@@ -182,6 +182,29 @@ abstract class OracleDialect extends SimpleSqlDialect
         return StringUtils.join(args, " || ");
     }
 
+    @Override
+    public SQLFragment sqlLocate(SQLFragment littleString, SQLFragment bigString)
+    {
+        return new SQLFragment("instr(").append(bigString).append(", ").append(littleString).append(")");
+    }
+
+    @Override
+    public SQLFragment sqlLocate(SQLFragment littleString, SQLFragment bigString, SQLFragment startIndex)
+    {
+        return new SQLFragment("instr(").append(bigString).append(", ").append(littleString).append(", ").append(startIndex).append(")");
+    }
+
+    @Override
+    public String getSubstringFunction(String s, String start, String length)
+    {
+        return "substr(" + s + ", " + start + ", " + length + ")";
+    }
+
+    @Override
+    public SQLFragment getSubstringFunction(SQLFragment s, SQLFragment start, SQLFragment length)
+    {
+        return new SQLFragment("substr(").append(s).append(", ").append(start).append(", ").append(length).append(")");
+    }
 
     @Override
     public SQLFragment concatenate(SQLFragment... args)


### PR DESCRIPTION
#### Rationale
When truncating ETLs (or anything else), it's better to return a well-defined set of values instead of an undocumented map of String keys/values. Add reset transform state function to DataIntegrationService for call from other modules

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/269

#### Changes
* Change return type for truncation method and document its usage
* Add resetTransformState