### PR TITLE
Item 9875: Assay QC state option to require comment on QC state change for assay run

### DIFF
--- a/api/schemas/qcStates.xsd
+++ b/api/schemas/qcStates.xsd
@@ -46,7 +46,7 @@
                 <xs:element name="requireCommentOnQCStateChange" type="xs:boolean" default="false" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>
-                            This setting determines whether a comment is required when updating an assay run QC state.
+                            This setting determines whether a comment is required when updating a QC state.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>

--- a/api/schemas/qcStates.xsd
+++ b/api/schemas/qcStates.xsd
@@ -43,6 +43,13 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>
+                <xs:element name="requireCommentOnQCStateChange" type="xs:boolean" default="false" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            This setting determines whether a comment is required when updating an assay run QC state.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
                 <xs:element name="insertUpdateDefault" type="xs:string" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>

--- a/api/src/org/labkey/api/assay/AssayQCService.java
+++ b/api/src/org/labkey/api/assay/AssayQCService.java
@@ -120,6 +120,12 @@ public interface AssayQCService
     void setIsBlankQCStatePublic(Container container, boolean isPublic);
 
     /**
+     * Gets/sets whether or not a comment is required on a QC State change
+     */
+    boolean isRequireCommentOnQCStateChange(Container container);
+    void setRequireCommentOnQCStateChange(Container container, boolean requireCommentOnQCStateChange);
+
+    /**
      * Returns the warnings view if the specified run has a current QC state associated with it
      */
     @Nullable
@@ -206,6 +212,17 @@ public interface AssayQCService
 
         @Override
         public void setIsBlankQCStatePublic(Container container, boolean isPublic)
+        {
+        }
+
+        @Override
+        public boolean isRequireCommentOnQCStateChange(Container container)
+        {
+            return false;
+        }
+
+        @Override
+        public void setRequireCommentOnQCStateChange(Container container, boolean isPublic)
         {
         }
     }

--- a/api/src/org/labkey/api/qc/AbstractManageQCStatesAction.java
+++ b/api/src/org/labkey/api/qc/AbstractManageQCStatesAction.java
@@ -32,10 +32,12 @@ import java.util.Set;
 @RequiresPermission(AdminPermission.class)
 public abstract class AbstractManageQCStatesAction<FORM extends AbstractManageDataStatesForm> extends FormViewAction<FORM>
 {
-    public abstract String getQcStateDefaultsPanel(Container container, DataStateHandler qcStateHandler);
-    public abstract String getDataVisibilityPanel(Container container, DataStateHandler qcStateHandler);
     public abstract boolean hasQcStateDefaultsPanel();
+    public abstract String getQcStateDefaultsPanel(Container container, DataStateHandler qcStateHandler);
     public abstract boolean hasDataVisibilityPanel();
+    public abstract String getDataVisibilityPanel(Container container, DataStateHandler qcStateHandler);
+    public abstract boolean hasRequiresCommentPanel();
+    public abstract String getRequiresCommentPanel(Container container, DataStateHandler qcStateHandler);
 
     protected DataStateHandler _dataStateHandler;
 

--- a/api/src/org/labkey/api/qc/DataStateHandler.java
+++ b/api/src/org/labkey/api/qc/DataStateHandler.java
@@ -27,6 +27,7 @@ public interface DataStateHandler<FORM extends AbstractManageDataStatesForm>
     List<DataState> getStates(Container container);
     boolean isStateInUse(Container container, DataState state);
     boolean isBlankStatePublic(Container container);
+    boolean isRequireCommentOnQCStateChange(Container container);
 
     /**
      * Check if a given state allows for changes based on things like if it is in-use, etc. and return the error

--- a/api/src/org/labkey/api/qc/export/AbstractDataStateImporter.java
+++ b/api/src/org/labkey/api/qc/export/AbstractDataStateImporter.java
@@ -91,6 +91,7 @@ public abstract class AbstractDataStateImporter
 
         helper.setShowPrivateDataByDefault(ctx.getContainer(), ctx.getUser(), qcXml.getShowPrivateDataByDefault());
         helper.setBlankQCStatePublic(ctx.getContainer(), ctx.getUser(), qcXml.getBlankQCStatePublic());
+        helper.setRequireCommentOnQCStateChange(ctx.getContainer(), ctx.getUser(), qcXml.getRequireCommentOnQCStateChange());
     }
 
     @NotNull

--- a/api/src/org/labkey/api/qc/export/DataStateImportExportHelper.java
+++ b/api/src/org/labkey/api/qc/export/DataStateImportExportHelper.java
@@ -62,4 +62,5 @@ public interface DataStateImportExportHelper
     void setDefaultDirectEntryQCState(Container container, User user, Integer stateId);
     void setShowPrivateDataByDefault(Container container, User user, boolean showPrivate);
     void setBlankQCStatePublic(Container container, User user, boolean isPublic);
+    void setRequireCommentOnQCStateChange(Container container, User user, boolean requireCommentOnQCStateChange);
 }

--- a/api/src/org/labkey/api/qc/view/manageQCStates.jsp
+++ b/api/src/org/labkey/api/qc/view/manageQCStates.jsp
@@ -107,17 +107,25 @@
         if (manageAction.hasQcStateDefaultsPanel())
         {
     %>
-    <labkey:panel title="<%=defaultStatesPanelTitle%>">
-        <%= text(manageAction.getQcStateDefaultsPanel(container, qcStateHandler)) %>
-    </labkey:panel>
+            <labkey:panel title="<%=defaultStatesPanelTitle%>">
+                <%= text(manageAction.getQcStateDefaultsPanel(container, qcStateHandler)) %>
+            </labkey:panel>
     <%
         }
         if (manageAction.hasDataVisibilityPanel())
         {
     %>
-    <labkey:panel title="Data visibility">
-        <%= text(manageAction.getDataVisibilityPanel(container, qcStateHandler)) %>
-    </labkey:panel>
+            <labkey:panel title="Data visibility">
+                <%= text(manageAction.getDataVisibilityPanel(container, qcStateHandler)) %>
+            </labkey:panel>
+    <%
+        }
+        if (manageAction.hasRequiresCommentPanel())
+        {
+    %>
+            <labkey:panel title="QC State Comments">
+                <%= text(manageAction.getRequiresCommentPanel(container, qcStateHandler)) %>
+            </labkey:panel>
     <%
         }
     %>

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -1619,7 +1619,7 @@ public class AssayController extends SpringActionController
 
                 if (_firstRun != null)
                 {
-                    if (AssayQCService.getProvider().isRequireCommentOnQCStateChange(_firstRun.getProtocol().getContainer()) && form.getComment() == null)
+                    if (AssayQCService.getProvider().isRequireCommentOnQCStateChange(_firstRun.getProtocol().getContainer()) && StringUtils.isBlank(form.getComment()))
                         errors.reject(ERROR_MSG, "A comment is required when changing a QC State for the selected run(s).");
                 }
             }

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -332,6 +332,7 @@ public class AssayController extends SpringActionController
         assayProperties.put("templateLink", urlProvider(AssayUrls.class).getProtocolURL(c, protocol, TemplateAction.class));
         if (provider instanceof PlateBasedAssayProvider)
             assayProperties.put("plateTemplate", ((PlateBasedAssayProvider)provider).getPlateTemplate(c, protocol));
+        assayProperties.put("requireCommentOnQCStateChange", AssayQCService.getProvider().isRequireCommentOnQCStateChange(protocol.getContainer()));
 
         // XXX: UGLY: Get the TableInfo associated with the Domain -- loop over all tables and ask for the Domains.
         AssayProtocolSchema schema = provider.createProtocolSchema(user, c, protocol, null);

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -1605,6 +1605,8 @@ public class AssayController extends SpringActionController
                 errors.reject(ERROR_MSG, "QC State cannot be blank");
             if (form.getRuns().isEmpty())
                 errors.reject(ERROR_MSG, "No runs were selected to update their QC State");
+            if (AssayQCService.getProvider().isRequireCommentOnQCStateChange(getContainer()) && form.getComment() == null)
+                errors.reject(ERROR_MSG, "A comment is required when changing a QC State for the selected run(s).");
         }
 
         @Override

--- a/assay/src/org/labkey/assay/view/updateQCState.jsp
+++ b/assay/src/org/labkey/assay/view/updateQCState.jsp
@@ -30,6 +30,7 @@
     UpdateQCStateForm form = (UpdateQCStateForm) HttpView.currentView().getModelBean();
     String currentState = null;
     String protocolContainerPath = null;
+    boolean requireComment = false;
 
     if (form.getRuns().size() == 1)
     {
@@ -45,9 +46,10 @@
     // get the protocol container to determine the folder where QC states are defined
     ExpRun expRun = ExperimentService.get().getExpRun(form.getRuns().stream().findFirst().get());
     if (expRun != null)
+    {
         protocolContainerPath = expRun.getProtocol().getContainer().getPath();
-
-    boolean requireComment = AssayQCService.getProvider().isRequireCommentOnQCStateChange(getContainer());
+        requireComment = AssayQCService.getProvider().isRequireCommentOnQCStateChange(expRun.getProtocol().getContainer());
+    }
 %>
 
 <script type="application/javascript">

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.7.2",
-        "@labkey/components": "2.116.0-fb-domainChangeType.4",
+        "@labkey/components": "2.119.0",
         "@labkey/themes": "1.2.1"
       },
       "devDependencies": {
@@ -2888,9 +2888,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.116.0-fb-domainChangeType.4",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.116.0-fb-domainChangeType.4.tgz",
-      "integrity": "sha1-NawyTrR3iJVahv8DisKROGi0dII=",
+      "version": "2.119.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.119.0.tgz",
+      "integrity": "sha1-3hvRdGKIPiFHj2aAH61xFdf13Z8=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -19130,9 +19130,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.116.0-fb-domainChangeType.4",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.116.0-fb-domainChangeType.4.tgz",
-      "integrity": "sha1-NawyTrR3iJVahv8DisKROGi0dII=",
+      "version": "2.119.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.119.0.tgz",
+      "integrity": "sha1-3hvRdGKIPiFHj2aAH61xFdf13Z8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -2528,6 +2528,7 @@ public class CoreController extends SpringActionController
     public static class ManageQCStatesForm extends AbstractManageDataStatesForm
     {
         private Integer _defaultQCState;
+        private boolean _requireCommentOnQCStateChange;
 
         public Integer getDefaultQCState()
         {
@@ -2537,6 +2538,16 @@ public class CoreController extends SpringActionController
         public void setDefaultQCState(Integer defaultQCState)
         {
             _defaultQCState = defaultQCState;
+        }
+
+        public boolean isRequireCommentOnQCStateChange()
+        {
+            return _requireCommentOnQCStateChange;
+        }
+
+        public void setRequireCommentOnQCStateChange(boolean requireCommentOnQCStateChange)
+        {
+            _requireCommentOnQCStateChange = requireCommentOnQCStateChange;
         }
     }
 
@@ -2552,12 +2563,6 @@ public class CoreController extends SpringActionController
         public boolean hasQcStateDefaultsPanel()
         {
             return true;
-        }
-
-        @Override
-        public boolean hasDataVisibilityPanel()
-        {
-            return false;
         }
 
         @Override
@@ -2581,9 +2586,44 @@ public class CoreController extends SpringActionController
         }
 
         @Override
+        public boolean hasDataVisibilityPanel()
+        {
+            return false;
+        }
+
+        @Override
         public String getDataVisibilityPanel(Container container, DataStateHandler qcStateHandler)
         {
-            throw new IllegalStateException("This action does not support a data visibility panel");
+            throw new IllegalStateException("This action does not support a data visibility panel.");
+        }
+
+        @Override
+        public boolean hasRequiresCommentPanel()
+        {
+            return true;
+        }
+
+        @Override
+        public String getRequiresCommentPanel(Container container, DataStateHandler qcStateHandler)
+        {
+            StringBuilder panelHtml = new StringBuilder();
+            panelHtml.append("  <table class=\"lk-fields-table\">");
+            panelHtml.append("      <tr>");
+            panelHtml.append("          <td colspan=\"2\">This setting determines whether a comment is required when updating an assay run QC state.");
+            panelHtml.append("      </tr>");
+            panelHtml.append("      <tr>");
+            panelHtml.append("          <th align=\"right\" width=\"300px\">Require Comment on QC State Change:</th>");
+            panelHtml.append("          <td>");
+            panelHtml.append("              <select name=\"requireCommentOnQCStateChange\">");
+            panelHtml.append("                  <option value=\"false\">No</option>");
+            String selectedText = (qcStateHandler.isRequireCommentOnQCStateChange(container)) ? " selected" : "";
+            panelHtml.append("                  <option value=\"true\"").append(selectedText).append(">Yes</option>");
+            panelHtml.append("              </select>");
+            panelHtml.append("          </td>");
+            panelHtml.append("      </tr>");
+            panelHtml.append("  </table>");
+
+            return panelHtml.toString();
         }
 
         @Override

--- a/core/src/org/labkey/core/qc/CoreQCStateHandler.java
+++ b/core/src/org/labkey/core/qc/CoreQCStateHandler.java
@@ -45,20 +45,26 @@ public class CoreQCStateHandler implements DataStateHandler<CoreController.Manag
         return AssayQCService.getProvider().isBlankQCStatePublic(container);
     }
 
+    @Override
+    public boolean isRequireCommentOnQCStateChange(Container container)
+    {
+        return AssayQCService.getProvider().isRequireCommentOnQCStateChange(container);
+    }
+
     public Integer getDefaultQCState(Container container)
     {
         DataState state = AssayQCService.getProvider().getDefaultDataImportState(container);
         return state != null ? state.getRowId() : null;
     }
 
-    private void setProps(Container container, boolean isBlankQCStatePublic, Integer defaultQCState)
+    private void setProps(Container container, boolean isBlankQCStatePublic, Integer defaultQCState, boolean isRequireCommentOnQCStateChange)
     {
         AssayQCService.getProvider().setIsBlankQCStatePublic(container, isBlankQCStatePublic);
+        AssayQCService.getProvider().setRequireCommentOnQCStateChange(container, isRequireCommentOnQCStateChange);
 
         DataState state = null;
         if (defaultQCState != null)
             state = QCStateManager.getInstance().getStateForRowId(container, defaultQCState);
-
         AssayQCService.getProvider().setDefaultDataImportState(container, state);
     }
 
@@ -79,10 +85,11 @@ public class CoreQCStateHandler implements DataStateHandler<CoreController.Manag
     @Override
     public void updateState(Container container, CoreController.ManageQCStatesForm form, User user)
     {
-        if (!DataStateHandler.nullSafeEqual(getDefaultQCState(container), form.getDefaultQCState()) ||
-                isBlankStatePublic(container) != form.isBlankQCStatePublic())
+        if (!DataStateHandler.nullSafeEqual(getDefaultQCState(container), form.getDefaultQCState())
+                || isBlankStatePublic(container) != form.isBlankQCStatePublic()
+                || isRequireCommentOnQCStateChange(container) != form.isRequireCommentOnQCStateChange())
         {
-            setProps(container, form.isBlankQCStatePublic(), form.getDefaultQCState());
+            setProps(container, form.isBlankQCStatePublic(), form.getDefaultQCState(), form.isRequireCommentOnQCStateChange());
         }
     }
 

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -3413,18 +3413,6 @@ public class StudyController extends BaseStudyController
         }
 
         @Override
-        public boolean hasQcStateDefaultsPanel()
-        {
-            return true;
-        }
-
-        @Override
-        public boolean hasDataVisibilityPanel()
-        {
-            return true;
-        }
-
-        @Override
         public ModelAndView getView(ManageQCStatesForm manageQCStatesForm, boolean reshow, BindException errors)
         {
             return new JspView<>("/org/labkey/api/qc/view/manageQCStates.jsp",
@@ -3447,6 +3435,12 @@ public class StudyController extends BaseStudyController
                 return getQCStateFilteredURL(successUrl, PUBLIC_STATES_LABEL, DATASET_DATAREGION_NAME, getContainer());
 
             return successUrl;
+        }
+
+        @Override
+        public boolean hasQcStateDefaultsPanel()
+        {
+            return true;
         }
 
         @Override
@@ -3478,6 +3472,12 @@ public class StudyController extends BaseStudyController
         }
 
         @Override
+        public boolean hasDataVisibilityPanel()
+        {
+            return true;
+        }
+
+        @Override
         public String getDataVisibilityPanel(Container container, DataStateHandler qcStateHandler)
         {
             StringBuilder panelHtml = new StringBuilder();
@@ -3499,6 +3499,18 @@ public class StudyController extends BaseStudyController
             panelHtml.append("  </table>");
 
             return panelHtml.toString();
+        }
+
+        @Override
+        public boolean hasRequiresCommentPanel()
+        {
+            return false;
+        }
+
+        @Override
+        public String getRequiresCommentPanel(Container container, DataStateHandler qcStateHandler)
+        {
+            throw new IllegalStateException("This action does not support a requires comment panel.");
         }
     }
 

--- a/study/src/org/labkey/study/qc/StudyQCImportExportHelper.java
+++ b/study/src/org/labkey/study/qc/StudyQCImportExportHelper.java
@@ -35,6 +35,7 @@ public class StudyQCImportExportHelper implements DataStateImportExportHelper
 
         qcXml.setShowPrivateDataByDefault(study.isShowPrivateDataByDefault());
         qcXml.setBlankQCStatePublic(study.isBlankQCStatePublic());
+        qcXml.setRequireCommentOnQCStateChange(false);
 
         // set the default states for each import type
         DataState pipelineImportState = getQCStateFromRowId(ctx.getContainer(), study.getDefaultPipelineQCState());
@@ -136,5 +137,11 @@ public class StudyQCImportExportHelper implements DataStateImportExportHelper
             study.setBlankQCStatePublic(isPublic);
             StudyManager.getInstance().updateStudy(user, study);
         }
+    }
+
+    @Override
+    public void setRequireCommentOnQCStateChange(Container container, User user, boolean requireCommentOnQCStateChange)
+    {
+
     }
 }

--- a/study/src/org/labkey/study/qc/StudyQCStateHandler.java
+++ b/study/src/org/labkey/study/qc/StudyQCStateHandler.java
@@ -106,6 +106,12 @@ public class StudyQCStateHandler implements DataStateHandler<StudyController.Man
     }
 
     @Override
+    public boolean isRequireCommentOnQCStateChange(Container container)
+    {
+        return false;
+    }
+
+    @Override
     public @Nullable String getStateChangeError(Container container, DataState state, Map<String, Object> rowUpdates)
     {
         return null;


### PR DESCRIPTION
#### Rationale
The NIAID Response Team has a FANG ELISA assay which they would like to use LabKey for the Assay QC workflow. They will be using Assay run QC states to track passing and failing plate/sample runs. The initial QC state for each run will be set during the file watcher pipeline import task, but users with proper permissions will be allowed to update QC states for a run after review within the LabKey UI. This story adds a feature so that an admin can set, via the Manage QC states page, that a comment is required when changing an assay run QC state.

#### Related Pull Requests
* https://github.com/LabKey/niaidElisa/pull/1
* https://github.com/LabKey/premium/pull/305
* https://github.com/LabKey/platform/pull/2954
* https://github.com/LabKey/sampleManagement/pull/806
* https://github.com/LabKey/testAutomation/pull/969

#### Changes
* add "requireCommentOnQCStateChange" setting to qcStates.xsd and support round tripping that setting via folder export / import
* AssayQCService update to add getter and setter for RequireCommentOnQCStateChange flag
* Assay Manage QC States UI update to add new panel for setting the "require comment" flag
* UpdateQCStateAction update to validate required comment based on the container flag
