### PR TITLE
Issue 44584: Encryption key change shouldn't be fatal

### DIFF
--- a/api/src/org/labkey/api/data/EncryptedPropertyStore.java
+++ b/api/src/org/labkey/api/data/EncryptedPropertyStore.java
@@ -37,7 +37,7 @@ public class EncryptedPropertyStore extends AbstractPropertyStore
     {
         super("Encrypted Properties");
 
-        if (Encryption.isMasterEncryptionPassPhraseSpecified())
+        if (Encryption.isEncryptionPassPhraseSpecified())
             _preferredPropertyEncryption = PropertyEncryption.AES128;
         else
             _preferredPropertyEncryption = PropertyEncryption.NoKey;

--- a/api/src/org/labkey/api/data/EncryptedPropertyStore.java
+++ b/api/src/org/labkey/api/data/EncryptedPropertyStore.java
@@ -24,7 +24,7 @@ import org.labkey.api.util.ConfigurationException;
 
 /**
  * A PropertyStore that encrypts its contents when writing to the database, and automatically decrypts on read. Uses
- * the MasterEncryptionKey, stored as a property in labkey.xml (or its equivalent deployment descriptor).
+ * the EncryptionKey, stored as a property in labkey.xml (or its equivalent deployment descriptor).
  *
  * User: adam
  * Date: 10/11/13
@@ -47,7 +47,7 @@ public class EncryptedPropertyStore extends AbstractPropertyStore
     protected void validateStore()
     {
         if (PropertyEncryption.AES128 != _preferredPropertyEncryption)
-            throw new ConfigurationException("Attempting to use the encrypted property store, but MasterEncryptionKey has not been specified in " + AppProps.getInstance().getWebappConfigurationFilename() + ".",
+            throw new ConfigurationException("Attempting to use the encrypted property store, but EncryptionKey has not been specified in " + AppProps.getInstance().getWebappConfigurationFilename() + ".",
                 "Edit " + AppProps.getInstance().getWebappConfigurationFilename() + " and provide a suitable encryption key. See the server configuration documentation on labkey.org.");
     }
 

--- a/api/src/org/labkey/api/data/PropertyEncryption.java
+++ b/api/src/org/labkey/api/data/PropertyEncryption.java
@@ -115,7 +115,7 @@ public enum PropertyEncryption
 
             private ConfigurationException getConfigurationException()
             {
-                return new ConfigurationException("Attempting to save encrypted properties but MasterEncryptionKey has not been specified in " + AppProps.getInstance().getWebappConfigurationFilename() + ".",
+                return new ConfigurationException("Attempting to save encrypted properties but EncryptionKey has not been specified in " + AppProps.getInstance().getWebappConfigurationFilename() + ".",
                         "Edit " + AppProps.getInstance().getWebappConfigurationFilename() + " and provide a suitable encryption key. See the server configuration documentation on labkey.org.");
             }
         },

--- a/api/src/org/labkey/api/data/PropertyEncryption.java
+++ b/api/src/org/labkey/api/data/PropertyEncryption.java
@@ -89,7 +89,7 @@ public enum PropertyEncryption
                 return "Test";
             }
         },
-    /** No master encryption key was specified in labkey.xml, so throw ConfigurationException */
+    /** No encryption key was specified in labkey.xml, so throw ConfigurationException */
     NoKey
         {
             @NotNull

--- a/api/src/org/labkey/api/data/PropertyManager.java
+++ b/api/src/org/labkey/api/data/PropertyManager.java
@@ -701,7 +701,7 @@ public class PropertyManager
             PropertyStore normal = getNormalStore();
             PropertyStore encrypted = getEncryptedStore();
 
-            // Test should still pass whether MasterEncryptionKey is specified or not
+            // Test should still pass whether EncryptionKey is specified or not
             if (ENCRYPTED_STORE.getPreferredPropertyEncryption() == PropertyEncryption.NoKey)
             {
                 // Just test the normal property store

--- a/api/src/org/labkey/api/security/ConfigurationSettings.java
+++ b/api/src/org/labkey/api/security/ConfigurationSettings.java
@@ -27,7 +27,7 @@ public class ConfigurationSettings
 
         if (null != encryptedPropertiesJson)
         {
-            if (Encryption.isMasterEncryptionPassPhraseSpecified())
+            if (Encryption.isEncryptionPassPhraseSpecified())
             {
                 try
                 {
@@ -40,7 +40,7 @@ public class ConfigurationSettings
             }
             else
             {
-                LOG.warn("Encrypted properties can't be read: master encryption key has not been set in " + AppProps.getInstance().getWebappConfigurationFilename() + "!");
+                LOG.warn("Encrypted properties can't be read: encryption key has not been set in " + AppProps.getInstance().getWebappConfigurationFilename() + "!");
             }
         }
 

--- a/api/src/org/labkey/api/security/ConfigurationSettings.java
+++ b/api/src/org/labkey/api/security/ConfigurationSettings.java
@@ -1,17 +1,17 @@
 package org.labkey.api.security;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 import org.labkey.api.data.AES;
 import org.labkey.api.settings.AppProps;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.util.Map;
 
 public class ConfigurationSettings
 {
-    private static final Logger LOG = LogManager.getLogger(ConfigurationSettings.class);
+    private static final Logger LOG = LogHelper.getLogger(ConfigurationSettings.class, "Loading of authentication configuration properties");
 
     private final Map<String, Object> _standardSettings;
     private final Map<String, Object> _properties;
@@ -23,23 +23,28 @@ public class ConfigurationSettings
         String propertiesJson = (String) settings.get("Properties");
         _properties = null != propertiesJson ? new JSONObject(propertiesJson) : new JSONObject();
         String encryptedPropertiesJson = (String) settings.get("EncryptedProperties");
+        Map<String, Object> encryptedProperties = new JSONObject();
 
         if (null != encryptedPropertiesJson)
         {
             if (Encryption.isMasterEncryptionPassPhraseSpecified())
             {
-                _encryptedProperties = new JSONObject(AES.get().decrypt(Base64.decodeBase64(encryptedPropertiesJson)));
+                try
+                {
+                    encryptedProperties = new JSONObject(AES.get().decrypt(Base64.decodeBase64(encryptedPropertiesJson)));
+                }
+                catch (Encryption.DecryptionException e)
+                {
+                    LOG.warn("Encrypted properties can't be read", e);
+                }
             }
             else
             {
                 LOG.warn("Encrypted properties can't be read: master encryption key has not been set in " + AppProps.getInstance().getWebappConfigurationFilename() + "!");
-                _encryptedProperties = new JSONObject();
             }
         }
-        else
-        {
-            _encryptedProperties = new JSONObject();
-        }
+
+        _encryptedProperties = encryptedProperties;
     }
 
     public Map<String, Object> getStandardSettings()

--- a/api/src/org/labkey/api/security/Encryption.java
+++ b/api/src/org/labkey/api/security/Encryption.java
@@ -66,9 +66,12 @@ public class Encryption
     private static final String CATEGORY = "Encryption";
     private static final String SALT_KEY = "Salt";
     private static final SecureRandom SR = new SecureRandom();
+    private static final String ENCRYPTION_PASS_PHRASE;
 
     static
     {
+        ENCRYPTION_PASS_PHRASE = loadEncryptionPassPhrase();
+
         WarningService.get().register(new WarningProvider() {
             @Override
             public void addDynamicWarnings(@NotNull Warnings warnings, @NotNull ViewContext context)
@@ -143,7 +146,7 @@ public class Encryption
     private static final String ENCRYPTION_KEY_PARAMETER_NAME = "EncryptionKey";
     private static final String OLD_ENCRYPTION_KEY_PARAMETER_NAME = "MasterEncryptionKey";
 
-    private static @Nullable String getEncryptionPassPhrase()
+    private static @Nullable String loadEncryptionPassPhrase()
     {
         ServletContext context = ModuleLoader.getServletContext();
 
@@ -163,6 +166,10 @@ public class Encryption
             return null;
     }
 
+    public static @Nullable String getEncryptionPassPhrase()
+    {
+        return ENCRYPTION_PASS_PHRASE;
+    }
 
     public static boolean isEncryptionPassPhraseSpecified()
     {

--- a/api/src/org/labkey/api/security/Encryption.java
+++ b/api/src/org/labkey/api/security/Encryption.java
@@ -53,7 +53,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Easy to use wrappers for common encryption algorithms. Also includes related helper methods for shared operations
- * such as generating salts & keys, and for retrieving & saving the master encryption key and standard salt.
+ * such as generating salts & keys, and for retrieving & saving the labkey.xml encryption key and standard salt.
  *
  * WARNING: Do not change the core algorithms or parameters of existing implementations; changes will likely
  * render existing data irrecoverable.
@@ -76,7 +76,7 @@ public class Encryption
                 int count = DECRYPTION_EXCEPTIONS.get();
 
                 if (count > 0)
-                    warnings.add(HtmlString.of("On " + StringUtilsLabKey.pluralize(count, "attempt") + " the server failed to decrypt encrypted content using the " + MASTER_ENCRYPTION_KEY_CHANGED +
+                    warnings.add(HtmlString.of("On " + StringUtilsLabKey.pluralize(count, "attempt") + " the server failed to decrypt encrypted content using the " + ENCRYPTION_KEY_CHANGED +
                         " An administrator should change the encryption key back to the previous value or be prepared to re-enter and re-save all saved credentials."));
             }
         });
@@ -140,28 +140,33 @@ public class Encryption
     }
 
 
-    private static final String MASTER_ENCRYPTION_KEY_PARAMETER_NAME = "MasterEncryptionKey";
+    private static final String ENCRYPTION_KEY_PARAMETER_NAME = "EncryptionKey";
+    private static final String OLD_ENCRYPTION_KEY_PARAMETER_NAME = "MasterEncryptionKey";
 
-    private static @Nullable String getMasterEncryptionPassPhrase()
+    private static @Nullable String getEncryptionPassPhrase()
     {
         ServletContext context = ModuleLoader.getServletContext();
 
         if (null == context)
             throw new IllegalStateException("ServletContext is null");
 
-        String masterEncryptionKey = context.getInitParameter(MASTER_ENCRYPTION_KEY_PARAMETER_NAME);
+        String encryptionKey = context.getInitParameter(ENCRYPTION_KEY_PARAMETER_NAME);
 
-        // Return the master key if it's there (not null, not blank, not whitespace, not default value), otherwise return null
-        if (!StringUtils.isBlank(masterEncryptionKey) && !masterEncryptionKey.trim().equals("@@masterEncryptionKey@@"))
-            return masterEncryptionKey;
+        // Backward compatibility -- look for old parameter name if new one is missing
+        if (null == encryptionKey)
+            encryptionKey = context.getInitParameter(OLD_ENCRYPTION_KEY_PARAMETER_NAME);
+
+        // Return the encryption key if it's there (not null, not blank, not whitespace, not default value), otherwise return null
+        if (!StringUtils.isBlank(encryptionKey) && !encryptionKey.trim().equals("@@masterEncryptionKey@@") && !encryptionKey.trim().equals("@@encryptionKey@@"))
+            return encryptionKey;
         else
             return null;
     }
 
 
-    public static boolean isMasterEncryptionPassPhraseSpecified()
+    public static boolean isEncryptionPassPhraseSpecified()
     {
-        return null != getMasterEncryptionPassPhrase();
+        return null != getEncryptionPassPhrase();
     }
 
 
@@ -256,7 +261,7 @@ public class Encryption
         }
     }
 
-    private static final String MASTER_ENCRYPTION_KEY_CHANGED = "currently configured MasterEncryptionKey; has the key changed in " + AppProps.getInstance().getWebappConfigurationFilename() + "?";
+    private static final String ENCRYPTION_KEY_CHANGED = "currently configured EncryptionKey; has the key changed in " + AppProps.getInstance().getWebappConfigurationFilename() + "?";
     private static final AtomicInteger DECRYPTION_EXCEPTIONS = new AtomicInteger(0);
 
     public static class DecryptionException extends ConfigurationException
@@ -269,15 +274,15 @@ public class Encryption
 
 
     /*
-        Return an encryption algorithm that uses AES and generates a 128-bit key from the master encryption key.
+        Return an encryption algorithm that uses AES and generates a 128-bit key from the labkey.xml encryption key.
         All other encryption parameters are documented in AES().
      */
     public static Algorithm getAES128()
     {
-        if (isMasterEncryptionPassPhraseSpecified())
-            return new AES(getMasterEncryptionPassPhrase(), 128, MASTER_ENCRYPTION_KEY_CHANGED);
+        if (isEncryptionPassPhraseSpecified())
+            return new AES(getEncryptionPassPhrase(), 128, ENCRYPTION_KEY_CHANGED);
         else
-            throw new IllegalStateException("MasterEncryptionKey has not been specified in " + AppProps.getInstance().getWebappConfigurationFilename() + "; this method should not be called");
+            throw new IllegalStateException("EncryptionKey has not been specified in " + AppProps.getInstance().getWebappConfigurationFilename() + "; this method should not be called");
     }
 
 
@@ -292,13 +297,13 @@ public class Encryption
 
             test(aesPassPhrase);
 
-            if (isMasterEncryptionPassPhraseSpecified())
+            if (isEncryptionPassPhraseSpecified())
             {
                 Algorithm aes = getAES128();
                 test(aes);
 
                 // Test that static factory method matches this configuration
-                Algorithm aes2 = new AES(getMasterEncryptionPassPhrase(), 128, "test pass phrase");
+                Algorithm aes2 = new AES(getEncryptionPassPhrase(), 128, "test pass phrase");
 
                 test(aes, aes2);
                 test(aes2, aes);

--- a/api/src/org/labkey/api/security/SaveConfigurationForm.java
+++ b/api/src/org/labkey/api/security/SaveConfigurationForm.java
@@ -62,7 +62,7 @@ public abstract class SaveConfigurationForm
 
     protected String encodeEncryptedProperties(JSONObject map)
     {
-        if (Encryption.isMasterEncryptionPassPhraseSpecified())
+        if (Encryption.isEncryptionPassPhraseSpecified())
         {
             return Base64.encodeBase64String(AES.get().encrypt(map.toString()));
         }

--- a/api/src/org/labkey/api/security/SaveConfigurationForm.java
+++ b/api/src/org/labkey/api/security/SaveConfigurationForm.java
@@ -68,7 +68,7 @@ public abstract class SaveConfigurationForm
         }
         else
         {
-            throw new ConfigurationException("Can't save this configuration: MasterEncryptionKey has not been specified in " + AppProps.getInstance().getWebappConfigurationFilename());
+            throw new ConfigurationException("Can't save this configuration: EncryptionKey has not been specified in " + AppProps.getInstance().getWebappConfigurationFilename());
         }
     }
 }

--- a/query/src/org/labkey/query/sql/Query.java
+++ b/query/src/org/labkey/query/sql/Query.java
@@ -894,11 +894,11 @@ public class Query
             if (null == cf && null != cfType)
                 cf = cfType.create(resolvedSchema);
 
-            if (resolvedSchema instanceof UserSchema)
+            if (resolvedSchema instanceof UserSchema userSchema)
             {
                 TableType tableType = lookupMetadataTable(key.getName());
                 boolean forWrite = tableType != null;
-                t = ((UserSchema) resolvedSchema)._getTableOrQuery(key.getName(), cf, true, forWrite, resolveExceptions);
+                t = userSchema._getTableOrQuery(key.getName(), cf, true, forWrite, resolveExceptions);
             }
             else
             {
@@ -928,13 +928,12 @@ public class Query
             throw new QueryNotFoundException(StringUtils.join(names, "."), null == node ? 0 : node.getLine(), null == node ? 0 : node.getColumn());
 		}
 
-        if (t instanceof TableInfo)
+        if (t instanceof TableInfo tableInfo)
         {
-            TableInfo tableInfo = (TableInfo)t;
             // I don't see why Query is being roped into helping with this??? Can't this be handled on the LinkedSchema side?
             TableType tableType = lookupMetadataTable(tableInfo.getName());
-            if (null != tableType && tableInfo.isMetadataOverrideable() && resolvedSchema instanceof UserSchema)
-                tableInfo.overlayMetadata(Collections.singletonList(tableType), (UserSchema)resolvedSchema, _parseErrors);
+            if (null != tableType && tableInfo.isMetadataOverrideable() && resolvedSchema instanceof UserSchema userSchema)
+                tableInfo.overlayMetadata(Collections.singletonList(tableType), userSchema, _parseErrors);
             _resolveCache.get(currentSchema).put(cacheKey, new Pair<>(resolvedSchema, tableInfo));
 
             String name = ((TableInfo) t).getName();
@@ -1151,7 +1150,9 @@ public class Query
             @Override
             public Map<String, Object> next()
             {
-                return _rowMapFactory.getRowMap(data[i++]);
+                // Leave this in place: javac complains without this cast. IntelliJ disagrees.
+                //noinspection RedundantCast
+                return _rowMapFactory.getRowMap((Object[])data[i++]);
             }
 
             @Override

--- a/query/src/org/labkey/query/view/manageRemoteConnections.jsp
+++ b/query/src/org/labkey/query/view/manageRemoteConnections.jsp
@@ -39,7 +39,7 @@
     Map<String, String> connectionMap = ((JspView<Map<String,String>>) HttpView.currentView()).getModelBean();
     if (connectionMap == null)
     { %>
-        <p style="color: red">MasterEncryptionKey has not been specified in <%= h(AppProps.getInstance().getWebappConfigurationFilename()) %>, or its value no longer matches key previously in use.</p>
+        <p style="color: red">EncryptionKey has not been specified in <%= h(AppProps.getInstance().getWebappConfigurationFilename()) %>, or its value no longer matches key previously in use.</p>
         <labkey:form method="post">
             <input type="hidden" name="reset" value="true" />
             <labkey:button text="Reset Remote Configurations"></labkey:button>


### PR DESCRIPTION
#### Rationale
Tolerate a bad encryption key

#### Changes
* Allow authentication configurations to load even if encrypted properties can't be read
* Track the number of failed decryption attempts; warn the admin and provide guidance
