### PR TITLE
Lists: improve cross-folder lookup support, permission checks

### DIFF
--- a/api/src/org/labkey/api/exp/PropertyColumn.java
+++ b/api/src/org/labkey/api/exp/PropertyColumn.java
@@ -17,9 +17,11 @@ package org.labkey.api.exp;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.LookupColumn;
 import org.labkey.api.data.MutableColumnInfo;
@@ -78,9 +80,21 @@ public class PropertyColumn extends LookupColumn
 
     // We must have a DomainProperty in order to retrieve the default values. TODO: Transition more callers to pass in DomainProperty
     // TODO handle pd.copyTo(MutableColumnInfo)
-    public static void copyAttributes(User user, MutableColumnInfo to, DomainProperty dp, Container container, FieldKey lsidColumnFieldKey)
+    public static void copyAttributes(User user, MutableColumnInfo to, DomainProperty dp, Container container, @Nullable FieldKey lsidColumnFieldKey)
     {
-        copyAttributes(user, (BaseColumnInfo)to, dp.getPropertyDescriptor(), container, null, null, null, lsidColumnFieldKey);
+        copyAttributes(user, to, dp, container, lsidColumnFieldKey, null);
+    }
+
+    public static void copyAttributes(
+        User user,
+        MutableColumnInfo to,
+        DomainProperty dp,
+        Container container,
+        @Nullable FieldKey lsidColumnFieldKey,
+        @Nullable final ContainerFilter cf
+    )
+    {
+        copyAttributes(user, (BaseColumnInfo)to, dp.getPropertyDescriptor(), container, null, null, null, lsidColumnFieldKey, cf);
         Map<DomainProperty, Object> map = DefaultValueService.get().getDefaultValues(container, dp.getDomain(), user);
 
         Object value = map.get(dp);
@@ -91,16 +105,26 @@ public class PropertyColumn extends LookupColumn
 
     public static void copyAttributes(User user, MutableColumnInfo to, PropertyDescriptor pd, Container container, FieldKey lsidColumnFieldKey)
     {
-        copyAttributes(user, (BaseColumnInfo)to, pd, container, null, null, null, lsidColumnFieldKey);
+        copyAttributes(user, (BaseColumnInfo)to, pd, container, null, null, null, lsidColumnFieldKey, null);
     }
 
     public static void copyAttributes(User user, MutableColumnInfo to, PropertyDescriptor pd, Container container, SchemaKey schemaKey, String queryName, FieldKey pkFieldKey)
     {
-        copyAttributes(user, (BaseColumnInfo)to, pd, container, schemaKey, queryName, pkFieldKey, null);
+        copyAttributes(user, (BaseColumnInfo)to, pd, container, schemaKey, queryName, pkFieldKey, null, null);
     }
 
     // TODO handle pd.copyTo(MutableColumnInfo)
-    private static void copyAttributes(User user, BaseColumnInfo to, final PropertyDescriptor pd, final Container container, final SchemaKey schemaKey, final String queryName, final FieldKey pkFieldKey, final FieldKey lsidColumnFieldKey)
+    private static void copyAttributes(
+        User user,
+        BaseColumnInfo to,
+        final PropertyDescriptor pd,
+        final Container container,
+        final SchemaKey schemaKey,
+        final String queryName,
+        final FieldKey pkFieldKey,
+        @Nullable final FieldKey lsidColumnFieldKey,
+        @Nullable final ContainerFilter cf
+    )
     {
         // ColumnRenderProperties
         pd.copyTo(to);
@@ -133,7 +157,7 @@ public class PropertyColumn extends LookupColumn
         }
 
         if (user != null && ((pd.getLookupSchema() != null && pd.getLookupQuery() != null) || pd.getConceptURI() != null))
-            to.setFk(PdLookupForeignKey.create(to.getParentTable().getUserSchema(), user, container, pd));
+            to.setFk(PdLookupForeignKey.create(to.getParentTable().getUserSchema(), user, container, pd, cf));
 
         to.setDefaultValueType(pd.getDefaultValueTypeEnum());
         to.setConditionalFormats(PropertyService.get().getConditionalFormats(pd));

--- a/api/src/org/labkey/api/exp/PropertyColumn.java
+++ b/api/src/org/labkey/api/exp/PropertyColumn.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.LookupColumn;
 import org.labkey.api.data.MutableColumnInfo;
@@ -82,19 +81,7 @@ public class PropertyColumn extends LookupColumn
     // TODO handle pd.copyTo(MutableColumnInfo)
     public static void copyAttributes(User user, MutableColumnInfo to, DomainProperty dp, Container container, @Nullable FieldKey lsidColumnFieldKey)
     {
-        copyAttributes(user, to, dp, container, lsidColumnFieldKey, null);
-    }
-
-    public static void copyAttributes(
-        User user,
-        MutableColumnInfo to,
-        DomainProperty dp,
-        Container container,
-        @Nullable FieldKey lsidColumnFieldKey,
-        @Nullable final ContainerFilter cf
-    )
-    {
-        copyAttributes(user, (BaseColumnInfo)to, dp.getPropertyDescriptor(), container, null, null, null, lsidColumnFieldKey, cf);
+        copyAttributes(user, (BaseColumnInfo)to, dp.getPropertyDescriptor(), container, null, null, null, lsidColumnFieldKey);
         Map<DomainProperty, Object> map = DefaultValueService.get().getDefaultValues(container, dp.getDomain(), user);
 
         Object value = map.get(dp);
@@ -105,12 +92,12 @@ public class PropertyColumn extends LookupColumn
 
     public static void copyAttributes(User user, MutableColumnInfo to, PropertyDescriptor pd, Container container, FieldKey lsidColumnFieldKey)
     {
-        copyAttributes(user, (BaseColumnInfo)to, pd, container, null, null, null, lsidColumnFieldKey, null);
+        copyAttributes(user, (BaseColumnInfo)to, pd, container, null, null, null, lsidColumnFieldKey);
     }
 
     public static void copyAttributes(User user, MutableColumnInfo to, PropertyDescriptor pd, Container container, SchemaKey schemaKey, String queryName, FieldKey pkFieldKey)
     {
-        copyAttributes(user, (BaseColumnInfo)to, pd, container, schemaKey, queryName, pkFieldKey, null, null);
+        copyAttributes(user, (BaseColumnInfo)to, pd, container, schemaKey, queryName, pkFieldKey, null);
     }
 
     // TODO handle pd.copyTo(MutableColumnInfo)
@@ -122,8 +109,7 @@ public class PropertyColumn extends LookupColumn
         final SchemaKey schemaKey,
         final String queryName,
         final FieldKey pkFieldKey,
-        @Nullable final FieldKey lsidColumnFieldKey,
-        @Nullable final ContainerFilter cf
+        @Nullable final FieldKey lsidColumnFieldKey
     )
     {
         // ColumnRenderProperties
@@ -157,7 +143,7 @@ public class PropertyColumn extends LookupColumn
         }
 
         if (user != null && ((pd.getLookupSchema() != null && pd.getLookupQuery() != null) || pd.getConceptURI() != null))
-            to.setFk(PdLookupForeignKey.create(to.getParentTable().getUserSchema(), user, container, pd, cf));
+            to.setFk(PdLookupForeignKey.create(to.getParentTable().getUserSchema(), user, container, pd));
 
         to.setDefaultValueType(pd.getDefaultValueTypeEnum());
         to.setConditionalFormats(PropertyService.get().getConditionalFormats(pd));

--- a/api/src/org/labkey/api/exp/list/ListDefinition.java
+++ b/api/src/org/labkey/api/exp/list/ListDefinition.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.DomainNotFoundException;
 import org.labkey.api.exp.PropertyType;
@@ -329,6 +330,7 @@ public interface ListDefinition extends Comparable<ListDefinition>
 
     @Nullable TableInfo getTable(User user);
     @Nullable TableInfo getTable(User user, Container c);
+    @Nullable TableInfo getTable(User user, Container c, @Nullable ContainerFilter cf);
 
     ActionURL urlShowDefinition();
     ActionURL urlUpdate(User user, Container container, @Nullable Object pk, @Nullable URLHelper returnUrl);

--- a/api/src/org/labkey/api/exp/list/ListService.java
+++ b/api/src/org/labkey/api/exp/list/ListService.java
@@ -16,8 +16,10 @@
 
 package org.labkey.api.exp.list;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.exp.TemplateInfo;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.query.UserSchema;
@@ -49,12 +51,15 @@ public interface ListService
     boolean hasLists(Container container, boolean includeProjectAndShared);
     ListDefinition createList(Container container, String name, ListDefinition.KeyType keyType);
     ListDefinition createList(Container container, String name, ListDefinition.KeyType keyType, @Nullable TemplateInfo templateInfo, @Nullable ListDefinition.Category category);
-    ListDefinition getList(Container container, int listId);
+    @Nullable ListDefinition getList(Container container, int listId);
     @Nullable ListDefinition getList(Container container, String name);
     @Nullable ListDefinition getList(Container container, String name, boolean includeProjectAndShared);
     ListDefinition getList(Domain domain);
     ActionURL getManageListsURL(Container container);
     UserSchema getUserSchema(User user, Container container);
+
+    /** Picklists can specify different container filtering configurations depending on the container context */
+    @Nullable ContainerFilter getPicklistContainerFilter(Container container, User user, @NotNull ListDefinition list);
 
     void importListArchive(InputStream is, BindException errors, Container c, User user) throws Exception;
 }

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -639,7 +639,7 @@ public class ExpSchema extends AbstractExpSchema
      * @param domainProperty the property on which the lookup is configured
      */
     @NotNull
-    public ForeignKey getMaterialIdForeignKey(@Nullable ExpSampleType targetSampleType, @Nullable DomainProperty domainProperty, ContainerFilter cfParent)
+    public ForeignKey getMaterialIdForeignKey(@Nullable ExpSampleType targetSampleType, @Nullable DomainProperty domainProperty, @Nullable ContainerFilter cfParent)
     {
         if (targetSampleType == null)
         {
@@ -656,7 +656,7 @@ public class ExpSchema extends AbstractExpSchema
                 }
             };
         }
-        return getSamplesSchema().materialIdForeignKey(targetSampleType, domainProperty);
+        return getSamplesSchema().materialIdForeignKey(targetSampleType, domainProperty, cfParent);
     }
 
     @NotNull

--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -188,6 +188,11 @@ public class SamplesSchema extends AbstractExpSchema
      */
     public ForeignKey materialIdForeignKey(@Nullable final ExpSampleType st, @Nullable DomainProperty domainProperty)
     {
+        return materialIdForeignKey(st, domainProperty, null);
+    }
+
+    public ForeignKey materialIdForeignKey(@Nullable final ExpSampleType st, @Nullable DomainProperty domainProperty, @Nullable ContainerFilter cfParent)
+    {
         final String tableName =  null == st ? ExpSchema.TableType.Materials.toString() : st.getName();
         final String schemaName = null == st ? ExpSchema.SCHEMA_NAME : SamplesSchema.SCHEMA_NAME;
 
@@ -219,6 +224,11 @@ public class SamplesSchema extends AbstractExpSchema
             @Override
             protected ContainerFilter getLookupContainerFilter()
             {
+                // If the lookup is configured to target a specific container,
+                // then respect that setting and ignore the supplied container filter.
+                boolean isTargetLookup = domainProperty != null && domainProperty.getLookup() != null && domainProperty.getLookup().getContainer() != null;
+                if (!isTargetLookup && cfParent != null)
+                    return cfParent;
                 return new ContainerFilter.SimpleContainerFilter(ExpSchema.getSearchContainers(getContainer(), st, domainProperty, getUser()));
             }
 

--- a/api/src/org/labkey/api/query/PdLookupForeignKey.java
+++ b/api/src/org/labkey/api/query/PdLookupForeignKey.java
@@ -18,7 +18,6 @@ package org.labkey.api.query;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.NamedObjectList;
 import org.labkey.api.data.AbstractForeignKey;
 import org.labkey.api.data.ColumnInfo;
@@ -47,14 +46,16 @@ public class PdLookupForeignKey extends AbstractForeignKey
     Container _currentContainer;
     private Container _targetContainer;
 
-    static public PdLookupForeignKey create(@NotNull QuerySchema sourceSchema, @NotNull PropertyDescriptor pd)
+    static public PdLookupForeignKey create(QuerySchema sourceSchema, @NotNull PropertyDescriptor pd)
     {
         return create(sourceSchema, sourceSchema.getUser(), sourceSchema.getContainer(), pd);
     }
 
-    static public PdLookupForeignKey create(@NotNull QuerySchema sourceSchema, @NotNull User user, @NotNull Container container, @NotNull PropertyDescriptor pd)
+    static public PdLookupForeignKey create(QuerySchema sourceSchema, @NotNull User user, @NotNull Container container, @NotNull PropertyDescriptor pd)
     {
         assert container != null : "Container cannot be null";
+
+        Container currentContainer = container;
         Container targetContainer = pd.getLookupContainer() == null ? null : ContainerManager.getForId(pd.getLookupContainer());
         String lookupSchemaName = pd.getLookupSchema();
         String lookupQuery = pd.getLookupQuery();
@@ -75,33 +76,19 @@ public class PdLookupForeignKey extends AbstractForeignKey
         if ("core".equalsIgnoreCase(lookupSchemaName) && "Containers".equalsIgnoreCase(lookupQuery))
             cf = new ContainerFilter.AllFolders(user);
         else
-            cf = new ContainerFilter.SimpleContainerFilterWithUser(user, targetContainer != null ? targetContainer : container);
+            cf = new ContainerFilter.SimpleContainerFilterWithUser(user, targetContainer!=null ? targetContainer : container);
 
-        return new PdLookupForeignKey(sourceSchema, container, user, cf, pd, lookupSchemaName, lookupQuery, targetContainer);
+        return new PdLookupForeignKey(sourceSchema, currentContainer, user, cf, pd, lookupSchemaName, lookupQuery, targetContainer);
     }
 
-    protected PdLookupForeignKey(@NotNull QuerySchema sourceSchema, @NotNull PropertyDescriptor pd)
-    {
-        this(sourceSchema, sourceSchema.getContainer(), sourceSchema.getUser(), null, pd, pd.getLookupSchema(), pd.getLookupQuery(), ContainerManager.getForId(pd.getLookupContainer()));
-    }
-
-    private PdLookupForeignKey(
-        @NotNull QuerySchema sourceSchema,
-        Container currentContainer,
-        @NotNull User user,
-        @Nullable ContainerFilter cf,
-        PropertyDescriptor pd,
-        String lookupSchemaName,
-        String lookupQuery,
-        @Nullable Container targetContainer
-    )
+    protected PdLookupForeignKey(@NotNull QuerySchema sourceSchema, Container currentContainer, @NotNull User user, ContainerFilter cf, PropertyDescriptor pd, String lookupSchemaName, String lookupQuery, Container targetContainer)
     {
         super(sourceSchema, cf, lookupSchemaName, lookupQuery, null);
         _pd = pd;
         _user = user;
         assert currentContainer != null : "Container cannot be null";
         _currentContainer = currentContainer;
-        _targetContainer = targetContainer;
+        _targetContainer = _pd.getLookupContainer() == null ? null : ContainerManager.getForId(_pd.getLookupContainer());
     }
 
 

--- a/api/src/org/labkey/api/query/PdLookupForeignKey.java
+++ b/api/src/org/labkey/api/query/PdLookupForeignKey.java
@@ -54,17 +54,6 @@ public class PdLookupForeignKey extends AbstractForeignKey
 
     static public PdLookupForeignKey create(@NotNull QuerySchema sourceSchema, @NotNull User user, @NotNull Container container, @NotNull PropertyDescriptor pd)
     {
-        return create(sourceSchema, user, container, pd, null);
-    }
-
-    static public PdLookupForeignKey create(
-        @NotNull QuerySchema sourceSchema,
-        @NotNull User user,
-        @NotNull Container container,
-        @NotNull PropertyDescriptor pd,
-        @Nullable ContainerFilter cf
-    )
-    {
         assert container != null : "Container cannot be null";
         Container targetContainer = pd.getLookupContainer() == null ? null : ContainerManager.getForId(pd.getLookupContainer());
         String lookupSchemaName = pd.getLookupSchema();
@@ -82,9 +71,10 @@ public class PdLookupForeignKey extends AbstractForeignKey
             }
         }
 
+        ContainerFilter cf;
         if ("core".equalsIgnoreCase(lookupSchemaName) && "Containers".equalsIgnoreCase(lookupQuery))
             cf = new ContainerFilter.AllFolders(user);
-        else if (cf == null)
+        else
             cf = new ContainerFilter.SimpleContainerFilterWithUser(user, targetContainer != null ? targetContainer : container);
 
         return new PdLookupForeignKey(sourceSchema, container, user, cf, pd, lookupSchemaName, lookupQuery, targetContainer);

--- a/issues/src/org/labkey/issue/query/IssuesTable.java
+++ b/issues/src/org/labkey/issue/query/IssuesTable.java
@@ -720,7 +720,7 @@ public class IssuesTable extends FilteredTable<IssuesQuerySchema> implements Upd
 
         public IssuesPdLookupForeignKey(IssuesQuerySchema schema, PropertyDescriptor pd)
         {
-            super(schema, pd);
+            super(schema, schema.getContainer(), schema.getUser(), null, pd, pd.getLookupSchema(), pd.getLookupQuery(), pd.getContainer());
             _user = schema.getUser();
             _container = schema.getContainer();
             _propName = pd.getName();

--- a/issues/src/org/labkey/issue/query/IssuesTable.java
+++ b/issues/src/org/labkey/issue/query/IssuesTable.java
@@ -720,7 +720,7 @@ public class IssuesTable extends FilteredTable<IssuesQuerySchema> implements Upd
 
         public IssuesPdLookupForeignKey(IssuesQuerySchema schema, PropertyDescriptor pd)
         {
-            super(schema, schema.getContainer(), schema.getUser(), null, pd, pd.getLookupSchema(), pd.getLookupQuery(), pd.getContainer());
+            super(schema, pd);
             _user = schema.getUser();
             _container = schema.getContainer();
             _propName = pd.getName();

--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -301,14 +301,19 @@ public class ListController extends SpringActionController
         private boolean canDelete(int listId)
         {
             ListDef listDef = ListManager.get().getList(getContainer(), listId);
+            ListDefinitionImpl list = ListDefinitionImpl.of(listDef);
+
+            if (list == null)
+                return false;
+
             boolean isPicklist = listDef.getCategory() != null;
             if (isPicklist)
             {
                 boolean isOwnPicklist = listDef.getCreatedBy() == getUser().getUserId();
-                return isOwnPicklist || (listDef.getCategory() == ListDefinition.Category.PublicPicklist && getContainer().hasPermission(getUser(), AdminPermission.class));
+                return isOwnPicklist || (listDef.getCategory() == ListDefinition.Category.PublicPicklist && list.getContainer().hasPermission(getUser(), AdminPermission.class));
 
             }
-            return getContainer().hasPermission(getUser(), DesignListPermission.class);
+            return list.getContainer().hasPermission(getUser(), DesignListPermission.class);
         }
 
         @Override

--- a/list/src/org/labkey/list/model/ListDefinitionImpl.java
+++ b/list/src/org/labkey/list/model/ListDefinitionImpl.java
@@ -70,7 +70,8 @@ public class ListDefinitionImpl implements ListDefinition
 {
     private static final Logger LOG = LogManager.getLogger(ListDefinitionImpl.class);
 
-    static public ListDefinitionImpl of(ListDef def)
+    @Nullable
+    static public ListDefinitionImpl of(@Nullable ListDef def)
     {
         if (def == null)
             return null;

--- a/list/src/org/labkey/list/model/ListDefinitionImpl.java
+++ b/list/src/org/labkey/list/model/ListDefinitionImpl.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.RuntimeSQLException;
@@ -680,6 +681,13 @@ public class ListDefinitionImpl implements ListDefinition
     @Nullable
     public TableInfo getTable(User user, Container c)
     {
+        return getTable(user, c, null);
+    }
+
+    @Override
+    @Nullable
+    public TableInfo getTable(User user, Container c, @Nullable ContainerFilter cf)
+    {
         TableInfo table;
         try
         {
@@ -687,7 +695,7 @@ public class ListDefinitionImpl implements ListDefinition
             {
                 // Go through the schema so we always get all of the XML metadata applied
                 UserSchema schema = new ListQuerySchema(user, c);
-                table = schema.getTable(getName(), null, true, false);
+                table = schema.getTable(getName(), cf, true, false);
             }
             else
             {

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -212,6 +212,7 @@ public class ListManager implements SearchService.DocumentProvider
         else return ti.getSelectName();  // if db is being upgraded from <= 13.1, lists are still SchemaTableInfo instances
     }
 
+    @Nullable
     public ListDef getList(Container container, int listId)
     {
         SimpleFilter filter = new PkFilter(getListMetadataTable(), new Object[]{container, listId});

--- a/list/src/org/labkey/list/model/ListManagerTable.java
+++ b/list/src/org/labkey/list/model/ListManagerTable.java
@@ -122,7 +122,9 @@ public class ListManagerTable extends FilteredTable<ListManagerSchema>
                 {
                     Integer listId = (Integer) ctx.get("ListID");
                     ListDef listDef = ListManager.get().getList(ctx.getContainer(), listId);
-                    ListDefinition list = new ListDefinitionImpl(listDef);
+                    ListDefinition list = ListDefinitionImpl.of(listDef);
+                    if (list == null)
+                        return 0;
                     return new TableSelector(list.getTable(userSchema.getUser())).getRowCount();
                 }
 

--- a/list/src/org/labkey/list/model/ListServiceImpl.java
+++ b/list/src/org/labkey/list/model/ListServiceImpl.java
@@ -31,6 +31,7 @@ import org.labkey.api.exp.list.ListDefinition;
 import org.labkey.api.exp.list.ListService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.util.FileUtil;
@@ -195,6 +196,9 @@ public class ListServiceImpl implements ListService
     @Nullable
     public ContainerFilter getPicklistContainerFilter(Container container, User user, @NotNull ListDefinition list)
     {
+        if (!QueryService.get().isProductSubfolderDataEnabled())
+            return null;
+
         if (container == null || user == null || !list.isPicklist() || container.isRoot())
             return null;
 

--- a/list/src/org/labkey/list/model/ListServiceImpl.java
+++ b/list/src/org/labkey/list/model/ListServiceImpl.java
@@ -17,11 +17,13 @@
 package org.labkey.list.model;
 
 import org.apache.logging.log4j.LogManager;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.admin.ImportException;
 import org.labkey.api.admin.InvalidFileException;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.TemplateInfo;
@@ -112,6 +114,7 @@ public class ListServiceImpl implements ListService
     }
 
     @Override
+    @Nullable
     public ListDefinition getList(Container container, int listId)
     {
         ListDef def = ListManager.get().getList(container, listId);
@@ -186,5 +189,18 @@ public class ListServiceImpl implements ListService
     public UserSchema getUserSchema(User user, Container container)
     {
         return new ListQuerySchema(user, container);
+    }
+
+    @Override
+    @Nullable
+    public ContainerFilter getPicklistContainerFilter(Container container, User user, @NotNull ListDefinition list)
+    {
+        if (container == null || user == null || !list.isPicklist() || container.isRoot())
+            return null;
+
+        if (container.isProject())
+            return new ContainerFilter.CurrentAndSubfoldersPlusShared(container, user);
+
+        return new ContainerFilter.CurrentPlusProjectAndShared(container, user);
     }
 }

--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -198,7 +198,7 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
                     if (null != pd)
                     {
                         col.setFieldKey(new FieldKey(null,pd.getName()));
-                        PropertyColumn.copyAttributes(schema.getUser(), col, dp, schema.getContainer(), FieldKey.fromParts("EntityId"));
+                        PropertyColumn.copyAttributes(schema.getUser(), col, dp, schema.getContainer(), FieldKey.fromParts("EntityId"), getContainerFilter());
 
                         if (pd.isMvEnabled())
                         {

--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -371,7 +371,7 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
     {
         // currently, picklists don't contain PHI and can always be deleted
         if (_list.isPicklist() && InsertPermission.class.equals(perm) || UpdatePermission.class.equals(perm) || DeletePermission.class.equals(perm))
-            return _list.getContainer().hasPermission(user, ManagePicklistsPermission.class);
+            return getContainer().hasPermission(user, ManagePicklistsPermission.class);
 
         boolean gate = true;
         if (InsertPermission.class.equals(perm) || UpdatePermission.class.equals(perm))

--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -81,6 +81,32 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
     private static final Logger LOG = LogManager.getLogger(ListTable.class);
     private final boolean _canAccessPhi;
 
+    // NK: Picklists are instances of Lists that are utilized to group Samples. As such, they are utilized
+    // in more specific ways than Lists in our system and necessitate a different collection of default
+    // columns. Having these columns declared here may not be ideal, however, until Picklists have their own
+    // standalone implementation this is the best place for broad support across folders, views, etc.
+    private static final String PICKLIST_SAMPLE_ID = "SampleID";
+    private static final List<FieldKey> defaultPicklistVisibleColumns = new ArrayList<>();
+
+    static
+    {
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "Name"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "LabelColor"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "SampleSet"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "SampleState"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "StoredAmount"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "Units"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "freezeThawCount"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "StorageStatus"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "checkedOutBy"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "Created"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "CreatedBy"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "StorageLocation"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "StorageRow"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "StorageCol"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "isAliquot"));
+    }
+
     public ListTable(ListQuerySchema schema, @NotNull ListDefinition listDef, @NotNull Domain domain, @Nullable ContainerFilter cf)
     {
         super(StorageProvisioner.createTableInfo(domain), schema, cf);
@@ -296,6 +322,14 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
         }
 
         _defaultVisibleColumns = Collections.unmodifiableList(QueryService.get().getDefaultVisibleColumns(defaultColumnsCandidates));
+    }
+
+    @Override
+    public List<FieldKey> getDefaultVisibleColumns()
+    {
+        if (_list != null && _list.isPicklist())
+            return defaultPicklistVisibleColumns;
+        return super.getDefaultVisibleColumns();
     }
 
     @Override

--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -224,7 +224,7 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
                     if (null != pd)
                     {
                         col.setFieldKey(new FieldKey(null,pd.getName()));
-                        PropertyColumn.copyAttributes(schema.getUser(), col, dp, schema.getContainer(), FieldKey.fromParts("EntityId"), getContainerFilter());
+                        PropertyColumn.copyAttributes(schema.getUser(), col, dp, schema.getContainer(), FieldKey.fromParts("EntityId"));
 
                         if (pd.isMvEnabled())
                         {
@@ -261,6 +261,12 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
                             col.setURL(StringExpressionFactory.createURL(
                                 ListController.getDownloadURL(listDef, "${EntityId}", "${" + col.getName() + "}")
                             ));
+                        }
+
+                        if (_list.isPicklist() && PICKLIST_SAMPLE_ID.equalsIgnoreCase(pd.getName()))
+                        {
+                            if (col.getFk() instanceof PdLookupForeignKey)
+                                ((PdLookupForeignKey) col.getFk()).setContainerFilter(getContainerFilter());
                         }
                     }
 


### PR DESCRIPTION
#### Rationale
This PR addresses some permission checks as well as improves cross-folder lookup support for container filters on Lists and Picklists.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/738
* https://github.com/LabKey/biologics/pull/1156
* https://github.com/LabKey/sampleManagement/pull/839
* https://github.com/LabKey/inventory/pull/377
* https://github.com/LabKey/platform/pull/3048

#### Changes
* Lists: fix permission check for deleting list definitions. Check the list domain's definition folder for `DesignListPermission` permissions rather than the current folder.
* Picklists
    * update permission checks for cross-folder support. Check the folder where data is being written for permissions rather than the list domain's folder.
    * Migrate declaration of default columns for picklists into `ListTable`. Formerly saved as a custom view alteration by the clientside. 
    * Pass provided `ContainerFilter` to `SampleID` column.
* ~~`PdLookupForeignKey`: Respect a provided `ContainerFilter` and continue to default to `SimpleContainerFilterWithUser`.~~
* ~~`PropertyColumn`: support for passing provided `ContainerFilter` to generated `PdLookupForeignKey`.~~
