### PR TITLE
Issue 44445: Redirect to default view if portal page does not exist

### DIFF
--- a/core/src/org/labkey/core/portal/ProjectController.java
+++ b/core/src/org/labkey/core/portal/ProjectController.java
@@ -323,10 +323,12 @@ public class ProjectController extends SpringActionController
             if (null == url || url.getExtraPath().equals("/"))
                 return HttpView.redirect(homeURL());
 
-            String pageId1 = url.getParameter("pageId");
-            if (null != pageId1)
+            String pageId = form.getPageId();
+            Portal.PortalPage portalPage = Portal.getPortalPage(c, pageId);
+
+            if (null != pageId)
             {
-                Container childContainer = ContainerManager.getChild(c, pageId1);
+                Container childContainer = ContainerManager.getChild(c, pageId);
                 if (null != childContainer && childContainer.isContainerTab())
                 {
                     // Redirect to child container, but only if user has permission
@@ -337,6 +339,10 @@ public class ProjectController extends SpringActionController
                         throw new RedirectException(new ActionURL(BeginAction.class, c));    // same class with no parameter
                     }
                 }
+
+                // Issue 44445: Redirect to default view if portal page does not exist
+                if (portalPage == null)
+                    throw new RedirectException(new ActionURL(BeginAction.class, c));
             }
 
             PageConfig page = getPageConfig();
@@ -349,7 +355,6 @@ public class ProjectController extends SpringActionController
             Template t = isPrint() ? Template.Print : Template.Home;
             HttpView<?> template = t.getTemplate(getViewContext(), new VBox(), page);
 
-            String pageId = form.getPageId();
             if (pageId == null)
             {
                 pageId = folderType.getDefaultPageId(getViewContext());
@@ -357,7 +362,6 @@ public class ProjectController extends SpringActionController
             Portal.populatePortalView(getViewContext(), pageId, template, isPrint());
 
             // Figure out title
-            Portal.PortalPage portalPage = Portal.getPortalPage(c, pageId);
             FolderTab folderTab = null;
             if (!DefaultFolderType.DEFAULT_DASHBOARD.equalsIgnoreCase(pageId))
                 folderTab = Portal.getFolderTabFromId(getViewContext(), pageId);


### PR DESCRIPTION
#### Rationale
In accordance with the desired behavior outlined in [Issue 44445](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44445) this PR updates the behavior when a portal page no longer exists.

#### Changes
* If a `pageId` parameter is supplied and the associated `Portal.PortalPage` cannot be found (i.e. is `null`), then redirect to the `BeginAction` in the current container.
