### PR TITLE
Avoid NPE when failing to get a connection

### DIFF
--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -999,7 +999,10 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
         {
             ResultSetUtil.close(rs);
             ResultSetUtil.close(stmt);
-            schema.getScope().releaseConnection(conn);
+            if (conn != null)
+            {
+                schema.getScope().releaseConnection(conn);
+            }
         }
     }
 


### PR DESCRIPTION
#### Rationale
IntelliJ warns that the conn variable may be null. This exception report agrees:

```
java.lang.NullPointerException
	at org.labkey.api.data.DbScope.releaseConnection(DbScope.java:1037)
	at org.labkey.core.attachment.AttachmentServiceImpl.writeDocument(AttachmentServiceImpl.java:1002)
	at org.labkey.api.settings.TemplateResourceHandler$3.getWriterForContainer(TemplateResourceHandler.java:155)
	at org.labkey.api.settings.TemplateResourceHandler.getWriter(TemplateResourceHandler.java:218)
	at org.labkey.api.settings.TemplateResourceHandler.sendResource(TemplateResourceHandler.java:202)
```

#### Changes
* Check for null