### PR TITLE
Issue 44425: StudyManager.ensureVisits() hits duplicate key constraint violation

### DIFF
--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -1102,6 +1102,8 @@ public class StudyManager
             if (result.getRowId() == 0)
             {
                 createVisit(study, user, result, visits);
+                // Refresh existing visits to avoid constraint violation, see #44425
+                visits = getVisits(study, Visit.Order.SEQUENCE_NUM);
                 created = true;
             }
         }


### PR DESCRIPTION
#### Rationale
`StudyManager.ensureVisits()` needs to remember visits that it creates, otherwise it may attempt to create duplicates