### PR TITLE
44704: Data Views checkbox for "queries" should read "grid views"

### DIFF
--- a/api/webapp/ext-4.2.1/ext-patches.js
+++ b/api/webapp/ext-4.2.1/ext-patches.js
@@ -1066,7 +1066,7 @@ Ext4.override(Ext4.tree.Column, {
 // EXTJS-13334 Tooltip is horizontally squished in Safari
 //
 // This override was found in a stackoverflow posting : https://stackoverflow.com/questions/15834689/extjs-4-2-tooltips-not-wide-enough-to-see-contents
-if (Ext4.isSafari || Ext4.isGecko) {
+if (Ext4.isSafari || Ext4.isGecko || Ext4.isChrome) {
     Ext4.override(Ext4.tip.QuickTip, {
         helperElId: 'ext-quicktips-tip-helper',
         initComponent: function ()

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -2733,6 +2733,7 @@ public class ReportsController extends SpringActionController
 
                 info.put("name", type.getName());
                 info.put("visible", visible);
+                info.put("description", type.getDescription());
 
                 types.put(type.getName(), info);
 

--- a/query/src/org/labkey/query/view/InheritedQueryDataViewProvider.java
+++ b/query/src/org/labkey/query/view/InheritedQueryDataViewProvider.java
@@ -27,7 +27,8 @@ import org.labkey.api.view.ViewContext;
  */
 public class InheritedQueryDataViewProvider extends AbstractQueryDataViewProvider
 {
-    public static final DataViewProvider.Type TYPE = new ProviderType("queries (inherited)", "Inherited Custom Views", false);
+    public static final DataViewProvider.Type TYPE = new ProviderType("grid views (inherited)", "Inherited grid views can be shown if the " +
+            "custom view in the parent folder has been saved with the inherit check box selected. Only certain data types can be inherited.", false);
 
     @Override
     public DataViewProvider.Type getType()

--- a/query/src/org/labkey/query/view/QueryDataViewProvider.java
+++ b/query/src/org/labkey/query/view/QueryDataViewProvider.java
@@ -35,7 +35,7 @@ import java.util.Map;
  */
 public class QueryDataViewProvider extends AbstractQueryDataViewProvider
 {
-    public static final DataViewProvider.Type TYPE = new ProviderType("queries", "Custom Views", true);
+    public static final DataViewProvider.Type TYPE = new ProviderType("grid views", "", true);
 
     @Override
     public DataViewProvider.Type getType()

--- a/query/webapp/dataview/DataViewsPanel.js
+++ b/query/webapp/dataview/DataViewsPanel.js
@@ -1143,15 +1143,22 @@ Ext4.define('LABKEY.ext4.DataViewsPanel', {
             sizeItems = [];
 
         if (Ext4.isArray(data.types)) {
-            for (var i=0; i < data.types.length; i++) {
-                cbItems.push({
-                    boxLabel: data.types[i].name,
-                    name: data.types[i].name,
-                    checked: data.types[i].visible,
+            Ext4.each(data.types, function(type) {
+
+                var item = {
+                    boxLabel: type.name,
+                    name: type.name,
+                    checked: type.visible,
                     width: 150,
                     uncheckedValue : '0'
-                });
-            }
+                };
+
+                // include the description as a tooltip on the element box label
+                if (type.description.length > 0)
+                    item.afterBoxLabelTpl = '<a href="#" data-qtip="' + type.description + '"><span class="labkey-help-pop-up">?</span></a>';
+
+                cbItems.push(item);
+            }, this);
         }
 
         if (data.visibleColumns) {

--- a/study/src/org/labkey/study/dataset/DatasetViewProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetViewProvider.java
@@ -61,7 +61,7 @@ import java.util.Map;
  */
 public class DatasetViewProvider implements DataViewProvider
 {
-    public static final DataViewProvider.Type TYPE = new ProviderType("datasets", "Provides a view of Study Datasets", true);
+    public static final DataViewProvider.Type TYPE = new ProviderType("datasets", "", true);
 
     @Override
     public DataViewProvider.Type getType()

--- a/study/src/org/labkey/study/reports/ReportViewProvider.java
+++ b/study/src/org/labkey/study/reports/ReportViewProvider.java
@@ -68,7 +68,7 @@ import java.util.Map;
  */
 public class ReportViewProvider implements DataViewProvider
 {
-    public static final DataViewProvider.Type TYPE = new ProviderType("reports", "Report Views", true);
+    public static final DataViewProvider.Type TYPE = new ProviderType("reports", "", true);
 
     @Override
     public DataViewProvider.Type getType()


### PR DESCRIPTION
#### Rationale
The data views option to show : queries only actually apply to gird views. To help clarify that, we are renaming the label to
- grid views
- grid views (inherited)

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44704

#### Changes
- Rename checkbox labels
- Add a tooltip for the data view type description, improved the inherited grid view description to help users understand better.
- Discovered that chrome was truncating Ext4 tooltips, updated ext-patches to apply the fix that was previously limited to `firefox` and `safari`