### PR TITLE
44544: Sample type linked to study gives error on Manage Dataset > Edit Definition Page

### DIFF
--- a/study/src/org/labkey/study/model/DatasetDomainKindProperties.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKindProperties.java
@@ -2,6 +2,7 @@ package org.labkey.study.model;
 
 import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.data.Container;
+import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.Study;
@@ -80,11 +81,11 @@ public class DatasetDomainKindProperties implements Cloneable
             _category = ds.getViewCategory().getLabel();
         }
 
-        ExpProtocol protocol = (ExpProtocol)ds.resolvePublishSource();
-        if (protocol != null)
+        ExpObject source = ds.resolvePublishSource();
+        if (source instanceof ExpProtocol)
         {
-            _sourceAssayName = protocol.getName();
-            _sourceAssayUrl = PageFlowUtil.urlProvider(AssayUrls.class).getAssayResultsURL(protocol.getContainer(), protocol).getLocalURIString();
+            _sourceAssayName = source.getName();
+            _sourceAssayUrl = PageFlowUtil.urlProvider(AssayUrls.class).getAssayResultsURL(source.getContainer(), (ExpProtocol) source).getLocalURIString();
         }
 
         if (null != ds.getDomain())


### PR DESCRIPTION
#### Rationale
I think this was an early refactor of the code in preparation for supporting linking samples to study and it never got cleaned up. In the final versions, the publish source is always an `ExpObject` and you have to check to see if it's either an `Assay` or a `SampleType`

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44544
