### PR TITLE
Publishing a date-based study with compliance turned on results in an NPE

### DIFF
--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1325,7 +1325,6 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
 
         TableInfo _storage;
         TableInfo _template;
-        final PHI _maxAllowed;
 
 
         private ColumnInfo getStorageColumn(String name)
@@ -1354,7 +1353,6 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
 
             _storage = def.getStorageTableInfo();
             _template = getTemplateTableInfo();
-            _maxAllowed = ComplianceService.get().getMaxAllowedPhi(_container, user);
 
             // ParticipantId
 
@@ -1655,18 +1653,9 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
         }
 
         @Override
-        public PHI getUserMaxAllowedPhiLevel()
-        {
-            return _maxAllowed;
-        }
-
-        /**
-         * Return true if the current user is allowed the maximum phi level set across all columns.
-         */
-        @Override
         public boolean canUserAccessPhi()
         {
-            return getMaxPhiLevel().isLevelAllowed(getUserMaxAllowedPhiLevel());
+            throw new IllegalStateException("Should not be called on DatasetDefinition");
         }
 
         @Override

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1655,7 +1655,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
         @Override
         public boolean canUserAccessPhi()
         {
-            throw new IllegalStateException("Should not be called on DatasetDefinition");
+            throw new IllegalStateException("Should not be called on DatasetSchemaTableInfo");
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
Fix the NPE. `DatasetSchemaTableInfo` shouldn't be thinking about PHI. And its callers shouldn't ask it to.

[Issue 44284: Publishing a date-based study with compliance turned on results in an NPE](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44284)