### PR TITLE
Issue 44568: Respect allowImportLookupByAlternateKey when finding data and materials during import 

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -1014,7 +1014,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                 {
                     String ssName = byNameSS != null ? byNameSS.getName() : null;
                     Container lookupContainer = byNameSS != null ? byNameSS.getContainer() : container;
-                    ExpMaterial material = exp.findExpMaterial(lookupContainer, user, byNameSS, ssName, (String)o, cache, materialCache);
+                    ExpMaterial material = exp.findExpMaterial(lookupContainer, user, byNameSS, ssName, (String)o, cache, materialCache, true);
                     if (material != null)
                     {
                         materialInputs.putIfAbsent(material, pd.getName());

--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -875,7 +875,7 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
                                      @NotNull Map<Integer, ExpMaterial> materialCache)
             throws ValidationException
     {
-        ExpMaterial material = ExperimentService.get().findExpMaterial(context.getContainer(), context.getUser(), null, null, sampleName, cache, materialCache);
+        ExpMaterial material = ExperimentService.get().findExpMaterial(context.getContainer(), context.getUser(), null, null, sampleName, cache, materialCache, true);
         if (material == null)
         {
             Logger logger = context.getLogger() != null ? context.getLogger() : LOG;

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -1232,8 +1232,8 @@ public class NameGenerator
             try
             {
                 ExpObject parentObject = isMaterialParent ?
-                        ExperimentService.get().findExpMaterial(_container, user, (ExpSampleType) parentObjectType, parentTypeName, parentName, renameCache, materialCache)
-                        : ExperimentService.get().findExpData(_container, user, (ExpDataClass) parentObjectType, parentTypeName, parentName, renameCache, dataCache);
+                        ExperimentService.get().findExpMaterial(_container, user, (ExpSampleType) parentObjectType, parentTypeName, parentName, renameCache, materialCache, true)
+                        : ExperimentService.get().findExpData(_container, user, (ExpDataClass) parentObjectType, parentTypeName, parentName, renameCache, dataCache, true);
 
                 if (parentObject == null)
                     throw new RuntimeValidationException("Unable to find parent " + parentName);

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -275,13 +275,6 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
 
             List<Triple<ColumnInfo, ColumnInfo, MultiValuedMap<?,?>>> maps = getMaps();
 
-            if (_pkColumnLookupMap != null)
-            {
-                Object v = fetch(_pkColumnLookupMap, k);
-                if (v != null)
-                    return v;
-            }
-
             for (Triple<ColumnInfo, ColumnInfo, MultiValuedMap<?,?>> triple : maps)
             {
                 Object v = fetch(triple, k);
@@ -292,6 +285,13 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             if (_titleColumnLookupMap != null)
             {
                 Object v = fetch(_titleColumnLookupMap, String.valueOf(k));
+                if (v != null)
+                    return v;
+            }
+
+            if (_pkColumnLookupMap != null)
+            {
+                Object v = fetch(_pkColumnLookupMap, k);
                 if (v != null)
                     return v;
             }

--- a/api/src/org/labkey/api/exp/api/ExpSampleType.java
+++ b/api/src/org/labkey/api/exp/api/ExpSampleType.java
@@ -41,7 +41,9 @@ import java.util.function.Function;
 public interface ExpSampleType extends ExpObject
 {
     String SEQUENCE_PREFIX = "org.labkey.experiment.api.MaterialSource";
-    String ALIQUOTED_FROM_EXPRESSION = "${AliquotedFrom}";
+    String CURRENT_SAMPLE_TYPE_NAME = "CurrentSampleType";
+    String ALIQUOTED_FROM_FIELD_NAME = "AliquotedFrom";
+    String ALIQUOTED_FROM_EXPRESSION = "${" + ALIQUOTED_FROM_FIELD_NAME + "}";
 
     String getMaterialLSIDPrefix();
 

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -299,13 +299,15 @@ public interface ExperimentService extends ExperimentRunTypeSource
     @Nullable ExpData findExpData(Container c, User user,
                                   @NotNull ExpDataClass dataClass,
                                   @NotNull String dataClassName, String dataName,
-                                  RemapCache cache, Map<Integer, ExpData> dataCache)
+                                  RemapCache cache, Map<Integer, ExpData> dataCache,
+                                  boolean allowImportLookupByAlternateKey)
             throws ValidationException;
 
     @Nullable ExpMaterial findExpMaterial(Container c, User user,
                                           ExpSampleType sampleType,
                                           String sampleTypeName, String sampleName,
-                                          RemapCache cache, Map<Integer, ExpMaterial> materialCache)
+                                          RemapCache cache, Map<Integer, ExpMaterial> materialCache,
+                                          boolean allowImportLookupByAlternateKey)
             throws ValidationException;
 
     ExpExperiment createHiddenRunGroup(Container container, User user, ExpRun... runs);

--- a/assay/api-src/org/labkey/api/assay/matrix/AbstractMatrixDataHandler.java
+++ b/assay/api-src/org/labkey/api/assay/matrix/AbstractMatrixDataHandler.java
@@ -195,7 +195,7 @@ public abstract class AbstractMatrixDataHandler extends AbstractExperimentDataHa
             ExpMaterial m;
             try
             {
-                m = ExperimentService.get().findExpMaterial(container, user, null, null, sampleName, cache, materialCache);
+                m = ExperimentService.get().findExpMaterial(container, user, null, null, sampleName, cache, materialCache, true);
             }
             catch (ValidationException e)
             {

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -855,12 +855,12 @@ public class ExpDataIterators
                         if (_isSample && _context.getInsertOption().mergeRows)
                         {
                             pair = UploadSamplesHelper.resolveInputsAndOutputs(
-                                    _user, _container, runItem, parentNames, cache, materialCache, dataCache, _sampleTypes, _dataClasses, aliquotedFrom, dataType);
+                                    _user, _container, runItem, parentNames, cache, materialCache, dataCache, _sampleTypes, _dataClasses, aliquotedFrom, dataType, _context.isAllowImportLookupByAlternateKey());
                         }
                         else
                         {
                             pair = UploadSamplesHelper.resolveInputsAndOutputs(
-                                    _user, _container, null, parentNames, cache, materialCache, dataCache, _sampleTypes, _dataClasses, aliquotedFrom, dataType);
+                                    _user, _container, null, parentNames, cache, materialCache, dataCache, _sampleTypes, _dataClasses, aliquotedFrom, dataType, _context.isAllowImportLookupByAlternateKey());
                         }
 
                         if (pair.first == null && pair.second == null) // no parents or children columns provided in input data and no existing parents to be updated

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -822,6 +822,7 @@ public class ExpDataIterators
                     Set<String> lsids = new LinkedHashSet<>();
                     lsids.addAll(_parentNames.keySet());
                     lsids.addAll(_aliquotParents.keySet());
+                    ExperimentService service =  ExperimentService.get();
                     for (String lsid : lsids)
                     {
                         Set<Pair<String, String>> parentNames = _parentNames.containsKey(lsid) ? _parentNames.get(lsid) : Collections.emptySet();
@@ -831,7 +832,7 @@ public class ExpDataIterators
                         String dataType = null;
                         if (_isSample)
                         {
-                            ExpMaterial m = ExperimentService.get().getExpMaterial(lsid);
+                            ExpMaterial m = service.getExpMaterial(lsid);
                             if (m != null)
                             {
                                 materialCache.put(m.getRowId(), m);
@@ -841,7 +842,7 @@ public class ExpDataIterators
                         }
                         else
                         {
-                            ExpData d = ExperimentService.get().getExpData(lsid);
+                            ExpData d = service.getExpData(lsid);
                             if (d != null)
                             {
                                 dataCache.put(d.getRowId(), d);

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1462,6 +1462,7 @@ public class ExperimentServiceImpl implements ExperimentService
 
         if (allowImportLookupByAlternateKey)
         {
+            // Issue 40302, Issue 44568: Unable to use samples or data class with integer like names as material or data input
             try
             {
                 data = findExpDataByName(c, user, dataClass, dataClassName, dataName, cache, dataCache);
@@ -1480,12 +1481,7 @@ public class ExperimentServiceImpl implements ExperimentService
             }
         }
 
-        data = findExpDataByRowId(dataClass, dataName, dataCache);
-        if (data != null)
-            return data;
-        // Issue 40302: Unable to use samples or data class with integer like names as material or data input
-        // Either dataName failed to parse as a rowId or the rowId didn't resolve. Attempt to resolve by alternate key.
-        return findExpDataByName(c, user, dataClass, dataClassName, dataName, cache, dataCache);
+        return findExpDataByRowId(dataClass, dataName, dataCache);
     }
 
     private @Nullable ExpData findExpDataByRowId(ExpDataClass dataClass, String dataName,  Map<Integer, ExpData> dataCache)
@@ -1532,7 +1528,7 @@ public class ExperimentServiceImpl implements ExperimentService
     {
         ExpMaterial material;
         if (allowImportLookupByAlternateKey) {
-            // first try to lookup using the name
+            // Issue 40302, Issue 44568: first try to lookup using the name
             try
             {
                 material = findExpMaterialByName(c, user, sampleType, sampleTypeName, sampleName, cache, materialCache);
@@ -1554,12 +1550,7 @@ public class ExperimentServiceImpl implements ExperimentService
         }
         else
         {
-            material = findExpMaterialByRowId(c, user, sampleType, sampleName, materialCache);
-            if (material != null)
-                return material;
-            // Issue 40302: Unable to use samples or data class with integer like names as material or data input
-            // Either sampleName failed to parse as a rowId or the rowId didn't resolve. Attempt to resolve by alternate key.
-            return findExpMaterialByName(c, user, sampleType, sampleTypeName, sampleName, cache, materialCache);
+            return findExpMaterialByRowId(c, user, sampleType, sampleName, materialCache);
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -253,7 +253,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
     public List<Map<String, Object>> insertRows(User user, Container container, List<Map<String, Object>> rows, BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext) throws SQLException
     {
         assert _sampleType != null : "SampleType required for insert/update, but not required for read/delete";
-        // insertRows with lineage is pretty good at deadlocking against it self, so use retry loop
+        // insertRows with lineage is pretty good at deadlocking against itself, so use retry loop
 
         DbScope scope = getSchema().getDbSchema().getScope();
         List<Map<String, Object>> results = scope.executeWithRetry(transaction ->

--- a/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
+++ b/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
@@ -361,6 +361,7 @@ public abstract class UploadSamplesHelper
      *                will be incorporated into the resolved inputs and outputs
      * @param entityNamePairs set of (parent column name, parent value) pairs.  Parent values that are empty
      *                    indicate the parent should be removed.
+     * @param allowImportLookupByAlternateKey if true, we attempt to find the inputs and outpus by interpreting the values as names first, then ids
      * @throws ExperimentException
      */
     @NotNull
@@ -372,7 +373,8 @@ public abstract class UploadSamplesHelper
                                                                                        Map<String, ExpSampleType> sampleTypes,
                                                                                        Map<String, ExpDataClass> dataClasses,
                                                                                        @Nullable String aliquotedFrom,
-                                                                                       String dataType /*sample type or source type name*/)
+                                                                                       String dataType, /*sample type or source type name*/
+                                                                                       boolean allowImportLookupByAlternateKey)
             throws ValidationException, ExperimentException
     {
         Map<ExpMaterial, String> parentMaterials = new LinkedHashMap<>();
@@ -393,7 +395,7 @@ public abstract class UploadSamplesHelper
             if (sampleType == null)
                 throw new ValidationException("Invalid sample type: " + dataType);
 
-            aliquotParent = findMaterial(c, user, sampleType, dataType, aliquotedFrom, cache, materialMap);
+            aliquotParent = findMaterial(c, user, sampleType, dataType, aliquotedFrom, cache, materialMap, allowImportLookupByAlternateKey);
 
             if (aliquotParent == null)
             {
@@ -425,7 +427,7 @@ public abstract class UploadSamplesHelper
                             throw new ValidationException(message);
                         }
 
-                        ExpMaterial sample = findMaterial(c, user, null, null, entityName, cache, materialMap);
+                        ExpMaterial sample = findMaterial(c, user, null, null, entityName, cache, materialMap, allowImportLookupByAlternateKey);
                         if (sample != null)
                             parentMaterials.put(sample, sampleRole(sample));
                         else
@@ -458,7 +460,7 @@ public abstract class UploadSamplesHelper
                             throw new ValidationException(message);
                         }
 
-                        ExpMaterial sample = findMaterial(c, user, sampleType, namePart, entityName, cache, materialMap);
+                        ExpMaterial sample = findMaterial(c, user, sampleType, namePart, entityName, cache, materialMap, allowImportLookupByAlternateKey);
                         if (sample != null)
                             parentMaterials.put(sample, sampleRole(sample));
                         else
@@ -474,7 +476,7 @@ public abstract class UploadSamplesHelper
 
                     if (!isEmptyEntity)
                     {
-                        ExpMaterial sample = findMaterial(c, user, sampleType, namePart, entityName, cache, materialMap);
+                        ExpMaterial sample = findMaterial(c, user, sampleType, namePart, entityName, cache, materialMap, allowImportLookupByAlternateKey);
                         if (sample != null)
                         {
                             if (StringUtils.isEmpty(sample.getAliquotedFromLSID()))
@@ -508,7 +510,7 @@ public abstract class UploadSamplesHelper
                             throw new ValidationException(message);
                         }
 
-                        ExpData data = findData(c, user, dataClass, namePart, entityName, cache, dataMap);
+                        ExpData data = findData(c, user, dataClass, namePart, entityName, cache, dataMap, allowImportLookupByAlternateKey);
                         if (data != null)
                             parentData.put(data, dataRole(data, user));
                         else
@@ -529,7 +531,7 @@ public abstract class UploadSamplesHelper
 
                     if (!isEmptyEntity)
                     {
-                        ExpData data = findData(c, user, dataClass, namePart, entityName, cache, dataMap);
+                        ExpData data = findData(c, user, dataClass, namePart, entityName, cache, dataMap, allowImportLookupByAlternateKey);
                         if (data != null)
                             childData.put(data, dataRole(data, user));
                         else
@@ -632,16 +634,16 @@ public abstract class UploadSamplesHelper
     }
 
 
-    private static ExpMaterial findMaterial(Container c, User user, ExpSampleType sampleType, String sampleTypeName, String sampleName, RemapCache cache, Map<Integer, ExpMaterial> materialCache)
+    private static ExpMaterial findMaterial(Container c, User user, ExpSampleType sampleType, String sampleTypeName, String sampleName, RemapCache cache, Map<Integer, ExpMaterial> materialCache, boolean allowImportLookupByAlternateKey)
             throws ValidationException
     {
-        return ExperimentService.get().findExpMaterial(c, user, sampleType, sampleTypeName, sampleName, cache, materialCache);
+        return ExperimentService.get().findExpMaterial(c, user, sampleType, sampleTypeName, sampleName, cache, materialCache, allowImportLookupByAlternateKey);
     }
 
-    private static ExpData findData(Container c, User user, @NotNull ExpDataClass dataClass, @NotNull String dataClassName, String dataName, RemapCache cache, Map<Integer, ExpData> dataCache)
+    private static ExpData findData(Container c, User user, @NotNull ExpDataClass dataClass, @NotNull String dataClassName, String dataName, RemapCache cache, Map<Integer, ExpData> dataCache, boolean allowImportLookupByAlternateKey)
             throws ValidationException
     {
-        return ExperimentService.get().findExpData(c, user, dataClass, dataClassName, dataName, cache, dataCache);
+        return ExperimentService.get().findExpData(c, user, dataClass, dataClassName, dataName, cache, dataCache, allowImportLookupByAlternateKey);
     }
 
     /* this might be generally useful

--- a/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
+++ b/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
@@ -92,6 +92,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.labkey.api.exp.api.ExpRunItem.PARENT_IMPORT_ALIAS_MAP_PROP;
+import static org.labkey.api.exp.api.ExpSampleType.CURRENT_SAMPLE_TYPE_NAME;
 
 public abstract class UploadSamplesHelper
 {
@@ -787,7 +788,8 @@ public abstract class UploadSamplesHelper
                             return Map.of(NameExpressionOptionService.FOLDER_PREFIX_TOKEN, StringUtils.trimToEmpty(NameExpressionOptionService.get().getExpressionPrefix(container)));
                         else
                             return Collections.emptyMap();
-                    });
+                    })
+                    .addExtraPropsFn(() -> Map.of(CURRENT_SAMPLE_TYPE_NAME, this.sampletype.getName()));
 
             return LoggingDataIterator.wrap(names);
         }


### PR DESCRIPTION
#### Rationale
When importing samples and data objects, we have not been using the `allowImportLookupByAlternateKey` to guide our logic for finding, assuming instead that if the value given parsed as an integer then it is a rowId.  We now (as of not too long ago) allow sample and data object names to be just strings of digits, which then look very much like rowIds.  This PR updates the logic within the `findExpMaterial` and `findExpData` methods so we will first interpret the value give as a name and then, if not found using the name, attempt to parse it as an integer rowId when the `allowImportLookupByAlternateKey` parameter is true.  

The change here is a little odd because we had already been trying both the name and the rowId regardless of this property, but in the opposite order, so this flag is really being used as a way to say "prefer name over rowId".  Perhaps it is better to change it so the case where `allowImportLookupByAlternateKey` is false no longer attempts to find objects by searching by name.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/702
* https://github.com/LabKey/sampleManagement/pull/795
* https://github.com/LabKey/biologics/pull/1117

#### Changes
* Pass through the `allowImportLookupByAlternateKey` config property to methods for finding samples
* Update other usages of the find methods to also prefer finding by name first/allow searching by both name and id
