### PR TITLE
Issue 44390: HTTP connection pool leak when remote ETLs fail before starting to iterate through results

### DIFF
--- a/internal/src/org/labkey/remoteapi/SelectRowsStreamHack.java
+++ b/internal/src/org/labkey/remoteapi/SelectRowsStreamHack.java
@@ -41,12 +41,20 @@ public class SelectRowsStreamHack
 {
     public static DataIteratorBuilder go(Connection cn, String container, SelectRowsCommand cmd, Container targetContainer) throws IOException, CommandException
     {
-        final Command.Response response = cmd._execute(cn, container);
         return new DataIteratorBuilder()
         {
             @Override
             public DataIterator getDataIterator(DataIteratorContext context)
             {
+                Command.Response response;
+                try
+                {
+                    response = cmd._execute(cn, container);
+                }
+                catch (CommandException | IOException e)
+                {
+                    throw new RuntimeException("Failed to execute remote query", e);
+                }
                 try
                 {
                     final InputStream is = response.getInputStream();

--- a/internal/src/org/labkey/remoteapi/SelectRowsStreamHack.java
+++ b/internal/src/org/labkey/remoteapi/SelectRowsStreamHack.java
@@ -49,6 +49,9 @@ public class SelectRowsStreamHack
                 Command.Response response;
                 try
                 {
+                    // Execute the request when we're creating the DataIterator so that it can be reliably closed.
+                    // When we did it early as part of creating the DataIteratorBuilder, it could lead to a HTTP
+                    // connection leak. See issue 44390
                     response = cmd._execute(cn, container);
                 }
                 catch (CommandException | IOException e)


### PR DESCRIPTION
#### Rationale
We leak HTTP connection on remote ETLs if there's a problem after we create the DataIteratorBuilder but before we use it to create the DataIterator. For example, a problem truncating the target table. This leaks a connection from the HTTP pool which can lead to eventually exhausting the pool and causing threads to hang forever.

#### Changes
* Don't execute the HTTP request until we're ready for the DataIterator, which will be closed as part of its lifecycle