### PR TITLE
Issue44305: Wiki attachments don't appear in the same order in imported folders

### DIFF
--- a/wiki/schemas/wiki.xsd
+++ b/wiki/schemas/wiki.xsd
@@ -41,7 +41,7 @@
         </xsd:attribute>
         <xsd:attribute name="attachmentsOrder" type="xsd:string">
             <xsd:annotation>
-                <xsd:documentation>The order in which this page's attachments should appear</xsd:documentation>
+                <xsd:documentation>The order in which this page's attachments should appear, as a semicolon-delimited list of file names</xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
     </xsd:complexType>

--- a/wiki/schemas/wiki.xsd
+++ b/wiki/schemas/wiki.xsd
@@ -39,5 +39,10 @@
                 <xsd:documentation>Whether this page should be indexed by the search service for full text search</xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
+        <xsd:attribute name="attachmentsOrder" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation>The order in which this page's attachments should appear</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
     </xsd:complexType>
 </xsd:schema>

--- a/wiki/src/org/labkey/wiki/WikiWebdavProvider.java
+++ b/wiki/src/org/labkey/wiki/WikiWebdavProvider.java
@@ -16,10 +16,12 @@
 
 package org.labkey.wiki;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.poi.util.IOUtils;
 import org.apache.xmlbeans.XmlOptions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.attachments.Attachment;
 import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -70,6 +72,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * User: matthewb
@@ -274,6 +277,8 @@ public class WikiWebdavProvider implements WebdavService.Provider
                     wikiXml.setTitle(wikiVersion.getTitle());
                     wikiXml.setShowAttachments(wiki.isShowAttachments());
                     wikiXml.setShouldIndex(wiki.isShouldIndex());
+                    List<String> attachmentNames = wiki.getAttachments().stream().map(Attachment::getName).collect(Collectors.toList());
+                    wikiXml.setAttachmentsOrder(StringUtils.join(attachmentNames, ';'));
                 }
 
                 XmlOptions options = new XmlOptions();

--- a/wiki/src/org/labkey/wiki/export/WikiImporterFactory.java
+++ b/wiki/src/org/labkey/wiki/export/WikiImporterFactory.java
@@ -45,12 +45,16 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  * User: jeckels
@@ -117,7 +121,7 @@ public class WikiImporterFactory extends AbstractFolderImportFactory
 
                         // TODO: We should add VirtualFile.getName()
                         String folderName = new File(wikiSubDir.getLocation()).getName();
-                        Wiki wiki = importWiki(wikiXml.getName(), wikiXml.getTitle(), shouldIndex, wikiXml.getShowAttachments(), wikiSubDir, folderName, ctx, displayOrder++);
+                        Wiki wiki = importWiki(wikiXml.getName(), wikiXml.getTitle(), shouldIndex, wikiXml.getShowAttachments(), wikiSubDir, folderName, ctx, displayOrder++, wikiXml.getAttachmentsOrder());
                         if (wikiXml.getParent() != null)
                         {
                             parentsToBeSet.put(wiki, wikiXml.getParent());
@@ -131,7 +135,7 @@ public class WikiImporterFactory extends AbstractFolderImportFactory
                         VirtualFile wikiSubDir = wikisDir.getDir(wikiSubDirName);
                         if (null != wikiSubDir && !importedFolderNames.contains(wikiSubDirName))
                         {
-                            importWiki(wikiSubDirName, null, true, true, wikiSubDir, wikiSubDirName, ctx, displayOrder++);
+                            importWiki(wikiSubDirName, null, true, true, wikiSubDir, wikiSubDirName, ctx, displayOrder++, null);
                             importedFolderNames.add(wikiSubDirName);
                         }
                     }
@@ -164,7 +168,7 @@ public class WikiImporterFactory extends AbstractFolderImportFactory
             }
         }
 
-        private Wiki importWiki(String name, String title, boolean shouldIndex, boolean showAttachments, VirtualFile wikiSubDir, String folderName, ImportContext<Folder> ctx, int displayOrder) throws IOException, ImportException
+        private Wiki importWiki(String name, String title, boolean shouldIndex, boolean showAttachments, VirtualFile wikiSubDir, String folderName, ImportContext<Folder> ctx, int displayOrder, String attachmentOrder) throws IOException, ImportException
         {
             Wiki existingWiki = WikiSelectManager.getWiki(ctx.getContainer(), name);
             List<String> existingAttachmentNames = new ArrayList<>();
@@ -205,6 +209,9 @@ public class WikiImporterFactory extends AbstractFolderImportFactory
                     attachments.add(new InputStreamAttachmentFile(aIS, fileName));
                 }
             }
+            AtomicInteger inc = new AtomicInteger();
+            Map<String, Integer> attachmentOrderMap = List.of(attachmentOrder.split(";")).stream().collect(Collectors.toMap(i -> i, i -> inc.getAndIncrement()));
+            attachments.sort(Comparator.comparing(e -> attachmentOrderMap.get(e.getFilename())));
 
             wikiversion.setTitle(title == null ? wiki.getName() : title);
             if (existingWiki == null)

--- a/wiki/src/org/labkey/wiki/export/WikiImporterFactory.java
+++ b/wiki/src/org/labkey/wiki/export/WikiImporterFactory.java
@@ -208,9 +208,11 @@ public class WikiImporterFactory extends AbstractFolderImportFactory
                     attachments.add(new InputStreamAttachmentFile(aIS, fileName));
                 }
             }
-            AtomicInteger inc = new AtomicInteger();
-            Map<String, Integer> attachmentOrderMap = List.of(attachmentOrder.split(";")).stream().collect(Collectors.toMap(i -> i, i -> inc.getAndIncrement()));
-            attachments.sort(Comparator.comparing(e -> attachmentOrderMap.get(e.getFilename())));
+            if (attachmentOrder != null) {
+                AtomicInteger inc = new AtomicInteger();
+                Map<String, Integer> attachmentOrderMap = List.of(attachmentOrder.split(";")).stream().collect(Collectors.toMap(i -> i, i -> inc.getAndIncrement()));
+                attachments.sort(Comparator.comparing(e -> attachmentOrderMap.get(e.getFilename())));
+            }
 
             wikiversion.setTitle(title == null ? wiki.getName() : title);
             if (existingWiki == null)

--- a/wiki/src/org/labkey/wiki/export/WikiImporterFactory.java
+++ b/wiki/src/org/labkey/wiki/export/WikiImporterFactory.java
@@ -45,7 +45,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;


### PR DESCRIPTION
#### Rationale
Previously, files attached to wiki pages don't appear in the same order when the folder is exported and reimported to another folder. 

#### Related Pull Requests
* N/A

#### Changes
* Add attr to wiki.xsd to keep track of file attachment order
* Sort incoming attachments based on above attr
