### PR TITLE
Deprecate FormattedError and eliminate four usages

### DIFF
--- a/api/src/org/labkey/api/action/FormattedError.java
+++ b/api/src/org/labkey/api/action/FormattedError.java
@@ -24,6 +24,7 @@ import org.labkey.api.view.ViewContext;
  * User: Matthew
  * Date: Feb 5, 2009
  */
+@Deprecated // Will be removed soon. HTML messages are problematic, see #44194.
 public class FormattedError extends LabKeyError
 {
     public FormattedError(String message)

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -28,7 +28,6 @@ import org.labkey.api.action.ConfirmAction;
 import org.labkey.api.action.ExportAction;
 import org.labkey.api.action.FormHandlerAction;
 import org.labkey.api.action.FormViewAction;
-import org.labkey.api.action.FormattedError;
 import org.labkey.api.action.LabKeyError;
 import org.labkey.api.action.MutatingApiAction;
 import org.labkey.api.action.ReadOnlyApiAction;
@@ -58,10 +57,10 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
-import org.labkey.api.security.AuthenticationConfiguration.LoginFormAuthenticationConfiguration;
-import org.labkey.api.security.AuthenticationConfiguration.SSOAuthenticationConfiguration;
-import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.*;
+import org.labkey.api.security.AuthenticationConfiguration.LoginFormAuthenticationConfiguration;
+import org.labkey.api.security.SecurityManager;
+import org.labkey.api.security.AuthenticationConfiguration.SSOAuthenticationConfiguration;
 import org.labkey.api.security.ValidEmail.InvalidEmailException;
 import org.labkey.api.security.permissions.AbstractActionPermissionTest;
 import org.labkey.api.security.permissions.AddUserPermission;
@@ -1373,11 +1372,11 @@ public class SecurityController extends SpringActionController
                     final ValidEmail emailToClone = new ValidEmail(cloneUser);
                     userToClone = UserManager.getUser(emailToClone);
                     if (userToClone == null)
-                        errors.addError(new FormattedError("Failed to clone user permissions " + PageFlowUtil.filter(emailToClone) + ": User email does not exist in the system"));
+                        errors.addError(new LabKeyError("Failed to clone user permissions " + emailToClone + ": User email does not exist in the system"));
                 }
                 catch (InvalidEmailException e)
                 {
-                    errors.addError(new FormattedError("Failed to clone user permissions " + PageFlowUtil.filter(cloneUser.trim()) + ": Invalid email address"));
+                    errors.addError(new LabKeyError("Failed to clone user permissions " + cloneUser.trim() + ": Invalid email address"));
                 }
             }
 
@@ -1391,7 +1390,7 @@ public class SecurityController extends SpringActionController
             {
                 // Ignore lines of all whitespace, otherwise show an error.
                 if (!"".equals(rawEmail.trim()))
-                    errors.addError(new FormattedError("Failed to create user " + PageFlowUtil.filter(rawEmail.trim()) + ": Invalid email address"));
+                    errors.addError(new LabKeyError("Failed to create user " + rawEmail.trim() + ": Invalid email address"));
             }
 
             List<Pair<String, String>> extraParams = new ArrayList<>();
@@ -1418,7 +1417,7 @@ public class SecurityController extends SpringActionController
                 else if (userToClone != null)
                 {
                     if (userToClone.hasSiteAdminPermission() && !getUser().hasSiteAdminPermission())
-                        errors.addError(new FormattedError(userToClone.getEmail() + " cannot be cloned.  Only site administrators can clone users with site administration permissions."));
+                        errors.addError(new LabKeyError(userToClone.getEmail() + " cannot be cloned. Only site administrators can clone users with site administration permissions."));
                     else
                         clonePermissions(userToClone, email);
                 }

--- a/core/src/org/labkey/core/security/addUsers.jsp
+++ b/core/src/org/labkey/core/security/addUsers.jsp
@@ -70,7 +70,7 @@
         {
             if (textElem.value != null && textElem.value.length > 0)
             {
-                var target = "<%=h(new UserUrlsImpl().getUserAccessURL(ContainerManager.getRoot()).addParameter("newEmail", null))%>" + textElem.value;
+                var target = <%=q(new UserUrlsImpl().getUserAccessURL(ContainerManager.getRoot()).addParameter("renderInHomeTemplate", false).addParameter("newEmail", null))%> + textElem.value;
                 window.open(target, "permissions", "height=450,width=500,scrollbars=yes,status=yes,toolbar=no,menubar=no,location=no,resizable=yes");
             }
         }

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -108,7 +108,6 @@ import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.util.URLHelper;
-import org.labkey.api.util.emailTemplate.EmailTemplate;
 import org.labkey.api.util.emailTemplate.EmailTemplateService;
 import org.labkey.api.util.emailTemplate.UserOriginatedEmailTemplate;
 import org.labkey.api.view.ActionURL;
@@ -137,7 +136,6 @@ import org.labkey.core.query.UsersDomainKind;
 import org.labkey.core.query.UsersTable;
 import org.labkey.core.security.SecurityController.AdminDeletePasswordAction;
 import org.labkey.core.security.SecurityController.AdminResetPasswordAction;
-import org.labkey.core.view.template.bootstrap.PrintTemplate;
 import org.springframework.beans.PropertyValues;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
@@ -1406,7 +1404,7 @@ public class UserController extends SpringActionController
     @RequiresPermission(AdminPermission.class)
     public class UserAccessAction extends QueryViewAction<UserAccessForm, QueryView>
     {
-        private boolean _showNavTrail;
+        private boolean _showNavTrail = false;
         private Integer _userId;
 
         public UserAccessAction()
@@ -1439,12 +1437,12 @@ public class UserController extends SpringActionController
                     }
                     else
                     {
-                        throw new NotFoundException();
+                        throw new NotFoundException("An existing user with that email address was not found");
                     }
                 }
                 catch (ValidEmail.InvalidEmailException e)
                 {
-                    throw new NotFoundException();
+                    throw new NotFoundException("Invalid email address");
                 }
             }
 
@@ -1465,10 +1463,13 @@ public class UserController extends SpringActionController
             if (form.getRenderInHomeTemplate())
             {
                 _showNavTrail = true;
-                return view;
+            }
+            else
+            {
+                getPageConfig().setTemplate(PageConfig.Template.Print);
             }
 
-            return new PrintTemplate(getViewContext(), view, getPageConfig());
+            return view;
         }
 
         @Override
@@ -2384,11 +2385,10 @@ public class UserController extends SpringActionController
         static final String DEFAULT_BODY =
                 "The email address associated with your account on the ^organizationName^ ^siteShortName^ Web Site has been updated, " +
                 "from ^oldEmailAddress^ to ^newEmailAddress^.\n\n" +
-                "If you did not request this change, please contact the server administrator immediately.  Otherwise, no further action " +
+                "If you did not request this change, please contact the server administrator immediately. Otherwise, no further action " +
                 "is required, and you may use the new email address when logging into the server going forward.";
         String _oldEmailAddress;
         String _newEmailAddress;
-        List<EmailTemplate.ReplacementParam> _replacements = new ArrayList<>();
 
         @SuppressWarnings("UnusedDeclaration") // Constructor called via reflection
         public ChangeAddressEmailTemplate()


### PR DESCRIPTION
#### Rationale
Per discussion in [issue 44194](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=44194), we want to remove `FormattedError`. This eliminates four usages of that class.

`UserAccessAction`: Fix the `renderInHomeTemplate=false` option of this action (previously, it would wrap the home template around the print template, for extra fun) and use this option from the add users page popup. Provide more specific not found messages for invalid and not found email addresses. Stop HTML encoding URL inside JavaScript.