### PR TITLE
Issue 44839: Field names or labels including the special chars <, &, and > display as &lt;, &amp;, &gt; in grid view customizer

### DIFF
--- a/api/src/org/labkey/api/data/JsonWriter.java
+++ b/api/src/org/labkey/api/data/JsonWriter.java
@@ -277,12 +277,12 @@ public class JsonWriter
         }
         else
         {
-            props.put("shortCaption", dc.getCaption());
+            props.put("shortCaption", dc.getCaption(null, false));
         }
 
-        props.put("caption", dc.getCaption());
+        props.put("caption", dc.getCaption(null, false));
         if (includeDomainFormat)
-            props.put("label", dc.getCaption());
+            props.put("label", dc.getCaption(null, false));
 
         if (includeLookup && cinfo != null)
         {

--- a/internal/webapp/internal/ViewDesigner/FieldMetaRecord.js
+++ b/internal/webapp/internal/ViewDesigner/FieldMetaRecord.js
@@ -44,7 +44,9 @@ Ext4.define('LABKEY.internal.ViewDesigner.FieldMetaRecord', {
             mapping: 'name',
             convert: function(v, rec) {
                 if (!Ext4.isEmpty(rec.raw.caption) && rec.raw.caption != '&nbsp;') {
-                    return rec.raw.caption; // + (rec.raw.hidden === true ? ' (hidden)' : '');
+                    // Ext.tree.Column uses tpl.apply to render nodes, which does html encoding.
+                    // caption is html encoded, need to decode here to avoid double encoding
+                    return Ext4.htmlDecode(rec.raw.caption);
                 }
                 return v;
             }

--- a/internal/webapp/internal/ViewDesigner/FieldMetaRecord.js
+++ b/internal/webapp/internal/ViewDesigner/FieldMetaRecord.js
@@ -43,10 +43,8 @@ Ext4.define('LABKEY.internal.ViewDesigner.FieldMetaRecord', {
             type: 'string',
             mapping: 'name',
             convert: function(v, rec) {
-                if (!Ext4.isEmpty(rec.raw.caption) && rec.raw.caption != '&nbsp;') {
-                    // Ext.tree.Column uses tpl.apply to render nodes, which does html encoding.
-                    // caption is html encoded, need to decode here to avoid double encoding
-                    return Ext4.htmlDecode(rec.raw.caption);
+                if (!Ext4.isEmpty(rec.raw.caption)) {
+                    return rec.raw.caption; // + (rec.raw.hidden === true ? ' (hidden)' : '');
                 }
                 return v;
             }

--- a/internal/webapp/internal/ViewDesigner/tab/ColumnsTab.js
+++ b/internal/webapp/internal/ViewDesigner/tab/ColumnsTab.js
@@ -119,8 +119,8 @@ Ext4.define('LABKEY.internal.ViewDesigner.tab.ColumnsTab', {
                             var fieldMeta = me.fieldMetaStore.getById(values.fieldKey);
                             if (fieldMeta) {
                                 var caption = fieldMeta.get('caption');
-                                if (caption && caption != '&nbsp;') {
-                                    return caption; // caption is already htmlEncoded
+                                if (caption) {
+                                    return Ext4.htmlEncode(caption);
                                 }
                                 return Ext4.htmlEncode(fieldMeta.get('name'));
                             }

--- a/internal/webapp/internal/ViewDesigner/tab/FilterTab.js
+++ b/internal/webapp/internal/ViewDesigner/tab/FilterTab.js
@@ -302,10 +302,9 @@ Ext4.define('LABKEY.internal.ViewDesigner.tab.FilterTab', {
                             var fieldKey = values.fieldKey;
                             var fieldMeta = me.fieldMetaStore.getById(fieldKey);
                             if (fieldMeta) {
-                                // caption is already htmlEncoded
                                 var caption = fieldMeta.get('caption');
-                                if (caption && caption != '&nbsp;') {
-                                    return caption;
+                                if (caption) {
+                                    return Ext4.htmlEncode(caption);
                                 }
                                 return Ext4.htmlEncode(fieldMeta.get('name'));
                             }

--- a/internal/webapp/internal/ViewDesigner/tab/SortTab.js
+++ b/internal/webapp/internal/ViewDesigner/tab/SortTab.js
@@ -98,9 +98,8 @@ Ext4.define('LABKEY.internal.ViewDesigner.tab.SortTab', {
                             var fieldMeta = me.fieldMetaStore.getById(fieldKey.toUpperCase());
                             if (fieldMeta)
                             {
-                                // caption is already htmlEncoded
-                                if (fieldMeta.data.caption && fieldMeta.data.caption != "&nbsp;") {
-                                    return fieldMeta.data.caption;
+                                if (fieldMeta.data.caption) {
+                                    return Ext4.htmlEncode(caption);
                                 }
                                 return Ext4.htmlEncode(fieldMeta.data.name);
                             }

--- a/internal/webapp/internal/ViewDesigner/tab/SortTab.js
+++ b/internal/webapp/internal/ViewDesigner/tab/SortTab.js
@@ -98,7 +98,8 @@ Ext4.define('LABKEY.internal.ViewDesigner.tab.SortTab', {
                             var fieldMeta = me.fieldMetaStore.getById(fieldKey.toUpperCase());
                             if (fieldMeta)
                             {
-                                if (fieldMeta.data.caption) {
+                                var caption = fieldMeta.get('caption');
+                                if (caption) {
                                     return Ext4.htmlEncode(caption);
                                 }
                                 return Ext4.htmlEncode(fieldMeta.data.name);


### PR DESCRIPTION
#### Rationale
field captions returned by getQueryDetails api are html encoded. Ext tree renders row using template.apply, which does html encoding, so the result is the caption displayed is double encoded. 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* skip encoding field captions for getQueryDetails api
* update Designer panels to explicitly encode caption since they not longer encoded by the server.
