### PR TITLE
44932: NPE in StudyPublishService on trial instances because the study module is not present

### DIFF
--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -952,7 +952,8 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
             st.setMetricUnit(options.getMetricUnit());
             st.setImportAliasMap(options.getImportAliases());
-            st.setAutoLinkTargetContainer(ContainerManager.getForId(options.getAutoLinkTargetContainerId()));
+            if (!StringUtils.isBlank(options.getAutoLinkTargetContainerId()))
+                st.setAutoLinkTargetContainer(ContainerManager.getForId(options.getAutoLinkTargetContainerId()));
             st.setAutoLinkCategory(options.getAutoLinkCategory());
             if (options.getCategory() != null) // update sample type category is currently not supported
                 st.setCategory(options.getCategory());

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -65,6 +65,7 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
+import org.labkey.api.study.publish.StudyPublishService;
 import org.labkey.api.util.Pair;
 import org.labkey.experiment.ExpDataIterators;
 import org.labkey.experiment.SampleTypeAuditProvider;
@@ -191,7 +192,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             if (InventoryService.get() != null)
                 dib = LoggingDataIterator.wrap(InventoryService.get().getPersistStorageItemDataIteratorBuilder(dib, userSchema.getContainer(), userSchema.getUser(), sampleType.getMetricUnit()));
 
-            if (sampleType.getAutoLinkTargetContainer() != null)
+            if (sampleType.getAutoLinkTargetContainer() != null && StudyPublishService.get() != null)
                 dib = LoggingDataIterator.wrap(new ExpDataIterators.AutoLinkToStudyDataIteratorBuilder(dib, getSchema(), userSchema.getContainer(), userSchema.getUser(), sampleType));
         }
         return dib;

--- a/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
+++ b/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
@@ -539,7 +539,8 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
             aliquotNameExpression = StringUtils.trimToNull(StringUtilsLabKey.replaceBadCharacters(arguments.getAliquotNameExpression()));
             labelColor = StringUtils.trimToNull(arguments.getLabelColor());
             metricUnit = StringUtils.trimToNull(arguments.getMetricUnit());
-            autoLinkTargetContainer = ContainerManager.getForId(arguments.getAutoLinkTargetContainerId());
+            if (!StringUtils.isBlank(arguments.getAutoLinkTargetContainerId()))
+                autoLinkTargetContainer = ContainerManager.getForId(arguments.getAutoLinkTargetContainerId());
             autoLinkCategory = StringUtils.trimToNull(arguments.getAutoLinkCategory());
             category = StringUtils.trimToNull(arguments.getCategory());
             aliases = arguments.getImportAliases();


### PR DESCRIPTION
#### Rationale
LKSM tests were failing on trial instances because the `Study` module was not present. Additionally an error was discovered during the updating of a sample type definition that might inadvertently set up an auto link target container of : `Root`.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44932

#### Changes
- Don't add the `AutoLinkToStudyDataIterator` if the `StudyPublishService` is not registered
- Don't set the `autoLinkTargetContainer` if the value is null or blank
