### PR TITLE
Deprecate support for SQL Server 2012

### DIFF
--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -55,6 +55,7 @@ import org.labkey.api.query.AliasManager;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.logging.LogHelper;
+import org.labkey.api.view.template.WarningService;
 import org.labkey.api.view.template.Warnings;
 
 import javax.servlet.ServletException;
@@ -1697,7 +1698,7 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     {
         ClrAssemblyManager.addAdminWarningMessages(warnings);
 
-        if ("2008R2".equals(_versionYear))
+        if (WarningService.get().showAllWarnings() || "2008R2".equals(_versionYear) || "2012".equals(_versionYear))
             warnings.add(HtmlString.of("LabKey Server no longer supports " + getProductName() + " " + _versionYear + "; please upgrade. " + MicrosoftSqlServerDialectFactory.RECOMMENDED));
     }
 

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
@@ -129,7 +129,12 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
                 return new MicrosoftSqlServer2014Dialect(_tableResolver);
 
             if (version >= 110)
+            {
+                if (logWarnings)
+                    LOG.warn("LabKey Server no longer supports " + getProductName() + " version " + databaseProductVersion + ". " + RECOMMENDED);
+
                 return new MicrosoftSqlServer2012Dialect(_tableResolver);
+            }
 
             // Accept 2008 or 2008R2 as an external/supplemental database, but not as the primary database
             if (!primaryDataSource)


### PR DESCRIPTION
#### Rationale
Support for SQL Server 2012 will end on July 12, 2022. This PR adds an admin warning to 22.3. We'll remove support for 2012 in 22.4.

https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=45025