### PR TITLE
Item 9748: Shared freezers across containers

### DIFF
--- a/api/src/org/labkey/api/audit/AuditLogService.java
+++ b/api/src/org/labkey/api/audit/AuditLogService.java
@@ -18,6 +18,7 @@ package org.labkey.api.audit;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
@@ -105,6 +106,8 @@ public interface AuditLogService
     <K extends AuditTypeEvent> K getAuditEvent(User user, String eventType, int rowId);
 
     <K extends AuditTypeEvent> List<K> getAuditEvents(Container container, User user, String eventType, @Nullable SimpleFilter filter, @Nullable Sort sort);
+
+    <K extends AuditTypeEvent> List<K> getAuditEvents(Container container, User user, String eventType, @Nullable SimpleFilter filter, @Nullable Sort sort, @Nullable ContainerFilter cf);
 
     String getTableName();
 

--- a/api/src/org/labkey/api/audit/DefaultAuditProvider.java
+++ b/api/src/org/labkey/api/audit/DefaultAuditProvider.java
@@ -19,6 +19,7 @@ package org.labkey.api.audit;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.query.DefaultAuditSchema;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.TableInfo;
@@ -65,6 +66,12 @@ public class DefaultAuditProvider implements AuditLogService, AuditLogService.Re
 
     @Override
     public <K extends AuditTypeEvent> List<K> getAuditEvents(Container container, User user, String eventType, @Nullable SimpleFilter filter, @Nullable Sort sort)
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <K extends AuditTypeEvent> List<K> getAuditEvents(Container container, User user, String eventType, @Nullable SimpleFilter filter, @Nullable Sort sort, @Nullable ContainerFilter cf)
     {
         return Collections.emptyList();
     }

--- a/audit/src/org/labkey/audit/AuditLogImpl.java
+++ b/audit/src/org/labkey/audit/AuditLogImpl.java
@@ -26,6 +26,7 @@ import org.labkey.api.audit.DetailedAuditTypeEvent;
 import org.labkey.api.audit.SampleTimelineAuditEvent;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
@@ -228,6 +229,12 @@ public class AuditLogImpl implements AuditLogService, StartupListener
     public <K extends AuditTypeEvent> List<K> getAuditEvents(Container container, User user, String eventType, @Nullable SimpleFilter filter, @Nullable Sort sort)
     {
         return LogManager.get().getAuditEvents(container, user, eventType, filter, sort);
+    }
+
+    @Override
+    public <K extends AuditTypeEvent> List<K> getAuditEvents(Container container, User user, String eventType, @Nullable SimpleFilter filter, @Nullable Sort sort, @Nullable ContainerFilter cf)
+    {
+        return LogManager.get().getAuditEvents(container, user, eventType, filter, sort, cf);
     }
 
     @Override

--- a/audit/src/org/labkey/audit/model/LogManager.java
+++ b/audit/src/org/labkey/audit/model/LogManager.java
@@ -25,6 +25,7 @@ import org.labkey.api.audit.AuditTypeProvider;
 import org.labkey.api.audit.query.DefaultAuditTypeTable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.ObjectFactory;
@@ -202,6 +203,10 @@ public class LogManager
 
     public <K extends AuditTypeEvent> List<K> getAuditEvents(Container container, User user, String eventType, @Nullable SimpleFilter filter, @Nullable Sort sort)
     {
+        return getAuditEvents(container, user, eventType, filter, sort, null);
+    }
+    public <K extends AuditTypeEvent> List<K> getAuditEvents(Container container, User user, String eventType, @Nullable SimpleFilter filter, @Nullable Sort sort, @Nullable ContainerFilter cf)
+    {
         AuditTypeProvider provider = AuditLogService.get().getAuditProvider(eventType);
         if (provider != null)
         {
@@ -209,7 +214,7 @@ public class LogManager
 
             if (schema != null)
             {
-                TableInfo table = schema.getTable(provider.getEventName());
+                TableInfo table = schema.getTable(provider.getEventName(), cf);
                 TableSelector selector = new TableSelector(table, filter, sort);
 
                 return (List<K>)selector.getArrayList(provider.getEventClass());


### PR DESCRIPTION
#### Rationale
Location History for a freezer location is backed by audit logs. In order to show full history of a location, not limited to the current folder's history, we will need to get audit events with appropriate container filters.  

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/756
* https://github.com/LabKey/platform/pull/3111
* https://github.com/LabKey/inventory/pull/388

#### Changes
* support getAuditEvents with containerFilter
