### PR TITLE
Issue 44761: Improve session duration metric

### DIFF
--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -162,7 +162,7 @@ public class SecurityManager
     public static final String TRANSFORM_SESSION_ID = "LabKeyTransformSessionId";  // issue 19748
     public static final String API_KEY = "apikey";
 
-    private static final String USER_ID_KEY = User.class.getName() + "$userId";
+    public static final String USER_ID_KEY = User.class.getName() + "$userId";
     private static final String IMPERSONATION_CONTEXT_FACTORY_KEY = User.class.getName() + "$ImpersonationContextFactoryKey";
     private static final String AUTHENTICATION_VALIDATORS_KEY = SecurityManager.class.getName() + "$AuthenticationValidators";
     private static final String AUTHENTICATION_METHOD = "SecurityManager.authenticationMethod";

--- a/api/src/org/labkey/api/util/UsageReportingLevel.java
+++ b/api/src/org/labkey/api/util/UsageReportingLevel.java
@@ -106,8 +106,7 @@ public enum UsageReportingLevel implements SafeToRenderEnum
             metrics.put("recentLoginCount", UserManager.getRecentLoginCount(startDate));
             metrics.put("recentLogoutCount", UserManager.getRecentLogOutCount(startDate));
             metrics.put("activeDayCount", UserManager.getActiveDaysCount(startDate));
-            Integer averageRecentDuration = UserManager.getAverageSessionDuration(startDate);
-            metrics.put("recentAvgSessionDuration", null == averageRecentDuration ? -1 : averageRecentDuration);
+            metrics.put("recentAvgSessionDuration", UserManager.getAverageSessionDuration());
             metrics.put("mostRecentLogin", DateUtil.formatDateISO8601(UserManager.getMostRecentLogin()));
 
             LookAndFeelProperties laf = LookAndFeelProperties.getInstance(ContainerManager.getRoot());

--- a/api/webapp/WEB-INF/web.xml
+++ b/api/webapp/WEB-INF/web.xml
@@ -9,6 +9,10 @@
         <listener-class>org.labkey.api.util.ContextListener</listener-class>
     </listener>
 
+    <listener>
+        <listener-class>org.labkey.api.security.UserManager$SessionListener</listener-class>
+    </listener>
+
     <!-- Example filter to set character encoding on each request -->
     <filter>
         <filter-name>Set Character Encoding</filter-name>


### PR DESCRIPTION
#### Rationale
Our current metric relies on users intentionally signing out, which they hardly ever do

#### Changes
* Listen for the end of a session, and for authenticated users, record the duration
* Metric now tracks sessions for the current web app startup, not for the past 30 days via the audit log