### PR TITLE
Issue 44568: Reverse the order of precedence for looking for samples and data objects by rowId vs. name

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1470,7 +1470,8 @@ public class ExperimentServiceImpl implements ExperimentService
         {
             errors.append("Failed to resolve '").append(dataName).append("' into a data. ").append(e2.getMessage());
             errors.append(" Use 'DataInputs/<DataClassName>' column header to resolve parents from a specific DataClass.");
-            errors.append(" ").append(e2.getMessage());
+            if (e2.getMessage() != null)
+                errors.append(" ").append(e2.getMessage());
         }
 
         try
@@ -1512,7 +1513,8 @@ public class ExperimentServiceImpl implements ExperimentService
             {
                 errors.append(" Use 'MaterialInputs/<SampleTypeName>' column header to resolve parent samples from a specific SampleType.");
             }
-            errors.append(" ").append(e2.getMessage());
+            if (e2.getMessage() != null)
+                errors.append(" ").append(e2.getMessage());
         }
 
         try


### PR DESCRIPTION
#### Rationale
In the fix for Issue 40302, we introduced the logic that will look up samples or data class objects by name if the lookup by RowId fails. This logic works just fine when there are no overlaps between rowIds and names, but if name contain only digits and thus parse like rowIds, we may find the wrong sample or data object when trying to hook up lineage.  By reversing the order of the lookup logic to first prefer the lookup by name, we will find the intended entities more often since most of the time users and applications are providing us with names instead of rowIds and we will correctly not remove leading 0s from names by parsing them as integers.  

In most cases, users will still be able to perform insert and update operations using either rowIds or entity names.  The one exception is when the names of the objects can overlap with the rowIds of objects of that type in the same container, in which case the use of rowIds will not work.

#### Changes
* reverse order of precedence when finding `ExpMaterial` and `ExpData` objects.
