### PR TITLE
Issue 44437: Permissions panel is taking minutes to render

### DIFF
--- a/specimen/src/org/labkey/specimen/security/roles/AbstractSpecimenRole.java
+++ b/specimen/src/org/labkey/specimen/security/roles/AbstractSpecimenRole.java
@@ -44,12 +44,15 @@ public class AbstractSpecimenRole extends AbstractRole
 
     private boolean branchContainsStudy(Container container)
     {
-        if (null != StudyService.get().getStudy(container))
+        StudyService ss = StudyService.get();
+        if (null != ss && null != ss.getStudy(container))
             return true;
 
         for (Container child : container.getChildren())
         {
-            if (branchContainsStudy(child))
+            // Issue 44437 - don't bother recursing into workbook children for perf reasons since they're not used
+            // for studies
+            if (!child.isWorkbook() && branchContainsStudy(child))
                 return true;
         }
 


### PR DESCRIPTION
#### Rationale
When you have ~10,000 workbook children, it takes a long time to ask them all about their enabled modules and if they have a study 

#### Changes
* We don't use workbooks for studies so don't interrogate workbook children