### PR TITLE
Fix MenuBarTest failure by clearing client dependencies during error rendering

### DIFF
--- a/api/src/org/labkey/api/query/QueryParseException.java
+++ b/api/src/org/labkey/api/query/QueryParseException.java
@@ -95,7 +95,7 @@ public class QueryParseException extends QueryException
     @Override
     public JSONObject toJSON(String sql)
     {
-        String lines[] = null;
+        String[] lines = null;
         if (sql != null)
             lines = sql.split("\n");
 
@@ -113,11 +113,11 @@ public class QueryParseException extends QueryException
             String errorStr = lines[getLine() - 1];
             error.put("errorStr", errorStr);
         }
-        Map<Enum,String> decorations = ExceptionUtil.getExceptionDecorations(this);
+        Map<Enum<?>, String> decorations = ExceptionUtil.getExceptionDecorations(this);
         if (!decorations.isEmpty())
         {
             JSONObject d = new JSONObject();
-            for (Map.Entry<Enum,String> entry : decorations.entrySet())
+            for (Map.Entry<Enum<?>, String> entry : decorations.entrySet())
                 d.put(entry.getKey().name(), entry.getValue());
             error.put("decorations",d);
         }

--- a/api/src/org/labkey/api/util/ErrorRenderer.java
+++ b/api/src/org/labkey/api/util/ErrorRenderer.java
@@ -150,8 +150,8 @@ public class ErrorRenderer
             // Since there might be SQL in here, maybe don't dump for non-admin/dev
             if (null != user && user.isPlatformDeveloper())
             {
-                Map<Enum,String> decorations = ExceptionUtil.getExceptionDecorations(_exception);
-                for (Map.Entry<Enum,String> e : decorations.entrySet())
+                Map<Enum<?>,String> decorations = ExceptionUtil.getExceptionDecorations(_exception);
+                for (Map.Entry<Enum<?>, String> e : decorations.entrySet())
                 {
                     out.print(PageFlowUtil.filter(e.getKey()));
                     out.print(" = ");

--- a/api/src/org/labkey/api/webdav/DavException.java
+++ b/api/src/org/labkey/api/webdav/DavException.java
@@ -111,8 +111,8 @@ public class DavException extends Exception
             o.put("resourceName", p.getName());
         }
         // check for interesting annotations
-        Map<Enum,String> map = ExceptionUtil.getExceptionDecorations(this);
-        for (Map.Entry<Enum,String> e : map.entrySet())
+        Map<Enum<?>, String> map = ExceptionUtil.getExceptionDecorations(this);
+        for (Map.Entry<Enum<?>, String> e : map.entrySet())
         {
             if (e.getKey() == ExceptionUtil.ExceptionInfo.ResolveURL ||
                     e.getKey() == ExceptionUtil.ExceptionInfo.ResolveText ||


### PR DESCRIPTION
#### Rationale
An intermittent crawler failure uncovered a problem when views initialize their client dependencies but we ultimately end up rendering an error page

https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyPostgres/1673626?buildTab=overview&showRootCauses=false&expandBuildChangesSection=true&expandBuildTestsSection=true

#### Changes
* During error rendering, create a fresh PageConfig object and only carry over the properties that we care to retain
* Misc lint fixup in ExceptionUtil
* Improve rendering of execution plans in Admin Console
