### PR TITLE
Issue 38906: Assay data import convert string pk

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -983,7 +983,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                     TableInfo lookupTable = remappableLookup.get(pd);
                     try
                     {
-                        Object remapped = cache.remap(lookupTable, (String)o);
+                        Object remapped = cache.remap(lookupTable, (String)o, true);
                         if (remapped == null)
                         {
                             errors.add(new PropertyValidationError("Failed to convert '" + pd.getName() + "': Could not translate value: " + o, pd.getName()));

--- a/api/src/org/labkey/api/data/RemapCache.java
+++ b/api/src/org/labkey/api/data/RemapCache.java
@@ -140,17 +140,17 @@ public class RemapCache
         return new Key(table);
     }
 
-    private SimpleTranslator.RemapPostConvert remapper(Key key, Map<Key, SimpleTranslator.RemapPostConvert> remapCache)
+    private SimpleTranslator.RemapPostConvert remapper(Key key, Map<Key, SimpleTranslator.RemapPostConvert> remapCache, boolean includePkLookup)
     {
         return remapCache.computeIfAbsent(key, (k) -> {
             TableInfo table = key.getTable();
-            return new SimpleTranslator.RemapPostConvert(table, true, SimpleTranslator.RemapMissingBehavior.Null, _allowBulkLoads, true);
+            return new SimpleTranslator.RemapPostConvert(table, true, SimpleTranslator.RemapMissingBehavior.Null, _allowBulkLoads, includePkLookup);
         });
     }
 
-    private <V> V remap(Key key, String value)
+    private <V> V remap(Key key, String value, boolean includePkLookup)
     {
-        SimpleTranslator.RemapPostConvert remap = remapper(key, remaps);
+        SimpleTranslator.RemapPostConvert remap = remapper(key, remaps, includePkLookup);
         if (remap == null)
             throw new NotFoundException("Failed to create remap: " + key._schemaKey.toString() + "." + key._queryName);
         //noinspection unchecked
@@ -158,19 +158,19 @@ public class RemapCache
     }
 
     /**
-     * Convert the string value to the target table's PK value by using the table's unique indices and pk.
+     * Convert the string value to the target table's PK value by using the table's unique indices.
      */
     public <V> V remap(SchemaKey schemaName, String queryName, User user, Container c, ContainerFilter.Type filterType, String value)
     {
-        return remap(key(schemaName, queryName, user, c, filterType), value);
+        return remap(key(schemaName, queryName, user, c, filterType), value, false);
     }
 
     /**
-     * Convert the string value to the target table's PK value by using the table's unique indices and pk.
+     * Convert the string value to the target table's PK value by using the table's unique indices and optionally pk.
      */
-    public <V> V remap(TableInfo lookupTable, String value)
+    public <V> V remap(TableInfo lookupTable, String value, boolean includePkLookup)
     {
-        return remap(key(lookupTable), value);
+        return remap(key(lookupTable), value, includePkLookup);
     }
 
 }

--- a/api/src/org/labkey/api/data/RemapCache.java
+++ b/api/src/org/labkey/api/data/RemapCache.java
@@ -144,7 +144,7 @@ public class RemapCache
     {
         return remapCache.computeIfAbsent(key, (k) -> {
             TableInfo table = key.getTable();
-            return new SimpleTranslator.RemapPostConvert(table, true, SimpleTranslator.RemapMissingBehavior.Null, _allowBulkLoads);
+            return new SimpleTranslator.RemapPostConvert(table, true, SimpleTranslator.RemapMissingBehavior.Null, _allowBulkLoads, true);
         });
     }
 
@@ -158,7 +158,7 @@ public class RemapCache
     }
 
     /**
-     * Convert the string value to the target table's PK value by using the table's unique indices.
+     * Convert the string value to the target table's PK value by using the table's unique indices and pk.
      */
     public <V> V remap(SchemaKey schemaName, String queryName, User user, Container c, ContainerFilter.Type filterType, String value)
     {
@@ -166,7 +166,7 @@ public class RemapCache
     }
 
     /**
-     * Convert the string value to the target table's PK value by using the table's unique indices.
+     * Convert the string value to the target table's PK value by using the table's unique indices and pk.
      */
     public <V> V remap(TableInfo lookupTable, String value)
     {

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -364,6 +364,16 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             final ColumnInfo pkCol = pair.getKey();
             Map map = pair.getValue();
 
+            try
+            {
+                // Ensure value is same type as pk
+                k = pkCol.getJdbcType().convert(k);
+            }
+            catch(ConversionException e)
+            {
+                return null;
+            }
+
             if (map.containsKey(k))
             {
                 Object v = map.get(k);


### PR DESCRIPTION
#### Rationale
Some file based assays like Simple2 have a string pk on import. This is getting an error that there is an incorrect data type. This is something we handle in other places to remap the string to the pk. Added pk mapping to assay import.

#### Changes
* Added attempted type conversion to SimpleTranslator.RemapPostConvert.fetch. If conversion fails than key not found.
* Update RemapCache to allow checking for key match when checking indices map.
* Update Assay TSV handler to use pk matching
