### PR TITLE
22.3 fb issue 44544

### DIFF
--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -95,6 +95,12 @@ public interface Dataset extends StudyEntity, StudyCachable<Dataset>
                     }
 
                     @Override
+                    public ActionURL getSourceActionURL(ExpObject source, Container container)
+                    {
+                        return PageFlowUtil.urlProvider(AssayUrls.class).getAssayResultsURL(container, (ExpProtocol) source);
+                    }
+
+                    @Override
                     public @Nullable ActionButton getSourceButton(Integer publishSourceId, ContainerFilter cf, Container container)
                     {
                         if (publishSourceId != null)
@@ -140,7 +146,7 @@ public interface Dataset extends StudyEntity, StudyCachable<Dataset>
                     }
 
                     @Override
-                    protected String getAuditMessageSourceType()
+                    public String getSourceType()
                     {
                         return "assay";
                     }
@@ -201,7 +207,7 @@ public interface Dataset extends StudyEntity, StudyCachable<Dataset>
                     }
 
                     @Override
-                    protected String getAuditMessageSourceType()
+                    public String getSourceType()
                     {
                         return "sample type";
                     }
@@ -218,21 +224,17 @@ public interface Dataset extends StudyEntity, StudyCachable<Dataset>
         public abstract @Nullable ActionButton getSourceButton(Integer publishSourceId, ContainerFilter cf, Container container);
         public abstract boolean hasUsefulDetailsPage(Integer publishSourceId);
         public abstract @Nullable Container resolveSourceLsidContainer(String sourceLsid, @Nullable Integer sourceRowId);
-
-        protected abstract String getAuditMessageSourceType();
-        public ActionURL getSourceActionURL(ExpObject source, Container container)
-        {
-            return null;
-        }
+        public abstract String getSourceType();
+        public abstract ActionURL getSourceActionURL(ExpObject source, Container container);
 
         public String getLinkToStudyAuditMessage(ExpObject source, int recordCount)
         {
-            return recordCount + " row(s) were linked to a study from the " + getAuditMessageSourceType() + ": " + source.getName();
+            return recordCount + " row(s) were linked to a study from the " + getSourceType() + ": " + source.getName();
         }
 
         public String getRecallFromStudyAuditMessage(String label, int recordCount)
         {
-            return recordCount + " row(s) were recalled from a study to the " + getAuditMessageSourceType() + ": " + label;
+            return recordCount + " row(s) were recalled from a study to the " + getSourceType() + ": " + label;
         }
     }
 

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/api": "1.7.2",
+        "@labkey/api": "1.10.0",
         "@labkey/components": "2.138.1",
         "@labkey/themes": "1.2.1"
       },
@@ -2847,9 +2847,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.7.2",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.7.2.tgz",
-      "integrity": "sha1-2G4KoFl6rLWxGVuh2qPmiwd7RdM=",
+      "version": "1.10.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.10.0.tgz",
+      "integrity": "sha1-+n1L8fL1dpJRP0sc0qyjxN2F6GA=",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2939,12 +2939,6 @@
         "react-dom": "^16.0",
         "reactn": "^2.2.7"
       }
-    },
-    "node_modules/@labkey/components/node_modules/@labkey/api": {
-      "version": "1.10.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.10.0.tgz",
-      "integrity": "sha1-+n1L8fL1dpJRP0sc0qyjxN2F6GA=",
-      "license": "Apache-2.0"
     },
     "node_modules/@labkey/eslint-config-base": {
       "version": "0.0.8",
@@ -19097,9 +19091,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.7.2",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.7.2.tgz",
-      "integrity": "sha1-2G4KoFl6rLWxGVuh2qPmiwd7RdM="
+      "version": "1.10.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.10.0.tgz",
+      "integrity": "sha1-+n1L8fL1dpJRP0sc0qyjxN2F6GA="
     },
     "@labkey/build": {
       "version": "5.0.0",
@@ -19177,13 +19171,6 @@
         "redux-actions": "2.3.2",
         "use-immer": "0.6.0",
         "vis-network": "6.5.2"
-      },
-      "dependencies": {
-        "@labkey/api": {
-          "version": "1.10.0",
-          "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.10.0.tgz",
-          "integrity": "sha1-+n1L8fL1dpJRP0sc0qyjxN2F6GA="
-        }
       }
     },
     "@labkey/eslint-config-base": {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.7.2",
-        "@labkey/components": "2.137.4-fb-issue-44544.0",
+        "@labkey/components": "2.138.1",
         "@labkey/themes": "1.2.1"
       },
       "devDependencies": {
@@ -2888,9 +2888,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.137.4-fb-issue-44544.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.137.4-fb-issue-44544.0.tgz",
-      "integrity": "sha1-1eDt7BgOErvYWiWAoA/ROxn8z3I=",
+      "version": "2.138.1",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.138.1.tgz",
+      "integrity": "sha1-QgSTQv9tq7Ylow+y7ILNOr1u3YM=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -2898,7 +2898,7 @@
         "@fortawesome/free-regular-svg-icons": "5.15.4",
         "@fortawesome/free-solid-svg-icons": "5.15.4",
         "@fortawesome/react-fontawesome": "0.1.15",
-        "@labkey/api": "1.9.0",
+        "@labkey/api": "1.10.0",
         "bootstrap": "3.4.1",
         "classnames": "2.3.1",
         "font-awesome": "4.7.0",
@@ -2941,9 +2941,9 @@
       }
     },
     "node_modules/@labkey/components/node_modules/@labkey/api": {
-      "version": "1.9.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.9.0.tgz",
-      "integrity": "sha1-khHffdwBxqIsjLyqLeVATQCiB1w=",
+      "version": "1.10.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.10.0.tgz",
+      "integrity": "sha1-+n1L8fL1dpJRP0sc0qyjxN2F6GA=",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/eslint-config-base": {
@@ -19136,16 +19136,16 @@
       }
     },
     "@labkey/components": {
-      "version": "2.137.4-fb-issue-44544.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.137.4-fb-issue-44544.0.tgz",
-      "integrity": "sha1-1eDt7BgOErvYWiWAoA/ROxn8z3I=",
+      "version": "2.138.1",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.138.1.tgz",
+      "integrity": "sha1-QgSTQv9tq7Ylow+y7ILNOr1u3YM=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-regular-svg-icons": "5.15.4",
         "@fortawesome/free-solid-svg-icons": "5.15.4",
         "@fortawesome/react-fontawesome": "0.1.15",
-        "@labkey/api": "1.9.0",
+        "@labkey/api": "1.10.0",
         "bootstrap": "3.4.1",
         "classnames": "2.3.1",
         "font-awesome": "4.7.0",
@@ -19180,9 +19180,9 @@
       },
       "dependencies": {
         "@labkey/api": {
-          "version": "1.9.0",
-          "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.9.0.tgz",
-          "integrity": "sha1-khHffdwBxqIsjLyqLeVATQCiB1w="
+          "version": "1.10.0",
+          "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.10.0.tgz",
+          "integrity": "sha1-+n1L8fL1dpJRP0sc0qyjxN2F6GA="
         }
       }
     },

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.7.2",
-        "@labkey/components": "2.134.0",
+        "@labkey/components": "2.137.4-fb-issue-44544.0",
         "@labkey/themes": "1.2.1"
       },
       "devDependencies": {
@@ -2888,9 +2888,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.134.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.134.0.tgz",
-      "integrity": "sha1-oUT035KRZatCK4eC0Sl/k59NKjk=",
+      "version": "2.137.4-fb-issue-44544.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.137.4-fb-issue-44544.0.tgz",
+      "integrity": "sha1-1eDt7BgOErvYWiWAoA/ROxn8z3I=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -19136,9 +19136,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.134.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.134.0.tgz",
-      "integrity": "sha1-oUT035KRZatCK4eC0Sl/k59NKjk=",
+      "version": "2.137.4-fb-issue-44544.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.137.4-fb-issue-44544.0.tgz",
+      "integrity": "sha1-1eDt7BgOErvYWiWAoA/ROxn8z3I=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.7.2",
-    "@labkey/components": "2.134.0",
+    "@labkey/components": "2.137.4-fb-issue-44544.0",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.7.2",
-    "@labkey/components": "2.137.4-fb-issue-44544.0",
+    "@labkey/components": "2.138.1",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -51,7 +51,7 @@
     "testResultsProcessor": "jest-teamcity-reporter"
   },
   "dependencies": {
-    "@labkey/api": "1.7.2",
+    "@labkey/api": "1.10.0",
     "@labkey/components": "2.138.1",
     "@labkey/themes": "1.2.1"
   },

--- a/core/src/client/DatasetDesigner/DatasetDesigner.tsx
+++ b/core/src/client/DatasetDesigner/DatasetDesigner.tsx
@@ -117,9 +117,9 @@ export class App extends PureComponent<any, State> {
 
         return (
             <BeforeUnload beforeunload={this.handleWindowBeforeUnload}>
-                {model && model.isFromAssay() &&
+                {model && model.isFromLinkedSource() &&
                     <p>
-                        This dataset was created by copying assay data from <a href={model.sourceAssayUrl}>{model.sourceAssayName}</a>.
+                        This dataset was created by linking {model.sourceType} data from <a href={model.sourceUrl}>{model.sourceName}</a>.
                     </p>
                 }
                 <DatasetDesignerPanels

--- a/study/src/org/labkey/study/model/DatasetDomainKindProperties.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKindProperties.java
@@ -28,8 +28,9 @@ public class DatasetDomainKindProperties implements Cloneable
     private Integer _cohortId = null;
     private String _tag;
     private boolean _showByDefault = true;
-    private String _sourceAssayName;
-    private String _sourceAssayUrl;
+    private String _sourceName;
+    private String _sourceType;
+    private String _sourceUrl;
     private String _dataSharing;
     private boolean _useTimeKeyField = false;
     private boolean _strictFieldValidation = true; // Set as false to skip validation check in DatasetDomainKind.createDomain (used in Rlabkey labkey.domain.createAndLoad)
@@ -81,11 +82,15 @@ public class DatasetDomainKindProperties implements Cloneable
             _category = ds.getViewCategory().getLabel();
         }
 
-        ExpObject source = ds.resolvePublishSource();
-        if (source instanceof ExpProtocol)
+        Dataset.PublishSource publishSource = ds.getPublishSource();
+        if (publishSource != null)
         {
-            _sourceAssayName = source.getName();
-            _sourceAssayUrl = PageFlowUtil.urlProvider(AssayUrls.class).getAssayResultsURL(source.getContainer(), (ExpProtocol) source).getLocalURIString();
+            _sourceName = publishSource.getLabel(ds.getPublishSourceId());
+            _sourceType = publishSource.getSourceType();
+
+            ExpObject sourceObject = publishSource.resolvePublishSource(ds.getPublishSourceId());
+            if (sourceObject != null)
+                _sourceUrl = publishSource.getSourceActionURL(sourceObject, sourceObject.getContainer()).getLocalURIString();
         }
 
         if (null != ds.getDomain())
@@ -249,24 +254,19 @@ public class DatasetDomainKindProperties implements Cloneable
         _showByDefault = showByDefault;
     }
 
-    public String getSourceAssayName()
+    public String getSourceName()
     {
-        return _sourceAssayName;
+        return _sourceName;
     }
 
-    public void setSourceAssayName(String sourceAssayName)
+    public String getSourceType()
     {
-        _sourceAssayName = sourceAssayName;
+        return _sourceType;
     }
 
-    public String getSourceAssayUrl()
+    public String getSourceUrl()
     {
-        return _sourceAssayUrl;
-    }
-
-    public void setSourceAssayUrl(String sourceAssayUrl)
-    {
-        _sourceAssayUrl = sourceAssayUrl;
+        return _sourceUrl;
     }
 
     public String getDataSharing()

--- a/study/src/org/labkey/study/model/DatasetDomainKindProperties.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKindProperties.java
@@ -1,13 +1,10 @@
 package org.labkey.study.model;
 
-import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.api.ExpObject;
-import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
-import org.labkey.api.util.PageFlowUtil;
 
 public class DatasetDomainKindProperties implements Cloneable
 {
@@ -254,14 +251,29 @@ public class DatasetDomainKindProperties implements Cloneable
         _showByDefault = showByDefault;
     }
 
+    public void setSourceName(String sourceName)
+    {
+        _sourceName = sourceName;
+    }
+
     public String getSourceName()
     {
         return _sourceName;
     }
 
+    public void setSourceType(String sourceType)
+    {
+        _sourceType = sourceType;
+    }
+
     public String getSourceType()
     {
         return _sourceType;
+    }
+
+    public void setSourceUrl(String sourceUrl)
+    {
+        _sourceUrl = sourceUrl;
     }
 
     public String getSourceUrl()


### PR DESCRIPTION
#### Rationale
In 21.7 we added the ability to link sample type data to studies. The dataset designer restricts what properties are editable for linked source type datasets (additional key fields, name, etc). However this was only happening for assays and not sample types.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/751
- https://github.com/LabKey/platform/pull/3098 (previous PR)

#### Changes
- generalize `DatasetDomainKindProperties` so that it uses : `sourceName`, `sourceUrl`, and `sourceType` to pass down to the client
- update the description for linked source datasets to work for both assays and sample types