### PR TITLE
automated test fixes : a user should always be able to see their own details

### DIFF
--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -602,7 +602,8 @@ public class User extends UserPrincipal implements Serializable, Cloneable
         JSONObject props = new JSONObject();
 
         props.put("id", user.getUserId());
-        if (container == null || SecurityManager.canSeeUserDetails(container, currentUser))
+        // check for permission to see user details, users can always see their own details
+        if (container == null || currentUser.equals(user) || SecurityManager.canSeeUserDetails(container, currentUser))
         {
             props.put("email", user.getEmail());
             props.put("phone", user.getPhone());


### PR DESCRIPTION
#### Rationale
The previous change to not leak user details from the `GetIssueAction` caused some test failures by being too restrictive:

https://github.com/LabKey/platform/pull/2990

Added a slight change to allow users to see their own details even if they aren't in the `SeeUserAndGroupDetailsRole`.
