### PR TITLE
Lists: use FieldKey in DetailsURL to allow for URL encoding

### DIFF
--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -276,7 +276,7 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
         setGridURL(gridURL);
 
         if (null != colKey)
-            setDetailsURL(new DetailsURL(_list.urlDetails(null, _userSchema.getContainer()), Collections.singletonMap("pk", colKey.getName())));
+            setDetailsURL(new DetailsURL(_list.urlDetails(null, _userSchema.getContainer()), "pk", colKey.getFieldKey()));
 
         if (!listDef.getAllowUpload() || !_canAccessPhi)
             setImportURL(LINK_DISABLER);


### PR DESCRIPTION
#### Rationale
Construction of `DetailsURL` in lists should use `getFieldKey()` from key column instead of `getName()`. This allows for `DetailURL` to ensure the value is properly URL encoded.

#### Related Pull Requests
* #3001 
* #3015

#### Changes
* Use `getFieldKey()` instead of `getName()` to ensure proper URL encoding.
