### PR TITLE
Avoid NPEs when restarting a server while impersonating a role that is not present after the restart

### DIFF
--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -3051,7 +3051,7 @@ public class SecurityManager
             return Set.of();
 
         var granted = policy.getOwnPermissions(principal);
-        principal.getContextualRoles(policy).forEach(r -> granted.addAll(r.getPermissions()));
+        principal.getContextualRoles(policy).forEach(r -> { if (r != null) granted.addAll(r.getPermissions()); });
         if (null != contextualRoles)
             contextualRoles.forEach(r -> granted.addAll(r.getPermissions()));
         if (principal instanceof User)

--- a/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
@@ -39,7 +39,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * User: adam
@@ -138,9 +140,11 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
 
     private String getRolesDisplayString(Set<String> roleNames)
     {
-        Set<String> roleDisplayNames = new HashSet<>();
-        for (String name : roleNames)
-            roleDisplayNames.add(RoleManager.getRole(name).getName());
+        Set<String> roleDisplayNames = roleNames.stream()
+                .map(RoleManager::getRole)
+                .filter(Objects::nonNull)
+                .map(Role::getName)
+                .collect(Collectors.toSet());
 
         if (roleDisplayNames.isEmpty())
             return "";


### PR DESCRIPTION
#### Rationale
If you happen to be impersonating a role that exists in one branch of the code and then rebuild your server for a different branch that doesn't have that role, when your server restarts with the new code, you can get NPEs in various places as it tries to determine the roles you are in.  

#### Changes
* Check for existence of roles in various places