### PR TITLE
Eliminate unnecessary _logDefault

### DIFF
--- a/api/src/org/labkey/api/data/ConnectionWrapper.java
+++ b/api/src/org/labkey/api/data/ConnectionWrapper.java
@@ -73,7 +73,6 @@ public class ConnectionWrapper implements java.sql.Connection
 
     private static final Map<ConnectionWrapper, Pair<Thread, Throwable>> _openConnections = Collections.synchronizedMap(new IdentityHashMap<>());
     private static final Set<ConnectionWrapper> _loggedLeaks = new HashSet<>();
-    private static final Logger _logDefault = LogManager.getLogger(ConnectionWrapper.class);
     private static final boolean _explicitLogger = initializeExplicitLogger();
     private static final AtomicLong COUNTER = new AtomicLong(0);
 
@@ -103,9 +102,9 @@ public class ConnectionWrapper implements java.sql.Connection
     private static boolean initializeExplicitLogger()
     {
         var loggerContext = (LoggerContext) LogManager.getContext(false);
-        var loggerConfig = loggerContext.getConfiguration().getLoggerConfig(_logDefault.getName());
+        var loggerConfig = loggerContext.getConfiguration().getLoggerConfig(LOG.getName());
 
-        return _logDefault.getLevel() != null || loggerConfig.getParent() != null  && loggerConfig.getParent().getName().equals("org.labkey.api.data");
+        return LOG.getLevel() != null || loggerConfig.getParent() != null  && loggerConfig.getParent().getName().equals("org.labkey.api.data");
     }
 
     public ConnectionWrapper(Connection conn, DbScope scope, Integer spid, ConnectionType type, @Nullable Logger log)
@@ -120,7 +119,7 @@ public class ConnectionWrapper implements java.sql.Connection
         _allocatingThreadName = Thread.currentThread().getName();
         _referencingThreadNames.add(_allocatingThreadName);
 
-        _openConnections.put(this,  new Pair<>(Thread.currentThread(), new Throwable()));
+        _openConnections.put(this, new Pair<>(Thread.currentThread(), new Throwable()));
 
         _log = log != null ? log : getConnectionLogger();
     }
@@ -130,7 +129,7 @@ public class ConnectionWrapper implements java.sql.Connection
     static Logger getConnectionLogger()
     {
         if (_explicitLogger)
-            return _logDefault;
+            return LOG;
         StackTraceElement[] stes = Thread.currentThread().getStackTrace();
         for (StackTraceElement ste : stes)
         {
@@ -140,7 +139,7 @@ public class ConnectionWrapper implements java.sql.Connection
             if (className.endsWith("Controller") && !className.startsWith("org.labkey.api.view"))
                 return LogManager.getLogger(className);
         }
-        return _logDefault;
+        return LOG;
     }
 
 
@@ -158,7 +157,7 @@ public class ConnectionWrapper implements java.sql.Connection
 
     public static boolean dumpOpenConnections()
     {
-        return dumpOpenConnections(_logDefault);
+        return dumpOpenConnections(LOG);
     }
 
     public static boolean dumpOpenConnections(@NotNull LoggerWriter logWriter)
@@ -185,7 +184,7 @@ public class ConnectionWrapper implements java.sql.Connection
 
     public static boolean dumpLeaksForThread(Thread t)
     {
-        return dumpLeaksForThread(t, _logDefault);
+        return dumpLeaksForThread(t, LOG);
     }
 
     public static boolean dumpLeaksForThread(Thread t, Logger log)
@@ -891,7 +890,7 @@ public class ConnectionWrapper implements java.sql.Connection
     {
         if (!isClosed())
         {
-            LOG.error("Connection was not closed! " + toString());
+            LOG.error("Connection was not closed! " + this);
             realClose();
         }
 

--- a/api/src/org/labkey/api/data/dialect/StatementWrapper.java
+++ b/api/src/org/labkey/api/data/dialect/StatementWrapper.java
@@ -2821,7 +2821,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
     }
     
 
-    private static Package _java_lang = java.lang.String.class.getPackage();
+    private static final Package _java_lang = java.lang.String.class.getPackage();
 
     private void _logStatement(String sql, @Nullable SQLException x, int rowsAffected, QueryLogging queryLogging)
     {
@@ -2884,7 +2884,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
             logEntry.append(" time ").append(DateUtil.formatDuration(elapsed));
 
         if (-1 != rowsAffected)
-            logEntry.append("\n    " + rowsAffected + " rows affected");
+            logEntry.append("\n    ").append(rowsAffected).append(" rows affected");
 
         logEntry.append("\n    ");
         logEntry.append(sql.trim().replace("\n", "\n    "));
@@ -2895,7 +2895,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
             {
                 try
                 {
-                    Object o = i <= _parameters.size() ? _parameters.get(i) : null;
+                    Object o = _parameters.get(i);
                     String value;
                     if (o == null)
                         value = "NULL";
@@ -2909,7 +2909,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
                         value = value.substring(0, 100) + ". . .";
                     logEntry.append("\n    --[").append(i).append("] ");
                     logEntry.append(value);
-                    Class c = null==o ? null : o.getClass();
+                    Class<?> c = null==o ? null : o.getClass();
                     if (null != c && c != String.class && c != Integer.class)
                         logEntry.append(" :").append(c.getPackage() == _java_lang ? c.getSimpleName() : c.getName());
                 }

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -6796,7 +6796,7 @@ public class AdminController extends SpringActionController
                     form.setFolderType(folderType.getName());
                 }
             }
-            JspView statusView = new JspView<>("/org/labkey/core/admin/createFolder.jsp", form, errors);
+            JspView<ManageFoldersForm> statusView = new JspView<>("/org/labkey/core/admin/createFolder.jsp", form, errors);
             vbox.addView(statusView);
 
             Container c = getViewContext().getContainerNoTab();         // Cannot create subfolder of tab folder


### PR DESCRIPTION
#### Rationale
Maybe I'm missing something, but it looks to me like `LOG` and `_logDefault` in `ConnectionWrapper` are completely redundant. Removing `_logDefault` simplifies the code and eliminates a warning.

Fix a few other miscellaneous warnings.
