### PR TITLE
Issue 44601: Roundtrip of sample type defined in subfolder 'moves' it to project

### DIFF
--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -32,6 +32,7 @@ import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.writer.VirtualFile;
 import org.labkey.experiment.XarReader;
+import org.labkey.experiment.xar.FolderXarImporterFactory;
 import org.labkey.experiment.xar.XarImportContext;
 
 import java.io.File;
@@ -168,7 +169,7 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                         };
                     }
 
-                    XarSource typesXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(typesXarFile.getFileName().toString()), typesXarFile, logFile, job);
+                    XarSource typesXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(typesXarFile.getFileName().toString()), typesXarFile, logFile, job, ctx.getContainer());
                     try
                     {
                         typesXarSource.init();
@@ -179,7 +180,7 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                         throw(e);
                     }
                     log.info("Importing the types XAR file: " + typesXarFile.getFileName().toString());
-                    XarReader typesReader = new XarReader(typesXarSource, job);
+                    XarReader typesReader = new FolderXarImporterFactory.FolderExportXarReader(typesXarSource, job);
                     typesReader.setStrictValidateExistingSampleType(xarCtx.isStrictValidateExistingSampleType());
                     typesReader.parseAndLoad(false, ctx.getAuditBehaviorType());
 
@@ -192,7 +193,7 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                     // handle wiring up any derivation runs
                     if (runsXarFile != null)
                     {
-                        XarSource runsXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(runsXarFile.getFileName().toString()), runsXarFile, logFile, job);
+                        XarSource runsXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(runsXarFile.getFileName().toString()), runsXarFile, logFile, job, ctx.getContainer());
                         try
                         {
                             runsXarSource.init();
@@ -203,7 +204,7 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                             throw(e);
                         }
                         log.info("Importing the runs XAR file: " + runsXarFile.getFileName().toString());
-                        XarReader runsReader = new XarReader(runsXarSource, job);
+                        XarReader runsReader = new FolderXarImporterFactory.FolderExportXarReader(runsXarSource, job);
                         runsReader.setStrictValidateExistingSampleType(xarCtx.isStrictValidateExistingSampleType());
                         runsReader.parseAndLoad(false, ctx.getAuditBehaviorType());
                     }

--- a/experiment/src/org/labkey/experiment/xar/FolderXarImporterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarImporterFactory.java
@@ -227,7 +227,7 @@ public class FolderXarImporterFactory extends AbstractFolderImportFactory
         }
     }
 
-    private static class FolderExportXarReader extends XarReader
+    public static class FolderExportXarReader extends XarReader
     {
         public FolderExportXarReader(XarSource source, PipelineJob job)
         {

--- a/internal/src/org/labkey/api/exp/CompressedInputStreamXarSource.java
+++ b/internal/src/org/labkey/api/exp/CompressedInputStreamXarSource.java
@@ -2,6 +2,7 @@ package org.labkey.api.exp;
 
 import org.apache.xmlbeans.XmlException;
 import org.fhcrc.cpas.exp.xml.ExperimentArchiveDocument;
+import org.labkey.api.data.Container;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.XmlBeansUtil;
@@ -30,9 +31,9 @@ public class CompressedInputStreamXarSource extends AbstractFileXarSource
     private final Path _logFile;
     private String _xml;
 
-    public CompressedInputStreamXarSource(InputStream xarInputStream, Path xarFile, Path logFile, PipelineJob job)
+    public CompressedInputStreamXarSource(InputStream xarInputStream, Path xarFile, Path logFile, PipelineJob job, Container container)
     {
-        super(job.getDescription(), job.getContainer(), job.getUser(), job);
+        super(job.getDescription(), container, job.getUser(), job);
         _xarInputStream = xarInputStream;
         _xmlFile = xarFile;
         _logFile = logFile;


### PR DESCRIPTION
#### Rationale
Import/export of a folder tree should retain the location for each type of object within the hierarchy

#### Changes
* Use the current container that's being imported instead of always using the job's container, which is always the starting location