### PR TITLE
Restore query validation option on study import

### DIFF
--- a/list/src/org/labkey/list/ListModule.java
+++ b/list/src/org/labkey/list/ListModule.java
@@ -137,13 +137,6 @@ public class ListModule extends SpringModule
             folderRegistry.addFactories(new FolderListWriter.Factory(), new FolderListImporter.Factory());
         }
 
-        // support importing lists from the study archive for backwards compatibility
-        StudySerializationRegistry studyRegistry = StudySerializationRegistry.get();
-        if (null != studyRegistry)
-        {
-            studyRegistry.addImportFactory(new FolderListImporter.Factory());
-        }                  
-
         SearchService ss = SearchService.get();
         if (null != ss)
         {

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -258,11 +258,13 @@ public class QueryModule extends DefaultModule
             folderRegistry.addFactories(new ExternalSchemaDefWriterFactory(), new ExternalSchemaDefImporterFactory());
         }
 
-        // support importing dataset & report categories from the /study subfolder for backward compatibility
         StudySerializationRegistry studyRegistry = StudySerializationRegistry.get();
         if (null != studyRegistry)
         {
+            // support importing dataset & report categories from study archives. TODO: Remove
             studyRegistry.addImportFactory(new ViewCategoryImporter.Factory());
+            // temporary: enables query validation option (postProcess()) when loading study archives. TODO: remove
+            studyRegistry.addImportFactory(new QueryImporter.Factory());
         }
 
         SearchService ss = SearchService.get();

--- a/study/webapp/WEB-INF/study/studyContext.xml
+++ b/study/webapp/WEB-INF/study/studyContext.xml
@@ -135,10 +135,10 @@
                         <list>
                             <bean class="org.labkey.api.formSchema.CheckboxField">
                                 <constructor-arg index="0" value="skipQueryValidation"/>
-                                <constructor-arg index="1" value="Validate All Queries After Reload"/>
+                                <constructor-arg index="1" value="Skip Query Validation After Reload"/>
                                 <constructor-arg index="2" value="false" />
                                 <constructor-arg index="3" value="false"/>
-                                <constructor-arg index="4" value="Enable to validate queries after reload is complete"/>
+                                <constructor-arg index="4" value="Enable to skip validation of queries after reload is complete"/>
                             </bean>
 
                             <bean class="org.labkey.api.formSchema.CheckboxField">


### PR DESCRIPTION
#### Rationale
In the related PR, I stopped registering `QueryImporter` with the `StudySerializationRegistry` since we no longer import queries from study archives. However, this also meant the query validation step was no longer invoked for study imports.

Note that all study import and reload functionality is going away, but we might as well keep the tests happy for now.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2957

#### Changes
* Re-register QueryImporter, for now
* Stop registering `ListImporter` as a study importer. We no longer support importing lists via study archives.
* Fix backwards wording for "query validation" option on study reload task