### PR TITLE
Restore SpecimenJobSupport to StudyJobSupport

### DIFF
--- a/study/src/org/labkey/study/importer/StudyImportJob.java
+++ b/study/src/org/labkey/study/importer/StudyImportJob.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.labkey.api.action.NullSafeBindException;
+import org.labkey.api.admin.ImportException;
 import org.labkey.api.admin.ImportOptions;
 import org.labkey.api.admin.PipelineJobLoggerGetter;
 import org.labkey.api.data.Container;
@@ -189,5 +190,17 @@ public class StudyImportJob extends PipelineJob implements StudyJobSupport, Stud
     public String getDescription()
     {
         return "Study " + (_reload ? "reload" : "import");
+    }
+
+    @Override
+    public Path getSpecimenArchivePath() throws ImportException
+    {
+        return _ctx.getSpecimenArchive(_root);
+    }
+
+    @Override
+    public boolean isMerge()
+    {
+        return false;
     }
 }

--- a/study/src/org/labkey/study/importer/StudyJobSupport.java
+++ b/study/src/org/labkey/study/importer/StudyJobSupport.java
@@ -17,6 +17,7 @@
 package org.labkey.study.importer;
 
 import org.labkey.api.cloud.CloudArchiveImporterSupport;
+import org.labkey.api.specimen.pipeline.SpecimenJobSupport;
 import org.labkey.api.writer.VirtualFile;
 import org.labkey.study.model.StudyImpl;
 import org.springframework.validation.BindException;
@@ -26,12 +27,13 @@ import org.springframework.validation.BindException;
 * Date: Aug 31, 2009
 * Time: 2:02:54 PM
 */
-public interface StudyJobSupport extends CloudArchiveImporterSupport
+public interface StudyJobSupport extends SpecimenJobSupport, CloudArchiveImporterSupport
 {
     StudyImpl getStudy();
 
     StudyImpl getStudy(boolean allowNullStudy);
 
+    @Override
     StudyImportContext getImportContext();
 
     @Override


### PR DESCRIPTION
#### Rationale
Removing `SpecimenJobSupport` might have been a tad aggressive. Daily tests are failing.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2957
