### PR TITLE
data views fixes for failed tests

### DIFF
--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -2888,7 +2888,7 @@ public class ReportsController extends SpringActionController
             String typeName = type.getName();
 
             if (typeName.equalsIgnoreCase("reports") ||
-                typeName.equalsIgnoreCase("queries"))
+                typeName.equalsIgnoreCase("grid views"))
             {
                 props.put(typeName, "1");
             }


### PR DESCRIPTION
#### Rationale
A recent change resulted in the renaming of `queries` to `grid views` for the data views types. The manage views version of data views relies on a static configuration of which types are pulled in and needed to also reflect this change to fix a test failure.

https://github.com/LabKey/platform/pull/3033