### PR TITLE
Issue 44526: Update to Log4J 2.17.0 to definitively protect against CVE-2021-45105

### DIFF
--- a/api/resources/credits/jars.txt
+++ b/api/resources/credits/jars.txt
@@ -36,9 +36,9 @@ jtidy-r918.jar|Java Tidy|r918|{link:SourceForge|http://jtidy.sourceforge.net/}|{
 junit-4.13.2.jar|JUnit|4.13.2|{link:Junit|http://www.junit.org}|{link:CPL 1.0|http://www.opensource.org/licenses/cpl1.0.php}|jeckels|Unit testing
 jxl-2.6.3.jar|API|2.6.3|{link:jexcelapi|http://www.jexcelapi.org/}|{link:LGPL|http://www.opensource.org/licenses/lgpl-license.php}|jeckels|Java Excel library
 kaptcha-2.3.jar|Captcha generator|2.3|{link:kaptcha|http://code.google.com/p/kaptcha/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|nicka|User signup forms
-log4j-api-2.16.0.jar|Log4j|2.16.0|{link:Apache|https://logging.apache.org/log4j/2.x/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|ankurj|Logging
-log4j-core-2.16.0.jar|Log4j|2.16.0|{link:Apache|https://logging.apache.org/log4j/2.x/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|ankurj|Logging
-log4j-1.2-api-2.16.0.jar|Log4j|2.16.0|{link:Apache|https://logging.apache.org/log4j/2.x/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|ankurj|Logging
+log4j-api-2.17.0.jar|Log4j|2.17.0|{link:Apache|https://logging.apache.org/log4j/2.x/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|ankurj|Logging
+log4j-core-2.17.0.jar|Log4j|2.17.0|{link:Apache|https://logging.apache.org/log4j/2.x/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|ankurj|Logging
+log4j-1.2-api-2.17.0.jar|Log4j|2.17.0|{link:Apache|https://logging.apache.org/log4j/2.x/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|ankurj|Logging
 opencsv-2.3.jar|OpenCSV|2.3|{link:OpenCSV|http://opencsv.sourceforge.net/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|adam|Parsing CSV files
 pdfbox-2.0.23.jar|Apache PDFBox®|2.0.23|{link:PDFBox|https://pdfbox.apache.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|adam|Extract text and produce thumbnails from PDFs
 poi-4.1.2.jar|Apache POI|4.1.2|{link:Apache|https://poi.apache.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|adam|Extracting text from and exporting to Microsoft document formats (Excel, Word, PowerPoint, etc.)


### PR DESCRIPTION
#### Rationale
Log4J has another patch for a variant on the previous vulnerability. LabKey Server does not use the configuration that's vulnerable, but we can still adopt the newest hot fix, 2.17.0.

#### Changes
* Adopt Log4J 2.17.0