### PR TITLE
Use EditableGridPanelDeprecated

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.102.0-fb-editable-grid-panel-deprecated.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.102.0-fb-editable-grid-panel-deprecated.0.tgz",
-      "integrity": "sha1-KBDuokq+48TihCw2jgxeyxUaZqU=",
+      "version": "2.102.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.102.0.tgz",
+      "integrity": "sha1-Y385C9lZY/s/dDb0fsIXqu5SK5A=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.101.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.101.0.tgz",
-      "integrity": "sha1-6EcC4Mqw8cbMED8lMGA43gV7WOw=",
+      "version": "2.102.0-fb-editable-grid-panel-deprecated.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.102.0-fb-editable-grid-panel-deprecated.0.tgz",
+      "integrity": "sha1-KBDuokq+48TihCw2jgxeyxUaZqU=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.6.10",
-    "@labkey/components": "2.101.0",
+    "@labkey/components": "2.102.0-fb-editable-grid-panel-deprecated.0",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.6.10",
-    "@labkey/components": "2.102.0-fb-editable-grid-panel-deprecated.0",
+    "@labkey/components": "2.102.0",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/src/client/LabKeyUIComponentsPage/EditableGridPage.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/EditableGridPage.tsx
@@ -7,9 +7,8 @@ import {List, Map} from "immutable";
 import {
     SchemaQuery,
     IGridLoader,
-    LoadingSpinner,
     EditableColumnMetadata,
-    EditableGridPanel,
+    EditableGridPanelDeprecated,
     getQueryGridModel,
     getStateQueryGridModel,
     gridInit,
@@ -129,11 +128,11 @@ class EditableGridPageImpl extends PureComponent<SchemaQueryInputContext> {
         return (
             <>
                 {model
-                    ? <EditableGridPanel
+                    ? <EditableGridPanelDeprecated
                         {...defaultProps}
                         model={this.getEditorQueryGridModel()}
                     />
-                    : <EditableGridPanel
+                    : <EditableGridPanelDeprecated
                         {...defaultProps}
                         model={editorModelWithData}
                         columnMetadata={columnMetadata}


### PR DESCRIPTION
#### Rationale
I am starting work on the EditableGrid refactor to support QueryModel and QueryGridModel, a future release will add a new EditableGridPanel which will be compatible with QueryModel.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/682

#### Changes
* Use EditableGridPanelDeprecated
