### PR TITLE
44527: Attempting to reorder subcategories fails

### DIFF
--- a/query/webapp/dataview/DataViewUtil.js
+++ b/query/webapp/dataview/DataViewUtil.js
@@ -540,7 +540,8 @@ Ext4.define('LABKEY.ext4.DataViewUtil', {
                         var store = data.view.getStore();
                         this.updateDisplayOrder(store);
                         this.categoriesSyncSaveAndLoad(store);
-                    }
+                    },
+                    scope: this
                 }
             },
             listeners : {


### PR DESCRIPTION
#### Rationale
Fixes [44527](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44527) by properly declaring `scope` for ExtJS listeners.

#### Changes
* Declare `scope: this` for `gridviewdragdrop` event listeners for subcategory panel.
