### PR TITLE
Fix "PSQLException: Unable to find server array type for provided name null"

### DIFF
--- a/api/src/org/labkey/api/data/CachedResultSet.java
+++ b/api/src/org/labkey/api/data/CachedResultSet.java
@@ -39,6 +39,7 @@ import java.net.URL;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
+import java.sql.Connection;
 import java.sql.Date;
 import java.sql.NClob;
 import java.sql.Ref;
@@ -166,8 +167,13 @@ public class CachedResultSet implements ResultSet, TableResultSet
         return this;
     }
 
+    @Override
+    public @Nullable Connection getConnection() throws SQLException
+    {
+        return null;
+    }
 
-    //
+//
     // ResultSet
     //
 

--- a/api/src/org/labkey/api/data/DataIteratorResultsImpl.java
+++ b/api/src/org/labkey/api/data/DataIteratorResultsImpl.java
@@ -30,6 +30,7 @@ import java.net.URL;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
+import java.sql.Connection;
 import java.sql.Date;
 import java.sql.NClob;
 import java.sql.Ref;
@@ -147,6 +148,12 @@ public class DataIteratorResultsImpl implements Results, TableResultSet
     {
         // TODO
         return null;
+    }
+
+    @Override
+    public @NotNull Connection getConnection() throws SQLException
+    {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/api/src/org/labkey/api/data/RenderContext.java
+++ b/api/src/org/labkey/api/data/RenderContext.java
@@ -411,15 +411,11 @@ public class RenderContext implements Map<String, Object>, Serializable
                     // two connections concurrently for a single grid render
                     if (_results != null)
                     {
-                        Statement statement = _results.getStatement();
-                        if (statement != null)
+                        Connection c = _results.getConnection();
+                        if (c != null && !c.isClosed())
                         {
-                            Connection c = statement.getConnection();
-                            if (!c.isClosed())
-                            {
-                                _shouldClose = false;
-                                return c;
-                            }
+                            _shouldClose = false;
+                            return c;
                         }
                     }
                     return super.getConnection();

--- a/api/src/org/labkey/api/data/ResultsImpl.java
+++ b/api/src/org/labkey/api/data/ResultsImpl.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
+import java.sql.Connection;
 import java.sql.Date;
 import java.sql.NClob;
 import java.sql.Ref;
@@ -146,6 +147,27 @@ public class ResultsImpl implements Results, DataIterator
         }
     }
 
+    @Override
+    public @NotNull Connection getConnection()
+    {
+        Connection result = null;
+        try
+        {
+            if (_rs instanceof TableResultSet trs)
+            {
+                result = trs.getConnection();
+            }
+            if (result == null)
+            {
+                result = _rs.getStatement().getConnection();
+            }
+            return result;
+        }
+        catch (SQLException e)
+        {
+            throw new RuntimeSQLException(e);
+        }
+    }
 
     @Deprecated
     public ResultsImpl(RenderContext ctx)

--- a/api/src/org/labkey/api/data/TableResultSet.java
+++ b/api/src/org/labkey/api/data/TableResultSet.java
@@ -16,7 +16,9 @@
 package org.labkey.api.data;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Iterator;
@@ -45,4 +47,10 @@ public interface TableResultSet extends ResultSet, Iterable<Map<String, Object>>
     {
         return getSize();
     }
+
+    /** @return the DB connection associated with this ResultSet. May be null if not backed by an active connection.
+     * Implementations should prefer to return ConnectionWrapper instead of the underlying connection as it has
+     * more context. */
+    @Nullable
+    Connection getConnection() throws SQLException;
 }


### PR DESCRIPTION
#### Rationale
The change to use the same DB connection for the aggregates query on a data region as used for the primary query caused test failures on Postgres. We need to use the ConnectionWrapper instead of the raw DB connection so that it knows how to create the right JDBC array type.

https://teamcity.labkey.org/buildConfiguration/bt20/1715835?buildTab=overview&showRootCauses=false&expandBuildTestsSection=true&expandBuildChangesSection=true

#### Changes
* Propagate the ConnectionWrapper instead of getting the Connection from the Statement, which returns the raw connection from the pool