### PR TITLE
Add Query metadata validation check for TableInfo.getPublicSchemaName()

### DIFF
--- a/query/src/org/labkey/query/persist/QueryManager.java
+++ b/query/src/org/labkey/query/persist/QueryManager.java
@@ -703,6 +703,9 @@ public class QueryManager
         if (null == table)
             throw new IllegalArgumentException("The query '" + queryName + "' was not found in the schema '" + schemaPath.getName() + "'!");
 
+        if (table.isPublic() && table.getPublicSchemaName() != null && !schemaPath.toString().equalsIgnoreCase(table.getPublicSchemaName()))
+            warnings.add(new QueryParseWarning("(metadata) TableInfo.getPublicSchemaName() does not match: set to '" + table.getPublicSchemaName() + "', expected '" + schemaPath + "'", null, 0,0));
+
         try
         {
             //validate foreign keys and other metadata warnings


### PR DESCRIPTION
#### Rationale
In the related PR, I fixed an issue where 2 of the Luminex schema table's where overriding the public schema name based on legacy behavior. This PR adds a check in the query metadata validation code path to compare the TableInfo.getPublicSchemaName() against the schemaPath being validated.

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/413

#### Changes
* QueryManager update to validateQueryMetadata() for getPublicSchemaName() check
