### PR TITLE
Round-trip data objects and their parent data classes through XARs

### DIFF
--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -1294,14 +1294,23 @@ public class XarReader extends AbstractXarImporter
 
         for (InputOutputRefsType.DataLSID inputDataLSID : inputDataLSIDs)
         {
-            String declaredType = (inputDataLSID.isSetCpasType() ? inputDataLSID.getCpasType() : "Data");
-            checkDataCpasType(declaredType);
+            String declaredType = (inputDataLSID.isSetCpasType() ? inputDataLSID.getCpasType() : ExpData.DEFAULT_CPAS_TYPE);
+            if (declaredType.contains("${"))
+            {
+                declaredType = LsidUtils.resolveLsidFromTemplate(declaredType, context, ExpDataClassImpl.NAMESPACE_PREFIX);
+            }
+            ExpDataClass dataClass = checkDataCpasType(declaredType);
             String lsid = LsidUtils.resolveLsidFromTemplate(inputDataLSID.getStringValue(), context, declaredType, new AutoFileLSIDReplacer(inputDataLSID.getDataFileUrl(), getContainer(), _xarSource));
 
             ExpData data = _xarSource.getData(firstApp ? null : new ExpRunImpl(experimentRun), new ExpProtocolApplicationImpl(protocolApp), lsid);
             if (firstApp)
             {
                 _xarSource.addData(experimentRun.getLSID(), data, null);
+            }
+
+            if (dataClass != null)
+            {
+                data.setCpasType(dataClass.getLSID());
             }
 
             SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("DataId"), data.getRowId());

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
@@ -61,7 +61,7 @@ import java.util.stream.Collectors;
  */
 public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> implements ExpDataClass
 {
-    protected static final String NAMESPACE_PREFIX = "DataClass";
+    public static final String NAMESPACE_PREFIX = "DataClass";
     private static final String SEARCH_CATEGORY_NAME = "dataClass";
     public static final SearchService.SearchCategory SEARCH_CATEGORY = new SearchService.SearchCategory(SEARCH_CATEGORY_NAME, "Collection of data objects");
 

--- a/experiment/src/org/labkey/experiment/xar/AbstractXarImporter.java
+++ b/experiment/src/org/labkey/experiment/xar/AbstractXarImporter.java
@@ -23,6 +23,7 @@ import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.XarSource;
 import org.labkey.api.exp.api.ExpData;
+import org.labkey.api.exp.api.ExpDataClass;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExperimentService;
@@ -47,14 +48,18 @@ public abstract class AbstractXarImporter
         _job = job;
     }
 
-    protected void checkDataCpasType(String declaredType) throws ExperimentException
+    protected ExpDataClass checkDataCpasType(String declaredType) throws ExperimentException
     {
+        ExpDataClass result = null;
         if (declaredType != null && !ExpData.DEFAULT_CPAS_TYPE.equals(declaredType))
         {
             // check if this is a reference to a data class
-            if (ExperimentService.get().getDataClass(declaredType) == null)
-                throw new ExperimentException("Unrecognized CpasType '" + declaredType + "' loaded for Data object.");
+
+            result = ExperimentService.get().getDataClass(declaredType);
+            if (result == null)
+                throw new ExperimentException("Unrecognized CpasType '" + declaredType + "' referenced for Data object.");
         }
+        return result;
     }
 
     protected ExpSampleTypeImpl checkMaterialCpasType(String declaredType) throws ExperimentException

--- a/experiment/src/org/labkey/experiment/xar/XarExpander.java
+++ b/experiment/src/org/labkey/experiment/xar/XarExpander.java
@@ -499,12 +499,7 @@ public class XarExpander extends AbstractXarImporter
     private void addMaterialObject(String protocolLSID, int actionSequence, String materialLSID)
     {
         PredecessorStep step = new PredecessorStep(protocolLSID, actionSequence);
-        List<String> outputs = _materialOutputs.get(step);
-        if (outputs == null)
-        {
-            outputs = new ArrayList<>();
-            _materialOutputs.put(step, outputs);
-        }
+        List<String> outputs = _materialOutputs.computeIfAbsent(step, k -> new ArrayList<>());
         outputs.add(materialLSID);
     }
 
@@ -575,12 +570,7 @@ public class XarExpander extends AbstractXarImporter
     private void addDataObject(String protocolLSID, int actionSequence, String dataLSID)
     {
         PredecessorStep step = new PredecessorStep(protocolLSID, actionSequence);
-        List<String> outputs = _dataOutputs.get(step);
-        if (outputs == null)
-        {
-            outputs = new ArrayList<>();
-            _dataOutputs.put(step, outputs);
-        }
+        List<String> outputs = _dataOutputs.computeIfAbsent(step, k -> new ArrayList<>());
         outputs.add(dataLSID);
     }
 


### PR DESCRIPTION
#### Rationale
We've gotten stricter about bad DataClass references during XAR import. We need to generate more fully formed XARs.

#### Changes
* Export relativized DataClass references consistently
* Expand LSIDs consistently on import
* Add DataClasses to XAR exports automatically