### PR TITLE
Issue #44384: Folder w/ Sample Type can not be used as template

### DIFF
--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -76,7 +76,8 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
 
         if (xarDir != null)
         {
-            Path xarDirPath = FileUtil.getPath(ctx.getContainer(), FileUtil.createUri(xarDir.getLocation()));
+            // #44384 Generate a relative Path object for the folder's VirtualFile
+            Path xarDirPath = Path.of(xarDir.getLocation());
             Path typesXarFile = null;
             Path runsXarFile = null;
             Map<String, String> sampleTypeDataFiles = new HashMap<>();


### PR DESCRIPTION
#### Rationale
Change to use Path objects fails to resolve the relative directory when using an existing project Sample Type folder as template
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44384

#### Changes
* Changed from using the FileUtil.getPath to Path.of --This should be safe as we are already working with a VirtualFile object
