### PR TITLE
Speed up EHR query analysis by ~75% by improving schema reuse

### DIFF
--- a/api/src/org/labkey/api/query/FolderSchemaProvider.java
+++ b/api/src/org/labkey/api/query/FolderSchemaProvider.java
@@ -29,7 +29,10 @@ import org.labkey.api.util.FileUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 abstract public class FolderSchemaProvider extends DefaultSchema.SchemaProvider
 {
@@ -41,6 +44,9 @@ abstract public class FolderSchemaProvider extends DefaultSchema.SchemaProvider
     static public class FolderSchema extends UserSchema implements QuerySchema.ContainerSchema
     {
         QuerySchema _fallback;
+
+        /** Cache created schemas to leverage their caching of queries and tables */
+        private final Map<String, QuerySchema> _cache = new HashMap<>();
 
         /**
          * @param fallback schema to look in first, before checking for child folders.
@@ -90,8 +96,13 @@ abstract public class FolderSchemaProvider extends DefaultSchema.SchemaProvider
 			return null;
 		}
 
-		@Override
+        @Override
         public QuerySchema getSchema(String name)
+        {
+            return _cache.computeIfAbsent(name, _schemaCreator);
+        }
+
+        private final Function<String, QuerySchema> _schemaCreator = (name) ->
         {
             if (_restricted)
                 return null;
@@ -126,7 +137,7 @@ abstract public class FolderSchemaProvider extends DefaultSchema.SchemaProvider
             }
 
             return new FolderSchema(name, _user, child, fallback);
-        }
+        };
 
         @Override
         public <R, P> R accept(SchemaTreeVisitor<R, P> visitor, SchemaTreeVisitor.Path path, P param)


### PR DESCRIPTION
#### Rationale
ONPRC_EHRTest2.manageCases is failing regularly across branches due to SQL deadlocks. The competing thread appears to be doing query analysis, which is very slow on TeamCity (~120 seconds). We can speed it up by reusing schema objects.

#### Changes
* Make FolderSchemaProvider cache the schemas it creates