### PR TITLE
Merge @labkey/components 21.11 patch fix to develop

### DIFF
--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.115.1"
+        "@labkey/components": "2.121.2-fb-mergeFrom2111v2.0"
       },
       "devDependencies": {
         "@labkey/build": "5.0.0",
@@ -2054,9 +2054,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.7.2",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.7.2.tgz",
-      "integrity": "sha1-2G4KoFl6rLWxGVuh2qPmiwd7RdM=",
+      "version": "1.7.3",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.7.3.tgz",
+      "integrity": "sha1-dsmSqmkySxgn4cuWhRoYFTyK7CU=",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2232,9 +2232,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.115.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.115.1.tgz",
-      "integrity": "sha1-PW6ZxQrUxDKc+a/rodhn1O47sSI=",
+      "version": "2.121.2-fb-mergeFrom2111v2.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.121.2-fb-mergeFrom2111v2.0.tgz",
+      "integrity": "sha1-yqeY0EEhrXQWFGnVZFW+XRYMNDo=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -2242,7 +2242,7 @@
         "@fortawesome/free-regular-svg-icons": "5.15.4",
         "@fortawesome/free-solid-svg-icons": "5.15.4",
         "@fortawesome/react-fontawesome": "0.1.15",
-        "@labkey/api": "1.7.2",
+        "@labkey/api": "1.7.3",
         "bootstrap": "3.4.1",
         "classnames": "2.3.1",
         "font-awesome": "4.7.0",
@@ -11853,9 +11853,9 @@
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@labkey/api": {
-      "version": "1.7.2",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.7.2.tgz",
-      "integrity": "sha1-2G4KoFl6rLWxGVuh2qPmiwd7RdM="
+      "version": "1.7.3",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.7.3.tgz",
+      "integrity": "sha1-dsmSqmkySxgn4cuWhRoYFTyK7CU="
     },
     "@labkey/build": {
       "version": "5.0.0",
@@ -11992,16 +11992,16 @@
       }
     },
     "@labkey/components": {
-      "version": "2.115.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.115.1.tgz",
-      "integrity": "sha1-PW6ZxQrUxDKc+a/rodhn1O47sSI=",
+      "version": "2.121.2-fb-mergeFrom2111v2.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.121.2-fb-mergeFrom2111v2.0.tgz",
+      "integrity": "sha1-yqeY0EEhrXQWFGnVZFW+XRYMNDo=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-regular-svg-icons": "5.15.4",
         "@fortawesome/free-solid-svg-icons": "5.15.4",
         "@fortawesome/react-fontawesome": "0.1.15",
-        "@labkey/api": "1.7.2",
+        "@labkey/api": "1.7.3",
         "bootstrap": "3.4.1",
         "classnames": "2.3.1",
         "font-awesome": "4.7.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.121.2-fb-mergeFrom2111v2.0"
+        "@labkey/components": "2.121.3"
       },
       "devDependencies": {
         "@labkey/build": "5.0.0",
@@ -2232,9 +2232,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.121.2-fb-mergeFrom2111v2.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.121.2-fb-mergeFrom2111v2.0.tgz",
-      "integrity": "sha1-yqeY0EEhrXQWFGnVZFW+XRYMNDo=",
+      "version": "2.121.3",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.121.3.tgz",
+      "integrity": "sha1-nfXtZ2aYwKqvt4ZthjGvtG9XWJo=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -11992,9 +11992,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.121.2-fb-mergeFrom2111v2.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.121.2-fb-mergeFrom2111v2.0.tgz",
-      "integrity": "sha1-yqeY0EEhrXQWFGnVZFW+XRYMNDo=",
+      "version": "2.121.3",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.121.3.tgz",
+      "integrity": "sha1-nfXtZ2aYwKqvt4ZthjGvtG9XWJo=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.115.1"
+    "@labkey/components": "2.121.2-fb-mergeFrom2111v2.0"
   },
   "devDependencies": {
     "@labkey/build": "5.0.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.121.2-fb-mergeFrom2111v2.0"
+    "@labkey/components": "2.121.3"
   },
   "devDependencies": {
     "@labkey/build": "5.0.0",


### PR DESCRIPTION
#### Rationale
The related PR pulls in the 21.11 patch fix for @labkey/components v2.90.4. This PR applies that version to the experiment module package.json file.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/719
* https://github.com/LabKey/platform/pull/2984

#### Changes
* update @labkey/components package version
