### PR TITLE
Issue 43496: View names are not really case-insensitive

### DIFF
--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -779,7 +779,7 @@ public class QueryServiceImpl implements QueryService
     protected Map<String, CustomView> getCustomViewMap(@NotNull User user, Container container, @Nullable User owner, QueryDefinition qd,
                                                        boolean inheritable, boolean sharedOnly)
     {
-        Map<String, CustomView> views = new CaseInsensitiveHashMap<>();
+        Map<String, CustomView> views = new HashMap<>();
 
         // module query views have lower precedence, so add them first
         for (CustomView view : qd.getSchema().getModuleCustomViews(container, qd))
@@ -843,7 +843,7 @@ public class QueryServiceImpl implements QueryService
                     }
                 });
 
-        Map<Path, CustomView> views = new HashMap<>();
+        Map<String, CustomView> views = new HashMap<>();
 
         for (String schemaName : moduleViewSchemas)
         {
@@ -866,7 +866,8 @@ public class QueryServiceImpl implements QueryService
 
                         for (CustomView view : qd.getSchema().getModuleCustomViews(container, qd))
                         {
-                            Path key = new Path(schema.getPath().toString(), view.getQueryDefinition().getName(), StringUtils.defaultString(view.getName(), ""));
+                            Path keyPath = new Path(schema.getPath().toString(), view.getQueryDefinition().getName(), StringUtils.defaultString(view.getName(), ""));
+                            String key = keyPath.toString();
                             if (!views.containsKey(key))
                                 views.put(key, view);
                         }
@@ -878,7 +879,8 @@ public class QueryServiceImpl implements QueryService
         // custom views in the database get highest precedence, so let them overwrite the module-defined views in the map
         for (CstmView cstmView : QueryManager.get().getAllCstmViews(container, null, null, owner, inheritable, sharedOnly))
         {
-            Path key = new Path(cstmView.getSchema(), cstmView.getQueryName(), StringUtils.defaultString(cstmView.getName(), ""));
+            Path keyPath = new Path(cstmView.getSchema(), cstmView.getQueryName(), StringUtils.defaultString(cstmView.getName(), ""));
+            String key = keyPath.toString();
             // The database custom views are in priority order so check if the view has already been added
             if (!views.containsKey(key))
             {

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -67,6 +67,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -315,7 +316,8 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
 
             List<Map<String, Object>> viewInfos = new ArrayList<>();
             Map<String, CustomView> allViews = queryDef.getCustomViews(getUser(), getViewContext().getRequest(), true, false);
-            Set<String> viewNames = new CaseInsensitiveHashSet("");
+            Set<String> viewNames = new HashSet();
+            viewNames.add("");
             if (form.getViewName() != null)
                 viewNames.addAll(Arrays.stream(form.getViewName()).map(String::trim).collect(toList()));
 
@@ -334,7 +336,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
             }
             else
             {
-                allViews = new CaseInsensitiveHashMap<>(allViews);
+                allViews = new HashMap<>(allViews);
                 for (String viewName : viewNames)
                 {
                     // NOTE viewName==null in the allViews map


### PR DESCRIPTION
#### Rationale
Custom views aren't case-insensitive but it's treated so on several UI areas.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* show all views for grid views dropdown and manage views 
