### PR TITLE
Use BinaryDocValues instead of SortedDocValues

### DIFF
--- a/search/src/org/labkey/search/SearchModule.java
+++ b/search/src/org/labkey/search/SearchModule.java
@@ -66,7 +66,7 @@ public class SearchModule extends DefaultModule
     @Override
     public Double getSchemaVersion()
     {
-        return 22.000;
+        return 22.001;
     }
 
     @Override

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -22,10 +22,10 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
-import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
@@ -611,7 +611,8 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
             doc.add(new Field(FIELD_NAME.container.toString(), r.getContainerId(), StringField.TYPE_STORED));
 
             // See: https://stackoverflow.com/questions/29695307/sortiing-string-field-alphabetically-in-lucene-5-0
-            doc.add(new SortedDocValuesField(FIELD_NAME.container.toString(), new BytesRef(r.getContainerId())));
+            // But note that Lucene 9.0.0 changed to require BinaryDocValuesField instead
+            doc.add(new BinaryDocValuesField(FIELD_NAME.container.toString(), new BytesRef(r.getContainerId())));
 
             // === Index and analyze, don't store ===
 
@@ -644,8 +645,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
             // === Store security context in DocValues field ===
             String resourceId = (String)props.get(PROPERTY.securableResourceId.toString());
             String securityContext = r.getContainerId() + (null != resourceId && !resourceId.equals(r.getContainerId()) ? "|" + resourceId : "");
-            // TODO: As of Lucene 9.0.0, BinaryDocValues is recommended instead of SortedDocValues (for performance)
-            doc.add(new SortedDocValuesField(FIELD_NAME.securityContext.toString(), new BytesRef(securityContext)));
+            doc.add(new BinaryDocValuesField(FIELD_NAME.securityContext.toString(), new BytesRef(securityContext)));
 
             // === Custom properties: Index and analyze, but don't store
             for (Map.Entry<String, ?> entry : props.entrySet())

--- a/search/src/org/labkey/search/model/SecurityQuery.java
+++ b/search/src/org/labkey/search/model/SecurityQuery.java
@@ -17,9 +17,9 @@
 package org.labkey.search.model;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.ConstantScoreWeight;
 import org.apache.lucene.search.IndexSearcher;
@@ -127,7 +127,7 @@ class SecurityQuery extends Query
                 int maxDoc = reader.maxDoc();
                 FixedBitSet bits = new FixedBitSet(maxDoc);
 
-                SortedDocValues securityContextDocValues = reader.getSortedDocValues(FIELD_NAME.securityContext.name());
+                BinaryDocValues securityContextDocValues = reader.getBinaryDocValues(FIELD_NAME.securityContext.name());
 
                 try
                 {
@@ -138,7 +138,7 @@ class SecurityQuery extends Query
                     {
                         while (NO_MORE_DOCS != (doc = securityContextDocValues.nextDoc()))
                         {
-                            BytesRef bytesRef = securityContextDocValues.lookupOrd(securityContextDocValues.ordValue());
+                            BytesRef bytesRef = securityContextDocValues.binaryValue();
                             String securityContext = StringUtils.trimToNull(bytesRef.utf8ToString());
 
                             final String containerId;


### PR DESCRIPTION
#### Rationale
Lucene's `SortedDocValues` used to be the preferred way to handle sorted fields and persist/iterate security policy IDs. As of Lucene 9.0.0, `SortedDocValues` no longer works for sorted fields and is no longer preferred for security policy IDs. Replace both usages with `BinaryDocValues`.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44741

### Related Pull Requests
* https://github.com/LabKey/platform/pull/2896
