### PR TITLE
Add some extra logging to DataSetTest

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
@@ -341,13 +341,16 @@ public class StudyDatasetsTest extends BaseWebDriverTest
         DataRegionTable dataregion = new DataRegionTable(regionName, getDriver());
         DatasetFacetPanel facetPanel = dataregion.openSideFilterPanel();
 
-        PagingWidget pagingWidget = dataregion.getPagingWidget();
-
         waitForElement(Locator.paginationText(24));
+
+        log(String.format("Filter for '%s'.", GROUP1A));
         facetPanel.clickGroupLabel(GROUP1A);
-        Assert.assertFalse(pagingWidget.getComponentElement().isDisplayed());
+
+        log(String.format("Check that links '%s' and '%s' are present.", PTIDS[0], PTIDS[1]));
         waitForElement(Locator.linkWithText(PTIDS[0]));
-        assertElementPresent(Locator.linkWithText(PTIDS[1]));
+        waitForElement(Locator.linkWithText(PTIDS[1]));
+
+        log("Verify that the correct filter was applied by making sure no other rows are present.");
         assertEquals("Wrong number of rows after filter", 2, dataregion.getDataRowCount());
 
         facetPanel.getGroupCheckbox(GROUP1B).check(); // GROUP1A OR GROUP1B


### PR DESCRIPTION
#### Rationale
Cleaning up a DataSetTest. Test continues to fail, but a little more logging has been added.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/980

#### Changes
* In StudyDatasetTest.verifyFilterPanelOnDemographics remove check for paging control, the check for the number of rows in the grid will catch the same error.
* Added some logging to help track down the failure.

