### PR TITLE
Migrate subfolder data experimental flag to platform

### DIFF
--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -48,6 +48,7 @@ import org.labkey.api.query.column.ConceptURIColumnInfoTransformer;
 import org.labkey.api.query.snapshot.QuerySnapshotDefinition;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
+import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.util.Path;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
@@ -69,6 +70,7 @@ import java.util.Set;
 public interface QueryService
 {
     String EXPERIMENTAL_LAST_MODIFIED = "queryMetadataLastModified";
+    String EXPERIMENTAL_SUBFOLDER_DATA_ENABLED = "isSubfolderDataEnabled";
 
     String MODULE_QUERIES_DIRECTORY = "queries";
     Path MODULE_QUERIES_PATH = Path.parse(MODULE_QUERIES_DIRECTORY);
@@ -612,5 +614,10 @@ public interface QueryService
                 d.apply(col);
         }
         return col;
+    }
+
+    default boolean isProductSubfolderDataEnabled()
+    {
+        return ExperimentalFeatureService.get().isFeatureEnabled(EXPERIMENTAL_SUBFOLDER_DATA_ENABLED);
     }
 }

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -219,6 +219,8 @@ public class QueryModule extends DefaultModule
         AdminConsole.addExperimentalFeatureFlag(QueryServiceImpl.EXPERIMENTAL_LAST_MODIFIED, "Include Last-Modified header on query metadata requests",
                 "For schema, query, and view metadata requests include a Last-Modified header such that the browser can cache the response. " +
                 "The metadata is invalidated when performing actions such as creating a new List or modifying the columns on a custom view", false);
+        AdminConsole.addExperimentalFeatureFlag(QueryServiceImpl.EXPERIMENTAL_SUBFOLDER_DATA_ENABLED, "Subfolder data in LabKey Products",
+                "View and interact with data from subfolders of a Product Project.", false);
     }
 
 
@@ -385,9 +387,10 @@ public class QueryModule extends DefaultModule
     @Override
     public JSONObject getPageContextJson(ContainerUser context)
     {
-        JSONObject json = new JSONObject(getDefaultPageContextJson(context.getContainer()));
+        JSONObject json = super.getPageContextJson(context);
         boolean hasEditQueriesPermission = context.getContainer().hasPermission(context.getUser(), EditQueriesPermission.class);
         json.put("hasEditQueriesPermission", hasEditQueriesPermission);
+        json.put(QueryServiceImpl.EXPERIMENTAL_SUBFOLDER_DATA_ENABLED, QueryService.get().isProductSubfolderDataEnabled());
 
         return json;
     }


### PR DESCRIPTION
#### Rationale
Migrates the subfolder data experimental flag from LKB module to platform for use in other modules / packages.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3068
* https://github.com/LabKey/biologics/pull/1162
* https://github.com/LabKey/labkey-ui-components/pull/741

#### Changes
* Migrate experimental flag "isSubfolderDataEnabled" to be exposed via `QueryService`.
