### PR TITLE
Revert "Issue 44749: Rendering query grid uses two DB connections"

### DIFF
--- a/api/src/org/labkey/api/data/AsyncQueryRequest.java
+++ b/api/src/org/labkey/api/data/AsyncQueryRequest.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.data;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.queryprofiler.QueryProfiler;
@@ -24,7 +25,6 @@ import org.labkey.api.miniprofiler.RequestInfo;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.UnexpectedException;
-import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.MockHttpResponseWithRealPassthrough;
 
 import javax.servlet.http.HttpServletResponse;
@@ -36,7 +36,7 @@ import java.util.concurrent.Callable;
 
 public class AsyncQueryRequest<T>
 {
-    private static final Logger _log = LogHelper.getLogger(AsyncQueryRequest.class, "Runs DB queries on a background thread");
+    private static final Logger _log = LogManager.getLogger(AsyncQueryRequest.class);
 
     private static class CancelledException extends RuntimeException
     {
@@ -161,14 +161,15 @@ public class AsyncQueryRequest<T>
 
                     if (_exception instanceof RuntimeSQLException)
                         _exception = ((RuntimeSQLException)_exception).getSQLException();
-                    if (_exception instanceof SQLException sqlE)
+                    if (_exception instanceof SQLException)
                     {
+                        SQLException sqlE = (SQLException) _exception;
                         SQLException sqlE2 = new SQLException(sqlE.getMessage(), sqlE.getSQLState(), sqlE.getErrorCode());
                         sqlE2.setNextException(sqlE);
                         throw sqlE2;
                     }
 
-                    throw UnexpectedException.wrap(_exception);
+                    throw new UnexpectedException(_exception);
                 }
 
                 if (clientDisconnectException == null)

--- a/api/src/org/labkey/api/data/ConnectionWrapper.java
+++ b/api/src/org/labkey/api/data/ConnectionWrapper.java
@@ -119,7 +119,7 @@ public class ConnectionWrapper implements java.sql.Connection
         _allocatingThreadName = Thread.currentThread().getName();
         _referencingThreadNames.add(_allocatingThreadName);
 
-        type.trackConnection(_openConnections, this);
+        _openConnections.put(this, new Pair<>(Thread.currentThread(), new Throwable()));
 
         _log = log != null ? log : getConnectionLogger();
     }

--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -833,29 +833,19 @@ public class DataRegion extends DisplayElement
 
             if (countAggregate)
             {
-                if (baseAggregates.isEmpty() && _complete && results.getSize() >= 0)
-                {
-                    // Issue 44749. Don't need to do a separate aggregate query as we already know how many rows
-                    // came back and that it was the complete results
-                    _totalRows = Long.valueOf(results.getSize());
-                    _aggregateResults = Collections.emptyMap();
-                }
-                else
-                {
-                    List<Aggregate> newAggregates = new LinkedList<>(baseAggregates);
+                List<Aggregate> newAggregates = new LinkedList<>(baseAggregates);
 
-                    newAggregates.add(Aggregate.createCountStar());
-                    _aggregateResults = ctx.getAggregates(_displayColumns, getTable(), getSettings(), getName(), newAggregates, getQueryParameters(), isAllowAsync());
-                    List<Aggregate.Result> result = _aggregateResults.remove(Aggregate.STAR);
+                newAggregates.add(Aggregate.createCountStar());
+                _aggregateResults = ctx.getAggregates(_displayColumns, getTable(), getSettings(), getName(), newAggregates, getQueryParameters(), isAllowAsync());
+                List<Aggregate.Result> result = _aggregateResults.remove(Aggregate.STAR);
 
-                    //Issue 14863: add null check
-                    if (result != null && result.size() > 0)
-                    {
-                        Aggregate.Result countStarResult = result.get(0);
-                        _totalRows = 0L;
-                        if (countStarResult.getValue() instanceof Number)
-                            _totalRows = ((Number) countStarResult.getValue()).longValue();
-                    }
+                //Issue 14863: add null check
+                if (result != null && result.size() > 0)
+                {
+                    Aggregate.Result countStarResult = result.get(0);
+                    _totalRows = 0L;
+                    if (countStarResult.getValue() instanceof Number)
+                        _totalRows = ((Number) countStarResult.getValue()).longValue();
                 }
             }
             else

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -796,29 +796,9 @@ public class DbScope
             {
                 closer.close();
             }
-        },
-        /** Someone else is going to be responsible for closing the connection */
-        Piggyback()
-        {
-            @Override
-            void close(DbScope scope, Connection conn, Closer closer)
-            {
-                // Intentional no-op
-            }
-
-            @Override
-            public void trackConnection(Map<ConnectionWrapper, Pair<java.lang.Thread, Throwable>> _openConnections, ConnectionWrapper wrapper)
-            {
-                // Intentional no-op - rely on the originating ConnectionWrapper to do the tracking for us
-            }
         };
 
         abstract void close(DbScope scope, Connection conn, Closer closer) throws SQLException;
-
-        public void trackConnection(Map<ConnectionWrapper, Pair<java.lang.Thread, Throwable>> _openConnections, ConnectionWrapper wrapper)
-        {
-            _openConnections.put(wrapper, Pair.of(java.lang.Thread.currentThread(), new Throwable()));
-        }
     }
 
     private class ConnectionHolder
@@ -1071,16 +1051,6 @@ public class DbScope
         if (!conn.getAutoCommit())
             throw new ConfigurationException("A database connection is in an unexpected state: auto-commit is false. This indicates a configuration problem with the datasource definition or the database connection pool.");
 
-        return wrap(conn, type, log);
-    }
-
-    @NotNull
-    public ConnectionWrapper wrap(Connection conn, ConnectionType type, @Nullable Logger log) throws SQLException
-    {
-        if (conn instanceof ConnectionWrapper wrapper)
-        {
-            return wrapper;
-        }
         //
         // Handle one time per-connection setup
         // relies on pool implementation reusing same connection/wrapper instances

--- a/api/src/org/labkey/api/data/RenderContext.java
+++ b/api/src/org/labkey/api/data/RenderContext.java
@@ -40,7 +40,6 @@ import org.springframework.validation.ObjectError;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.Serializable;
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -399,25 +398,7 @@ public class RenderContext implements Map<String, Object>, Serializable
 
         if (!aggregates.isEmpty())
         {
-            Results r = getResults();
-            TableSelector selector = new TableSelector(tinfo, cols, filter, null)
-            {
-                @Override
-                public Connection getConnection() throws SQLException
-                {
-                    // Issue 44749. Piggyback on the primary results DB connection if possible so that we don't end
-                    // up using two concurrently
-                    if (r != null && r.getStatement() != null)
-                    {
-                        Connection conn = r.getStatement().getConnection();
-                        if (conn != null && !conn.isClosed())
-                        {
-                            return getScope().wrap(conn, DbScope.ConnectionType.Piggyback, null);
-                        }
-                    }
-                    return super.getConnection();
-                }
-            }.setNamedParameters(parameters);
+            TableSelector selector = new TableSelector(tinfo, cols, filter, null).setNamedParameters(parameters);
 
             if (async)
                 return selector.getAggregatesAsync(aggregates, getViewContext().getResponse());

--- a/api/src/org/labkey/api/data/TableSelector.java
+++ b/api/src/org/labkey/api/data/TableSelector.java
@@ -17,6 +17,7 @@
 package org.labkey.api.data;
 
 import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -25,11 +26,9 @@ import org.labkey.api.data.Aggregate.Result;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
-import org.labkey.api.util.logging.LogHelper;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -48,7 +47,7 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
 {
     public static final Set<String> ALL_COLUMNS = Collections.emptySet();
 
-    private static final Logger LOG = LogHelper.getLogger(TableSelector.class, "Runs DB queries against TableInfos");
+    private static final Logger LOG = LogManager.getLogger(TableSelector.class);
 
     private final TableInfo _table;
     private final Collection<ColumnInfo> _columns;
@@ -432,7 +431,7 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
                 // Issue 17536: Issue a warning instead of blowing up if there is no result row containing the aggregate values.
                 if (!rs.next())
                 {
-                    LOG.warn("Expected a non-empty resultset from aggregate query.");
+                    LogManager.getLogger(TableSelector.class).warn("Expected a non-empty resultset from aggregate query.");
                 }
                 else
                 {


### PR DESCRIPTION
This reverts commit 7a6f319e4eacff8c0ee9179fffcd93e4210c9cb8.

#### Rationale
I thought I had fixed a problem but it appears to be intermittent. Example failures:

https://teamcity.labkey.org/buildConfiguration/bt7/1701396?buildTab=tests&expandedTest=build%3A%28id%3A1701396%29%2Cid%3A1680

https://teamcity.labkey.org/buildConfiguration/bt8/1701394?showRootCauses=false&expandBuildChangesSection=true&expandBuildTestsSection=true

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2989

#### Changes
* Undo attempted fix, to be revisited