### PR TITLE
Fix AssayQCTest after improvements to aggregate query handling

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -28,6 +28,7 @@ import org.labkey.api.assay.query.ResultsQueryView;
 import org.labkey.api.assay.query.RunListQueryView;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.AbstractTableInfo;
+import org.labkey.api.data.Aggregate;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ColumnRenderProperties;
@@ -711,17 +712,17 @@ public abstract class AssayProtocolSchema extends AssaySchema implements UserSch
                                 baseQueryView.setMessageSupplier(dataRegion -> {
                                     try
                                     {
-                                        // Issue 40921: Getting all results for the data region requires an operation that iterates
-                                        // through and counts the total rows in the data region. getAggregateResults
-                                        // with ALL_ROWS will perform this calculation
-                                        int maxRows = dataRegion.getSettings().getMaxRows();
-                                        dataRegion.getSettings().setMaxRows(Table.ALL_ROWS);
-                                        dataRegion.getAggregateResults(renderContext);
-                                        dataRegion.getSettings().setMaxRows(maxRows);
+                                        // Get a fresh set of aggregates from the render context. We're applying
+                                        // a different set of filters based on QC state than the main DataRegion
+                                        Aggregate countAgg = Aggregate.createCountStar();
+                                        Map<String, List<Aggregate.Result>> allAggResults = renderContext.getAggregates(dataRegion.getDisplayColumns(), dataRegion.getTable(), dataRegion.getSettings(), dataRegion.getName(), Collections.singletonList(countAgg), dataRegion.getQueryParameters(), dataRegion.isAllowAsync());
+                                        List<Aggregate.Result> aggResults = allAggResults.get(countAgg.getFieldKey().toString());
+                                        assert aggResults.size() == 1 : "Expected a single aggregate result but got " + aggResults.size();
+                                        int totalRows = ((Number)aggResults.get(0).getValue()).intValue();
 
-                                        if (dataRegion.getTotalRows() != null && dataRegion.getTotalRows() < rowCount)
+                                        if (totalRows < rowCount)
                                         {
-                                            long count = rowCount - dataRegion.getTotalRows();
+                                            long count = rowCount - totalRows;
                                             String msg = count > 1 ? "There are " + count + " rows not shown due to unapproved QC state."
                                                     : "There is one row not shown due to unapproved QC state.";
                                             DataRegion.Message drm = new DataRegion.Message(msg, DataRegion.MessageType.WARNING, DataRegion.MessagePart.view);


### PR DESCRIPTION
#### Rationale
Assay QC scenarios involve getting the count of all assay runs to see if the user is missing any from their view of the data based on the runs' QC state. The improvements to not issue a separate aggregates query for normal grid rendering has broken this codepath, which looks like it was probably always problematic due to a mix of cached results for totalRows and aggregates in DataRegion even if the header showed as expected.

https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_GitSqlserver2014/1712781?showRootCauses=false&expandBuildChangesSection=true&expandBuildTestsSection=true

#### Changes
* Issue a separate aggregate query request against RenderContext to get the count of total rows
