### PR TITLE
Issue 43726: Reduce auditing behavior when ETLing tables with bulk load

### DIFF
--- a/api/src/org/labkey/api/dataiterator/DetailedAuditLogDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/DetailedAuditLogDataIterator.java
@@ -23,6 +23,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.QueryService;
+import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.security.User;
 
 import java.io.IOException;
@@ -69,6 +70,7 @@ public class DetailedAuditLogDataIterator extends AbstractDataIterator
 
         assert DETAILED == table.getAuditBehavior() || DETAILED == context.getConfigParameter(AuditConfigs.AuditBehavior);
         assert !context.getInsertOption().mergeRows || _data.supportsGetExistingRecord();
+        assert !context.getConfigParameterBoolean(QueryUpdateService.ConfigParameters.BulkLoad);
 
         _existingRows = _data.supportsGetExistingRecord() ? new ArrayList<>() : null;
     }
@@ -126,7 +128,9 @@ public class DetailedAuditLogDataIterator extends AbstractDataIterator
             AuditBehaviorType auditType = AuditBehaviorType.NONE;
             if (queryTable.supportsAuditTracking())
                 auditType = queryTable.getAuditBehavior((AuditBehaviorType) context.getConfigParameter(AuditConfigs.AuditBehavior));
-            if (auditType == DETAILED)
+
+            // Detailed auditing and not set to bulk load in ETL
+            if (auditType == DETAILED && !context.getConfigParameterBoolean(QueryUpdateService.ConfigParameters.BulkLoad))
             {
                 DataIterator it = builder.getDataIterator(context);
                 DataIterator in = DataIteratorUtil.wrapMap(it, true);

--- a/api/src/org/labkey/api/query/QueryUpdateService.java
+++ b/api/src/org/labkey/api/query/QueryUpdateService.java
@@ -93,7 +93,8 @@ public interface QueryUpdateService extends HasPermission
         // used by Dataspace currently
         TargetMultipleContainers,    // (Bool) allow multi container import
         SkipTriggers,         // (Bool) skip setup and firing of trigger scripts
-        SkipRequiredFieldValidation        // (Bool) skip validation of required fields, used during import when the import of data happens in two hitches (e.g., samples in one file and sample statuses in a second)
+        SkipRequiredFieldValidation,        // (Bool) skip validation of required fields, used during import when the import of data happens in two hitches (e.g., samples in one file and sample statuses in a second)
+        BulkLoad                // (Bool) skips detailed auditing
     }
 
 


### PR DESCRIPTION
#### Rationale
When bulk load is set to true on an ETL transform step we should be doing reduced auditing (as is stated in etl.xsd). This PR makes detailed audit logging not possible when bulk loading, opting instead to do summary auditing.

#### Related Pull Requests
* https://github.com/LabKey/dataintegration/pull/154

#### Changes
* Add bulk load config paramter 
* Don't allow DetailedAuditLogDataIterator to be instantiated if DI context is bulk load
* DetailedAuditLogDataIterator.getDataIteratorBuilder doesn't add DetailedAuditLogDataIterator if bulk loading
