### PR TITLE
Stop logging cancelled queries on SQLServer as errors

### DIFF
--- a/api/src/org/labkey/api/data/Table.java
+++ b/api/src/org/labkey/api/data/Table.java
@@ -469,7 +469,7 @@ public class Table
                 // Log this ConstraintException if log Level is WARN (the default) or lower. Skip logging for callers that request just ERRORs.
                 if (Level.WARN.isMoreSpecificThan(logLevel))
                 {
-                    _log.warn("SQL Exception", e);
+                    _log.warn("SQL Exception" + (e.getSQLState() == null ? "" : (" with SQLState: " + e.getSQLState())), e);
                     _logQuery(Level.WARN, sql, conn);
                 }
             }
@@ -478,7 +478,7 @@ public class Table
                 // Log this SQLException if log level is ERROR or lower.
                 if (Level.ERROR.isMoreSpecificThan(logLevel))
                 {
-                    _log.error("SQL Exception", e);
+                    _log.error("SQL Exception" + (e.getSQLState() == null ? "" : (" with SQLState: " + e.getSQLState())), e);
                     _logQuery(Level.ERROR, sql, conn);
                 }
             }

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -344,9 +344,10 @@ public abstract class SqlDialect
     public static boolean isCancelException(SQLException x)
     {
         String sqlState = x.getSQLState();
-        if (null == sqlState || !sqlState.startsWith("57"))
+        if (null == sqlState)
             return false;
-        return sqlState.equals("57014"); // TODO verify SQL Server
+        return sqlState.equals("57014") || // Postgres
+               sqlState.equalsIgnoreCase("HY000") || sqlState.equalsIgnoreCase("HY008"); // SQLServer
     }
 
 


### PR DESCRIPTION
#### Rationale
We're getting TeamCity failures in TargetedMS tests with SQLExceptions saying "The server returned an unspecified error". Upon investigation, it's because we cancelled the query after the browser navigated away

An example: https://teamcity.labkey.org/buildConfiguration/LabKey_222Release_Community_ModuleSuites_TargettedMSSqlserve/1714673?showRootCauses=false&expandBuildChangesSection=true&expandBuildTestsSection=true

#### Changes
* Log SQLState along with SQLException itself
* Ignore SQLServer cancelled queries based on SQLState