### PR TITLE
Update references to study archives

### DIFF
--- a/api/schemas/study.xsd
+++ b/api/schemas/study.xsd
@@ -5,8 +5,8 @@
            elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:annotation>
 		<xs:documentation xml:lang="en">
-            Describes a file-based study. This is the top-level file in a study archive. It defines the top-level study
-            settings and points to the other files in the archive.
+            Describes a file-based study. This is the top-level file in the study node of a folder archive. It defines
+            the top-level study settings and points to the other files in the archive.
         </xs:documentation>
 	</xs:annotation>
 

--- a/api/schemas/study.xsd
+++ b/api/schemas/study.xsd
@@ -5,8 +5,8 @@
            elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:annotation>
 		<xs:documentation xml:lang="en">
-            Describes a file-based study. This is the top-level file in the study node of a folder archive. It defines
-            the top-level study settings and points to the other files in the archive.
+            Describes a file-based study. This is the top-level file in the /study subfolder of a folder archive. It
+            defines the top-level study settings and points to the other files in the archive.
         </xs:documentation>
 	</xs:annotation>
 

--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -277,7 +277,7 @@ public interface Dataset extends StudyEntity, StudyCachable<Dataset>
 
     /**
      * @return true if this dataset is backed by published data (assay, sample type etc). Note that if a dataset happens
-     * to contain published data but isn't linked to the publish source in the server (ie., when importing a study folder),
+     * to contain published data but isn't linked to the publish source in the server (ie., when importing a folder archive),
      * this method will return false.
      */
     boolean isPublishedData();

--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -277,7 +277,8 @@ public interface Dataset extends StudyEntity, StudyCachable<Dataset>
 
     /**
      * @return true if this dataset is backed by published data (assay, sample type etc). Note that if a dataset happens
-     * to contain published data but isn't linked to the publish source in the server (ie., when importing a study archive), this method will return false.
+     * to contain published data but isn't linked to the publish source in the server (ie., when importing a study folder),
+     * this method will return false.
      */
     boolean isPublishedData();
 

--- a/core/src/org/labkey/core/admin/importFolder.jsp
+++ b/core/src/org/labkey/core/admin/importFolder.jsp
@@ -61,41 +61,45 @@
 
     // default to the display options for a folder import and change the wording/actions based on if this is a
     // first time study import or a study reload
-    String noun = "Folder";
-    String action = "Import";
-    String mainDescription = "You can import a folder archive to populate a folder with data and configuration. A folder archive is " +
-            "a .folder.zip file or a collection of individual files that comforms to the LabKey folder export conventions " +
-            "and formats.  In most cases, a folder archive is created using the folder export feature.  Using export " +
-            "and import, a folder can be moved from one server to another or a new folder can be created using a " +
-            "standard template. You can also populate a new folder from a template folder on the current server using " +
-            "the \"Create Folder From Template\" option from the folder creation page.";
-    String helpLinkTxt = "For more information about exporting and importing folders, see " +
-            helpLink("importExportFolder", "the folder documentation") + ".";
+    final String noun;
+    final String action;
+    final String mainDescription;
+    final String helpLinkTxt;
+
+    final String whatIsAFolderArchive = "A folder archive is a .folder.zip file or a collection of individual files that " +
+        "conforms to the LabKey folder archive conventions and formats. A folder archive can be created using the folder " +
+        "export feature or via scripts that write data from a master repository into the correct formats. ";
 
     if (requestOrigin.equals("Study"))
     {
         noun = "Study";
         action = "Import";
-        mainDescription = "You can import a study archive, or a folder containing a study, to create and populate a new " +
-            "study.  A study archive is a .study.zip file or a collection of individual files that conforms to the LabKey " +
-            "study export conventions and formats.  In most cases, a study archive is created using the study export " +
-            "feature. Using export and import, a study can be moved from one server to another or a new study can be " +
+        mainDescription = "You can create and populate a new study by importing a folder archive. " + whatIsAFolderArchive +
+            "Using export and import, a study's contents can be moved from one server to another or a new study can be " +
             "created using a standard template.";
         helpLinkTxt = "For more information about exporting, importing, and reloading studies, see " +
-                helpLink("importExportStudy", "the study documentation") + ".";
+            helpLink("importExportStudy", "the study import/export/reload documentation") + ".";
     }
-    else if(requestOrigin.equals("Reload"))
+    else if (requestOrigin.equals("Reload"))
     {
         noun = "Study";
         action = "Reload";
-        mainDescription = "You can reload a folder archive to update an existing study with new settings and data. " +
-            "A folder archive is a .folder.zip file or a collection of individual files that conforms to the LabKey " +
-            "study export conventions and formats.  A folder archive can be created using the study export feature " +
-            "or via scripts that write data from a master repository into the correct formats.  You may also reload " +
-            "using a study archive, which has the format .study.zip. Note: Reloading a study will replace existing " +
-            "study data with the data in the archive.";
+        mainDescription = "You can update an existing study with new settings and data by reloading a folder archive. " +
+            whatIsAFolderArchive + "Note: Reloading a folder archive will replace existing study data with the data in " +
+            "the archive.";
         helpLinkTxt = "For more information about exporting, importing, and reloading studies, see " +
-                helpLink("importExportStudy", "the study documentation") + ".";
+            helpLink("importExportStudy", "the study import/export/reload documentation") + ".";
+    }
+    else
+    {
+        noun = "Folder";
+        action = "Import";
+        mainDescription = "You can populate a folder with data and configuration by importing a folder archive. " +
+            whatIsAFolderArchive + "Using export and import, a folder's contents can be moved from one server to another " +
+            "or a new folder can be created using a standard template. You can also populate a new folder from a template " +
+            "folder on the current server using the \"Create Folder From Template\" option on the folder creation page.";
+        helpLinkTxt = "For more information about exporting and importing folders, see " +
+            helpLink("importExportFolder", "the folder export/import documentation") + ".";
     }
 %>
 <style type="text/css">

--- a/core/src/org/labkey/core/admin/importFolder.jsp
+++ b/core/src/org/labkey/core/admin/importFolder.jsp
@@ -68,7 +68,7 @@
 
     final String whatIsAFolderArchive = "A folder archive is a .folder.zip file or a collection of individual files that " +
         "conforms to the LabKey folder archive conventions and formats. A folder archive can be created using the folder " +
-        "export feature or via scripts that write data from a master repository into the correct formats. ";
+        "export feature or via scripts that write data from a source repository into the correct formats. ";
 
     if (requestOrigin.equals("Study"))
     {

--- a/pipeline/webapp/pipeline/ImportAdvancedOptions.js
+++ b/pipeline/webapp/pipeline/ImportAdvancedOptions.js
@@ -94,7 +94,7 @@ Ext4.define('LABKEY.import.OptionsPanel', {
         {
             var data = [{
                 header: 'Validate Queries',
-                description: 'By default, queries will be validated upon import of a study/folder archive and any failure '
+                description: 'By default, queries will be validated upon import of a folder archive and any failure '
                     + 'to validate will cause the import job to raise an error. To suppress this validation step, uncheck '
                     + 'the box below.',
                 name: 'validateQueries',
@@ -130,7 +130,7 @@ Ext4.define('LABKEY.import.OptionsPanel', {
                 data.splice(1, 0, {
                     header: 'Study Import Options',
                     description: 'By default, new visit rows will be created in the study during import for any dataset or specimen rows which have a new, undefined visit. '
-                    + 'If, instead, you would like for the import of the study archive to fail when it encounters a visit that is not already defined in the study '
+                    + 'If, instead, you would like for the import of the folder archive to fail when it encounters a visit that is not already defined in the study '
                     + 'or as part of the incoming visit map, check the box below.',
                     name: 'failForUndefinedVisits',
                     initChecked: this.isFailForUndefinedVisits ? "checked": "",

--- a/query/src/org/labkey/query/reports/ReportServiceImpl.java
+++ b/query/src/org/labkey/query/reports/ReportServiceImpl.java
@@ -900,7 +900,7 @@ public class ReportServiceImpl extends AbstractContainerListener implements Repo
             List<Report> existingReports = new ArrayList<>(getReports(ctx.getUser(), ctx.getContainer(), key));
 
             // in 13.2, there was a change to use dataset names instead of label for query references in reports, views, etc.
-            // so if we are importing an older study archive, we need to also check for existing reports using the query name (i.e. dataset name)
+            // so if we are importing an older folder archive, we need to also check for existing reports using the query name (i.e. dataset name)
             // NOTE: this will then be fixed up in the ReportImporter.postProcess
             if (ctx.getArchiveVersion() != null && ctx.getArchiveVersion() < 13.11)
             {

--- a/study/api-src/org/labkey/api/study/importer/SimpleStudyImporter.java
+++ b/study/api-src/org/labkey/api/study/importer/SimpleStudyImporter.java
@@ -2,7 +2,7 @@ package org.labkey.api.study.importer;
 
 import org.labkey.api.admin.ImportException;
 
-// Implemented by importers that import from a study archive but are registered by other modules,
+// Implemented by importers that import from the study node of a folder archive but are registered by other modules,
 // namely specimen importers
 public interface SimpleStudyImporter extends BaseStudyImporter<SimpleStudyImportContext>
 {

--- a/study/api-src/org/labkey/api/study/importer/SimpleStudyImporter.java
+++ b/study/api-src/org/labkey/api/study/importer/SimpleStudyImporter.java
@@ -2,7 +2,7 @@ package org.labkey.api.study.importer;
 
 import org.labkey.api.admin.ImportException;
 
-// Implemented by importers that import from the study node of a folder archive but are registered by other modules,
+// Implemented by importers that import from the /study subfolder of a folder archive but are registered by other modules,
 // namely specimen importers
 public interface SimpleStudyImporter extends BaseStudyImporter<SimpleStudyImportContext>
 {

--- a/study/src/org/labkey/study/importer/StudyImportInitialTask.java
+++ b/study/src/org/labkey/study/importer/StudyImportInitialTask.java
@@ -65,7 +65,7 @@ public class StudyImportInitialTask
             // verify the archiveVersion
             double currVersion = AppProps.getInstance().getSchemaVersion();
             if (studyXml.isSetArchiveVersion() && studyXml.getArchiveVersion() > currVersion)
-                throw new PipelineJobException("Can't import study archive. The archive version " + studyXml.getArchiveVersion() + " is newer than the server version " + currVersion + ".");
+                throw new PipelineJobException("Can't import study contents. The archive version " + studyXml.getArchiveVersion() + " is newer than the server version " + currVersion + ".");
 
             // Check if a delay has been requested for testing purposes, to make it easier to cancel the job in a reliable way
             if (studyXml.isSetImportDelay() && studyXml.getImportDelay() > 0)

--- a/study/src/org/labkey/study/pipeline/DatasetInferSchemaReader.java
+++ b/study/src/org/labkey/study/pipeline/DatasetInferSchemaReader.java
@@ -41,14 +41,14 @@ import java.util.stream.Collectors;
 
 /**
  * Implementation of a SchemaReader that can infer dataset metadata from only the datafiles in the
- * datasets location of the study archive
+ * datasets location of the folder archive
  */
 public class DatasetInferSchemaReader extends DatasetFileReader implements SchemaReader
 {
     protected Pattern _filePattern = Pattern.compile("^(.*)\\.(?:tsv|txt|xls|xlsx)$");
 
-    private Map<Integer, DatasetImportInfo> _datasetInfoMap = new LinkedHashMap<>();
-    private List<ImportTypesHelper.Builder> _builders = new ArrayList<>();
+    private final Map<Integer, DatasetImportInfo> _datasetInfoMap = new LinkedHashMap<>();
+    private final List<ImportTypesHelper.Builder> _builders = new ArrayList<>();
     private Map<File, Pair<String, String>> _inputDataMap;
 
     public DatasetInferSchemaReader(VirtualFile datasetsDirectory, String datasetsFileName, StudyImpl study, StudyImportContext studyImportContext)

--- a/study/src/org/labkey/study/writer/StudySerializationRegistry.java
+++ b/study/src/org/labkey/study/writer/StudySerializationRegistry.java
@@ -75,7 +75,7 @@ public class StudySerializationRegistry
         );
     }
 
-    // These writers are related to study and serialize into the study node of a folder archive, but are registered by other modules
+    // These writers are related to study and serialize into the /study subfolder of a folder archive, but are registered by other modules
     public Collection<SimpleStudyWriter> getSimpleStudyWriters()
     {
         return SimpleStudyWriterRegistry.getSimpleStudyWriters();

--- a/study/src/org/labkey/study/writer/StudySerializationRegistry.java
+++ b/study/src/org/labkey/study/writer/StudySerializationRegistry.java
@@ -75,7 +75,7 @@ public class StudySerializationRegistry
         );
     }
 
-    // These writers are related to study and serialize into the study archive, but are registered by other modules
+    // These writers are related to study and serialize into the study node of a folder archive, but are registered by other modules
     public Collection<SimpleStudyWriter> getSimpleStudyWriters()
     {
         return SimpleStudyWriterRegistry.getSimpleStudyWriters();

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
@@ -17,7 +17,6 @@
 package org.labkey.test.tests.study;
 
 import org.jetbrains.annotations.Nullable;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -28,7 +27,6 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.LookAndFeelScatterPlot;
 import org.labkey.test.components.LookAndFeelTimeChart;
-import org.labkey.test.components.PagingWidget;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.ext4.Checkbox;
 import org.labkey.test.components.ext4.Window;

--- a/study/test/src/org/labkey/test/tests/study/StudyProtocolDesignerTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyProtocolDesignerTest.java
@@ -60,7 +60,7 @@ import static org.junit.Assert.assertTrue;
 public class StudyProtocolDesignerTest extends BaseWebDriverTest
 {
     private static final File STUDY_ARCHIVE = TestFileUtils.getSampleData("studies/CohortStudy.zip");
-    // Cohorts: defined in study archive
+    // Cohorts: defined in folder archive
     private static final String[] COHORTS = {"Positive", "Negative"};
 
     private static final File FOLDER_ARCHIVE = TestFileUtils.getSampleData("FolderExport/ProtocolLookup.folder.zip");

--- a/study/test/src/org/labkey/test/tests/study/StudyReloadColumnInferenceTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyReloadColumnInferenceTest.java
@@ -44,7 +44,7 @@ public class StudyReloadColumnInferenceTest extends StudyBaseTest
     * */
     private static final File LIST_ARCHIVE = TestFileUtils.getSampleData("studyreload/listsSetup.zip");
 
-    /* Study node:
+    /* /study subfolder:
         -datasets
             -dataset1000.tsv
             -dataset1001.tsv
@@ -56,7 +56,7 @@ public class StudyReloadColumnInferenceTest extends StudyBaseTest
     * */
     private static final File FOLDER_ARCHIVE = TestFileUtils.getSampleData("studyreload/datasetsSetup.zip");
 
-    /* Study node:
+    /* /study subfolder:
         -datasets
             -Demographics.xlsx (content same as dataset1000.tsv)
             -Lab Results.tsv (content same as dataset1001.tsv)
@@ -68,7 +68,7 @@ public class StudyReloadColumnInferenceTest extends StudyBaseTest
     * */
     private static final File initialReloadTestFile = TestFileUtils.getSampleData("studyreload/originalMixedFileTypes.zip");
 
-    /* Study node:
+    /* /study subfolder:
         -datasets
             -Demographics.xlsx
             -Medical History.tsv

--- a/study/test/src/org/labkey/test/tests/study/StudyReloadColumnInferenceTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyReloadColumnInferenceTest.java
@@ -36,14 +36,15 @@ import java.util.List;
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
 public class StudyReloadColumnInferenceTest extends StudyBaseTest
 {
-    /*List archive:
+    /* List archive:
         -Languages.tsv
         -Countries.tsv
         -lists.xml
         -settings.xml
     * */
     private static final File LIST_ARCHIVE = TestFileUtils.getSampleData("studyreload/listsSetup.zip");
-    /*Study archive: dataset file content match original STUDY_ARCHIVE
+
+    /* Study node:
         -datasets
             -dataset1000.tsv
             -dataset1001.tsv
@@ -53,9 +54,9 @@ public class StudyReloadColumnInferenceTest extends StudyBaseTest
             -Study.dataset
         -study.xml
     * */
-    private static final File STUDY_ARCHIVE = TestFileUtils.getSampleData("studyreload/datasetsSetup.zip");
+    private static final File FOLDER_ARCHIVE = TestFileUtils.getSampleData("studyreload/datasetsSetup.zip");
 
-    /*Study archive:
+    /* Study node:
         -datasets
             -Demographics.xlsx (content same as dataset1000.tsv)
             -Lab Results.tsv (content same as dataset1001.tsv)
@@ -67,7 +68,7 @@ public class StudyReloadColumnInferenceTest extends StudyBaseTest
     * */
     private static final File initialReloadTestFile = TestFileUtils.getSampleData("studyreload/originalMixedFileTypes.zip");
 
-    /*Study archive:
+    /* Study node:
         -datasets
             -Demographics.xlsx
             -Medical History.tsv
@@ -80,12 +81,14 @@ public class StudyReloadColumnInferenceTest extends StudyBaseTest
     * */
     private static final File secondReloadTestFile = TestFileUtils.getSampleData("studyreload/editedMixedFileTypes.zip");
 
-    /*Study archive:
-    -datasets
-        -Demographics.xlsx (with added int, number, string boolean columns)
-    -lists
-        -Languages.xlsx (with added int, number, string boolean columns)
-    -study.xml
+    /* Folder archive:
+        -lists
+            -Languages.xlsx (with added int, number, string boolean columns)
+        -study
+            -datasets
+                -Demographics.xlsx (with added int, number, string boolean columns)
+            -study.xml
+        -folder.xml
     * */
     private static final File thirdReloadTestFile = TestFileUtils.getSampleData("studyreload/editedMixedFieldTypes.zip");
 
@@ -182,7 +185,7 @@ public class StudyReloadColumnInferenceTest extends StudyBaseTest
     protected void doCreateSteps()
     {
         initializeFolder();
-        importStudyFromZip(STUDY_ARCHIVE);
+        importStudyFromZip(FOLDER_ARCHIVE);
         clickFolder(getFolderName());
         _listHelper.importListArchive(LIST_ARCHIVE);
     }


### PR DESCRIPTION
#### Rationale
Primary goal is to modernize the descriptions and remove "study archive" references on the Folder Import page: [Issue 45014: Update descriptions in UI for study reload and folder import](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45014)

While we're at it, fix "study archive" references in other places in this repo to reduce confusion.
