### PR TITLE
Issue 43529: OntologyManager.updateObjectProperty() update to attempt looking up value by display value on ConversionException

### DIFF
--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -28,7 +28,6 @@ import org.labkey.api.assay.pipeline.AssayUploadPipelineJob;
 import org.labkey.api.assay.plate.PlateMetadataDataHandler;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.DbScope;
@@ -71,7 +70,6 @@ import org.labkey.api.qc.TransformDataHandler;
 import org.labkey.api.qc.TransformResult;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.PropertyValidationError;
-import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.SimpleValidationError;
 import org.labkey.api.query.ValidationError;
 import org.labkey.api.query.ValidationException;
@@ -1209,8 +1207,7 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
                 boolean skipError = false;
                 if (lookup != null)
                 {
-                    Container container = lookup.getContainer() != null ? lookup.getContainer() : context.getContainer();
-                    Object remappedValue = cache.remap(SchemaKey.fromParts(lookup.getSchemaName()), lookup.getQueryName(), context.getUser(), container, ContainerFilter.Type.CurrentPlusProjectAndShared, value);
+                    Object remappedValue = OntologyManager.getRemappedValueForLookup(context.getUser(), context.getContainer(), cache, lookup, value);
                     if (remappedValue != null)
                         skipError = true;
                 }

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -23,7 +23,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.DbSequenceManager;
@@ -39,7 +38,6 @@ import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyDescriptor;
-import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
@@ -55,7 +53,6 @@ import org.labkey.api.qc.DataStateManager;
 import org.labkey.api.qc.SampleStatusService;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryRowReference;
-import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
@@ -628,8 +625,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
                     boolean skipError = false;
                     if (dp.getLookup() != null)
                     {
-                        Container container = dp.getLookup().getContainer() != null ? dp.getLookup().getContainer() : getContainer();
-                        Object remappedValue = cache.remap(SchemaKey.fromParts(dp.getLookup().getSchemaName()), dp.getLookup().getQueryName(), user, container, ContainerFilter.Type.CurrentPlusProjectAndShared, String.valueOf(value));
+                        Object remappedValue = OntologyManager.getRemappedValueForLookup(user, getContainer(), cache, dp.getLookup(), value);
                         if (remappedValue != null)
                         {
                             value = remappedValue;


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43529

When the LK UI creates an input form and has a domain field with a lookup to a table with > 10,000 rows we will often show a text input instead of trying to render a select input. In many of those cases, we will try to resolve the lookup first by the value and then by the display value (via a RemapCache) when the user enters a value into that text input. The assay run upload batch and run properties form was not doing this "attempt to resolve lookup by display value" and was instead showing an error (see issue 43529).

This PR supports that assay batch/run property case by catching the ConversionException and attempting to resolve by the lookup display value. It also refactors a few other usages to use a new, shared OntologyManager.getRemappedValueForLookup() helper.

#### Changes
* Add OntologyManager.getRemappedValueForLookup() helper
* Catch ConversionException and retry with display value for lookup via getRemappedValueForLookup() in assay run prop case
