### PR TITLE
Ignore auto-generated jars.txt from Experiment module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ core/resources/web/core/css
 */resources/web/gen
 */resources/views/gen
 
-/experiment/resources/credits/jars.txt
+experiment/resources/credits/jars.txt
 internal/resources/credits/jars.txt
 
 # Gradle

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ core/resources/web/core/css
 */resources/web/gen
 */resources/views/gen
 
+/experiment/resources/credits/jars.txt
 internal/resources/credits/jars.txt
 
 # Gradle


### PR DESCRIPTION
#### Rationale
Earlier this year, we switched to auto-generate this file. Thus, we don't need it committed to Git.

#### Changes
* Ignore the file