### PR TITLE
Issue 44873: Deleting Pipeline Jobs via "Select All" fails to delete some jobs

### DIFF
--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -743,7 +743,9 @@ public class StatusController extends SpringActionController
         @Override
         public void validateCommand(ConfirmDeleteStatusForm form, Errors errors)
         {
-            Set<String> runs = DataRegionSelection.getSelected(getViewContext(), true);
+            // Don't clear the state yet because we're just validating at this point. We'll clear it as part of the
+            // delete itself. See issue 44873
+            Set<String> runs = DataRegionSelection.getSelected(getViewContext(), false);
 
             try
             {

--- a/pipeline/src/org/labkey/pipeline/status/deleteStatus.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/deleteStatus.jsp
@@ -139,7 +139,7 @@
 
     Set<ExpRun> allRuns = new LinkedHashSet<>();
 %>
-<p>Delete selected pipeline jobs? Only inactive jobs (e.g. Complete, Canceled) may be deleted.</p>
+<p>Delete the <%= files.size() %> selected pipeline job<%= h(files.size() == 1 ? "" : "s")%>? Only inactive jobs (e.g. Complete, Canceled) may be deleted.</p>
 
 <ul>
 <% for (PipelineStatusFileImpl file : files) { %>


### PR DESCRIPTION
#### Rationale
If your job selection state goes beyond the current page of the grid, only the ones from the current page get deleted. It's because we're prematurely clearing the selection state prior to the delete itself.

#### Changes
* Don't clear the state until we're actually doing the delete
* Show the user the number of jobs to be deleted on the confirmation page