### PR TITLE
Assert if SQL script is badly named

### DIFF
--- a/api/src/org/labkey/api/data/FileSqlScriptProvider.java
+++ b/api/src/org/labkey/api/data/FileSqlScriptProvider.java
@@ -360,6 +360,8 @@ public class FileSqlScriptProvider implements SqlScriptProvider
 
             if (_fromVersion < _toVersion)
                 _validName = true;
+            else
+                assert false : fileName + " has bad version numbers!"; // Ignore on production, throw on development
         }
 
         // Used for DROP and CREATE scripts... so we don't bother verifying filename or parsing info from it

--- a/api/src/org/labkey/api/data/FileSqlScriptProvider.java
+++ b/api/src/org/labkey/api/data/FileSqlScriptProvider.java
@@ -369,7 +369,7 @@ public class FileSqlScriptProvider implements SqlScriptProvider
                 throw new IllegalStateException("SQL scripts and null schema version do not compute");
 
             if (_toVersion > schemaVersion)
-                _log.warn(fileName + " will never execute because " + _provider._module.getName() + " schema version is less than its \"to\" version");
+                _log.warn(fileName + " will never execute because " + _provider._module.getName() + " schema version is less than this script's \"to\" version");
         }
 
         // Used for DROP and CREATE scripts... so we don't bother verifying filename or parsing info from it

--- a/api/src/org/labkey/api/data/FileSqlScriptProvider.java
+++ b/api/src/org/labkey/api/data/FileSqlScriptProvider.java
@@ -362,6 +362,14 @@ public class FileSqlScriptProvider implements SqlScriptProvider
                 _validName = true;
             else
                 assert false : fileName + " has bad version numbers!"; // Ignore on production, throw on development
+
+            Double schemaVersion = _provider._module.getSchemaVersion();
+
+            if (schemaVersion == null)
+                throw new IllegalStateException("SQL scripts and null schema version do not compute");
+
+            if (_toVersion > schemaVersion)
+                _log.warn(fileName + " will never execute because " + _provider._module.getName() + " schema version is less than its \"to\" version");
         }
 
         // Used for DROP and CREATE scripts... so we don't bother verifying filename or parsing info from it


### PR DESCRIPTION
#### Rationale
A recent SQL script was committed with bad version numbers. LabKey should flag this during development instead of silently ignoring such a script.

Note: Initially, this branch should fail to bootstrap on a full build that includes the immport module. It should then switch to success once 21.11 script changes are merged.
