### PR TITLE
Issue 44680: Datasets indices display in schema browser

### DIFF
--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -494,9 +494,11 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
     @Override
     public Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices()
     {
+        // Get indices from underlying storage table
         Map<String, Pair<IndexType, List<ColumnInfo>>> ret = new HashMap<>(wrapTableIndices(getDatasetDefinition().getStorageTableInfo()));
         String subjectColName = StudyService.get().getSubjectColumnName(getContainer());
 
+        // Index enforced in code not on actual database for demographic datasets only
         if (getColumn(subjectColName) != null && getDatasetDefinition().isDemographicData())
         {
             ret.put("uq_dataset_subject", Pair.of(IndexType.Unique, Arrays.asList(getColumn(subjectColName))));

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -494,10 +494,10 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
     @Override
     public Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices()
     {
-        Map<String, Pair<IndexType, List<ColumnInfo>>> ret = new HashMap<>(super.getUniqueIndices());
+        Map<String, Pair<IndexType, List<ColumnInfo>>> ret = new HashMap<>(wrapTableIndices(getDatasetDefinition().getStorageTableInfo()));
         String subjectColName = StudyService.get().getSubjectColumnName(getContainer());
 
-        if (getColumn(subjectColName) != null)
+        if (getColumn(subjectColName) != null && getDatasetDefinition().isDemographicData())
         {
             ret.put("uq_dataset_subject", Pair.of(IndexType.Unique, Arrays.asList(getColumn(subjectColName))));
         }


### PR DESCRIPTION
#### Rationale
Study dataset indices were not being displayed in the schema browser except for an index on participantId which is incorrectly showing for all datasets.  This PR updates to show the indices of the underlying storage table for the dataset and only show the hard coded index on participantId for demographic datasets.

#### Changes
* Update DatasetTableImpl.getUniqueIndices to get the indices from the underlying storage table.
* Show uq_dataset_subject index only for demographic datasets
