### PR TITLE
44921: Assay Link to Study Dataset View Permissions: 21.11

### DIFF
--- a/assay/api-src/org/labkey/api/assay/AssayResultTable.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultTable.java
@@ -62,7 +62,6 @@ import org.labkey.api.query.column.BuiltInColumnTypes;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.DeletePermission;
-import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
@@ -538,7 +537,7 @@ public class AssayResultTable extends FilteredTable<AssayProtocolSchema> impleme
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
         if (perm.equals(ReadPermission.class))
-            return _userSchema.getContainer().hasPermission(user, perm);
+            return _userSchema.getContainer().hasPermission(user, perm, _userSchema.getContextualRoles());
         if (DeletePermission.class.isAssignableFrom(perm) || UpdatePermission.class.isAssignableFrom(perm))
                 return _provider.isEditableResults(_protocol) && _userSchema.getContainer().hasPermission(user, perm);
         return false;


### PR DESCRIPTION
#### Rationale
For linked to study assay data, as long as the user had read access to the dataset, they should be able to view the dataset even if they didn't have read access to the source assay:

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44921

We were passing a `ContextualRole` into the `AssayProtocolSchema` we just weren't using it because `AssayResultTable` overrides `hasPermission`.