### PR TITLE
Pass user to container property change event

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1052,7 +1052,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
         }
 
         props.save();
-        ContainerManager.notifyContainerChange(getId(), ContainerManager.Property.Modules);
+        ContainerManager.notifyContainerChange(getId(), ContainerManager.Property.Modules, user);
     }
 
     public void appendWorkbookModulesToParent(Set<Module> newModules, @Nullable User user)

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1906,6 +1906,11 @@ public class ContainerManager
 
     public static void notifyContainerChange(String id, Property prop)
     {
+        notifyContainerChange(id, prop, null);
+    }
+
+    public static void notifyContainerChange(String id, Property prop, @Nullable User u)
+    {
         Container c = getForId(id);
         if (null != c)
         {
@@ -1913,7 +1918,7 @@ public class ContainerManager
             c = getForId(id);  // load a fresh container since the original might be stale.
             if (null != c)
             {
-                ContainerPropertyChangeEvent evt = new ContainerPropertyChangeEvent(c, prop, null, null);
+                ContainerPropertyChangeEvent evt = new ContainerPropertyChangeEvent(c, u, prop, null, null);
                 firePropertyChangeEvent(evt);
             }
         }


### PR DESCRIPTION
#### Rationale
Pass through user to property change event, if available.  Needed for container initialization on trial server.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/770

#### Changes
* Add new notifyContainerChange signature with user param.  Attach user to ContainerPropertyChangeEvent.
