### PR TITLE
Wait for facet panel to load selections

### DIFF
--- a/study/webapp/study/ReportFilterPanel.js
+++ b/study/webapp/study/ReportFilterPanel.js
@@ -841,6 +841,7 @@ Ext4.define('LABKEY.ext4.filter.SelectPanel', {
                 this.allSelected();
 
                 this.fireEvent('initSelectionComplete', this.panelSelectCount, this);
+                LABKEY.Utils.signalWebDriverTest('initSelectionComplete', this.panelSelectCount);
             }
         }
     }


### PR DESCRIPTION
#### Rationale
Tests need a way to detect when the facet panel's initial selections state has been fully applied.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Add test signal for initial facet panel selections
