### PR TITLE
Issue 44749: Rendering query grid uses two DB connections concurrently

### DIFF
--- a/api/src/org/labkey/api/data/AsyncQueryRequest.java
+++ b/api/src/org/labkey/api/data/AsyncQueryRequest.java
@@ -16,7 +16,6 @@
 
 package org.labkey.api.data;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.queryprofiler.QueryProfiler;
@@ -25,6 +24,7 @@ import org.labkey.api.miniprofiler.RequestInfo;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.UnexpectedException;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.MockHttpResponseWithRealPassthrough;
 
 import javax.servlet.http.HttpServletResponse;
@@ -36,7 +36,7 @@ import java.util.concurrent.Callable;
 
 public class AsyncQueryRequest<T>
 {
-    private static final Logger _log = LogManager.getLogger(AsyncQueryRequest.class);
+    private static final Logger _log = LogHelper.getLogger(AsyncQueryRequest.class, "Runs DB queries on a background thread");
 
     private static class CancelledException extends RuntimeException
     {
@@ -161,15 +161,14 @@ public class AsyncQueryRequest<T>
 
                     if (_exception instanceof RuntimeSQLException)
                         _exception = ((RuntimeSQLException)_exception).getSQLException();
-                    if (_exception instanceof SQLException)
+                    if (_exception instanceof SQLException sqlE)
                     {
-                        SQLException sqlE = (SQLException) _exception;
                         SQLException sqlE2 = new SQLException(sqlE.getMessage(), sqlE.getSQLState(), sqlE.getErrorCode());
                         sqlE2.setNextException(sqlE);
                         throw sqlE2;
                     }
 
-                    throw new UnexpectedException(_exception);
+                    throw UnexpectedException.wrap(_exception);
                 }
 
                 if (clientDisconnectException == null)

--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -833,19 +833,29 @@ public class DataRegion extends DisplayElement
 
             if (countAggregate)
             {
-                List<Aggregate> newAggregates = new LinkedList<>(baseAggregates);
-
-                newAggregates.add(Aggregate.createCountStar());
-                _aggregateResults = ctx.getAggregates(_displayColumns, getTable(), getSettings(), getName(), newAggregates, getQueryParameters(), isAllowAsync());
-                List<Aggregate.Result> result = _aggregateResults.remove(Aggregate.STAR);
-
-                //Issue 14863: add null check
-                if (result != null && result.size() > 0)
+                if (baseAggregates.isEmpty() && _complete && results.getSize() >= 0)
                 {
-                    Aggregate.Result countStarResult = result.get(0);
-                    _totalRows = 0L;
-                    if (countStarResult.getValue() instanceof Number)
-                        _totalRows = ((Number) countStarResult.getValue()).longValue();
+                    // Issue 44749. Don't need to do a separate aggregate query as we already know how many rows
+                    // came back and that it was the complete results
+                    _totalRows = Long.valueOf(results.getSize());
+                    _aggregateResults = Collections.emptyMap();
+                }
+                else
+                {
+                    List<Aggregate> newAggregates = new LinkedList<>(baseAggregates);
+
+                    newAggregates.add(Aggregate.createCountStar());
+                    _aggregateResults = ctx.getAggregates(_displayColumns, getTable(), getSettings(), getName(), newAggregates, getQueryParameters(), isAllowAsync());
+                    List<Aggregate.Result> result = _aggregateResults.remove(Aggregate.STAR);
+
+                    //Issue 14863: add null check
+                    if (result != null && result.size() > 0)
+                    {
+                        Aggregate.Result countStarResult = result.get(0);
+                        _totalRows = 0L;
+                        if (countStarResult.getValue() instanceof Number)
+                            _totalRows = ((Number) countStarResult.getValue()).longValue();
+                    }
                 }
             }
             else

--- a/api/src/org/labkey/api/data/TableSelector.java
+++ b/api/src/org/labkey/api/data/TableSelector.java
@@ -17,7 +17,6 @@
 package org.labkey.api.data;
 
 import org.apache.commons.collections4.MultiValuedMap;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -26,6 +25,7 @@ import org.labkey.api.data.Aggregate.Result;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
+import org.labkey.api.util.logging.LogHelper;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -47,7 +47,7 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
 {
     public static final Set<String> ALL_COLUMNS = Collections.emptySet();
 
-    private static final Logger LOG = LogManager.getLogger(TableSelector.class);
+    private static final Logger LOG = LogHelper.getLogger(TableSelector.class, "Runs DB queries against TableInfos");
 
     private final TableInfo _table;
     private final Collection<ColumnInfo> _columns;
@@ -431,7 +431,7 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
                 // Issue 17536: Issue a warning instead of blowing up if there is no result row containing the aggregate values.
                 if (!rs.next())
                 {
-                    LogManager.getLogger(TableSelector.class).warn("Expected a non-empty resultset from aggregate query.");
+                    LOG.warn("Expected a non-empty resultset from aggregate query.");
                 }
                 else
                 {


### PR DESCRIPTION
#### Rationale
I had to back out my original attempt to fix this as it caused intermittent failures on TeamCity, likely due to cancelled queries when the browser navigated away during render. I'll revisit how the connection gets reused. But this part of the change, which prevents the need for the separate aggregate query when we know the result set is complete is safe and makes it less likely we'll end up using two connections concurrently.

#### Changes
* Don't execute a separate aggregate query to get the count when we already know the number of rows
* Minor code cleanup