### PR TITLE
Remove unused <categories> element and default format attributes from datasets.xsd

### DIFF
--- a/api/schemas/datasets.xsd
+++ b/api/schemas/datasets.xsd
@@ -14,18 +14,6 @@
 	<xs:element name="datasets">
 		<xs:complexType>
 			<xs:all>
-                <xs:element name="categories" minOccurs="0">
-                    <xs:annotation>
-                        <xs:documentation>
-                             Categories are used to organize datasets. Each dataset can belong to one category.
-                        </xs:documentation>
-                    </xs:annotation>
-                    <xs:complexType>
-                        <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                            <xs:element name="category" type="xs:string"/>
-                        </xs:sequence>
-                    </xs:complexType>
-                </xs:element>
 				<xs:element name="datasets" minOccurs="0">
 					<xs:complexType>
 						<xs:sequence minOccurs="0" maxOccurs="unbounded">
@@ -111,22 +99,6 @@
 					</xs:complexType>
 				</xs:element>
 			</xs:all>
-			<xs:attribute name="defaultDateFormat" type="xs:string">
-                <xs:annotation>
-                    <xs:documentation xmlns="http://www.w3.org/1999/xhtml">
-                         Indicates the default date format. See
-                         <a href="https://www.labkey.org/Documentation/wiki-page.view?name=dateFormats" target="_top" rel="noopener noreferrer">Date and Number Formats</a>.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
-			<xs:attribute name="defaultNumberFormat" type="xs:string">
-                <xs:annotation>
-                    <xs:documentation xmlns="http://www.w3.org/1999/xhtml">
-                        Indicates the default number format. See
-                         <a href="https://www.labkey.org/Documentation/wiki-page.view?name=dateFormats" target="_top" rel="noopener noreferrer">Date and Number Formats</a>.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
 			<xs:attribute name="metaDataFile" type="xs:string">
                 <xs:annotation>
                     <xs:documentation>

--- a/study/src/org/labkey/study/importer/DatasetDefinitionImporter.java
+++ b/study/src/org/labkey/study/importer/DatasetDefinitionImporter.java
@@ -81,40 +81,8 @@ public class DatasetDefinitionImporter implements InternalStudyImporter
 
                 if (null != manifestDatasetsXml)
                 {
-                    Container c = ctx.getContainer();
-
-                    // This is only for backwards compatibility; we now export default formats to folder.xml
-                    if (manifestDatasetsXml.isSetDefaultDateFormat())
-                    {
-                        try
-                        {
-                            ctx.getLogger().debug("[" + c.getPath() + "] Default date format from dataset metadata (obsolete): " + manifestDatasetsXml.getDefaultDateFormat());
-                            WriteableFolderLookAndFeelProperties.saveDefaultDateFormat(c, manifestDatasetsXml.getDefaultDateFormat());
-                        }
-                        catch (IllegalArgumentException e)
-                        {
-                            ctx.getLogger().warn("Illegal default date format specified: " + e.getMessage());
-                        }
-                    }
-
-                    // This is only for backwards compatibility; we now export default formats to folder.xml
-                    if (manifestDatasetsXml.isSetDefaultNumberFormat())
-                    {
-                        try
-                        {
-                            ctx.getLogger().debug("[" + c.getPath() + "] Default date format from dataset metadata (obsolete): " + manifestDatasetsXml.getDefaultNumberFormat());
-                            WriteableFolderLookAndFeelProperties.saveDefaultNumberFormat(c, manifestDatasetsXml.getDefaultNumberFormat());
-                        }
-                        catch (IllegalArgumentException e)
-                        {
-                            ctx.getLogger().warn("Illegal default number format specified: " + e.getMessage());
-                        }
-                    }
-
                     DatasetsDocument.Datasets.Datasets2.Dataset[] datasets = manifestDatasetsXml.getDatasets().getDatasetArray();
-
                     extraProps = getDatasetImportProperties(manifestDatasetsXml);
-
                     orderedIds = new ArrayList<>(datasets.length);
 
                     for (DatasetsDocument.Datasets.Datasets2.Dataset dataset : datasets)


### PR DESCRIPTION
#### Rationale
The `<categories>` element in datasets_manifest.xml has been completely unused since 2013; remove it from datasets.xsd.

The `defaultDateFormat` and `defaultNumberFormat` attributes moved to folder.xml in 2013; remove these attributes from datasets.xsd and delete the legacy import code.

#### Related Pull Requests
* See below