### PR TITLE
45023: Unauthorized exception for readonly user - Dataset linked from flow data

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpRunItemTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunItemTableImpl.java
@@ -62,8 +62,14 @@ public abstract class ExpRunItemTableImpl<C extends Enum> extends ExpTableImpl<C
     {
         if (!isAllowedPermission(perm))
             return false;
-        if (!getContainer().hasPermission(user, perm))
+        if (_userSchema instanceof UserSchema.HasContextualRoles)
+        {
+            if (!getContainer().hasPermission(user, perm, ((UserSchema.HasContextualRoles)_userSchema).getContextualRoles()))
+                return false;
+        }
+        else if (!getContainer().hasPermission(user, perm))
             return false;
+
         return perm.equals(ReadPermission.class) || canUserAccessPhi();
     }
 


### PR DESCRIPTION
#### Rationale
Datasets sourced from Flow data weren't respecting `ContextualRoles` when resolving the underlying tables:

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45023

#### Related Pull Requests
- https://github.com/LabKey/commonAssays/pull/439

#### Changes
- Teach the `ExpRunItemTable` to use `ContextualRoles` when checking permissions
- 