### PR TITLE
Issue 44310: Help guide users to the best authentication option based on their email address

### DIFF
--- a/api/src/org/labkey/api/action/ApiResponseWriter.java
+++ b/api/src/org/labkey/api/action/ApiResponseWriter.java
@@ -532,6 +532,11 @@ public abstract class ApiResponseWriter implements AutoCloseable
                 jsonError.put("adviceHref", errorWithLink.getAdviceHref());
             }
 
+            if (error instanceof LabKeyErrorWithHtml errorWithHtml)
+            {
+                jsonError.put("html", errorWithHtml.getHtml());
+            }
+
             if (null == exceptionMessage)
                 exceptionMessage = msg;
 

--- a/api/src/org/labkey/api/action/LabKeyErrorWithHtml.java
+++ b/api/src/org/labkey/api/action/LabKeyErrorWithHtml.java
@@ -1,0 +1,30 @@
+package org.labkey.api.action;
+
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
+import org.labkey.api.view.ViewContext;
+
+public class LabKeyErrorWithHtml extends LabKeyError
+{
+    private final HtmlString _html;
+
+    public LabKeyErrorWithHtml(String message, HtmlString html)
+    {
+        super(message);
+        _html = html;
+    }
+
+    @Override
+    public HtmlString renderToHTML(ViewContext context)
+    {
+        HtmlStringBuilder builder = HtmlStringBuilder.of(super.renderToHTML(context));
+        builder.append(_html);
+
+        return builder.getHtmlString();
+    }
+
+    public HtmlString getHtml()
+    {
+        return _html;
+    }
+}

--- a/api/src/org/labkey/api/collections/LabKeyCollectors.java
+++ b/api/src/org/labkey/api/collections/LabKeyCollectors.java
@@ -6,6 +6,8 @@ import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.json.JSONArray;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 
 import java.util.Arrays;
 import java.util.Comparator;
@@ -107,6 +109,22 @@ public class LabKeyCollectors
     public static Collector<String, ?, Set<String>> toCaseInsensitiveHashSet()
     {
         return Collectors.toCollection(CaseInsensitiveHashSet::new);
+    }
+
+    /**
+     * Returns a {@link Collector} that joins {@link HtmlString}s into a single {@link HtmlString} separated by delimiter
+     */
+    public static Collector<HtmlString, HtmlStringBuilder, HtmlString> joining(HtmlString delimiter) {
+        return Collector.of(
+            HtmlStringBuilder::of,
+            (builder, hs) -> {
+                if (!builder.isEmpty())
+                    builder.append(delimiter);
+                builder.append(hs);
+            },
+            (h1, h2) -> { h1.append(h2.getHtmlString()); return h1; },
+            HtmlStringBuilder::getHtmlString
+        );
     }
 
     public static class TestCase extends Assert

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -238,6 +238,12 @@ public class AuthenticationManager
         return builder.getHtmlString();
     }
 
+    @Deprecated // Left behind for backwards compatibility. Remove once mGAP adjusts usages.
+    public static boolean isLdapEmail(ValidEmail email)
+    {
+        return isLdapOrSsoEmail(email);
+    }
+
     // Ignores domain == "*"
     public static boolean isLdapOrSsoEmail(ValidEmail email)
     {

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -898,9 +898,9 @@ public class SecurityManager
             return _email;
         }
 
-        public boolean isLdapEmail()
+        public boolean isLdapOrSsoEmail()
         {
-            return AuthenticationManager.isLdapEmail(_email);
+            return AuthenticationManager.isLdapOrSsoEmail(_email);
         }
 
         public String getVerification()
@@ -1006,7 +1006,7 @@ public class SecurityManager
 
         try (DbScope.Transaction transaction = scope.ensureTransaction())
         {
-            if (createLogin && !status.isLdapEmail())
+            if (createLogin && !status.isLdapOrSsoEmail())
             {
                 String verification = SecurityManager.createLogin(email);
                 status.setVerification(verification);
@@ -2392,10 +2392,10 @@ public class SecurityManager
 
             User newUser = newUserStatus.getUser();
 
-            if (newUserStatus.isLdapEmail())
+            if (newUserStatus.isLdapOrSsoEmail())
             {
-                message.append(newUser.getEmail()).append(" added as a new user to the system and NOT emailed since this user will be authenticated via LDAP.");
-                UserManager.addToUserHistory(newUser, newUser.getEmail() + " was added to the system NOT emailed since this user will be authenticated via LDAP.");
+                message.append(newUser.getEmail()).append(" added as a new user to the system and NOT emailed since this user will be authenticated via LDAP or SSO.");
+                UserManager.addToUserHistory(newUser, newUser.getEmail() + " was added to the system NOT emailed since this user will be authenticated via LDAP or SSO.");
             }
             else if (sendMail)
             {

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -898,6 +898,12 @@ public class SecurityManager
             return _email;
         }
 
+        @Deprecated // Left behind for backwards compatibility. Remove once mGAP adjusts usages.
+        public boolean isLdapEmail()
+        {
+            return isLdapOrSsoEmail();
+        }
+
         public boolean isLdapOrSsoEmail()
         {
             return AuthenticationManager.isLdapOrSsoEmail(_email);

--- a/api/src/org/labkey/api/util/HtmlString.java
+++ b/api/src/org/labkey/api/util/HtmlString.java
@@ -93,6 +93,7 @@ public final class HtmlString implements SafeToRender, DOM.Renderable, Comparabl
         return null==html ? "" : html.toString();
     }
 
+    // For a Stream variant, see LabKeyCollectors.joining()
     public static HtmlString join(Iterable<HtmlString> htmlStrings, HtmlString delimiter)
     {
         HtmlString sep = HtmlString.EMPTY_STRING;

--- a/api/src/org/labkey/api/util/HtmlStringBuilder.java
+++ b/api/src/org/labkey/api/util/HtmlStringBuilder.java
@@ -101,10 +101,14 @@ public class HtmlStringBuilder implements HasHtmlString, SafeToRender
         return this;
     }
 
-
     public int length()
     {
         return _sb.length();
+    }
+
+    public boolean isEmpty()
+    {
+        return length() == 0;
     }
 
     private static String h(String s)

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -279,11 +279,6 @@ public class LoginController extends SpringActionController
         }
     }
 
-    private static LoginUrlsImpl getUrls()
-    {
-        return new LoginUrlsImpl();
-    }
-
     private static boolean authenticate(LoginForm form, BindException errors, HttpServletRequest request)
     {
         if (request != null)
@@ -319,7 +314,7 @@ public class LoginController extends SpringActionController
                 else
                 {
                     // Explicit test for valid email
-                    new ValidEmail(form.getEmail());
+                    ValidEmail email = new ValidEmail(form.getEmail());
 
                     if (status.requiresRedirect())
                     {
@@ -327,7 +322,8 @@ public class LoginController extends SpringActionController
                     }
                     else
                     {
-                        status.addUserErrorMessage(errors, result);
+                        // Pass in normalized email address, but only if user provided a full email address
+                        status.addUserErrorMessage(errors, result, form.getEmail().contains("@") ? email.getEmailAddress() : null, form.getReturnURLHelper());
                     }
                 }
             }
@@ -1808,7 +1804,7 @@ public class LoginController extends SpringActionController
         {
             if (!SecurityManager.loginExists(email))
             {
-                if (AuthenticationManager.isLdapEmail(email))
+                if (AuthenticationManager.isLdapOrSsoEmail(email))
                     errors.reject("setPassword", "Your account will authenticate using LDAP and you do not need to set a separate password.");
                 else
                     errors.reject("setPassword", "This email address is not associated with an account. Make sure you've copied the entire link into your browser's address bar.");


### PR DESCRIPTION
#### Rationale
[Issue 44310: Help guide users to the best authentication option based on their email address](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44310)

This PR provides user guidance after a failed sign in on the LabKey login page, pointing toward the SSO configuration(s) claiming that user's email domain, For example:

![image](https://user-images.githubusercontent.com/5107383/153769261-f0ea53b0-2429-4873-91a7-3e7479e719b8.png)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3018

#### Changes
* Add `LabKeyErrorWithHtml` to convey server-generated HTML to the client
* Login.js: render multiple error messages, if present. Render HTML if provided.
* Add `LabKeyCollectors.joining()` to join streams of `HtmlString`
* Pass attempted email address and return URL to authentication error message generating methods if form-based authentication fails
* Return additional guidance (text and SSO logo(s)) if user's email address is claimed by one or more SSO configurations