### PR TITLE
Stop creating shared datasets when importing folder archives

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
@@ -121,7 +121,7 @@ public class SharedStudyTest extends BaseWebDriverTest
 
         setPipelineRoot(STUDY_DIR.getAbsolutePath());
         _containerHelper.createSubfolder(getProjectName(), STUDY1, "Study");
-        importFolderFromPipeline("folder.xml", 1, false);
+        importFolderFromPipeline("folder.xml", 1, false, false);
 
         _containerHelper.createSubfolder(getProjectName(), STUDY2, "Study");
         clickButton("Create Study");

--- a/study/test/src/org/labkey/test/tests/study/StudyDataspaceTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDataspaceTest.java
@@ -207,7 +207,7 @@ public class StudyDataspaceTest extends StudyBaseTest
         _containerHelper.createSubfolder(getProjectName(), getProjectName(), SUBFOLDER_STUDY5, "Collaboration", null, true);
         clickFolder(SUBFOLDER_STUDY5);
         setPipelineRoot(StudyHelper.getStudySubfolderPath());
-        importFolderFromPipeline("/export/folder.xml", 1, false);
+        importFolderFromPipeline("/export/folder.xml", 1, false, false);
         clickFolder(SUBFOLDER_STUDY5);
         assertTextPresent("tracks data in", "over 6 time points", "Data is present for 3 Participants");
         verifyLabResultsDataset(6, null);


### PR DESCRIPTION
#### Rationale
The folder import page now offers the "create shared datasets" option when in a dataspace folder, on by default. These tests weren't expecting shared datasets, so they need to uncheck that option.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1022
