### PR TITLE
Issue 44382: Data views throws when dataset security restricts access to any dataset

### DIFF
--- a/study/src/org/labkey/study/dataset/DatasetViewProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetViewProvider.java
@@ -109,7 +109,7 @@ public class DatasetViewProvider implements DataViewProvider
                 for (Dataset ds : study.getDatasets())
                 {
                     TableInfo t = sqs.getDatasetTable((DatasetDefinition)ds, null);
-                    if (t.hasPermission(user, ReadPermission.class))
+                    if (t != null && t.hasPermission(user, ReadPermission.class))
                     {
                         DefaultViewInfo view = new DefaultViewInfo(TYPE, ds.getEntityId(), ds.getLabel(), ds.getContainer());
 


### PR DESCRIPTION
#### Rationale
Correctly handle when user has no access to dataset at all (a null TableInfo)

#### Changes
* Check for null before checking for read permission