### PR TITLE
Issue 44869: Conditional format export can produce an invalid XML fragment

### DIFF
--- a/api/src/org/labkey/api/data/ConditionalFormat.java
+++ b/api/src/org/labkey/api/data/ConditionalFormat.java
@@ -256,7 +256,7 @@ public class ConditionalFormat extends GWTConditionalFormat
         return result;
     }
 
-    public static void convertToXML(List<? extends GWTConditionalFormat> formats, ColumnType xmlColumn)
+    public static void convertToXML(List<? extends GWTConditionalFormat> formats, ColumnType xmlColumn, String tableName)
     {
         if (xmlColumn.isSetConditionalFormats())
         {
@@ -268,7 +268,7 @@ public class ConditionalFormat extends GWTConditionalFormat
             ConditionalFormatsType xmlFormats = xmlColumn.addNewConditionalFormats();
             if (!addToXML(formats, xmlFormats))
             {
-                LOG.warn("One or more invalid conditional formats were discovered on column \"" + xmlColumn.getColumnName() + "\"");
+                LOG.warn("One or more invalid conditional formats were discovered on table \"" + tableName + "\", column \"" + xmlColumn.getColumnName() + "\"");
             }
         }
     }

--- a/api/src/org/labkey/api/data/ConditionalFormat.java
+++ b/api/src/org/labkey/api/data/ConditionalFormat.java
@@ -266,7 +266,10 @@ public class ConditionalFormat extends GWTConditionalFormat
         if (!formats.isEmpty())
         {
             ConditionalFormatsType xmlFormats = xmlColumn.addNewConditionalFormats();
-            addToXML(formats, xmlFormats);
+            if (!addToXML(formats, xmlFormats))
+            {
+                LOG.warn("One or more invalid conditional formats were discovered on column \"" + xmlColumn.getColumnName() + "\"");
+            }
         }
     }
 
@@ -280,7 +283,10 @@ public class ConditionalFormat extends GWTConditionalFormat
         if (!formats.isEmpty())
         {
             ConditionalFormatsType xmlFormats = xmlProp.addNewConditionalFormats();
-            addToXML(formats, xmlFormats);
+            if (!addToXML(formats, xmlFormats))
+            {
+                LOG.warn("One or more invalid conditional formats were discovered on property \"" + xmlProp.getName() + "\"");
+            }
         }
     }
 
@@ -309,17 +315,20 @@ public class ConditionalFormat extends GWTConditionalFormat
         return getParsedColor(getBackgroundColor());
     }
 
-    private static void addToXML(List<? extends GWTConditionalFormat> formats, ConditionalFormatsType xmlFormats)
+    // Returns true if all formats were valid and successfully serialized to XML
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    private static boolean addToXML(List<? extends GWTConditionalFormat> formats, ConditionalFormatsType xmlFormats)
     {
+        boolean success = true;
+
         for (GWTConditionalFormat baseFormat : formats)
         {
             ConditionalFormat format = new ConditionalFormat(baseFormat);
-            ConditionalFormatType xmlFormat = xmlFormats.addNewConditionalFormat();
             SimpleFilter simpleFilter = format.getSimpleFilter();
+            // issue 20350 and subsequent failures - don't create a conditional format until we know the filter has clauses.
             if (null != simpleFilter.getClauses() && !simpleFilter.getClauses().isEmpty())
             {
-                // issue 20350 - don't add a <filters> element until we know the filter
-                // has clauses.
+                ConditionalFormatType xmlFormat = xmlFormats.addNewConditionalFormat();
                 xmlFormat.addNewFilters();
                 for (FilterClause filterClause : simpleFilter.getClauses())
                 {
@@ -338,27 +347,33 @@ public class ConditionalFormat extends GWTConditionalFormat
                         throw new IllegalArgumentException("Unsupported filter clause: " + filterClause);
                     }
                 }
+                if (format.isBold())
+                {
+                    xmlFormat.setBold(true);
+                }
+                if (format.isItalic())
+                {
+                    xmlFormat.setItalics(true);
+                }
+                if (format.isStrikethrough())
+                {
+                    xmlFormat.setStrikethrough(true);
+                }
+                if (format.getBackgroundColor() != null)
+                {
+                    xmlFormat.setBackgroundColor(format.getBackgroundColor());
+                }
+                if (format.getTextColor() != null)
+                {
+                    xmlFormat.setTextColor(format.getTextColor());
+                }
             }
-            if (format.isBold())
+            else
             {
-                xmlFormat.setBold(true);
-            }
-            if (format.isItalic())
-            {
-                xmlFormat.setItalics(true);
-            }
-            if (format.isStrikethrough())
-            {
-                xmlFormat.setStrikethrough(true);
-            }
-            if (format.getBackgroundColor() != null)
-            {
-                xmlFormat.setBackgroundColor(format.getBackgroundColor());
-            }
-            if (format.getTextColor() != null)
-            {
-                xmlFormat.setTextColor(format.getTextColor());
+                success = false;
             }
         }
+
+        return success;
     }
 }

--- a/api/src/org/labkey/api/data/TableInfoWriter.java
+++ b/api/src/org/labkey/api/data/TableInfoWriter.java
@@ -16,7 +16,6 @@
 
 package org.labkey.api.data;
 
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.exp.property.IPropertyValidator;
 import org.labkey.api.exp.property.Type;
@@ -214,7 +213,7 @@ public class TableInfoWriter
         }
 
         // GWT PropertyEditor always saves Attachment columns with DefaultValueType set to FIXED_EDITABLE. That's a bug we should fix,
-        // but we'll workaround it here for now. Also, consider Type.allowsDefaultValue() to generalize this concept.
+        // but we'll work around it here for now. Also, consider Type.allowsDefaultValue() to generalize this concept.
         if (t != Type.AttachmentType)
         {
             DefaultValueType defaultValueType = column.getDefaultValueType();

--- a/api/src/org/labkey/api/data/TableInfoWriter.java
+++ b/api/src/org/labkey/api/data/TableInfoWriter.java
@@ -230,7 +230,7 @@ public class TableInfoWriter
             }
         }
 
-        ConditionalFormat.convertToXML(column.getConditionalFormats(), columnXml);
+        ConditionalFormat.convertToXML(column.getConditionalFormats(), columnXml, column.getParentTable().getName());
 
         List<? extends IPropertyValidator> validators = column.getValidators();
 

--- a/query/src/org/labkey/query/MetadataTableJSON.java
+++ b/query/src/org/labkey/query/MetadataTableJSON.java
@@ -16,7 +16,6 @@
 package org.labkey.query;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlOptions;
@@ -36,7 +35,6 @@ import org.labkey.api.exp.property.Lookup;
 import org.labkey.api.gwt.client.model.GWTConditionalFormat;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.query.QueryDefinition;
 import org.labkey.api.query.QueryParseException;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
@@ -72,6 +70,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
     private boolean _userDefinedQuery;
     /** If metadata is not stored in the current container, the folder path where it is stored */
     private String _definitionFolder;
+
     private static final Logger log = LogHelper.getLogger(MetadataTableJSON.class, "Visual editor support for table/query metadata");
 
     @Override
@@ -431,7 +430,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             // Set the conditional formats
             if (shouldStoreValue(metadataColumnJSON.getConditionalFormats(), convertToGWT(rawColumnInfo.getConditionalFormats())))
             {
-                ConditionalFormat.convertToXML(metadataColumnJSON.getConditionalFormats(), xmlColumn);
+                ConditionalFormat.convertToXML(metadataColumnJSON.getConditionalFormats(), xmlColumn, xmlTable.getTableName());
             }
 
             // Set conceptURI


### PR DESCRIPTION
#### Rationale
Better to produce a valid XML document and log a warning if we encounter a bogus conditional format

I'd rather stick the warning in the pipeline log, but that would have been a lot of wiring for a rare scenario
