### PR TITLE
Lists: improve support for cross-folder lists

### DIFF
--- a/api/src/org/labkey/api/exp/list/ListService.java
+++ b/api/src/org/labkey/api/exp/list/ListService.java
@@ -42,14 +42,16 @@ public interface ListService
     }
 
     Map<String, ListDefinition> getLists(Container container);
-    Map<String, ListDefinition> getLists(Container container, boolean includePicklists, boolean includeProjectAndShared);
-    Map<String, ListDefinition> getLists(Container container, User user, boolean checkVisibility);
+    Map<String, ListDefinition> getLists(Container container, @Nullable User user);
+    Map<String, ListDefinition> getLists(Container container, @Nullable User user, boolean checkVisibility);
+    Map<String, ListDefinition> getLists(Container container, @Nullable User user, boolean checkVisibility, boolean includePicklists, boolean includeProjectAndShared);
     boolean hasLists(Container container);
     boolean hasLists(Container container, boolean includeProjectAndShared);
     ListDefinition createList(Container container, String name, ListDefinition.KeyType keyType);
     ListDefinition createList(Container container, String name, ListDefinition.KeyType keyType, @Nullable TemplateInfo templateInfo, @Nullable ListDefinition.Category category);
     ListDefinition getList(Container container, int listId);
     @Nullable ListDefinition getList(Container container, String name);
+    @Nullable ListDefinition getList(Container container, String name, boolean includeProjectAndShared);
     ListDefinition getList(Domain domain);
     ActionURL getManageListsURL(Container container);
     UserSchema getUserSchema(User user, Container container);

--- a/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
+++ b/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
@@ -109,6 +109,13 @@ public class FileQueryUpdateService extends AbstractQueryUpdateService
 
         Map<String, Object> rowMap = new HashMap<>();
         Map<FieldKey, ColumnInfo> cols = QueryService.get().getColumns(getQueryTable(), queryColumns);
+
+        // Since we are fetching the "urlValue" of field properties we need to
+        // include any columns needed by the URL renderers to resolve.
+        for (ColumnInfo col : cols.values())
+            col.getRenderer().addQueryFieldKeys(queryColumns);
+        cols = QueryService.get().getColumns(getQueryTable(), queryColumns);
+
         try (Results results = new TableSelector(getQueryTable(), cols.values(), filter, null).getResults())
         {
             if (results.next())

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -367,7 +367,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
             throw new ApiUsageException("List name must not be null");
         if (name.length() > MAX_NAME_LENGTH)
             throw new ApiUsageException("List name cannot be longer than " + MAX_NAME_LENGTH + " characters");
-        if (ListService.get().getList(container, name) != null)
+        if (ListService.get().getList(container, name, false) != null)
             throw new ApiUsageException("The name '" + name + "' is already in use.");
         if (StringUtils.isEmpty(keyName))
             throw new ApiUsageException("List keyName must not be null");
@@ -496,7 +496,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
                 {
                     return exception.addGlobalError("List name cannot be longer than " + MAX_NAME_LENGTH + " characters.");
                 }
-                else if (ListService.get().getList(container, update.getName()) != null)
+                else if (ListService.get().getList(container, update.getName(), false) != null)
                 {
                     return exception.addGlobalError("The name '" + update.getName() + "' is already in use.");
                 }

--- a/list/src/org/labkey/list/model/ListImporter.java
+++ b/list/src/org/labkey/list/model/ListImporter.java
@@ -98,7 +98,7 @@ public class ListImporter
     {
         //Since we don't have a definition here, try to get one from the fileName & context
 
-        Map<String, ListDefinition> lists = ListService.get().getLists(c, user, false);
+        Map<String, ListDefinition> lists = getLists(c, user);
         ListDefinition def = lists.get(FileUtil.getBaseName(fileName));
 
         if (_importContext.getInputDataMap() != null)
@@ -354,7 +354,7 @@ public class ListImporter
             }
         }
 
-        Map<String, ListDefinition> lists = ListService.get().getLists(c, user, false);
+        Map<String, ListDefinition> lists = getLists(c, user);
         int failedLists = 0;
         int successfulLists = 0;
         for (String listName : lists.keySet())
@@ -537,7 +537,7 @@ public class ListImporter
 
         TablesType tablesXml = tablesDoc.getTables();
 
-        Map<String, ListDefinition> lists = ListService.get().getLists(c, user, false);
+        Map<String, ListDefinition> lists = getLists(c, user);
 
         for (TableType tableType : tablesXml.getTableArray())
         {
@@ -600,6 +600,12 @@ public class ListImporter
                 queryDef.setMetadataXml(null);
             */
         }
+    }
+
+    private Map<String, ListDefinition> getLists(Container c, User u)
+    {
+        // When importing lists we do not want to resolve lists in other containers
+        return ListService.get().getLists(c, u, false, true, false);
     }
 
     // This is a general-purpose validator importing class that should work for datasets and specimens as well as lists,

--- a/list/src/org/labkey/list/model/ListManagerSchema.java
+++ b/list/src/org/labkey/list/model/ListManagerSchema.java
@@ -124,9 +124,9 @@ public class ListManagerSchema extends UserSchema
     @Override
     public QueryView createView(ViewContext context, @NotNull QuerySettings settings, BindException errors)
     {
-        if (null != settings.getQueryName() && settings.getQueryName().equalsIgnoreCase(LIST_MANAGER))
+        if (LIST_MANAGER.equalsIgnoreCase(settings.getQueryName()))
         {
-            return new QueryView(this, settings, errors)
+            QueryView qv = new QueryView(this, settings, errors)
             {
                 QuerySettings s = getSettings();
 
@@ -235,6 +235,15 @@ public class ListManagerSchema extends UserSchema
                     }
                 }
             };
+
+            qv.setAllowableContainerFilterTypes(
+                ContainerFilter.Type.Current,
+                ContainerFilter.Type.CurrentAndSubfolders,
+                ContainerFilter.Type.CurrentPlusProjectAndShared,
+                ContainerFilter.Type.AllFolders
+            );
+
+            return qv;
         }
         return super.createView(context, settings, errors);
     }

--- a/list/src/org/labkey/list/model/ListManagerTable.java
+++ b/list/src/org/labkey/list/model/ListManagerTable.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.list.model;
 
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
@@ -34,7 +33,6 @@ import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.util.HtmlString;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -155,11 +153,5 @@ public class ListManagerTable extends FilteredTable<ListManagerSchema>
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
         return _userSchema.getContainer().hasPermission(this.getClass().getName() + " " + getName(), user, perm);
-    }
-
-    @Override
-    public List<FieldKey> getDefaultVisibleColumns()
-    {
-        return super.getDefaultVisibleColumns();
     }
 }

--- a/list/src/org/labkey/list/model/ListServiceImpl.java
+++ b/list/src/org/labkey/list/model/ListServiceImpl.java
@@ -52,13 +52,13 @@ public class ListServiceImpl implements ListService
     @Override
     public Map<String, ListDefinition> getLists(Container container)
     {
-        return getLists(container, null, false);
+        return getLists(container, null);
     }
 
     @Override
-    public Map<String, ListDefinition> getLists(Container container, boolean includePicklists, boolean includeProjectAndShared)
+    public Map<String, ListDefinition> getLists(Container container, @Nullable User user)
     {
-        return getLists(container, null, false, includePicklists, includeProjectAndShared);
+        return getLists(container, user, false);
     }
 
     @Override
@@ -67,7 +67,14 @@ public class ListServiceImpl implements ListService
         return getLists(container, user, checkVisibility, true, true);
     }
 
-    private Map<String, ListDefinition> getLists(Container container, @Nullable User user, boolean checkVisibility, boolean includePicklists, boolean includeProjectAndShared)
+    @Override
+    public Map<String, ListDefinition> getLists(
+        Container container,
+        @Nullable User user,
+        boolean checkVisibility,
+        boolean includePicklists,
+        boolean includeProjectAndShared
+    )
     {
         Map<String, ListDefinition> ret = new CaseInsensitiveHashMap<>();
         for (ListDef def : ListManager.get().getLists(container, user, checkVisibility, includePicklists, includeProjectAndShared))
@@ -115,9 +122,16 @@ public class ListServiceImpl implements ListService
     @Nullable
     public ListDefinition getList(Container container, String name)
     {
+        return getList(container, name, true);
+    }
+
+    @Override
+    @Nullable
+    public ListDefinition getList(Container container, String name, boolean includeProjectAndShared)
+    {
         if (name != null)
         {
-            for (ListDef def : ListManager.get().getLists(container))
+            for (ListDef def : ListManager.get().getLists(container, includeProjectAndShared))
             {
                 // DB stores actual name, but can be referenced with different case (#24476)
                 if (name.equalsIgnoreCase(def.getName()))

--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -276,7 +276,7 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
         setGridURL(gridURL);
 
         if (null != colKey)
-            setDetailsURL(new DetailsURL(_list.urlDetails(null, _userSchema.getContainer()), Collections.singletonMap("pk", colKey.getAlias())));
+            setDetailsURL(new DetailsURL(_list.urlDetails(null, _userSchema.getContainer()), Collections.singletonMap("pk", colKey.getName())));
 
         if (!listDef.getAllowUpload() || !_canAccessPhi)
             setImportURL(LINK_DISABLER);

--- a/list/src/org/labkey/list/model/ListWriter.java
+++ b/list/src/org/labkey/list/model/ListWriter.java
@@ -90,7 +90,7 @@ public class ListWriter
     {
         // We exclude picklists because they contain just sampleIds, which will be different in the new container.
         // Picklists are meant to be transient, so not including them in the export makes sense.
-        Map<String, ListDefinition> lists = ListService.get().getLists(c, false, true);
+        Map<String, ListDefinition> lists = ListService.get().getLists(c, user, false, false, true);
         PHI exportPhiLevel = (ctx != null) ? ctx.getPhiLevel() : PHI.NotPHI;
 
         if (!lists.isEmpty())

--- a/list/src/org/labkey/list/view/ListQueryView.java
+++ b/list/src/org/labkey/list/view/ListQueryView.java
@@ -18,24 +18,15 @@ package org.labkey.list.view;
 
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
-import org.labkey.api.data.DetailsColumn;
-import org.labkey.api.data.DisplayColumn;
-import org.labkey.api.data.RenderContext;
-import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.list.ListDefinition;
 import org.labkey.api.lists.permissions.DesignListPermission;
-import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
-import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DataView;
 import org.labkey.list.model.ListQuerySchema;
 import org.springframework.validation.BindException;
-
-import java.util.HashSet;
-import java.util.Set;
 
 public class ListQueryView extends QueryView
 {
@@ -88,20 +79,5 @@ public class ListQueryView extends QueryView
     public ListDefinition getList()
     {
         return _list;
-    }
-
-    @Override
-    protected DisplayColumn createDetailsColumn(StringExpression urlDetails, TableInfo table)
-    {
-        return new DetailsColumn(urlDetails, table)
-        {
-            @Override
-            public boolean areURLExpressionValuesPresent(RenderContext ctx)
-            {
-                Set<FieldKey> fieldKeys = new HashSet<>();
-                table.getPkColumns().forEach(column -> fieldKeys.add(new FieldKey(null, column.getAlias())));
-                return getURLExpression().canRender(fieldKeys);
-            }
-        };
     }
 }

--- a/list/src/org/labkey/list/view/ListsWebPart.java
+++ b/list/src/org/labkey/list/view/ListsWebPart.java
@@ -85,7 +85,7 @@ public class ListsWebPart extends WebPartView<ViewContext>
 
     private void renderNarrowView(ViewContext model, PrintWriter out)
     {
-        Map<String, ListDefinition> lists = ListService.get().getLists(model.getContainer(), model.getUser(), true);
+        Map<String, ListDefinition> lists = ListService.get().getLists(model.getContainer(), model.getUser(), true, true, false);
         out.write("<table>");
         if (lists.isEmpty())
         {

--- a/list/src/org/labkey/list/view/listsWebPart.jsp
+++ b/list/src/org/labkey/list/view/listsWebPart.jsp
@@ -37,7 +37,7 @@
     assert null != me;
     Container c = getContainer();
     User user = getUser();
-    Map<String, ListDefinition> lists = ListService.get().getLists(c, getUser(), true);
+    Map<String, ListDefinition> lists = ListService.get().getLists(c, getUser(), true, true, false);
     NavTree links;
 %>
 <table id="lists">

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -1410,7 +1410,7 @@ public class QueryServiceImpl implements QueryService
                 }
 
                 for (ColumnInfo column : pkColumns)
-                    pkColumnMap.add(new FieldKey(null, column.getAlias()));
+                    pkColumnMap.add(new FieldKey(null, column.getName()));
 
                 titleURL = table.getDetailsURL(pkColumnMap, null);
             }


### PR DESCRIPTION
#### Rationale
This PR addresses a few inconsistencies that came about with #3001 with regards to cross-folder support for lists. The main thing is that when creating or importing a list definition we will now only resolve against lists within the target folder. This restores the behavior where a user could define a list with the same name in a subfolder.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3001

#### Changes
* Lists: create/import list resolves only lists current folder
* ListService: telescope getLists() signatures
* ListWebPart: only display lists from current folder
* ListManager: display `CurrentPlusProjectAndShared` in the UI
