### PR TITLE
Use absolute values for standard percent deviation y-axis QC plots

### DIFF
--- a/internal/webapp/vis/src/plot.js
+++ b/internal/webapp/vis/src/plot.js
@@ -1708,7 +1708,7 @@ boxPlot.render();
             if (isNaN(calc))
                 return 100;
 
-            return calc;
+            return Math.abs(calc);
         };
 
         var convertToStandardDeviation = function(value, mean, stddev) {
@@ -1716,7 +1716,7 @@ boxPlot.render();
             if (isNaN(calc))
                 return 0;
 
-            return calc;
+            return Math.abs(calc);
         };
 
         var convertValues = function(conversion) {


### PR DESCRIPTION
#### Rationale
It's confusing and unnecessarily noisy to have both positive and negative values when doing QC plots of the standard deviation or percent deviation as the y-axis, especially when the raw value is bouncing around zero. While this came up in the context of Panorama QC folders, it's equally helpful for other QC plotting scenarios.

#### Changes
* Switch to use absolute values for these plot options