### PR TITLE
Issue 44749: Rendering query grid uses two DB connections concurrently

### DIFF
--- a/api/src/org/labkey/api/data/RenderContext.java
+++ b/api/src/org/labkey/api/data/RenderContext.java
@@ -403,6 +403,7 @@ public class RenderContext implements Map<String, Object>, Serializable
         {
             TableSelector selector = new TableSelector(tinfo, cols, filter, null)
             {
+                private boolean _shouldClose = true;
                 @Override
                 public Connection getConnection() throws SQLException
                 {
@@ -416,11 +417,22 @@ public class RenderContext implements Map<String, Object>, Serializable
                             Connection c = statement.getConnection();
                             if (!c.isClosed())
                             {
+                                _shouldClose = false;
                                 return c;
                             }
                         }
                     }
                     return super.getConnection();
+                }
+
+                @Override
+                protected void close(@Nullable ResultSet rs, @Nullable Connection conn)
+                {
+                    // Don't close if we're just borrowing someone else's connection
+                    if (_shouldClose)
+                    {
+                        super.close(rs, conn);
+                    }
                 }
             };
 


### PR DESCRIPTION
#### Rationale
Using multiple connections concurrently is bad because it can lead to deadlocks trying to get DB connections from the pool during heavy load. Better to use a single connection when possible, including for the main grid and its aggregate query

#### Changes
* Check if we have a Connection we can reuse from the primary ResultSet that's driving the grid's data