### PR TITLE
remove X-XSS-Protection header

### DIFF
--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -649,7 +649,6 @@ public class ExceptionUtil
                 {
                     if (!"ALLOW".equals(AppProps.getInstance().getXFrameOptions()))
                         response.setHeader("X-Frame-Options", AppProps.getInstance().getXFrameOptions());
-                    response.setHeader("X-XSS-Protection", "1; mode=block");
                     response.setHeader("X-Content-Type-Options", "nosniff");
                 }
             }

--- a/internal/src/org/labkey/api/security/AuthFilter.java
+++ b/internal/src/org/labkey/api/security/AuthFilter.java
@@ -80,7 +80,6 @@ public class AuthFilter implements Filter
         {
             if (!"ALLOW".equals(AppProps.getInstance().getXFrameOptions()))
                 resp.setHeader("X-Frame-Options", AppProps.getInstance().getXFrameOptions());
-            resp.setHeader("X-XSS-Protection", "1; mode=block");
             resp.setHeader("X-Content-Type-Options", "nosniff");
             resp.setHeader("Referrer-Policy", "origin-when-cross-origin" );
         }

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -1135,9 +1135,6 @@ public class StudyController extends BaseStudyController
             CustomParticipantView customParticipantView = StudyManager.getInstance().getCustomParticipantView(study);
             if (customParticipantView != null && customParticipantView.isActive())
             {
-                // issue : 18595 chrome will complain that the script we are executing matches the script sent down in the request
-                getViewContext().getResponse().setHeader("X-XSS-Protection", "0");
-
                 vbox.addView(customParticipantView.getView());
             }
             else
@@ -4686,9 +4683,6 @@ public class StudyController extends BaseStudyController
             CustomParticipantView view = StudyManager.getInstance().getCustomParticipantView(study);
             if (view != null)
             {
-                // issue : 18595 chrome will complain that the script we are executing matches the script sent down in the request
-                getViewContext().getResponse().setHeader("X-XSS-Protection", "0");
-
                 form.setCustomScript(view.getBody());
                 form.setUseCustomView(view.isActive());
                 form.setEditable(!view.isModuleParticipantView());


### PR DESCRIPTION
#### Rationale
X-XSS-Protection header is no longer supported by most browsers and no longer recommended.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
