### PR TITLE
Issue 44494: QueryLogging errors not treated as a true error condition

### DIFF
--- a/api/src/org/labkey/api/data/LoggingResultSetWrapper.java
+++ b/api/src/org/labkey/api/data/LoggingResultSetWrapper.java
@@ -15,10 +15,9 @@
  */
 package org.labkey.api.data;
 
-import org.apache.tomcat.util.buf.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.audit.AuditLogService;
-import org.labkey.api.view.UnauthorizedException;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;


### PR DESCRIPTION
#### Rationale
When we don't find a column that's required for logging purposes, we're stopping on the first one and throwing an UnauthorizedException. This achieves the goal of preventing users from seeing data where we aren't in a position to do the full audit logging. However, it doesn't up us track down these problems as UnauthorizedException is treated as a lack of permission instead of a failure to include the right columns in the data. 

#### Changes
* Use IllegalStateException to capture details in mothership reports and logging
* Concat all of the missing columns into the error