### PR TITLE
Eliminate useless ReloadTask and unused method

### DIFF
--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -201,8 +201,8 @@ import org.labkey.study.designer.StudySchedule;
 import org.labkey.study.importer.DatasetImportUtils;
 import org.labkey.study.importer.SchemaReader;
 import org.labkey.study.importer.SchemaTsvReader;
+import org.labkey.study.importer.StudyReload;
 import org.labkey.study.importer.StudyReload.ReloadStatus;
-import org.labkey.study.importer.StudyReload.ReloadTask;
 import org.labkey.study.importer.VisitMapImporter;
 import org.labkey.study.model.*;
 import org.labkey.study.pipeline.DatasetFileReader;
@@ -6165,7 +6165,6 @@ public class StudyController extends BaseStudyController
         @Override
         public ApiResponse execute(ReloadForm form, BindException errors) throws Exception
         {
-            ReloadTask task = new ReloadTask();
             String message;
 
             try
@@ -6179,7 +6178,7 @@ public class StudyController extends BaseStudyController
 
                 source = "a script invoking the \"CheckForReload\" action while authenticated as user \"" + user.getDisplayName(null) + "\"";
 
-                ReloadStatus status = task.attemptReload(options, source);
+                ReloadStatus status = StudyReload.attemptReload(options, source);
 
                 message = status.getMessage();
             }

--- a/study/src/org/labkey/study/importer/StudyReload.java
+++ b/study/src/org/labkey/study/importer/StudyReload.java
@@ -31,7 +31,6 @@ import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.study.Study;
-import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
@@ -39,8 +38,6 @@ import org.labkey.folder.xml.FolderDocument;
 import org.labkey.study.controllers.StudyController;
 import org.labkey.study.model.StudyImpl;
 import org.labkey.study.model.StudyManager;
-import org.quartz.Job;
-import org.quartz.JobExecutionContext;
 import org.springframework.validation.BindException;
 
 import java.io.File;
@@ -73,210 +70,182 @@ public class StudyReload
         return root;
     }
 
-    private static final String CONTAINER_ID_KEY = "StudyContainerId";
+    private static final String STUDY_LOAD_FILENAME = "studyload.txt";
 
-    public static class ReloadTask implements Job
+    public static StudyImpl validateStudyForReload(Container c) throws ImportException
     {
-        private static final String STUDY_LOAD_FILENAME = "studyload.txt";
+        StudyImpl study = StudyManager.getInstance().getStudy(c);
 
-        @Override
-        public void execute(JobExecutionContext context)
+        if (null == study)
         {
-            String studyContainerId = (String)context.getJobDetail().getJobDataMap().get(CONTAINER_ID_KEY);
-            try
-            {
-                ImportOptions options = new ImportOptions(studyContainerId, null);
-                attemptReload(options, "a configured automatic reload timer");    // Ignore success messages
-            }
-            catch (ImportException ie)
-            {
-                Container c = ContainerManager.getForId(studyContainerId);
-                String message = null != c ? " in folder " + c.getPath() : "";
-
-                LOG.error("Study reload failed" + message, ie);
-            }
-            catch (Throwable t)
-            {
-                // Throwing from run() will kill the reload task, suppressing all future attempts; log to mothership and continue, so we retry later.
-                ExceptionUtil.logExceptionToMothership(null, t);
-            }
+            // Study must have been deleted... but if so, timer should have been disabled
+            throw new ImportException("Study does not exist in folder " + c.getPath());
         }
-
-        public StudyImpl validateStudyForReload(Container c) throws ImportException
+        else
         {
-            StudyImpl study = StudyManager.getInstance().getStudy(c);
-
-            if (null == study)
-            {
-                // Study must have been deleted... but if so, timer should have been disabled
-                throw new ImportException("Study does not exist in folder " + c.getPath());
-            }
-            else
-            {
-                return study;
-            }
+            return study;
         }
+    }
 
-        public PipeRoot validatePipeRoot(Container c) throws ImportException
+    public static PipeRoot validatePipeRoot(Container c) throws ImportException
+    {
+        PipeRoot root = PipelineService.get().findPipelineRoot(c);
+
+        if (null == root)
+            throw new ImportException("Pipeline root is not set in folder " + c.getPath());
+
+        if (!root.isValid())
+            throw new ImportException("Pipeline root does not exist in folder " + c.getPath());
+
+        return root;
+    }
+
+    public static ReloadStatus attemptTriggeredReload(ImportOptions options, String source) throws ImportException
+    {
+        Container c = ContainerManager.getForId(options.getContainerId());
+        if (null == c)
+            throw new ImportException("Container " + options.getContainerId() + " does not exist");
+        else
         {
-            PipeRoot root = PipelineService.get().findPipelineRoot(c);
+            StudyImpl study = validateStudyForReload(c);
+            if (study == null)
+                throw new ImportException("Reload failed. Study doesn't exist.");
 
-            if (null == root)
-                throw new ImportException("Pipeline root is not set in folder " + c.getPath());
-
-            if (!root.isValid())
-                throw new ImportException("Pipeline root does not exist in folder " + c.getPath());
-
-            return root;
+            return reloadStudy(study, options, source, null);
         }
+    }
 
-        public ReloadStatus attemptTriggeredReload(ImportOptions options, String source) throws ImportException
+    public static ReloadStatus attemptReload(ImportOptions options, String source) throws ImportException
+    {
+        Container c = ContainerManager.getForId(options.getContainerId());
+
+        if (null == c)
         {
-            Container c = ContainerManager.getForId(options.getContainerId());
-            if (null == c)
-                throw new ImportException("Container " + options.getContainerId() + " does not exist");
-            else
-            {
-                StudyImpl study = validateStudyForReload(c);
-                if (study == null)
-                    throw new ImportException("Reload failed. Study doesn't exist.");
-
-                return reloadStudy(study, options, source, null);
-            }
+            // Container must have been deleted
+            throw new ImportException("Container " + options.getContainerId() + " does not exist");
         }
-
-        public ReloadStatus attemptReload(ImportOptions options, String source) throws ImportException
+        else
         {
-            Container c = ContainerManager.getForId(options.getContainerId());
+            StudyImpl study = validateStudyForReload(c);
+            if (study == null)
+                throw new ImportException("Reload failed. Study doesn't exist.");
 
-            if (null == c)
+            PipeRoot root = validatePipeRoot(c);
+            File studyload = root.resolvePath(STUDY_LOAD_FILENAME);
+
+            if (studyload != null && studyload.isFile())
             {
-                // Container must have been deleted
-                throw new ImportException("Container " + options.getContainerId() + " does not exist");
-            }
-            else
-            {
-                StudyImpl study = validateStudyForReload(c);
-                if (study == null)
-                    throw new ImportException("Reload failed. Study doesn't exist.");
+                Long lastModified = studyload.lastModified();
+                Date lastReload = study.getLastReload();
 
-                PipeRoot root = validatePipeRoot(c);
-                File studyload = root.resolvePath(STUDY_LOAD_FILENAME);
-
-                if (studyload != null && studyload.isFile())
+                if (null == lastReload || studyload.lastModified() > (lastReload.getTime() + 1000))  // Add a second since SQL Server rounds datetimes
                 {
-                    Long lastModified = studyload.lastModified();
-                    Date lastReload = study.getLastReload();
+                    return reloadStudy(study, options, source, lastModified);
+                }
+            }
+            else
+            {
+                throw new ImportException("Could not find file " + STUDY_LOAD_FILENAME + " in the pipeline root for " + getDescription(study));
+            }
+        }
 
-                    if (null == lastReload || studyload.lastModified() > (lastReload.getTime() + 1000))  // Add a second since SQL Server rounds datetimes
+        return new ReloadStatus("Reload failed");
+    }
+
+    private static void userCanReloadStudy(User user, StudyImpl study)
+    {
+        if (user == null || !user.isActive())
+        {
+            throw new UnauthorizedException("Reload user is inactive");
+        }
+
+        if (!study.hasPermission(user, UpdatePermission.class))
+        {
+            throw new UnauthorizedException("Reload user has insufficient permissions");
+        }
+    }
+
+    public static ReloadStatus reloadStudy(StudyImpl study, @NotNull ImportOptions options, String source, Long lastModified)
+    {
+        options.addMessage("Study reload was initiated by " + source);
+
+        User reloadUser = options.getUser();
+        userCanReloadStudy(reloadUser, study);
+
+        // Try to add this study to the reload queue; if it's full, wait until next time
+        // We could submit reload pipeline jobs directly, but:
+        //  1) we need a way to throttle automatic reloads and
+        //  2) the initial import steps happen synchronously; they aren't part of the pipeline job
+
+        // TODO: Better throttling behavior (e.g., prioritize studies that check infrequently)
+
+        // Careful: Naive approach would be to offer the container to the queue and set last reload
+        // time on the study only if successful. This will introduce a race condition, since the
+        // import job and the update are likely to be updating the study at roughly the same time.
+        // Instead, we optimistically update the last reload time before offering the container and
+        // back out that change if the queue is full.
+        study = study.createMutable();
+        study.setLastReload(lastModified == null ? new Date() : new Date(lastModified));
+        StudyManager.getInstance().updateStudy(null, study);
+
+        StudyManager manager = StudyManager.getInstance();
+        Container c = null;
+
+        try
+        {
+            c = ContainerManager.getForId(options.getContainerId());
+            Path studyXml;
+            PipeRoot root = StudyReload.getPipelineRoot(c);
+
+            // Task overrides default analysis directory, usually when study.xml is located
+            // in a subdirectory underneath the pipeline root
+            if (options.getAnalysisDir() != null)
+            {
+                studyXml = Files.list(options.getAnalysisDir())
+                        .filter(p -> p.getFileName().toString().equalsIgnoreCase("study.xml"))
+                        .findFirst()
+                        .orElse(null);
+            }
+            else
+            {
+                studyXml = root.resolveRelativePath("study.xml");
+            }
+
+            assert c != null;
+            study = manager.getStudy(c);
+            //noinspection ThrowableInstanceNeverThrown
+            BindException errors = new NullSafeBindException(c, "reload");
+            ActionURL manageStudyURL = new ActionURL(StudyController.ManageStudyAction.class, c);
+
+            LOG.info("Handling " + c.getPath());
+
+            // issue 15681: if there is a folder archive instead of a study archive, see if the folder.xml exists to point to the study root dir
+            if (studyXml == null || !Files.exists(studyXml))
+            {
+                Path folderXml = root.resolveToNioPath("folder.xml");
+                if (folderXml != null && Files.exists(folderXml))
+                {
+                    FolderImportContext folderCtx = new FolderImportContext(reloadUser, c, folderXml, null, new StaticLoggerGetter(LOG), null);
+                    FolderDocument folderDoc = folderCtx.getDocument();
+                    if (folderDoc.getFolder().getStudy() != null && folderDoc.getFolder().getStudy().getDir() != null)
                     {
-                        return reloadStudy(study, options, source, lastModified);
+                        studyXml = root.resolveRelativePath("/" + folderDoc.getFolder().getStudy().getDir() + "/study.xml");
                     }
                 }
-                else
-                {
-                    throw new ImportException("Could not find file " + STUDY_LOAD_FILENAME + " in the pipeline root for " + getDescription(study));
-                }
             }
-
-            return new ReloadStatus("Reload failed");
+            if (studyXml != null)
+                PipelineService.get().queueJob(new StudyImportJob(c, reloadUser, manageStudyURL, studyXml, studyXml.getFileName().toString(), errors, root, options));
+            else
+                LOG.error("Study.xml does not exist in the analysis directory or pipeline root.");
         }
-
-        private void userCanReloadStudy(User user, StudyImpl study)
+        catch (Throwable t)
         {
-            if (user == null || !user.isActive())
-            {
-                throw new UnauthorizedException("Reload user is inactive");
-            }
-
-            if (!study.hasPermission(user, UpdatePermission.class))
-            {
-                throw new UnauthorizedException("Reload user has insufficient permissions");
-            }
+            String studyDescription = (null != study ? " \"" + getDescription(study) + "\"" : "");
+            String folderPath = (null != c ? " in folder " + c.getPath() : "");
+            LOG.error("Error while reloading study" + studyDescription + folderPath, t);
         }
 
-        public ReloadStatus reloadStudy(StudyImpl study, @NotNull ImportOptions options, String source, Long lastModified)
-        {
-            options.addMessage("Study reload was initiated by " + source);
-
-            User reloadUser = options.getUser();
-            userCanReloadStudy(reloadUser, study);
-
-            // Try to add this study to the reload queue; if it's full, wait until next time
-            // We could submit reload pipeline jobs directly, but:
-            //  1) we need a way to throttle automatic reloads and
-            //  2) the initial import steps happen synchronously; they aren't part of the pipeline job
-
-            // TODO: Better throttling behavior (e.g., prioritize studies that check infrequently)
-
-            // Careful: Naive approach would be to offer the container to the queue and set last reload
-            // time on the study only if successful. This will introduce a race condition, since the
-            // import job and the update are likely to be updating the study at roughly the same time.
-            // Instead, we optimistically update the last reload time before offering the container and
-            // back out that change if the queue is full.
-            study = study.createMutable();
-            study.setLastReload(lastModified == null ? new Date() : new Date(lastModified));
-            StudyManager.getInstance().updateStudy(null, study);
-
-            StudyManager manager = StudyManager.getInstance();
-            Container c = null;
-
-            try
-            {
-                c = ContainerManager.getForId(options.getContainerId());
-                Path studyXml;
-                PipeRoot root = StudyReload.getPipelineRoot(c);
-
-                // Task overrides default analysis directory, usually when study.xml is located
-                // in a subdirectory underneath the pipeline root
-                if (options.getAnalysisDir() != null)
-                {
-                    studyXml = Files.list(options.getAnalysisDir())
-                            .filter(p -> p.getFileName().toString().equalsIgnoreCase("study.xml"))
-                            .findFirst()
-                            .orElse(null);
-                }
-                else
-                {
-                    studyXml = root.resolveRelativePath("study.xml");
-                }
-
-                assert c != null;
-                study = manager.getStudy(c);
-                //noinspection ThrowableInstanceNeverThrown
-                BindException errors = new NullSafeBindException(c, "reload");
-                ActionURL manageStudyURL = new ActionURL(StudyController.ManageStudyAction.class, c);
-
-                LOG.info("Handling " + c.getPath());
-
-                // issue 15681: if there is a folder archive instead of a study archive, see if the folder.xml exists to point to the study root dir
-                if (studyXml == null || !Files.exists(studyXml))
-                {
-                    Path folderXml = root.resolveToNioPath("folder.xml");
-                    if (folderXml != null && Files.exists(folderXml))
-                    {
-                        FolderImportContext folderCtx = new FolderImportContext(reloadUser, c, folderXml, null, new StaticLoggerGetter(LOG), null);
-                        FolderDocument folderDoc = folderCtx.getDocument();
-                        if (folderDoc.getFolder().getStudy() != null && folderDoc.getFolder().getStudy().getDir() != null)
-                        {
-                            studyXml = root.resolveRelativePath("/" + folderDoc.getFolder().getStudy().getDir() + "/study.xml");
-                        }
-                    }
-                }
-                if (studyXml != null)
-                    PipelineService.get().queueJob(new StudyImportJob(c, reloadUser, manageStudyURL, studyXml, studyXml.getFileName().toString(), errors, root, options));
-                else
-                    LOG.error("Study.xml does not exist in the analysis directory or pipeline root.");
-            }
-            catch (Throwable t)
-            {
-                String studyDescription = (null != study ? " \"" + getDescription(study) + "\"" : "");
-                String folderPath = (null != c ? " in folder " + c.getPath() : "");
-                LOG.error("Error while reloading study" + studyDescription + folderPath, t);
-            }
-
-            return new ReloadStatus("Reloading " + getDescription(study));
-        }
+        return new ReloadStatus("Reloading " + getDescription(study));
     }
 
 

--- a/study/src/org/labkey/study/importer/StudyReloadTask.java
+++ b/study/src/org/labkey/study/importer/StudyReloadTask.java
@@ -53,7 +53,6 @@ public class StudyReloadTask extends PipelineJob.Task<StudyReloadTask.Factory>
         FileAnalysisJobSupport support = job.getJobSupport(FileAnalysisJobSupport.class);
         job.setLogFile(new File(support.getDataDirectory(), FileUtil.makeFileNameWithTimestamp("triggered_study_reload", "log")));
         Map<String, String> params = support.getParameters();
-        StudyReload.ReloadTask reloadTask = new StudyReload.ReloadTask();
         String containerId = getJob().getContainer().getId();
 
         try
@@ -66,7 +65,7 @@ public class StudyReloadTask extends PipelineJob.Task<StudyReloadTask.Factory>
                 options.setFailForUndefinedVisits(BooleanUtils.toBoolean(params.get(FAIL_FOR_UNDEFINED_VISITS)));
 
             options.setAnalysisDir(support.getDataDirectoryPath());
-            StudyReload.ReloadStatus status = reloadTask.attemptTriggeredReload(options, "a configured study reload filewatcher");
+            StudyReload.ReloadStatus status = StudyReload.attemptTriggeredReload(options, "a configured study reload filewatcher");
             job.setStatus(status.getMessage());
         }
         catch (ImportException ie)


### PR DESCRIPTION
#### Rationale
`ReloadTask` began its life as a timer task then evolved to be a Quartz job, but we removed the scheduling feature when we introduced file watchers. ReloadTask never got the memo, though; it still implements Quartz Job but is never registered. And its `execute()` method is therefore never called. Sadly, I see no reason for ReloadTask to exist in the world any more...

I suspect more refactors of `StudyReload` will occur as we eliminate study archives, but this is a good checkpoint.
