### PR TITLE
44372: Participant group selection with filter bug

### DIFF
--- a/study/src/org/labkey/study/controllers/ParticipantGroupController.java
+++ b/study/src/org/labkey/study/controllers/ParticipantGroupController.java
@@ -32,7 +32,6 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DataRegionSelection;
 import org.labkey.api.data.DbScope;
-import org.labkey.api.data.Table;
 import org.labkey.api.query.QueryForm;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
@@ -418,8 +417,23 @@ public class ParticipantGroupController extends BaseStudyController
             try
             {
                 Set<String> ptids = new LinkedHashSet<>();
-
                 QuerySettings settings = form.getQuerySettings();
+
+                if (form.isAllParticipants())
+                {
+                    // if the user has selected all participants, remove any special dataset params on the URL
+                    // such as cohort or visit ID
+                    getViewContext().setActionURL(new ActionURL());
+                }
+                else
+                {
+                    // if the group is created from selected participants (even if the select all checkbox is selected), we
+                    // want to apply any filters on the dataregion
+                    ActionURL url = new ActionURL();
+                    url.setRawQuery(form.getRequestURL());
+                    settings.setSortFilterURL(url);
+                }
+
                 UserSchema schema = QueryService.get().getUserSchema(getUser(), getContainer(), form.getSchemaName());
                 if (schema == null)
                 {
@@ -434,6 +448,7 @@ public class ParticipantGroupController extends BaseStudyController
                     return null;
                 }
 
+                // select all was checked
                 if (form.isSelectAll())
                 {
                     for (String ptid : StudyController.generateParticipantList(view))
@@ -457,8 +472,9 @@ public class ParticipantGroupController extends BaseStudyController
 
     public static class ParticipantSelection extends QueryForm
     {
-        private String[] _selections;
-        private boolean _selectAll;
+        private String[] _selections;       // specific selections
+        private boolean _selectAll;         // select all is checked
+        private boolean _allParticipants;   // all participants option
         private String _requestURL;
 
         public String getRequestURL()
@@ -489,6 +505,16 @@ public class ParticipantGroupController extends BaseStudyController
         public void setSelectAll(boolean selectAll)
         {
             _selectAll = selectAll;
+        }
+
+        public boolean isAllParticipants()
+        {
+            return _allParticipants;
+        }
+
+        public void setAllParticipants(boolean allParticipants)
+        {
+            _allParticipants = allParticipants;
         }
     }
 

--- a/study/webapp/study/ParticipantGroup.js
+++ b/study/webapp/study/ParticipantGroup.js
@@ -45,6 +45,7 @@ Ext4.define('Study.window.ParticipantGroup', {
                         jsonData.selections = checked;
                 }
                 else {
+                    jsonData.allParticipants = true;
                     jsonData.selectAll = true;
                 }
 


### PR DESCRIPTION
#### Rationale
This PR addresses the fix for 44372.  

What was happening was that any filters on the data region were not being respected when a user filtered down the list and selected records using the select all checkbox. The cause of the bug was due to a fix I made for 43552 when I deleted code in `ParticipantGroupController` because I thought it was a noop.
 
Additionally during the course of testing, I found another bug where if a user chose `Create Participant Group -> From All Participants`, if there was a cohort filter on the data region we would select less than all participants in the dataset. The selectAll parameter was no longer sufficient to detect whether the user wanted all participants or just everything selected in the current (filtered) data region. This is why there is a new parameter from the client to make this distinction and determines whether we apply any filters as well are strip off the parameters from the URL.

Relevant issues:
- [44372: Participant group selection with filter bug](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44372)
- [43552: Adding participants to a group from a dataset only choosing participants on the first page](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43552)

