### PR TITLE
Issue 45008: Warnings about duplicate search.crawlcollections rows

### DIFF
--- a/search/src/org/labkey/search/model/SavePaths.java
+++ b/search/src/org/labkey/search/model/SavePaths.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.search.model;
 
+import org.apache.logging.log4j.Level;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.Cache;
@@ -193,7 +194,8 @@ public class SavePaths implements DavCrawler.SavePaths
             insert.add(valueName);
             db.getSqlDialect().addReselect(insert, id, null);
 
-            Integer ident = new SqlSelector(getSearchSchema(),insert).getObject(Integer.class);
+            // Issue 45008 - avoid logging warning when there's a duplicate row
+            Integer ident = new SqlSelector(getSearchSchema(),insert).setLogLevel(Level.ERROR).getObject(Integer.class);
             if (null == ident)
                 return getId(path);
             return ident;


### PR DESCRIPTION
#### Rationale
Some servers get a lot of warnings about attempts to insert duplicate rows into search.crawlcollections. The code is tolerant of this, so the logging is just spam.

#### Changes
* Skip logging the warning on this constraint violation