### PR TITLE
Experiment: improve container filter support

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExpSampleType.java
+++ b/api/src/org/labkey/api/exp/api/ExpSampleType.java
@@ -182,7 +182,8 @@ public interface ExpSampleType extends ExpObject
 
     String createSampleName(@NotNull Map<String, Object> rowMap,
                             @Nullable Set<ExpData> parentDatas,
-                            @Nullable Set<ExpMaterial> parentSamples) throws ExperimentException;
+                            @Nullable Set<ExpMaterial> parentSamples,
+                            @Nullable Container container) throws ExperimentException;
 
 
     void setIdCol1(String s);

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -702,7 +702,13 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     List<? extends ExpProtocol> getAllExpProtocols();
 
-    List<? extends ExpProtocol> getExpProtocolsWithParameterValue(@NotNull String parameterURI, @NotNull String parameterValue, @Nullable Container c);
+    List<? extends ExpProtocol> getExpProtocolsWithParameterValue(
+        @NotNull String parameterURI,
+        @NotNull String parameterValue,
+        @Nullable Container c,
+        @Nullable User user,
+        boolean includeProjectAndShared
+    );
 
     void registerRunEditor(ExpRunEditor editor);
 

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -74,6 +74,7 @@ import org.labkey.api.query.DefaultQueryUpdateService;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.InvalidKeyException;
+import org.labkey.api.query.PdLookupForeignKey;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
@@ -410,6 +411,9 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                     wrappedMvCol.getFieldKey();
                     wrapped.setMvColumnName(wrappedMvCol.getFieldKey());
                 }
+
+                if (wrapped.getFk() instanceof PdLookupForeignKey)
+                    ((PdLookupForeignKey) wrapped.getFk()).setContainerFilter(getContainerFilter());
             }
 
             addColumn(wrapped);

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -412,7 +412,8 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                     wrapped.setMvColumnName(wrappedMvCol.getFieldKey());
                 }
 
-                if (wrapped.getFk() instanceof PdLookupForeignKey)
+                boolean isTargetLookup = dp.getLookup() != null && dp.getLookup().getContainer() != null;
+                if (!isTargetLookup && wrapped.getFk() instanceof PdLookupForeignKey)
                     ((PdLookupForeignKey) wrapped.getFk()).setContainerFilter(getContainerFilter());
             }
 

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -53,6 +53,7 @@ import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.LookupForeignKey;
+import org.labkey.api.query.PdLookupForeignKey;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUrls;
@@ -780,6 +781,10 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                     addColumn(mvColumn);
                     propColumn.setMvColumnName(FieldKey.fromParts(dp.getName() + MvColumn.MV_INDICATOR_SUFFIX));
                 }
+
+                boolean isTargetLookup = dp.getLookup() != null && dp.getLookup().getContainer() != null;
+                if (!isTargetLookup && propColumn.getFk() instanceof PdLookupForeignKey)
+                    ((PdLookupForeignKey) propColumn.getFk()).setContainerFilter(getContainerFilter());
             }
 
             if (!mvColumns.contains(propColumn.getFieldKey()))


### PR DESCRIPTION
#### Rationale
Adds support for container filtering to lookups in `ExpMaterialTable` and `ExpDataClassDataTable`. Updates `getExpProtocolsWithParameterValue` to support searching in Projects and Shared for `ExpProtocol` by specified criteria.

Note, the lookup handling could likely be consolidated into `PdForeignLookupKey`, however, I was unsuccessful in this endeavor in previous iterations. There are some subtle use cases of `PdForeignLookupKey` that I will have to triage to better understand the implications.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/752
* https://github.com/LabKey/biologics/pull/1177
* https://github.com/LabKey/platform/pull/3102
* https://github.com/LabKey/recipe/pull/60

#### Changes
* Adds support for container filtering to lookups in `ExpMaterialTable` and `ExpDataClassDataTable`. 
* Updates `getExpProtocolsWithParameterValue` to support searching in Projects and Shared for `ExpProtocol` by specified criteria.
