### PR TITLE
Issue 43909: SubjectID custom column issues

### DIFF
--- a/study/resources/schemas/dbscripts/postgresql/study-21.004-21.005.sql
+++ b/study/resources/schemas/dbscripts/postgresql/study-21.004-21.005.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('ensureParticipantIds');

--- a/study/resources/schemas/dbscripts/sqlserver/study-21.004-21.005.sql
+++ b/study/resources/schemas/dbscripts/sqlserver/study-21.004-21.005.sql
@@ -1,0 +1,1 @@
+EXEC core.executeJavaUpgradeCode 'ensureParticipantIds';

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -240,7 +240,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
     @Override
     public Double getSchemaVersion()
     {
-        return 21.004;
+        return 21.005;
     }
 
     @Override

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -410,7 +410,6 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
             setupError("Missing required field SequenceNum");
 
         // Issue 43909: Don't allow insert/update if subject id is overwritten with custom column (no longer allowed).
-        boolean subjectIdConflict = false;
         for (DomainProperty p : Objects.requireNonNull(_datasetDefinition.getDomain()).getProperties())
         {
             if (p.getName().equalsIgnoreCase(_datasetDefinition.getStudy().getSubjectColumnName()))

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -407,6 +407,10 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
         if (timetype.isVisitBased() && null == it.indexSequenceNumOutput)
             setupError("Missing required field SequenceNum");
 
+        if (!inputMap.containsKey(DatasetDefinition.getStudyBaseURI() + "ParticipantId"))
+            setupError(_datasetDefinition.getStudy().getSubjectColumnName() + " is not mapped correctly, ensure the dataset " +
+                    "design does not overwrite this column with a custom column.");
+
         it.setInput(ErrorIterator.wrap(input, context, false, setupError));
         DataIterator ret = LoggingDataIterator.wrap(it);
 

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -415,14 +415,11 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
         {
             if (p.getName().equalsIgnoreCase(_datasetDefinition.getStudy().getSubjectColumnName()))
             {
-                subjectIdConflict = true;
+                setupError(_datasetDefinition.getStudy().getSubjectColumnName() + " is a reserved name for this study. Remove " +
+                        "this column from " + _datasetDefinition.getName() + " dataset design and try again.");
                 break;
             }
         }
-
-        if (subjectIdConflict)
-            setupError(_datasetDefinition.getStudy().getSubjectColumnName() + " is a reserved name for this study. Remove " +
-                    "this column from " + _datasetDefinition.getName() + " dataset design and try again.");
 
         it.setInput(ErrorIterator.wrap(input, context, false, setupError));
         DataIterator ret = LoggingDataIterator.wrap(it);

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -114,7 +114,7 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
         DATASPACE_BASE_PROPERTIES = new HashSet<>(Arrays.asList(
             new PropertyStorageSpec(DSROWID, JdbcType.BIGINT, 0, PropertyStorageSpec.Special.PrimaryKeyNonClustered, false, true, null),
             new PropertyStorageSpec(CONTAINER, JdbcType.GUID).setNullable(false),
-            new PropertyStorageSpec(PARTICIPANTID, JdbcType.VARCHAR, 32),
+            new PropertyStorageSpec(PARTICIPANTID, JdbcType.VARCHAR, 32).setNullable(false),
             new PropertyStorageSpec(LSID, JdbcType.VARCHAR, 200),
             new PropertyStorageSpec(SEQUENCENUM, JdbcType.DECIMAL),
             new PropertyStorageSpec(SOURCELSID, JdbcType.VARCHAR, 200),

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -4758,7 +4758,7 @@ public class StudyManager
                                     {   // set participantid to NA if it is null and doesn't match the above case. Only way known that it could
                                         // happen is if the above case was corrected before running this script, but should catch any other edge cases
                                         SQLFragment updateSql = new SQLFragment("UPDATE studydataset.").append(dom.getStorageTableName());
-                                        updateSql.append(" SET participantid = 'NA'");
+                                        updateSql.append(" SET participantid = 'Unknown'");
                                         updateSql.append(" WHERE participantid IS NULL");
                                         int rows = new SqlExecutor(StudySchema.getInstance().getScope()).execute(updateSql);
                                         if (rows > 0)

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -4752,17 +4752,17 @@ public class StudyManager
                                         updateSql.append(" WHERE participantid IS NULL");
                                         int rows = new SqlExecutor(StudySchema.getInstance().getScope()).execute(updateSql);
                                         if (rows > 0)
-                                            _log.info(dataset.getName() + " updated " + rows + " participantId rows.");
+                                            _log.info(dataset.getName() + " in " + study.getContainer().getName() + " updated " + rows + " participantId rows.");
                                     }
                                     else
-                                    {   // set participantid to NA if it is null and doesn't match the above case. Only way known that it could
+                                    {   // set participantid to Unknown if it is null and doesn't match the above case. Only way known that it could
                                         // happen is if the above case was corrected before running this script, but should catch any other edge cases
                                         SQLFragment updateSql = new SQLFragment("UPDATE studydataset.").append(dom.getStorageTableName());
                                         updateSql.append(" SET participantid = 'Unknown'");
                                         updateSql.append(" WHERE participantid IS NULL");
                                         int rows = new SqlExecutor(StudySchema.getInstance().getScope()).execute(updateSql);
                                         if (rows > 0)
-                                            _log.info(dataset.getName() + " updated " + rows + " participantId rows.");
+                                            _log.info(dataset.getName() + " in " + study.getContainer().getName() + " updated " + rows + " participantId rows.");
                                     }
                                 }
 

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -4724,7 +4724,7 @@ public class StudyManager
         {
             if (!context.isNewInstall())
             {
-                _log.info("Ensuring study participantIds in all study datasets");
+                _log.info("Ensuring participantIds in all study datasets");
                 try (Transaction transaction = StudySchema.getInstance().getScope().ensureTransaction())
                 {
                     // Iterate through all studies

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -189,6 +189,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.WeakHashMap;
+import java.util.stream.Collectors;
 
 import static org.labkey.api.action.SpringActionController.ERROR_MSG;
 import static org.labkey.study.query.StudyQuerySchema.PERSONNEL_TABLE_NAME;
@@ -4715,6 +4716,76 @@ public class StudyManager
                 StudyDesignManager mgr = StudyDesignManager.get();
                 StudyManager.getInstance().getAllStudies()
                     .forEach(study->mgr.ensureStudyDesignDomains(study.getContainer(), context.getUpgradeUser()));
+            }
+        }
+
+        @SuppressWarnings({"UnusedDeclaration"})
+        public void ensureParticipantIds(final ModuleContext context)
+        {
+            if (!context.isNewInstall())
+            {
+                _log.info("Ensuring study participantIds in all study datasets");
+                try (Transaction transaction = StudySchema.getInstance().getScope().ensureTransaction())
+                {
+                    // Iterate through all studies
+                    Set<? extends StudyImpl> studies = StudyManager.getInstance().getAllStudies();
+                    for (StudyImpl study : studies)
+                    {
+                        String subjectColName = study.getSubjectColumnName();
+
+                        // Iterate datasets
+                        List<DatasetDefinition> datasets = study.getDatasets();
+                        for (DatasetDefinition dataset : datasets)
+                        {
+                            Domain dom = dataset.getDomain();
+                            if (null != dom)
+                            {
+                                // If subject id renamed then try to correct
+                                if (!subjectColName.equalsIgnoreCase("ParticipantId"))
+                                {
+                                    // Try to correct datasets with subject id overwritten with custom column
+                                    List<? extends DomainProperty> dupeId = dom.getProperties().stream().filter(d -> d.getName().equalsIgnoreCase(subjectColName)).collect(Collectors.toList());
+                                    if (dupeId.size() > 0)
+                                    {
+                                        SQLFragment updateSql = new SQLFragment("UPDATE studydataset.").append(dom.getStorageTableName());
+                                        updateSql.append(" SET participantid = ").append(subjectColName);
+                                        updateSql.append(" WHERE participantid IS NULL");
+                                        int rows = new SqlExecutor(StudySchema.getInstance().getScope()).execute(updateSql);
+                                        if (rows > 0)
+                                            _log.info(dataset.getName() + " updated " + rows + " participantId rows.");
+                                    }
+                                    else
+                                    {   // set participantid to NA if it is null and doesn't match the above case. Only way known that it could
+                                        // happen is if the above case was corrected before running this script, but should catch any other edge cases
+                                        SQLFragment updateSql = new SQLFragment("UPDATE studydataset.").append(dom.getStorageTableName());
+                                        updateSql.append(" SET participantid = 'NA'");
+                                        updateSql.append(" WHERE participantid IS NULL");
+                                        int rows = new SqlExecutor(StudySchema.getInstance().getScope()).execute(updateSql);
+                                        if (rows > 0)
+                                            _log.info(dataset.getName() + " updated " + rows + " participantId rows.");
+                                    }
+                                }
+
+                                SQLFragment constraintSql = new SQLFragment("ALTER TABLE studydataset.").append(dom.getStorageTableName());
+                                if (StudySchema.getInstance().getSqlDialect().isPostgreSQL())
+                                {
+                                    constraintSql.append(" ALTER COLUMN participantid SET NOT NULL");
+                                }
+                                else
+                                {
+                                    // Adding not null constraint avoids having to drop indexes to re-declare column as not null
+                                    constraintSql.append(" WITH CHECK ADD CONSTRAINT ").append(dom.getStorageTableName()).append("_participantid_not_null");
+                                    constraintSql.append(" CHECK (participantid IS NOT NULL);");
+                                }
+
+                                new SqlExecutor(StudySchema.getInstance().getScope()).execute(constraintSql);
+                            }
+                        }
+
+                    }
+
+                    transaction.commit();
+                }
             }
         }
     }


### PR DESCRIPTION
#### Rationale
The change that caused this issue was in effect for about 8 months so this tries to correct any cases where participantid is null and put a not null constraint on the column.  Additionally a check is put in place to NOT allow any more mutations of the data in these datasets until the subject id custom column is removed from the design.  The goal is to try to preserve the data but force the user to fix or create a new dataset.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2661

#### Changes
* Upgrade script that iterates studies and datasets, trying to correct any null value participantids and add a null constraint to the participantid column of all datasets
* Check in DatasetDataIteratorBuilder to throw an error if a dataset has a custom column of the same name as the subject alias for the study, and not allow any mutations of the data in the dataset
