### PR TITLE
Prevent stack overflow writing job output

### DIFF
--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -1598,12 +1598,12 @@ abstract public class PipelineJob extends Job implements Serializable
                     try
                     {
                         Files.createDirectories(parentFile);
+                        write(message, t, level);
                     }
                     catch (IOException dirE)
                     {
                         _log.error("Failed appending to file. Unable to create parent directories", e);
                     }
-                    write(message, t, level);
                 }
                 else
                     _log.error("Failed appending to file.", e);


### PR DESCRIPTION
#### Rationale
It hasn't caused any problems but we retry writing to a pipeline job's log file even if we fail to create the file's parent directory. This could cause a stack overflow if the condition preventing directory creation is permanent. This looks to be an accidental change in behavior introduce when migrating to use nio `Path`s for pipeline stuff.

#### Related Pull Requests
* #2541

#### Changes
* Retry write to job log only if able to create parent folder
