### PR TITLE
Remove `Comparable` interface from modules

### DIFF
--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -153,10 +153,21 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
     }
 
     @Override
-    public int compareTo(@NotNull Module m)
+    public final int compareTo(@NotNull Module m)
     {
-        //sort by name--core module will override to ensure first in sort
-        return getName().compareToIgnoreCase(m.getName());
+        // Ensure that the "Core" module is listed first
+        if (this.getName().equalsIgnoreCase("core") && !m.getName().equalsIgnoreCase("core"))
+        {
+            return 1;
+        }
+        else if (!this.getName().equalsIgnoreCase("core") && m.getName().equalsIgnoreCase("core"))
+        {
+            return -1;
+        }
+        else
+        {
+            return getName().compareToIgnoreCase(m.getName());
+        }
     }
 
     @Override

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -153,24 +153,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
     }
 
     @Override
-    public final int compareTo(@NotNull Module m)
-    {
-        // Ensure that the "Core" module is listed first
-        if (this.getName().equalsIgnoreCase(CORE_MODULE_NAME) && !m.getName().equalsIgnoreCase(CORE_MODULE_NAME))
-        {
-            return -1;
-        }
-        else if (!this.getName().equalsIgnoreCase(CORE_MODULE_NAME) && m.getName().equalsIgnoreCase(CORE_MODULE_NAME))
-        {
-            return 1;
-        }
-        else
-        {
-            return getName().compareToIgnoreCase(m.getName());
-        }
-    }
-
-    @Override
     final public void initialize()
     {
         for (String dsName : ModuleLoader.getInstance().getModuleDataSourceNames(this))

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -156,13 +156,13 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
     public final int compareTo(@NotNull Module m)
     {
         // Ensure that the "Core" module is listed first
-        if (this.getName().equalsIgnoreCase("core") && !m.getName().equalsIgnoreCase("core"))
-        {
-            return 1;
-        }
-        else if (!this.getName().equalsIgnoreCase("core") && m.getName().equalsIgnoreCase("core"))
+        if (this.getName().equalsIgnoreCase(CORE_MODULE_NAME) && !m.getName().equalsIgnoreCase(CORE_MODULE_NAME))
         {
             return -1;
+        }
+        else if (!this.getName().equalsIgnoreCase(CORE_MODULE_NAME) && m.getName().equalsIgnoreCase(CORE_MODULE_NAME))
+        {
+            return 1;
         }
         else
         {

--- a/api/src/org/labkey/api/module/MockModule.java
+++ b/api/src/org/labkey/api/module/MockModule.java
@@ -73,12 +73,6 @@ public class MockModule implements Module
     }
 
     @Override
-    public int compareTo(@NotNull Module m)
-    {
-        return (m instanceof MockModule) ? 0 : 1;
-    }
-
-    @Override
     public void initialize()
     {
     }

--- a/api/src/org/labkey/api/module/Module.java
+++ b/api/src/org/labkey/api/module/Module.java
@@ -58,7 +58,7 @@ import java.util.stream.Collectors;
  * User: migra
  * Date: Jul 14, 2005
  */
-public interface Module extends Comparable<Module>
+public interface Module
 {
     enum TabDisplayMode
     {

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -279,14 +279,6 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
     }
 
     @Override
-    public int compareTo(@NotNull Module m)
-    {
-        //core module always sorts first
-        // TODO: Nice try, but this doesn't work consistently, since no one told DefaultModule.compareTo() that core is special -- fix this or remove the override
-        return (m instanceof CoreModule) ? 0 : -1;
-    }
-
-    @Override
     public boolean hasScripts()
     {
         return true;

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -80,8 +80,8 @@ import org.labkey.api.cloud.CloudStoreService;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveTreeSet;
 import org.labkey.api.compliance.ComplianceService;
-import org.labkey.api.data.*;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.*;
 import org.labkey.api.data.Container.ContainerException;
 import org.labkey.api.data.queryprofiler.QueryProfiler;
 import org.labkey.api.data.queryprofiler.QueryProfiler.QueryStatTsvWriter;
@@ -254,6 +254,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.labkey.api.data.MultiValuedRenderContext.VALUE_DELIMITER_REGEX;
+import static org.labkey.api.module.DefaultModule.CORE_MODULE_NAME;
 import static org.labkey.api.settings.AdminConsole.SettingsLinkType.Configuration;
 import static org.labkey.api.settings.AdminConsole.SettingsLinkType.Diagnostics;
 import static org.labkey.api.util.DOM.A;
@@ -958,7 +959,10 @@ public class AdminController extends SpringActionController
         {
             VBox views = new VBox();
             List<Module> modules = new ArrayList<>(ModuleLoader.getInstance().getModules());
-            modules.sort(Comparator.naturalOrder());
+            modules.sort(Comparator.comparing(module ->
+                    // List 'Core' module credits first
+                    module.getName().equalsIgnoreCase(CORE_MODULE_NAME) ? "" : module.getName(),
+                    String.CASE_INSENSITIVE_ORDER));
 
             String jarRegEx = "^([\\w-\\.]+\\.jar)\\|";
             StringBuilder errorSource = new StringBuilder();


### PR DESCRIPTION
#### Rationale
[Issue 45019: Module.compareTo breaks interface contract](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45019)
Our module `compareTo` method is not commutative when the core module is involved. With the right set/number of modules, `Arrays.sort` will complain thusly:
```
java.lang.IllegalArgumentException: Comparison method violates its general contract!
	at java.util.TimSort.mergeHi(TimSort.java:903) ~[?:?]
	at java.util.TimSort.mergeAt(TimSort.java:520) ~[?:?]
	at java.util.TimSort.mergeForceCollapse(TimSort.java:461) ~[?:?]
	at java.util.TimSort.sort(TimSort.java:254) ~[?:?]
	at java.util.Arrays.sort(Arrays.java:1307) ~[?:?]
	at java.util.ArrayList.sort(ArrayList.java:1721) ~[?:?]
	at org.labkey.core.admin.AdminController$CreditsAction.getView(AdminController.java:956) ~[core-22.3-SNAPSHOT.jar:?]
```
The credits page is the only place that wants this particular ordering so it can take responsibility for creating it.

#### Changes
* Remove `Comparable` interface from modules
