### PR TITLE
Issue 44686: Put Lucene index in a versioned subfolder if in dev mode

### DIFF
--- a/api/src/org/labkey/api/action/BaseViewAction.java
+++ b/api/src/org/labkey/api/action/BaseViewAction.java
@@ -240,7 +240,7 @@ public abstract class BaseViewAction<FORM> extends PermissionCheckableAction imp
 
     public void setHelpTopic(HelpTopic topic)
     {
-        assert null != getPageConfig() : "action not initialized property";
+        assert null != getPageConfig() : "action not initialized properly";
         getPageConfig().setHelpTopic(topic);
     }
 

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -119,7 +119,7 @@ public class SearchController extends SpringActionController
 
 
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleRedirectAction
+    public class BeginAction extends SimpleRedirectAction<Object>
     {
         @Override
         public ActionURL getRedirectURL(Object o)
@@ -256,8 +256,9 @@ public class SearchController extends SpringActionController
         {
         }
 
-        public AdminAction(PageConfig pageConfig)
+        public AdminAction(ViewContext ctx, PageConfig pageConfig)
         {
+            setViewContext(ctx);
             setPageConfig(pageConfig);
         }
 
@@ -385,18 +386,18 @@ public class SearchController extends SpringActionController
 
 
     @AdminConsoleAction
-    public class IndexContentsAction extends SimpleViewAction
+    public class IndexContentsAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
         {
-            return new JspView("/org/labkey/search/view/exportContents.jsp");
+            return new JspView<>("/org/labkey/search/view/exportContents.jsp");
         }
 
         @Override
         public void addNavTrail(NavTree root)
         {
-            new AdminAction(getPageConfig()).addNavTrail(root);
+            new AdminAction(getViewContext(), getPageConfig()).addNavTrail(root);
             root.addChild("Index Contents");
         }
     }

--- a/search/src/org/labkey/search/model/IndexInspector.java
+++ b/search/src/org/labkey/search/model/IndexInspector.java
@@ -79,7 +79,7 @@ public class IndexInspector
 
     private static Path getIndexDirectory()
     {
-        return SearchPropertyManager.getIndexDirectory().toPath();
+        return LuceneSearchServiceImpl.getIndexDirectory().toPath();
     }
 
     private static class TSVIndexWriter extends TSVWriter


### PR DESCRIPTION
#### Rationale
Reduce churn when switching between branches with different Lucene versions

Fix exception when visiting export index action