### PR TITLE
Update fb_dropIfExists on SQL Server to correctly escape identifiers

### DIFF
--- a/announcements/resources/schemas/dbscripts/postgresql/comm-0.00-18.20.sql
+++ b/announcements/resources/schemas/dbscripts/postgresql/comm-0.00-18.20.sql
@@ -37,6 +37,7 @@ CREATE TABLE comm.Announcements
     DiscussionSrcIdentifier VARCHAR(100) NULL,
     DiscussionSrcURL VARCHAR(1000) NULL,
     LastIndexed TIMESTAMP NULL,
+    Approved TIMESTAMP NULL,
 
     CONSTRAINT PK_Announcements PRIMARY KEY (RowId),
     CONSTRAINT UQ_Announcements UNIQUE (Container, Parent, RowId)
@@ -88,69 +89,6 @@ CREATE TABLE comm.PageVersions
 ALTER TABLE comm.Pages
     ADD CONSTRAINT FK_Pages_PageVersions FOREIGN KEY (PageVersionId) REFERENCES comm.PageVersions (RowId);
 
-/* Managed by the core module, as of 20.1.x
-CREATE TABLE comm.EmailOptions
-(
-    EmailOptionId INT4 NOT NULL,
-    EmailOption VARCHAR(50),
-    Type VARCHAR(60) NOT NULL DEFAULT 'messages',
-
-    CONSTRAINT PK_EmailOptions PRIMARY KEY (EmailOptionId)
-);
-
-INSERT INTO comm.EmailOptions (EmailOptionId, EmailOption) VALUES (0, 'No Email');
-INSERT INTO comm.EmailOptions (EmailOptionId, EmailOption) VALUES (1, 'All conversations');
-INSERT INTO comm.EmailOptions (EmailOptionId, EmailOption) VALUES (2, 'My conversations');
-INSERT INTO comm.EmailOptions (EmailOptionId, EmailOption) VALUES (257, 'Daily digest of all conversations');
-INSERT INTO comm.EmailOptions (EmailOptionId, EmailOption) VALUES (258, 'Daily digest of my conversations');
-
--- new file email notification options
-INSERT INTO comm.emailOptions (EmailOptionId, EmailOption, Type) VALUES
-  (512, 'No Email', 'files'),
-  (513, '15 minute digest', 'files'),
-  (514, 'Daily digest', 'files');
-
-CREATE TABLE comm.EmailFormats
-(
-    EmailFormatId INT4 NOT NULL,
-    EmailFormat VARCHAR(20),
-
-    CONSTRAINT PK_EmailFormats PRIMARY KEY (EmailFormatId)
-);
-
-INSERT INTO comm.EmailFormats (EmailFormatId, EmailFormat) VALUES (0, 'Plain Text');
-INSERT INTO comm.EmailFormats (EmailFormatId, EmailFormat) VALUES (1, 'HTML');
-
-CREATE TABLE comm.PageTypes
-(
-    PageTypeId INT4 NOT NULL,
-    PageType VARCHAR(20),
-
-    CONSTRAINT PK_PageTypes PRIMARY KEY (PageTypeId)
-);
-
-INSERT INTO comm.PageTypes (PageTypeId, PageType) VALUES (0, 'Message');
-INSERT INTO comm.PageTypes (PageTypeId, PageType) VALUES (1, 'Wiki');
-
-CREATE TABLE comm.EmailPrefs
-(
-    Container ENTITYID,
-    UserId USERID,
-    EmailOptionId INT4 NOT NULL,
-    EmailFormatId INT4 NOT NULL,
-    PageTypeId INT4 NOT NULL,
-    LastModifiedBy USERID,
-    Type VARCHAR(60) NOT NULL DEFAULT 'messages',
-    SrcIdentifier VARCHAR(100) NOT NULL, -- allow subscriptions to multiple forums within a single container
-
-    CONSTRAINT PK_EmailPrefs PRIMARY KEY (Container, UserId, Type, SrcIdentifier),
-    CONSTRAINT FK_EmailPrefs_Containers FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
-    CONSTRAINT FK_EmailPrefs_Principals FOREIGN KEY (UserId) REFERENCES core.Principals (UserId),
-    CONSTRAINT FK_EmailPrefs_EmailOptions FOREIGN KEY (EmailOptionId) REFERENCES comm.EmailOptions (EmailOptionId),
-    CONSTRAINT FK_EmailPrefs_EmailFormats FOREIGN KEY (EmailFormatId) REFERENCES comm.EmailFormats (EmailFormatId),
-    CONSTRAINT FK_EmailPrefs_PageTypes FOREIGN KEY (PageTypeId) REFERENCES comm.PageTypes (PageTypeId)
-);
-*/
 -- Discussions can be private, constrained to a certain subset of users (like a Cc: line)
 CREATE TABLE comm.UserList
 (
@@ -183,23 +121,17 @@ CREATE TABLE comm.RSSFeeds
 
 CREATE TABLE comm.Tours
 (
-  RowId SERIAL,
-  Title VARCHAR(500) NOT NULL,
-  Description VARCHAR(4000),
-  Container ENTITYID NOT NULL,
-  EntityId ENTITYID NOT NULL,
-  Created TIMESTAMP,
-  CreatedBy USERID,
-  Modified TIMESTAMP,
-  ModifiedBy USERID,
-  Json VARCHAR,
-  Mode INT NOT NULL DEFAULT 0,
+    RowId SERIAL,
+    Title VARCHAR(500) NOT NULL,
+    Description VARCHAR(4000),
+    Container ENTITYID NOT NULL,
+    EntityId ENTITYID NOT NULL,
+    Created TIMESTAMP,
+    CreatedBy USERID,
+    Modified TIMESTAMP,
+    ModifiedBy USERID,
+    Json VARCHAR,
+    Mode INT NOT NULL DEFAULT 0,
 
-  CONSTRAINT PK_ToursId PRIMARY KEY (RowId)
+    CONSTRAINT PK_ToursId PRIMARY KEY (RowId)
 );
-
-/* comm-18.10-18.20.sql */
-
-ALTER TABLE comm.Announcements ADD COLUMN Approved TIMESTAMP NULL;
-
-UPDATE comm.Announcements SET Approved = Created;

--- a/announcements/resources/schemas/dbscripts/sqlserver/comm-0.00-18.20.sql
+++ b/announcements/resources/schemas/dbscripts/sqlserver/comm-0.00-18.20.sql
@@ -38,6 +38,7 @@ CREATE TABLE comm.Announcements
     DiscussionSrcIdentifier NVARCHAR(100) NULL,
     DiscussionSrcURL NVARCHAR(1000) NULL,
     LastIndexed DATETIME NULL,
+    Approved DATETIME NULL,
 
     CONSTRAINT PK_Announcements PRIMARY KEY (RowId),
     CONSTRAINT UQ_Announcements UNIQUE CLUSTERED (Container, Parent, RowId)
@@ -87,69 +88,6 @@ CREATE TABLE comm.PageVersions
 ALTER TABLE comm.Pages
     ADD CONSTRAINT FK_Pages_PageVersions FOREIGN KEY (PageVersionId) REFERENCES comm.PageVersions (RowId);
 
-/* Managed by the core module, as of 20.1.0
-CREATE TABLE comm.EmailOptions
-(
-    EmailOptionId INT NOT NULL,
-    EmailOption NVARCHAR(50),
-    Type NVARCHAR(60) NOT NULL DEFAULT 'messages',
-
-    CONSTRAINT PK_EmailOptions PRIMARY KEY (EmailOptionId)
-);
-
-INSERT INTO comm.EmailOptions (EmailOptionId, EmailOption) VALUES (0, 'No Email');
-INSERT INTO comm.EmailOptions (EmailOptionId, EmailOption) VALUES (1, 'All conversations');
-INSERT INTO comm.EmailOptions (EmailOptionId, EmailOption) VALUES (2, 'My conversations');
-INSERT INTO comm.EmailOptions (EmailOptionId, EmailOption) VALUES (257, 'Daily digest of all conversations');
-INSERT INTO comm.EmailOptions (EmailOptionId, EmailOption) VALUES (258, 'Daily digest of my conversations');
-
--- new file email notification options
-INSERT INTO comm.emailOptions (EmailOptionId, EmailOption, Type) VALUES (512, 'No Email', 'files');
-INSERT INTO comm.emailOptions (EmailOptionId, EmailOption, Type) VALUES (513, '15 minute digest', 'files');
-INSERT INTO comm.emailOptions (EmailOptionId, EmailOption, Type) VALUES (514, 'Daily digest', 'files');
-
-CREATE TABLE comm.EmailFormats
-(
-    EmailFormatId INT NOT NULL,
-    EmailFormat NVARCHAR(20),
-
-    CONSTRAINT PK_EmailFormats PRIMARY KEY (EmailFormatId)
-);
-
-INSERT INTO comm.EmailFormats (EmailFormatId, EmailFormat) VALUES (0, 'Plain Text');
-INSERT INTO comm.EmailFormats (EmailFormatId, EmailFormat) VALUES (1, 'HTML');
-
-CREATE TABLE comm.PageTypes
-(
-    PageTypeId INT NOT NULL,
-    PageType NVARCHAR(20),
-
-    CONSTRAINT PK_PageTypes PRIMARY KEY (PageTypeId)
-);
-
-INSERT INTO comm.PageTypes (PageTypeId, PageType) VALUES (0, 'Message');
-INSERT INTO comm.PageTypes (PageTypeId, PageType) VALUES (1, 'Wiki');
-
-CREATE TABLE comm.EmailPrefs
-(
-    Container ENTITYID,
-    UserId USERID,
-    EmailOptionId INT NOT NULL,
-    EmailFormatId INT NOT NULL,
-    PageTypeId INT NOT NULL,
-    LastModifiedBy USERID,
-    Type NVARCHAR(60) NOT NULL DEFAULT 'messages',
-    SrcIdentifier NVARCHAR(100) NOT NULL,  -- allow subscriptions to multiple forums within a single container
-
-    CONSTRAINT PK_EmailPrefs PRIMARY KEY (Container, UserId, Type, SrcIdentifier),
-    CONSTRAINT FK_EmailPrefs_Containers FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
-    CONSTRAINT FK_EmailPrefs_Principals FOREIGN KEY (UserId) REFERENCES core.Principals (UserId),
-    CONSTRAINT FK_EmailPrefs_EmailOptions FOREIGN KEY (EmailOptionId) REFERENCES comm.EmailOptions (EmailOptionId),
-    CONSTRAINT FK_EmailPrefs_EmailFormats FOREIGN KEY (EmailFormatId) REFERENCES comm.EmailFormats (EmailFormatId),
-    CONSTRAINT FK_EmailPrefs_PageTypes FOREIGN KEY (PageTypeId) REFERENCES comm.PageTypes (PageTypeId)
-);
-*/
-
 -- Discussions can be private, constrained to a certain subset of users (like a Cc: line)
 CREATE TABLE comm.UserList
 (
@@ -196,10 +134,3 @@ CREATE TABLE comm.Tours
 
   CONSTRAINT PK_ToursId PRIMARY KEY (RowId)
 );
-
-/* comm-18.10-18.20.sql */
-
-ALTER TABLE comm.Announcements ADD Approved DATETIME NULL;
-GO
-
-UPDATE comm.Announcements SET Approved = Created;

--- a/api/src/org/labkey/api/security/roles/CanUseSendMessageApi.java
+++ b/api/src/org/labkey/api/security/roles/CanUseSendMessageApi.java
@@ -21,7 +21,7 @@ public class CanUseSendMessageApi extends AbstractRootContainerRole
 {
     public CanUseSendMessageApi()
     {
-        super("Use SendMessage API", "Allows users to use the send message API.  This API can be used to author code which sends emails to users and potentially non-users of the system.",
+        super("Use SendMessage API", "Allows users to invoke the send message API. This API can be called by code that sends emails to users and potentially non-users of the system.",
                 true,
                 CanUseSendMessageApiPermission.class);
     }

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 22.000
+SchemaVersion: 22.001
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/core-0.000-21.000.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-0.000-21.000.sql
@@ -473,55 +473,6 @@ INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES
                                                                      (513, '15 minute digest', 'files'),
                                                                      (514, 'Daily digest', 'files');
 
-CREATE TABLE core.EmailFormats
-(
-    EmailFormatId INT4 NOT NULL,
-    EmailFormat VARCHAR(20),
-
-    CONSTRAINT PK_EmailFormats PRIMARY KEY (EmailFormatId)
-);
-
-INSERT INTO core.EmailFormats (EmailFormatId, EmailFormat) VALUES (0, 'Plain Text');
-INSERT INTO core.EmailFormats (EmailFormatId, EmailFormat) VALUES (1, 'HTML');
-
-CREATE TABLE core.PageTypes
-(
-    PageTypeId INT4 NOT NULL,
-    PageType VARCHAR(20),
-
-    CONSTRAINT PK_PageTypes PRIMARY KEY (PageTypeId)
-);
-
-INSERT INTO core.PageTypes (PageTypeId, PageType) VALUES (0, 'Message');
-INSERT INTO core.PageTypes (PageTypeId, PageType) VALUES (1, 'Wiki');
-
-CREATE TABLE core.EmailPrefs
-(
-    Container ENTITYID,
-    UserId USERID,
-    EmailOptionId INT4 NOT NULL,
-    EmailFormatId INT4 NOT NULL,
-    PageTypeId INT4 NOT NULL,
-    LastModifiedBy USERID,
-    Type VARCHAR(60) NOT NULL DEFAULT 'messages',
-    SrcIdentifier VARCHAR(100) NOT NULL, -- allow subscriptions to multiple forums within a single container
-
-    CONSTRAINT PK_EmailPrefs PRIMARY KEY (Container, UserId, Type, SrcIdentifier),
-    CONSTRAINT FK_EmailPrefs_Containers FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
-    CONSTRAINT FK_EmailPrefs_Principals FOREIGN KEY (UserId) REFERENCES core.Principals (UserId),
-    CONSTRAINT FK_EmailPrefs_EmailOptions FOREIGN KEY (EmailOptionId) REFERENCES core.EmailOptions (EmailOptionId),
-    CONSTRAINT FK_EmailPrefs_EmailFormats FOREIGN KEY (EmailFormatId) REFERENCES core.EmailFormats (EmailFormatId),
-    CONSTRAINT FK_EmailPrefs_PageTypes FOREIGN KEY (PageTypeId) REFERENCES core.PageTypes (PageTypeId)
-);
-
-ALTER TABLE core.EmailPrefs DROP CONSTRAINT FK_EmailPrefs_PageTypes;
-ALTER TABLE core.EmailPrefs DROP COLUMN PageTypeId;
-ALTER TABLE core.EmailPrefs DROP CONSTRAINT FK_EmailPrefs_EmailFormats;
-ALTER TABLE core.EmailPrefs DROP COLUMN EmailFormatId;
-DROP TABLE core.PageTypes;
-
-DROP TABLE core.EmailFormats;
-
 -- sample manager email notification options
 INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (701, 'No Email', 'samplemanager');
 INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (702, 'All emails', 'samplemanager');
@@ -529,6 +480,21 @@ INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (702, 'A
 -- labbook email notification options
 INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (801, 'No Email', 'labbook');
 INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (802, 'All emails', 'labbook');
+
+CREATE TABLE core.EmailPrefs
+(
+    Container ENTITYID,
+    UserId USERID,
+    EmailOptionId INT4 NOT NULL,
+    LastModifiedBy USERID,
+    Type VARCHAR(60) NOT NULL DEFAULT 'messages',
+    SrcIdentifier VARCHAR(100) NOT NULL, -- allow subscriptions to multiple forums within a single container
+
+    CONSTRAINT PK_EmailPrefs PRIMARY KEY (Container, UserId, Type, SrcIdentifier),
+    CONSTRAINT FK_EmailPrefs_Containers FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
+    CONSTRAINT FK_EmailPrefs_Principals FOREIGN KEY (UserId) REFERENCES core.Principals (UserId),
+    CONSTRAINT FK_EmailPrefs_EmailOptions FOREIGN KEY (EmailOptionId) REFERENCES core.EmailOptions (EmailOptionId)
+);
 
 -- This empty stored procedure doesn't directly change the database, but calling it from a sql script signals the
 -- script runner to invoke the specified method at this point in the script running process. See implementations

--- a/core/resources/schemas/dbscripts/postgresql/core-0.000-21.000.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-0.000-21.000.sql
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* core-0.00-15.30.sql */
-
 CREATE DOMAIN public.UNIQUEIDENTIFIER AS VARCHAR(36);
 CREATE DOMAIN public.ENTITYID AS VARCHAR(36);
 CREATE DOMAIN public.USERID AS INT;
@@ -34,6 +32,8 @@ CREATE TABLE core.Logins
   Verification VARCHAR(64),
   LastChanged TIMESTAMP NULL,
   PreviousCrypts VARCHAR(1000),
+  RequestedEmail VARCHAR(255),
+  VerificationTimeout TIMESTAMP,
 
   CONSTRAINT PK_Logins PRIMARY KEY (Email)
 );
@@ -90,6 +90,7 @@ CREATE TABLE core.UsersData
   IM VARCHAR(64)  NULL,
   Description VARCHAR(255),
   LastLogin TIMESTAMP,
+  ExpirationDate TIMESTAMP,
 
   CONSTRAINT PK_UsersData PRIMARY KEY (UserId),
   CONSTRAINT UQ_DisplayName UNIQUE (DisplayName)
@@ -125,7 +126,7 @@ CREATE TABLE core.Modules
 (
   Name VARCHAR(255),
   ClassName VARCHAR(255),
-  InstalledVersion FLOAT8,
+  SchemaVersion FLOAT8 NULL,
   Enabled BOOLEAN DEFAULT '1',
   AutoUninstall BOOLEAN NOT NULL DEFAULT FALSE,  -- TRUE means LabKey should uninstall this module (drop schemas, delete SqlScripts rows, delete Modules rows), if it no longer exists
   Schemas VARCHAR(4000) NULL,                    -- Schemas managed by this module; LabKey will drop these schemas when a module marked AutoUninstall = TRUE is missing
@@ -268,19 +269,19 @@ CREATE TABLE core.PortalPages
   Permanent BOOLEAN NOT NULL DEFAULT false, -- may not be renamed,hidden,deleted (w/o changing folder type)
   Properties TEXT,
 
-  CONSTRAINT PK_PortalPages PRIMARY KEY (Container, PageId),
-  CONSTRAINT FK_PortalPages_Containers FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
-  CONSTRAINT UQ_PortalPage UNIQUE (Container, Index)
+  CONSTRAINT FK_PortalPages_Containers FOREIGN KEY (Container) REFERENCES core.Containers (EntityId)
 );
 
-CLUSTER PK_PortalPages ON core.PortalPages;
+-- We don't normally designate a column as "PRIMARY KEY", since it generates an unpredictable PK name. But all existing
+-- deployments already have this, so keep it for consistency
+ALTER TABLE core.portalpages ADD COLUMN rowId SERIAL PRIMARY KEY;
+
 CREATE INDEX IX_PortalPages_EntityId ON core.PortalPages(EntityId);
 
 CREATE TABLE core.PortalWebParts
 (
   RowId SERIAL NOT NULL,
   Container ENTITYID NOT NULL,
-  PageId VARCHAR(50) NOT NULL,
   Index INT NOT NULL,
   Name VARCHAR(64),
   Location VARCHAR(16),    -- 'body', 'left', 'right'
@@ -288,17 +289,18 @@ CREATE TABLE core.PortalWebParts
   Permanent BOOLEAN NOT NULL DEFAULT FALSE,
   Permission VARCHAR(256),
   PermissionContainer ENTITYID,
+  PortalPageId INTEGER NOT NULL,
 
   CONSTRAINT PK_PortalWebParts PRIMARY KEY (RowId),
   CONSTRAINT FK_PortalWebParts_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
-  CONSTRAINT FK_PortalWebPartPages FOREIGN KEY (Container, PageId) REFERENCES core.PortalPages (Container, PageId),
+  CONSTRAINT fk_portalwebpartpages FOREIGN KEY (PortalPageId) REFERENCES core.portalpages (RowId),
   CONSTRAINT FK_PortalWebParts_PermissionContainer FOREIGN KEY (PermissionContainer) REFERENCES core.containers (EntityId) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE SET NULL
 );
 
 CREATE INDEX IX_PortalWebParts ON core.PortalWebParts(Container);
 CLUSTER IX_PortalWebParts ON core.PortalWebParts;
 
--- represents a grouping category for views (reports etc.)
+-- represents a grouping category for reports and datasets
 CREATE TABLE core.ViewCategory
 (
   RowId SERIAL,
@@ -348,11 +350,201 @@ CREATE TABLE core.ShortURL
   CONSTRAINT UQ_ShortURL_ShortURL UNIQUE (ShortURL)
 );
 
+CREATE TABLE core.Notifications
+(
+  RowId SERIAL,
+  Container ENTITYID NOT NULL,
+  CreatedBy USERID,
+  Created TIMESTAMP,
+
+  UserId USERID NOT NULL,
+  ObjectId VARCHAR(64) NOT NULL,
+  Type VARCHAR(200) NOT NULL,
+  ReadOn TIMESTAMP,
+  ActionLinkText VARCHAR(2000),
+  ActionLinkURL VARCHAR(4000),
+  Content TEXT,
+  ContentType VARCHAR(100),
+
+  CONSTRAINT PK_Notifications PRIMARY KEY (RowId),
+  CONSTRAINT FK_Notifications_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
+  CONSTRAINT UQ_Notifications_ContainerUserObjectType UNIQUE (Container, UserId, ObjectId, Type)
+);
+
+CREATE TABLE core.QCState
+(
+  RowId SERIAL,
+  Label VARCHAR(64) NULL,
+  Description VARCHAR(500) NULL,
+  Container ENTITYID NOT NULL,
+  PublicData BOOLEAN NOT NULL,
+  CONSTRAINT PK_QCState PRIMARY KEY (RowId),
+  CONSTRAINT UQ_QCState_Label UNIQUE(Label, Container)
+);
+
+CREATE TABLE core.APIKeys
+(
+    RowId SERIAL,
+    CreatedBy USERID,
+    Created TIMESTAMP,
+    Crypt VARCHAR(100),
+    Expiration TIMESTAMP NULL,
+
+    CONSTRAINT PK_APIKeys PRIMARY KEY (RowId),
+    CONSTRAINT UQ_CRYPT UNIQUE (Crypt)
+);
+
+CREATE TABLE core.ReportEngines
+(
+  RowId SERIAL,
+  Name VARCHAR(255) NOT NULL,
+  CreatedBy USERID,
+  ModifiedBy USERID,
+  Created TIMESTAMP,
+  Modified TIMESTAMP,
+
+  Enabled BOOLEAN NOT NULL DEFAULT FALSE,
+  Type VARCHAR(64) NOT NULL,
+  Description VARCHAR(255),
+  Configuration TEXT,
+
+  CONSTRAINT PK_ReportEngines PRIMARY KEY (RowId),
+  CONSTRAINT UQ_Name_Type UNIQUE (Name, Type)
+);
+
+CREATE TABLE core.ReportEngineMap
+(
+  EngineId INTEGER NOT NULL,
+  Container ENTITYID NOT NULL,
+  EngineContext VARCHAR(64) NOT NULL DEFAULT 'report',
+
+  CONSTRAINT PK_ReportEngineMap PRIMARY KEY (EngineId, Container, EngineContext),
+  CONSTRAINT FK_ReportEngineMap_ReportEngines FOREIGN KEY (EngineId) REFERENCES core.ReportEngines (RowId)
+);
+
+CREATE TABLE core.PrincipalRelations
+(
+  userid USERID NOT NULL,
+  otherid USERID NOT NULL,
+  relationship VARCHAR(100) NOT NULL,
+  created TIMESTAMP,
+
+  CONSTRAINT PK_PrincipalRelations PRIMARY KEY (userid, otherid, relationship)
+);
+
+CREATE TABLE core.AuthenticationConfigurations
+(
+    RowId SERIAL,
+    EntityId ENTITYID NOT NULL,
+    CreatedBy USERID,
+    Created TIMESTAMP,
+    ModifiedBy USERID,
+    Modified TIMESTAMP,
+
+    Provider VARCHAR(64) NOT NULL,
+    Description VARCHAR(255) NOT NULL,
+    Enabled BOOLEAN NOT NULL,
+    AutoRedirect BOOLEAN NOT NULL DEFAULT FALSE,
+    SortOrder SMALLINT NOT NULL DEFAULT 32767, -- ensure that new configurations appear at the bottom of the list by default
+    Properties TEXT,
+    EncryptedProperties TEXT,
+
+    CONSTRAINT PK_AuthenticationConfigurations PRIMARY KEY (RowId)
+);
+
+CREATE TABLE core.EmailOptions
+(
+    EmailOptionId INT4 NOT NULL,
+    EmailOption VARCHAR(50),
+    Type VARCHAR(60) NOT NULL DEFAULT 'messages',
+
+    CONSTRAINT PK_EmailOptions PRIMARY KEY (EmailOptionId)
+);
+
+INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (0, 'No Email');
+INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (1, 'All conversations');
+INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (2, 'My conversations');
+INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (257, 'Daily digest of all conversations');
+INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (258, 'Daily digest of my conversations');
+
+-- new file email notification options
+INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES
+                                                                     (512, 'No Email', 'files'),
+                                                                     (513, '15 minute digest', 'files'),
+                                                                     (514, 'Daily digest', 'files');
+
+CREATE TABLE core.EmailFormats
+(
+    EmailFormatId INT4 NOT NULL,
+    EmailFormat VARCHAR(20),
+
+    CONSTRAINT PK_EmailFormats PRIMARY KEY (EmailFormatId)
+);
+
+INSERT INTO core.EmailFormats (EmailFormatId, EmailFormat) VALUES (0, 'Plain Text');
+INSERT INTO core.EmailFormats (EmailFormatId, EmailFormat) VALUES (1, 'HTML');
+
+CREATE TABLE core.PageTypes
+(
+    PageTypeId INT4 NOT NULL,
+    PageType VARCHAR(20),
+
+    CONSTRAINT PK_PageTypes PRIMARY KEY (PageTypeId)
+);
+
+INSERT INTO core.PageTypes (PageTypeId, PageType) VALUES (0, 'Message');
+INSERT INTO core.PageTypes (PageTypeId, PageType) VALUES (1, 'Wiki');
+
+CREATE TABLE core.EmailPrefs
+(
+    Container ENTITYID,
+    UserId USERID,
+    EmailOptionId INT4 NOT NULL,
+    EmailFormatId INT4 NOT NULL,
+    PageTypeId INT4 NOT NULL,
+    LastModifiedBy USERID,
+    Type VARCHAR(60) NOT NULL DEFAULT 'messages',
+    SrcIdentifier VARCHAR(100) NOT NULL, -- allow subscriptions to multiple forums within a single container
+
+    CONSTRAINT PK_EmailPrefs PRIMARY KEY (Container, UserId, Type, SrcIdentifier),
+    CONSTRAINT FK_EmailPrefs_Containers FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
+    CONSTRAINT FK_EmailPrefs_Principals FOREIGN KEY (UserId) REFERENCES core.Principals (UserId),
+    CONSTRAINT FK_EmailPrefs_EmailOptions FOREIGN KEY (EmailOptionId) REFERENCES core.EmailOptions (EmailOptionId),
+    CONSTRAINT FK_EmailPrefs_EmailFormats FOREIGN KEY (EmailFormatId) REFERENCES core.EmailFormats (EmailFormatId),
+    CONSTRAINT FK_EmailPrefs_PageTypes FOREIGN KEY (PageTypeId) REFERENCES core.PageTypes (PageTypeId)
+);
+
+ALTER TABLE core.EmailPrefs DROP CONSTRAINT FK_EmailPrefs_PageTypes;
+ALTER TABLE core.EmailPrefs DROP COLUMN PageTypeId;
+ALTER TABLE core.EmailPrefs DROP CONSTRAINT FK_EmailPrefs_EmailFormats;
+ALTER TABLE core.EmailPrefs DROP COLUMN EmailFormatId;
+DROP TABLE core.PageTypes;
+
+DROP TABLE core.EmailFormats;
+
+-- sample manager email notification options
+INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (701, 'No Email', 'samplemanager');
+INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (702, 'All emails', 'samplemanager');
+
+-- labbook email notification options
+INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (801, 'No Email', 'labbook');
+INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (802, 'All emails', 'labbook');
+
 -- This empty stored procedure doesn't directly change the database, but calling it from a sql script signals the
 -- script runner to invoke the specified method at this point in the script running process. See implementations
 -- of the UpgradeCode interface for more details.
 CREATE FUNCTION core.executeJavaUpgradeCode(text) RETURNS void AS $$
 DECLARE note TEXT := 'Empty function that signals script runner to execute Java upgrade code. See implementations of UpgradeCode.java.';
+BEGIN
+END
+$$ LANGUAGE plpgsql;
+
+-- This empty stored procedure is a synonym for core.executeJavaUpgradeCode(), but is meant to denote Java code that is used to
+-- initialize data in a schema (e.g., pre-populating a table with values), not transform existing data. We mark these cases with
+-- a different procedure name because our bootstrap scripts still need to invoke them, as opposed to invocations of upgrade code
+-- which we remove from bootstrap scripts. See implementations of the UpgradeCode interface to find the initialization code.
+CREATE FUNCTION core.executeJavaInitializationCode(text) RETURNS void AS $$
+DECLARE note TEXT := 'Empty function that signals script runner to execute Java initialization code. See implementations of UpgradeCode.java.';
 BEGIN
 END
 $$ LANGUAGE plpgsql;
@@ -380,28 +572,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TABLE core.Notifications
-(
-  RowId SERIAL,
-  Container ENTITYID NOT NULL,
-  CreatedBy USERID,
-  Created TIMESTAMP,
-
-  UserId USERID NOT NULL,
-  ObjectId VARCHAR(64) NOT NULL,
-  Type VARCHAR(200) NOT NULL,
-  Description TEXT,
-  ReadOn TIMESTAMP,
-  ActionLinkText VARCHAR(2000),
-  ActionLinkURL VARCHAR(4000),
-
-  CONSTRAINT PK_Notifications PRIMARY KEY (RowId),
-  CONSTRAINT FK_Notifications_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
-  CONSTRAINT UQ_Notifications_ContainerUserObjectType UNIQUE (Container, UserId, ObjectId, Type)
-);
-
-/* core-15.30-16.10.sql */
-
 -- An empty stored procedure (similar to executeJavaUpgradeCode) that, when detected by the script runner,
 -- imports a tabular data file (TSV, XLSX, etc.) into the specified table.
 CREATE FUNCTION core.bulkImport(text, text, text, boolean = false) RETURNS void AS $$
@@ -409,21 +579,6 @@ DECLARE note TEXT := 'Empty function that signals script runner to bulk import a
 BEGIN
 END
 $$ LANGUAGE plpgsql;
-
-/* core-16.10-16.20.sql */
-
-ALTER TABLE core.Notifications ADD Content TEXT;
-ALTER TABLE core.Notifications ADD ContentType VARCHAR(100);
-
-UPDATE core.Notifications SET Content = Description, ContentType='text/plain';
-ALTER TABLE core.Notifications DROP COLUMN Description;
-
-ALTER TABLE core.Logins ADD RequestedEmail VARCHAR(255);
-ALTER TABLE core.Logins ADD VerificationTimeout TIMESTAMP;
-
-/* core-16.30-17.10.sql */
-
-ALTER TABLE core.UsersData ADD ExpirationDate TIMESTAMP;
 
 -- Add ability to drop columns
 CREATE FUNCTION core.fn_dropifexists(
@@ -565,259 +720,3 @@ END;
 $BODY$
 LANGUAGE plpgsql VOLATILE
 COST 100;
-
-/* core-17.20-17.30.sql */
-
-CREATE TABLE core.QCState
-(
-  RowId SERIAL,
-  Label VARCHAR(64) NULL,
-  Description VARCHAR(500) NULL,
-  Container ENTITYID NOT NULL,
-  PublicData BOOLEAN NOT NULL,
-  CONSTRAINT PK_QCState PRIMARY KEY (RowId),
-  CONSTRAINT UQ_QCState_Label UNIQUE(Label, Container)
-);
-
-/* core-17.30-18.10.sql */
-
-CREATE TABLE core.APIKeys
-(
-    CreatedBy USERID,
-    Created TIMESTAMP,
-    Crypt VARCHAR(100),
-    Expiration TIMESTAMP NULL,
-
-    CONSTRAINT PK_APIKeys PRIMARY KEY (Crypt)
-);
-
-ALTER TABLE core.APIKeys
-    ADD COLUMN RowId SERIAL,
-    DROP CONSTRAINT PK_APIKeys,
-    ADD CONSTRAINT PK_APIKeys PRIMARY KEY (RowId),
-    ADD CONSTRAINT UQ_CRYPT UNIQUE (Crypt);
-
-/* core-18.20-18.30.sql */
-
-UPDATE core.principals SET type = 'g' WHERE name = 'Developers' AND userid < 0;
-
-CREATE TABLE core.ReportEngines
-(
-  RowId SERIAL,
-  Name VARCHAR(255) NOT NULL,
-  CreatedBy USERID,
-  ModifiedBy USERID,
-  Created TIMESTAMP,
-  Modified TIMESTAMP,
-
-  Enabled BOOLEAN NOT NULL DEFAULT FALSE,
-  Type VARCHAR(64) NOT NULL,
-  Description VARCHAR(255),
-  Configuration TEXT,
-
-  CONSTRAINT PK_ReportEngines PRIMARY KEY (RowId),
-  CONSTRAINT UQ_Name_Type UNIQUE (Name, Type)
-);
-
-CREATE TABLE core.ReportEngineMap
-(
-  EngineId INTEGER NOT NULL,
-  Container ENTITYID NOT NULL,
-
-  CONSTRAINT PK_ReportEngineMap PRIMARY KEY (EngineId, Container),
-  CONSTRAINT FK_ReportEngineMap_ReportEngines FOREIGN KEY (EngineId) REFERENCES core.ReportEngines (RowId)
-);
-
-CREATE TABLE core.PrincipalRelations
-(
-  userid USERID NOT NULL,
-  otherid USERID NOT NULL,
-  relationship VARCHAR(100) NULL,
-  created TIMESTAMP,
-
-  CONSTRAINT PK_PrincipalRelations PRIMARY KEY (userid, otherid, relationship)
-);
-
-SELECT core.fn_dropifexists('PrincipalRelations', 'core', 'TABLE', NULL);
-
-CREATE TABLE core.PrincipalRelations
-(
-  userid USERID NOT NULL,
-  otherid USERID NOT NULL,
-  relationship VARCHAR(100) NOT NULL,
-  created TIMESTAMP,
-
-  CONSTRAINT PK_PrincipalRelations PRIMARY KEY (userid, otherid, relationship)
-);
-
-/* core-18.30-19.10.sql */
-
-SELECT core.fn_dropifexists('portalwebparts', 'core', 'CONSTRAINT', 'fk_portalwebpartpages');
-SELECT core.fn_dropifexists('portalpages', 'core', 'CONSTRAINT', 'pk_portalpages');
-SELECT core.fn_dropifexists('portalpages', 'core', 'CONSTRAINT', 'uq_portalpage');
-ALTER TABLE core.portalpages ADD COLUMN rowId SERIAL PRIMARY KEY;
-ALTER TABLE core.portalwebparts ADD COLUMN portalPageId INTEGER;
-UPDATE core.portalwebparts web SET portalPageId = page.rowId
-    FROM core.portalpages page
-    WHERE web.pageId = page.pageId;
-ALTER TABLE core.portalwebparts DROP COLUMN pageId;
-ALTER TABLE core.portalwebparts ALTER COLUMN portalPageId SET NOT NULL;
-ALTER TABLE core.portalwebparts ADD CONSTRAINT fk_portalwebpartpages FOREIGN KEY (portalPageId) REFERENCES core.portalpages (rowId);
-
--- Fix webparts that referenced incorrect portal pages
-UPDATE core.portalwebparts parts
-    SET portalPageId = (SELECT rowId AS newPortalPageId FROM core.portalpages p2
-                        WHERE p2.pageid = page.pageid AND p2.Container = parts.Container)
-FROM core.portalpages page
-WHERE page.rowid = parts.portalpageid AND page.Container <> parts.Container;
-
-UPDATE core.RoleAssignments SET role = 'org.labkey.api.security.roles.SeeUserDetailsRole' WHERE role = 'org.labkey.api.security.roles.SeeEmailAddressesRole';
-
-UPDATE core.RoleAssignments SET role = 'org.labkey.api.security.roles.QCAnalystRole' WHERE role = 'org.labkey.api.security.roles.QCEditorRole';
-
-ALTER TABLE core.ReportEngineMap DROP CONSTRAINT PK_ReportEngineMap;
-ALTER TABLE core.ReportEngineMap ADD EngineContext VARCHAR(64) NOT NULL DEFAULT 'report';
-ALTER TABLE core.ReportEngineMap ADD CONSTRAINT PK_ReportEngineMap PRIMARY KEY (EngineId, Container, EngineContext);
-
-/* core-19.10-19.20.sql */
-
-SELECT core.fn_dropifexists('*', 'ms1', 'schema', null);
-
-/* core-19.20-19.30.sql */
-
--- This empty stored procedure is a synonym for core.executeJavaUpgradeCode(), but is meant to denote Java code that is used to
--- initialize data in a schema (e.g., pre-populating a table with values), not transform existing data. We mark these cases with
--- a different procedure name because our bootstrap scripts still need to invoke them, as opposed to invocations of upgrade code
--- which we remove from bootstrap scripts. See implementations of the UpgradeCode interface to find the initialization code.
-CREATE FUNCTION core.executeJavaInitializationCode(text) RETURNS void AS $$
-DECLARE note TEXT := 'Empty function that signals script runner to execute Java initialization code. See implementations of UpgradeCode.java.';
-BEGIN
-END
-$$ LANGUAGE plpgsql;
-
-CREATE TABLE core.AuthenticationConfigurations
-(
-    RowId SERIAL,
-    EntityId ENTITYID NOT NULL,
-    CreatedBy USERID,
-    Created TIMESTAMP,
-    ModifiedBy USERID,
-    Modified TIMESTAMP,
-
-    Provider VARCHAR(64) NOT NULL,
-    Description VARCHAR(255) NOT NULL,
-    Enabled BOOLEAN NOT NULL,
-    AutoRedirect BOOLEAN NOT NULL DEFAULT FALSE,
-    SortOrder INTEGER NOT NULL DEFAULT 0,
-    Properties TEXT,
-    EncryptedProperties TEXT,
-
-    CONSTRAINT PK_AuthenticationConfigurations PRIMARY KEY (RowId)
-);
-
-/*
-    For LabKey 19.3.x and earlier, the email preferences tables lived in the 'comm' schema and were managed by the
-    announcements module. As of 20.1.0, the core module now manages these tables in the 'core' schema. This script
-    moves or creates the tables, as appropriate. Once we no longer upgrade from 19.3.x, we can remove the conditionals.
- */
-DO $$
-BEGIN
-
-    IF (SELECT EXISTS (SELECT * FROM pg_tables WHERE schemaname = 'comm' AND tablename = 'emailoptions')) THEN
-
-        ALTER TABLE comm.EmailOptions SET SCHEMA core;
-        ALTER TABLE comm.EmailFormats SET SCHEMA core;
-        ALTER TABLE comm.PageTypes SET SCHEMA core;
-        ALTER TABLE comm.EmailPrefs SET SCHEMA core;
-
-    ELSE
-
-        CREATE TABLE core.EmailOptions
-        (
-            EmailOptionId INT4 NOT NULL,
-            EmailOption VARCHAR(50),
-            Type VARCHAR(60) NOT NULL DEFAULT 'messages',
-
-            CONSTRAINT PK_EmailOptions PRIMARY KEY (EmailOptionId)
-        );
-
-        INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (0, 'No Email');
-        INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (1, 'All conversations');
-        INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (2, 'My conversations');
-        INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (257, 'Daily digest of all conversations');
-        INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (258, 'Daily digest of my conversations');
-
-        -- new file email notification options
-        INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES
-        (512, 'No Email', 'files'),
-        (513, '15 minute digest', 'files'),
-        (514, 'Daily digest', 'files');
-
-        CREATE TABLE core.EmailFormats
-        (
-            EmailFormatId INT4 NOT NULL,
-            EmailFormat VARCHAR(20),
-
-            CONSTRAINT PK_EmailFormats PRIMARY KEY (EmailFormatId)
-        );
-
-        INSERT INTO core.EmailFormats (EmailFormatId, EmailFormat) VALUES (0, 'Plain Text');
-        INSERT INTO core.EmailFormats (EmailFormatId, EmailFormat) VALUES (1, 'HTML');
-
-        CREATE TABLE core.PageTypes
-        (
-            PageTypeId INT4 NOT NULL,
-            PageType VARCHAR(20),
-
-            CONSTRAINT PK_PageTypes PRIMARY KEY (PageTypeId)
-        );
-
-        INSERT INTO core.PageTypes (PageTypeId, PageType) VALUES (0, 'Message');
-        INSERT INTO core.PageTypes (PageTypeId, PageType) VALUES (1, 'Wiki');
-
-        CREATE TABLE core.EmailPrefs
-        (
-            Container ENTITYID,
-            UserId USERID,
-            EmailOptionId INT4 NOT NULL,
-            EmailFormatId INT4 NOT NULL,
-            PageTypeId INT4 NOT NULL,
-            LastModifiedBy USERID,
-            Type VARCHAR(60) NOT NULL DEFAULT 'messages',
-            SrcIdentifier VARCHAR(100) NOT NULL, -- allow subscriptions to multiple forums within a single container
-
-            CONSTRAINT PK_EmailPrefs PRIMARY KEY (Container, UserId, Type, SrcIdentifier),
-            CONSTRAINT FK_EmailPrefs_Containers FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
-            CONSTRAINT FK_EmailPrefs_Principals FOREIGN KEY (UserId) REFERENCES core.Principals (UserId),
-            CONSTRAINT FK_EmailPrefs_EmailOptions FOREIGN KEY (EmailOptionId) REFERENCES core.EmailOptions (EmailOptionId),
-            CONSTRAINT FK_EmailPrefs_EmailFormats FOREIGN KEY (EmailFormatId) REFERENCES core.EmailFormats (EmailFormatId),
-            CONSTRAINT FK_EmailPrefs_PageTypes FOREIGN KEY (PageTypeId) REFERENCES core.PageTypes (PageTypeId)
-        );
-
-    END IF;
-
-END $$;
-
-ALTER TABLE core.EmailPrefs DROP CONSTRAINT FK_EmailPrefs_PageTypes;
-ALTER TABLE core.EmailPrefs DROP COLUMN PageTypeId;
-DROP TABLE core.PageTypes;
-
-ALTER TABLE core.EmailPrefs DROP CONSTRAINT FK_EmailPrefs_EmailFormats;
-ALTER TABLE core.EmailPrefs DROP COLUMN EmailFormatId;
-DROP TABLE core.EmailFormats;
-
--- sample manager email notification options
-INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (701, 'No Email', 'samplemanager');
-INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (702, 'All emails', 'samplemanager');
-
--- Change SortOrder type to SMALLINT and default to MAX_SMALL_INT to ensure that new configurations appear at the bottom of the list by default
-SELECT core.fn_dropifexists('AuthenticationConfigurations', 'core', 'DEFAULT', 'SortOrder');
-ALTER TABLE core.AuthenticationConfigurations ALTER COLUMN SortOrder TYPE SMALLINT;
-ALTER TABLE core.AuthenticationConfigurations ALTER COLUMN SortOrder SET DEFAULT 32767;
-
-ALTER TABLE core.Modules RENAME COLUMN InstalledVersion TO SchemaVersion;
-ALTER TABLE core.Modules ALTER COLUMN SchemaVersion DROP NOT NULL;
-
--- labbook email notification options
-INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (801, 'No Email', 'labbook');
-INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (802, 'All emails', 'labbook');

--- a/core/resources/schemas/dbscripts/sqlserver/core-0.000-21.000.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-0.000-21.000.sql
@@ -555,7 +555,6 @@ CREATE PROCEDURE core.bulkImport(@schema VARCHAR(200), @table VARCHAR(200), @fil
 
 GO
 
--- Add ability to drop columns
 CREATE PROCEDURE [core].[fn_dropifexists] (@objname VARCHAR(250), @objschema VARCHAR(50), @objtype VARCHAR(50), @subobjname VARCHAR(250) = NULL, @printCmds BIT = 0)
 AS
 BEGIN
@@ -900,6 +899,6 @@ BEGIN
     RAISERROR('Invalid object type - %s   Valid values are TABLE, VIEW, INDEX, CONSTRAINT, DEFAULT, SCHEMA, PROCEDURE, FUNCTION, AGGREGATE, SYNONYM, COLUMN', 16,1, @objtype )
 
   RETURN @ret_code;
-END
+END;
 
 GO

--- a/core/resources/schemas/dbscripts/sqlserver/core-0.000-21.000.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-0.000-21.000.sql
@@ -40,6 +40,9 @@ CREATE TABLE core.Logins
     CONSTRAINT PK_Logins PRIMARY KEY (Email)
 );
 
+ALTER TABLE core.Logins ADD RequestedEmail NVARCHAR(255);
+ALTER TABLE core.Logins ADD VerificationTimeout DATETIME;
+
 -- Principals is used for managing security related information
 -- It is not used for validating login, that requires an 'external'
 -- process, either using SMB, LDAP, JDBC etc (see Logins table)
@@ -58,6 +61,10 @@ CREATE TABLE core.Principals
     CONSTRAINT PK_Principals PRIMARY KEY (UserId),
     CONSTRAINT UQ_Principals_Container_Name_OwnerId UNIQUE (Container, Name, OwnerId)
 );
+
+/* core-18.20-18.30.sql */
+
+UPDATE core.principals SET type = 'g' WHERE name = 'Developers' AND userid < 0;
 
 -- maps users to groups
 CREATE TABLE core.Members
@@ -94,6 +101,12 @@ CREATE TABLE core.UsersData
     CONSTRAINT PK_UsersData PRIMARY KEY (UserId),
     CONSTRAINT UQ_DisplayName UNIQUE (DisplayName)
 );
+
+/* core-16.30-17.10.sql */
+
+ALTER TABLE core.UsersData ADD ExpirationDate DATETIME;
+
+GO
 
 CREATE TABLE core.Containers
 (
@@ -132,6 +145,9 @@ CREATE TABLE core.Modules
 
     CONSTRAINT PK_Modules PRIMARY KEY (Name)
 );
+
+EXEC sp_rename 'core.Modules.InstalledVersion', 'SchemaVersion', 'COLUMN';
+ALTER TABLE core.Modules ALTER COLUMN SchemaVersion FLOAT NULL;
 
 -- keep track of sql scripts that have been run in each module
 CREATE TABLE core.SqlScripts
@@ -243,6 +259,8 @@ CREATE TABLE core.RoleAssignments
     CONSTRAINT FK_RA_UP FOREIGN KEY(UserId) REFERENCES core.Principals(UserId)
 );
 
+UPDATE core.RoleAssignments SET role = 'org.labkey.api.security.roles.QCAnalystRole' WHERE role = 'org.labkey.api.security.roles.QCEditorRole';
+
 CREATE TABLE core.MvIndicators
 (
     Container ENTITYID NOT NULL,
@@ -269,11 +287,12 @@ CREATE TABLE core.PortalPages
     Permanent BIT NOT NULL DEFAULT 0, -- may not be renamed,hidden,deleted (w/o changing folder type)
     Properties TEXT,
 
-    CONSTRAINT PK_PortalPages PRIMARY KEY CLUSTERED (Container, PageId),
-    CONSTRAINT FK_PortalPages_Containers FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
-    CONSTRAINT UQ_PortalPage UNIQUE (Container, [Index])
+    CONSTRAINT FK_PortalPages_Containers FOREIGN KEY (Container) REFERENCES core.Containers (EntityId)
 );
 CREATE INDEX IX_PortalPages_EntityId ON core.PortalPages(EntityId);
+
+ALTER TABLE core.PortalPages ADD RowId INT IDENTITY(1,1) NOT NULL;
+ALTER TABLE core.PortalPages ADD CONSTRAINT PK_PortalPages PRIMARY KEY (RowId);
 
 CREATE TABLE core.PortalWebParts
 (
@@ -290,12 +309,36 @@ CREATE TABLE core.PortalWebParts
 
     CONSTRAINT PK_PortalWebParts PRIMARY KEY (RowId),
     CONSTRAINT FK_PortalWebParts_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
-    CONSTRAINT FK_PortalWebPartPages FOREIGN KEY (Container, PageId) REFERENCES core.PortalPages (Container, PageId),
     CONSTRAINT FK_PortalWebParts_PermissionContainer FOREIGN KEY (PermissionContainer) REFERENCES core.Containers (EntityId) ON UPDATE NO ACTION ON DELETE SET NULL
 );
 
 -- Add an index and FK on the Container column
 CREATE INDEX IX_PortalWebParts ON core.PortalWebParts(Container);
+
+/* core-18.30-19.10.sql */
+
+ALTER TABLE core.PortalWebParts ADD PortalPageId INT;
+GO
+
+UPDATE core.portalwebparts SET PortalPageId = page.RowId
+    FROM core.PortalPages page, core.PortalWebParts web
+    WHERE web.PageId = page.PageId;
+GO
+
+ALTER TABLE core.PortalWebParts DROP COLUMN PageId;
+ALTER TABLE core.PortalWebParts ALTER COLUMN PortalPageId INT NOT NULL;
+ALTER TABLE core.PortalWebParts ADD CONSTRAINT FK_PortalWebPartPages FOREIGN KEY (PortalPageId) REFERENCES core.PortalPages (rowId);
+GO
+
+-- Fix webparts that referenced incorrect portal pages
+UPDATE core.portalwebparts
+    SET portalPageId = (SELECT rowId AS newPortalPageId FROM core.portalpages p2
+                        WHERE p2.pageid = page.pageid AND p2.Container = parts.Container)
+FROM core.portalwebparts parts
+JOIN core.portalpages page ON page.rowid = parts.portalpageid
+WHERE page.Container <> parts.Container
+
+UPDATE core.RoleAssignments SET role = 'org.labkey.api.security.roles.SeeUserDetailsRole' WHERE role = 'org.labkey.api.security.roles.SeeEmailAddressesRole';
 
 -- represents a grouping category for views (reports etc.)
 CREATE TABLE core.ViewCategory
@@ -347,6 +390,182 @@ CREATE TABLE core.ShortURL
 
 GO
 
+/* core-15.20-15.30.sql */
+
+CREATE TABLE core.Notifications
+(
+  RowId INT IDENTITY(1,1) NOT NULL,
+  Container ENTITYID NOT NULL,
+  CreatedBy USERID,
+  Created DATETIME,
+
+  UserId USERID NOT NULL,
+  ObjectId NVARCHAR(64) NOT NULL,
+  Type NVARCHAR(200) NOT NULL,
+  Description NVARCHAR(MAX),
+  ReadOn DATETIME,
+  ActionLinkText NVARCHAR(2000),
+  ActionLinkURL NVARCHAR(4000),
+
+  CONSTRAINT PK_Notifications PRIMARY KEY (RowId),
+  CONSTRAINT FK_Notifications_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
+  CONSTRAINT UQ_Notifications_ContainerUserObjectType UNIQUE (Container, UserId, ObjectId, Type)
+);
+
+GO
+
+/* core-16.10-16.20.sql */
+
+ALTER TABLE core.Notifications ADD Content NVARCHAR(MAX);
+ALTER TABLE core.Notifications ADD ContentType NVARCHAR(100);
+GO
+
+UPDATE core.Notifications SET Content = Description, ContentType='text/plain';
+ALTER TABLE core.Notifications DROP COLUMN Description;
+GO
+
+/* core-17.20-17.30.sql */
+
+CREATE TABLE core.QCState
+(
+  RowId INT IDENTITY(1,1),
+  Label NVARCHAR(64) NULL,
+  Description NVARCHAR(500) NULL,
+  Container ENTITYID NOT NULL,
+  PublicData BIT NOT NULL,
+
+  CONSTRAINT PK_QCState PRIMARY KEY (RowId),
+  CONSTRAINT UQ_QCState_Label UNIQUE(Label, Container)
+);
+
+/* core-17.30-18.10.sql */
+
+CREATE TABLE core.APIKeys
+(
+    CreatedBy USERID,
+    Created DATETIME,
+    Crypt VARCHAR(100),
+    Expiration DATETIME NULL,
+
+    CONSTRAINT PK_APIKeys PRIMARY KEY (Crypt)
+);
+
+ALTER TABLE core.APIKeys ADD RowId INT IDENTITY(1, 1);
+ALTER TABLE core.APIKeys DROP CONSTRAINT PK_APIKeys;
+ALTER TABLE core.APIKeys ADD CONSTRAINT PK_APIKeys PRIMARY KEY (RowId);
+ALTER TABLE core.APIKeys ADD CONSTRAINT UQ_CRYPT UNIQUE (Crypt);
+
+CREATE TABLE core.ReportEngines
+(
+  RowId INT IDENTITY(1,1) NOT NULL,
+  Name NVARCHAR(255) NOT NULL,
+  CreatedBy USERID,
+  ModifiedBy USERID,
+  Created DATETIME,
+  Modified DATETIME,
+
+  Enabled BIT NOT NULL DEFAULT 0,
+  Type NVARCHAR(64),
+  Description NVARCHAR(255),
+  Configuration NVARCHAR(MAX),
+
+  CONSTRAINT PK_ReportEngines PRIMARY KEY (RowId),
+  CONSTRAINT UQ_Name_Type UNIQUE (Name, Type)
+);
+
+UPDATE core.ReportEngines SET Type = 'External' WHERE TYPE IS NULL;
+ALTER TABLE core.ReportEngines DROP CONSTRAINT UQ_Name_Type;
+ALTER TABLE core.ReportEngines ALTER COLUMN Type NVARCHAR(64) NOT NULL;
+ALTER TABLE core.ReportEngines ADD CONSTRAINT UQ_Name_Type UNIQUE (Name, Type);
+
+CREATE TABLE core.ReportEngineMap
+(
+  EngineId INTEGER NOT NULL,
+  Container ENTITYID NOT NULL,
+
+  CONSTRAINT PK_ReportEngineMap PRIMARY KEY (EngineId, Container),
+  CONSTRAINT FK_ReportEngineMap_ReportEngines FOREIGN KEY (EngineId) REFERENCES core.ReportEngines (RowId)
+);
+
+ALTER TABLE core.ReportEngineMap DROP CONSTRAINT PK_ReportEngineMap;
+ALTER TABLE core.ReportEngineMap ADD EngineContext NVARCHAR(64) NOT NULL DEFAULT 'report';
+ALTER TABLE core.ReportEngineMap ADD CONSTRAINT PK_ReportEngineMap PRIMARY KEY (EngineId, Container, EngineContext);
+
+CREATE TABLE core.PrincipalRelations
+(
+  userid USERID NOT NULL,
+  otherid USERID NOT NULL,
+  relationship NVARCHAR(100) NOT NULL,
+  created DATETIME,
+
+  CONSTRAINT PK_PrincipalRelations PRIMARY KEY (userid, otherid, relationship)
+);
+
+CREATE TABLE core.AuthenticationConfigurations
+(
+    RowId INT IDENTITY(1,1),
+    EntityId ENTITYID NOT NULL,
+    CreatedBy USERID,
+    Created DATETIME,
+    ModifiedBy USERID,
+    Modified DATETIME,
+
+    Provider NVARCHAR(64) NOT NULL,
+    Description NVARCHAR(255) NOT NULL,
+    Enabled BIT NOT NULL,
+    AutoRedirect BIT NOT NULL DEFAULT 0,
+    SortOrder SMALLINT NOT NULL DEFAULT 32767, -- ensure that new configurations appear at the bottom of the list by default
+    Properties NVARCHAR(MAX),
+    EncryptedProperties NVARCHAR(MAX),
+
+    CONSTRAINT PK_AuthenticationConfigurations PRIMARY KEY (RowId)
+);
+
+CREATE TABLE core.EmailOptions
+(
+    EmailOptionId INT NOT NULL,
+    EmailOption NVARCHAR(50),
+    Type NVARCHAR(60) NOT NULL DEFAULT 'messages',
+
+    CONSTRAINT PK_EmailOptions PRIMARY KEY (EmailOptionId)
+);
+
+INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (0, 'No Email');
+INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (1, 'All conversations');
+INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (2, 'My conversations');
+INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (257, 'Daily digest of all conversations');
+INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (258, 'Daily digest of my conversations');
+
+-- new file email notification options
+INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (512, 'No Email', 'files');
+INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (513, '15 minute digest', 'files');
+INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (514, 'Daily digest', 'files');
+
+-- sample manager email notification options
+INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (701, 'No Email', 'samplemanager');
+INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (702, 'All emails', 'samplemanager');
+
+-- labbook email notification options
+INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (801, 'No Email', 'labbook');
+INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (802, 'All emails', 'labbook');
+
+CREATE TABLE core.EmailPrefs
+(
+    Container ENTITYID,
+    UserId USERID,
+    EmailOptionId INT NOT NULL,
+    LastModifiedBy USERID,
+    Type NVARCHAR(60) NOT NULL DEFAULT 'messages',
+    SrcIdentifier NVARCHAR(100) NOT NULL,  -- allow subscriptions to multiple forums within a single container
+
+    CONSTRAINT PK_EmailPrefs PRIMARY KEY (Container, UserId, Type, SrcIdentifier),
+    CONSTRAINT FK_EmailPrefs_Containers FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
+    CONSTRAINT FK_EmailPrefs_Principals FOREIGN KEY (UserId) REFERENCES core.Principals (UserId),
+    CONSTRAINT FK_EmailPrefs_EmailOptions FOREIGN KEY (EmailOptionId) REFERENCES core.EmailOptions (EmailOptionId)
+);
+
+GO
+
 -- This empty stored procedure doesn't directly change the database, but calling it from a sql script signals the
 -- script runner to invoke the specified method at this point in the script running process. See implementations of
 -- the UpgradeCode interface for more details.
@@ -354,6 +573,18 @@ CREATE PROCEDURE core.executeJavaUpgradeCode(@Name VARCHAR(255)) AS
 BEGIN
     DECLARE @notice VARCHAR(255)
     SET @notice = 'Empty function that signals script runner to execute Java initialization code. See implementations of UpgradeCode.java.'
+END;
+
+GO
+
+-- This empty stored procedure is a synonym for core.executeJavaUpgradeCode(), but is meant to denote Java code that is used to
+-- initialize data in a schema (e.g., pre-populating a table with values), not transform existing data. We mark these cases with
+-- a different procedure name because our bootstrap scripts still need to invoke them, as opposed to invocations of upgrade code
+-- which we remove from bootstrap scripts. See implementations of the UpgradeCode interface to find the initialization code.
+CREATE PROCEDURE core.executeJavaInitializationCode(@Name VARCHAR(255)) AS
+BEGIN
+DECLARE @notice VARCHAR(255)
+SET @notice = 'Empty function that signals script runner to execute initialization Java code. See implementations of UpgradeCode.java.'
 END;
 
 GO
@@ -385,30 +616,6 @@ AS
 
 GO
 
-/* core-15.20-15.30.sql */
-
-CREATE TABLE core.Notifications
-(
-  RowId INT IDENTITY(1,1) NOT NULL,
-  Container ENTITYID NOT NULL,
-  CreatedBy USERID,
-  Created DATETIME,
-
-  UserId USERID NOT NULL,
-  ObjectId NVARCHAR(64) NOT NULL,
-  Type NVARCHAR(200) NOT NULL,
-  Description NVARCHAR(MAX),
-  ReadOn DATETIME,
-  ActionLinkText NVARCHAR(2000),
-  ActionLinkURL NVARCHAR(4000),
-
-  CONSTRAINT PK_Notifications PRIMARY KEY (RowId),
-  CONSTRAINT FK_Notifications_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
-  CONSTRAINT UQ_Notifications_ContainerUserObjectType UNIQUE (Container, UserId, ObjectId, Type)
-);
-
-GO
-
 /* core-15.30-16.10.sql */
 
 -- An empty stored procedure (similar to executeJavaUpgradeCode) that, when detected by the script runner,
@@ -418,25 +625,6 @@ CREATE PROCEDURE core.bulkImport(@schema VARCHAR(200), @table VARCHAR(200), @fil
     DECLARE @notice VARCHAR(255)
     SET @notice = 'Empty function that signals script runner to bulk import a file into a table.'
   END;
-
-GO
-
-/* core-16.10-16.20.sql */
-
-ALTER TABLE core.Notifications ADD Content NVARCHAR(MAX);
-ALTER TABLE core.Notifications ADD ContentType NVARCHAR(100);
-GO
-
-UPDATE core.Notifications SET Content = Description, ContentType='text/plain';
-ALTER TABLE core.Notifications DROP COLUMN Description;
-GO
-
-ALTER TABLE core.Logins ADD RequestedEmail NVARCHAR(255);
-ALTER TABLE core.Logins ADD VerificationTimeout DATETIME;
-
-/* core-16.30-17.10.sql */
-
-ALTER TABLE core.UsersData ADD ExpirationDate DATETIME;
 
 GO
 
@@ -540,7 +728,7 @@ BEGIN
         BEGIN
           IF (@objname is NOT NULL AND @objname NOT IN ('', '*'))
             BEGIN
-              RAISERROR ('Invalid @objname for @objtype of SCHEMA   must be either "*" (to drop all dependent objects) or NULL (for dropping empty schema )' , 16, 1)
+              RAISERROR ('Invalid @objname for @objtype of SCHEMA; must be either "*" (to drop all dependent objects) or NULL (for dropping empty schema)' , 16, 1)
               RETURN @ret_code
             END
           ELSE IF (@objname = '*' )
@@ -788,274 +976,3 @@ BEGIN
 END
 
 GO
-
-/* core-17.20-17.30.sql */
-
-CREATE TABLE core.QCState
-(
-  RowId INT IDENTITY(1,1),
-  Label NVARCHAR(64) NULL,
-  Description NVARCHAR(500) NULL,
-  Container ENTITYID NOT NULL,
-  PublicData BIT NOT NULL,
-
-  CONSTRAINT PK_QCState PRIMARY KEY (RowId),
-  CONSTRAINT UQ_QCState_Label UNIQUE(Label, Container)
-);
-
-/* core-17.30-18.10.sql */
-
-CREATE TABLE core.APIKeys
-(
-    CreatedBy USERID,
-    Created DATETIME,
-    Crypt VARCHAR(100),
-    Expiration DATETIME NULL,
-
-    CONSTRAINT PK_APIKeys PRIMARY KEY (Crypt)
-);
-
-ALTER TABLE core.APIKeys ADD RowId INT IDENTITY(1, 1);
-ALTER TABLE core.APIKeys DROP CONSTRAINT PK_APIKeys;
-ALTER TABLE core.APIKeys ADD CONSTRAINT PK_APIKeys PRIMARY KEY (RowId);
-ALTER TABLE core.APIKeys ADD CONSTRAINT UQ_CRYPT UNIQUE (Crypt);
-
-/* core-18.20-18.30.sql */
-
-UPDATE core.principals SET type = 'g' WHERE name = 'Developers' AND userid < 0;
-
-CREATE TABLE core.ReportEngines
-(
-  RowId INT IDENTITY(1,1) NOT NULL,
-  Name NVARCHAR(255) NOT NULL,
-  CreatedBy USERID,
-  ModifiedBy USERID,
-  Created DATETIME,
-  Modified DATETIME,
-
-  Enabled BIT NOT NULL DEFAULT 0,
-  Type NVARCHAR(64),
-  Description NVARCHAR(255),
-  Configuration NVARCHAR(MAX),
-
-  CONSTRAINT PK_ReportEngines PRIMARY KEY (RowId),
-  CONSTRAINT UQ_Name_Type UNIQUE (Name, Type)
-);
-
-CREATE TABLE core.ReportEngineMap
-(
-  EngineId INTEGER NOT NULL,
-  Container ENTITYID NOT NULL,
-
-  CONSTRAINT PK_ReportEngineMap PRIMARY KEY (EngineId, Container),
-  CONSTRAINT FK_ReportEngineMap_ReportEngines FOREIGN KEY (EngineId) REFERENCES core.ReportEngines (RowId)
-);
-
-CREATE TABLE core.PrincipalRelations
-(
-  userid ENTITYID NOT NULL,
-  otherid ENTITYID NOT NULL,
-  relationship VARCHAR(100) NOT NULL,
-  created DATETIME,
-
-  CONSTRAINT PK_PrincipalRelations PRIMARY KEY (userid, otherid, relationship)
-);
-
-EXEC core.fn_dropifexists 'PrincipalRelations','core','TABLE';
-
-CREATE TABLE core.PrincipalRelations
-(
-  userid USERID NOT NULL,
-  otherid USERID NOT NULL,
-  relationship NVARCHAR(100) NOT NULL,
-  created DATETIME,
-
-  CONSTRAINT PK_PrincipalRelations PRIMARY KEY (userid, otherid, relationship)
-);
-
-UPDATE core.ReportEngines SET Type = 'External' WHERE TYPE IS NULL;
-ALTER TABLE core.ReportEngines DROP CONSTRAINT UQ_Name_Type;
-ALTER TABLE core.ReportEngines ALTER COLUMN Type NVARCHAR(64) NOT NULL;
-ALTER TABLE core.ReportEngines ADD CONSTRAINT UQ_Name_Type UNIQUE (Name, Type);
-
-/* core-18.30-19.10.sql */
-
-EXEC core.fn_dropifexists 'portalwebparts', 'core', 'CONSTRAINT', 'FK_PortalWebPartPages';
-EXEC core.fn_dropifexists 'portalpages', 'core', 'CONSTRAINT', 'PK_PortalPages';
-EXEC core.fn_dropifexists 'portalpages', 'core', 'CONSTRAINT', 'UQ_PortalPage';
-
-ALTER TABLE core.PortalPages ADD RowId INT IDENTITY(1,1) NOT NULL;
-ALTER TABLE core.PortalWebParts ADD PortalPageId INT;
-GO
-
-ALTER TABLE core.PortalPages ADD CONSTRAINT PK_PortalPages PRIMARY KEY (RowId);
-UPDATE core.portalwebparts SET PortalPageId = page.RowId
-    FROM core.PortalPages page, core.PortalWebParts web
-    WHERE web.PageId = page.PageId;
-GO
-
-ALTER TABLE core.PortalWebParts DROP COLUMN PageId;
-ALTER TABLE core.PortalWebParts ALTER COLUMN PortalPageId INT NOT NULL;
-ALTER TABLE core.PortalWebParts ADD CONSTRAINT FK_PortalWebPartPages FOREIGN KEY (PortalPageId) REFERENCES core.PortalPages (rowId);
-GO
-
--- Fix webparts that referenced incorrect portal pages
-UPDATE core.portalwebparts
-    SET portalPageId = (SELECT rowId AS newPortalPageId FROM core.portalpages p2
-                        WHERE p2.pageid = page.pageid AND p2.Container = parts.Container)
-FROM core.portalwebparts parts
-JOIN core.portalpages page ON page.rowid = parts.portalpageid
-WHERE page.Container <> parts.Container
-
-UPDATE core.RoleAssignments SET role = 'org.labkey.api.security.roles.SeeUserDetailsRole' WHERE role = 'org.labkey.api.security.roles.SeeEmailAddressesRole';
-
-UPDATE core.RoleAssignments SET role = 'org.labkey.api.security.roles.QCAnalystRole' WHERE role = 'org.labkey.api.security.roles.QCEditorRole';
-
-ALTER TABLE core.ReportEngineMap DROP CONSTRAINT PK_ReportEngineMap;
-ALTER TABLE core.ReportEngineMap ADD EngineContext NVARCHAR(64) NOT NULL DEFAULT 'report';
-ALTER TABLE core.ReportEngineMap ADD CONSTRAINT PK_ReportEngineMap PRIMARY KEY (EngineId, Container, EngineContext);
-
-/* core-19.10-19.20.sql */
-
-EXEC core.fn_dropifexists '*', 'ms1', 'SCHEMA';
-
-GO
-
-/* core-19.20-19.30.sql */
-
--- This empty stored procedure is a synonym for core.executeJavaUpgradeCode(), but is meant to denote Java code that is used to
--- initialize data in a schema (e.g., pre-populating a table with values), not transform existing data. We mark these cases with
--- a different procedure name because our bootstrap scripts still need to invoke them, as opposed to invocations of upgrade code
--- which we remove from bootstrap scripts. See implementations of the UpgradeCode interface to find the initialization code.
-CREATE PROCEDURE core.executeJavaInitializationCode(@Name VARCHAR(255)) AS
-BEGIN
-DECLARE @notice VARCHAR(255)
-SET @notice = 'Empty function that signals script runner to execute initialization Java code. See implementations of UpgradeCode.java.'
-END;
-
-GO
-
-CREATE TABLE core.AuthenticationConfigurations
-(
-    RowId INT IDENTITY(1,1),
-    EntityId ENTITYID NOT NULL,
-    CreatedBy USERID,
-    Created DATETIME,
-    ModifiedBy USERID,
-    Modified DATETIME,
-
-    Provider NVARCHAR(64) NOT NULL,
-    Description NVARCHAR(255) NOT NULL,
-    Enabled BIT NOT NULL,
-    AutoRedirect BIT NOT NULL DEFAULT 0,
-    SortOrder INTEGER NOT NULL DEFAULT 0,
-    Properties NVARCHAR(MAX),
-    EncryptedProperties NVARCHAR(MAX),
-
-    CONSTRAINT PK_AuthenticationConfigurations PRIMARY KEY (RowId)
-);
-
-/*
-    For LabKey 19.3.x and earlier, the email preferences tables lived in the 'comm' schema and were managed by the
-    announcements module. As of 20.1.0, the core module now manages these tables in the 'core' schema. This script
-    moves or creates the tables, as appropriate. Once we no longer upgrade from 19.3.x, we can remove the conditionals.
- */
-IF (EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'comm' AND TABLE_NAME = 'EmailOptions'))
-    BEGIN
-
-        ALTER SCHEMA core TRANSFER comm.EmailOptions;
-        ALTER SCHEMA core TRANSFER comm.EmailFormats;
-        ALTER SCHEMA core TRANSFER comm.PageTypes;
-        ALTER SCHEMA core TRANSFER comm.EmailPrefs;
-
-    END
-ELSE
-    BEGIN
-
-        CREATE TABLE core.EmailOptions
-        (
-            EmailOptionId INT NOT NULL,
-            EmailOption NVARCHAR(50),
-            Type NVARCHAR(60) NOT NULL DEFAULT 'messages',
-
-            CONSTRAINT PK_EmailOptions PRIMARY KEY (EmailOptionId)
-        );
-
-        INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (0, 'No Email');
-        INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (1, 'All conversations');
-        INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (2, 'My conversations');
-        INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (257, 'Daily digest of all conversations');
-        INSERT INTO core.EmailOptions (EmailOptionId, EmailOption) VALUES (258, 'Daily digest of my conversations');
-
-        -- new file email notification options
-        INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (512, 'No Email', 'files');
-        INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (513, '15 minute digest', 'files');
-        INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (514, 'Daily digest', 'files');
-
-        CREATE TABLE core.EmailFormats
-        (
-            EmailFormatId INT NOT NULL,
-            EmailFormat NVARCHAR(20),
-
-            CONSTRAINT PK_EmailFormats PRIMARY KEY (EmailFormatId)
-        );
-
-        INSERT INTO core.EmailFormats (EmailFormatId, EmailFormat) VALUES (0, 'Plain Text');
-        INSERT INTO core.EmailFormats (EmailFormatId, EmailFormat) VALUES (1, 'HTML');
-
-        CREATE TABLE core.PageTypes
-        (
-            PageTypeId INT NOT NULL,
-            PageType NVARCHAR(20),
-
-            CONSTRAINT PK_PageTypes PRIMARY KEY (PageTypeId)
-        );
-
-        INSERT INTO core.PageTypes (PageTypeId, PageType) VALUES (0, 'Message');
-        INSERT INTO core.PageTypes (PageTypeId, PageType) VALUES (1, 'Wiki');
-
-        CREATE TABLE core.EmailPrefs
-        (
-            Container ENTITYID,
-            UserId USERID,
-            EmailOptionId INT NOT NULL,
-            EmailFormatId INT NOT NULL,
-            PageTypeId INT NOT NULL,
-            LastModifiedBy USERID,
-            Type NVARCHAR(60) NOT NULL DEFAULT 'messages',
-            SrcIdentifier NVARCHAR(100) NOT NULL,  -- allow subscriptions to multiple forums within a single container
-
-            CONSTRAINT PK_EmailPrefs PRIMARY KEY (Container, UserId, Type, SrcIdentifier),
-            CONSTRAINT FK_EmailPrefs_Containers FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
-            CONSTRAINT FK_EmailPrefs_Principals FOREIGN KEY (UserId) REFERENCES core.Principals (UserId),
-            CONSTRAINT FK_EmailPrefs_EmailOptions FOREIGN KEY (EmailOptionId) REFERENCES core.EmailOptions (EmailOptionId),
-            CONSTRAINT FK_EmailPrefs_EmailFormats FOREIGN KEY (EmailFormatId) REFERENCES core.EmailFormats (EmailFormatId),
-            CONSTRAINT FK_EmailPrefs_PageTypes FOREIGN KEY (PageTypeId) REFERENCES core.PageTypes (PageTypeId)
-        );
-
-    END
-GO
-
-ALTER TABLE core.EmailPrefs DROP CONSTRAINT FK_EmailPrefs_PageTypes;
-ALTER TABLE core.EmailPrefs DROP COLUMN PageTypeId;
-DROP TABLE core.PageTypes;
-
-ALTER TABLE core.EmailPrefs DROP CONSTRAINT FK_EmailPrefs_EmailFormats;
-ALTER TABLE core.EmailPrefs DROP COLUMN EmailFormatId;
-DROP TABLE core.EmailFormats;
-
--- sample manager email notification options
-INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (701, 'No Email', 'samplemanager');
-INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (702, 'All emails', 'samplemanager');
-
--- Change SortOrder type to SMALLINT and default to MAX_SMALL_INT to ensure that new configurations appear at the bottom of the list by default
-EXEC core.fn_dropifexists 'AuthenticationConfigurations', 'core', 'DEFAULT', 'SortOrder';
-ALTER TABLE core.AuthenticationConfigurations ALTER COLUMN SortOrder SMALLINT;
-ALTER TABLE core.AuthenticationConfigurations ADD CONSTRAINT DF_SortOrder DEFAULT 32767 FOR SortOrder;
-
-EXEC sp_rename 'core.Modules.InstalledVersion', 'SchemaVersion', 'COLUMN';
-ALTER TABLE core.Modules ALTER COLUMN SchemaVersion FLOAT NULL;
-
--- labbook email notification options
-INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (801, 'No Email', 'labbook');
-INSERT INTO core.emailOptions (EmailOptionId, EmailOption, Type) VALUES (802, 'All emails', 'labbook');

--- a/core/resources/schemas/dbscripts/sqlserver/core-22.000-22.001.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-22.000-22.001.sql
@@ -1,0 +1,357 @@
+DROP PROCEDURE [core].[fn_dropifexists];
+
+GO
+
+CREATE PROCEDURE [core].[fn_dropifexists] (@objname VARCHAR(250), @objschema VARCHAR(50), @objtype VARCHAR(50), @subobjname VARCHAR(250) = NULL, @printCmds BIT = 0)
+AS
+BEGIN
+  /*
+    Procedure to safely drop most database object types without error if the object does not exist. Schema deletion
+     will cascade to the tables and programability objects in that schema. Column deletion will cascade to any keys,
+     constraints, and indexes on the column.
+       Usage:
+       EXEC core.fn_dropifexists objname, objschema, objtype, subobjname, printCmds
+       where:
+       objname    Required. For TABLE, VIEW, PROCEDURE, FUNCTION, AGGREGATE, SYNONYM, this is the name of the object to be dropped
+                   for SCHEMA, specify '*' to drop all dependent objects, or NULL to drop an empty schema
+                   for INDEX, CONSTRAINT, DEFAULT, or COLUMN, specify the name of the table
+       objschema  Required. The name of the schema for the object, or the schema being dropped
+       objtype    Required. The type of object being dropped. Valid values are TABLE, VIEW, INDEX, CONSTRAINT, DEFAULT, SCHEMA, PROCEDURE, FUNCTION, AGGREGATE, SYNONYM, COLUMN
+       subobjtype Optional. When dropping INDEX, CONSTRAINT, DEFAULT, or COLUMN, the name of the object being dropped
+       printCmds  Optional, 1 or 0. If 1, the cascading drop commands for SCHEMA and COLUMN will be printed for debugging purposes
+
+    Note for implementors: Names that are part of SQL commands executed below should be bracketed to handle names that
+    have spaces, special characters, or reserved words. Names that are used in comparisons, in this code and in WHERE
+    clauses, must not be bracketed. @fullname is bracketed, since it's only used in SQL commands. All other vars are not
+    bracketed since they're often used in comparisons. When referencing @objname, @objschema, @subobjname, etc. be sure
+    to add brackets where required.
+   */
+  DECLARE @ret_code INTEGER
+  DECLARE @fullname VARCHAR(500)
+  DECLARE @fkConstName sysname, @fkTableName sysname, @fkSchema sysname
+  SELECT @ret_code = 0
+  SELECT @fullname = ('[' + @objschema + '].[' + @objname + ']') -- @fullname is always bracketed, to handle names that are reserved words, etc.
+  IF (UPPER(@objtype)) = 'TABLE'
+    BEGIN
+      IF OBJECTPROPERTY(OBJECT_ID(@fullname), 'IsTable') =1
+        BEGIN
+          EXEC('DROP TABLE ' + @fullname )
+          SELECT @ret_code = 1
+        END
+      ELSE IF @objname LIKE '##%' AND OBJECT_ID('tempdb.dbo.[' + @objname + ']') IS NOT NULL
+        BEGIN
+          EXEC('DROP TABLE [' + @objname + ']')
+          SELECT @ret_code = 1
+        END
+    END
+  ELSE IF (UPPER(@objtype)) = 'VIEW'
+    BEGIN
+      IF OBJECTPROPERTY(OBJECT_ID(@fullname), 'IsView') =1
+        BEGIN
+          EXEC('DROP VIEW ' + @fullname )
+          SELECT @ret_code =1
+        END
+    END
+  ELSE IF (UPPER(@objtype)) = 'INDEX'
+    BEGIN
+      DECLARE @fullername VARCHAR(500)
+      SELECT @fullername = @fullname + '.[' + @subobjname + ']' -- Unlikely to require brackets, but doesn't hurt
+      IF INDEXPROPERTY(OBJECT_ID(@fullname), @subobjname, 'IndexID') IS NOT NULL
+        BEGIN
+          EXEC('DROP INDEX ' + @fullername )
+          SELECT @ret_code =1
+        END
+      ELSE IF EXISTS (SELECT * FROM sys.indexes si
+      WHERE si.name = @subobjname
+            AND OBJECT_NAME(si.object_id) <> @objname)
+        BEGIN
+          RAISERROR ('Index does not belong to specified table ' , 16, 1)
+          RETURN @ret_code
+        END
+    END
+  ELSE IF (UPPER(@objtype)) = 'CONSTRAINT'
+    BEGIN
+      IF OBJECTPROPERTY(OBJECT_ID(@objschema + '.' + @subobjname), 'IsConstraint') = 1
+        BEGIN
+          EXEC('ALTER TABLE ' + @fullname + ' DROP CONSTRAINT [' + @subobjname + ']')
+          SELECT @ret_code =1
+        END
+    END
+  ELSE IF (UPPER(@objtype)) = 'DEFAULT'
+    BEGIN
+      DECLARE @DEFAULT sysname
+      SELECT 	@DEFAULT = s.name
+      FROM sys.objects s
+        join sys.columns c ON s.object_id = c.default_object_id
+      WHERE
+        s.type = 'D'
+        and c.object_id = OBJECT_ID(@fullname)
+        and c.name = @subobjname
+
+      IF @DEFAULT IS NOT NULL AND OBJECTPROPERTY(OBJECT_ID(@objschema + '.' + @DEFAULT), 'IsConstraint') = 1
+        BEGIN
+          EXEC('ALTER TABLE ' + @fullname + ' DROP CONSTRAINT [' + @DEFAULT + ']')
+          if (@printCmds = 1) PRINT('ALTER TABLE ' + @fullname + ' DROP CONSTRAINT [' + @DEFAULT + ']')
+          SELECT @ret_code =1
+        END
+    END
+  ELSE IF (UPPER(@objtype)) = 'SCHEMA'
+    BEGIN
+      DECLARE @schemaid INT, @principalid int
+
+      SELECT @schemaid=schema_id, @principalid=principal_id
+      FROM sys.schemas
+      WHERE name = @objschema
+
+      IF @schemaid IS NOT NULL
+        BEGIN
+          IF (@objname is NOT NULL AND @objname NOT IN ('', '*'))
+            BEGIN
+              RAISERROR ('Invalid @objname for @objtype of SCHEMA; must be either "*" (to drop all dependent objects) or NULL (for dropping empty schema)' , 16, 1)
+              RETURN @ret_code
+            END
+          ELSE IF (@objname = '*' )
+            BEGIN
+              DECLARE fkCursor CURSOR LOCAL for
+                SELECT object_name(sfk.object_id) as fk_constraint_name, object_name(sfk.parent_object_id) as fk_table_name,
+                       schema_name(sfk.schema_id) as fk_schema_name
+                FROM sys.foreign_keys sfk
+                  INNER JOIN sys.objects fso ON (sfk.referenced_object_id = fso.object_id)
+                WHERE fso.schema_id=@schemaid
+                      AND sfk.type = 'F'
+
+              OPEN fkCursor
+              FETCH NEXT FROM fkCursor INTO @fkConstName, @fkTableName, @fkSchema
+              WHILE @@fetch_status = 0
+                BEGIN
+                  SELECT @fullname = '[' + @fkSchema + '].[' +@fkTableName + ']'
+                  EXEC('ALTER TABLE ' + @fullname + ' DROP CONSTRAINT [' + @fkConstName + ']')
+                  if (@printCmds = 1) PRINT('ALTER TABLE ' + @fullname + ' DROP CONSTRAINT [' + @fkConstName + ']')
+
+                  FETCH NEXT FROM fkCursor INTO @fkConstName, @fkTableName, @fkSchema
+                END
+              CLOSE fkCursor
+              DEALLOCATE fkCursor
+
+              DECLARE @soName sysname, @parent INT, @type CHAR(2), @fkschemaid int
+              DECLARE soCursor CURSOR LOCAL for
+                SELECT so.name, so.type, so.parent_object_id, so.schema_id
+                FROM sys.objects so
+                WHERE (so.schema_id=@schemaid)
+                ORDER BY (CASE  WHEN so.type='V' THEN 1
+                          WHEN so.type='P' THEN 2
+                          WHEN so.type IN ('FN', 'IF', 'TF', 'FS', 'FT') THEN 3
+                          WHEN so.type='AF' THEN 4
+                          WHEN so.type='U' THEN 5
+                          WHEN so.type='SN' THEN 6
+                          ELSE 7
+                          END)
+              OPEN soCursor
+              FETCH NEXT FROM soCursor INTO @soName, @type, @parent, @fkschemaid
+              WHILE @@fetch_status = 0
+                BEGIN
+                  SELECT @fullname = '[' + @objschema + '].[' + @soName + ']'
+                  IF (@type = 'V')
+                    BEGIN
+                      EXEC('DROP VIEW ' + @fullname)
+                      if (@printCmds = 1) PRINT('DROP VIEW ' + @fullname)
+                    END
+                  ELSE IF (@type = 'P')
+                    BEGIN
+                      EXEC('DROP PROCEDURE ' + @fullname)
+                      if (@printCmds = 1) PRINT('DROP PROCEDURE ' + @fullname)
+                    END
+                  ELSE IF (@type IN ('FN', 'IF', 'TF', 'FS', 'FT'))
+                    BEGIN
+                      EXEC('DROP FUNCTION ' + @fullname)
+                      if (@printCmds = 1) PRINT('DROP FUNCTION ' + @fullname)
+                    END
+                  ELSE IF (@type = 'AF')
+                    BEGIN
+                      EXEC('DROP AGGREGATE ' + @fullname)
+                      if (@printCmds = 1) PRINT('DROP AGGREGATE ' + @fullname)
+                    END
+                  ELSE IF (@type = 'U')
+                    BEGIN
+                      EXEC('DROP TABLE ' + @fullname)
+                      if (@printCmds = 1) PRINT('DROP TABLE ' + @fullname)
+                    END
+                  ELSE IF (@type = 'SN')
+                    BEGIN
+                      EXEC('DROP SYNONYM ' + @fullname)
+                      if (@printCmds = 1) PRINT('DROP SYNONYM ' + @fullname)
+                    END
+                  ELSE
+                    BEGIN
+                      DECLARE @msg NVARCHAR(255)
+                      SELECT @msg=' Found object of type: ' + @type + ' name: ' + @fullname + ' in this schema. Schema not dropped. '
+                      RAISERROR (@msg, 16, 1)
+                      RETURN @ret_code
+                    END
+                  FETCH NEXT FROM soCursor INTO @soName, @type, @parent, @fkschemaid
+                END
+              CLOSE soCursor
+              DEALLOCATE soCursor
+            END
+
+          IF (@objSchema != 'dbo')
+            BEGIN
+              DECLARE @approlename sysname
+              SELECT @approlename = name
+              FROM sys.database_principals
+              WHERE principal_id=@principalid AND type='A'
+
+              IF (@approlename IS NOT NULL)
+                BEGIN
+                  EXEC sp_dropapprole @approlename
+                  if (@printCmds = 1) PRINT ('sp_dropapprole '+ @approlename)
+                END
+              ELSE
+                BEGIN
+                  EXEC('DROP SCHEMA [' + @objschema + ']')
+                  if (@printCmds = 1) PRINT('DROP SCHEMA [' + @objschema + ']')
+                END
+            END
+          SELECT @ret_code =1
+        END
+    END
+  ELSE IF (UPPER(@objtype)) = 'PROCEDURE'
+    BEGIN
+      IF (@objschema = 'sys')
+        BEGIN
+          RAISERROR ('Invalid @objschema, not attempting to drop sys object', 16, 1)
+          RETURN @ret_code
+        END
+      IF OBJECTPROPERTY(OBJECT_ID(@fullname), 'IsProcedure') =1
+        BEGIN
+          EXEC('DROP PROCEDURE ' + @fullname )
+          SELECT @ret_code =1
+        END
+    END
+  ELSE IF (UPPER(@objtype)) = 'FUNCTION'
+    BEGIN
+      IF EXISTS (SELECT 1 FROM sys.objects o JOIN sys.schemas s ON o.schema_id = s.schema_id WHERE s.name = @objschema AND o.name = @objname AND o.type IN ('FN', 'IF', 'TF', 'FS', 'FT'))
+        BEGIN
+          EXEC('DROP FUNCTION ' + @fullname )
+          SELECT @ret_code =1
+        END
+    END
+  ELSE IF (UPPER(@objtype)) = 'AGGREGATE'
+    BEGIN
+      IF EXISTS (SELECT 1 FROM sys.objects o JOIN sys.schemas s ON o.schema_id = s.schema_id WHERE s.name = @objschema AND o.name = @objname AND o.type = 'AF')
+        BEGIN
+          EXEC('DROP AGGREGATE ' + @fullname )
+          SELECT @ret_code =1
+        END
+    END
+  ELSE IF (UPPER(@objtype)) = 'SYNONYM'
+    BEGIN
+      IF EXISTS (SELECT 1 FROM sys.objects o JOIN sys.schemas s ON o.schema_id = s.schema_id WHERE s.name = @objschema AND o.name = @objname AND o.type = 'SN')
+        BEGIN
+          EXEC('DROP SYNONYM ' + @fullname )
+          SELECT @ret_code =1
+        END
+    END
+  ELSE IF (UPPER(@objtype)) = 'COLUMN'
+    BEGIN
+      DECLARE @tableID		INT
+      SET @tableID = OBJECT_ID(@fullname)
+      IF EXISTS (SELECT 1 FROM sys.columns WHERE Name = N'' + @subobjname AND Object_ID = @tableID)
+        BEGIN
+          -- Drop any indexes and constraints on the column
+          DECLARE @index          SYSNAME
+          DECLARE cur_indexes CURSOR FOR
+            SELECT
+              i.Name
+            FROM
+              sys.indexes i
+              INNER JOIN
+              sys.index_columns ic ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+              INNER JOIN
+              sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+            WHERE
+              c.name = @subobjname
+              AND is_primary_key = 0
+              AND i.object_id = @tableID
+
+          DECLARE fkCursor CURSOR LOCAL for
+            SELECT object_name(fk.object_id), object_name(fkc.parent_object_id), schema_name(fk.schema_id)
+            FROM sys.foreign_keys fk JOIN sys.foreign_key_columns fkc ON fk.object_id = fkc.constraint_object_id
+              JOIN sys.columns c ON fkc.referenced_object_id = c.object_id AND c.column_id = fkc.referenced_column_id
+            WHERE fk.referenced_object_id = @tableID AND c.name = @subobjname
+
+          BEGIN TRANSACTION
+          BEGIN TRY
+          -- Drop indexes
+          OPEN cur_indexes
+          FETCH NEXT FROM cur_indexes INTO @index
+          WHILE (@@FETCH_STATUS = 0)
+            BEGIN
+              if (@printCmds = 1) PRINT('DROP INDEX [' + @index + '] ON ' + @fullname + '-- index drop')
+              EXEC('DROP INDEX [' + @index + '] ON ' + @fullname)
+              FETCH NEXT FROM cur_indexes INTO @index
+            END
+          CLOSE cur_indexes
+
+          -- Drop foreign keys
+          DECLARE @fkFullName sysname
+          OPEN fkCursor
+          FETCH NEXT FROM fkCursor INTO @fkConstName, @fkTableName, @fkSchema
+          WHILE @@fetch_status = 0
+            BEGIN
+              SELECT @fkFullName = '[' + @fkSchema + '].[' +@fkTableName + ']'
+              if (@printCmds = 1) PRINT('ALTER TABLE ' + @fkFullName + ' DROP CONSTRAINT [' + @fkConstName + '] -- FK drop')
+              EXEC('ALTER TABLE ' + @fkFullname + ' DROP CONSTRAINT [' + @fkConstName + ']')
+              FETCH NEXT FROM fkCursor INTO @fkConstName, @fkTableName, @fkSchema
+            END
+          CLOSE fkCursor
+
+          -- Drop default constraint on column
+          DECLARE @ConstraintName nvarchar(200)
+          SELECT @ConstraintName = Name FROM SYS.DEFAULT_CONSTRAINTS WHERE PARENT_OBJECT_ID = @tableID AND PARENT_COLUMN_ID = (SELECT column_id FROM sys.columns WHERE NAME = N'' + @subobjname AND object_id = @tableID)
+          IF @ConstraintName IS NOT NULL
+            BEGIN
+              if (@printCmds = 1) PRINT ('ALTER TABLE ' + @fullname + ' DROP CONSTRAINT [' + @ConstraintName + '] -- default constraint drop')
+              EXEC('ALTER TABLE ' + @fullname + ' DROP CONSTRAINT [' + @ConstraintName + ']')
+            END
+
+          -- Drop other constraints, including PK
+          SET @ConstraintName = NULL
+          while 0=0 begin
+            set @constraintName = (
+              select top 1 constraint_name
+              from information_schema.constraint_column_usage
+              where TABLE_SCHEMA = @objschema and table_name = @objname and column_name = @subobjname )
+            if @constraintName is null break
+            if (@printCmds = 1) PRINT ('ALTER TABLE ' + @fullname + ' DROP CONSTRAINT [' + @ConstraintName + '] -- other constraint drop')
+            exec ('ALTER TABLE ' + @fullname + ' DROP CONSTRAINT [' + @ConstraintName + ']')
+          end
+
+          -- Now drop the column
+          if (@printCmds = 1) PRINT ('ALTER TABLE ' + @fullname + ' DROP COLUMN [' + @subobjname + ']')
+          EXEC('ALTER TABLE ' + @fullname + ' DROP COLUMN [' + @subobjname + ']')
+          SELECT @ret_code =1
+
+          DEALLOCATE cur_indexes
+          DEALLOCATE fkCursor
+          COMMIT TRANSACTION
+          END TRY
+          BEGIN CATCH
+          ROLLBACK TRANSACTION
+          DEALLOCATE cur_indexes
+          DEALLOCATE fkCursor
+
+          DECLARE @error varchar(max)
+          SET @error = 'Error dropping column %s. The column has not been changed. This procedure can automatically drop indexes, foreign keys or primary keys, defaults, and other constraints on a column, but not other objects such as triggers or rules.
+			Original error from SQL Server was: ' + ERROR_MESSAGE()
+          RAISERROR(@error, 16, 1, @subobjname)
+          END CATCH
+        END
+    END
+  ELSE
+    RAISERROR('Invalid object type - %s   Valid values are TABLE, VIEW, INDEX, CONSTRAINT, DEFAULT, SCHEMA, PROCEDURE, FUNCTION, AGGREGATE, SYNONYM, COLUMN', 16, 1, @objtype )
+
+  RETURN @ret_code;
+END;
+
+GO


### PR DESCRIPTION
#### Rationale
Stored procedure `fn_dropIfExists` fails to bracket-escape table, schema, and other object names on SQL Server. This results in SQL exceptions when attempting to operate on names with spaces, special characters, or reserved words. One concrete example: attempt to drop the ETLTest schema (which has a table named "Delete").

#### Changes
* Rid the core bootstrap scripts of calls to fb_dropIfExists
* Reorder and coalesce the core and comm bootstrap scripts
* Bracket all object names when used in SQL commands