### PR TITLE
Issue 44557: Optimize queries within Panorama QC folders for faster plot rendering

### DIFF
--- a/api/src/org/labkey/api/admin/notification/NotificationService.java
+++ b/api/src/org/labkey/api/admin/notification/NotificationService.java
@@ -69,6 +69,12 @@ public interface NotificationService
     List<Notification> getNotificationsByUser(Container container, int notifyUserId, boolean unreadOnly);
 
     /*
+     * Returns just the count of notifications for a specific user. At any given instant, will match the length of the
+     * list returned by getNotificationsByUser(), and is significantly more efficient to query.
+     */
+    long getNotificationCountByUser(Container container, int notifyUserId, boolean unreadOnly);
+
+    /*
      * Returns a list of notifications for a specific user based on the specified type.
      */
     List<Notification> getNotificationsByType(Container container, @NotNull String type, int notifyUserId, boolean unreadOnly);

--- a/api/src/org/labkey/api/data/LazyForeignKey.java
+++ b/api/src/org/labkey/api/data/LazyForeignKey.java
@@ -18,13 +18,15 @@ import java.util.function.Supplier;
 public class LazyForeignKey implements ForeignKey
 {
     private final Supplier<ForeignKey> _supplier;
+    private final boolean _suggestColumns;
 
     private boolean _delegateCreationAttempted = false;
     private ForeignKey _delegate;
 
-    public LazyForeignKey(Supplier<ForeignKey> supplier)
+    public LazyForeignKey(Supplier<ForeignKey> supplier, boolean suggestColumns)
     {
         _supplier = supplier;
+        _suggestColumns = suggestColumns;
     }
 
     private ForeignKey getDelegate()
@@ -100,6 +102,10 @@ public class LazyForeignKey implements ForeignKey
     @Override
     public @Nullable Set<FieldKey> getSuggestedColumns()
     {
+        if (!_suggestColumns)
+        {
+            return null;
+        }
         return getDelegate() == null ? null : getDelegate().getSuggestedColumns();
     }
 }

--- a/api/src/org/labkey/api/data/Table.java
+++ b/api/src/org/labkey/api/data/Table.java
@@ -171,10 +171,11 @@ public class Table
             sqlLine = sqlLine.trim();
             if (!sqlLine.startsWith("--"))
             {
-                // First non-comment line must start with SELECT
+                // First non-comment line must start with SELECT or WITH (for a CTE)
                 if (!select)
                 {
-                    if (StringUtils.startsWithIgnoreCase(sqlLine, "SELECT"))
+                    if (StringUtils.startsWithIgnoreCase(sqlLine, "SELECT") ||
+                            (StringUtils.startsWithIgnoreCase(sqlLine, "WITH") && StringUtils.containsIgnoreCase(sql, "SELECT")))
                         select = true;
                     else
                         return false;

--- a/api/src/org/labkey/api/data/Table.java
+++ b/api/src/org/labkey/api/data/Table.java
@@ -171,11 +171,10 @@ public class Table
             sqlLine = sqlLine.trim();
             if (!sqlLine.startsWith("--"))
             {
-                // First non-comment line must start with SELECT or WITH (for a CTE)
+                // First non-comment line must start with SELECT
                 if (!select)
                 {
-                    if (StringUtils.startsWithIgnoreCase(sqlLine, "SELECT") ||
-                            (StringUtils.startsWithIgnoreCase(sqlLine, "WITH") && StringUtils.containsIgnoreCase(sql, "SELECT")))
+                    if (StringUtils.startsWithIgnoreCase(sqlLine, "SELECT"))
                         select = true;
                     else
                         return false;

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -141,6 +141,8 @@ public interface QueryService
 
     void writeTables(Container c, User user, VirtualFile dir, Map<String, List<Map<String, Object>>> schemas, ColumnHeaderType header) throws IOException;
 
+    TableInfo createTable(QuerySchema schema, String sql, @Nullable Map<String, TableInfo> tableMap, boolean strictColumnList);
+
     /**
      * Get the list of custom views.
      * If schema, query, or owner is null, return custom views for all schemas/queries/users.

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -2227,7 +2227,7 @@ public class PageFlowUtil
         json.put("jdkJavaDocLinkPrefix", HelpTopic.getJdkJavaDocLinkPrefix());
 
         if (AppProps.getInstance().isExperimentalFeatureEnabled(NotificationMenuView.EXPERIMENTAL_NOTIFICATION_MENU))
-            json.put("notifications", Map.of("unreadCount", NotificationService.get().getNotificationsByUser(null, user.getUserId(), true).size()));
+            json.put("notifications", Map.of("unreadCount", NotificationService.get().getNotificationCountByUser(null, user.getUserId(), true)));
 
         JSONObject defaultHeaders = new JSONObject();
         defaultHeaders.put("X-ONUNAUTHORIZED", "UNAUTHORIZED");

--- a/core/src/org/labkey/core/notification/NotificationServiceImpl.java
+++ b/core/src/org/labkey/core/notification/NotificationServiceImpl.java
@@ -188,6 +188,12 @@ public class NotificationServiceImpl extends AbstractContainerListener implement
     }
 
     @Override
+    public long getNotificationCountByUser(Container container, int notifyUserId, boolean unreadOnly)
+    {
+        return createSelectorByUserOrType(container, null, notifyUserId, unreadOnly).getRowCount();
+    }
+
+    @Override
     public List<Notification> getNotificationsByType(Container container, @NotNull String type, int notifyUserId, boolean unreadOnly)
     {
         return getNotificationsByUserOrType(container, Collections.singletonList(type), notifyUserId, unreadOnly);
@@ -203,7 +209,7 @@ public class NotificationServiceImpl extends AbstractContainerListener implement
         return getNotificationsByUserOrType(container, types, notifyUserId, unreadOnly);
     }
 
-    private List<Notification> getNotificationsByUserOrType(Container container, @Nullable List<String> types, int notifyUserId, boolean unreadOnly)
+    private TableSelector createSelectorByUserOrType(Container container, @Nullable List<String> types, int notifyUserId, boolean unreadOnly)
     {
         SimpleFilter filter = new SimpleFilter();
         if (null != container)
@@ -217,8 +223,12 @@ public class NotificationServiceImpl extends AbstractContainerListener implement
         Sort sort = new Sort();
         sort.appendSortColumn(FieldKey.fromParts("Created"), Sort.SortDirection.DESC, false);
 
-        TableSelector selector = new TableSelector(getTable(), filter, sort);
-        return selector.getArrayList(Notification.class);
+        return new TableSelector(getTable(), filter, sort);
+    }
+
+    private List<Notification> getNotificationsByUserOrType(Container container, @Nullable List<String> types, int notifyUserId, boolean unreadOnly)
+    {
+        return createSelectorByUserOrType(container, types, notifyUserId, unreadOnly).getArrayList(Notification.class);
     }
 
     @Override

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -2297,7 +2297,7 @@ public class QueryServiceImpl implements QueryService
         return createTable(schema, sql, null, false);
     }
 
-    private TableInfo createTable(QuerySchema schema, String sql, @Nullable Map<String, TableInfo> tableMap, boolean strictColumnList)
+    public TableInfo createTable(QuerySchema schema, String sql, @Nullable Map<String, TableInfo> tableMap, boolean strictColumnList)
     {
         Query q = new Query(schema);
         q.setStrictColumnList(strictColumnList);


### PR DESCRIPTION
#### Rationale
Fast pages are good. QC folders in Panorama are slower than we want, and there are some platform changes to help improve the SQL we run.

Also, on my dev machine where I have many notifications queued up (4000+) every page render was taking 200ms to stream them all back into Java objects when all we cared about was the count.

#### Changes
* Make LazyForeignKey even lazier, meaning it's less likely to initialize the full FK
* Offer the execution plan for queries that have a CTE
* Expose a QueryService method to turn LabKey SQL into minimal TableInfos to be embedded in other, larger SQL queries 