### PR TITLE
44850: detailsURL is missing the issue ID

### DIFF
--- a/issues/src/org/labkey/issue/IssueServiceImpl.java
+++ b/issues/src/org/labkey/issue/IssueServiceImpl.java
@@ -155,7 +155,7 @@ public class IssueServiceImpl implements IssueService
                     change += " as " + resolution; // Issue 12273
                 }
                 changeSummary.sendUpdateEmail(container, user, issueObject.getComment(),
-                        new ActionURL(IssuesController.DetailsAction.class, container),
+                        new ActionURL(IssuesController.DetailsAction.class, container).addParameter("issueId", issueObject.getIssueId()),
                         change, attachments);
 
                 if (!errors.hasErrors())


### PR DESCRIPTION
#### Rationale
The issue details link on email notifications is broken because the issue ID wasn't being added to the URL. This was introduced by a recent refactor.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44850