### PR TITLE
Issue 44093: Admin option to update paths in the DB, separate from moving files

### DIFF
--- a/api/src/org/labkey/api/files/FileContentService.java
+++ b/api/src/org/labkey/api/files/FileContentService.java
@@ -270,13 +270,18 @@ public interface FileContentService
         if (!FileUtil.hasCloudScheme(created))
             fireFileCreateEvent(created.toFile(), user, container);
     }
-    /** Notifies all registered FileListeners that a file or directory has moved */
-    void fireFileMoveEvent(@NotNull File src, @NotNull File dest, @Nullable User user, @Nullable Container container);
-    default void fireFileMoveEvent(@NotNull Path src, @NotNull Path dest, @Nullable User user, @Nullable Container container)
+    /**
+     * Notifies all registered FileListeners that a file or directory has moved
+     * @return number of rows updated across all listeners
+     */
+    int fireFileMoveEvent(@NotNull File src, @NotNull File dest, @Nullable User user, @Nullable Container container);
+    default int fireFileMoveEvent(@NotNull Path src, @NotNull Path dest, @Nullable User user, @Nullable Container container)
     {
         if (!FileUtil.hasCloudScheme(src) && !FileUtil.hasCloudScheme(dest))
-            fireFileMoveEvent(src.toFile(), dest.toFile(), user, container);
+            return fireFileMoveEvent(src.toFile(), dest.toFile(), user, container);
+        return 0;
     }
+
     /** Add a listener that will be notified when files are created or are moved */
     void addFileListener(FileListener listener);
 

--- a/api/src/org/labkey/api/files/FileListener.java
+++ b/api/src/org/labkey/api/files/FileListener.java
@@ -56,11 +56,12 @@ public interface FileListener
      * @param user if available, the user who initiated the move
      * @param container if available, the container in which the move was initiated
      */
-    void fileMoved(@NotNull File src, @NotNull File dest, @Nullable User user, @Nullable Container container);
-    default void fileMoved(@NotNull Path src, @NotNull Path dest, @Nullable User user, @Nullable Container container)
+    int fileMoved(@NotNull File src, @NotNull File dest, @Nullable User user, @Nullable Container container);
+    default int fileMoved(@NotNull Path src, @NotNull Path dest, @Nullable User user, @Nullable Container container)
     {
         if (!FileUtil.hasCloudScheme(src) && !FileUtil.hasCloudScheme(dest))
-            fileMoved(src.toFile(), dest.toFile(), user, container);
+            return fileMoved(src.toFile(), dest.toFile(), user, container);
+        return 0;
     }
 
     /**

--- a/api/src/org/labkey/api/files/TableUpdaterFileListener.java
+++ b/api/src/org/labkey/api/files/TableUpdaterFileListener.java
@@ -203,13 +203,13 @@ public class TableUpdaterFileListener implements FileListener
     }
 
     @Override
-    public void fileMoved(@NotNull File src, @NotNull File dest, @Nullable User user, @Nullable Container container)
+    public int fileMoved(@NotNull File src, @NotNull File dest, @Nullable User user, @Nullable Container container)
     {
-        fileMoved(src.toPath(), dest.toPath(), user, container);
+        return fileMoved(src.toPath(), dest.toPath(), user, container);
     }
 
     @Override
-    public void fileMoved(@NotNull Path src, @NotNull Path dest, @Nullable User user, @Nullable Container container)
+    public int fileMoved(@NotNull Path src, @NotNull Path dest, @Nullable User user, @Nullable Container container)
     {
         DbSchema schema = _table.getSchema();
         SqlDialect dialect = schema.getSqlDialect();
@@ -295,7 +295,9 @@ public class TableUpdaterFileListener implements FileListener
             childRowsUpdated += new SqlExecutor(schema).execute(childPathsSQL);
 
             LOG.info("Updated " + childRowsUpdated + " child paths in " + _table + " rows for move from " + src + " to " + dest);
+            return childRowsUpdated;
         }
+        return 0;
     }
 
     @NotNull

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -286,6 +286,7 @@ public class AdminController extends SpringActionController
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(
         AdminController.class,
         FilesSiteSettingsAction.class,
+        UpdateFilePathsAction.class,
         FileListAction.class
     );
 

--- a/core/src/org/labkey/core/admin/FilesSiteSettingsAction.java
+++ b/core/src/org/labkey/core/admin/FilesSiteSettingsAction.java
@@ -61,13 +61,13 @@ public class FilesSiteSettingsAction extends AbstractFileSiteSettingsAction<File
         {
             File root = _svc.getSiteDefaultRoot();
 
-            if (root != null && root.exists())
+            if (root.exists())
                 form.setRootPath(FileUtil.getAbsoluteCaseSensitiveFile(root).getAbsolutePath());
 
             if (AppProps.getInstance().isExperimentalFeatureEnabled(AppProps.EXPERIMENTAL_USER_FOLDERS))
             {
                 File userRoot = _svc.getUserFilesRoot();
-                if (userRoot != null && userRoot.exists())
+                if (userRoot.exists())
                     form.setUserRootPath(FileUtil.getAbsoluteCaseSensitiveFile(userRoot).getAbsolutePath());
             }
 

--- a/core/src/org/labkey/core/admin/UpdateFilePathsAction.java
+++ b/core/src/org/labkey/core/admin/UpdateFilePathsAction.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2009-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.labkey.core.admin;
+
+import org.apache.commons.lang3.StringUtils;
+import org.labkey.api.action.FormHandlerAction;
+import org.labkey.api.action.FormViewAction;
+import org.labkey.api.action.LabKeyError;
+import org.labkey.api.admin.AdminUrls;
+import org.labkey.api.audit.AuditLogService;
+import org.labkey.api.audit.provider.SiteSettingsAuditProvider;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.files.FileContentService;
+import org.labkey.api.premium.PremiumService;
+import org.labkey.api.security.AdminConsoleAction;
+import org.labkey.api.security.RequiresPermission;
+import org.labkey.api.security.permissions.AdminOperationsPermission;
+import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.URLHelper;
+import org.labkey.api.view.JspView;
+import org.labkey.api.view.NavTree;
+import org.springframework.validation.BindException;
+import org.springframework.validation.Errors;
+import org.springframework.web.servlet.ModelAndView;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import java.nio.file.Path;
+
+@AdminConsoleAction
+@RequiresPermission(AdminOperationsPermission.class)
+public class UpdateFilePathsAction extends FormViewAction<UpdateFilePathsAction.UpdateFilePathsForm>
+{
+    public static class UpdateFilePathsForm
+    {
+        private String _originalPrefix;
+        private String _newPrefix;
+
+        public String getOriginalPrefix()
+        {
+            return _originalPrefix;
+        }
+
+        public void setOriginalPrefix(String originalPrefix)
+        {
+            _originalPrefix = originalPrefix;
+        }
+
+        public String getNewPrefix()
+        {
+            return _newPrefix;
+        }
+
+        public void setNewPrefix(String newPrefix)
+        {
+            _newPrefix = newPrefix;
+        }
+    }
+
+    @Override
+    public void validateCommand(UpdateFilePathsForm form, Errors errors)
+    {
+    }
+
+    @Override
+    public boolean handlePost(UpdateFilePathsForm form, BindException errors) throws Exception
+    {
+        Path source = null;
+        try
+        {
+            if (StringUtils.isEmpty(form.getOriginalPrefix()))
+            {
+                errors.addError(new LabKeyError("No original prefix specified"));
+            }
+            else
+            {
+                source = Path.of(new URI(form.getOriginalPrefix()));
+            }
+        }
+        catch (URISyntaxException | IllegalArgumentException e)
+        {
+            errors.addError(new LabKeyError("Invalid original prefix: " + form.getOriginalPrefix()));
+        }
+        Path target = null;
+        try
+        {
+            if (StringUtils.isEmpty(form.getNewPrefix()))
+            {
+                errors.addError(new LabKeyError("No new prefix specified"));
+            }
+            else
+            {
+                target = Path.of(new URI(form.getNewPrefix()));
+            }
+        }
+        catch (URISyntaxException | IllegalArgumentException e)
+        {
+            errors.addError(new LabKeyError("Invalid original prefix: " + form.getNewPrefix()));
+        }
+
+        if (source == null || target == null)
+        {
+            return false;
+        }
+
+        int rows = FileContentService.get().fireFileMoveEvent(source, target, getUser(), null);
+        SiteSettingsAuditProvider.SiteSettingsAuditEvent event = new SiteSettingsAuditProvider.SiteSettingsAuditEvent(
+                ContainerManager.getRoot().getId(),
+                "Updated site-wide file paths from " + source + " to " + target);
+        event.setChanges(rows + " row(s) updated in database tables");
+        AuditLogService.get().addEvent(getUser(), event);
+
+        return true;
+    }
+
+    @Override
+    public ModelAndView getView(UpdateFilePathsForm form, boolean reshow, BindException errors) throws Exception
+    {
+        return new JspView<>("/org/labkey/core/admin/view/updateFilePaths.jsp", form, errors);
+    }
+
+    @Override
+    public void addNavTrail(NavTree root)
+    {
+        root.addChild("Admin Console", PageFlowUtil.urlProvider(AdminUrls.class).getAdminConsoleURL());
+        root.addChild("Files", PageFlowUtil.urlProvider(AdminUrls.class).getFilesSiteSettingsURL(false));
+        root.addChild("Update File Paths");
+    }
+
+    @Override
+    public URLHelper getSuccessURL(UpdateFilePathsForm updateFilePathsForm)
+    {
+        return PageFlowUtil.urlProvider(AdminUrls.class).getFilesSiteSettingsURL(false);
+    }
+}

--- a/core/src/org/labkey/core/admin/view/filesSiteSettings.jsp
+++ b/core/src/org/labkey/core/admin/view/filesSiteSettings.jsp
@@ -29,6 +29,7 @@
 <%@ page import="org.labkey.core.admin.FileListAction" %>
 <%@ page import="org.labkey.core.admin.FileSettingsForm" %>
 <%@ page import="org.labkey.core.admin.FilesSiteSettingsAction" %>
+<%@ page import="org.labkey.core.admin.UpdateFilePathsAction" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -45,7 +46,7 @@
 <labkey:errors/>
 <labkey:form action="<%=urlFor(FilesSiteSettingsAction.class)%>" method="post">
     <input type="hidden" name="upgrade" value="<%=bean.isUpgrade()%>">
-    <table width="80%">
+    <table class="lk-fields-table" style="width: 80%">
         <tr><td colspan="2"><h4>Site-Level File Root</h4></td></tr>
         <tr><td colspan="2" class="labkey-title-area-line"></td></tr>
 
@@ -59,7 +60,8 @@
             </td></tr>
         <% } else { %>
         <tr><td colspan="2">When a site-level file root is set, each folder for every project has a corresponding subdirectory in the file system.
-            If the root is changed, all files will be automatically moved to the new location.</td></tr>
+            If the root is changed, all files will be automatically moved to the new location. If files have been moved through other means, it is also
+            possible to <a href="<%= h(new ActionURL(UpdateFilePathsAction.class, getContainer())) %>">update paths stored in the database</a>.</td></tr>
         <% } %>
         <tr><td>&nbsp;</td></tr>
         

--- a/core/src/org/labkey/core/admin/view/updateFilePaths.jsp
+++ b/core/src/org/labkey/core/admin/view/updateFilePaths.jsp
@@ -1,0 +1,83 @@
+<%
+/*
+ * Copyright (c) 2009-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+%>
+<%@ page import="org.apache.commons.lang3.StringUtils"%>
+<%@ page import="org.apache.commons.lang3.SystemUtils" %>
+<%@ page import="org.labkey.api.admin.AdminUrls" %>
+<%@ page import="org.labkey.api.data.ContainerManager" %>
+<%@ page import="org.labkey.api.premium.PremiumService" %>
+<%@ page import="org.labkey.api.settings.AppProps" %>
+<%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
+<%@ page import="org.labkey.core.admin.AdminController.MapNetworkDriveAction" %>
+<%@ page import="org.labkey.core.admin.FileListAction" %>
+<%@ page import="org.labkey.core.admin.FileSettingsForm" %>
+<%@ page import="org.labkey.core.admin.FilesSiteSettingsAction" %>
+<%@ page import="org.labkey.core.admin.UpdateFilePathsAction" %>
+<%@ page import="org.labkey.api.util.PageFlowUtil" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+<%!
+    @Override
+    public void addClientDependencies(ClientDependencies dependencies)
+    {
+        dependencies.add("Ext4");
+    }
+%>
+<%
+    UpdateFilePathsAction.UpdateFilePathsForm bean = ((JspView<UpdateFilePathsAction.UpdateFilePathsForm>)HttpView.currentView()).getModelBean();
+%>
+
+<labkey:errors/>
+
+<labkey:form action="<%=urlFor(UpdateFilePathsAction.class)%>" method="post">
+
+    <p style="width: 60em;">
+        LabKey Server stores file paths in a variety of database tables. If files have moved from one location
+        to another and the server hasn't updated its stored paths, you can use this page to make the changes.
+    </p>
+
+    <p style="width: 60em;">
+        Use URIs that represent the root of the original path and the root of the new location. For example,
+        <em>file:/Volumes/NetworkShare/SubDir</em> or <em>file:/labkey/build/deploy/files</em>
+    </p>
+
+    <p style="width: 60em;">
+        Please use caution as this can
+        break the association of metadata and download links if the updated paths don't match the actual file system
+        layout.
+    </p>
+
+    <table class="lk-fields-table">
+        <tr>
+            <td class="labkey-form-label"><label for="originalPrefix">Original path URI prefix</label></td>
+            <td><input size="50" id="originalPrefix" name="originalPrefix" value="<%= h(bean.getOriginalPrefix())%>"></td>
+        </tr>
+        <tr>
+            <td class="labkey-form-label"><label for="newPrefix">New path URI prefix</label></td>
+            <td><input size="50" id="newPrefix" name="newPrefix" value="<%= h(bean.getNewPrefix())%>"></td>
+        </tr>
+        <tr>
+            <td></td>
+            <td><labkey:button text="Submit" /> <labkey:button text="Cancel" href="<%= PageFlowUtil.urlProvider(AdminUrls.class).getFilesSiteSettingsURL(false) %>" /></td>
+        </tr>
+    </table>
+
+
+</labkey:form>

--- a/experiment/src/org/labkey/experiment/ExpDataFileListener.java
+++ b/experiment/src/org/labkey/experiment/ExpDataFileListener.java
@@ -42,13 +42,13 @@ public class ExpDataFileListener extends TableUpdaterFileListener
     }
 
     @Override
-    public void fileMoved(@NotNull File src, @NotNull File dest, @Nullable User user, @Nullable Container container)
+    public int fileMoved(@NotNull File src, @NotNull File dest, @Nullable User user, @Nullable Container container)
     {
-        fileMoved(src.toPath(), dest.toPath(), user, container);
+        return fileMoved(src.toPath(), dest.toPath(), user, container);
     }
 
     @Override
-    public void fileMoved(@NotNull Path src, @NotNull Path dest, @Nullable User user, @Nullable Container c)
+    public int fileMoved(@NotNull Path src, @NotNull Path dest, @Nullable User user, @Nullable Container c)
     {
         ExpData data = ExperimentService.get().getExpDataByURL(src, c);
 
@@ -62,13 +62,15 @@ public class ExpDataFileListener extends TableUpdaterFileListener
             data = ExperimentService.get().createData(c, UPLOADED_FILE);
         }
 
+        int extra = 0;
         if (data != null && src.equals(data.getFilePath()) && !src.equals(dest))
         {
             // The file has been renamed, so rename the exp.data row if its name matches
             data.setName(FileUtil.getFileName(dest));
             data.save(user);
+            extra = 1;
         }
 
-        super.fileMoved(src, dest, user, c);
+        return super.fileMoved(src, dest, user, c) + extra;
     }
 }

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -1136,21 +1136,23 @@ public class FileContentServiceImpl implements FileContentService
     }
 
     @Override
-    public void fireFileMoveEvent(@NotNull File src, @NotNull File dest, @Nullable User user, @Nullable Container container)
+    public int fireFileMoveEvent(@NotNull File src, @NotNull File dest, @Nullable User user, @Nullable Container container)
     {
-        fireFileMoveEvent(src.toPath(), dest.toPath(), user, container);
+        return fireFileMoveEvent(src.toPath(), dest.toPath(), user, container);
     }
 
     @Override
-    public void fireFileMoveEvent(@NotNull java.nio.file.Path src, @NotNull java.nio.file.Path dest, @Nullable User user, @Nullable Container container)
+    public int fireFileMoveEvent(@NotNull java.nio.file.Path src, @NotNull java.nio.file.Path dest, @Nullable User user, @Nullable Container container)
     {
         // Make sure that we've got the best representation of the file that we can
         java.nio.file.Path absSrc = FileUtil.getAbsoluteCaseSensitivePath(container, src);
         java.nio.file.Path absDest = FileUtil.getAbsoluteCaseSensitivePath(container, dest);
+        int result = 0;
         for (FileListener fileListener : _fileListeners)
         {
-            fileListener.fileMoved(absSrc, absDest, user, container);
+            result += fileListener.fileMoved(absSrc, absDest, user, container);
         }
+        return result;
     }
 
     @Override

--- a/internal/src/org/labkey/api/webdav/WebFilesResolverImpl.java
+++ b/internal/src/org/labkey/api/webdav/WebFilesResolverImpl.java
@@ -161,18 +161,19 @@ public class WebFilesResolverImpl extends AbstractWebdavResolver implements File
     }
 
     @Override
-    public void fileMoved(@NotNull File src, @NotNull File dest, @Nullable User user, @Nullable Container container)
+    public int fileMoved(@NotNull File src, @NotNull File dest, @Nullable User user, @Nullable Container container)
     {
-        fileMoved(src.toPath(), dest.toPath(), user, container);
+        return fileMoved(src.toPath(), dest.toPath(), user, container);
     }
 
     @Override
-    public void fileMoved(@NotNull java.nio.file.Path src, @NotNull java.nio.file.Path dest, @Nullable User user, @Nullable Container container)
+    public int fileMoved(@NotNull java.nio.file.Path src, @NotNull java.nio.file.Path dest, @Nullable User user, @Nullable Container container)
     {
         if (AppProps.getInstance().isWebfilesRootEnabled() && container != null)
         {
             invalidateCache(container.getParsedPath(), true);
         }
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
It's a pain to fix up paths stored in the DB when they've been moved by something external to LabKey Server.

#### Changes
* New link on the Admin Console->Files page that lets an admin update paths across the various tables that store them
* Audit log under "Site Settings" heading that gives the old/new paths and the number of DB rows affected