### PR TITLE
Reject bogus .oldValues parameters instead of throwing ZipException

### DIFF
--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -71,6 +71,7 @@ import org.labkey.api.stats.AnalyticsProviderRegistry;
 import org.labkey.api.util.Button.ButtonBuilder;
 import org.labkey.api.util.Link.LinkBuilder;
 import org.labkey.api.view.ActionURL;
+import org.labkey.api.view.BadRequestException;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.ViewContext;
@@ -150,6 +151,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
+import java.util.zip.ZipException;
 
 import static org.apache.commons.lang3.StringUtils.startsWith;
 import static org.labkey.api.util.DOM.Attribute.valign;
@@ -820,6 +822,10 @@ public class PageFlowUtil
         catch (IllegalArgumentException x)
         {
             throw new IOException(x);
+        }
+        catch (ZipException x)
+        {
+            throw new BadRequestException("Invalid .oldValues parameter value", BadRequestException.HowBad.Malicious);
         }
     }
 


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/repository/download/LabkeyTrunk_DailySuites_DailyESqlserver/1705191:id/ColumnChartTest.tar.gz!/0_AfterClass.html

#### Changes
* Treat a bogus .oldValues parameter as a likely malicious request