### PR TITLE
Update package-lock to 2.119.0 (should have been included in PR 2930)

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.7.2",
-        "@labkey/components": "2.116.0-fb-domainChangeType.4",
+        "@labkey/components": "2.119.0",
         "@labkey/themes": "1.2.1"
       },
       "devDependencies": {
@@ -2888,9 +2888,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.116.0-fb-domainChangeType.4",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.116.0-fb-domainChangeType.4.tgz",
-      "integrity": "sha1-NawyTrR3iJVahv8DisKROGi0dII=",
+      "version": "2.119.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.119.0.tgz",
+      "integrity": "sha1-3hvRdGKIPiFHj2aAH61xFdf13Z8=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -19130,9 +19130,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.116.0-fb-domainChangeType.4",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.116.0-fb-domainChangeType.4.tgz",
-      "integrity": "sha1-NawyTrR3iJVahv8DisKROGi0dII=",
+      "version": "2.119.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.119.0.tgz",
+      "integrity": "sha1-3hvRdGKIPiFHj2aAH61xFdf13Z8=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",


### PR DESCRIPTION
#### Rationale
In PR 2930 I updated package.json but missed the update to package-lock.json

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2930

#### Changes
* Point everything at ui-components 2.119.0