### PR TITLE
Item 9782: Text Choice data type support for field editor updates to in use values

### DIFF
--- a/api/gwtsrc/org/labkey/api/gwt/client/model/GWTPropertyValidator.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/model/GWTPropertyValidator.java
@@ -31,10 +31,6 @@ import java.util.Map;
 */
 public class GWTPropertyValidator implements Serializable, IsSerializable
 {
-    public static final String TYPE_REGEX = "regex";
-    public static final String TYPE_RANGE = "range";
-    public static final String TYPE_LOOKUP = "lookup";
-
     private int _rowId;
     private String _name;
     private PropertyValidatorType _type;
@@ -43,7 +39,8 @@ public class GWTPropertyValidator implements Serializable, IsSerializable
     private String _errorMessage;
     private boolean _isNew;
 
-    private Map<String, String> _properties = new HashMap<String, String>();
+    private Map<String, String> _properties = new HashMap<>();
+    private Map<String, Map<String, Object>> _extraProperties = new HashMap<>();
 
     public GWTPropertyValidator()
     {
@@ -140,6 +137,16 @@ public class GWTPropertyValidator implements Serializable, IsSerializable
     public void setProperties(Map<String, String> properties)
     {
         _properties = properties;
+    }
+
+    public Map<String, Map<String, Object>> getExtraProperties()
+    {
+        return _extraProperties;
+    }
+
+    public void setExtraProperties(Map<String, Map<String, Object>> extraProperties)
+    {
+        _extraProperties = extraProperties;
     }
 
     public boolean isNew()

--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -237,5 +237,5 @@ public interface AssayService
     /**
      * Returns the TableInfo for the given assay domain based on the assay domain ID.
      */
-    TableInfo getTableInfoForDomainId(User user, Container container, int domainId);
+    TableInfo getTableInfoForDomainId(User user, Container container, int domainId, @Nullable ContainerFilter cf);
 }

--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -18,6 +18,7 @@ package org.labkey.api.exp.property;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.NameExpressionValidationResult;
@@ -253,14 +254,14 @@ abstract public class DomainKind<T>  implements Handler<String>
         return false;
     }
 
-    public TableInfo getTableInfo(User user, Container container, String name)
+    public TableInfo getTableInfo(User user, Container container, String name, @Nullable ContainerFilter cf)
     {
         return null;
     }
 
-    public TableInfo getTableInfo(User user, Container container, Domain domain)
+    public TableInfo getTableInfo(User user, Container container, Domain domain, @Nullable ContainerFilter cf)
     {
-        return getTableInfo(user, container, domain.getName());
+        return getTableInfo(user, container, domain.getName(), cf);
     }
 
     /** Called for provisioned tables after StorageProvisioner has loaded them from JDBC but before they are locked and

--- a/assay/api-src/org/labkey/api/assay/AssayDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayDomainKind.java
@@ -21,6 +21,7 @@ import org.json.JSONObject;
 import org.labkey.api.assay.security.DesignAssayPermission;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.DomainDescriptor;
@@ -234,8 +235,8 @@ public abstract class AssayDomainKind extends BaseAbstractDomainKind
     }
 
     @Override
-    public TableInfo getTableInfo(User user, Container container, Domain domain)
+    public TableInfo getTableInfo(User user, Container container, Domain domain, @Nullable ContainerFilter cf)
     {
-        return AssayService.get().getTableInfoForDomainId(user, container, domain.getTypeId());
+        return AssayService.get().getTableInfoForDomainId(user, container, domain.getTypeId(), cf);
     }
 }

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -395,14 +395,14 @@ public class AssayManager implements AssayService
         return null;
     }
 
-    public TableInfo getTableInfoForDomainId(User user, Container container, int domainId) {
+    public TableInfo getTableInfoForDomainId(User user, Container container, int domainId, @Nullable ContainerFilter cf) {
         for (ExpProtocol protocol : getAssayProtocols(container))
         {
             AssayProvider provider = getProvider(protocol);
             AssayProtocolSchema schema = provider.createProtocolSchema(user, container, protocol, null);
             for (String tableName : schema.getTableNames())
             {
-                TableInfo table = schema.getTable(tableName, null, true, true);
+                TableInfo table = schema.getTable(tableName, cf, true, true);
                 if (table != null && table.getDomain() != null && table.getDomain().getTypeId() == domainId)
                     return table;
             }

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.111.0-fb-textChoiceUpdates.2",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.0-fb-textChoiceUpdates.2.tgz",
-      "integrity": "sha1-wwnzdVIglx7l/h3INbEdk0HixGs=",
+      "version": "2.111.0-fb-textChoiceUpdates.3",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.0-fb-textChoiceUpdates.3.tgz",
+      "integrity": "sha1-CQb0xcSdd9GtqWQwMoHf8fxzdY0=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.111.1-fb-textChoiceUpdates.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.1-fb-textChoiceUpdates.1.tgz",
-      "integrity": "sha1-sjDEuG7RsoIvMtQf3zE8SK9KY2E=",
+      "version": "2.111.1-fb-textChoiceUpdates.2",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.1-fb-textChoiceUpdates.2.tgz",
+      "integrity": "sha1-+aWpOtQu7/kB+0XEwBa6tmDEZwc=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.111.1-fb-textChoiceUpdates.2",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.1-fb-textChoiceUpdates.2.tgz",
-      "integrity": "sha1-+aWpOtQu7/kB+0XEwBa6tmDEZwc=",
+      "version": "2.111.1-fb-textChoiceUpdates.3",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.1-fb-textChoiceUpdates.3.tgz",
+      "integrity": "sha1-qlBwItO3N/z/zECaoKgfmj3+8w8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.111.0-fb-textChoiceUpdates.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.0-fb-textChoiceUpdates.1.tgz",
-      "integrity": "sha1-2DXKto4Rc1E0oUm2xjg1ufpmO6Y=",
+      "version": "2.111.0-fb-textChoiceUpdates.2",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.0-fb-textChoiceUpdates.2.tgz",
+      "integrity": "sha1-wwnzdVIglx7l/h3INbEdk0HixGs=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.110.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.110.0.tgz",
-      "integrity": "sha1-K+TXAE1EZl8gphUtgctsIISKdhE=",
+      "version": "2.111.0-fb-textChoiceUpdates.1",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.0-fb-textChoiceUpdates.1.tgz",
+      "integrity": "sha1-2DXKto4Rc1E0oUm2xjg1ufpmO6Y=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -2455,9 +2455,9 @@
       }
     },
     "@types/react-redux": {
-      "version": "7.1.20",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.20.tgz",
-      "integrity": "sha512-q42es4c8iIeTgcnB+yJgRTTzftv3eYYvCZOh1Ckn2eX/3o5TdsQYKUWpLoLuGlcY/p+VAhV9IOEZJcWk/vfkXw==",
+      "version": "7.1.21",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.21.tgz",
+      "integrity": "sha512-bLdglUiBSQNzWVVbmNPKGYYjrzp3/YDPwfOH3nLEz99I4awLlaRAPWjo6bZ2POpxztFWtDDXIPxBLVykXqBt+w==",
       "requires": {
         "@types/hoist-non-react-statics": "^3.3.0",
         "@types/react": "*",
@@ -4445,9 +4445,9 @@
       }
     },
     "date-fns": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.27.0.tgz",
-      "integrity": "sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q=="
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "debug": {
       "version": "4.3.2",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.111.1-fb-textChoiceUpdates.6",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.1-fb-textChoiceUpdates.6.tgz",
-      "integrity": "sha1-cpOEKvhLA4G7viz3aineVofu/Bk=",
+      "version": "2.112.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.112.0.tgz",
+      "integrity": "sha1-8luSlJiW/V8BE9DHc4YXRkXrqNQ=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.111.1-fb-textChoiceUpdates.5",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.1-fb-textChoiceUpdates.5.tgz",
-      "integrity": "sha1-N6LgmCpDuePO5GjCMbHN7KCEPBY=",
+      "version": "2.111.1-fb-textChoiceUpdates.6",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.1-fb-textChoiceUpdates.6.tgz",
+      "integrity": "sha1-cpOEKvhLA4G7viz3aineVofu/Bk=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.111.1-fb-textChoiceUpdates.4",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.1-fb-textChoiceUpdates.4.tgz",
-      "integrity": "sha1-GtbBVCiiteZ4nkibj7tFD0Xgcuk=",
+      "version": "2.111.1-fb-textChoiceUpdates.5",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.1-fb-textChoiceUpdates.5.tgz",
+      "integrity": "sha1-N6LgmCpDuePO5GjCMbHN7KCEPBY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.111.1-fb-textChoiceUpdates.3",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.1-fb-textChoiceUpdates.3.tgz",
-      "integrity": "sha1-qlBwItO3N/z/zECaoKgfmj3+8w8=",
+      "version": "2.111.1-fb-textChoiceUpdates.4",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.1-fb-textChoiceUpdates.4.tgz",
+      "integrity": "sha1-GtbBVCiiteZ4nkibj7tFD0Xgcuk=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.111.1-fb-textChoiceUpdates.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.1-fb-textChoiceUpdates.0.tgz",
-      "integrity": "sha1-KbCfVye1m+79jLy9pGnCmPqmiwo=",
+      "version": "2.111.1-fb-textChoiceUpdates.1",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.1-fb-textChoiceUpdates.1.tgz",
+      "integrity": "sha1-sjDEuG7RsoIvMtQf3zE8SK9KY2E=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.111.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.1.tgz",
-      "integrity": "sha1-+VUArKVg0R1OdBnOSlL4RgjlmdE=",
+      "version": "2.111.1-fb-textChoiceUpdates.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.1-fb-textChoiceUpdates.0.tgz",
+      "integrity": "sha1-KbCfVye1m+79jLy9pGnCmPqmiwo=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -2093,9 +2093,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.111.0-fb-textChoiceUpdates.3",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.0-fb-textChoiceUpdates.3.tgz",
-      "integrity": "sha1-CQb0xcSdd9GtqWQwMoHf8fxzdY0=",
+      "version": "2.111.0-fb-textChoiceUpdates.4",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.111.0-fb-textChoiceUpdates.4.tgz",
+      "integrity": "sha1-gWd2qqV+JErA9tXjI3qgjiXZq5Y=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.7.1",
-    "@labkey/components": "2.110.0",
+    "@labkey/components": "2.111.0-fb-textChoiceUpdates.1",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.7.1",
-    "@labkey/components": "2.111.1-fb-textChoiceUpdates.0",
+    "@labkey/components": "2.111.1-fb-textChoiceUpdates.1",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.7.1",
-    "@labkey/components": "2.111.0-fb-textChoiceUpdates.1",
+    "@labkey/components": "2.111.0-fb-textChoiceUpdates.2",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.7.1",
-    "@labkey/components": "2.111.1-fb-textChoiceUpdates.1",
+    "@labkey/components": "2.111.1-fb-textChoiceUpdates.2",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.7.1",
-    "@labkey/components": "2.111.1-fb-textChoiceUpdates.3",
+    "@labkey/components": "2.111.1-fb-textChoiceUpdates.4",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.7.1",
-    "@labkey/components": "2.111.1-fb-textChoiceUpdates.6",
+    "@labkey/components": "2.112.0",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.7.1",
-    "@labkey/components": "2.111.1-fb-textChoiceUpdates.5",
+    "@labkey/components": "2.111.1-fb-textChoiceUpdates.6",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.7.1",
-    "@labkey/components": "2.111.1-fb-textChoiceUpdates.4",
+    "@labkey/components": "2.111.1-fb-textChoiceUpdates.5",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.7.1",
-    "@labkey/components": "2.111.0-fb-textChoiceUpdates.2",
+    "@labkey/components": "2.111.0-fb-textChoiceUpdates.3",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.7.1",
-    "@labkey/components": "2.111.1",
+    "@labkey/components": "2.111.1-fb-textChoiceUpdates.0",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.7.1",
-    "@labkey/components": "2.111.0-fb-textChoiceUpdates.3",
+    "@labkey/components": "2.111.0-fb-textChoiceUpdates.4",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.7.1",
-    "@labkey/components": "2.111.1-fb-textChoiceUpdates.2",
+    "@labkey/components": "2.111.1-fb-textChoiceUpdates.3",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
@@ -362,10 +363,10 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
     }
 
     @Override
-    public TableInfo getTableInfo(User user, Container container, String name)
+    public TableInfo getTableInfo(User user, Container container, String name, @Nullable ContainerFilter cf)
     {
         UserSchema schema = new DataClassUserSchema(container, user);
-        return schema.getTable(name);
+        return schema.getTable(name, cf);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -555,7 +555,7 @@ public class DomainImpl implements Domain
             {
                 try
                 {
-                    TableInfo tableInfo = kind.getTableInfo(user, getContainer(), getName());
+                    TableInfo tableInfo = kind.getTableInfo(user, getContainer(), getName(), null);
                     if (tableInfo == null)
                     {
                         throw new ChangePropertyDescriptorException("Couldn't resolve TableInfo for domain kind " + kind + " with name " + getName());

--- a/experiment/src/org/labkey/experiment/types/typeDetails.jsp
+++ b/experiment/src/org/labkey/experiment/types/typeDetails.jsp
@@ -45,7 +45,7 @@
     ActionURL urlView = kind != null ? kind.urlShowData(d, getViewContext()) : null;
     ActionURL urlEdit = kind != null ? kind.urlEditDefinition(d, getViewContext()) : null;
 
-    TableInfo table = kind != null ? kind.getTableInfo(getUser(), getContainer(), d.getName()) : null;
+    TableInfo table = kind != null ? kind.getTableInfo(getUser(), getContainer(), d.getName(), null) : null;
     ActionURL urlSchemaBrowser = table != null ? PageFlowUtil.urlProvider(QueryUrls.class).urlSchemaBrowser(getContainer(), table.getPublicSchemaName(), table.getPublicName()) : null;
 
 %>

--- a/internal/src/org/labkey/api/exp/property/DomainTemplate.java
+++ b/internal/src/org/labkey/api/exp/property/DomainTemplate.java
@@ -451,7 +451,7 @@ public class DomainTemplate
 
         // NOTE: Unfortunately, there currently is no direct mapping from domain->table.
         // NOTE: Getting the TableInfo for the Domain only works for some domain kinds.
-        TableInfo table = kind.getTableInfo(u, c, domainName);
+        TableInfo table = kind.getTableInfo(u, c, domainName, null);
         if (table == null)
             throw new IllegalStateException();
 

--- a/internal/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/internal/src/org/labkey/api/exp/property/DomainUtil.java
@@ -1008,7 +1008,7 @@ public class DomainUtil
             if (domainTable != null && domainTable.getUpdateService() != null)
             {
                 // we need to make all of the row updates for this domain property at one time to prevent the
-                // double mapping if one choice value want from a -> b and another from b -> c
+                // double mapping if one choice value was changed from a -> b and another from b -> c
                 // (not sure why someone would do that though)
                 List<Map<String, Object>> rows = new ArrayList<>();
 

--- a/internal/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/internal/src/org/labkey/api/exp/property/DomainUtil.java
@@ -1024,7 +1024,12 @@ public class DomainUtil
 
                     // put the updated property value into the row map as well
                     for (Map<String, Object> valueRow : valueRows)
+                    {
                         valueRow.put(propName, entry.getValue());
+
+                        // remove extra "_row" value (from ResultSetDataIterator) if it exists
+                        valueRow.remove("_row");
+                    }
 
                     rows.addAll(valueRows);
                 }

--- a/internal/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/internal/src/org/labkey/api/exp/property/DomainUtil.java
@@ -67,6 +67,7 @@ import org.labkey.api.view.UnauthorizedException;
 import org.labkey.data.xml.ColumnType;
 import org.labkey.data.xml.ConditionalFormatFilterType;
 import org.labkey.data.xml.ConditionalFormatType;
+import org.labkey.experiment.api.SampleTypeDomainKind;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -1016,6 +1017,9 @@ public class DomainUtil
                 {
                     // query for the row PKs of domain rows that have the original text choice value
                     SimpleFilter filter = new SimpleFilter(FieldKey.fromParts(propName), entry.getKey());
+                    // filter out aliquots for sample type domain
+                    if (domain.getDomainKind() instanceof SampleTypeDomainKind)
+                        filter.addCondition(FieldKey.fromParts("IsAliquot"), false);
                     List<Map<String, Object>> valueRows = new TableSelector(domainTable, domainTable.getPkColumns(), filter, null).getMapCollection().stream().toList();
 
                     // put the updated property value into the row map as well

--- a/internal/src/org/labkey/api/issues/AbstractIssuesListDefDomainKind.java
+++ b/internal/src/org/labkey/api/issues/AbstractIssuesListDefDomainKind.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
@@ -383,9 +384,9 @@ public abstract class AbstractIssuesListDefDomainKind extends AbstractDomainKind
     }
 
     @Override
-    public TableInfo getTableInfo(User user, Container container, String name)
+    public TableInfo getTableInfo(User user, Container container, String name, @Nullable ContainerFilter cf)
     {
         UserSchema schema = QueryService.get().getUserSchema(user, container, IssuesSchema.SCHEMA_NAME);
-        return schema.getTable(name);
+        return schema.getTable(name, cf);
     }
 }

--- a/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
+++ b/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
@@ -570,10 +571,10 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
     }
 
     @Override
-    public TableInfo getTableInfo(User user, Container container, String name)
+    public TableInfo getTableInfo(User user, Container container, String name, @Nullable ContainerFilter cf)
     {
         UserSchema schema = new SamplesSchema(user, container);
-        return schema.getTable(name, null);
+        return schema.getTable(name, cf);
     }
 
     @Override

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -24,6 +24,7 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.JdbcType;
@@ -320,9 +321,9 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
     }
 
     @Override
-    public TableInfo getTableInfo(User user, Container container, String name)
+    public TableInfo getTableInfo(User user, Container container, String name, @Nullable ContainerFilter cf)
     {
-        return new ListQuerySchema(user, container).createTable(name);
+        return new ListQuerySchema(user, container).createTable(name, cf);
     }
 
     @Override

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -531,7 +531,7 @@ public class StudyPublishManager implements StudyPublishService
         assert pvs.isProvenanceSupported();
 
         String domainName = dataset.getDomain().getName();
-        TableInfo datasetTable = dataset.getDomainKind().getTableInfo(user, targetContainer, domainName);
+        TableInfo datasetTable = dataset.getDomainKind().getTableInfo(user, targetContainer, domainName, null);
         ColumnInfo datasetLsidCol = datasetTable.getColumn("lsid");
         ColumnInfo sourceRowLsidCol = datasetTable.getColumn(SOURCE_ROW_LSID);
         if (sourceRowLsidCol == null)

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.JdbcType;
@@ -752,7 +753,7 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
 
 
     @Override
-    public TableInfo getTableInfo(User user, Container container, String name)
+    public TableInfo getTableInfo(User user, Container container, String name, @Nullable ContainerFilter cf)
     {
         StudyImpl study = StudyManager.getInstance().getStudy(container);
         if (null == study)
@@ -762,7 +763,7 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
         if (null == dsd)
             return null;
 
-        return DatasetFactory.createDataset(schema, null, dsd);
+        return DatasetFactory.createDataset(schema, cf, dsd);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
For this round of changes to the Text Choice data type epic, we are adding support for allowing updates to in use text choice values from within the field editor UI along with locking those values that are in use by a "locked" item (i.e. sample with a locked status). This PR includes the server side updates to update the rows for any in use text choice values which are updated in the field editor UI. The DomainUtil class has helpers to use the query update server for the given domain table to call the updateRows() method, which will give us the detailed audit logging we want for this action.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/697
* https://github.com/LabKey/platform/pull/2903
* https://github.com/LabKey/biologics/pull/1109
* https://github.com/LabKey/sampleManagement/pull/789

#### Changes
* update core module @labkey/components version
* during the DomainUtil.updateDomainDescriptor() method, detect text choice validator value updates and call updateRows() to remap values in those rows
