### PR TITLE
Appease crawler by making AbstractCreateFolderAction abstract

### DIFF
--- a/api/src/org/labkey/api/security/roles/ProjectCreatorRole.java
+++ b/api/src/org/labkey/api/security/roles/ProjectCreatorRole.java
@@ -11,7 +11,7 @@ public class ProjectCreatorRole extends AbstractRootContainerRole
         super
         (
             "Project Creator",
-            "Allows users to create new projects via the CreateProject action and grant themselves the Project Administrator role after creation",
+            "Allows users to create new projects and grant themselves the Project Administrator role after creation via the CreateProject API",
             CreateProjectPermission.class
         );
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -6869,7 +6869,7 @@ public class AdminController extends SpringActionController
         }
     }
 
-    public static class AbstractCreateFolderAction<FORM extends ManageFoldersForm> extends FormViewAction<FORM>
+    private static abstract class AbstractCreateFolderAction<FORM extends ManageFoldersForm> extends FormViewAction<FORM>
     {
         private ActionURL _successURL;
 


### PR DESCRIPTION
#### Rationale
Sneaky crawler found and invoked AbstractCreateFolderAction, which resulted in a missing permission annotation complaint. Also, reword the Project Creator description to emphasize that the corresponding action is an API.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3138