### PR TITLE
Throw compliance-related unauthorized exceptions only if logging is enabled

### DIFF
--- a/api/src/org/labkey/api/data/QueryLogging.java
+++ b/api/src/org/labkey/api/data/QueryLogging.java
@@ -38,8 +38,9 @@ public class QueryLogging
     private final boolean _readOnly;
     private final boolean _metadataQuery;
     private final String _debugName;
-    private boolean _shouldAudit = true;
+    private Boolean _shouldAudit = null;
     private SelectQueryAuditProvider _selectQueryAuditProvider = null;
+    private RuntimeException _exceptionToThrowIfLoggingIsEnabled = null;
 
     public QueryLogging()
     {
@@ -164,6 +165,8 @@ public class QueryLogging
 
     public boolean isShouldAudit()
     {
+        if (null == _shouldAudit)
+            throw new IllegalStateException("ShouldAudit has not been set!");
         return _shouldAudit;
     }
 
@@ -172,11 +175,19 @@ public class QueryLogging
         // Commented out until Issue 42791 is resolved
 //        if (_readOnly)
 //            throw new IllegalStateException("This QueryLogging instance is read-only: " + _debugName);
+        if (shouldAudit && null != _exceptionToThrowIfLoggingIsEnabled)
+            throw _exceptionToThrowIfLoggingIsEnabled;
+
         _shouldAudit = shouldAudit;
     }
 
     public SelectQueryAuditProvider getSelectQueryAuditProvider()
     {
         return _selectQueryAuditProvider;
+    }
+
+    public void setExceptionToThrowIfLoggingIsEnabled(RuntimeException exceptionToThrowIfLoggingIsEnabled)
+    {
+        _exceptionToThrowIfLoggingIsEnabled = exceptionToThrowIfLoggingIsEnabled;
     }
 }

--- a/query/src/org/labkey/query/sql/QuerySelectView.java
+++ b/query/src/org/labkey/query/sql/QuerySelectView.java
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
  *
  * I did not call this class "QueryView" because we already have a "QueryView"!
  *
- * NOTE: one oddness is that a list of ColumnInfo objects is passed in.  This is because of of how DataRegion/QueryView
+ * NOTE: one oddness is that a list of ColumnInfo objects is passed in. This is because of how DataRegion/QueryView
  * have always worked. See QueryServiceImpl.getColumns() and RenderContext.getSelectColumns()
  *
  * We can still implement getTableInfo etc, but we probably want to preserve the aliases of the initial ColumnInfo objects.
@@ -276,7 +276,7 @@ public class QuerySelectView extends QueryRelation
                     // Looking for matching column in allColumns; must match by ColumnLogging object, which gets propagated up sql parse tree
                     for (ColumnInfo column : allColumns)
                         if (shouldLogNameToDataLoggingMapEntry.getKey().getColumnLogging().equals(column.getColumnLogging()))
-                            throw new UnauthorizedException("Unable to locate required logging column '" + fieldKey.toString() + "'.");
+                            queryLogging.setExceptionToThrowIfLoggingIsEnabled(new UnauthorizedException("Unable to locate required logging column '" + fieldKey.toString() + "'."));
                 }
             }
         }
@@ -285,7 +285,7 @@ public class QuerySelectView extends QueryRelation
             queryLogging.setQueryLogging(table.getUserSchema().getUser(), table.getUserSchema().getContainer(), columnLoggingComment,
                     shouldLogNameLoggings, dataLoggingColumns, selectQueryAuditProvider);
         else if (!shouldLogNameLoggings.isEmpty())
-            throw new UnauthorizedException("Column logging is required but cannot set query logging object.");
+            queryLogging.setExceptionToThrowIfLoggingIsEnabled(new UnauthorizedException("Column logging is required but cannot set query logging object."));
 
         // Check columns again: ensureRequiredColumns() may have added new columns
         assert Table.checkAllColumns(table, allColumns, "getSelectSQL() results of ensureRequiredColumns()", true);


### PR DESCRIPTION
#### Rationale
Addresses https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44900

`QuerySelectView.getSelectSQL()` adds "logging columns" when selecting PHI columns and throws `UnauthorizedException` if it's unable to find a participant ID column, for example, when attempting to execute an aggregate query over a PHI column. The issue complains that the exception is thrown even if compliance logging is disabled. The obvious fix would seem to be to do these checks and throw only if compliance logging is available and enabled. However, that proved to be an untenable approach... `getSelectSQL()` lacks the container and user context needed plus the method is used so extensively that checking compliance settings results in ugly re-entrancy problems. Instead, I chose to do the bookkeeping unconditionally but stash any exceptions in `QueryLogging` until `setShouldAudit()` is called. Checks were added to ensure this method is called in all cases.