### PR TITLE
Issue 45042: Domain creation and save APIs don't properly set the description value for the domain

### DIFF
--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -333,6 +333,10 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
         List<GWTPropertyDescriptor> properties = (List<GWTPropertyDescriptor>)domain.getFields();
         List<GWTIndex> indices = (List<GWTIndex>)domain.getIndices();
 
+        // Issue 45042: Allow for the dataClass description to be set via the create domain API calls
+        if (options.getDescription() == null && domain.getDescription() != null)
+            options.setDescription(domain.getDescription());
+
         try
         {
             ExpDataClass dataClass = ExperimentService.get().createDataClass(container, user, name, options, properties, indices, templateInfo);

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -396,7 +396,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
         ListDefinition list = ListService.get().createList(container, name, keyType, templateInfo, category);
         list.setKeyName(keyName);
 
-        // Issue 45042: Allow for the list description to be set via the create/save domain API calls
+        // Issue 45042: Allow for the list description to be set via the create domain API calls
         if (listProperties.getDescription() == null && domain.getDescription() != null)
             listProperties.setDescription(domain.getDescription());
         list.setDescription(listProperties.getDescription());
@@ -518,7 +518,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
 
                 updateListProperties(container, user, listDefinition.getListId(), listProperties);
             }
-            // Issue 45042: Allow for the list description to be set via the create/save domain API calls
+            // Issue 45042: Allow for the list description to be set via the save domain API calls
             else if (update.getDescription() != null)
             {
                 listProperties = getListProperties(container, user, listDefinition.getListId());

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -396,7 +396,7 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
     {
         arguments.setName(domain.getName());
         String name = arguments.getName();
-        String description = arguments.getDescription();
+        String description = arguments.getDescription() != null ? arguments.getDescription() : domain.getDescription();
         String label = (arguments.getLabel() == null || arguments.getLabel().length() == 0) ? arguments.getName() : arguments.getLabel();
         Integer cohortId = arguments.getCohortId();
         String tag = arguments.getTag();


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45042

If you create a LabKey domain via the API (R, python, etc.), the description value for the domain that you pass to the POST body is not persisted in the LK database with the domain. Note that you can set the description for a domain (i.e. list, dataset, sample type) through the UI in LK server. This PR allows for that description to be persisted in the list, dataset, and data class cases (it was already supported for sample type creation).

#### Changes
* DataSetDomainKind/ListDomainKind/DataClassDomainKind update createDomain() to look for description value from domain object if not present in options/arguments
