### PR TITLE
Issue 44015: Migrate remaining log4j 1.2 usages to 2.x

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -58,7 +58,6 @@ List caching = [
 List logging = [
         "org.apache.logging.log4j:log4j-core:${log4j2Version}",
         "org.apache.logging.log4j:log4j-api:${log4j2Version}",
-        "org.apache.logging.log4j:log4j-1.2-api:${log4j2Version}",
         "commons-logging:commons-logging:${commonsLoggingVersion}"
 ]
 

--- a/api/resources/credits/jars.txt
+++ b/api/resources/credits/jars.txt
@@ -38,7 +38,6 @@ jxl-2.6.3.jar|API|2.6.3|{link:jexcelapi|http://www.jexcelapi.org/}|{link:LGPL|ht
 kaptcha-2.3.jar|Captcha generator|2.3|{link:kaptcha|http://code.google.com/p/kaptcha/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|nicka|User signup forms
 log4j-api-2.17.0.jar|Log4j|2.17.0|{link:Apache|https://logging.apache.org/log4j/2.x/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|ankurj|Logging
 log4j-core-2.17.0.jar|Log4j|2.17.0|{link:Apache|https://logging.apache.org/log4j/2.x/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|ankurj|Logging
-log4j-1.2-api-2.17.0.jar|Log4j|2.17.0|{link:Apache|https://logging.apache.org/log4j/2.x/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|ankurj|Logging
 opencsv-2.3.jar|OpenCSV|2.3|{link:OpenCSV|http://opencsv.sourceforge.net/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|adam|Parsing CSV files
 pdfbox-2.0.25.jar|Apache PDFBox®|2.0.25|{link:PDFBox|https://pdfbox.apache.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|adam|Extract text and produce thumbnails from PDFs
 poi-4.1.2.jar|Apache POI|4.1.2|{link:Apache|https://poi.apache.org/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|adam|Extracting text from and exporting to Microsoft document formats (Excel, Word, PowerPoint, etc.)

--- a/api/src/org/labkey/api/action/ReturnUrlForm.java
+++ b/api/src/org/labkey/api/action/ReturnUrlForm.java
@@ -18,7 +18,8 @@ package org.labkey.api.action;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.HtmlString;
@@ -36,7 +37,7 @@ import org.labkey.api.view.HttpView;
  */
 public class ReturnUrlForm
 {
-    public static Logger LOG = Logger.getLogger(ReturnUrlForm.class);
+    public static final Logger LOG = LogManager.getLogger(ReturnUrlForm.class);
 
     private ReturnURLString _returnUrl;
     private ReturnURLString _cancelUrl;

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -18,7 +18,8 @@ package org.labkey.api.query;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.AfterClass;
@@ -1125,7 +1126,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
                 @Override
                 public void addRowError(ValidationException vex)
                 {
-                    Logger.getLogger(AbstractQueryUpdateService.class).error("test error", vex);
+                    LogManager.getLogger(AbstractQueryUpdateService.class).error("test error", vex);
                     fail(vex.getMessage());
                 }
             };

--- a/api/src/org/labkey/api/query/column/ContainerIdColumnInfoTransformer.java
+++ b/api/src/org/labkey/api/query/column/ContainerIdColumnInfoTransformer.java
@@ -1,6 +1,7 @@
 package org.labkey.api.query.column;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ContainerDisplayColumn;
@@ -22,7 +23,7 @@ public class ContainerIdColumnInfoTransformer implements ConceptURIColumnInfoTra
     {
         if (column.getJdbcType() != JdbcType.GUID && column.getJdbcType() != JdbcType.VARCHAR)
         {
-            Logger.getLogger(UserIdColumnInfoTransformer.class).warn("Column is not of type GUID: " + column.getName());
+            LogManager.getLogger(UserIdColumnInfoTransformer.class).warn("Column is not of type GUID: " + column.getName());
             return column;
         }
 
@@ -42,5 +43,4 @@ public class ContainerIdColumnInfoTransformer implements ConceptURIColumnInfoTra
         }
         return column;
     }
-
 }

--- a/api/src/org/labkey/api/query/column/UserIdColumnInfoTransformer.java
+++ b/api/src/org/labkey/api/query/column/UserIdColumnInfoTransformer.java
@@ -1,12 +1,12 @@
 package org.labkey.api.query.column;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.query.UserIdQueryForeignKey;
 import org.labkey.api.query.UserSchema;
-
 
 public class UserIdColumnInfoTransformer implements ConceptURIColumnInfoTransformer
 {
@@ -21,7 +21,7 @@ public class UserIdColumnInfoTransformer implements ConceptURIColumnInfoTransfor
     {
         if (column.getJdbcType() != JdbcType.INTEGER)
         {
-            Logger.getLogger(UserIdColumnInfoTransformer.class).error("Column is not of type INT: " + column.getName());
+            LogManager.getLogger(UserIdColumnInfoTransformer.class).error("Column is not of type INT: " + column.getName());
             return column;
         }
 

--- a/api/src/org/labkey/api/security/AuthenticationConfigurationCache.java
+++ b/api/src/org/labkey/api/security/AuthenticationConfigurationCache.java
@@ -2,8 +2,8 @@ package org.labkey.api.security;
 
 import org.apache.commons.collections4.SetValuedMap;
 import org.apache.commons.collections4.multimap.AbstractSetValuedMap;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.BlockingCache;

--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -17,8 +17,8 @@ package org.labkey.api.settings;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.SpringActionController;

--- a/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
+++ b/api/src/org/labkey/api/study/query/PublishResultsQueryView.java
@@ -17,7 +17,8 @@
 package org.labkey.api.study.query;
 
 import org.apache.commons.beanutils.ConversionException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AbstractAssayProvider;
 import org.labkey.api.data.ActionButton;
@@ -95,7 +96,7 @@ import java.util.stream.Collectors;
  */
 public class PublishResultsQueryView extends QueryView
 {
-    private static final Logger LOG = Logger.getLogger(PublishResultsQueryView.class);
+    private static final Logger LOG = LogManager.getLogger(PublishResultsQueryView.class);
 
     private final SimpleFilter _filter;
     private final Container _targetStudyContainer;

--- a/core/src/org/labkey/core/statistics/FourParameterSimplex.java
+++ b/core/src/org/labkey/core/statistics/FourParameterSimplex.java
@@ -11,7 +11,8 @@ import org.apache.commons.math3.optim.nonlinear.scalar.ObjectiveFunction;
 import org.apache.commons.math3.optim.nonlinear.scalar.noderiv.NelderMeadSimplex;
 import org.apache.commons.math3.optim.nonlinear.scalar.noderiv.PowellOptimizer;
 import org.apache.commons.math3.optim.nonlinear.scalar.noderiv.SimplexOptimizer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.labkey.api.data.statistics.DoublePoint;
 import org.labkey.api.data.statistics.FitFailedException;
 import org.labkey.api.data.statistics.StatsService;
@@ -24,7 +25,7 @@ import org.labkey.api.data.statistics.StatsService;
  */
 public class FourParameterSimplex extends ParameterCurveFit implements MultivariateFunction
 {
-    Logger _log = Logger.getLogger(FourParameterSimplex.class);
+    private static final Logger _log = LogManager.getLogger(FourParameterSimplex.class);
 
     private static final double REL_TOLERANCE = 1.0e-10;            // relative convergence factor
     private static final double ABS_TOLERANCE = 1.0e-20;            // absolute convergence factor

--- a/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
@@ -2,7 +2,8 @@ package org.labkey.pipeline.status;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import edu.emory.mathcs.backport.java.util.Collections;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.StringBuilderWriter;
 import org.labkey.api.exp.api.ExpRun;
@@ -36,7 +37,7 @@ import static org.labkey.pipeline.api.PipelineStatusManager.getSplitStatusFiles;
 @JsonInclude(JsonInclude.Include.NON_NULL) // Don't serialize null values
 public class StatusDetailsBean
 {
-    public static final Logger LOG = Logger.getLogger(StatusDetailsBean.class);
+    public static final Logger LOG = LogManager.getLogger(StatusDetailsBean.class);
 
     public final int rowId;
     public final String jobId;

--- a/specimen/src/org/labkey/specimen/actions/SpecimenController.java
+++ b/specimen/src/org/labkey/specimen/actions/SpecimenController.java
@@ -1,8 +1,8 @@
 package org.labkey.specimen.actions;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;


### PR DESCRIPTION
#### Rationale
Recent events notwithstanding, we prefer log4j 2.x. Migrate 1.2 usages that snuck in after our big migration.

Also, remove the log4j 1.2 -> 2.x bridge to keep additional log4j 1.2 references from creeping in.