### PR TITLE
Issue 44835: LKSM: Unable to use MaterialInputs/SampleTypeName in naming pattern

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -876,17 +876,26 @@ public class NameGenerator
                             throw new UnsupportedOperationException(errorMsg);
                     }
 
-                    if (_parentTable == null && domainFields.isEmpty())
+                    if (isLineagePart)
                     {
-                        String errorMsg = "Parent table is required for name expressions with lookups: " + fkTok + ".";
-                        if (_validateSyntax)
-                            _syntaxErrors.add(errorMsg);
-                        else
-                            throw new UnsupportedOperationException(errorMsg);
+                        boolean isInput = sTok.startsWith(INPUT_PARENT.toLowerCase());
+                        boolean isMaterial = sTok.startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase());
+                        Object preview = isInput ? SubstitutionValue.Inputs.getPreviewValue() : (isMaterial ? SubstitutionValue.MaterialInputs.getPreviewValue() : SubstitutionValue.DataInputs.getPreviewValue());
+                        previewCtx.put(fkTok.toString(), preview);
                     }
+                    else
+                    {
+                        if (_parentTable == null && domainFields.isEmpty())
+                        {
+                            String errorMsg = "Parent table is required for name expressions with lookups: " + fkTok + ".";
+                            if (_validateSyntax)
+                                _syntaxErrors.add(errorMsg);
+                            else
+                                throw new UnsupportedOperationException(errorMsg);
+                        }
 
-                    if (!isLineagePart)
                         lookups.add(fkTok);
+                    }
                 }
             }
         }
@@ -2269,7 +2278,7 @@ public class NameGenerator
 
             validateNameResult("S-${Inputs/a/b/d}", withErrors("Only one level of lookup is supported for lineage input: Inputs/a/b/d."));
 
-            validateNameResult("S-${Inputs/SampleTypeNotExist}", withErrors("Parent input does not exist: Inputs/SampleTypeNotExist"));
+            validateNameResult("S-${Inputs/SampleTypeNotExist}", withErrors("Lineage lookup field does not exist: Inputs/SampleTypeNotExist"));
         }
 
         @Test

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -590,6 +590,7 @@ public class NameGenerator
     {
         boolean isMaterial = inputPrefix.toLowerCase().startsWith("materialinputs") || inputPrefix.toLowerCase().startsWith("inputs");
         boolean isData = inputPrefix.toLowerCase().startsWith("datainputs") || inputPrefix.toLowerCase().startsWith("inputs");
+        boolean isInput = isMaterial && isData; // "Inputs"
         switch (inputDataTypeOrLookupField.toLowerCase())
         {
             case "rowid":
@@ -641,7 +642,7 @@ public class NameGenerator
             List<String> dataTypeNames = dataTypes.stream().map(Identifiable::getName).toList();
 
             if (dataTypeNames.contains(inputDataTypeOrLookupField) || inputDataTypeOrLookupField.equals(currentDataType))
-                return isMaterial && isData ? SubstitutionValue.Inputs.getPreviewValue() : (isMaterial ? SubstitutionValue.MaterialInputs.getPreviewValue() : SubstitutionValue.DataInputs.getPreviewValue());
+                return isInput ? SubstitutionValue.Inputs.getPreviewValue() : (isMaterial ? SubstitutionValue.MaterialInputs.getPreviewValue() : SubstitutionValue.DataInputs.getPreviewValue());
         }
 
         for (ExpObject dataType : dataTypes)

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -282,10 +282,10 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
         return domain.getContainer().hasPermission(user, DesignDataClassPermission.class);
     }
 
-    private @NotNull ValidationException getNamePatternValidationResult(String patten, List<? extends GWTPropertyDescriptor> properties, @Nullable Map<String, String> importAliases, Container container)
+    private @NotNull ValidationException getNamePatternValidationResult(String dataClassName, String patten, List<? extends GWTPropertyDescriptor> properties, @Nullable Map<String, String> importAliases, Container container)
     {
         ValidationException errors = new ValidationException();
-        NameExpressionValidationResult results = NameGenerator.getValidationMessages(patten, properties, importAliases, container);
+        NameExpressionValidationResult results = NameGenerator.getValidationMessages(dataClassName, patten, properties, importAliases, container);
         if (results.errors() != null && !results.errors().isEmpty())
             results.errors().forEach(error -> errors.addError(new SimpleValidationError(error)));
         return errors;
@@ -300,7 +300,7 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
             List<String> warnings = new ArrayList<>();
             List<String> previewNames = new ArrayList<>();
 
-            NameExpressionValidationResult results = NameGenerator.getValidationMessages(options.getNameExpression(), domainDesign.getFields(), null, container);
+            NameExpressionValidationResult results = NameGenerator.getValidationMessages(domainDesign.getName(), options.getNameExpression(), domainDesign.getFields(), null, container);
             if (results.errors() != null && !results.errors().isEmpty())
                 results.errors().forEach(error -> errors.add("Name Pattern error: " + error));
             if (results.warnings() != null && !results.warnings().isEmpty())
@@ -319,7 +319,7 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
         super.validateOptions(container, user, options, name, domain, updatedDomainDesign);
         if (StringUtils.isNotBlank(options.getNameExpression()))
         {
-            ValidationException errors = getNamePatternValidationResult(options.getNameExpression(), updatedDomainDesign.getFields(), null, container);
+            ValidationException errors = getNamePatternValidationResult(name, options.getNameExpression(), updatedDomainDesign.getFields(), null, container);
             if (errors.hasErrors())
                 throw new IllegalArgumentException(errors.getMessage());
         }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1503,6 +1503,8 @@ public class ExperimentServiceImpl implements ExperimentService
         // First attempt to resolve by name.
         try
         {
+            // TODO, rowId is not found for samples newly created in the same import.
+            // This is causing name patterns containing lineage lookup to fail to generate the correct names if the child samples and their parents are created from the same import file
             Integer rowId = (sampleTypeName == null) ?
                     cache.remap(ExpSchema.SCHEMA_EXP, ExpSchema.TableType.Materials.name(), user, c, ContainerFilter.Type.CurrentPlusProjectAndShared, sampleName) :
                     cache.remap(SamplesSchema.SCHEMA_SAMPLES, sampleTypeName, user, c, ContainerFilter.Type.CurrentPlusProjectAndShared, sampleName);

--- a/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
+++ b/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
@@ -337,7 +337,7 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
         List<String> previewNames = new ArrayList<>();
         if (StringUtils.isNotBlank(options.getNameExpression()))
         {
-            NameExpressionValidationResult results = NameGenerator.getValidationMessages(options.getNameExpression(), domainDesign.getFields(), options.getImportAliases(), container);
+            NameExpressionValidationResult results = NameGenerator.getValidationMessages(domainDesign.getName(), options.getNameExpression(), domainDesign.getFields(), options.getImportAliases(), container);
             if (results.errors() != null && !results.errors().isEmpty())
                 results.errors().forEach(error -> errors.add("Name Pattern error: " + error));
             if (results.warnings() != null && !results.warnings().isEmpty())
@@ -352,7 +352,7 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
 
         if (StringUtils.isNotBlank(options.getAliquotNameExpression()))
         {
-            NameExpressionValidationResult results = NameGenerator.getValidationMessages(options.getAliquotNameExpression(), domainDesign.getFields(), options.getImportAliases(), container);
+            NameExpressionValidationResult results = NameGenerator.getValidationMessages(domainDesign.getName(), options.getAliquotNameExpression(), domainDesign.getFields(), options.getImportAliases(), container);
             if (results.errors() != null && !results.errors().isEmpty())
                 results.errors().forEach(error -> errors.add("Aliquot Name Pattern error: " + error));
             if (results.warnings() != null && !results.warnings().isEmpty())
@@ -365,10 +365,10 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
         return new NameExpressionValidationResult(errors, warnings, previewNames);
     }
 
-    private @NotNull ValidationException getNamePatternValidationResult(String patten, List<? extends GWTPropertyDescriptor> properties, @Nullable Map<String, String> importAliases, Container container)
+    private @NotNull ValidationException getNamePatternValidationResult(String currentSampleType, String patten, List<? extends GWTPropertyDescriptor> properties, @Nullable Map<String, String> importAliases, Container container)
     {
         ValidationException errors = new ValidationException();
-        NameExpressionValidationResult results = NameGenerator.getValidationMessages(patten, properties, importAliases, container);
+        NameExpressionValidationResult results = NameGenerator.getValidationMessages(currentSampleType, patten, properties, importAliases, container);
         if (results.errors() != null && !results.errors().isEmpty())
             results.errors().forEach(error -> errors.addError(new SimpleValidationError(error)));
         return errors;
@@ -486,14 +486,14 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
         String errorMsg = "";
         if (StringUtils.isNotBlank(options.getNameExpression()))
         {
-            ValidationException errors = getNamePatternValidationResult(options.getNameExpression(), properties, aliasMap, container);
+            ValidationException errors = getNamePatternValidationResult(name, options.getNameExpression(), properties, aliasMap, container);
             if (errors.hasErrors())
                 errorMsg += "Invalid Name Expression:" + errors.getMessage();
         }
 
         if (StringUtils.isNotBlank(options.getAliquotNameExpression()))
         {
-            ValidationException errors = getNamePatternValidationResult(options.getAliquotNameExpression(), properties, aliasMap, container);
+            ValidationException errors = getNamePatternValidationResult(name, options.getAliquotNameExpression(), properties, aliasMap, container);
             if (errors.hasErrors())
                 errorMsg += "Invalid Aliquot Name Expression:" + errors.getMessage();
         }


### PR DESCRIPTION
#### Rationale
When support for lineage lookup in name expression was added, expression containing 2 parts can be interpreted as  both lookup or regular parent input: Inputs/Fields, Inputs/SampleType1. However, the change caused regression in recognizing Inputs/SampleType1 as parent input and rejected it as a lookup, because SampleType1 is not a sample property field. 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
