### PR TITLE
Remove obsolete upgrade code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -165,7 +165,6 @@ api/src/org/labkey/api/action/ExportException.java -text
 api/src/org/labkey/api/action/ExtendedApiQueryResponse.java -text
 api/src/org/labkey/api/action/ExtFormResponseWriter.java -text
 api/src/org/labkey/api/action/FormArrayList.java -text
-api/src/org/labkey/api/action/FormattedError.java -text
 api/src/org/labkey/api/action/FormHandlerAction.java -text
 api/src/org/labkey/api/action/FormViewAction.java -text
 api/src/org/labkey/api/action/HasBindParameters.java -text
@@ -221,7 +220,6 @@ api/src/org/labkey/api/admin/FolderWriterImpl.java -text
 api/src/org/labkey/api/admin/ImportContext.java -text
 api/src/org/labkey/api/admin/ImportException.java -text
 api/src/org/labkey/api/admin/ImportOptions.java -text
-api/src/org/labkey/api/admin/InternalFolderWriter.java -text
 api/src/org/labkey/api/admin/InvalidFileException.java -text
 api/src/org/labkey/api/admin/LoggerGetter.java -text
 api/src/org/labkey/api/admin/notification/Notification.java -text
@@ -2634,7 +2632,6 @@ issues/src/org/labkey/issue/IssueUserListener.java -text
 issues/src/org/labkey/issue/model/CommentAttachmentParent.java -text
 issues/src/org/labkey/issue/model/CustomColumn.java -text
 issues/src/org/labkey/issue/model/GeneralIssuesListDefProvider.java -text
-issues/src/org/labkey/issue/model/Issue.java -text
 issues/src/org/labkey/issue/model/IssueCommentType.java -text
 issues/src/org/labkey/issue/model/IssueListDef.java -text
 issues/src/org/labkey/issue/model/IssueListDefCache.java -text
@@ -3053,8 +3050,6 @@ query/webapp/reports/ScriptReportPanel.js -text
 query/webapp/scriptreporteditor.lib.xml -text
 search/module.properties -text
 search/resources/credits/jars.txt -text
-search/resources/schemas/dbscripts/postgresql/search-0.00-13.10.sql -text
-search/resources/schemas/dbscripts/sqlserver/search-0.00-13.10.sql -text
 search/resources/schemas/search.xml -text
 search/src/org/labkey/search/audit/SearchAuditProvider.java -text
 search/src/org/labkey/search/model/DocumentConversionServiceImpl.java -text
@@ -3165,7 +3160,6 @@ study/src/org/labkey/study/importer/DatasetDefinitionImporter.java -text
 study/src/org/labkey/study/importer/DatasetImportUtils.java -text
 study/src/org/labkey/study/importer/DefaultStudyDesignImporter.java -text
 study/src/org/labkey/study/importer/InternalStudyImporter.java -text
-study/src/org/labkey/study/importer/MissingValueImporterFactory.java -text
 study/src/org/labkey/study/importer/ParticipantCommentImporter.java -text
 study/src/org/labkey/study/importer/ParticipantGroupImporter.java -text
 study/src/org/labkey/study/importer/PipeDelimParser.java -text
@@ -3188,7 +3182,6 @@ study/src/org/labkey/study/importer/StudyViewsImporter.java -text
 study/src/org/labkey/study/importer/TopLevelStudyPropertiesImporter.java -text
 study/src/org/labkey/study/importer/TreatmentDataImporter.java -text
 study/src/org/labkey/study/importer/TreatmentVisitMapImporter.java -text
-study/src/org/labkey/study/importer/ViewCategoryImporter.java -text
 study/src/org/labkey/study/importer/VisitCohortAssigner.java -text
 study/src/org/labkey/study/importer/VisitImporter.java -text
 study/src/org/labkey/study/importer/VisitMapImporter.java -text
@@ -3437,7 +3430,6 @@ study/src/org/labkey/study/writer/AssayScheduleWriter.java -text
 study/src/org/labkey/study/writer/CohortWriter.java -text
 study/src/org/labkey/study/writer/DefaultStudyDesignWriter.java -text
 study/src/org/labkey/study/writer/InternalStudyWriter.java -text
-study/src/org/labkey/study/writer/MissingValueWriterFactory.java -text
 study/src/org/labkey/study/writer/OutputStreamWrapper.java -text
 study/src/org/labkey/study/writer/ParticipantCommentWriter.java -text
 study/src/org/labkey/study/writer/ParticipantGroupWriter.java -text
@@ -3451,7 +3443,6 @@ study/src/org/labkey/study/writer/StudyWriter.java -text
 study/src/org/labkey/study/writer/StudyWriterFactory.java -text
 study/src/org/labkey/study/writer/StudyXmlWriter.java -text
 study/src/org/labkey/study/writer/TreatmentDataWriter.java -text
-study/src/org/labkey/study/writer/ViewCategoryWriter.java -text
 study/src/org/labkey/study/writer/VisitMapWriter.java -text
 study/src/org/labkey/study/writer/XmlVisitMapWriter.java -text
 study/test/sampledata/study/commondata/APX-1.tsv -text

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -595,9 +595,8 @@ public class AuthenticationManager
         AuthenticationConfigurationCache.clear();
     }
 
-    // leave public until upgrade from 19.3 is no longer allowed (and CoreUpgrade migration method is removed)
-    public static final String AUTHENTICATION_CATEGORY = "Authentication";
-    public static final String PROVIDERS_KEY = "Authentication";
+    // Used by start-up properties
+    private static final String AUTHENTICATION_CATEGORY = "Authentication";
 
     public static final String SELF_REGISTRATION_KEY = "SelfRegistration";
     public static final String AUTO_CREATE_ACCOUNTS_KEY = "AutoCreateAccounts";

--- a/api/src/org/labkey/api/security/SaveConfigurationAction.java
+++ b/api/src/org/labkey/api/security/SaveConfigurationAction.java
@@ -123,15 +123,4 @@ public abstract class SaveConfigurationAction<F extends SaveConfigurationForm, A
         AC configuration = getFromCache(rowId);
         return AuthenticationManager.getConfigurationMap(configuration);
     }
-
-    // Remove after we no longer upgrade from 20.1
-    public static void saveOldProperties(@Nullable SaveConfigurationForm form, @Nullable User user)
-    {
-        if (null != form)
-        {
-            form.setEnabled(true);
-            form.setDescription(form.getProvider() + " Configuration");
-            saveForm(form, user);
-        }
-    }
 }

--- a/core/resources/schemas/dbscripts/postgresql/core-0.000-21.000.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-0.000-21.000.sql
@@ -715,8 +715,6 @@ CREATE TABLE core.AuthenticationConfigurations
     CONSTRAINT PK_AuthenticationConfigurations PRIMARY KEY (RowId)
 );
 
-SELECT core.executeJavaUpgradeCode('migrateAuthenticationConfigurations');
-
 /*
     For LabKey 19.3.x and earlier, the email preferences tables lived in the 'comm' schema and were managed by the
     announcements module. As of 20.1.0, the core module now manages these tables in the 'core' schema. This script
@@ -816,8 +814,6 @@ INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (702, 'A
 SELECT core.fn_dropifexists('AuthenticationConfigurations', 'core', 'DEFAULT', 'SortOrder');
 ALTER TABLE core.AuthenticationConfigurations ALTER COLUMN SortOrder TYPE SMALLINT;
 ALTER TABLE core.AuthenticationConfigurations ALTER COLUMN SortOrder SET DEFAULT 32767;
-
-SELECT core.executeJavaUpgradeCode('migrateSecondaryAuthenticationConfigurations');
 
 ALTER TABLE core.Modules RENAME COLUMN InstalledVersion TO SchemaVersion;
 ALTER TABLE core.Modules ALTER COLUMN SchemaVersion DROP NOT NULL;

--- a/core/resources/schemas/dbscripts/sqlserver/core-0.000-21.000.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-0.000-21.000.sql
@@ -955,8 +955,6 @@ CREATE TABLE core.AuthenticationConfigurations
     CONSTRAINT PK_AuthenticationConfigurations PRIMARY KEY (RowId)
 );
 
-EXEC core.executeJavaUpgradeCode 'migrateAuthenticationConfigurations';
-
 /*
     For LabKey 19.3.x and earlier, the email preferences tables lived in the 'comm' schema and were managed by the
     announcements module. As of 20.1.0, the core module now manages these tables in the 'core' schema. This script
@@ -1055,9 +1053,7 @@ EXEC core.fn_dropifexists 'AuthenticationConfigurations', 'core', 'DEFAULT', 'So
 ALTER TABLE core.AuthenticationConfigurations ALTER COLUMN SortOrder SMALLINT;
 ALTER TABLE core.AuthenticationConfigurations ADD CONSTRAINT DF_SortOrder DEFAULT 32767 FOR SortOrder;
 
-EXEC core.executeJavaUpgradeCode 'migrateSecondaryAuthenticationConfigurations';
-
-sp_rename 'core.Modules.InstalledVersion', 'SchemaVersion', 'COLUMN';
+EXEC sp_rename 'core.Modules.InstalledVersion', 'SchemaVersion', 'COLUMN';
 ALTER TABLE core.Modules ALTER COLUMN SchemaVersion FLOAT NULL;
 
 -- labbook email notification options

--- a/core/src/org/labkey/core/CoreUpgradeCode.java
+++ b/core/src/org/labkey/core/CoreUpgradeCode.java
@@ -22,30 +22,20 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DeferredUpgrade;
-import org.labkey.api.data.PropertyManager;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.UpgradeCode;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.AuthenticationConfiguration.SSOAuthenticationConfiguration;
 import org.labkey.api.security.AuthenticationManager;
-import org.labkey.api.security.User;
 import org.labkey.api.settings.AbstractWriteableSettingsGroup;
 import org.labkey.api.settings.WriteableAppProps;
-import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.GUID;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.labkey.api.security.AuthenticationManager.AUTHENTICATION_CATEGORY;
-import static org.labkey.api.security.AuthenticationManager.PROVIDERS_KEY;
 
 /**
  * User: adam
@@ -70,72 +60,6 @@ public class CoreUpgradeCode implements UpgradeCode
     public void handleUnknownModules(ModuleContext context)
     {
         ModuleLoader.getInstance().handleUnkownModules();
-    }
-
-    /**
-     * Invoked from 19.20-19.30 to move existing primary authentication property configurations to core.AuthenticationConfigurations table
-     */
-    @SuppressWarnings({"UnusedDeclaration"})
-    @DeferredUpgrade
-    public void migrateAuthenticationConfigurations(final ModuleContext context)
-    {
-        if (!context.isNewInstall())
-        {
-            migrateAuthenticationConfigurations(User.getSearchUser());
-        }
-    }
-
-    public void migrateAuthenticationConfigurations(User user)
-    {
-        Set<String> active = getActiveProviderNamesFromProperties();
-        AuthenticationManager.getAllPrimaryProviders().forEach(provider->{
-            try
-            {
-                provider.migrateOldConfiguration(active.contains(provider.getName()), user);
-            }
-            catch (Throwable t)
-            {
-                ExceptionUtil.logExceptionToMothership(null, t);
-            }
-        });
-    }
-
-    /**
-     * Invoked at 19.35 to move existing secondary authentication property configurations to core.AuthenticationConfigurations table
-     */
-    @SuppressWarnings({"UnusedDeclaration"})
-    @DeferredUpgrade
-    public void migrateSecondaryAuthenticationConfigurations(ModuleContext context)
-    {
-        if (!context.isNewInstall())
-        {
-            User user = context.getUpgradeUser();
-            Set<String> active = getActiveProviderNamesFromProperties();
-            AuthenticationManager.getAllSecondaryProviders().forEach(provider -> {
-                try
-                {
-                    provider.migrateOldConfiguration(active.contains(provider.getName()), user);
-                }
-                catch (Throwable t)
-                {
-                    ExceptionUtil.logExceptionToMothership(null, t);
-                }
-            });
-        }
-    }
-
-    private static final String PROP_SEPARATOR = ":";
-    // Provider names stored in properties; they're not necessarily all valid providers
-
-    public static Set<String> getActiveProviderNamesFromProperties()
-    {
-        Map<String, String> props = PropertyManager.getProperties(AUTHENTICATION_CATEGORY);
-        String activeProviderProp = props.get(PROVIDERS_KEY);
-
-        Set<String> set = new HashSet<>();
-        Collections.addAll(set, null != activeProviderProp ? activeProviderProp.split(PROP_SEPARATOR) : new String[0]);
-
-        return set;
     }
 
     /**

--- a/core/src/org/labkey/core/admin/sql/SqlScriptController.java
+++ b/core/src/org/labkey/core/admin/sql/SqlScriptController.java
@@ -532,7 +532,7 @@ public class SqlScriptController extends SpringActionController
         {
             html.append("    <tr><td colspan=2><input type=\"checkbox\" name=\"includeSingleScripts\"");
             html.append(form.getIncludeSingleScripts() ? " checked" : "");
-            html.append("/>Include single scripts that don't start with 0.00</td></tr>\n");
+            html.append("/>Include single scripts that don't start with 0.000</td></tr>\n");
         }
 
         @Override

--- a/core/src/org/labkey/core/admin/sql/SqlScriptController.java
+++ b/core/src/org/labkey/core/admin/sql/SqlScriptController.java
@@ -633,6 +633,7 @@ public class SqlScriptController extends SpringActionController
             Pattern copyrightPattern = Pattern.compile("^/\\*\\s*\\*\\s*Copyright.*?\\*/\\s*", Pattern.CASE_INSENSITIVE + Pattern.DOTALL + Pattern.MULTILINE);
             StringBuilder sb = new StringBuilder();
             boolean firstScript = true;
+            int lastLoggedYear = 0;
 
             for (SqlScript script : getScripts())
             {
@@ -649,10 +650,6 @@ public class SqlScriptController extends SpringActionController
                         sb.append(contents, 0, contentStartIndex);
                     }
 
-                    // Skip for incremental and existing bootstrap scripts
-                    if (!script.isIncremental() && script.getFromVersion() != 0.0)
-                        sb.append("/* ").append(script.getDescription()).append(" */\n\n");
-
                     sb.append(contents.substring(contentStartIndex));
                     firstScript = false;
                 }
@@ -660,9 +657,13 @@ public class SqlScriptController extends SpringActionController
                 {
                     sb.append("\n\n");
 
-                    // Skip for incremental scripts
-                    if (!script.isIncremental())
-                        sb.append("/* ").append(script.getDescription()).append(" */\n\n");
+                    // Optimized for bootstrap script consolidation: single comment at the start of each year's scripts.
+                    int year = (int)script.getFromVersion();
+                    if (lastLoggedYear < year)
+                    {
+                        sb.append("/* ").append(year).append(".xxx SQL scripts */\n\n");
+                        lastLoggedYear = year;
+                    }
 
                     sb.append(licenseMatcher.replaceFirst(""));    // Remove license
                 }

--- a/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
+++ b/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
@@ -17,7 +17,6 @@ package org.labkey.core.login;
 
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.AuthenticationManager.AuthenticationValidator;
 import org.labkey.api.security.AuthenticationProvider.LoginFormAuthenticationProvider;
@@ -25,7 +24,6 @@ import org.labkey.api.security.ConfigurationSettings;
 import org.labkey.api.security.LoginUrls;
 import org.labkey.api.security.PasswordExpiration;
 import org.labkey.api.security.PasswordRule;
-import org.labkey.api.security.SaveConfigurationForm;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
@@ -127,12 +125,6 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
         }
 
         return AuthenticationResponse.createSuccessResponse(configuration, email);
-    }
-
-    @Override
-    public @Nullable SaveConfigurationForm getFormFromOldConfiguration(boolean active)
-    {
-        return null;  // We don't migrate the database login configuration
     }
 
     @Override

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -19,12 +19,10 @@ package org.labkey.core.login;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
-import org.labkey.api.action.ConfirmAction;
 import org.labkey.api.action.FormHandlerAction;
 import org.labkey.api.action.FormViewAction;
 import org.labkey.api.action.MutatingApiAction;
@@ -90,7 +88,6 @@ import org.labkey.api.view.WebPartView;
 import org.labkey.api.view.template.PageConfig;
 import org.labkey.api.wiki.WikiRendererType;
 import org.labkey.api.wiki.WikiRenderingService;
-import org.labkey.core.CoreUpgradeCode;
 import org.labkey.core.admin.AdminController;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
@@ -2722,39 +2719,6 @@ public class LoginController extends SpringActionController
         }
     }
 
-    @RequiresPermission(AdminOperationsPermission.class)
-    public class MigrateAuthenticationConfigurationsAction extends ConfirmAction
-    {
-        @Override
-        public ModelAndView getConfirmView(Object o, BindException errors)
-        {
-            if (getPageConfig().getTitle() == null)
-                setTitle("Migrate Authentication Configurations");
-
-            return new HtmlView(HtmlString.of("Are you sure you want to re-run the authentication configuration migration? This may cause duplicate configurations (which can be deleted)."));
-        }
-
-        @Override
-        public void validateCommand(Object o, Errors errors)
-        {
-        }
-
-        @Override
-        public boolean handlePost(Object o, BindException errors) throws Exception
-        {
-            new CoreUpgradeCode().migrateAuthenticationConfigurations(getUser());
-
-            return true;
-        }
-
-        @Override
-        public @NotNull URLHelper getSuccessURL(Object o)
-        {
-            return urlProvider(LoginUrls.class).getConfigureURL();
-        }
-    }
-
-
     /**
      * Simple action for verifying proper CSRF token handling from external scripts and programs. Referenced in the
      * HTTP Interface docs: https://www.labkey.org/Documentation/wiki-page.view?name=remoteAPIs
@@ -2787,7 +2751,6 @@ public class LoginController extends SpringActionController
             // @RequiresPermission(AdminOperationsPermission.class)
             assertForAdminOperationsPermission(user,
                 controller.new DeleteConfigurationAction(),
-                controller.new MigrateAuthenticationConfigurationsAction(),
                 controller.new SaveDbLoginPropertiesAction(),
                 controller.new SaveSettingsAction(),
                 controller.new SetAuthenticationParameterAction()

--- a/devtools/src/org/labkey/devtools/authentication/TestSecondaryProvider.java
+++ b/devtools/src/org/labkey/devtools/authentication/TestSecondaryProvider.java
@@ -18,12 +18,10 @@ package org.labkey.devtools.authentication;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.security.SaveConfigurationForm;
 import org.labkey.api.security.AuthenticationProvider.SecondaryAuthenticationProvider;
 import org.labkey.api.security.ConfigurationSettings;
 import org.labkey.api.view.ActionURL;
 import org.labkey.devtools.authentication.TestSecondaryController.TestSecondarySaveConfigurationAction;
-import org.labkey.devtools.authentication.TestSecondaryController.TestSecondarySaveConfigurationForm;
 
 /**
  * User: adam
@@ -64,11 +62,5 @@ public class TestSecondaryProvider implements SecondaryAuthenticationProvider<Te
     public boolean bypass()
     {
         return false;
-    }
-
-    @Override
-    public @Nullable SaveConfigurationForm getFormFromOldConfiguration(boolean active)
-    {
-        return active ? new TestSecondarySaveConfigurationForm() : null;
     }
 }

--- a/devtools/src/org/labkey/devtools/authentication/TestSsoProvider.java
+++ b/devtools/src/org/labkey/devtools/authentication/TestSsoProvider.java
@@ -16,7 +16,6 @@
 package org.labkey.devtools.authentication;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.AuthenticationProvider.SSOAuthenticationProvider;
@@ -24,7 +23,6 @@ import org.labkey.api.security.ConfigurationSettings;
 import org.labkey.api.security.SettingsField;
 import org.labkey.api.view.ActionURL;
 import org.labkey.devtools.authentication.TestSsoController.TestSsoSaveConfigurationAction;
-import org.labkey.devtools.authentication.TestSsoController.TestSsoSaveConfigurationForm;
 
 /**
  * Created by adam on 6/5/2016.
@@ -64,13 +62,5 @@ public class TestSsoProvider implements SSOAuthenticationProvider<TestSsoConfigu
     {
         return new JSONArray()
             .put(SettingsField.of("autoRedirect", SettingsField.FieldType.checkbox, "Default to this TestSSO configuration", "Redirects the login page directly to the TestSSO page instead of requiring the user to click on a logo.", false, false));
-    }
-
-    // TODO: Remove this once we stop upgrading from 19.3
-
-    @Override
-    public @Nullable TestSsoSaveConfigurationForm getFormFromOldConfiguration(boolean active, boolean hasLogos)
-    {
-        return active || hasLogos ? new TestSsoSaveConfigurationForm() : null;
     }
 }

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-0.000-21.000.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-0.000-21.000.sql
@@ -1217,34 +1217,6 @@ CREATE TABLE exp.Edge
 ALTER TABLE exp.propertydescriptor
   ADD TextExpression varchar(200) NULL;
 
-CREATE TABLE exp.Exclusions
-(
-  RowId SERIAL NOT NULL,
-  RunId INT NOT NULL,
-  Comment TEXT NULL,
-  Created TIMESTAMP NULL,
-  CreatedBy INT NULL,
-  Modified TIMESTAMP NULL,
-  ModifiedBy INT NULL,
-  CONSTRAINT PK_Exclusion_RowId PRIMARY KEY (RowId),
-  CONSTRAINT FK_Exclusion_RunId FOREIGN KEY (RunId) REFERENCES exp.ExperimentRun (RowId)
-);
-CREATE INDEX IX_Exclusion_RunId ON exp.Exclusions(RunId);
-
-CREATE TABLE exp.ExclusionMaps
-(
-  RowId SERIAL NOT NULL,
-  ExclusionId INT NOT NULL,
-  DataRowId INT NOT NULL,
-  Created TIMESTAMP NULL,
-  CreatedBy INT NULL,
-  Modified TIMESTAMP NULL,
-  ModifiedBy INT NULL,
-  CONSTRAINT PK_ExclusionMap_RowId PRIMARY KEY (RowId),
-  CONSTRAINT FK_ExclusionMap_ExclusionId FOREIGN KEY (ExclusionId) REFERENCES exp.Exclusions (RowId),
-  CONSTRAINT UQ_ExclusionMap_ExclusionId_DataId UNIQUE (ExclusionId, DataRowId)
-);
-
 ALTER TABLE exp.DomainDescriptor ALTER COLUMN DomainURI TYPE VARCHAR(300);
 ALTER TABLE exp.PropertyDescriptor ALTER COLUMN PropertyURI TYPE VARCHAR(300);
 
@@ -1393,8 +1365,6 @@ ALTER TABLE exp.ExperimentRun ADD LastIndexed TIMESTAMP NULL;
 ALTER TABLE exp.ProtocolApplication ALTER COLUMN Comments TYPE TEXT;
 
 ALTER TABLE exp.DataClass ADD COLUMN Category VARCHAR(20) NULL;
-
-SELECT core.executeJavaUpgradeCode('addProvisionedDataClassNameClassId');
 
 ALTER TABLE exp.dataclass
     ADD COLUMN lastindexed TIMESTAMP NULL;

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-0.000-21.000.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-0.000-21.000.sql
@@ -1213,34 +1213,6 @@ CREATE TABLE exp.Edge
 ALTER TABLE exp.PropertyDescriptor
   ADD TextExpression nvarchar(200) NULL
 
-CREATE TABLE exp.Exclusions
-(
-  RowId INT IDENTITY (1, 1) NOT NULL,
-  RunId INT NOT NULL,
-  Comment TEXT NULL,
-  Created DATETIME  NULL,
-  CreatedBy INT NULL,
-  Modified DATETIME  NULL,
-  ModifiedBy INT NULL,
-  CONSTRAINT PK_Exclusion_RowId PRIMARY KEY (RowId),
-  CONSTRAINT FK_Exclusion_RunId FOREIGN KEY (RunId) REFERENCES exp.ExperimentRun (RowId)
-);
-CREATE INDEX IX_Exclusion_RunId ON exp.Exclusions(RunId);
-
-CREATE TABLE exp.ExclusionMaps
-(
-  RowId INT IDENTITY (1, 1) NOT NULL,
-  ExclusionId INT NOT NULL,
-  DataRowId INT NOT NULL,
-  Created DATETIME  NULL,
-  CreatedBy INT NULL,
-  Modified DATETIME  NULL,
-  ModifiedBy INT NULL,
-  CONSTRAINT PK_ExclusionMap_RowId PRIMARY KEY (RowId),
-  CONSTRAINT FK_ExclusionMap_ExclusionId FOREIGN KEY (ExclusionId) REFERENCES exp.Exclusions (RowId),
-  CONSTRAINT UQ_ExclusionMap_ExclusionId_DataId UNIQUE (ExclusionId, DataRowId)
-);
-
 ALTER TABLE exp.DomainDescriptor ALTER COLUMN DomainURI NVARCHAR(300) NOT NULL;
 ALTER TABLE exp.PropertyDescriptor ALTER COLUMN PropertyURI NVARCHAR(300) NOT NULL;
 
@@ -1395,8 +1367,6 @@ ALTER TABLE exp.ExperimentRun ADD LastIndexed DATETIME NULL;
 ALTER TABLE exp.ProtocolApplication ALTER COLUMN Comments NVARCHAR(MAX);
 
 ALTER TABLE exp.DataClass ADD Category NVARCHAR(20) NULL;
-
-EXEC core.executeJavaUpgradeCode 'addProvisionedDataClassNameClassId';
 
 ALTER TABLE exp.DataClass ADD LastIndexed DATETIME NULL;
 

--- a/issues/src/org/labkey/issue/IssuesModule.java
+++ b/issues/src/org/labkey/issue/IssuesModule.java
@@ -67,6 +67,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.labkey.api.issues.IssuesSchema.ISSUE_DEF_SCHEMA_NAME;
+
 /**
  * User: migra
  * Date: Jul 18, 2005
@@ -202,7 +204,18 @@ public class IssuesModule extends DefaultModule implements SearchService.Documen
     @NotNull
     public Set<String> getSchemaNames()
     {
-        return PageFlowUtil.set(IssuesSchema.getInstance().getSchemaName());
+        return Set.of(
+            IssuesSchema.getInstance().getSchemaName(),
+            ISSUE_DEF_SCHEMA_NAME
+        );
+    }
+
+    @Override
+    public @NotNull Collection<String> getProvisionedSchemaNames()
+    {
+        return Set.of(
+            ISSUE_DEF_SCHEMA_NAME
+        );
     }
 
     @Override

--- a/mothership/src/org/labkey/mothership/MothershipModule.java
+++ b/mothership/src/org/labkey/mothership/MothershipModule.java
@@ -116,7 +116,13 @@ public class MothershipModule extends DefaultModule
     private void bootstrap(ModuleContext moduleContext)
     {
         Container c = ContainerManager.ensureContainer(MothershipReport.CONTAINER_PATH);
-        Group mothershipGroup = SecurityManager.createGroup(c, NAME);
+        final Group mothershipGroup;
+        Integer groupId = SecurityManager.getGroupId(c, NAME, false);
+        // Group will exist in the case where mothership module is deleted and re-added to a deployment
+        if (null != groupId)
+            mothershipGroup = SecurityManager.getGroup(groupId);
+        else
+            mothershipGroup = SecurityManager.createGroup(c, NAME);
         MutableSecurityPolicy policy = new MutableSecurityPolicy(c, SecurityPolicyManager.getPolicy(c));
         Role noPermsRole = RoleManager.getRole(NoPermissionsRole.class);
         Role projAdminRole = RoleManager.getRole(ProjectAdminRole.class);


### PR DESCRIPTION
#### Rationale

- This `core` and `exp` upgrade code no-ops at bootstrap time, the only case where it's called now. Clean up authentication migration code that's no longer called.
- Stop creating `Exclusions` and `ExclusionMaps` tables in `exp` and then moving them to `premium`; instead, create them directly in `premium`. This allows re-bootstrapping of premium.
- Adjust .gitattributes for deleted source files
- At server startup, log all missing dependencies and their dependents instead of logging just the first one encountered
- Tolerate existing "Mothership" security group. Allows re-bootstrapping the mothership module.
- Properly declare the "IssueDef" schema. Allows re-bootstrapping the issues module.
