### PR TITLE
Issue 44579: XARs Allow Creation of Samples Without a Sample Type

### DIFF
--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -891,8 +891,7 @@ public class XarReader extends AbstractXarImporter
                 experimentDataObject.setBatchProtocolId(batchProtocol.getRowId());
             }
 
-            experimentDataObject = Table.insert(getUser(), tiExperiment, experimentDataObject);
-            experiment = new ExpExperimentImpl(experimentDataObject);
+            Table.insert(getUser(), tiExperiment, experimentDataObject);
 
             ObjectProperty contactProperty = null;
             if (null != exp.getContact())
@@ -1235,7 +1234,7 @@ public class XarReader extends AbstractXarImporter
             protocolApp.setLSID(protAppLSID);
             protocolApp.setName(trimString(xmlProtocolApp.getName()));
             String cpasType = trimString(xmlProtocolApp.getCpasType());
-            checkProtocolApplicationCpasType(cpasType, getLog());
+            checkProtocolApplicationCpasType(cpasType);
             protocolApp.setCpasType(cpasType);
             protocolApp.setProtocolLSID(protocolLSID);
             protocolApp.setActivityDate(sqlDateTime);
@@ -1348,7 +1347,7 @@ public class XarReader extends AbstractXarImporter
     private ExpMaterial loadMaterial(MaterialBaseType xbMaterial,
                                   @Nullable ExperimentRun run,
                                   Integer sourceApplicationId,
-                                  XarContext context) throws XarFormatException
+                                  XarContext context) throws XarFormatException, ExperimentException
     {
         TableInfo tiMaterial = ExperimentServiceImpl.get().getTinfoMaterial();
 
@@ -2414,7 +2413,7 @@ public class XarReader extends AbstractXarImporter
 
         XmlCursor c = xObj.newCursor();
         XmlCursor cTest;
-        Map m = new HashMap();
+        Map<String, String> m = new HashMap<>();
         c.getAllNamespaces(m);
         String nsObject = c.getName().getNamespaceURI();
 

--- a/experiment/src/org/labkey/experiment/xar/AbstractXarImporter.java
+++ b/experiment/src/org/labkey/experiment/xar/AbstractXarImporter.java
@@ -19,6 +19,7 @@ package org.labkey.experiment.xar;
 import org.apache.logging.log4j.Logger;
 import org.fhcrc.cpas.exp.xml.ExperimentArchiveType;
 import org.labkey.api.data.Container;
+import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.XarSource;
 import org.labkey.api.exp.api.ExpData;
@@ -46,17 +47,17 @@ public abstract class AbstractXarImporter
         _job = job;
     }
 
-    protected void checkDataCpasType(String declaredType)
+    protected void checkDataCpasType(String declaredType) throws ExperimentException
     {
         if (declaredType != null && !ExpData.DEFAULT_CPAS_TYPE.equals(declaredType))
         {
             // check if this is a reference to a data class
             if (ExperimentService.get().getDataClass(declaredType) == null)
-                _job.getLogger().warn("Unrecognized CpasType '" + declaredType + "' loaded for Data object.");
+                throw new ExperimentException("Unrecognized CpasType '" + declaredType + "' loaded for Data object.");
         }
     }
 
-    protected ExpSampleTypeImpl checkMaterialCpasType(String declaredType)
+    protected ExpSampleTypeImpl checkMaterialCpasType(String declaredType) throws ExperimentException
     {
         ExpSampleTypeImpl result = null;
         if (declaredType != null && !ExpMaterial.DEFAULT_CPAS_TYPE.equals(declaredType))
@@ -64,20 +65,20 @@ public abstract class AbstractXarImporter
             result = SampleTypeServiceImpl.get().getSampleType(declaredType);
             if (result == null)
             {
-                _job.getLogger().warn("Unrecognized CpasType '" + declaredType + "' loaded for Material object.");
+                throw new ExperimentException("Unrecognized CpasType '" + declaredType + "' loaded for Material object.");
             }
         }
         return result;
     }
 
-    protected void checkProtocolApplicationCpasType(String cpasType, Logger logger)
+    protected void checkProtocolApplicationCpasType(String cpasType) throws ExperimentException
     {
         if (cpasType != null &&
                 !ExpProtocol.ApplicationType.ProtocolApplication.toString().equals(cpasType) &&
                 !ExpProtocol.ApplicationType.ExperimentRun.toString().equals(cpasType) &&
                 !ExpProtocol.ApplicationType.ExperimentRunOutput.toString().equals(cpasType))
         {
-            logger.warn("Unrecognized CpasType '" + cpasType + "' loaded for ProtocolApplication object.");
+            throw new ExperimentException("Unrecognized CpasType '" + cpasType + "' loaded for ProtocolApplication object.");
         }
     }
 


### PR DESCRIPTION
#### Rationale
Don't allow XAR imports that reference sample types and data classes that don't exist and will cause problems later

#### Changes
* Switch warning dating back to 2008 to a hard error