### PR TITLE
Improve error message when a DB connection can't be created

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1045,7 +1045,13 @@ public class DbScope
         }
         catch (SQLException e)
         {
-            throw new ConfigurationException("Can't create a database connection to " + getDataSource().toString(), e);
+            String message = "Can't create a database connection for data source " + getDbScopeLoader().getDsName();
+            try
+            {
+                message += " to URL " + getDbScopeLoader().getDsProps().getUrl();
+            }
+            catch (ServletException ignored) {}
+            throw new ConfigurationException(message, e);
         }
 
         if (!conn.getAutoCommit())

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1045,13 +1045,7 @@ public class DbScope
         }
         catch (SQLException e)
         {
-            String message = "Can't create a database connection for data source " + getDbScopeLoader().getDsName();
-            try
-            {
-                message += " to URL " + getDbScopeLoader().getDsProps().getUrl();
-            }
-            catch (ServletException ignored) {}
-            throw new ConfigurationException(message, e);
+            throw new ConfigurationException("Can't create a database connection for data source " + getDbScopeLoader().getDsName(), e);
         }
 
         if (!conn.getAutoCommit())


### PR DESCRIPTION
#### Rationale
toString() on DataSource is pretty useless, meaning we get a message like:

Can't create a database connection to org.apache.tomcat.dbcp.dbcp2.BasicDataSource@269d3b6b

#### Changes
* Include DataSource name and URL instead of useless toString()