### PR TITLE
Add dependency on `org.apache.pdfbox:pdfbox-tools`

### DIFF
--- a/search/build.gradle
+++ b/search/build.gradle
@@ -110,6 +110,19 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
+            "org.apache.pdfbox:pdfbox-tools:${pdfboxVersion}",
+            "Apache PDFBox®",
+            "PDFBox",
+            "https://pdfbox.apache.org/",
+            ExternalDependency.APACHE_2_LICENSE_NAME,
+            ExternalDependency.APACHE_2_LICENSE_URL,
+            "PDFBox dependency for PDF OCR"
+        )
+    )
+
+    BuildUtils.addExternalDependency(
+        project,
+        new ExternalDependency(
             "com.drewnoakes:metadata-extractor:2.16.0",
             "Metadata Extractor",
             "drewnoakes",

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -110,19 +110,6 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "org.apache.pdfbox:pdfbox-tools:${pdfboxVersion}",
-            "Apache PDFBox®",
-            "PDFBox",
-            "https://pdfbox.apache.org/",
-            ExternalDependency.APACHE_2_LICENSE_NAME,
-            ExternalDependency.APACHE_2_LICENSE_URL,
-            "PDFBox dependency for PDF OCR"
-        )
-    )
-
-    BuildUtils.addExternalDependency(
-        project,
-        new ExternalDependency(
             "com.drewnoakes:metadata-extractor:2.16.0",
             "Metadata Extractor",
             "drewnoakes",
@@ -223,6 +210,20 @@ dependencies {
             "Extract text and produce thumbnails from PDFs"
         )
     )
+
+    BuildUtils.addExternalDependency(
+        project,
+        new ExternalDependency(
+            "org.apache.pdfbox:pdfbox-tools:${pdfboxVersion}",
+            "PDFBox Tools",
+            "PDFBox",
+            "https://pdfbox.apache.org/",
+            ExternalDependency.APACHE_2_LICENSE_NAME,
+            ExternalDependency.APACHE_2_LICENSE_URL,
+            "PDFBox dependency"
+        )
+    )
+
 }
 
 // TODO move resources files into resources directory to avoid this overlap


### PR DESCRIPTION
#### Rationale
We are unable to index some PDFs. The `pdfbox-tools` package resolves this gap.

#### Changes
* Add dependency on `org.apache.pdfbox:pdfbox-tools`