### PR TITLE
44748: GetIssueAction doesn't respect SeeUserAndGroupDetailsRole

### DIFF
--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -602,9 +602,12 @@ public class User extends UserPrincipal implements Serializable, Cloneable
         JSONObject props = new JSONObject();
 
         props.put("id", user.getUserId());
-        props.put("displayName", user.getDisplayName(currentUser));
-        props.put("email", user.getEmail());
-        props.put("phone", user.getPhone());
+        if (container == null || SecurityManager.canSeeUserDetails(container, currentUser))
+        {
+            props.put("displayName", user.getDisplayName(currentUser));
+            props.put("email", user.getEmail());
+            props.put("phone", user.getPhone());
+        }
         props.put("avatar", user.getAvatarThumbnailPath());
 
         if (includePermissionProps)

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -604,10 +604,10 @@ public class User extends UserPrincipal implements Serializable, Cloneable
         props.put("id", user.getUserId());
         if (container == null || SecurityManager.canSeeUserDetails(container, currentUser))
         {
-            props.put("displayName", user.getDisplayName(currentUser));
             props.put("email", user.getEmail());
             props.put("phone", user.getPhone());
         }
+        props.put("displayName", user.getDisplayName(currentUser));
         props.put("avatar", user.getAvatarThumbnailPath());
 
         if (includePermissionProps)

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -2607,17 +2607,12 @@ public class UserController extends SpringActionController
             if (nameFilter.length() > 0)
                 response.put("name", nameFilter);
 
-            boolean includeEmail = SecurityManager.canSeeUserDetails(container, currentUser);
-
             for (User user : users)
             {
                 //according to the docs, startsWith will return true even if nameFilter is empty string
                 if (user.getEmail().toLowerCase().startsWith(nameFilter) || user.getDisplayName(null).toLowerCase().startsWith(nameFilter))
                 {
                     JSONObject userInfo = User.getUserProps(user, currentUser, container, false);
-
-                    if (!includeEmail)
-                        userInfo.remove("email");
 
                     // Backwards compatibility. This interface specifies "userId" while User.getUserProps() specifies "id"
                     userInfo.put("userId", user.getUserId());

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -2054,7 +2054,7 @@ public class IssuesController extends SpringActionController
                 var user = UserManager.getUser(userId);
 
                 if (user != null)
-                    users.put(String.valueOf(user.getUserId()), User.getUserProps(user, currentUser, null, false));
+                    users.put(String.valueOf(user.getUserId()), User.getUserProps(user, currentUser, getContainer(), false));
             }
             return users;
         }
@@ -2070,6 +2070,11 @@ public class IssuesController extends SpringActionController
             jsonIssue.remove("lastComment");
             jsonIssue.remove("class");
 
+            if (!SecurityManager.canSeeUserDetails(getContainer(), getUser()))
+            {
+                jsonIssue.remove("notifyListUserEmail");
+                jsonIssue.remove("notifyListEmail");
+            }
             var userIds = new HashSet<Integer>();
             userIds.add(issue.getAssignedTo());
             userIds.add(issue.getCreatedBy());


### PR DESCRIPTION
#### Rationale
`Issues.getIssue.api` was leaking email and user details information to users who did not have the `SeeUserAndGroupDetailsRole` security role: 

https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=44748

#### Changes
- Check for `SecurityManager.canSeeUserDetails` in `User.getUserProps`
- Don't include properties : `notifyListEmail` and `notifyListUserEmail` in `issues.getIssue.api` is the user is not allowed to see user and group details.
