### PR TITLE
44969: Not possible to un-set ST Link-to-Study option

### DIFF
--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -952,8 +952,8 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
             st.setMetricUnit(options.getMetricUnit());
             st.setImportAliasMap(options.getImportAliases());
-            if (!StringUtils.isBlank(options.getAutoLinkTargetContainerId()))
-                st.setAutoLinkTargetContainer(ContainerManager.getForId(options.getAutoLinkTargetContainerId()));
+            String targetContainerId = StringUtils.trimToNull(options.getAutoLinkTargetContainerId());
+            st.setAutoLinkTargetContainer(targetContainerId != null ? ContainerManager.getForId(targetContainerId) : null);
             st.setAutoLinkCategory(options.getAutoLinkCategory());
             if (options.getCategory() != null) // update sample type category is currently not supported
                 st.setCategory(options.getCategory());


### PR DESCRIPTION
#### Rationale
Sample types need to be able to clear the auto copy target container from the settings panel. Previously we were only updating the option if the target container wasn't blank.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44969