### PR TITLE
Lineage columns don't return the display value for 8.3 API responses

### DIFF
--- a/experiment/src/org/labkey/experiment/api/LineageDisplayColumn.java
+++ b/experiment/src/org/labkey/experiment/api/LineageDisplayColumn.java
@@ -2,6 +2,7 @@ package org.labkey.experiment.api;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.json.JSONArray;
 import org.labkey.api.collections.ResultSetRowMapFactory;
 import org.labkey.api.data.AbstractTableInfo;
 import org.labkey.api.data.BaseColumnInfo;
@@ -186,7 +187,7 @@ public class LineageDisplayColumn extends DataColumn implements IMultiValuedDisp
     public Object getJsonValue(RenderContext ctx)
     {
         // issue: 44337. Doesn't seem to be a reason to return the object ID, even in the extended API response
-        return getJsonValues(ctx).stream().map(o -> o == null ? " " : o.toString()).collect(Collectors.joining(", "));
+        return new JSONArray(getJsonValues(ctx).stream().map(o -> o == null ? " " : o.toString()).collect(Collectors.toList()));
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/LineageDisplayColumn.java
+++ b/experiment/src/org/labkey/experiment/api/LineageDisplayColumn.java
@@ -183,6 +183,13 @@ public class LineageDisplayColumn extends DataColumn implements IMultiValuedDisp
     }
 
     @Override
+    public Object getJsonValue(RenderContext ctx)
+    {
+        // issue: 44337. Doesn't seem to be a reason to return the object ID, even in the extended API response
+        return getDisplayValue(ctx);
+    }
+
+    @Override
     public List<String> getTsvFormattedValues(RenderContext ctx)
     {
         if (null == innerDisplayColumn)

--- a/experiment/src/org/labkey/experiment/api/LineageDisplayColumn.java
+++ b/experiment/src/org/labkey/experiment/api/LineageDisplayColumn.java
@@ -186,7 +186,7 @@ public class LineageDisplayColumn extends DataColumn implements IMultiValuedDisp
     public Object getJsonValue(RenderContext ctx)
     {
         // issue: 44337. Doesn't seem to be a reason to return the object ID, even in the extended API response
-        return getDisplayValue(ctx);
+        return getJsonValues(ctx).stream().map(o -> o == null ? " " : o.toString()).collect(Collectors.joining(", "));
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44337

The R API only supports the 8.3 response format (non-extended). When the response is generated, only the display column method `getJsonValue` is called whereas both `getDisplayValue` and `getJsonValue` are called in the 9.1 response format. The lineage display columns are designed to return the `objectid` unless the display value is requested. 

I think we want to return the display value for the lineage DC by calling `getJsonValues` and joining them together if there are multiples. It does mean that the 9.1 response format will no longer return the `objectid` but it seems like that was never useful.
