### PR TITLE
Handle bad 'filename' parameter on Windows

### DIFF
--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -83,6 +83,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Date;
 import java.util.Set;
@@ -556,7 +557,15 @@ public class StatusController extends SpringActionController
                     String basename = statusName.substring(0, statusName.lastIndexOf('.'));
 
                     Path dir = fileStatus.getParent();
-                    Path fileShow = dir.resolve(fileName);
+                    Path fileShow;
+                    try
+                    {
+                        fileShow = dir.resolve(fileName);
+                    }
+                    catch (InvalidPathException ex)
+                    {
+                        fileShow = null;
+                    }
 
                     if (NetworkDrive.exists(fileShow))
                     {


### PR DESCRIPTION
#### Rationale
The crawler attempts to pass garbage values in to various actions. The Windows file system doesn't allow some of the characters we use and errors when resolving the bad `filename` parameter of `ShowFileAction`, 

```
java.nio.file.InvalidPathException: Illegal char <>> at index 2: -->">'>'"<script>alert('8(')</script>.xml
	at sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182) ~[?:?]
	at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153) ~[?:?]
	at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77) ~[?:?]
	at sun.nio.fs.WindowsPath.parse(WindowsPath.java:92) ~[?:?]
	at sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:232) ~[?:?]
	at java.nio.file.Path.resolve(Path.java:515) ~[?:?]
	at org.labkey.api.pipeline.PipelineProtocolFactory.getProtocolFile(PipelineProtocolFactory.java:145) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.pipeline.file.AbstractFileAnalysisProtocolFactory.getProtocol(AbstractFileAnalysisProtocolFactory.java:371) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.pipeline.analysis.AnalysisController$ProtocolDetailsAction.getView(AnalysisController.java:503) ~[pipeline-22.3-SNAPSHOT.jar:?]
```

#### Changes
* Catch exception from `path.resolve`
