### PR TITLE
Issue 44559: LKS grid filtering does not respect non-US date parsing setting

### DIFF
--- a/api/webapp/clientapi/ext3/FilterDialog.js
+++ b/api/webapp/clientapi/ext3/FilterDialog.js
@@ -710,6 +710,12 @@ LABKEY.FilterDialog.View.Default = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
         return filters;
     },
 
+    getAltDateFormats: function() {
+        if (this.jsonType == "date")
+            return 'Y-m-d|' + LABKEY.Utils.getDateAltFormats(); // always support ISO
+        return undefined;
+    },
+
     getInputConfig : function(idx) {
         var me = this;
         return {
@@ -722,7 +728,7 @@ LABKEY.FilterDialog.View.Default = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
             validateOnBlur: true,
             value         : null,
             format        : this.jsonType == "date" && !LABKEY.useMDYDateParsing ? LABKEY.extDefaultDateFormat : undefined, // Unless in "Non-U.S. date parsing (DMY)" mode, always use ISO date format for input forms
-            altFormats: (this.jsonType == "date" ? LABKEY.Utils.getDateAltFormats() : undefined),
+            altFormats    : this.getAltDateFormats(),
             validator : function(value) {
 
                 // support for filtering '∞'

--- a/api/webapp/clientapi/ext3/FilterDialog.js
+++ b/api/webapp/clientapi/ext3/FilterDialog.js
@@ -479,7 +479,13 @@ LABKEY.FilterDialog.View.Default = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
             }
         }
 
-        const inputValue = filter.getURLParameterValue();
+        var inputValue = filter.getURLParameterValue();
+
+        if (this.jsonType == "date" && !LABKEY.useMDYDateParsing && inputValue) {
+            const dateVal = Date.parseDate(inputValue, LABKEY.extDateInputFormat); // date inputs are formatted to ISO date format on server
+            inputValue = dateVal.format(LABKEY.extDefaultDateFormat); // convert back to date field accepted format for render
+        }
+
         if (this.inputs[f]) {
             this.inputs[f].setValue(inputValue);
         }
@@ -715,6 +721,7 @@ LABKEY.FilterDialog.View.Default = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
             blankText     : 'You must enter a value.',
             validateOnBlur: true,
             value         : null,
+            format        : this.jsonType == "date" && !LABKEY.useMDYDateParsing ? LABKEY.extDefaultDateFormat : undefined, // Unless in "Non-U.S. date parsing (DMY)" mode, always use ISO date format for input forms
             altFormats: (this.jsonType == "date" ? LABKEY.Utils.getDateAltFormats() : undefined),
             validator : function(value) {
 

--- a/api/webapp/clientapi/ext3/FilterDialog.js
+++ b/api/webapp/clientapi/ext3/FilterDialog.js
@@ -481,7 +481,7 @@ LABKEY.FilterDialog.View.Default = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
 
         var inputValue = filter.getURLParameterValue();
 
-        if (this.jsonType == "date" && !LABKEY.useMDYDateParsing && inputValue) {
+        if (this.jsonType === "date" && inputValue) {
             const dateVal = Date.parseDate(inputValue, LABKEY.extDateInputFormat); // date inputs are formatted to ISO date format on server
             inputValue = dateVal.format(LABKEY.extDefaultDateFormat); // convert back to date field accepted format for render
         }
@@ -711,14 +711,14 @@ LABKEY.FilterDialog.View.Default = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
     },
 
     getAltDateFormats: function() {
-        if (this.jsonType == "date")
+        if (this.jsonType === "date")
             return 'Y-m-d|' + LABKEY.Utils.getDateAltFormats(); // always support ISO
         return undefined;
     },
 
     getInputConfig : function(idx) {
         var me = this;
-        return {
+        var config = {
             xtype         : this.getXtype(),
             itemId        : 'inputField' + idx,
             filterIndex   : idx,
@@ -727,7 +727,6 @@ LABKEY.FilterDialog.View.Default = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
             blankText     : 'You must enter a value.',
             validateOnBlur: true,
             value         : null,
-            format        : this.jsonType == "date" && !LABKEY.useMDYDateParsing ? LABKEY.extDefaultDateFormat : undefined,
             altFormats    : this.getAltDateFormats(),
             validator : function(value) {
 
@@ -773,6 +772,15 @@ LABKEY.FilterDialog.View.Default = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
             },
             scope: this
         };
+        if (this.jsonType === "date") {
+            config.format = LABKEY.extDefaultDateFormat;
+
+            // default invalidText : "{0} is not a valid date - it must be in the format {1}",
+            // override the default warning msg as there is one preferred format, but there are also a set of acceptable altFormats
+            config.invalidText = "{0} might not be a valid date - the preferred format is {1}";
+        }
+
+        return config;
     },
 
     inputListener : function(input, newVal, oldVal) {

--- a/api/webapp/clientapi/ext3/FilterDialog.js
+++ b/api/webapp/clientapi/ext3/FilterDialog.js
@@ -727,7 +727,7 @@ LABKEY.FilterDialog.View.Default = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
             blankText     : 'You must enter a value.',
             validateOnBlur: true,
             value         : null,
-            format        : this.jsonType == "date" && !LABKEY.useMDYDateParsing ? LABKEY.extDefaultDateFormat : undefined, // Unless in "Non-U.S. date parsing (DMY)" mode, always use ISO date format for input forms
+            format        : this.jsonType == "date" && !LABKEY.useMDYDateParsing ? LABKEY.extDefaultDateFormat : undefined,
             altFormats    : this.getAltDateFormats(),
             validator : function(value) {
 


### PR DESCRIPTION
#### Rationale
The current EXT date field on filter dialog is missing a format config, resulting in Ext's default 'm/d/Y' format always being the format for the input. LKS only accepts ISO date format as inputs on the server side and Query.Filter converts all client side date objects to Y-m-d format string before sending to the server, so it's safe to have the dialog uses a non-iso format. 

Additionally, we want to add ISO date format as one of the formats that's always supported, regardless of settings. 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Use configured date format as date input format on filter dialog 
* Always accept ISO format date input, regardless of format or parsing setting
