### PR TITLE
ForeignKey definitions should really hold a SchemaKey not a String.

### DIFF
--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -70,6 +70,7 @@ import org.labkey.api.qc.TransformDataHandler;
 import org.labkey.api.qc.TransformResult;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.PropertyValidationError;
+import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.SimpleValidationError;
 import org.labkey.api.query.ValidationError;
 import org.labkey.api.query.ValidationException;
@@ -604,6 +605,10 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
         }
     }
 
+    static final SchemaKey SCHEMA_EXP = SchemaKey.fromParts(ExpSchema.SCHEMA_NAME);
+    static final SchemaKey SCHEMA_SAMPLES = SchemaKey.fromParts(SamplesSchema.SCHEMA_NAME);
+    static final SchemaKey SCHEMA_EXP_MATERIALS = SchemaKey.fromParts(ExpSchema.SCHEMA_NAME, ExpSchema.TableType.Materials.name());
+
     /** returns the lookup ExpSampleType if the property has a lookup to samples.<SampleTypeName> or exp.materials.<SampleTypeName> and is an int or string. */
     @Nullable
     public static ExpSampleType getLookupSampleType(@NotNull DomainProperty dp, @NotNull Container container, @NotNull User user)
@@ -613,7 +618,7 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
             return null;
 
         // TODO: Use concept URI instead of the lookup target schema to determine if the column is a sample.
-        if (!(SamplesSchema.SCHEMA_NAME.equalsIgnoreCase(lookup.getSchemaName()) || "exp.materials".equalsIgnoreCase(lookup.getSchemaName())))
+        if (!(SCHEMA_SAMPLES.equals(lookup.getSchemaKey()) || SCHEMA_EXP_MATERIALS.equals(lookup.getSchemaKey())))
             return null;
 
         JdbcType type = dp.getPropertyType().getJdbcType();
@@ -631,7 +636,7 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
         if (lookup == null)
             return false;
 
-        if (!(ExpSchema.SCHEMA_NAME.equalsIgnoreCase(lookup.getSchemaName()) && ExpSchema.TableType.Materials.name().equalsIgnoreCase(lookup.getQueryName())))
+        if (!SCHEMA_EXP.equals(lookup.getSchemaKey()) && ExpSchema.TableType.Materials.name().equalsIgnoreCase(lookup.getQueryName()))
             return false;
 
         JdbcType type = dp.getPropertyType().getJdbcType();

--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -636,7 +636,7 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
         if (lookup == null)
             return false;
 
-        if (!SCHEMA_EXP.equals(lookup.getSchemaKey()) && ExpSchema.TableType.Materials.name().equalsIgnoreCase(lookup.getQueryName()))
+        if (!(SCHEMA_EXP.equals(lookup.getSchemaKey()) && ExpSchema.TableType.Materials.name().equalsIgnoreCase(lookup.getQueryName())))
             return false;
 
         JdbcType type = dp.getPropertyType().getJdbcType();

--- a/api/src/org/labkey/api/data/AbstractForeignKey.java
+++ b/api/src/org/labkey/api/data/AbstractForeignKey.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.NamedObjectList;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QuerySchema;
+import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.util.Pair;
@@ -41,7 +42,7 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractForeignKey implements ForeignKey, Cloneable
 {
-    protected String _lookupSchemaName;
+    protected SchemaKey _lookupSchemaKey;
     protected String _tableName;
     protected String _columnName;
     protected String _displayColumnName;
@@ -70,19 +71,26 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
     
     protected AbstractForeignKey(QuerySchema sourceSchema, ContainerFilter cf, String tableName, String columnName)
     {
-        this(sourceSchema, cf, null, tableName, columnName);
+        this(sourceSchema, cf, (SchemaKey)null, tableName, columnName, null);
     }
 
+    @Deprecated
     protected AbstractForeignKey(QuerySchema sourceSchema, ContainerFilter cf, @Nullable String lookupSchemaName, String tableName, @Nullable String columnName)
     {
-        this(sourceSchema, cf, lookupSchemaName, tableName, columnName, null);
+        this(sourceSchema, cf, null==lookupSchemaName?null:SchemaKey.fromString(lookupSchemaName), tableName, columnName, null);
     }
 
+    @Deprecated
     protected AbstractForeignKey(QuerySchema sourceSchema, @Nullable ContainerFilter cf, @Nullable String lookupSchemaName, String tableName, @Nullable String columnName, @Nullable String displayColumnName)
+    {
+        this(sourceSchema, cf, null==lookupSchemaName?null:SchemaKey.fromString(lookupSchemaName), tableName, columnName, displayColumnName);
+    }
+
+    protected AbstractForeignKey(QuerySchema sourceSchema, @Nullable ContainerFilter cf, @Nullable SchemaKey lookupSchemaKey, String tableName, @Nullable String columnName, @Nullable String displayColumnName)
     {
         _sourceSchema = sourceSchema;
         _containerFilter = cf;
-        _lookupSchemaName = lookupSchemaName;
+        _lookupSchemaKey = lookupSchemaKey;
         _tableName = tableName;
         _columnName = columnName;
         _displayColumnName = displayColumnName;
@@ -125,14 +133,13 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
         return cf;
     }
 
-    @Override
-    public String getLookupSchemaName()
+    public SchemaKey getLookupSchemaKey()
     {
-        if (_lookupSchemaName == null)
+        if (_lookupSchemaKey == null)
         {
             initTableAndColumnNames();
         }
-        return _lookupSchemaName;
+        return _lookupSchemaKey;
     }
 
     @Override
@@ -189,9 +196,9 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
             TableInfo table = getLookupTableInfo();
             if (table != null)
             {
-                if (_lookupSchemaName == null)
+                if (_lookupSchemaKey == null)
                 {
-                    _lookupSchemaName = table.getPublicSchemaName();
+                    _lookupSchemaKey = new SchemaKey(null, table.getPublicSchemaName());
                 }
 
                 if (_tableName == null)

--- a/api/src/org/labkey/api/data/AbstractForeignKey.java
+++ b/api/src/org/labkey/api/data/AbstractForeignKey.java
@@ -198,7 +198,9 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
             {
                 if (_lookupSchemaKey == null)
                 {
-                    _lookupSchemaKey = new SchemaKey(null, table.getPublicSchemaName());
+                    String publicSchemaName = table.getPublicSchemaName();
+                    if (null != publicSchemaName)
+                        _lookupSchemaKey = SchemaKey.fromString(publicSchemaName);
                 }
 
                 if (_tableName == null)

--- a/api/src/org/labkey/api/data/AggregateColumnInfo.java
+++ b/api/src/org/labkey/api/data/AggregateColumnInfo.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.NamedObjectList;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.LookupForeignKey;
+import org.labkey.api.query.SchemaKey;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.StringExpressionFactory;
 
@@ -128,6 +129,12 @@ public class AggregateColumnInfo extends BaseColumnInfo
                 public String getLookupSchemaName()
                 {
                     return fk.getLookupSchemaName();
+                }
+
+                @Override
+                public SchemaKey getLookupSchemaKey()
+                {
+                    return fk.getLookupSchemaKey();
                 }
 
                 @Override

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -42,6 +42,8 @@ import org.labkey.api.ontology.OntologyService;
 import org.labkey.api.query.AliasManager;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryParseException;
+import org.labkey.api.query.SchemaKey;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.column.BuiltInColumnTypes;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringExpression;
@@ -1579,9 +1581,10 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
         }
 
         @Override
-        public String getLookupSchemaName()
+        public SchemaKey getLookupSchemaKey()
         {
-            return _dbSchemaName;
+            // schema foreign keys always have one part schema name
+            return new SchemaKey(null, _dbSchemaName);
         }
 
         @Override

--- a/api/src/org/labkey/api/data/ForeignKey.java
+++ b/api/src/org/labkey/api/data/ForeignKey.java
@@ -20,12 +20,14 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.NamedObjectList;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.SchemaKey;
 import org.labkey.api.util.StringExpression;
 import org.labkey.data.xml.queryCustomView.FilterType;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -84,7 +86,14 @@ public interface ForeignKey
      * Just for introspection.
      * @return The name of the foreign user schema table.
      */
-    String getLookupSchemaName();
+    @Deprecated
+    default String getLookupSchemaName()
+    {
+        return Objects.toString(getLookupSchemaKey(),null);
+    }
+
+    /* Schema path relative to the DefaultSchema (e.g. container) */
+    SchemaKey getLookupSchemaKey();
 
     /**
      * Just for introspection.

--- a/api/src/org/labkey/api/data/ForeignKey.java
+++ b/api/src/org/labkey/api/data/ForeignKey.java
@@ -85,6 +85,8 @@ public interface ForeignKey
     /**
      * Just for introspection.
      * @return The name of the foreign user schema table.
+     *
+     * Consider using getLookupSchemaKey() instead.
      */
     @Deprecated
     default String getLookupSchemaName()

--- a/api/src/org/labkey/api/data/LazyForeignKey.java
+++ b/api/src/org/labkey/api/data/LazyForeignKey.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.NamedObjectList;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.SchemaKey;
 import org.labkey.api.util.StringExpression;
 
 import java.util.Map;
@@ -79,6 +80,12 @@ public class LazyForeignKey implements ForeignKey
     public String getLookupSchemaName()
     {
         return getDelegate() == null ? null : getDelegate().getLookupSchemaName();
+    }
+
+    @Override
+    public SchemaKey getLookupSchemaKey()
+    {
+        return getDelegate() == null ? null : getDelegate().getLookupSchemaKey();
     }
 
     @Override

--- a/api/src/org/labkey/api/data/MultiValuedForeignKey.java
+++ b/api/src/org/labkey/api/data/MultiValuedForeignKey.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.NamedObjectList;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.SchemaKey;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.StringExpressionFactory;
 
@@ -258,6 +259,12 @@ public class MultiValuedForeignKey implements ForeignKey
     public String getLookupSchemaName()
     {
         return _fk.getLookupSchemaName();
+    }
+
+    @Override
+    public SchemaKey getLookupSchemaKey()
+    {
+        return _fk.getLookupSchemaKey();
     }
 
     @Override

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -2694,7 +2694,7 @@ public class OntologyManager
     public static Object getRemappedValueForLookup(User user, Container container, RemapCache cache, Lookup lookup, Object value)
     {
         Container lkContainer = lookup.getContainer() != null ? lookup.getContainer() : container;
-        return cache.remap(SchemaKey.fromParts(lookup.getSchemaName()), lookup.getQueryName(), user, lkContainer, ContainerFilter.Type.CurrentPlusProjectAndShared, String.valueOf(value));
+        return cache.remap(SchemaKey.fromParts(lookup.getSchemaKey()), lookup.getQueryName(), user, lkContainer, ContainerFilter.Type.CurrentPlusProjectAndShared, String.valueOf(value));
     }
 
     public static List<PropertyUsages> findPropertyUsages(User user, List<Integer> propertyIds, int maxUsageCount)

--- a/api/src/org/labkey/api/exp/property/Lookup.java
+++ b/api/src/org/labkey/api/exp/property/Lookup.java
@@ -33,8 +33,8 @@ public class Lookup
     {
     }
 
-    // Callers need to be explicit about whether this name is encoded or not
-    // I'm going to assume SchemaName is "/" encoded
+    // Callers need to be explicit about how this is encode.  This constructer assumes "SchmeaKey.toString()" encoding.
+    // Consider using ScehmaKey constructor instead.
     @Deprecated
     public Lookup(Container c, String schema, String query)
     {

--- a/api/src/org/labkey/api/exp/property/Lookup.java
+++ b/api/src/org/labkey/api/exp/property/Lookup.java
@@ -33,8 +33,8 @@ public class Lookup
     {
     }
 
-    // Callers need to be explicit about how this is encode.  This constructer assumes "SchmeaKey.toString()" encoding.
-    // Consider using ScehmaKey constructor instead.
+    // Callers need to be explicit about how this is encoded.  This constructor assumes "SchemaKey.toString()" encoding.
+    // Consider using SchemaKey constructor instead.
     @Deprecated
     public Lookup(Container c, String schema, String query)
     {

--- a/api/src/org/labkey/api/exp/property/Lookup.java
+++ b/api/src/org/labkey/api/exp/property/Lookup.java
@@ -19,21 +19,34 @@ package org.labkey.api.exp.property;
 import org.json.JSONObject;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.query.SchemaKey;
+
+import java.util.Objects;
 
 public class Lookup
 {
     Container _container;
-    String _schemaName;
+    SchemaKey _schemaKey;
     String _queryName;
 
     public Lookup()
     {
     }
 
+    // Callers need to be explicit about whether this name is encoded or not
+    // I'm going to assume SchemaName is "/" encoded
+    @Deprecated
     public Lookup(Container c, String schema, String query)
     {
         _container = c;
-        _schemaName = schema;
+        _schemaKey = null == schema ? null : SchemaKey.fromString(schema);
+        _queryName = query;
+    }
+
+    public Lookup(Container c, SchemaKey schema, String query)
+    {
+        _container = c;
+        _schemaKey = schema;
         _queryName = query;
     }
 
@@ -42,9 +55,15 @@ public class Lookup
         return _container;
     }
 
+    @Deprecated
     public String getSchemaName()
     {
-        return _schemaName;
+        return Objects.toString(_schemaKey,null);
+    }
+
+    public SchemaKey getSchemaKey()
+    {
+        return _schemaKey;
     }
 
     public String getQueryName()
@@ -59,7 +78,7 @@ public class Lookup
 
     public void setSchemaName(String name)
     {
-        _schemaName = name;
+        _schemaKey = null == name ? null : new SchemaKey(null, name);;
     }
 
     public void setQueryName(String name)
@@ -77,7 +96,7 @@ public class Lookup
 
         if (_container != null ? !_container.equals(lookup._container) : lookup._container != null) return false;
         if (_queryName != null ? !_queryName.equalsIgnoreCase(lookup._queryName) : lookup._queryName != null) return false;
-        if (_schemaName != null ? !_schemaName.equalsIgnoreCase(lookup._schemaName) : lookup._schemaName != null) return false;
+        if (_schemaKey != null ? !_schemaKey.equals(lookup._schemaKey) : lookup._schemaKey != null) return false;
 
         return true;
     }
@@ -86,7 +105,7 @@ public class Lookup
     public int hashCode()
     {
         int result = _container != null ? _container.hashCode() : 0;
-        result = 31 * result + (_schemaName != null ? _schemaName.hashCode() : 0);
+        result = 31 * result + (_schemaKey != null ? _schemaKey.hashCode() : 0);
         result = 31 * result + (_queryName != null ? _queryName.hashCode() : 0);
         return result;
     }

--- a/api/src/org/labkey/api/query/PdLookupForeignKey.java
+++ b/api/src/org/labkey/api/query/PdLookupForeignKey.java
@@ -57,33 +57,33 @@ public class PdLookupForeignKey extends AbstractForeignKey
 
         Container currentContainer = container;
         Container targetContainer = pd.getLookupContainer() == null ? null : ContainerManager.getForId(pd.getLookupContainer());
-        String lookupSchemaName = pd.getLookupSchema();
+        SchemaKey lookupSchemaKey = null == pd.getLookupSchema() ? null : SchemaKey.fromString(pd.getLookupSchema());
         String lookupQuery = pd.getLookupQuery();
 
         // check for conceptURI if the lookup container/schema/query are not already specified
-        if (pd.getConceptURI() != null && targetContainer == null && lookupSchemaName == null && lookupQuery == null)
+        if (pd.getConceptURI() != null && targetContainer == null && lookupSchemaKey == null && lookupQuery == null)
         {
             Lookup lookup = ConceptURIProperties.getLookup(container, pd.getConceptURI());
             if (lookup != null)
             {
                 targetContainer = lookup.getContainer();
-                lookupSchemaName = lookup.getSchemaName();
+                lookupSchemaKey = lookup.getSchemaKey();
                 lookupQuery = lookup.getQueryName();
             }
         }
 
         ContainerFilter cf;
-        if ("core".equalsIgnoreCase(lookupSchemaName) && "Containers".equalsIgnoreCase(lookupQuery))
+        if ("core".equalsIgnoreCase(null==lookupSchemaKey?null:lookupSchemaKey.getName()) && "CoClassImposteriserntainers".equalsIgnoreCase(lookupQuery))
             cf = new ContainerFilter.AllFolders(user);
         else
             cf = new ContainerFilter.SimpleContainerFilterWithUser(user, targetContainer!=null ? targetContainer : container);
 
-        return new PdLookupForeignKey(sourceSchema, currentContainer, user, cf, pd, lookupSchemaName, lookupQuery, targetContainer);
+        return new PdLookupForeignKey(sourceSchema, currentContainer, user, cf, pd, lookupSchemaKey, lookupQuery, targetContainer);
     }
 
-    protected PdLookupForeignKey(@NotNull QuerySchema sourceSchema, Container currentContainer, @NotNull User user, ContainerFilter cf, PropertyDescriptor pd, String lookupSchemaName, String lookupQuery, Container targetContainer)
+    protected PdLookupForeignKey(@NotNull QuerySchema sourceSchema, Container currentContainer, @NotNull User user, ContainerFilter cf, PropertyDescriptor pd, SchemaKey lookupSchemaKey, String lookupQuery, Container targetContainer)
     {
-        super(sourceSchema, cf, lookupSchemaName, lookupQuery, null);
+        super(sourceSchema, cf, lookupSchemaKey, lookupQuery, null, null);
         _pd = pd;
         _user = user;
         assert currentContainer != null : "Container cannot be null";
@@ -99,9 +99,9 @@ public class PdLookupForeignKey extends AbstractForeignKey
     }
 
     @Override
-    public String getLookupSchemaName()
+    public SchemaKey getLookupSchemaKey()
     {
-        return _lookupSchemaName;
+        return _lookupSchemaKey;
     }
 
     @Override
@@ -113,7 +113,7 @@ public class PdLookupForeignKey extends AbstractForeignKey
     @Override
     public TableInfo getLookupTableInfo()
     {
-        if (_lookupSchemaName == null || _tableName == null)
+        if (_lookupSchemaKey == null || _tableName == null)
             return null;
 
         TableInfo table;
@@ -164,9 +164,9 @@ public class PdLookupForeignKey extends AbstractForeignKey
 
         QuerySchema schema;
         if (null != _sourceSchema && _sourceSchema.getContainer().equals(container))
-            schema = DefaultSchema.resolve(_sourceSchema, SchemaKey.fromString(_lookupSchemaName));
+            schema = DefaultSchema.resolve(_sourceSchema, _lookupSchemaKey);
         else
-            schema = QueryService.get().getUserSchema(_user, container, SchemaKey.fromString(_lookupSchemaName));
+            schema = QueryService.get().getUserSchema(_user, container, _lookupSchemaKey);
         if (!(schema instanceof UserSchema))
             return null;
 

--- a/api/src/org/labkey/api/query/PdLookupForeignKey.java
+++ b/api/src/org/labkey/api/query/PdLookupForeignKey.java
@@ -73,7 +73,7 @@ public class PdLookupForeignKey extends AbstractForeignKey
         }
 
         ContainerFilter cf;
-        if ("core".equalsIgnoreCase(null==lookupSchemaKey?null:lookupSchemaKey.getName()) && "CoClassImposteriserntainers".equalsIgnoreCase(lookupQuery))
+        if ("core".equalsIgnoreCase(null==lookupSchemaKey?null:lookupSchemaKey.getName()) && "Containers".equalsIgnoreCase(lookupQuery))
             cf = new ContainerFilter.AllFolders(user);
         else
             cf = new ContainerFilter.SimpleContainerFilterWithUser(user, targetContainer!=null ? targetContainer : container);

--- a/api/src/org/labkey/api/query/QueryForeignKey.java
+++ b/api/src/org/labkey/api/query/QueryForeignKey.java
@@ -66,7 +66,7 @@ public class QueryForeignKey extends AbstractForeignKey
 
         // target schema definition
         Container effectiveContainer;
-        SchemaKey lookupSchemaName;
+        SchemaKey lookupSchemaKey;
         UserSchema targetSchema;
 
         // FK definition
@@ -98,14 +98,14 @@ public class QueryForeignKey extends AbstractForeignKey
 
         public Builder schema(SchemaKey lookupSchemaKey)
         {
-            this.lookupSchemaName = lookupSchemaKey;
+            this.lookupSchemaKey = lookupSchemaKey;
             this.targetSchema = null;
             return this;
         }
 
         public Builder schema(UserSchema lookupSchema)
         {
-            lookupSchemaName = lookupSchema.getSchemaPath();
+            lookupSchemaKey = lookupSchema.getSchemaPath();
             this.targetSchema = lookupSchema;
             effectiveContainer = lookupSchema.getContainer();
             return this;
@@ -114,7 +114,7 @@ public class QueryForeignKey extends AbstractForeignKey
 
         public Builder schema(String schemaName)
         {
-            lookupSchemaName = SchemaKey.fromString(schemaName);
+            lookupSchemaKey = SchemaKey.fromString(schemaName);
             // the caller might have defaulted the targetSchema to sourceSchema, so clear if schema is set by name
             targetSchema = null;
             return this;
@@ -124,7 +124,7 @@ public class QueryForeignKey extends AbstractForeignKey
         // effectiveContainer is the container used when resolving schemaName if there is not an explicit fkFolderPath defined
         public Builder schema(String schemaName, Container effectiveContainer)
         {
-            lookupSchemaName = SchemaKey.fromString(schemaName);
+            lookupSchemaKey = SchemaKey.fromString(schemaName);
             // the caller might have defaulted the targetSchema to sourceSchema, so clear if schema is set by name
             targetSchema = null;
             if (null != effectiveContainer)
@@ -217,14 +217,14 @@ public class QueryForeignKey extends AbstractForeignKey
         @Override
         public ForeignKey build()
         {
-            if (null == lookupSchemaName && null == targetSchema)
+            if (null == lookupSchemaKey && null == targetSchema)
                 targetSchema = (UserSchema)sourceSchema;
 
             /* see 41054 move the core.containers special case handling here from PdLookupForeignKey */
             boolean isLabKeyScope = null != sourceSchema && (null == sourceSchema.getDbSchema() || sourceSchema.getDbSchema().getScope().isLabKeyScope());
             if (isLabKeyScope)
             {
-                if ("core".equalsIgnoreCase(lookupSchemaName.getName()) && "containers".equalsIgnoreCase(lookupTableName) && effectiveContainer.equals(sourceSchema.getContainer()))
+                if (null != lookupSchemaKey && "core".equalsIgnoreCase(lookupSchemaKey.getName()) && "containers".equalsIgnoreCase(lookupTableName) && effectiveContainer.equals(sourceSchema.getContainer()))
                 {
                     if (null == containerFilter)
                         containerFilter = new ContainerFilter.AllFolders(user);
@@ -242,7 +242,7 @@ public class QueryForeignKey extends AbstractForeignKey
 
     public QueryForeignKey(Builder builder)
     {
-        super(builder.sourceSchema, builder.containerFilter, builder.lookupSchemaName, builder.lookupTableName, builder.lookupKey, builder.displayField);
+        super(builder.sourceSchema, builder.containerFilter, builder.lookupSchemaKey, builder.lookupTableName, builder.lookupKey, builder.displayField);
         _effectiveContainer = builder.effectiveContainer;
         _lookupContainer = builder.lookupContainer;
         _user = builder.user;

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -154,6 +154,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -443,12 +444,12 @@ public class AssayController extends SpringActionController
                 // @deprecated (remove in future API version), use lookup.{} instead
                 String containerPath = l.getContainer() != null ? l.getContainer().getPath() : null;
                 properties.put("lookupContainer", containerPath);
-                properties.put("lookupSchema", l.getSchemaName());
+                properties.put("lookupSchema", Objects.toString(l.getSchemaKey(),null));
                 properties.put("lookupQuery", l.getQueryName());
 
                 // let's be consistent with Query metadata
                 HashMap<String,String> lookup = new HashMap<>();
-                lookup.put("schema", l.getSchemaName());
+                lookup.put("schema", Objects.toString(l.getSchemaKey(),null));
                 lookup.put("table", l.getQueryName());
                 lookup.put("container", null!=l.getContainer() ? l.getContainer().getPath() : null);
 
@@ -457,7 +458,7 @@ public class AssayController extends SpringActionController
                 Container lookupContainer = l.getContainer();
                 if (lookupContainer == null)
                     lookupContainer = property.getContainer();
-                UserSchema schema = QueryService.get().getUserSchema(user, lookupContainer, l.getSchemaName());
+                UserSchema schema = QueryService.get().getUserSchema(user, lookupContainer, l.getSchemaKey());
                 if (schema != null)
                 {
                     try

--- a/experiment/src/org/labkey/experiment/XarExporter.java
+++ b/experiment/src/org/labkey/experiment/XarExporter.java
@@ -99,6 +99,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
@@ -801,7 +802,7 @@ public class XarExporter
         {
             PropertyDescriptorType.FK xFK = xProp.addNewFK();
             xFK.setQuery(lookup.getQueryName());
-            xFK.setSchema(lookup.getSchemaName());
+            xFK.setSchema(Objects.toString(lookup.getSchemaKey(),null));
             if (lookup.getContainer() != null && !lookup.getContainer().equals(prop.getContainer()))
             {
                 // Export the lookup's target path if it's set and it's not the same as the property descriptor's container

--- a/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
@@ -820,9 +820,9 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
         }
 
         @Override
-        public String getLookupSchemaName()
+        public SchemaKey getLookupSchemaKey()
         {
-            return ExpSchema.SCHEMA_NAME;
+            return new SchemaKey(null, ExpSchema.SCHEMA_NAME);
         }
 
         @Override

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -63,6 +63,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
+import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.Permission;
@@ -458,7 +459,7 @@ public class DomainImpl implements Domain
         if (dp.getLookup() != null)
         {
             Container lookupContainer = dp.getLookup().getContainer();
-            String schemaName = dp.getLookup().getSchemaName();
+            SchemaKey schemaKey = dp.getLookup().getSchemaKey();
             String queryName = dp.getLookup().getQueryName();
 
             if (lookupContainer == null)
@@ -466,7 +467,7 @@ public class DomainImpl implements Domain
                 lookupContainer = dp.getContainer();
             }
 
-            UserSchema schema = QueryService.get().getUserSchema(user, lookupContainer, schemaName);
+            UserSchema schema = QueryService.get().getUserSchema(user, lookupContainer, schemaKey);
             if (schema != null)
             {
                 TableInfo table = schema.getTable(queryName);
@@ -483,7 +484,7 @@ public class DomainImpl implements Domain
                         ColumnInfo pkColumnInfo = table.getColumn(pkCol);
                         if (!dp.getPropertyType().getJdbcType().equals(pkColumnInfo.getJdbcType()))
                         {
-                            throw new ChangePropertyDescriptorException("Property " + dp.getName() + ": Lookup table " + schemaName + "." + queryName
+                            throw new ChangePropertyDescriptorException("Property " + dp.getName() + ": Lookup table " + schemaKey + "." + queryName
                                     + " pk does not match property data type. Expected: " + pkColumnInfo.getJdbcType() + ", Actual: " + dp.getPropertyType().getJdbcType());
                         }
                     }
@@ -951,7 +952,7 @@ public class DomainImpl implements Domain
                 str.append("Lookup: [");
                 if (null != lookup.getContainer())
                     str.append("Container: ").append(lookup.getContainer().getName()).append(", ");
-                str.append("Schema: ").append(lookup.getSchemaName()).append(", ")
+                str.append("Schema: ").append(lookup.getSchemaKey()).append(", ")
                    .append("Query: ").append(lookup.getQueryName()).append("]; ");
             }
 

--- a/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
@@ -31,7 +31,6 @@ import org.labkey.api.data.PHI;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.Table;
-import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.exp.ChangePropertyDescriptorException;
 import org.labkey.api.exp.DomainDescriptor;
 import org.labkey.api.exp.Lsid;
@@ -49,13 +48,13 @@ import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.gwt.client.DefaultScaleType;
 import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.gwt.client.FacetingBehaviorType;
-import org.labkey.api.query.AliasManager;
 import org.labkey.api.security.User;
 import org.labkey.api.util.StringExpressionFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class DomainPropertyImpl implements DomainProperty
@@ -592,7 +591,7 @@ public class DomainPropertyImpl implements DomainProperty
         // current will return null if the schema or query is null so check
         // for this case in the passed in lookup
         if (current == null)
-            if (lookup.getQueryName() == null || lookup.getSchemaName() == null)
+            if (lookup.getQueryName() == null || lookup.getSchemaKey() == null)
                 return;
 
         if (current != null && current.equals(lookup))
@@ -614,7 +613,7 @@ public class DomainPropertyImpl implements DomainProperty
             edit().setLookupContainer(lookup.getContainer().getId());
         }
         edit().setLookupQuery(lookup.getQueryName());
-        edit().setLookupSchema(lookup.getSchemaName());
+        edit().setLookupSchema(Objects.toString(lookup.getSchemaKey(),null));
     }
 
     @Override
@@ -1180,7 +1179,7 @@ public class DomainPropertyImpl implements DomainProperty
                     assertTrue(StringUtils.equals(l.getContainer().getId(), _pd.getLookupContainer()));
 
                 assertTrue(StringUtils.equals(l.getQueryName(), _pd.getLookupQuery()));
-                assertTrue(StringUtils.equals(l.getSchemaName(),_pd.getLookupSchema()));
+                assertTrue(StringUtils.equals(l.getSchemaKey().toString(), _pd.getLookupSchema()));
             }
         }
 

--- a/internal/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/internal/src/org/labkey/api/exp/property/DomainUtil.java
@@ -136,7 +136,7 @@ public class DomainUtil
             Container lookupContainer = property.getLookup().getContainer();
             if (lookupContainer == null)
                 lookupContainer = property.getContainer();
-            UserSchema schema = QueryService.get().getUserSchema(user, lookupContainer, property.getLookup().getSchemaName());
+            UserSchema schema = QueryService.get().getUserSchema(user, lookupContainer, property.getLookup().getSchemaKey());
             if (schema != null)
             {
                 TableInfo table = schema.getTable(property.getLookup().getQueryName());
@@ -407,7 +407,9 @@ public class DomainUtil
         {
             gwtProp.setLookupContainer(prop.getLookup().getContainer() == null ? null : prop.getLookup().getContainer().getPath());
             gwtProp.setLookupQuery(prop.getLookup().getQueryName());
-            gwtProp.setLookupSchema(prop.getLookup().getSchemaName());
+            var key = prop.getLookup().getSchemaKey();
+            if (null != key)
+               gwtProp.setLookupSchema(key.toString());
         }
         return gwtProp;
     }

--- a/issues/src/org/labkey/issue/query/IssuesTable.java
+++ b/issues/src/org/labkey/issue/query/IssuesTable.java
@@ -54,6 +54,7 @@ import org.labkey.api.query.PdLookupForeignKey;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.RowIdForeignKey;
+import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserIdForeignKey;
 import org.labkey.api.query.UserIdRenderer;
 import org.labkey.api.query.UserSchema;
@@ -720,7 +721,7 @@ public class IssuesTable extends FilteredTable<IssuesQuerySchema> implements Upd
 
         public IssuesPdLookupForeignKey(IssuesQuerySchema schema, PropertyDescriptor pd)
         {
-            super(schema, schema.getContainer(), schema.getUser(), null, pd, pd.getLookupSchema(), pd.getLookupQuery(), pd.getContainer());
+            super(schema, schema.getContainer(), schema.getUser(), null, pd, null==pd.getLookupSchema()?null:SchemaKey.fromString(pd.getLookupSchema()), pd.getLookupQuery(), pd.getContainer());
             _user = schema.getUser();
             _container = schema.getContainer();
             _propName = pd.getName();

--- a/query/src/org/labkey/query/MetadataTableJSON.java
+++ b/query/src/org/labkey/query/MetadataTableJSON.java
@@ -382,7 +382,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
 
                 // Check if it's the same FK, based on schema, query, and container
                 if (lookup == null ||
-                        !metadataColumnJSON.getLookupSchema().equals(lookup.first.getSchemaName()) ||
+                        !metadataColumnJSON.getLookupSchema().equals(lookup.first.getSchemaKey()) ||
                         !metadataColumnJSON.getLookupQuery().equals(lookup.first.getQueryName()) ||
                         !Objects.equals(metadataColumnJSON.getLookupContainer(), lookup.first.getContainer() != null ? lookup.first.getContainer().getPath() : null))
                 {
@@ -617,7 +617,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
                         metadataColumnJSON.setLookupCustom(true);
                     else
                     {
-                        metadataColumnJSON.setLookupSchema(lookup.first.getSchemaName());
+                        metadataColumnJSON.setLookupSchema(Objects.toString(lookup.first.getSchemaKey(),null));
                         metadataColumnJSON.setLookupQuery(lookup.first.getQueryName());
                         if (lookup.first.getContainer() != null)
                             metadataColumnJSON.setLookupContainer(lookup.first.getContainer().getPath());

--- a/query/src/org/labkey/query/sql/QueryPivot.java
+++ b/query/src/org/labkey/query/sql/QueryPivot.java
@@ -28,6 +28,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryException;
 import org.labkey.api.query.QueryParseException;
 import org.labkey.api.query.QueryService;
+import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.view.UnauthorizedException;
@@ -1163,7 +1164,7 @@ public class QueryPivot extends QueryRelation
         }
 
         @Override
-        public String getLookupSchemaName()
+        public SchemaKey getLookupSchemaKey()
         {
             return null;
         }


### PR DESCRIPTION
#### Rationale
Since schemas live in a tree, we should use SchemaKey where possible instead of String to reduce ambiguity.  E.g. SchemaKey.fromParts("exp","data") instead of "exp.data"

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
