### PR TITLE
45034: CIML's BSIImport module failing due to S3 bug from 21.11

### DIFF
--- a/specimen/src/org/labkey/specimen/pipeline/FileAnalysisSpecimenTask.java
+++ b/specimen/src/org/labkey/specimen/pipeline/FileAnalysisSpecimenTask.java
@@ -97,7 +97,8 @@ public class FileAnalysisSpecimenTask extends AbstractSpecimenTask<FileAnalysisS
                         ctx.getLogger().info("Single specimen file detected, moving to a temp folder for processing.");
                         String tempDirName = DateUtil.formatDateTime(new Date(), "yyMMddHHmmssSSS");
                         _tempDir = inputFile.getParent().resolve(tempDirName);
-                        Files.copy(inputFile, _tempDir);
+                        Files.createDirectory(_tempDir);
+                        Files.copy(inputFile, _tempDir.resolve(inputFile.getFileName()));
 
                         return new FileSystemFile(_tempDir);
                     }


### PR DESCRIPTION
#### Rationale
I think this was introduced during the recent S3 work to support file watchers. We just need to make sure we are creating the directory first and then copying into the correct target temp file. The existing code was just copying the source file into a file which was the temp directory name (with no extension).

https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=45034
