### PR TITLE
Preserve original IOException

### DIFF
--- a/filecontent/src/org/labkey/filecontent/FileSystemAttachmentParent.java
+++ b/filecontent/src/org/labkey/filecontent/FileSystemAttachmentParent.java
@@ -129,7 +129,7 @@ public class FileSystemAttachmentParent implements AttachmentDirectory
         }
         catch (IOException e)
         {
-            throw new RuntimeException(e.getMessage());
+            throw new RuntimeException(e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
This background is that we had an issue with the file root of a folder: the tomcat user didnt have R/W on it. This caused a cryptic error. Currently, the IOException is caught and rethrown as a RuntimeException; however, it didnt preserve the original IOException stack. This is a very minor change to keep that.