### PR TITLE
Fix container path encoding problem introduced by PR 2941

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
@@ -876,7 +876,7 @@ public class ExpDataTableImpl extends ExpRunItemTableImpl<ExpDataTable.Column> i
 
                 PipeRoot pr = PipelineService.get().getPipelineRootSetting(getProject());
 
-                return pr.getWebdavURL() + getUrlRelative();
+                return org.labkey.api.util.Path.parse(pr.getWebdavURL()).encode() + getUrlRelative();
             }
 
             public String getUrlRelative()

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -936,7 +936,7 @@ public class FileContentServiceImpl implements FileContentService
 
     /**
      * Move the file or directory into a ".deleted" directory under the parent directory.
-     * @return True if succesfully moved.
+     * @return True if successfully moved.
      */
     private static boolean moveToDeleted(File fileToMove)
     {
@@ -1337,8 +1337,8 @@ public class FileContentServiceImpl implements FileContentService
                 return switch (type)
                         {
                             case folderRelative -> relPath;
-                            case serverRelative -> root.getWebdavURL() + relPath;
-                            case full -> AppProps.getInstance().getBaseServerUrl() + root.getWebdavURL() + relPath;
+                            case serverRelative -> Path.parse(root.getWebdavURL()).encode() + relPath;
+                            case full -> AppProps.getInstance().getBaseServerUrl() + Path.parse(root.getWebdavURL()).encode() + relPath;
                             default -> throw new IllegalArgumentException("Unexpected path type: " + type);
                         };
             }
@@ -1557,15 +1557,12 @@ public class FileContentServiceImpl implements FileContentService
         if (!FileUtil.hasCloudScheme(path))
         {
             File file = path.toFile();
-            if (null != file)
-            {
-                String legacyUrl = file.toURI().toString();
-                if (existingUrls.contains(legacyUrl))      // Legacy URI format (file:/users/...)
-                    return true;
+            String legacyUrl = file.toURI().toString();
+            if (existingUrls.contains(legacyUrl))      // Legacy URI format (file:/users/...)
+                return true;
 
-                if (existingUrls.contains(file.getPath()))
-                    return true;
-            }
+            if (existingUrls.contains(file.getPath()))
+                return true;
         }
         return false;
     }


### PR DESCRIPTION
#### Rationale
The TargetedMS suite caught a URL encoding problem but I didn't see it until I merged the platform PR.

https://teamcity.labkey.org/buildConfiguration/LabKey_2111Release_Community_ModuleSuites_TargettedMSSqlserve/1670482?buildTab=artifacts#%2FtomcatLogs.tar.gz

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2941

#### Changes
* Encode the container path too. Probably we should change PipeRootImpl.getWebdavUrl() so that it properly encodes, but there are bunch of callers and I haven't chased them all down to see if they'd double-encode yet.