### PR TITLE
Issue 43618: Remove additional inappropriate advice for UnauthorizedException subclasses

### DIFF
--- a/core/src/client/ErrorHandler/ErrorHandler.spec.tsx
+++ b/core/src/client/ErrorHandler/ErrorHandler.spec.tsx
@@ -8,7 +8,6 @@ import { ErrorDetails, ErrorType } from './model';
 
 describe('ErrorHandler', () => {
     test('Not found exception', () => {
-        const notFoundMessage = 'Oops! The requested page cannot be found.';
         const errorDetails: ErrorDetails = {
             errorType: ErrorType.notFound,
             errorCode: '123XYZ',
@@ -16,7 +15,6 @@ describe('ErrorHandler', () => {
         };
         const wrapper = mount(<ErrorHandler context={{ errorDetails }} />);
         expect(wrapper.find('.labkey-error-heading').text().includes(errorDetails.message)).toBeTruthy();
-        expect(wrapper.find('.labkey-error-subheading').text().includes(notFoundMessage)).toBeTruthy();
         expect(wrapper.find('.error-details-container')).toHaveLength(0);
 
         wrapper.setState({ showDetails: true });

--- a/core/src/client/ErrorHandler/ErrorType.tsx
+++ b/core/src/client/ErrorHandler/ErrorType.tsx
@@ -43,7 +43,7 @@ const NOTFOUND_HEADING = (errorMessage?: string) => (<>
 const NOTFOUND_SUBHEADING = (errorMessage?: string) => (
     <>
         {errorMessage !== undefined
-            ? 'Oops! The requested page cannot be found.'
+            ? ''
             : 'It seems like something went wrong.'}
     </>
 );
@@ -116,18 +116,24 @@ const PERMISSION_SUBHEADING = (errorMessage: string) => (
 
 const PERMISSION_INSTRUCTION = (errorDetails: ErrorDetails) => <>{errorDetails.advice} </>;
 
-const PERMISSION_DETAILS = () => (
+const PERMISSION_DETAILS = (errorDetails: ErrorDetails) => (
     <>
-        <p className="labkey-error-details labkey-error-details-question">What is a permission error?</p>
+        {errorDetails.advice === undefined ?
+            <>
+                <p className="labkey-error-details labkey-error-details-question">What is a permission error?</p>
 
-        <p className="labkey-error-details">
-            A permission error occurs when the account you've logged into does not have the set permissions to access
-            this page. <HelpLink topic="permissionLevels" referrer={HELP_LINK_REFERRER.ERROR_PAGE}>Read More &gt;</HelpLink>
-        </p>
-        <div className="labkey-error-details labkey-error-subdetails">
-            <FontAwesomeIcon icon={faCheckCircle} className="domain-panel-status-icon-green" /> Try contacting your
-            server administrator to request access to this page.
-        </div>
+                <p className="labkey-error-details">
+                    A permission error occurs when the account you've logged into does not have the required permissions to
+                    access
+                    this page. <HelpLink topic="permissionLevels" referrer={HELP_LINK_REFERRER.ERROR_PAGE}>Read
+                    More &gt;</HelpLink>
+                </p>
+                <div className="labkey-error-details labkey-error-subdetails">
+                <FontAwesomeIcon icon={faCheckCircle} className="domain-panel-status-icon-green" /> Try contacting your
+                server administrator to request access to this page.
+                </div>
+            </> : <p className="labkey-error-details">{errorDetails.advice}</p>
+        }
         <div className="labkey-error-details">
             <ul>
                 <li>


### PR DESCRIPTION
#### Rationale
This PR removes generic unauthorized error pages advice with provided advices.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3074

#### Changes
* display the error advice instead of permission details section when provided
* change the text from 'set' permissions to 'required' permissions
* remove 'Oops! the requested page cannot be found' from not found subheading
