### PR TITLE
44913: Set the default properties for all new instances of the Subfolders webpart

### DIFF
--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -592,15 +592,20 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             new AlwaysAvailableWebPartFactory("Subfolders", WebPartFactory.LOCATION_BODY, WebPartFactory.LOCATION_RIGHT)
             {
                 @Override
+                public WebPart createWebPart()
+                {
+                    // Issue 44913: Set the default properties for all new instances of the Subfolders webpart
+                    WebPart webPart = super.createWebPart();
+                    return setDefaultProperties(webPart);
+                }
+
+                @Override
                 public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull WebPart webPart)
                 {
                     if (webPart.getPropertyMap().isEmpty())
                     {
                         // Configure to show subfolders if not previously configured
-                        webPart = new WebPart(webPart);
-                        webPart.getPropertyMap().put("title", "Subfolders");
-                        webPart.getPropertyMap().put("containerFilter", ContainerFilter.Type.CurrentAndFirstChildren.name());
-                        webPart.getPropertyMap().put("containerTypes", "folder");
+                        webPart = setDefaultProperties(new WebPart(webPart));
                     }
 
                     JspView<WebPart> view = new JspView<>("/org/labkey/core/project/projects.jsp", webPart);
@@ -612,7 +617,16 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                         customize.setScript("customizeProjectWebpart" + webPart.getRowId() + "(" + webPart.getRowId() + ", " + PageFlowUtil.jsString(webPart.getPageId()) + ", " + webPart.getIndex() + ");");
                         view.setCustomize(customize);
                     }
+
                     return view;
+                }
+
+                private WebPart setDefaultProperties(WebPart webPart)
+                {
+                    webPart.setProperty("title", "Subfolders");
+                    webPart.setProperty("containerFilter", ContainerFilter.Type.CurrentAndFirstChildren.name());
+                    webPart.setProperty("containerTypes", "folder");
+                    return webPart;
                 }
             },
             new AlwaysAvailableWebPartFactory("Custom Menu", true, true, WebPartFactory.LOCATION_MENUBAR)


### PR DESCRIPTION
#### Rationale
[Issue 44913](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44913) outlines how some default properties on the "Subfolders" webpart are no longer applying as expected (apparently starting in v21.11 but I was not able to confirm this). This PR fixes that webpart's instantiation to apply the default properties to new webpart instances like those created using the JavaScript `LABKEY.WebPart` component.

#### Changes
* Apply default properties on "Subfolders" webpart upon construction.
