### PR TITLE
Add link in pipeline details page to show raw log file

### DIFF
--- a/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
@@ -2,15 +2,23 @@ package org.labkey.pipeline.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import edu.emory.mathcs.backport.java.util.Collections;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.StringBuilderWriter;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.files.FileContentService;
+import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.pipeline.PipelineStatusFile;
+import org.labkey.api.settings.AppProps;
+import org.labkey.api.settings.ResourceURL;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.pipeline.api.PipelineStatusFileImpl;
 import org.labkey.pipeline.api.PipelineStatusManager;
@@ -44,6 +52,7 @@ public class StatusDetailsBean
     public final String modified;
     public final String email;
     public final String status;
+    public final Container container;
     public final String description;
     public final String info;
     public final boolean active;
@@ -75,6 +84,7 @@ public class StatusDetailsBean
         this.modified = DateUtil.formatDateTime(c, psf.getModified());
         this.email = psf.getEmail();
         this.status = psf.getStatus();
+        this.container = psf.lookupContainer();
         this.description = psf.getDescription();
         this.info = psf.getInfo();
         this.active = psf.isActive();
@@ -168,6 +178,7 @@ public class StatusDetailsBean
     // skipping offset characters and closing the PrintWriter when complete.
     private static long transferTo(StringBuilder out, Path p, long offset) throws IOException
     {
+        //TODO
         // Pipeline log files are written in platform default encoding.
         // See PipelineJob.createPrintWriter() and PipelineJob.OutputLogger.write()
         // Use platform default encoding when reading the log file.

--- a/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
@@ -265,4 +265,53 @@ public class StatusDetailsBean
         }
     }
 
+    public @Nullable URLHelper getWebDavUrl()
+    {
+        if (filePath == null)
+        {
+            return null;
+        }
+
+        Path logFile = Path.of(filePath);
+
+        if (container == null)
+        {
+            return null;
+        }
+
+        PipeRoot root = PipelineService.get().getPipelineRootSetting(container);
+        if (root == null)
+        {
+            return null;
+        }
+
+        if (!root.isUnderRoot(logFile))
+        {
+            return null;
+        }
+
+        // TODO: if this the best cloud-aware way to test whether this file exists?
+        if (!Files.exists(logFile))
+        {
+            return null;
+        }
+
+        String relPath = root.relativePath(logFile);
+        if (relPath == null)
+        {
+            return null;
+        }
+
+        if (!FileContentService.get().isCloudRoot(container))
+        {
+            relPath = org.labkey.api.util.Path.parse(FilenameUtils.separatorsToUnix(relPath)).encode();
+        }
+        else
+        {
+            // Do not encode path from S3 folder.  It is already encoded.
+            relPath = org.labkey.api.util.Path.parse(FilenameUtils.separatorsToUnix(relPath)).toString();
+        }
+
+        return new ResourceURL(AppProps.getInstance().getBaseServerUrl() + root.getWebdavURL() + relPath);
+    }
 }

--- a/pipeline/src/org/labkey/pipeline/status/details.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/details.jsp
@@ -232,7 +232,7 @@
             if (url != null)
             {
         %>
-            <%=link("Show raw log file").id("show-raw-log").attributes(Map.of("data-details", "false")).href(url)%>
+            <%=link("Show raw log file").id("show-raw-log").attributes(Map.of("data-details", "false")).href(url).target("_blank")%>
         <%
             }
         %>

--- a/pipeline/src/org/labkey/pipeline/status/details.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/details.jsp
@@ -16,12 +16,13 @@
  */
 %>
 <%@ page import="org.labkey.api.pipeline.PipelineJob.TaskStatus" %>
+<%@ page import="org.labkey.api.util.URLHelper" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.pipeline.status.LogFileParser" %>
 <%@ page import="org.labkey.pipeline.status.StatusController" %>
 <%@ page import="org.labkey.pipeline.status.StatusDetailsBean" %>
-<%@ page import="java.util.Map" %>
 <%@ page import="java.util.Date" %>
+<%@ page import="java.util.Map" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -226,6 +227,15 @@
 <labkey:panel title="Log File" type="portal">
     <div id="log-controls">
         <%=link("Show full log file").id("show-full-log").attributes(Map.of("data-details", "false")).onClick("toggleShowFullLog();return false;")%>
+        <%
+            URLHelper url = status.getWebDavUrl();
+            if (url != null)
+            {
+        %>
+            <%=link("Show raw log file").id("show-raw-log").attributes(Map.of("data-details", "false")).href(url)%>
+        <%
+            }
+        %>
         <%=link("Copy to clipboard").id("copy-log-text").onClick("copyLogText(event);return false;")%>
     </div>
     <br>


### PR DESCRIPTION
This is related to issue: https://www.labkey.org/ONPRC/Support%20Tickets/issues-details.view?issueId=44525

The rationale is that pipeline logs can be long, and there are situations when viewing a plain text file can be useful. This adds a simple link next to 'show full log file', which loads the raw log via webdav in a new tab.