### PR TITLE
Move "Categories" export out of "Study" section

### DIFF
--- a/api/schemas/folder.xsd
+++ b/api/schemas/folder.xsd
@@ -44,6 +44,17 @@
                         </xs:attribute>
                     </xs:complexType>
                 </xs:element>
+                <xs:element name="categories" minOccurs="0">
+                    <xs:complexType>
+                        <xs:attribute name="file" type="xs:string">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    Indicates the "file" (string) that contains category definitions.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
                 <xs:element name="qcStates" minOccurs="0">
                     <xs:complexType>
                         <xs:attribute name="showPrivateDataByDefault" type="xs:boolean">

--- a/api/src/org/labkey/api/admin/AbstractImportContext.java
+++ b/api/src/org/labkey/api/admin/AbstractImportContext.java
@@ -138,6 +138,7 @@ public abstract class AbstractImportContext<XmlRoot extends XmlObject, XmlDocume
         _loggerGetter = loggerGetter;
     }
 
+    @Override
     public VirtualFile getRoot()
     {
         if (_root == null)

--- a/api/src/org/labkey/api/admin/FolderArchiveDataTypes.java
+++ b/api/src/org/labkey/api/admin/FolderArchiveDataTypes.java
@@ -44,4 +44,5 @@ public class FolderArchiveDataTypes
     public static final String ETLS = "ETL Definitions";
     public static final String SAMPLE_TYPES_AND_DATA_CLASSES = "Sample Types and Data Classes";
     public static final String INVENTORY = "Inventory locations and items";
+    public static final String VIEW_CATEGORIES = "Categories";
 }

--- a/api/src/org/labkey/api/admin/ImportContext.java
+++ b/api/src/org/labkey/api/admin/ImportContext.java
@@ -35,6 +35,7 @@ public interface ImportContext<XmlType extends XmlObject> extends ContainerUser
 {
     XmlType getXml() throws ImportException;
     VirtualFile getDir(String xmlNodeName) throws ImportException;
+    VirtualFile getRoot();
     Logger getLogger();
     LoggerGetter getLoggerGetter();
     Set<String> getDataTypes();

--- a/core/src/org/labkey/core/admin/writer/FolderSerializationRegistryImpl.java
+++ b/core/src/org/labkey/core/admin/writer/FolderSerializationRegistryImpl.java
@@ -72,8 +72,7 @@ public class FolderSerializationRegistryImpl implements FolderSerializationRegis
 
     private List<FolderImporterFactory> getSortedFactories()
     {
-        List<FolderImporterFactory> factories = new ArrayList<>();
-        factories.addAll(IMPORTER_FACTORIES);
+        List<FolderImporterFactory> factories = new ArrayList<>(IMPORTER_FACTORIES);
 
         // sort the factories by priority in ascending order
         factories.sort(Comparator.comparingInt(FolderImporterFactory::getPriority));

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -143,6 +143,7 @@ import org.labkey.study.designer.view.StudyDesignsWebPart;
 import org.labkey.study.importer.MissingValueImporterFactory;
 import org.labkey.study.importer.StudyImportProvider;
 import org.labkey.study.importer.StudyImporterFactory;
+import org.labkey.study.importer.ViewCategoryImporter;
 import org.labkey.study.model.CohortDomainKind;
 import org.labkey.study.model.ContinuousDatasetDomainKind;
 import org.labkey.study.model.DatasetDefinition;
@@ -195,6 +196,7 @@ import org.labkey.study.writer.DefaultStudyDesignWriter;
 import org.labkey.study.writer.MissingValueWriterFactory;
 import org.labkey.study.writer.StudySerializationRegistryImpl;
 import org.labkey.study.writer.StudyWriterFactory;
+import org.labkey.study.writer.ViewCategoryWriter;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -416,6 +418,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
         {
             folderRegistry.addFactories(new MissingValueWriterFactory(), new MissingValueImporterFactory());
             folderRegistry.addFactories(new StudyWriterFactory(), new StudyImporterFactory());
+            folderRegistry.addFactories(new ViewCategoryWriter.Factory(), new ViewCategoryImporter.Factory());
         }
 
         FileContentService.get().addFileListener(new TableUpdaterFileListener(StudySchema.getInstance().getTableInfoUploadLog(), "FilePath", TableUpdaterFileListener.Type.filePath, "RowId"));

--- a/study/src/org/labkey/study/importer/CreateChildStudyPipelineJob.java
+++ b/study/src/org/labkey/study/importer/CreateChildStudyPipelineJob.java
@@ -410,7 +410,7 @@ public class CreateChildStudyPipelineJob extends AbstractStudyPipelineJob
         {
             importContext = new StudyImportContext(getUser(), newStudy.getContainer(), studyDoc, null, new PipelineJobLoggerGetter(this), studyDir);
 
-            // missing values, qc states, and view categories
+            // missing values and qc states
             new MissingValueImporterFactory().create().process(null, importContext, studyDir);
             new StudyQcStatesImporter().process(importContext, studyDir, errors);
 

--- a/study/src/org/labkey/study/importer/CreateChildStudyPipelineJob.java
+++ b/study/src/org/labkey/study/importer/CreateChildStudyPipelineJob.java
@@ -349,8 +349,9 @@ public class CreateChildStudyPipelineJob extends AbstractStudyPipelineJob
         dataTypes.add(StudyArchiveDataTypes.VISIT_MAP);
         dataTypes.add(StudyArchiveDataTypes.STUDY_DATASETS_DEFINITIONS);
         dataTypes.add(StudyArchiveDataTypes.DATASET_DATA);
-        dataTypes.add(StudyArchiveDataTypes.VIEW_CATEGORIES);
         dataTypes.add(StudyArchiveDataTypes.PARTICIPANT_GROUPS);
+
+        dataTypes.add(FolderArchiveDataTypes.VIEW_CATEGORIES);
 
         if (StudySnapshotType.ancillary.equals(form.getMode()))
         {
@@ -409,7 +410,7 @@ public class CreateChildStudyPipelineJob extends AbstractStudyPipelineJob
         {
             importContext = new StudyImportContext(getUser(), newStudy.getContainer(), studyDoc, null, new PipelineJobLoggerGetter(this), studyDir);
 
-            // missing values and qc states
+            // missing values, qc states, and view categories
             new MissingValueImporterFactory().create().process(null, importContext, studyDir);
             new StudyQcStatesImporter().process(importContext, studyDir, errors);
 
@@ -430,10 +431,6 @@ public class CreateChildStudyPipelineJob extends AbstractStudyPipelineJob
             // custom participant view
             StudyViewsImporter viewsImporter = new StudyViewsImporter();
             viewsImporter.process(importContext, studyDir, errors);
-
-            // view categories
-            ViewCategoryImporter categoryImporter = new ViewCategoryImporter();
-            categoryImporter.process(importContext, studyDir, errors);
 
             if (errors.hasErrors())
                 throw new RuntimeException("Error importing study objects : " + errors.getMessage());

--- a/study/src/org/labkey/study/importer/StudyImportFinalTask.java
+++ b/study/src/org/labkey/study/importer/StudyImportFinalTask.java
@@ -88,7 +88,6 @@ public class StudyImportFinalTask extends PipelineJob.Task<StudyImportFinalTask.
             internalImporters.add(new ParticipantCommentImporter());
             internalImporters.add(new ParticipantGroupImporter());
             internalImporters.add(new ProtocolDocumentImporter());
-            internalImporters.add(new ViewCategoryImporter());
             internalImporters.add(new StudyViewsImporter());
 
             // TreatmentVisitMap needs to import after cohort info is loaded (issue 19947)

--- a/study/src/org/labkey/study/importer/StudyImportInitialTask.java
+++ b/study/src/org/labkey/study/importer/StudyImportInitialTask.java
@@ -37,7 +37,6 @@ import org.labkey.study.xml.StudyDocument;
 import org.springframework.validation.BindException;
 import org.springframework.validation.ObjectError;
 
-import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;

--- a/study/src/org/labkey/study/writer/StudySerializationRegistryImpl.java
+++ b/study/src/org/labkey/study/writer/StudySerializationRegistryImpl.java
@@ -90,7 +90,6 @@ public class StudySerializationRegistryImpl implements StudySerializationRegistr
                 new StudyDatasetData(),
                 new StudyDatasetDefinition(),
                 new AssayScheduleWriter(),
-                new ViewCategoryWriter(),
                 new CohortWriter(),
                 new ParticipantCommentWriter(),
                 new ParticipantGroupWriter(),
@@ -112,7 +111,6 @@ public class StudySerializationRegistryImpl implements StudySerializationRegistr
     {
         return Arrays.asList(
             new AssayScheduleImporter(),
-            new ViewCategoryImporter(),
             new CohortImporter(),
             new DatasetDefinitionImporter(),
             new DatasetCohortAssigner(),

--- a/study/src/org/labkey/study/writer/StudySerializationRegistryImpl.java
+++ b/study/src/org/labkey/study/writer/StudySerializationRegistryImpl.java
@@ -35,7 +35,6 @@ import org.labkey.study.importer.StudyViewsImporter;
 import org.labkey.study.importer.TopLevelStudyPropertiesImporter;
 import org.labkey.study.importer.TreatmentDataImporter;
 import org.labkey.study.importer.TreatmentVisitMapImporter;
-import org.labkey.study.importer.ViewCategoryImporter;
 import org.labkey.study.importer.VisitCohortAssigner;
 import org.labkey.study.importer.VisitImporter;
 
@@ -83,21 +82,21 @@ public class StudySerializationRegistryImpl implements StudySerializationRegistr
     {
         // New up the writers every time since these classes can be stateful
         return List.of(
-                new AssayDatasetData(),
-                new AssayDatasetDefinition(),
-                new SampleTypeDatasetData(),
-                new SampleTypeDatasetDefinition(),
-                new StudyDatasetData(),
-                new StudyDatasetDefinition(),
-                new AssayScheduleWriter(),
-                new CohortWriter(),
-                new ParticipantCommentWriter(),
-                new ParticipantGroupWriter(),
-                new ProtocolDocumentWriter(),
-                new TreatmentDataWriter(),
-                new VisitMapWriter(),
-                new StudyViewsWriter(),
-                new StudyXmlWriter()  // Note: Must be the last study writer since it writes out the study.xml file (to which other writers contribute)
+            new AssayDatasetData(),
+            new AssayDatasetDefinition(),
+            new SampleTypeDatasetData(),
+            new SampleTypeDatasetDefinition(),
+            new StudyDatasetData(),
+            new StudyDatasetDefinition(),
+            new AssayScheduleWriter(),
+            new CohortWriter(),
+            new ParticipantCommentWriter(),
+            new ParticipantGroupWriter(),
+            new ProtocolDocumentWriter(),
+            new TreatmentDataWriter(),
+            new VisitMapWriter(),
+            new StudyViewsWriter(),
+            new StudyXmlWriter()  // Note: Must be the last study writer since it writes out the study.xml file (to which other writers contribute)
         );
     }
 

--- a/study/src/org/labkey/study/writer/ViewCategoryWriter.java
+++ b/study/src/org/labkey/study/writer/ViewCategoryWriter.java
@@ -15,10 +15,16 @@
  */
 package org.labkey.study.writer;
 
+import org.labkey.api.admin.BaseFolderWriter;
+import org.labkey.api.admin.FolderArchiveDataTypes;
+import org.labkey.api.admin.FolderWriter;
+import org.labkey.api.admin.FolderWriterFactory;
+import org.labkey.api.admin.ImportContext;
+import org.labkey.api.data.Container;
 import org.labkey.api.reports.model.ViewCategory;
 import org.labkey.api.reports.model.ViewCategoryManager;
 import org.labkey.api.writer.VirtualFile;
-import org.labkey.study.model.StudyImpl;
+import org.labkey.folder.xml.FolderDocument.Folder;
 import org.labkey.study.xml.viewCategory.CategoriesDocument;
 import org.labkey.study.xml.viewCategory.CategoryType;
 import org.labkey.study.xml.viewCategory.ViewCategoryType;
@@ -30,18 +36,18 @@ import java.util.List;
  * Date: Oct 21, 2011
  * Time: 2:48:09 PM
  */
-public class ViewCategoryWriter implements InternalStudyWriter
+public class ViewCategoryWriter extends BaseFolderWriter
 {
     public static final String FILE_NAME = "view_categories.xml";
 
     @Override
     public String getDataType()
     {
-        return StudyArchiveDataTypes.VIEW_CATEGORIES;
+        return FolderArchiveDataTypes.VIEW_CATEGORIES;
     }
 
     @Override
-    public void write(StudyImpl object, StudyExportContext ctx, VirtualFile vf) throws Exception
+    public void write(Container object, ImportContext<Folder> ctx, VirtualFile vf) throws Exception
     {
         List<ViewCategory> categories = ViewCategoryManager.getInstance().getAllCategories(ctx.getContainer());
 
@@ -60,7 +66,19 @@ public class ViewCategoryWriter implements InternalStudyWriter
                 if (category.getParentCategory() != null)
                     ct.setParent(category.getParentCategory().getLabel());
             }
+
             vf.saveXmlBean(FILE_NAME, doc);
+            Folder.Categories categoriesElement = ctx.getXml().addNewCategories();
+            categoriesElement.setFile(FILE_NAME);
+        }
+    }
+
+    public static class Factory implements FolderWriterFactory
+    {
+        @Override
+        public FolderWriter create()
+        {
+            return new ViewCategoryWriter();
         }
     }
 }


### PR DESCRIPTION
#### Rationale
[Issue 44563: Categories export should be available in non-Study folders](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44563)
