### PR TITLE
Update AssayFileWriter temp file name to include milliseconds

### DIFF
--- a/api/src/org/labkey/api/assay/AssayFileWriter.java
+++ b/api/src/org/labkey/api/assay/AssayFileWriter.java
@@ -117,7 +117,7 @@ public class AssayFileWriter<ContextType extends AssayRunUploadContext<? extends
     public static File createFile(ExpProtocol protocol, File dir, String extension)
     {
         Date dateCreated = new Date();
-        String dateString = DateUtil.formatDateTime(dateCreated, "yyy-MM-dd-HHmmss");
+        String dateString = DateUtil.formatDateTime(dateCreated, "yyy-MM-dd-HHmmss-SSS");
         int id = 0;
 
         String protocolName = protocol.getName();


### PR DESCRIPTION
#### Rationale
As mentioned in the TeamCity triage note for this failure, it looks like if "Save and Import Another Run" is used by the tests for multiple assay run creation (i.e. AssayExportImportTest failure), it can go so fast the the temp file names used for the assay data aren't unique and some runs are stomping on each other. This PR adds in milliseconds into the temp file name.

#### Changes
* Update AssayFileWriter temp file name to include milliseconds
