### PR TITLE
Track temp function and updated pipeline feedback

### DIFF
--- a/api/src/org/labkey/api/data/StatementUtils.java
+++ b/api/src/org/labkey/api/data/StatementUtils.java
@@ -956,6 +956,8 @@ public class StatementUtils
             // wrap in a function with a single ROW() constructor argument
             SQLFragment fn = new SQLFragment();
             String fnName = _dialect.getGlobalTempTablePrefix() + "fn_" + GUID.makeHash();
+            TempTableTracker.track(fnName, fn);
+
             String typeName = fnName + "type";
             fn.append("CREATE TYPE ").append(typeName).append(" AS (");
             // TODO d.execute() doesn't handle temp schema

--- a/pipeline/src/org/labkey/pipeline/status/details.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/details.jsp
@@ -679,7 +679,7 @@ ended very recently. --%>
                         updateField(createdEl, status.created);
                         updateField(modifiedEl, status.modified);
                         updateField(emailEl, status.email);
-                        updateField(infoEl, status.info);
+                        updateField(infoEl, status.info ?? "");
                         updateField(descriptionEl, status.description);
                         updateField(queuePosition, status.queuePosition);
                         updateStatus(active, status.status, status.hadError);


### PR DESCRIPTION
#### Rationale
- We are now running EHR ETLs in startup scripts, which created a condition where an untracked PG temp function was created by StatementUtils then purged by the TempTableTracker.init before the function was finished being used. This update adds the temp function to the tracker so the tracker is initialized before the temp function is created.
- Issue 44081: Pipeline status page showing partial row count in info section at end.  Need to just empty the field out, it is only used for RUNNING jobs.

#### Changes
* Add temp function to TempTableTracker
* Issue 44081: Convert null value to empty string
