### PR TITLE
Issue 44180: NPE in ExistingRecordDataIterator

### DIFF
--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -169,6 +169,9 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
         return context ->
         {
             DataIterator di = dib.getDataIterator(context);
+            if (null == di)
+                return null;           // Can happen if context has errors
+
             assert !di.supportsGetExistingRecord();
             if (di.supportsGetExistingRecord())
                 return di;


### PR DESCRIPTION
#### Rationale
From mothership exception report. Handle null di.

#### Changes
* null check
