### PR TITLE
Issue 44262: Fix container filter and cell display for group audit logs for proper sorting and exporting

### DIFF
--- a/api/src/org/labkey/api/audit/provider/GroupAuditProvider.java
+++ b/api/src/org/labkey/api/audit/provider/GroupAuditProvider.java
@@ -425,31 +425,5 @@ public class GroupAuditProvider extends AbstractAuditTypeProvider implements Aud
         {
             keys.add(_principalId.getFieldKey());
         }
-
-        @Override
-        public Object getDisplayValue(RenderContext ctx)
-        {
-            Integer id = (Integer)getBoundColumn().getValue(ctx);
-            if (id != null)
-            {
-                UserPrincipal p = SecurityManager.getPrincipal(id);
-                if (p == null)
-                    return null;
-
-                if (p.getPrincipalType() == PrincipalType.GROUP)
-                {
-                    Group g = SecurityManager.getGroup(id);
-
-                    return g != null ? g.getName() : null;
-                }
-                else
-                {
-                    var loggedInUser = ctx.getViewContext().getUser();
-                    User u = UserManager.getUser(id);
-                    return u != null ? u.getDisplayName(loggedInUser) : p.getName();
-                }
-            }
-            return null;
-        }
     }
 }

--- a/api/src/org/labkey/api/audit/provider/GroupAuditProvider.java
+++ b/api/src/org/labkey/api/audit/provider/GroupAuditProvider.java
@@ -376,6 +376,10 @@ public class GroupAuditProvider extends AbstractAuditTypeProvider implements Aud
                         User u = UserManager.getUser(id);
                         if (u != null)
                         {
+                            // don't display anything for the non-user "guest"
+                            if (u.isGuest())
+                                return;
+
                             String displayText = PageFlowUtil.filter(u.getDisplayName(loggedInUser));
                             ActionURL url = UserManager.getUserDetailsURL(ctx.getContainer(), loggedInUser, id);
                             if (url != null)
@@ -403,35 +407,6 @@ public class GroupAuditProvider extends AbstractAuditTypeProvider implements Aud
         public void addQueryFieldKeys(Set<FieldKey> keys)
         {
             keys.add(_principalId.getFieldKey());
-        }
-
-        // This override is needed to handle the "guest" user (not be be confused with the Guests group),
-        // which does not have a representation in the core.principals table.  We could, instead hide
-        // the "guest" display value from the Member column in renderGridCellContents, but that also
-        // seems a little odd.
-        @Override
-        public Object getDisplayValue(RenderContext ctx)
-        {
-            Integer id = (Integer)getBoundColumn().getValue(ctx);
-            if (id != null)
-            {
-                UserPrincipal p = SecurityManager.getPrincipal(id);
-                if (p != null)
-                {
-                    if (p.getPrincipalType() == PrincipalType.GROUP)
-                        return p.getName();
-                    else
-                    {
-                        var loggedInUser = ctx.getViewContext().getUser();
-                        User u = UserManager.getUser(id);
-                        if (u != null)
-                            return u.getDisplayName(loggedInUser);
-                        else
-                            return p.getName();
-                    }
-                }
-            }
-            return null;
         }
     }
 }

--- a/api/src/org/labkey/api/audit/provider/GroupAuditProvider.java
+++ b/api/src/org/labkey/api/audit/provider/GroupAuditProvider.java
@@ -26,7 +26,6 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.PropertyStorageSpec.Index;
@@ -37,8 +36,6 @@ import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.query.FilteredTable;
-import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.PrincipalIdForeignKey;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
@@ -140,7 +137,7 @@ public class GroupAuditProvider extends AbstractAuditTypeProvider implements Aud
                 if (COLUMN_NAME_GROUP.equalsIgnoreCase(col.getName()))
                 {
                     col.setLabel("Group");
-                    col.setFk(new GroupForeignKey(userSchema));
+                    col.setFk(new PrincipalIdForeignKey(userSchema));
                     col.setDisplayColumnFactory(PrincipalUserDisplayColumn::new);
                 }
                 else if (COLUMN_NAME_USER.equalsIgnoreCase(col.getName()))
@@ -319,29 +316,6 @@ public class GroupAuditProvider extends AbstractAuditTypeProvider implements Aud
         public String getKindName()
         {
             return NAME;
-        }
-    }
-
-    public static class GroupForeignKey extends LookupForeignKey
-    {
-        private final UserSchema _userSchema;
-
-        public GroupForeignKey(UserSchema userSchema)
-        {
-            super("UserId", "Name");
-            _userSchema = userSchema;
-        }
-
-        @Override
-        public TableInfo getLookupTableInfo()
-        {
-            TableInfo tinfoUsers = CoreSchema.getInstance().getTableInfoPrincipals();
-            FilteredTable<UserSchema> ret = new FilteredTable<>(tinfoUsers, _userSchema);
-            ret.setContainerFilter(ContainerFilter.EVERYTHING);
-            ret.addWrapColumn(tinfoUsers.getColumn("UserId"));
-            ret.addColumn(ret.wrapColumn("Name", tinfoUsers.getColumn("Name")));
-            ret.setTitleColumn("Name");
-            return ret;
         }
     }
 

--- a/api/src/org/labkey/api/query/PrincipalIdForeignKey.java
+++ b/api/src/org/labkey/api/query/PrincipalIdForeignKey.java
@@ -16,31 +16,13 @@
 
 package org.labkey.api.query;
 
-import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.CoreSchema;
-import org.labkey.api.data.DisplayColumn;
-import org.labkey.api.data.DisplayColumnFactory;
-import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.TableInfo;
 
 public class PrincipalIdForeignKey extends LookupForeignKey
 {
     private final UserSchema _userSchema;
-
-    static public ColumnInfo initColumn(MutableColumnInfo column)
-    {
-        column.setFk(new PrincipalIdForeignKey(column.getParentTable().getUserSchema()));
-        column.setDisplayColumnFactory(new DisplayColumnFactory()
-        {
-            @Override
-            public DisplayColumn createRenderer(ColumnInfo colInfo)
-            {
-                return new UserIdRenderer(colInfo);
-            }
-        });
-        return column;
-    }
-
 
     public PrincipalIdForeignKey(UserSchema userSchema)
     {
@@ -52,7 +34,8 @@ public class PrincipalIdForeignKey extends LookupForeignKey
     public TableInfo getLookupTableInfo()
     {
         TableInfo tinfoUsersData = CoreSchema.getInstance().getTableInfoPrincipals();
-        FilteredTable ret = new FilteredTable<>(tinfoUsersData, _userSchema);
+        FilteredTable<UserSchema> ret = new FilteredTable<>(tinfoUsersData, _userSchema);
+        ret.setContainerFilter(ContainerFilter.EVERYTHING);
         ret.addWrapColumn(tinfoUsersData.getColumn("UserId"));
         ret.addColumn(ret.wrapColumn("Name", tinfoUsersData.getColumn("Name")));
         ret.setTitleColumn("Name");

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -1388,7 +1388,8 @@ public class SecurityApiActions
 
         protected void writeToAuditLog(Group newGroup, ViewContext viewContext)
         {
-            AuditTypeEvent event = new AuditTypeEvent(GroupManager.GROUP_AUDIT_EVENT, viewContext.getContainer().getId(),"A new security group named " + newGroup.getName() + " was created." );
+            GroupAuditProvider.GroupAuditEvent event = new GroupAuditProvider.GroupAuditEvent(getContainer().getId(), "A new security group named " + newGroup.getName() + " was created.");
+            event.setGroup(newGroup.getUserId());
             AuditLogService.get().addEvent(viewContext.getUser(), event);
         }
 


### PR DESCRIPTION
#### Rationale
The Group Audit log table has fields that reference the `core.Principals` table, but because of the application of a container filter for the current container, which is the root container when looking at the audit logs, the names of users and groups were not resolving properly.  This led to empty values in the export and the sort functionality using the ids instead of the display names.  

Additionally, I've removed some logic that would not display certain group names in the audit log table.  We had been displaying only the Administrators group and project groups, but this leads to audit entries that reference the name of a group in the comment but then don't show that group in the field.  I'm unclear why we need to not display the group names that are referenced in the comments.

#### Changes
* Create `PrincipalUserDisplayColumn` for use in displaying both the Group and the Member column. 
* Change container filter for the Principal lookups for groups and users
* Remove logic that filters the names of groups displayed in the Group column.
* Other misc. clean up
