### PR TITLE
44643: Boolean formatString does not import from folder or list archive

### DIFF
--- a/api/src/org/labkey/api/exp/ImportTypesHelper.java
+++ b/api/src/org/labkey/api/exp/ImportTypesHelper.java
@@ -482,6 +482,9 @@ public class ImportTypesHelper
                             // UNDONE: don't import date format until we have default format for study
                             // UNDONE: it looks bad to have mixed formats
                             break;
+                        case BOOLEAN:
+                            _format = format;
+                            break;
                         case STRING:
                         case MULTI_LINE:
                         default:


### PR DESCRIPTION
#### Rationale
Format strings for `Boolean` field types were not being round-tripped via folder archives. While the format was being written into the archive that property was not being imported:

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44643

The `ImportTypesHelper` just needed to be modified slightly to allow `Boolean` format strings. Most likely when we added this support we missed the export/import scenario.