### PR TITLE
Fix OOR display

### DIFF
--- a/api/src/org/labkey/api/data/OutOfRangeDisplayColumn.java
+++ b/api/src/org/labkey/api/data/OutOfRangeDisplayColumn.java
@@ -104,6 +104,12 @@ public class OutOfRangeDisplayColumn extends DataColumn
     }
 
     @Override
+    public String getTsvFormattedValue(RenderContext ctx)
+    {
+        return getOORPrefix(ctx) + super.getTsvFormattedValue(ctx);
+    }
+
+    @Override
     public void addQueryColumns(Set<ColumnInfo> columns)
     {
         super.addQueryColumns(columns);

--- a/api/src/org/labkey/api/data/OutOfRangeDisplayColumn.java
+++ b/api/src/org/labkey/api/data/OutOfRangeDisplayColumn.java
@@ -17,6 +17,7 @@
 package org.labkey.api.data;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.util.HtmlString;
@@ -40,7 +41,6 @@ import java.util.Set;
 public class OutOfRangeDisplayColumn extends DataColumn
 {
     private ColumnInfo _oorIndicatorColumn;
-    private boolean _doneWithSuperclassConstructor = true;
 
     /**
      * Look up the OORIndicator column through QueryService
@@ -54,19 +54,6 @@ public class OutOfRangeDisplayColumn extends DataColumn
     {
         super(numberColumn);
         _oorIndicatorColumn = oorIndicatorColumn;
-    }
-
-    @Override
-    public Class getDisplayValueClass()
-    {
-        if (_doneWithSuperclassConstructor)
-        {
-            return String.class;
-        }
-        else
-        {
-            return Double.class;
-        }
     }
 
     @Override @NotNull
@@ -111,9 +98,9 @@ public class OutOfRangeDisplayColumn extends DataColumn
     }
 
     @Override
-    public Object getDisplayValue(RenderContext ctx)
+    public @Nullable String getFormattedText(RenderContext ctx)
     {
-        return getOORPrefix(ctx) + super.getDisplayValue(ctx);
+        return getOORPrefix(ctx) + super.getFormattedText(ctx);
     }
 
     @Override

--- a/api/src/org/labkey/api/data/OutOfRangeDisplayColumn.java
+++ b/api/src/org/labkey/api/data/OutOfRangeDisplayColumn.java
@@ -219,6 +219,10 @@ public class OutOfRangeDisplayColumn extends DataColumn
             assertEquals("<0.50", txt);
             tsv = dc.getTsvFormattedValue(renderContext(0.5, "<"));
             assertEquals("<0.50", tsv);
+
+            dc.setTsvFormatString("0.000");
+            tsv = dc.getTsvFormattedValue(renderContext(0.5, ">"));
+            assertEquals(">0.500", tsv);
         }
     }
 }

--- a/api/src/org/labkey/api/data/OutOfRangeDisplayColumn.java
+++ b/api/src/org/labkey/api/data/OutOfRangeDisplayColumn.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.data;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.query.FieldKey;
@@ -65,14 +66,10 @@ public class OutOfRangeDisplayColumn extends DataColumn
     @NotNull
     private String getOORPrefix(RenderContext ctx)
     {
-        StringBuilder result = new StringBuilder();
         if (_oorIndicatorColumn != null)
         {
             Object oorValue = _oorIndicatorColumn.getValue(ctx);
-            if (oorValue != null)
-            {
-                result.append(oorValue);
-            }
+            return null == oorValue ? "" : oorValue.toString();
         }
         else
         {
@@ -90,23 +87,22 @@ public class OutOfRangeDisplayColumn extends DataColumn
             }
             if (row == 1)
             {
-                String msg = "<missing column " + getColumnInfo().getName() + OORDisplayColumnFactory.OOR_INDICATOR_COLUMN_SUFFIX + ">";
-                result.append(msg);
+                return "<missing column " + getColumnInfo().getName() + OORDisplayColumnFactory.OOR_INDICATOR_COLUMN_SUFFIX + ">";
             }
         }
-        return result.toString();
+        return "";
     }
 
     @Override
     public @Nullable String getFormattedText(RenderContext ctx)
     {
-        return getOORPrefix(ctx) + super.getFormattedText(ctx);
+        return getOORPrefix(ctx) + StringUtils.defaultString(super.getFormattedText(ctx));
     }
 
     @Override
     public String getTsvFormattedValue(RenderContext ctx)
     {
-        return getOORPrefix(ctx) + super.getTsvFormattedValue(ctx);
+        return getOORPrefix(ctx) + StringUtils.defaultString(super.getTsvFormattedValue(ctx));
     }
 
     @Override

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1107,6 +1107,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         return Set.of(
             CommandLineTokenizer.TestCase.class,
             CopyFileRootPipelineJob.TestCase.class,
+            OutOfRangeDisplayColumn.TestCase.class,
             PostgreSqlVersion.TestCase.class,
             ScriptEngineManagerImpl.TestCase.class,
             StatsServiceImpl.TestCase.class


### PR DESCRIPTION
#### Rationale
OutOfRangeDisplayColumn display column broke because of a small refactor to DataColumn.getFormattedHtml(). I think this version is more inline with the intended uses of these methods.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
Move the OOR concatenation to the "format" methods.  I think this will make a change to the "new" JSON response format changing displayValue to no longer have the OOR concatenated, only the formattedValue will have it.