### PR TITLE
Close open stream that was causing IOExceptions

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -208,9 +208,8 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
             }
         }
 
-        try
+        try (DataLoader loader = DataLoader.get().createLoader(dataFile, null, true, null, TabLoader.TSV_FILE_TYPE))
         {
-            DataLoader loader = DataLoader.get().createLoader(dataFile, null, true, null, TabLoader.TSV_FILE_TYPE);
             loader.setThrowOnErrors(settings.isThrowOnErrors());
             loader.setInferTypes(shouldInferTypes);
 

--- a/api/src/org/labkey/api/assay/AssayFileWriter.java
+++ b/api/src/org/labkey/api/assay/AssayFileWriter.java
@@ -57,7 +57,7 @@ public class AssayFileWriter<ContextType extends AssayRunUploadContext<? extends
 
     public static final String DIR_NAME = "assaydata";
     public static final String ARCHIVED_DIR_NAME = "archived";
-    public static final String TEMP_DIR_NAME = "uploadTemp";
+    public static final String TEMP_DIR_NAME = ".uploadTemp";
 
     /** Make sure there's an assaydata subdirectory available for this container */
     public static File ensureUploadDirectory(Container container) throws ExperimentException

--- a/api/src/org/labkey/api/assay/TsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/TsvDataHandler.java
@@ -104,7 +104,7 @@ public class TsvDataHandler extends AbstractAssayTsvDataHandler implements Trans
         if (!data.isFinalRunOutput())
             return defaultName;
 
-        if (defaultName.startsWith("uploadTemp"))
+        if (defaultName.startsWith(AssayFileWriter.TEMP_DIR_NAME))
             return FilenameUtils.getBaseName(defaultName) + ".tsv";
         else
             return FilenameUtils.getFullPath(defaultName) + FilenameUtils.getBaseName(defaultName) + ".tsv";

--- a/api/src/org/labkey/api/data/ExcelColumn.java
+++ b/api/src/org/labkey/api/data/ExcelColumn.java
@@ -38,6 +38,7 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Row.MissingCellPolicy;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.util.Units;
 import org.apache.poi.xssf.usermodel.XSSFAnchor;
 import org.apache.poi.xssf.usermodel.XSSFClientAnchor;
@@ -58,7 +59,6 @@ import org.labkey.api.query.QueryForm;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
-import org.labkey.api.reader.ExcelFactory;
 import org.labkey.api.security.User;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.Pair;
@@ -897,7 +897,7 @@ public class ExcelColumn extends RenderColumn
                 try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
                 {
                     excel.write(baos);
-                    Sheet wb = ExcelFactory.create(new ByteArrayInputStream(baos.toByteArray())).getSheetAt(0);
+                    Sheet wb = WorkbookFactory.create(new ByteArrayInputStream(baos.toByteArray())).getSheetAt(0);
                     DataFormatter formatter = new DataFormatter();
                     for (int rowIdx = 0; rowIdx < DATA.length; rowIdx++)
                     {

--- a/api/src/org/labkey/api/data/SqlScriptExecutor.java
+++ b/api/src/org/labkey/api/data/SqlScriptExecutor.java
@@ -297,7 +297,7 @@ public class SqlScriptExecutor
                 if (null == r || !r.isFile())
                     throw new IllegalStateException("Data file not found for data loading: " + path.toString());
                 String contentType = new MimeMap().getContentTypeFor(r.getName());
-                DataLoader loader;
+                DataLoader loader = null;
 
                 // I'm not sure ExcelLoader closes its input stream, so let's just make sure
                 try (InputStream is = r.getInputStream())
@@ -334,6 +334,13 @@ public class SqlScriptExecutor
                         if (rowNumber > 0)
                             msg.append(" in file row ").append(rowNumber).append(" (including header row)");
                         throw new IllegalStateException(msg.toString(), errors);
+                    }
+                }
+                finally
+                {
+                    if (loader != null)
+                    {
+                        loader.close();
                     }
                 }
             }

--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -308,12 +308,14 @@ public class DataIteratorUtil
     {
         BatchValidationException errors = new BatchValidationException();
         DataIteratorContext context = new DataIteratorContext(errors);
-        DataLoader loader = DataLoaderService.get().createLoader(from, null, true, c, TabLoader.TSV_FILE_TYPE);
-        loader.setInferTypes(false);
-        int count = copy(context, loader, to, c, user);
-        if (errors.hasErrors())
-            throw errors;
-        return count;
+        try (DataLoader loader = DataLoaderService.get().createLoader(from, null, true, c, TabLoader.TSV_FILE_TYPE))
+        {
+            loader.setInferTypes(false);
+            int count = copy(context, loader, to, c, user);
+            if (errors.hasErrors())
+                throw errors;
+            return count;
+        }
     }
 
 

--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -571,6 +571,8 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         }
         finally
         {
+            if (loader != null)
+                loader.close();
             if (null != file)
                 file.closeInputStream();
             if (null != dataFile && !Boolean.parseBoolean(saveToPipeline) && !_useAsync)

--- a/api/src/org/labkey/api/query/QueryImportPipelineJob.java
+++ b/api/src/org/labkey/api/query/QueryImportPipelineJob.java
@@ -11,7 +11,6 @@ import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.pipeline.PipelineValidationException;
 import org.labkey.api.reader.DataLoader;
 import org.labkey.api.util.URLHelper;
-import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.springframework.util.StringUtils;
 
@@ -251,6 +250,7 @@ public class QueryImportPipelineJob extends PipelineJob
         BatchValidationException ve = new BatchValidationException();
 
         PipelineJobNotificationProvider notificationProvider = getNotificationProvider();
+        DataLoader loader = null;
 
         try
         {
@@ -268,7 +268,7 @@ public class QueryImportPipelineJob extends PipelineJob
 
             QueryUpdateService updateService = target.getUpdateService();
 
-            DataLoader loader = DataLoader.get().createLoader(_importContextBuilder.getPrimaryFile(), _importContextBuilder.getFileContentType(), _importContextBuilder.isHasColumnHeaders(), null, null);
+            loader = DataLoader.get().createLoader(_importContextBuilder.getPrimaryFile(), _importContextBuilder.getFileContentType(), _importContextBuilder.isHasColumnHeaders(), null, null);
 
             AbstractQueryImportAction.configureLoader(loader, target, _importContextBuilder.getRenamedColumns(), _importContextBuilder.isHasLineageColumns());
 
@@ -306,6 +306,13 @@ public class QueryImportPipelineJob extends PipelineJob
 
             if (notificationProvider != null)
                 notificationProvider.onJobError(this, e.getMessage());
+        }
+        finally
+        {
+            if (loader != null)
+            {
+                loader.close();
+            }
         }
 
     }

--- a/api/src/org/labkey/api/reader/ExcelFactory.java
+++ b/api/src/org/labkey/api/reader/ExcelFactory.java
@@ -155,7 +155,7 @@ public class ExcelFactory
 
 
     // throw FileNotFoundException instead of InvalidOperationException or InvalidFormatException
-    static OPCPackage readOPCPackage(@NotNull File file) throws IOException, InvalidFormatException
+    static OPCPackage openOPCPackage(@NotNull File file) throws IOException, InvalidFormatException
     {
         if (!file.isFile())
             throw new FileNotFoundException("file not found");
@@ -165,9 +165,9 @@ public class ExcelFactory
 
     public static WorkbookMetadata getMetadata(@NotNull File file) throws IOException, InvalidFormatException
     {
-        try
+        try (OPCPackage opc = openOPCPackage(file))
         {
-            return getMetadata(readOPCPackage(file));
+            return getMetadata(opc);
         }
         // might be OLE2 formet
         catch (InvalidFormatException|UnsupportedFileFormatException e)
@@ -223,9 +223,8 @@ public class ExcelFactory
     @NotNull
     public static Workbook create(@NotNull File file) throws IOException, InvalidFormatException
     {
-        try
+        try (OPCPackage opc = openOPCPackage(file))
         {
-            OPCPackage opc = readOPCPackage(file);
             return new XSSFWorkbook(opc)
             {
                 // This overload is here to make it easy to see which code paths are inadvertently loading spreadsheet data the expensive way!

--- a/api/src/org/labkey/api/reader/ExcelLoader.java
+++ b/api/src/org/labkey/api/reader/ExcelLoader.java
@@ -443,14 +443,19 @@ public class ExcelLoader extends DataLoader
     @Override
     public void close()
     {
+        if (_workbook != null)
+        {
+            try
+            {
+                _workbook.close();
+            }
+            catch (IOException ignore)
+            {
+            }
+        }
+
         if (shouldDeleteFile && null != _file)
             FileUtil.deleteTempFile(_file);
-        try
-        {
-            _workbook.close();
-        }
-        catch (IOException ignore)
-        {}
     }
 
 

--- a/api/src/org/labkey/api/reader/ExcelLoader.java
+++ b/api/src/org/labkey/api/reader/ExcelLoader.java
@@ -445,6 +445,12 @@ public class ExcelLoader extends DataLoader
     {
         if (shouldDeleteFile && null != _file)
             FileUtil.deleteTempFile(_file);
+        try
+        {
+            _workbook.close();
+        }
+        catch (IOException ignore)
+        {}
     }
 
 

--- a/api/src/org/labkey/api/reader/jxl/JxlWorkbook.java
+++ b/api/src/org/labkey/api/reader/jxl/JxlWorkbook.java
@@ -381,7 +381,7 @@ public class JxlWorkbook implements Workbook
     @Override
     public void close()
     {
-        throw new UnsupportedOperationException("method not yet supported");
+        _workbook.close();
     }
 
     @Override

--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -99,7 +99,7 @@ public class FileUtil
             }
             catch (IOException x)
             {
-                /* pass */
+                p.toFile().deleteOnExit();
             }
         }
         paths.clear();
@@ -1198,8 +1198,8 @@ quickScan:
     {
         if (null != f && f.isFile())
         {
-            f.delete();
-            tempPaths.get().remove(f.toPath());
+            if(f.delete())
+                tempPaths.get().remove(f.toPath());
         }
     }
 

--- a/assay/api-src/org/labkey/api/assay/plate/ExcelPlateReader.java
+++ b/assay/api-src/org/labkey/api/assay/plate/ExcelPlateReader.java
@@ -46,11 +46,9 @@ public class ExcelPlateReader extends AbstractPlateReader implements PlateReader
     @Override
     public double[][] loadFile(PlateTemplate template, File dataFile) throws ExperimentException
     {
-        try
+        DataLoaderFactory factory = DataLoader.get().findFactory(dataFile, null);
+        try (DataLoader loader = factory.createLoader(dataFile, false))
         {
-            DataLoaderFactory factory = DataLoader.get().findFactory(dataFile, null);
-            DataLoader loader = factory.createLoader(dataFile, false);
-
             return PlateUtils.parseGrid(dataFile, loader.load(), template.getRows(), template.getColumns(), this);
         }
         catch (IOException ioe)
@@ -62,11 +60,9 @@ public class ExcelPlateReader extends AbstractPlateReader implements PlateReader
     @Override
     public Map<String, double[][]> loadMultiGridFile(PlateTemplate template, File dataFile) throws ExperimentException
     {
-        try
+        DataLoaderFactory factory = DataLoader.get().findFactory(dataFile, null);
+        try (DataLoader loader = factory.createLoader(dataFile, false))
         {
-            DataLoaderFactory factory = DataLoader.get().findFactory(dataFile, null);
-            DataLoader loader = factory.createLoader(dataFile, false);
-
             return PlateUtils.parseAllGrids(dataFile, loader.load(), template.getRows(), template.getColumns(), this);
         }
         catch (IOException ioe)

--- a/assay/api-src/org/labkey/api/assay/plate/PlateSampleFilePropertyHelper.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateSampleFilePropertyHelper.java
@@ -16,6 +16,11 @@
 package org.labkey.api.assay.plate;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AssayDataCollector;
+import org.labkey.api.assay.AssayFileWriter;
+import org.labkey.api.assay.actions.AssayRunUploadForm;
+import org.labkey.api.assay.actions.PlateUploadForm;
+import org.labkey.api.assay.nab.NabUrls;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DataRegion;
 import org.labkey.api.data.RenderContext;
@@ -23,7 +28,6 @@ import org.labkey.api.data.SimpleDisplayColumn;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.property.DomainProperty;
-import org.labkey.api.assay.nab.NabUrls;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.reader.ColumnDescriptor;
@@ -31,10 +35,6 @@ import org.labkey.api.reader.DataLoader;
 import org.labkey.api.reader.DataLoaderService;
 import org.labkey.api.reader.ExcelLoader;
 import org.labkey.api.security.User;
-import org.labkey.api.assay.actions.AssayRunUploadForm;
-import org.labkey.api.assay.actions.PlateUploadForm;
-import org.labkey.api.assay.AssayDataCollector;
-import org.labkey.api.assay.AssayFileWriter;
 import org.labkey.api.study.assay.SampleMetadataInputFormat;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.InsertView;
@@ -213,11 +213,9 @@ public class PlateSampleFilePropertyHelper extends PlateSamplePropertyHelper
             return null;
 
         Map<String, Map<DomainProperty, String>> allProperties = new HashMap<>();
-        try
+        try (DataLoader loader = DataLoaderService.get().createLoader(metadataFile, null, true, null, ExcelLoader.FILE_TYPE))
         {
             Map<String, WellGroupTemplate> sampleGroupNames = getSampleWellGroupNameMap();
-
-            DataLoader loader = DataLoaderService.get().createLoader(metadataFile, null, true, null, ExcelLoader.FILE_TYPE);
 
             boolean hasSampleNameCol = false;
             ColumnDescriptor[] columns = loader.getColumns();

--- a/assay/src/org/labkey/assay/pipeline/AssayImportRunTask.java
+++ b/assay/src/org/labkey/assay/pipeline/AssayImportRunTask.java
@@ -263,22 +263,24 @@ public class AssayImportRunTask extends PipelineJob.Task<AssayImportRunTask.Fact
                 {
                     job.getLogger().info("Processing excel file: " + dataFile.getName());
                     // check to see if this is a multi-sheet format
-                    ExcelLoader loader = new ExcelLoader(dataFile, true);
-                    List<String> sheets = loader.getSheetNames();
-                    if (sheets.size() > 1)
+                    try (ExcelLoader loader = new ExcelLoader(dataFile, true))
                     {
-                        job.getLogger().info("Processing excel multi-sheet format");
-
-                        // if a sheet name with results exist, use that as the results data, otherwise
-                        // default to the first sheet in the workbook
-                        if (sheets.contains(RESULTS_NAME))
+                        List<String> sheets = loader.getSheetNames();
+                        if (sheets.size() > 1)
                         {
-                            job.getLogger().info("Found sheet named : " + RESULTS_NAME + ", loading into results data.");
-                            loader.setSheetName(RESULTS_NAME);
+                            job.getLogger().info("Processing excel multi-sheet format");
+
+                            // if a sheet name with results exist, use that as the results data, otherwise
+                            // default to the first sheet in the workbook
+                            if (sheets.contains(RESULTS_NAME))
+                            {
+                                job.getLogger().info("Found sheet named : " + RESULTS_NAME + ", loading into results data.");
+                                loader.setSheetName(RESULTS_NAME);
+                            }
+                            else
+                                job.getLogger().info("Couldn't find sheet named : " + RESULTS_NAME + ", loading data from the first sheet.");
+                            return loader.load();
                         }
-                        else
-                            job.getLogger().info("Couldn't find sheet named : " + RESULTS_NAME + ", loading data from the first sheet.");
-                        return loader.load();
                     }
                 }
                 else if (FileUtil.getExtension(dataFile).equals("zip"))
@@ -413,9 +415,8 @@ public class AssayImportRunTask extends PipelineJob.Task<AssayImportRunTask.Fact
 
         private Map<String, Object> loadProperties(File dataFile, String sheetName, Logger log) throws PipelineJobException
         {
-            try
+            try (ExcelLoader loader = new ExcelLoader(dataFile, true))
             {
-                ExcelLoader loader = new ExcelLoader(dataFile, true);
                 if (loader.getSheetNames().contains(sheetName))
                 {
                     log.info("Found sheet named : " + sheetName + ", loading properties from this sheet.");

--- a/assay/src/org/labkey/assay/pipeline/AssayImportRunTask.java
+++ b/assay/src/org/labkey/assay/pipeline/AssayImportRunTask.java
@@ -293,9 +293,10 @@ public class AssayImportRunTask extends PipelineJob.Task<AssayImportRunTask.Fact
                     {
                         File resultFile = results[0];
                         job.getLogger().info("Found results file named : " + resultFile + ", loading into results data.");
-                        DataLoader loader = DataLoaderService.get().createLoader(resultFile, null, true, null, null);
-
-                        return loader.load();
+                        try (DataLoader loader = DataLoaderService.get().createLoader(resultFile, null, true, null, null))
+                        {
+                            return loader.load();
+                        }
                     }
                 }
             }
@@ -325,9 +326,10 @@ public class AssayImportRunTask extends PipelineJob.Task<AssayImportRunTask.Fact
                     {
                         File resultFile = results[0];
                         job.getLogger().info("Found batch properties file named : " + resultFile + ", loading into results data.");
-                        DataLoader loader = DataLoaderService.get().createLoader(resultFile, null, true, null, null);
-
-                        return loadProperties(loader);
+                        try (DataLoader loader = DataLoaderService.get().createLoader(resultFile, null, true, null, null))
+                        {
+                            return loadProperties(loader);
+                        }
                     }
                 }
             }
@@ -357,9 +359,10 @@ public class AssayImportRunTask extends PipelineJob.Task<AssayImportRunTask.Fact
                     {
                         File resultFile = results[0];
                         job.getLogger().info("Found run properties file named : " + resultFile + ", loading into results data.");
-                        DataLoader loader = DataLoaderService.get().createLoader(resultFile, null, true, null, null);
-
-                        return loadProperties(loader);
+                        try (DataLoader loader = DataLoaderService.get().createLoader(resultFile, null, true, null, null))
+                        {
+                            return loadProperties(loader);
+                        }
                     }
                 }
             }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -2368,12 +2368,13 @@ public class ExperimentController extends SpringActionController
                 String filename = rootObject.has("fileName") ? rootObject.getString("fileName") : "ExcelExport.xls";
                 ExcelWriter.ExcelDocumentType docType = filename.toLowerCase().endsWith(".xlsx") ? ExcelWriter.ExcelDocumentType.xlsx : ExcelWriter.ExcelDocumentType.xls;
 
-                Workbook workbook = ExcelFactory.createFromArray(sheetsArray, docType);
-
-                response.setContentType(docType.getMimeType());
-                response.setHeader("Content-disposition", "attachment; filename=\"" + filename + "\"");
-                ResponseHelper.setPrivate(response);
-                workbook.write(response.getOutputStream());
+                try (Workbook workbook = ExcelFactory.createFromArray(sheetsArray, docType))
+                {
+                    response.setContentType(docType.getMimeType());
+                    response.setHeader("Content-disposition", "attachment; filename=\"" + filename + "\"");
+                    ResponseHelper.setPrivate(response);
+                    workbook.write(response.getOutputStream());
+                }
             }
             catch (JSONException | ClassCastException e)
             {

--- a/internal/src/org/labkey/api/exp/property/DomainTemplate.java
+++ b/internal/src/org/labkey/api/exp/property/DomainTemplate.java
@@ -497,6 +497,13 @@ public class DomainTemplate
             else
                 throw new RuntimeSQLException(x);
         }
+        finally
+        {
+            if (dl != null)
+            {
+                dl.close();
+            }
+        }
 
         return 0;
     }

--- a/specimen/src/org/labkey/specimen/pipeline/SampleMindedTransformTask.java
+++ b/specimen/src/org/labkey/specimen/pipeline/SampleMindedTransformTask.java
@@ -498,13 +498,15 @@ public class SampleMindedTransformTask extends AbstractSpecimenTransformTask
             DataLoaderFactory df = DataLoader.get().findFactory(source, null);
             if (null == df)
                 return;
-            DataLoader dl = df.createLoader(source, true, study.getContainer());
-            DataIteratorBuilder sampleminded = wrapSampleMindedTransform(job.getUser(), dl, context, study, target);
-            Map<String,Object> empty = new HashMap<>();
+            try (DataLoader dl = df.createLoader(source, true, study.getContainer()))
+            {
+                DataIteratorBuilder sampleminded = wrapSampleMindedTransform(job.getUser(), dl, context, study, target);
+                Map<String, Object> empty = new HashMap<>();
 
-            // would be nice to have deleteAll() in QueryUpdateService
-            new SqlExecutor(scope).execute("DELETE FROM rho." + target.getName() + " WHERE container=?", study.getContainer());
-            int count = target.getUpdateService().importRows(job.getUser(), study.getContainer(), sampleminded, context.getErrors(), null, empty);
+                // would be nice to have deleteAll() in QueryUpdateService
+                new SqlExecutor(scope).execute("DELETE FROM rho." + target.getName() + " WHERE container=?", study.getContainer());
+                int count = target.getUpdateService().importRows(job.getUser(), study.getContainer(), sampleminded, context.getErrors(), null, empty);
+            }
             if (!context.getErrors().hasErrors())
             {
                 transaction.commit();


### PR DESCRIPTION
#### Rationale
[Issue 45051: File streams are left open after import from Excel ](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45051)
Close open stream that was causing IOExceptions on Windows

#### Related PR
Seems related to https://github.com/LabKey/platform/pull/2942

#### Changes
* Add workbook.close to close method of ExcelLoader
* Use try-with-resources for ExcelLoaders
