### PR TITLE
DomainKind and SimpleTableDomainKind pass through User props

### DIFF
--- a/api/src/org/labkey/api/audit/query/AbstractAuditDomainKind.java
+++ b/api/src/org/labkey/api/audit/query/AbstractAuditDomainKind.java
@@ -291,7 +291,7 @@ public abstract class AbstractAuditDomainKind extends DomainKind<JSONObject>
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         Set<String> names = new HashSet<>();
 

--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -103,6 +103,14 @@ abstract public class DomainKind<T>  implements Handler<String>
      */
     abstract public Set<String> getReservedPropertyNames(Domain domain);
 
+    /**
+     * Override this function if the user is necessary for getReservedPropertyNames
+     */
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    {
+        return getReservedPropertyNames(domain);
+    }
+
     public Set<String> getReservedPropertyNamePrefixes()
     {
         return Collections.emptySet();

--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -101,15 +101,7 @@ abstract public class DomainKind<T>  implements Handler<String>
      * the names of columns from the hard table underlying this type
      * @return set of strings containing the names. This will be compared ignoring case
      */
-    abstract public Set<String> getReservedPropertyNames(Domain domain);
-
-    /**
-     * Override this function if the user is necessary for getReservedPropertyNames
-     */
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
-    {
-        return getReservedPropertyNames(domain);
-    }
+    abstract public Set<String> getReservedPropertyNames(Domain domain, User user);
 
     public Set<String> getReservedPropertyNamePrefixes()
     {

--- a/api/src/org/labkey/api/exp/property/TestDomainKind.java
+++ b/api/src/org/labkey/api/exp/property/TestDomainKind.java
@@ -151,7 +151,7 @@ public class TestDomainKind extends DomainKind<JSONObject>
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         throw new UnsupportedOperationException();
     }

--- a/assay/api-src/org/labkey/api/assay/AssayBatchDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayBatchDomainKind.java
@@ -18,6 +18,7 @@ package org.labkey.api.assay;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.query.ExpExperimentTable;
+import org.labkey.api.security.User;
 
 import java.util.Set;
 
@@ -39,7 +40,7 @@ public class AssayBatchDomainKind extends AssayDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         Set<String> result = super.getAssayReservedPropertyNames();
         for (ExpExperimentTable.Column column : ExpExperimentTable.Column.values())

--- a/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
@@ -23,6 +23,7 @@ import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.security.User;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 
@@ -91,7 +92,7 @@ public class AssayResultDomainKind extends AssayDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         Set<String> result = getAssayReservedPropertyNames();
         result.add("Run");

--- a/assay/api-src/org/labkey/api/assay/AssayRunDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayRunDomainKind.java
@@ -18,6 +18,7 @@ package org.labkey.api.assay;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.query.ExpRunTable;
+import org.labkey.api.security.User;
 import org.labkey.api.util.Pair;
 
 import java.util.Set;
@@ -42,7 +43,7 @@ public class AssayRunDomainKind extends AssayDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         Set<String> result = getAssayReservedPropertyNames();
         for (ExpRunTable.Column column : ExpRunTable.Column.values())

--- a/assay/src/org/labkey/assay/AssayImportServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayImportServiceImpl.java
@@ -254,7 +254,7 @@ public class AssayImportServiceImpl extends DomainImporterServiceBase implements
                 ExpProtocol protocol = ExperimentService.get().getExpProtocol(gwtProtocol.getProtocolId());
                 Domain domain = provider.getResultsDomain(protocol);
 
-                Set<String> reservedNames = domain.getDomainKind().getReservedPropertyNames(domain);
+                Set<String> reservedNames = domain.getDomainKind().getReservedPropertyNames(domain, null);
 
                 return domain.getTypeURI();
             }

--- a/assay/src/org/labkey/assay/DefaultAssayDomainKind.java
+++ b/assay/src/org/labkey/assay/DefaultAssayDomainKind.java
@@ -18,6 +18,7 @@ package org.labkey.assay;
 import org.labkey.api.assay.AssayDomainKind;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.security.User;
 
 import java.util.Set;
 
@@ -41,7 +42,7 @@ public class DefaultAssayDomainKind extends AssayDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return getAssayReservedPropertyNames();
     }

--- a/assay/src/org/labkey/assay/PlateBasedAssaySampleTypeDomainKind.java
+++ b/assay/src/org/labkey/assay/PlateBasedAssaySampleTypeDomainKind.java
@@ -56,7 +56,7 @@ public class PlateBasedAssaySampleTypeDomainKind extends SampleTypeDomainKind
             }
 
             @Override
-            public Set<String> getReservedPropertyNames(Domain domain)
+            public Set<String> getReservedPropertyNames(Domain domain, User user)
             {
                 return null;
             }

--- a/assay/src/org/labkey/assay/plate/AssayPlateDataDomainKind.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateDataDomainKind.java
@@ -45,7 +45,7 @@ public class AssayPlateDataDomainKind extends AssayDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return getAssayReservedPropertyNames();
     }

--- a/core/src/org/labkey/core/query/UsersDomainKind.java
+++ b/core/src/org/labkey/core/query/UsersDomainKind.java
@@ -148,7 +148,7 @@ public class UsersDomainKind extends SimpleTableDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return _reservedNames;
     }

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -204,7 +204,7 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return RESERVED_NAMES;
     }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -7090,7 +7090,7 @@ public class ExperimentServiceImpl implements ExperimentService
         Domain domain = PropertyService.get().createDomain(c, lsid.toString(), name, templateInfo);
         DomainKind kind = domain.getDomainKind();
 
-        Set<String> reservedNames = kind.getReservedPropertyNames(domain, null);
+        Set<String> reservedNames = kind.getReservedPropertyNames(domain, u);
         Set<String> lowerReservedNames = reservedNames.stream().map(String::toLowerCase).collect(toSet());
 
         Map<DomainProperty, Object> defaultValues = new HashMap<>();

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -96,7 +96,6 @@ import org.labkey.api.pipeline.RecordedActionSet;
 import org.labkey.api.qc.SampleStatusService;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.query.QueryForm;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryViewProvider;
@@ -7091,7 +7090,7 @@ public class ExperimentServiceImpl implements ExperimentService
         Domain domain = PropertyService.get().createDomain(c, lsid.toString(), name, templateInfo);
         DomainKind kind = domain.getDomainKind();
 
-        Set<String> reservedNames = kind.getReservedPropertyNames(domain);
+        Set<String> reservedNames = kind.getReservedPropertyNames(domain, null);
         Set<String> lowerReservedNames = reservedNames.stream().map(String::toLowerCase).collect(toSet());
 
         Map<DomainProperty, Object> defaultValues = new HashMap<>();

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -677,7 +677,8 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         Lsid lsid = getSampleTypeLsid(name, c);
         Domain domain = PropertyService.get().createDomain(c, lsid.toString(), name, templateInfo);
         DomainKind kind = domain.getDomainKind();
-        Set<String> reservedNames = kind.getReservedPropertyNames(domain, null);
+        Set<String> reservedNames = kind.getReservedPropertyNames(domain, u);
+
         Set<String> reservedPrefixes = kind.getReservedPropertyNamePrefixes();
         Set<String> lowerReservedNames = reservedNames.stream().map(String::toLowerCase).collect(Collectors.toSet());
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -677,7 +677,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         Lsid lsid = getSampleTypeLsid(name, c);
         Domain domain = PropertyService.get().createDomain(c, lsid.toString(), name, templateInfo);
         DomainKind kind = domain.getDomainKind();
-        Set<String> reservedNames = kind.getReservedPropertyNames(domain);
+        Set<String> reservedNames = kind.getReservedPropertyNames(domain, null);
         Set<String> reservedPrefixes = kind.getReservedPropertyNamePrefixes();
         Set<String> lowerReservedNames = reservedNames.stream().map(String::toLowerCase).collect(Collectors.toSet());
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -678,7 +678,6 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         Domain domain = PropertyService.get().createDomain(c, lsid.toString(), name, templateInfo);
         DomainKind kind = domain.getDomainKind();
         Set<String> reservedNames = kind.getReservedPropertyNames(domain, u);
-
         Set<String> reservedPrefixes = kind.getReservedPropertyNamePrefixes();
         Set<String> lowerReservedNames = reservedNames.stream().map(String::toLowerCase).collect(Collectors.toSet());
 

--- a/experiment/src/org/labkey/experiment/api/VocabularyDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/VocabularyDomainKind.java
@@ -70,7 +70,7 @@ public class VocabularyDomainKind extends BaseAbstractDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         Set<String> reservedProperties = new HashSet<>();
         reservedProperties.add("RowId");

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -1778,7 +1778,7 @@ renaming a property AND toggling mvindicator on in the same change.
                 }
 
                 @Override
-                public Set<String> getReservedPropertyNames(Domain domain)
+                public Set<String> getReservedPropertyNames(Domain domain, User user)
                 {
                     return Set.of();
                 }

--- a/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
+++ b/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
@@ -1067,7 +1067,8 @@ public class PropertyController extends SpringActionController
             List<GWTPropertyDescriptor> fields = new ArrayList<>();
             List<GWTPropertyDescriptor> reservedFields = new ArrayList<>();
             DomainKind domainKind = domainKindName == null ? null : PropertyService.get().getDomainKindByName(domainKindName);
-            Set<String> reservedNames = domainKind == null ? Collections.emptySet() : domainKind.getReservedPropertyNames(null, null);
+            Set<String> reservedNames = domainKind == null ? Collections.emptySet() : domainKind.getReservedPropertyNames(null, getUser());
+
             Set<String> reservedPrefixes = domainKind == null ? Collections.emptySet() : domainKind.getReservedPropertyNamePrefixes();
 
             if (loader != null)

--- a/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
+++ b/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
@@ -52,7 +52,6 @@ import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.LsidManager;
 import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.OntologyManager;
-import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.TemplateInfo;
 import org.labkey.api.exp.api.DomainKindDesign;
 import org.labkey.api.exp.api.ExperimentJSONConverter;
@@ -1068,7 +1067,7 @@ public class PropertyController extends SpringActionController
             List<GWTPropertyDescriptor> fields = new ArrayList<>();
             List<GWTPropertyDescriptor> reservedFields = new ArrayList<>();
             DomainKind domainKind = domainKindName == null ? null : PropertyService.get().getDomainKindByName(domainKindName);
-            Set<String> reservedNames = domainKind == null ? Collections.emptySet() : domainKind.getReservedPropertyNames(null);
+            Set<String> reservedNames = domainKind == null ? Collections.emptySet() : domainKind.getReservedPropertyNames(null, null);
             Set<String> reservedPrefixes = domainKind == null ? Collections.emptySet() : domainKind.getReservedPropertyNamePrefixes();
 
             if (loader != null)

--- a/experiment/src/org/labkey/experiment/pipeline/SampleReloadTask.java
+++ b/experiment/src/org/labkey/experiment/pipeline/SampleReloadTask.java
@@ -122,7 +122,7 @@ public class SampleReloadTask extends PipelineJob.Task<SampleReloadTask.Factory>
                 try (DataLoader loader = DataLoader.get().createLoader(dataFile, null, true, job.getContainer(), null))
                 {
                     DomainKind domainKind = PropertyService.get().getDomainKindByName(SampleTypeDomainKind.NAME);
-                    Set<String> reservedProps = domainKind.getReservedPropertyNames(null, null);
+                    Set<String> reservedProps = domainKind.getReservedPropertyNames(null, job.getUser());
                     reservedProps.remove("name");
                     List<GWTPropertyDescriptor> props = new ArrayList<>();
                     boolean hasNameField = false;

--- a/experiment/src/org/labkey/experiment/pipeline/SampleReloadTask.java
+++ b/experiment/src/org/labkey/experiment/pipeline/SampleReloadTask.java
@@ -122,7 +122,7 @@ public class SampleReloadTask extends PipelineJob.Task<SampleReloadTask.Factory>
                 try (DataLoader loader = DataLoader.get().createLoader(dataFile, null, true, job.getContainer(), null))
                 {
                     DomainKind domainKind = PropertyService.get().getDomainKindByName(SampleTypeDomainKind.NAME);
-                    Set<String> reservedProps = domainKind.getReservedPropertyNames(null);
+                    Set<String> reservedProps = domainKind.getReservedPropertyNames(null, null);
                     reservedProps.remove("name");
                     List<GWTPropertyDescriptor> props = new ArrayList<>();
                     boolean hasNameField = false;

--- a/filecontent/src/org/labkey/filecontent/FilePropertiesDomainKind.java
+++ b/filecontent/src/org/labkey/filecontent/FilePropertiesDomainKind.java
@@ -23,6 +23,7 @@ import org.labkey.api.exp.property.BaseAbstractDomainKind;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.query.ExpDataTable;
 import org.labkey.api.gwt.client.DefaultValueType;
+import org.labkey.api.security.User;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.writer.ContainerUser;
@@ -99,7 +100,7 @@ public class FilePropertiesDomainKind extends BaseAbstractDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return _reservedFieldSet;
     }

--- a/internal/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/internal/src/org/labkey/api/exp/property/DomainUtil.java
@@ -242,7 +242,7 @@ public class DomainUtil
         d.setFields(list);
 
         // Handle reserved property names
-        Set<String> reservedProperties = domainKind.getReservedPropertyNames(domain);
+        Set<String> reservedProperties = domainKind.getReservedPropertyNames(domain, user);
         d.setReservedFieldNames(new CaseInsensitiveHashSet(reservedProperties));
         d.setReservedFieldNamePrefixes(domainKind.getReservedPropertyNamePrefixes());
         d.setMandatoryFieldNames(new CaseInsensitiveHashSet(mandatoryProperties));
@@ -509,7 +509,7 @@ public class DomainUtil
         if (!kind.canCreateDefinition(user, container))
             throw new UnauthorizedException("You don't have permission to create a new domain");
 
-        ValidationException ve = DomainUtil.validateProperties(null, domain, null, null);
+        ValidationException ve = DomainUtil.validateProperties(null, domain, null, null, user);
         if (ve.hasErrors())
         {
             throw new ValidationException(ve);
@@ -541,7 +541,7 @@ public class DomainUtil
         }
 
         DomainKind<?> kind = d.getDomainKind();
-        ValidationException validationException = validateProperties(d, update, kind, orig);
+        ValidationException validationException = validateProperties(d, update, kind, orig, user);
 
         if (validationException.hasErrors())
         {
@@ -972,9 +972,9 @@ public class DomainUtil
      * @param domain The updated domain to validate
      * @return List of errors strings found during the validation
      */
-    public static ValidationException validateProperties(@Nullable Domain domain, @NotNull GWTDomain updates, @Nullable DomainKind domainKind, @Nullable GWTDomain orig)
+    public static ValidationException validateProperties(@Nullable Domain domain, @NotNull GWTDomain updates, @Nullable DomainKind domainKind, @Nullable GWTDomain orig, @Nullable User user)
     {
-        Set<String> reservedNames = (null != domain && null != domainKind) ? new CaseInsensitiveHashSet(domainKind.getReservedPropertyNames(domain))
+        Set<String> reservedNames = (null != domain && null != domainKind) ? new CaseInsensitiveHashSet(domainKind.getReservedPropertyNames(domain, user))
                 : new CaseInsensitiveHashSet(updates.getReservedFieldNames());
         Set<String> reservedPrefixes = (null != domain && null != domainKind) ? domainKind.getReservedPropertyNamePrefixes() : updates.getReservedFieldNamePrefixes();
         Map<String, Integer> namePropertyIdMap = new CaseInsensitiveHashMap<>();

--- a/internal/src/org/labkey/api/issues/AbstractIssuesListDefDomainKind.java
+++ b/internal/src/org/labkey/api/issues/AbstractIssuesListDefDomainKind.java
@@ -322,7 +322,7 @@ public abstract class AbstractIssuesListDefDomainKind extends AbstractDomainKind
             Domain newDomain = IssuesListDefService.get().getDomainFromIssueDefId(issueDefId, container, user);
             if (newDomain != null)
             {
-                Set<String> reservedNames = getReservedPropertyNames(newDomain, null);
+                Set<String> reservedNames = getReservedPropertyNames(newDomain, user);
                 Set<String> lowerReservedNames = reservedNames.stream().map(String::toLowerCase).collect(Collectors.toSet());
                 Set<String> existingProperties = newDomain.getProperties().stream().map(o -> o.getName().toLowerCase()).collect(Collectors.toSet());
                 Map<DomainProperty, Object> defaultValues = new HashMap<>();

--- a/internal/src/org/labkey/api/issues/AbstractIssuesListDefDomainKind.java
+++ b/internal/src/org/labkey/api/issues/AbstractIssuesListDefDomainKind.java
@@ -322,7 +322,7 @@ public abstract class AbstractIssuesListDefDomainKind extends AbstractDomainKind
             Domain newDomain = IssuesListDefService.get().getDomainFromIssueDefId(issueDefId, container, user);
             if (newDomain != null)
             {
-                Set<String> reservedNames = getReservedPropertyNames(newDomain);
+                Set<String> reservedNames = getReservedPropertyNames(newDomain, null);
                 Set<String> lowerReservedNames = reservedNames.stream().map(String::toLowerCase).collect(Collectors.toSet());
                 Set<String> existingProperties = newDomain.getProperties().stream().map(o -> o.getName().toLowerCase()).collect(Collectors.toSet());
                 Map<DomainProperty, Object> defaultValues = new HashMap<>();

--- a/internal/src/org/labkey/api/query/SimpleTableDomainKind.java
+++ b/internal/src/org/labkey/api/query/SimpleTableDomainKind.java
@@ -18,6 +18,7 @@ package org.labkey.api.query;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
@@ -64,8 +65,13 @@ public class SimpleTableDomainKind extends BaseAbstractDomainKind
     {
     }
 
-    // uck. To get from a Domain to the SimpleTable we need to parse the Domain's type uri.
     public SimpleUserSchema.SimpleTable getTable(Domain domain)
+    {
+        return getTable(domain, null);
+    }
+
+    // uck. To get from a Domain to the SimpleTable we need to parse the Domain's type uri.
+    public SimpleUserSchema.SimpleTable getTable(Domain domain, @Nullable User user)
     {
         String domainURI = domain.getTypeURI();
         if (domainURI == null)
@@ -80,7 +86,9 @@ public class SimpleTableDomainKind extends BaseAbstractDomainKind
             String queryName = lsid.getObjectId();
 
             // HACK: have to reach out to get the user
-            User user = HttpView.currentContext().getUser();
+            if (user == null)
+                user = HttpView.currentContext().getUser();
+
             UserSchema schema = QueryService.get().getUserSchema(user, domain.getContainer(), schemaName);
             if (schema != null)
             {
@@ -175,7 +183,7 @@ public class SimpleTableDomainKind extends BaseAbstractDomainKind
     @Override
     public ActionURL urlShowData(Domain domain, ContainerUser containerUser)
     {
-        SimpleUserSchema.SimpleTable table = getTable(domain);
+        SimpleUserSchema.SimpleTable table = getTable(domain, containerUser.getUser());
         if (table == null)
             return null;
 
@@ -235,7 +243,13 @@ public class SimpleTableDomainKind extends BaseAbstractDomainKind
     @Override
     public Set<String> getReservedPropertyNames(Domain domain)
     {
-        SimpleUserSchema.SimpleTable table = getTable(domain);
+        return getReservedPropertyNames(domain, null);
+    }
+
+    @Override
+    public Set<String> getReservedPropertyNames(Domain domain, @Nullable User user)
+    {
+        SimpleUserSchema.SimpleTable table = getTable(domain, user);
         if (table != null)
         {
             // return the set of built-in column names.

--- a/internal/src/org/labkey/api/query/SimpleTableDomainKind.java
+++ b/internal/src/org/labkey/api/query/SimpleTableDomainKind.java
@@ -241,13 +241,7 @@ public class SimpleTableDomainKind extends BaseAbstractDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
-    {
-        return getReservedPropertyNames(domain, null);
-    }
-
-    @Override
-    public Set<String> getReservedPropertyNames(Domain domain, @Nullable User user)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         SimpleUserSchema.SimpleTable table = getTable(domain, user);
         if (table != null)

--- a/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
+++ b/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
@@ -382,7 +382,8 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
         SampleTypeService ss = SampleTypeService.get();
         ExpSampleType sampleType = options.getRowId() >= 0 ? ss.getSampleType(options.getRowId()) : null;
         Domain stDomain = sampleType != null ? sampleType.getDomain() : null;
-        Set<String> reservedNames = new CaseInsensitiveHashSet(this.getReservedPropertyNames(stDomain, null));
+        Set<String> reservedNames = new CaseInsensitiveHashSet(this.getReservedPropertyNames(stDomain, user));
+
         Set<String> existingAliases = new CaseInsensitiveHashSet();
         Set<String> dupes = new CaseInsensitiveHashSet();
 

--- a/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
+++ b/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
@@ -221,7 +221,7 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         Set<String> reserved = new CaseInsensitiveHashSet(RESERVED_NAMES);
 
@@ -382,7 +382,7 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
         SampleTypeService ss = SampleTypeService.get();
         ExpSampleType sampleType = options.getRowId() >= 0 ? ss.getSampleType(options.getRowId()) : null;
         Domain stDomain = sampleType != null ? sampleType.getDomain() : null;
-        Set<String> reservedNames = new CaseInsensitiveHashSet(this.getReservedPropertyNames(stDomain));
+        Set<String> reservedNames = new CaseInsensitiveHashSet(this.getReservedPropertyNames(stDomain, null));
         Set<String> existingAliases = new CaseInsensitiveHashSet();
         Set<String> dupes = new CaseInsensitiveHashSet();
 

--- a/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
+++ b/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
@@ -383,7 +383,6 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
         ExpSampleType sampleType = options.getRowId() >= 0 ? ss.getSampleType(options.getRowId()) : null;
         Domain stDomain = sampleType != null ? sampleType.getDomain() : null;
         Set<String> reservedNames = new CaseInsensitiveHashSet(this.getReservedPropertyNames(stDomain, user));
-
         Set<String> existingAliases = new CaseInsensitiveHashSet();
         Set<String> dupes = new CaseInsensitiveHashSet();
 

--- a/issues/src/org/labkey/issue/query/IssueDefDomainKind.java
+++ b/issues/src/org/labkey/issue/query/IssueDefDomainKind.java
@@ -110,7 +110,7 @@ public class IssueDefDomainKind extends AbstractIssuesListDefDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return RESERVED_NAMES;
     }

--- a/issues/src/org/labkey/issue/query/IssuesTable.java
+++ b/issues/src/org/labkey/issue/query/IssuesTable.java
@@ -55,7 +55,6 @@ import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.RowIdForeignKey;
 import org.labkey.api.query.UserIdForeignKey;
-import org.labkey.api.query.UserIdQueryForeignKey;
 import org.labkey.api.query.UserIdRenderer;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
@@ -75,7 +74,6 @@ import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.Tuple3;
 import org.labkey.api.view.ActionURL;
-import org.labkey.api.view.UnauthorizedException;
 import org.labkey.issue.IssuesController;
 import org.labkey.issue.model.Issue;
 import org.labkey.issue.model.IssueListDef;
@@ -133,11 +131,11 @@ public class IssuesTable extends FilteredTable<IssuesQuerySchema> implements Upd
         IssuesQuerySchema schema = getUserSchema();
         Set<String> baseProps = new CaseInsensitiveHashSet();
         Map<String, String> colNameMap = new HashMap<>();
-        for (String colName : getDomainKind().getReservedPropertyNames(getDomain()))
+        for (String colName : getDomainKind().getReservedPropertyNames(getDomain(), null))
         {
             colNameMap.put(colName.toLowerCase(), colName);
         }
-        baseProps.addAll(getDomainKind().getReservedPropertyNames(getDomain()));
+        baseProps.addAll(getDomainKind().getReservedPropertyNames(getDomain(), null));
 
         setDescription("Contains a row for each issue created in this folder.");
 

--- a/issues/src/org/labkey/issue/query/IssuesTable.java
+++ b/issues/src/org/labkey/issue/query/IssuesTable.java
@@ -131,11 +131,11 @@ public class IssuesTable extends FilteredTable<IssuesQuerySchema> implements Upd
         IssuesQuerySchema schema = getUserSchema();
         Set<String> baseProps = new CaseInsensitiveHashSet();
         Map<String, String> colNameMap = new HashMap<>();
-        for (String colName : getDomainKind().getReservedPropertyNames(getDomain(), null))
+        for (String colName : getDomainKind().getReservedPropertyNames(getDomain(), schema.getUser()))
         {
             colNameMap.put(colName.toLowerCase(), colName);
         }
-        baseProps.addAll(getDomainKind().getReservedPropertyNames(getDomain(), null));
+        baseProps.addAll(getDomainKind().getReservedPropertyNames(getDomain(), schema.getUser()));
 
         setDescription("Contains a row for each issue created in this folder.");
 

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -405,7 +405,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
         {
             Domain d = list.getDomain();
 
-            Set<String> reservedNames = getReservedPropertyNames(d, null);
+            Set<String> reservedNames = getReservedPropertyNames(d, user);
             Set<String> lowerReservedNames = reservedNames.stream().map(String::toLowerCase).collect(Collectors.toSet());
 
             Map<DomainProperty, Object> defaultValues = new HashMap<>();

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -55,7 +55,6 @@ import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTIndex;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.lists.permissions.DesignListPermission;
-import org.labkey.api.lists.permissions.ManagePicklistsPermission;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
@@ -64,7 +63,6 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
-import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.data.xml.domainTemplate.DomainTemplateType;
 import org.labkey.data.xml.domainTemplate.ListOptionsType;
@@ -231,7 +229,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
     abstract Collection<KeyType> getSupportedKeyTypes();
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         Set<String> properties = new CaseInsensitiveHashSet();
         for (PropertyStorageSpec pss : BASE_PROPERTIES)
@@ -407,7 +405,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
         {
             Domain d = list.getDomain();
 
-            Set<String> reservedNames = getReservedPropertyNames(d);
+            Set<String> reservedNames = getReservedPropertyNames(d, null);
             Set<String> lowerReservedNames = reservedNames.stream().map(String::toLowerCase).collect(Collectors.toSet());
 
             Map<DomainProperty, Object> defaultValues = new HashMap<>();

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -1162,7 +1162,7 @@ public class ListManager implements SearchService.DocumentProvider
         if (null != ti)
         {
             Map<String, String> recordChangedMap = new CaseInsensitiveHashMap<>();
-            Set<String> reserved = list.getDomain().getDomainKind().getReservedPropertyNames(list.getDomain(), null);
+            Set<String> reserved = list.getDomain().getDomainKind().getReservedPropertyNames(list.getDomain(), user);
 
             // Match props to columns
             for (Map.Entry<String, Object> entry : props.entrySet())

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -1162,7 +1162,7 @@ public class ListManager implements SearchService.DocumentProvider
         if (null != ti)
         {
             Map<String, String> recordChangedMap = new CaseInsensitiveHashMap<>();
-            Set<String> reserved = list.getDomain().getDomainKind().getReservedPropertyNames(list.getDomain());
+            Set<String> reserved = list.getDomain().getDomainKind().getReservedPropertyNames(list.getDomain(), null);
 
             // Match props to columns
             for (Map.Entry<String, Object> entry : props.entrySet())

--- a/study/api-src/org/labkey/api/specimen/model/AbstractSpecimenDomainKind.java
+++ b/study/api-src/org/labkey/api/specimen/model/AbstractSpecimenDomainKind.java
@@ -42,7 +42,6 @@ import org.labkey.api.specimen.importer.RollupHelper;
 import org.labkey.api.specimen.importer.RollupInstance;
 import org.labkey.api.specimen.importer.VialSpecimenRollup;
 import org.labkey.api.study.SpecimenTablesTemplate;
-import org.labkey.api.study.StudyService;
 import org.labkey.api.study.StudyUrls;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
@@ -108,7 +107,7 @@ public abstract class AbstractSpecimenDomainKind extends BaseAbstractDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return new HashSet<>();
     }

--- a/study/api-src/org/labkey/api/specimen/model/SpecimenDomainKind.java
+++ b/study/api-src/org/labkey/api/specimen/model/SpecimenDomainKind.java
@@ -224,7 +224,7 @@ public final class SpecimenDomainKind extends AbstractSpecimenDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         Set<String> names = new HashSet<>();
         names.add(COMMENTS);

--- a/study/api-src/org/labkey/api/specimen/model/SpecimenEventDomainKind.java
+++ b/study/api-src/org/labkey/api/specimen/model/SpecimenEventDomainKind.java
@@ -265,7 +265,7 @@ public final class SpecimenEventDomainKind extends AbstractSpecimenDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         Set<String> names = new HashSet<>();
         names.add(COLUMN);

--- a/study/api-src/org/labkey/api/specimen/model/VialDomainKind.java
+++ b/study/api-src/org/labkey/api/specimen/model/VialDomainKind.java
@@ -228,7 +228,7 @@ public final class VialDomainKind extends AbstractSpecimenDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         Set<String> names = new HashSet<>();
         names.add(COMMENTS);

--- a/study/src/org/labkey/study/model/BaseStudyDomainKind.java
+++ b/study/src/org/labkey/study/model/BaseStudyDomainKind.java
@@ -22,6 +22,7 @@ import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.property.BaseAbstractDomainKind;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.security.User;
 
 import java.util.Set;
 
@@ -71,7 +72,7 @@ public abstract class BaseStudyDomainKind extends BaseAbstractDomainKind
     protected abstract TableInfo getTableInfo();
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         TableInfo table = getTableInfo();
         return table.getColumnNameSet();

--- a/study/src/org/labkey/study/model/ContinuousDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/ContinuousDatasetDomainKind.java
@@ -16,6 +16,7 @@
 package org.labkey.study.model;
 
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.security.User;
 import org.labkey.api.study.TimepointType;
 
 import java.util.Collections;
@@ -54,7 +55,7 @@ public class ContinuousDatasetDomainKind extends DatasetDomainKind
 
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         HashSet<String> fields = new HashSet<>(getStudySubjectReservedName(domain));
         fields.addAll(DatasetDefinition.DEFAULT_ABSOLUTE_DATE_FIELDS);

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -488,7 +488,7 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
                 Domain newDomain = def.getDomain();
                 if (newDomain != null)
                 {
-                    Set<String> reservedNames = getReservedPropertyNames(newDomain, null);
+                    Set<String> reservedNames = getReservedPropertyNames(newDomain, user);
                     Set<String> lowerReservedNames = reservedNames.stream().map(String::toLowerCase).collect(Collectors.toSet());
                     Set<String> existingProperties = newDomain.getProperties().stream().map(o -> o.getName().toLowerCase()).collect(Collectors.toSet());
                     Map<DomainProperty, Object> defaultValues = new HashMap<>();

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -281,7 +281,7 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
     }
 
     @Override
-    public abstract Set<String> getReservedPropertyNames(Domain domain);
+    public abstract Set<String> getReservedPropertyNames(Domain domain, User user);
 
     @Override
     public Set<PropertyStorageSpec> getBaseProperties(Domain domain)
@@ -488,7 +488,7 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
                 Domain newDomain = def.getDomain();
                 if (newDomain != null)
                 {
-                    Set<String> reservedNames = getReservedPropertyNames(newDomain);
+                    Set<String> reservedNames = getReservedPropertyNames(newDomain, null);
                     Set<String> lowerReservedNames = reservedNames.stream().map(String::toLowerCase).collect(Collectors.toSet());
                     Set<String> existingProperties = newDomain.getProperties().stream().map(o -> o.getName().toLowerCase()).collect(Collectors.toSet());
                     Map<DomainProperty, Object> defaultValues = new HashMap<>();

--- a/study/src/org/labkey/study/model/DateDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DateDatasetDomainKind.java
@@ -16,6 +16,7 @@
 package org.labkey.study.model;
 
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.security.User;
 import org.labkey.api.study.TimepointType;
 
 import java.util.Collections;
@@ -56,7 +57,7 @@ public class DateDatasetDomainKind extends DatasetDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         HashSet<String> fields = new HashSet<>(getStudySubjectReservedName(domain));
         fields.addAll(DatasetDefinition.DEFAULT_RELATIVE_DATE_FIELDS);

--- a/study/src/org/labkey/study/model/TestDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/TestDatasetDomainKind.java
@@ -17,6 +17,7 @@ package org.labkey.study.model;
 
 import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.security.User;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 
@@ -47,7 +48,7 @@ public class TestDatasetDomainKind extends DatasetDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return Collections.emptySet();
     }

--- a/study/src/org/labkey/study/model/VisitDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/VisitDatasetDomainKind.java
@@ -17,6 +17,7 @@ package org.labkey.study.model;
 
 import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.security.User;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.TimepointType;
@@ -56,7 +57,7 @@ public class VisitDatasetDomainKind extends DatasetDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         HashSet<String> fields = new HashSet<>(getStudySubjectReservedName(domain));
         fields.addAll(DatasetDefinition.DEFAULT_VISIT_FIELDS);

--- a/study/src/org/labkey/study/query/studydesign/AbstractStudyDesignDomainKind.java
+++ b/study/src/org/labkey/study/query/studydesign/AbstractStudyDesignDomainKind.java
@@ -174,7 +174,7 @@ public abstract class AbstractStudyDesignDomainKind extends BaseAbstractDomainKi
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         Set<String> names = new HashSet<>();
 


### PR DESCRIPTION
#### Rationale
In order for SimpleTable (extensible table) domains to be updated in startup scripts in EHR, we cannot rely on getting the user from HTTPView context. This passes through user in a couple spots to be used instead of HTTPView context.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/323

#### Changes
* Update DomainKind.getReservedPropertyNames with user parameter
* Update SimpleTableDomainKind to use passed in User (when available) for getTable and getReservedPropertyNames
* Update DomainUtil.validateProperties to pass through user
