### PR TITLE
Issue 44434: Add admin action for adjusting timestamps for Created and Modified fields.

### DIFF
--- a/api/src/org/labkey/api/data/DbSchemaCache.java
+++ b/api/src/org/labkey/api/data/DbSchemaCache.java
@@ -70,7 +70,7 @@ public class DbSchemaCache
     void remove(String schemaName, DbSchemaType type)
     {
         if (type == DbSchemaType.Module)
-            LOG.warn("removing module schema: " + schemaName, new Throwable("removing module schema: " + schemaName));
+            LOG.debug("removing module schema: " + schemaName, new Throwable("removing module schema: " + schemaName));
         else
             LOG.debug("remove " + type + " schema: " + schemaName);
         _cache.removeUsingFilter(new Cache.StringPrefixFilter(getKey(schemaName, type)));

--- a/api/src/org/labkey/api/data/SchemaTableInfoCache.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfoCache.java
@@ -52,7 +52,7 @@ public class SchemaTableInfoCache
     void remove(@NotNull DbSchema schema, @NotNull String tableName)
     {
         if (schema.getType() == DbSchemaType.Module)
-            LOG.warn("removing module schema table: " + schema.getName() + "." + tableName, new Throwable("removing module schema table: " + schema.getName() + "." + tableName));
+            LOG.debug("removing module schema table: " + schema.getName() + "." + tableName, new Throwable("removing module schema table: " + schema.getName() + "." + tableName));
         else
             LOG.debug("remove " + schema.getType() + " schema table: " + schema.getName() + "." + tableName);
         String key = getCacheKey(schema, tableName);
@@ -62,7 +62,7 @@ public class SchemaTableInfoCache
     void remove(@NotNull String schemaName, @NotNull String tableName, @NotNull DbSchemaType type)
     {
         if (type == DbSchemaType.Module)
-            LOG.warn("removing module schema table: " + schemaName + "." + tableName, new Throwable("removing module schema table: " + schemaName + "." + tableName));
+            LOG.debug("removing module schema table: " + schemaName + "." + tableName, new Throwable("removing module schema table: " + schemaName + "." + tableName));
         else
             LOG.debug("remove " + type + " schema table: " + schemaName + "." + tableName);
         String key = getCacheKey(schemaName, tableName, type);
@@ -72,7 +72,7 @@ public class SchemaTableInfoCache
     void removeAllTables(@NotNull String schemaName, DbSchemaType type)
     {
         if (type == DbSchemaType.Module)
-            LOG.warn("removing all module schema tables: " + schemaName, new Throwable("removing all module schema tables: " + schemaName));
+            LOG.debug("removing all module schema tables: " + schemaName, new Throwable("removing all module schema tables: " + schemaName));
         else
             LOG.debug("remove all " + type + " schema tables: " + schemaName);
         final String prefix = type.getCacheKey(schemaName);

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10541,6 +10541,7 @@ public class AdminController extends SpringActionController
                 });
                 t.commit();
             }
+            logger.info("DONE Adjusting all " + toUpdate + " timestamp fields in all tables by " + form.getHourDelta() + " hours.");
             return true;
         }
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10527,7 +10527,7 @@ public class AdminController extends SpringActionController
                 ModuleLoader.getInstance().getModules().forEach(module -> {
                     logger.info("==> Beginning update of timestamps for module: " + module.getName());
                     module.getSchemaNames().stream().sorted().forEach(schemaName -> {
-                        DbSchema schema = DbSchema.get(schemaName, DbSchemaType.Module); // Will these always be Module schemas ??
+                        DbSchema schema = DbSchema.get(schemaName, DbSchemaType.Module);
                         schema.getTableNames().forEach(tableName -> {
                             TableInfo tInfo = schema.getTable(tableName);
                             if (tInfo.getTableType() == DatabaseTableType.TABLE)

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10515,7 +10515,6 @@ public class AdminController extends SpringActionController
         {
             logger.info("Adjusting all Created and Modified timestamp fields in all tables by " + form.getHourDelta() + " hours.");
             DbScope scope = DbScope.getLabKeyScope();
-            // Use a different transaction kind to ensure a different DB connection is used
             try (DbScope.Transaction t = scope.ensureTransaction())
             {
                 ModuleLoader.getInstance().getModules().forEach(module -> {

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10528,6 +10528,7 @@ public class AdminController extends SpringActionController
                     logger.info("==> Beginning update of timestamps for module: " + module.getName());
                     module.getSchemaNames().stream().sorted().forEach(schemaName -> {
                         DbSchema schema = DbSchema.get(schemaName, DbSchemaType.Module);
+                        scope.invalidateSchema(schema); // Issue 44452: assure we have a fresh set of tables to work from
                         schema.getTableNames().forEach(tableName -> {
                             TableInfo tInfo = schema.getTable(tableName);
                             if (tInfo.getTableType() == DatabaseTableType.TABLE)

--- a/core/src/org/labkey/core/admin/adjustTimestamps.jsp
+++ b/core/src/org/labkey/core/admin/adjustTimestamps.jsp
@@ -1,0 +1,30 @@
+<%@ page import="org.labkey.core.admin.AdminController" %>
+<%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.api.view.JspView" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+
+<%
+    AdminController.AdjustTimestampsForm form = ((JspView<AdminController.AdjustTimestampsForm>) HttpView.currentView()).getModelBean();
+%>
+
+<labkey:errors/>
+
+<labkey:form action="<%=urlFor(AdminController.AdjustSystemTimestampsAction.class)%>" method="post">
+   <p>
+       This form can be used to adjust the values for system-created timestamp fields (Created and Modified)
+       for <b>all tables</b> in <b>all schemas</b> in <b>all modules</b>.  It is intended to be used to adjust
+       for data created using an incorrect timezone.
+   </p>
+    <p>No audit log entries will be created for these changes.</p>
+    <p>
+        Enter the positive or negative integer corresponding to the number of <b>hours</b>
+        by which to adjust all of the Created and Modified timestamp fields.
+    </p>
+    Hour Delta: <input id="hourDelta" name="hourDelta" type="number" value=<%=h(form.getHourDelta())%>>
+    <%= button("Update Timestamps").submit(true).name("update")%>
+    <br/><br/>
+    <p>
+    Upon success, you will be redirected to the Admin Console.
+    </p>
+</labkey:form>

--- a/core/src/org/labkey/core/admin/adjustTimestamps.jsp
+++ b/core/src/org/labkey/core/admin/adjustTimestamps.jsp
@@ -21,8 +21,8 @@
             <li>diCreated</li>
             <li>diModified</li>
         </ul>
-       for <b>all tables</b> in <b>all schemas</b> in <b>all modules</b>.  It is intended to be used to adjust
-       for data created using an incorrect timezone in conjunction with updating the server to use the correct timezone.
+       for <b>all tables</b> in <b>all schemas</b> in <b>all modules</b>.  It is intended to be used in conjunction with
+       an update to the server (system and Tomcat) timezone properties to adjust for data created using an incorrect timezone.
    </p>
     <p>
         We do not currently update the following system-created timestamp fields:

--- a/core/src/org/labkey/core/admin/adjustTimestamps.jsp
+++ b/core/src/org/labkey/core/admin/adjustTimestamps.jsp
@@ -11,12 +11,28 @@
 <labkey:errors/>
 
 <labkey:form action="<%=urlFor(AdminController.AdjustSystemTimestampsAction.class)%>" method="post">
-   <p>
-       This form can be used to adjust the values for system-created timestamp fields (Created and Modified)
+   <h3>What Will Be Updated</h3>
+    <p>
+       This form will adjust the values for the following system-created timestamp fields:
+       <ul>
+            <li>Created</li>
+            <li>Modified</li>
+            <li>lastIndexed</li>
+            <li>diCreated</li>
+            <li>diModified</li>
+        </ul>
        for <b>all tables</b> in <b>all schemas</b> in <b>all modules</b>.  It is intended to be used to adjust
-       for data created using an incorrect timezone.
+       for data created using an incorrect timezone in conjunction with updating the server to use the correct timezone.
    </p>
+    <p>
+        We do not currently update the following system-created timestamp fields:
+        <ul>
+            <li>_ts</li>
+        </ul>
+    </p>
     <p>No audit log entries will be created for these changes.</p>
+    <br/>
+    <h3>Update</h3>
     <p>
         Enter the positive or negative integer corresponding to the number of <b>hours</b>
         by which to adjust all of the Created and Modified timestamp fields.


### PR DESCRIPTION
#### Rationale
System-created timestamp values are created using the server's timestamp.  When we adjust the timezone for the server to correspond to the client's usual timezone, existing timestamps remain in the original timezone.  This action provides a way to adjust these system-created timestamp values so they line up with the adjusted server timestamp.

#### Changes
* Add `AdjustSystemTimestampAction` to `AdminController`
