### PR TITLE
Show buffer memory usage in Admin Console

### DIFF
--- a/api/src/org/labkey/api/util/MothershipReport.java
+++ b/api/src/org/labkey/api/util/MothershipReport.java
@@ -313,10 +313,10 @@ public class MothershipReport implements Runnable
                 connection.disconnect();
             }
         }
-        catch (Exception ignored)
+        catch (Throwable t)
         {
             // Don't bother the client if this report fails
-            LOG.debug("Failed to submit report to " + this._target + " at " + _url, ignored);
+            LOG.debug("Failed to submit report to " + this._target + " at " + _url, t);
         }
     }
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -81,6 +81,7 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveTreeSet;
 import org.labkey.api.compliance.ComplianceService;
 import org.labkey.api.data.*;
+import org.labkey.api.data.Container;
 import org.labkey.api.data.Container.ContainerException;
 import org.labkey.api.data.queryprofiler.QueryProfiler;
 import org.labkey.api.data.queryprofiler.QueryProfiler.QueryStatTsvWriter;
@@ -199,6 +200,7 @@ import org.springframework.web.servlet.mvc.Controller;
 import javax.mail.MessagingException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.awt.*;
 import java.beans.Introspector;
 import java.io.File;
 import java.io.FileFilter;
@@ -209,12 +211,14 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ClassLoadingMXBean;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
+import java.lang.management.OperatingSystemMXBean;
 import java.lang.management.RuntimeMXBean;
 import java.lang.management.ThreadMXBean;
 import java.net.URI;
@@ -3406,13 +3410,19 @@ public class AdminController extends SpringActionController
                 graphNames.add(pool.getName());
             }
 
+            for (BufferPoolMXBean pool : ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class))
+            {
+                memoryUsages.add(new Pair<>("Buffer pool " + pool.getName(), new MemoryUsageSummary(pool)));
+                graphNames.add(pool.getName());
+            }
+
             // class loader:
             ClassLoadingMXBean classbean = ManagementFactory.getClassLoadingMXBean();
             if (classbean != null)
             {
-                systemProperties.add(new Pair<>("Loaded Class Count", classbean.getLoadedClassCount()));
-                systemProperties.add(new Pair<>("Unloaded Class Count", classbean.getUnloadedClassCount()));
-                systemProperties.add(new Pair<>("Total Loaded Class Count", classbean.getTotalLoadedClassCount()));
+                systemProperties.add(new Pair<>("Loaded Class Count", Formats.commaf0.format(classbean.getLoadedClassCount())));
+                systemProperties.add(new Pair<>("Unloaded Class Count", Formats.commaf0.format(classbean.getUnloadedClassCount())));
+                systemProperties.add(new Pair<>("Total Loaded Class Count", Formats.commaf0.format(classbean.getTotalLoadedClassCount())));
             }
 
             // runtime:
@@ -3450,7 +3460,19 @@ public class AdminController extends SpringActionController
             if (null != cacheMem)
                 systemProperties.add(new Pair<>("Most Recent Estimated Cache Memory Usage", cacheMem));
 
-            systemProperties.add(new Pair<>("In-Use DB Connections", ConnectionWrapper.getActiveConnectionCount()));
+            OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
+            if (osBean != null)
+            {
+                systemProperties.add(new Pair<>("CPU count", osBean.getAvailableProcessors()));
+
+                if (osBean instanceof com.sun.management.OperatingSystemMXBean sunOsBean)
+                {
+                    systemProperties.add(new Pair<>("Total OS memory", FileUtils.byteCountToDisplaySize(sunOsBean.getTotalMemorySize())));
+                    systemProperties.add(new Pair<>("Free OS memory", FileUtils.byteCountToDisplaySize(sunOsBean.getFreeMemorySize())));
+                    systemProperties.add(new Pair<>("OS CPU load", Formats.f3.format(sunOsBean.getCpuLoad())));
+                    systemProperties.add(new Pair<>("JVM CPU load", Formats.f3.format(sunOsBean.getProcessCpuLoad())));
+                }
+            }
 
             //noinspection ConstantConditions
             assert assertsEnabled = true;
@@ -3483,6 +3505,14 @@ public class AdminController extends SpringActionController
             _used = FileUtils.byteCountToDisplaySize(usage.getUsed());
             _committed = FileUtils.byteCountToDisplaySize(usage.getCommitted());
             _max = FileUtils.byteCountToDisplaySize(usage.getMax());
+        }
+
+        public MemoryUsageSummary(BufferPoolMXBean pool)
+        {
+            _init = null;
+            _used = FileUtils.byteCountToDisplaySize(pool.getMemoryUsed());
+            _committed = null;
+            _max = FileUtils.byteCountToDisplaySize(pool.getTotalCapacity());
         }
 
         public String getInit()
@@ -3573,6 +3603,7 @@ public class AdminController extends SpringActionController
         {
             MemoryUsage usage = null;
             boolean showLegend = false;
+            String title = form.getType();
             if ("Heap".equals(form.getType()))
             {
                 usage = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage();
@@ -3591,16 +3622,47 @@ public class AdminController extends SpringActionController
                 }
             }
 
-            if (usage == null)
-                throw new NotFoundException();
-
-            DefaultCategoryDataset dataset = new DefaultCategoryDataset();
             List<MemoryCategory> types = new ArrayList<>(4);
 
-            types.add(new MemoryCategory("Init", usage.getInit() / (1024 * 1024)));
-            types.add(new MemoryCategory("Used", usage.getUsed() / (1024 * 1024)));
-            types.add(new MemoryCategory("Committed", usage.getCommitted() / (1024 * 1024)));
-            types.add(new MemoryCategory("Max", usage.getMax() / (1024 * 1024)));
+            if (usage == null)
+            {
+                boolean found = false;
+                for (Iterator<BufferPoolMXBean> it = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class).iterator(); it.hasNext() && !found;)
+                {
+                    BufferPoolMXBean pool = it.next();
+                    if (form.getType().equals(pool.getName()))
+                    {
+                        title = "Buffer pool " + title;
+
+                        double total = pool.getTotalCapacity();
+                        double used = pool.getMemoryUsed();
+
+                        while (total > 4096)
+                        {
+                            total /= 1024;
+                            used /= 1024;
+                        }
+
+                        types.add(new MemoryCategory("Used", (long)used));
+                        types.add(new MemoryCategory("Max", (long)total));
+                        found = true;
+                    }
+                }
+                if (!found)
+                {
+                    throw new NotFoundException();
+                }
+            }
+            else
+            {
+                types.add(new MemoryCategory("Init", usage.getInit() / (1024 * 1024)));
+                types.add(new MemoryCategory("Used", usage.getUsed() / (1024 * 1024)));
+                types.add(new MemoryCategory("Committed", usage.getCommitted() / (1024 * 1024)));
+                types.add(new MemoryCategory("Max", usage.getMax() / (1024 * 1024)));
+            }
+
+            DefaultCategoryDataset dataset = new DefaultCategoryDataset();
+
             Collections.sort(types);
 
             for (int i = 0; i < types.size(); i++)
@@ -3609,7 +3671,8 @@ public class AdminController extends SpringActionController
                 dataset.addValue(mbPastPrevious, types.get(i).getType(), "");
             }
 
-            JFreeChart chart = ChartFactory.createStackedBarChart(form.getType(), null, null, dataset, PlotOrientation.HORIZONTAL, showLegend, false, false);
+            JFreeChart chart = ChartFactory.createStackedBarChart(title, null, null, dataset, PlotOrientation.HORIZONTAL, showLegend, false, false);
+            chart.getTitle().setFont(new Font("SansSerif", Font.BOLD, 14));
             response.setContentType("image/png");
 
             ChartUtilities.writeChartAsPNG(response.getOutputStream(), chart, showLegend ? 800 : 398, showLegend ? 100 : 70);

--- a/core/src/org/labkey/core/admin/memTracker.jsp
+++ b/core/src/org/labkey/core/admin/memTracker.jsp
@@ -60,11 +60,11 @@
                     // Hacky - assuming that the first one should be a different size
                     if (i == 0)
                     {
-                        %><img vspace="2" hspace="2" width="800" height="100" style="border: 1px solid" src="<%=h(urlFor(AdminController.MemoryChartAction.class).addParameter("type", graphName))%>"/> <%
+                        %><img alt="<%= h(graphName) %>" style="border: 1px solid black; margin: 2px;" width="804" height="100" src="<%=h(urlFor(AdminController.MemoryChartAction.class).addParameter("type", graphName))%>"/> <%
                     }
                     else
                     {
-                        %><img hspace="2" vspace="2" width="398" height="70" style="border: 1px solid" src="<%=h(urlFor(AdminController.MemoryChartAction.class).addParameter("type", graphName))%>"/> <%
+                        %><img alt="<%= h(graphName) %>" style="border: 1px solid black; margin: 2px;" width="398" height="70" src="<%=h(urlFor(AdminController.MemoryChartAction.class).addParameter("type", graphName))%>"/> <%
                     }
                     if (i % 2 == 0)
                     {
@@ -98,10 +98,10 @@
             %>
                 <tr class="<%=getShadeRowClass(counter)%>">
                     <td><%= h(property.getKey()) %></td>
-                    <td align="right"><%= h(property.getValue() == null ? "" : property.getValue().getInit()) %></td>
-                    <td align="right"><%= h(property.getValue() == null ? "" : property.getValue().getUsed()) %></td>
-                    <td align="right"><%= h(property.getValue() == null ? "" : property.getValue().getCommitted()) %></td>
-                    <td align="right"><%= h(property.getValue() == null ? "" : property.getValue().getMax()) %></td>
+                    <td style="text-align: right"><%= h(property.getValue() == null ? "" : property.getValue().getInit()) %></td>
+                    <td style="text-align: right"><%= h(property.getValue() == null ? "" : property.getValue().getUsed()) %></td>
+                    <td style="text-align: right"><%= h(property.getValue() == null ? "" : property.getValue().getCommitted()) %></td>
+                    <td style="text-align: right"><%= h(property.getValue() == null ? "" : property.getValue().getMax()) %></td>
                 </tr>
             <%
                     counter++;
@@ -145,10 +145,10 @@
             <table class="labkey-data-region-legacy labkey-show-borders" name="leaks" id="leaks">
                 <tr>
                     <th>&nbsp;</th>
-                    <th align="left">Object Class</th>
-                    <th align="left">Object toString()</th>
-                    <th align="left">Age</th>
-                    <th align="left">Allocation Stack</th>
+                    <th>Object Class</th>
+                    <th>Object toString()</th>
+                    <th>Age</th>
+                    <th>Allocation Stack</th>
                 </tr>
             <%
                     long currentMillis = System.currentTimeMillis();


### PR DESCRIPTION
#### Rationale
The JVM may be using a lot of buffer memory, causing instances to crash when the OS runs low on memory. Having some visibility will be helpful while we get full perf monitoring in place

#### Changes
* Avoid infinite mothership reporting on Throwables
* Show buffer pool usages
* Better formatting on memory info page
* Show CPU info and total OS memory