### PR TITLE
Help user understand why a clipboard copy failed

### DIFF
--- a/pipeline/src/org/labkey/pipeline/status/details.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/details.jsp
@@ -343,7 +343,11 @@
                     },
                     function () {
                         e.target.innerHTML = "Copy failed. Ensure the browser's security policy allows clipboard APIs and the page is using HTTPS.";
-                    });
+                    }).catch(function(error) {
+                        console.log(error);
+                        e.target.innerText = "Copy failed: " + error;
+                    }
+            );
         }
     }
 

--- a/pipeline/src/org/labkey/pipeline/status/details.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/details.jsp
@@ -333,13 +333,17 @@
 
     function copyLogText(e) {
         if (logDataEl) {
-            navigator.clipboard.writeText(logDataEl.innerText).then(function () {
-                let orig = e.target.innerHTML;
-                e.target.innerHTML = "Copied!";
-                setTimeout(function () {
-                    e.target.innerHTML = orig;
-                }, 2000);
-            });
+            navigator.clipboard.writeText(logDataEl.innerText).then(
+                    function () {
+                        let orig = e.target.innerHTML;
+                        e.target.innerHTML = "Copied!";
+                        setTimeout(function () {
+                            e.target.innerHTML = orig;
+                        }, 2000);
+                    },
+                    function () {
+                        e.target.innerHTML = "Copy failed. Ensure the browser's security policy allows clipboard APIs and the page is using HTTPS.";
+                    });
         }
     }
 


### PR DESCRIPTION
#### Rationale
navigator.clipboard APIs require HTTPS (or localhost, which makes this harder to test). While all servers should be using HTTPS, we can do better by giving feedback to the user

#### Changes
* Detect failure and show helpful text