### PR TITLE
Issue 44875: Validating system queries/metadata in sends 400 and 500 response codes to legit HTTP requests

### DIFF
--- a/query/webapp/query/browser/view/Validate.js
+++ b/query/webapp/query/browser/view/Validate.js
@@ -389,10 +389,16 @@ Ext4.define('LABKEY.query.browser.view.Validate', {
         this.advance();
     },
 
-    onValidQuery : function() {
-        this.numValid++;
-        this.setStatus(this.getStatusPrefix()  + ": Validating '" + this.getCurrentQueryLabel() + "'...OK");
-        this.advance();
+    onValidQuery : function(response) {
+        // Issue 44875 - handle responses with success=false as failures (revisit
+        if (response && response.success === false) {
+            this.onValidationFailure(response);
+        }
+        else {
+            this.numValid++;
+            this.setStatus(this.getStatusPrefix() + ": Validating '" + this.getCurrentQueryLabel() + "'...OK");
+            this.advance();
+        }
     },
 
     recurseContainers : function(containersInfo, containerArray) {


### PR DESCRIPTION
#### Rationale
The browser sent us a legitimate request to see if a query is error- and warning-free. We shouldn't treat problems as if they were bad HTTP requests or a server error.

#### Changes
* Use 200 status code for query parse errors and warnings
* Check for success and route to appropriate handler