### PR TITLE
Issue 44387 : fix double resync problem

### DIFF
--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -368,8 +368,11 @@ public interface Dataset extends StudyEntity, StudyCachable<Dataset>
      * @param u user performing the update
      * @param lsid the lsid of the dataset row
      * @param data the data to be updated
+     *
+     * Don't use this method unless you are DatasetUpdateService
      */
-    String updateDatasetRow(User u, String lsid, Map<String,Object> data) throws ValidationException;
+    @Deprecated
+    String updateDatasetRow_forDatasetUpdateService(User u, String lsid, Map<String,Object> data) throws ValidationException;
 
     /**
      * Fetches a single row from a dataset given an LSID

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -2670,8 +2670,11 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
     }
 
 
+    // This is tragically convoluted this method is only called by DatasetUpdateService.updateRow(), but calls back to
+    // a new instance of DatasetUpdateService, often within a loop.
+    // CONSIDER moving this logic to DatasetUpdateService.updateRow() and simplifying the whole thing
     @Override
-    public String updateDatasetRow(User u, String lsid, Map<String, Object> data) throws ValidationException
+    public String updateDatasetRow_forDatasetUpdateService(User u, String lsid, Map<String, Object> data) throws ValidationException
     {
         boolean allowAliasesInUpdate = false; // SEE https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=12592
 

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -3539,7 +3539,9 @@ public class StudyManager
         if (defaultQCState != null)
             options.put(DatasetUpdateService.Config.DefaultQCState, defaultQCState);
         options.put(DatasetUpdateService.Config.CheckForDuplicates, checkDuplicates);
+        // if we are being called by QUS we don't want to call triggers twice or resync twice
         options.put(QueryUpdateService.ConfigParameters.SkipTriggers, skipTriggers);
+        options.put(DatasetUpdateService.Config.SkipResyncStudy, skipTriggers);
         context.setConfigParameters(options);
 
         DataLoader loader = new MapLoader(data);

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -463,7 +463,7 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
         String lsid = keyFromMap(oldRow);
         // Make sure we've found the original participant before doing the update
         String oldParticipant = getParticipant(oldRow, user, container);
-        String newLsid = _dataset.updateDatasetRow(user, lsid, row);
+        String newLsid = _dataset.updateDatasetRow_forDatasetUpdateService(user, lsid, row);
         //update the lsid and return
         row.put("lsid", newLsid);
 


### PR DESCRIPTION
#### Rationale
Bug fix for 44387.  DatasetDefinition.updateDatasetRow() code path should set SkipResyncStudy as well as SkipTriggers to avoid double bookkeeping.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
