### PR TITLE
Update newUploadWarnings.jsp to use protocol.getRowId() instead of getting it from the form object

### DIFF
--- a/api/src/org/labkey/api/assay/actions/newUploadWarnings.jsp
+++ b/api/src/org/labkey/api/assay/actions/newUploadWarnings.jsp
@@ -37,7 +37,7 @@
     JspView<AssayRunUploadForm> me = (JspView<AssayRunUploadForm>) HttpView.currentView();
     AssayRunUploadForm<? extends AssayProvider> bean = me.getModelBean();
 
-    ActionURL returnURL = urlFor(AssayRunsAction.class).addParameter("rowId", bean.getRowId())
+    ActionURL returnURL = urlFor(AssayRunsAction.class).addParameter("rowId", bean.getProtocol().getRowId())
             .addParameter("uploadAttemptID", bean.getUploadAttemptID());
 
     if (bean.getTransformResult().getWarnings() != null)


### PR DESCRIPTION
#### Rationale
The crawler hit an NPE when running the FlagColumnTest because it was trying to use the assay protocol RowId from the URL form bean. This PR updates that to get the protocol RowId from the form.getProtocol() object instead.

#### Changes
* Update newUploadWarnings.jsp to use protocol.getRowId() instead of getting it from the form object
