### PR TITLE
Issue 44995: Filter disabled folder types from folder management admin

### DIFF
--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -1447,7 +1447,7 @@ public class CoreController extends SpringActionController
         public ApiResponse execute(Object form, BindException errors)
         {
             Map<String, Object> folderTypes = new HashMap<>();
-            for (FolderType folderType : FolderTypeManager.get().getEnabledFolderTypes())
+            for (FolderType folderType : FolderTypeManager.get().getEnabledFolderTypes(true))
             {
                 Map<String, Object> folderTypeJSON = new HashMap<>();
                 folderTypeJSON.put("name", folderType.getName());

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -8660,7 +8660,8 @@ public class AdminController extends SpringActionController
                 var defaultFolderType = manager.getDefaultFolderType();
                 // If a default folder type has not yet been configuration use "Collaboration" folder type as the default
                 defaultFolderType = defaultFolderType != null ? defaultFolderType : manager.getFolderType(CollaborationFolderType.TYPE_NAME);
-                bean = new FolderTypesBean(manager.getAllFolderTypes(), manager.getEnabledFolderTypes(), defaultFolderType);
+                boolean userHasEnableRestrictedModulesPermission = getContainer().hasEnableRestrictedModules(getUser());
+                bean = new FolderTypesBean(manager.getAllFolderTypes(), manager.getEnabledFolderTypes(userHasEnableRestrictedModulesPermission), defaultFolderType);
             }
 
             return new JspView<>("/org/labkey/core/admin/enabledFolderTypes.jsp", bean, errors);

--- a/core/src/org/labkey/core/admin/folderType.jsp
+++ b/core/src/org/labkey/core/admin/folderType.jsp
@@ -51,7 +51,7 @@ var defaultModules = {};  <% // This is used... Java code below generates JavaSc
     final ViewContext context = getViewContext();
     Container c = getContainer();
     boolean userHasEnableRestrictedModulesPermission = c.hasEnableRestrictedModules(getUser());
-    Collection<FolderType> allFolderTypes = FolderTypeManager.get().getFolderTypes(userHasEnableRestrictedModulesPermission);
+    Collection<FolderType> allFolderTypes = FolderTypeManager.get().getEnabledFolderTypes(userHasEnableRestrictedModulesPermission);
     List<Module> allModules = new ArrayList<>(ModuleLoader.getInstance().getModules(userHasEnableRestrictedModulesPermission));
     allModules.sort(Comparator.comparing(module -> module.getTabName(context), String.CASE_INSENSITIVE_ORDER));
     Set<Module> activeModules = c.getActiveModules();

--- a/core/src/org/labkey/core/workbook/createWorkbook.jsp
+++ b/core/src/org/labkey/core/workbook/createWorkbook.jsp
@@ -32,7 +32,8 @@
     Container container = getContainer();
 
     Set<FolderType> folderTypes = new LinkedHashSet<>();
-    for (FolderType folderType : FolderTypeManager.get().getEnabledFolderTypes())
+    boolean userHasEnableRestrictedModulesPermission = container.hasEnableRestrictedModules(getUser());
+    for (FolderType folderType : FolderTypeManager.get().getEnabledFolderTypes(userHasEnableRestrictedModulesPermission))
     {
         if (folderType.isWorkbookType())
         {


### PR DESCRIPTION
#### Rationale
We're filtering out admin-disabled folder types when you create a new container but not when you manage an existing container. We're also inconsistent about filtering out restricted modules.

#### Changes
* Consolidate methods to increase likelihood of calling the right one
* Update callers to use the filtering one