### PR TITLE
44946: IllegalStateException in org.labkey.assay.plate.WellGroupImpl.populateStatsFromTable()

### DIFF
--- a/assay/api-src/org/labkey/api/assay/nab/view/RunDetailsHeaderView.java
+++ b/assay/api-src/org/labkey/api/assay/nab/view/RunDetailsHeaderView.java
@@ -270,25 +270,32 @@ public class RunDetailsHeaderView extends AssayHeaderView
         return menu;
     }
 
+    public static boolean canShowQCData(DilutionAssayRun assayRun)
+    {
+        if (assayRun != null)
+        {
+            // QC workflow currently only works for single virus configurations
+            return assayRun.getVirusNames().size() <= 1;
+        }
+        return false;
+    }
+
     private NavTree getQCMenu()
     {
         try
         {
-            // QC workflow currently only works for single virus configurations
-            DilutionAssayRun assay = ((DilutionAssayProvider)_provider).getDataHandler().getAssayResults(_run, _user);
-            boolean disable = assay.getVirusNames().size() > 1;
-
+            boolean showQC = canShowQCData(((DilutionAssayProvider)_provider).getDataHandler().getAssayResults(_run, _user));
             NavTree qcMenu = new NavTree("View QC");
 
             // must be an administrator to access the QC workflow
             if (_container.hasPermission(_user, AdminPermission.class))
             {
                 NavTree excludedDataMenu = new NavTree("Review/QC Data", ((DilutionAssayProvider)_provider).getAssayQCRunURL(_viewContext, _run));
-                excludedDataMenu.setDisabled(disable);
+                excludedDataMenu.setDisabled(!showQC);
                 qcMenu.addChild(excludedDataMenu);
             }
             NavTree excludedDataMenu = new NavTree("View Excluded Data", ((DilutionAssayProvider)_provider).getAssayQCRunURL(_viewContext, _run).addParameter("edit", false));
-            excludedDataMenu.setDisabled(disable);
+            excludedDataMenu.setDisabled(!showQC);
             qcMenu.addChild(excludedDataMenu);
 
             return qcMenu;


### PR DESCRIPTION
#### Rationale
NAb QC is only available for assays that have plate designs with a single virus. We disable the menu items from the details view but don't shut it off at the action. We have made some improvements on the error handling in the `qcData.view` so in 22.3 we wouldn't throw an exception but this gives a slightly nicer error message.

#### Related Pull Requests
- https://github.com/LabKey/commonAssays/pull/437