### PR TITLE
Item 10056: Sample Finder v1 - Wire up new lineage filters

### DIFF
--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -579,6 +579,11 @@ public abstract class SqlDialect
 
     public abstract boolean supportsSelectConcat();
 
+    public boolean supportsGroupConcatSubSelect()
+    {
+        return true;
+    }
+
     // SelectConcat returns SQL that will generate a comma separated list of the results from the passed in select SQL.
     // This is not generally usable within a GROUP BY. Include distinct, order by, etc. in the selectSql if desired
     public abstract SQLFragment getSelectConcat(SQLFragment selectSql, String delimiter);

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -630,6 +630,12 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
 
     private static final Pattern SELECT = Pattern.compile("\\bSELECT\\b", Pattern.CASE_INSENSITIVE);
 
+    @Override
+    public boolean supportsGroupConcatSubSelect()
+    {
+        return false;
+    }
+
     // Uses custom CLR aggregate function defined in group_concat_install.sql
     @Override
     public SQLFragment getGroupConcat(SQLFragment sql, boolean distinct, boolean sorted, @NotNull String delimiterSQL)

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -159,6 +159,8 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
         if (null == tinfo)
             throw new NotFoundException("Could not find the query '" + form.getQueryName() + "' in the schema '" + form.getSchemaName() + "'!");
 
+        resp.put("supportGroupConcatSubSelect", tinfo.getSqlDialect().supportsGroupConcatSubSelect());
+
         // check if this query is shadowing a local table
         if (isUserDefined)
         {


### PR DESCRIPTION
#### Rationale
MSSQL does not support sub select in group concate. Lineage lookup fields are added to sample finder results grid using MVFK, which is not able to render columns that are backed by ExprColumns with sub select clauses. We will exclude those fields from sample finder when the DB used is sql server. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/124
* https://github.com/LabKey/labkey-ui-components/pull/743
* https://github.com/LabKey/sampleManagement/pull/847
* https://github.com/LabKey/biologics/pull/1165

#### Changes
* Add supportGroupConcatSubSelect to getQueryDetails response. 