### PR TITLE
Issue 45055: Email notification setting result in NPE when creating a new announcement

### DIFF
--- a/announcements/src/org/labkey/announcements/model/EmailPrefsSelector.java
+++ b/announcements/src/org/labkey/announcements/model/EmailPrefsSelector.java
@@ -121,11 +121,16 @@ public abstract class EmailPrefsSelector
         DiscussionService.Settings settings = AnnouncementsController.getSettings(_c);
         int emailPreference = up.getEmailOptionId();
 
-        DiscussionSrcTypeProvider typeProvider = AnnouncementService.get().getDiscussionSrcTypeProvider(ann.getDiscussionSrcEntityType());
+        DiscussionSrcTypeProvider typeProvider = null;
+
         Set<User> extraRecipients = new HashSet<>();
-        if (typeProvider != null)
+        if (ann != null)
         {
-            extraRecipients = typeProvider.getRecipients(_c, user, ann.getDiscussionSrcIdentifier());
+            typeProvider = AnnouncementService.get().getDiscussionSrcTypeProvider(ann.getDiscussionSrcEntityType());
+            if (typeProvider != null)
+            {
+                extraRecipients = typeProvider.getRecipients(_c, user, ann.getDiscussionSrcIdentifier());
+            }
         }
 
         if (EmailOption.MESSAGES_MINE.getValue() == emailPreference || EmailOption.MESSAGES_MINE_DAILY_DIGEST.getValue() == emailPreference)


### PR DESCRIPTION
#### Rationale
```
java.lang.NullPointerException: Cannot invoke "org.labkey.announcements.model.AnnouncementModel.getDiscussionSrcEntityType()" because "ann" is null
org.labkey.announcements.model.EmailPrefsSelector.shouldSend(EmailPrefsSelector.java:124)
org.labkey.announcements.model.EmailPrefsSelector.getNotificationUsers(EmailPrefsSelector.java:167)
org.labkey.announcements.AnnouncementsController$BaseInsertView.<init>(AnnouncementsController.java:1144)
```

Introduced in https://github.com/LabKey/platform/pull/2885

#### Changes
* Check if nullable value is null