### PR TITLE
Prevent configuration error during directoryType switch

### DIFF
--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -1199,7 +1199,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
         try
         {
             // Run the query before delete, but only if Log4J debug level is set
-            if (_log.isDebugEnabled())
+            if (_log.isDebugEnabled() && _indexManager.isReal())
             {
                 _log.debug("Deleting " + getDocCount(query) + " docs with prefix \"" + prefix + "\"");
             }
@@ -1215,11 +1215,6 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
 
     private long getDocCount(Query query) throws IOException
     {
-        if (!_indexManager.isReal())
-        {
-            return 0;
-        }
-
         IndexSearcher searcher = _indexManager.getSearcher();
 
         try
@@ -1264,7 +1259,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
             Query query = new TermQuery(new Term(FIELD_NAME.container.toString(), id));
 
             // Run the query before delete, but only if Log4J debug level is set
-            if (_log.isDebugEnabled())
+            if (_log.isDebugEnabled() && _indexManager.isReal())
             {
                 _log.debug("Deleting " + getDocCount(query) + " docs from container " + id);
             }
@@ -1293,7 +1288,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
                     .build();
 
             // Run the query before delete, but only if Log4J debug level is set
-            if (_log.isDebugEnabled())
+            if (_log.isDebugEnabled() && _indexManager.isReal())
             {
                 _log.debug("Deleting " + getDocCount(query) + " docs from container " + container);
             }

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -1215,6 +1215,11 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
 
     private long getDocCount(Query query) throws IOException
     {
+        if (!_indexManager.isReal())
+        {
+            return 0;
+        }
+
         IndexSearcher searcher = _indexManager.getSearcher();
 
         try


### PR DESCRIPTION
#### Rationale
TeamCity tests the various document types that we support. It also enables debug logging during the search tests. During the directoryType switch, delete operations should no-op (via the `NoopWritableIndex`). Several such operations attempt to log document counts for debugging. The delete operations no-op but the query to get the document count cannot.

```
ERROR AbstractSearchService    2022-03-17T09:16:18,877     SearchService:runner : Error running org.labkey.query.ExternalSchemaDocumentProvider$$Lambda$1303/0x0000000801cb9718@5afd78bb
org.labkey.api.search.SearchMisconfiguredException: The search index is misconfigured. An administrator will need to correct this via the full-text search configuration page.
	at org.labkey.search.model.NoopWritableIndex.getSearcher(NoopWritableIndex.java:63) ~[search-22.3-SNAPSHOT.jar:?]
	at org.labkey.search.model.LuceneSearchServiceImpl.getDocCount(LuceneSearchServiceImpl.java:1218) ~[search-22.3-SNAPSHOT.jar:?]
	at org.labkey.search.model.LuceneSearchServiceImpl.deleteDocumentsForPrefix(LuceneSearchServiceImpl.java:1204) ~[search-22.3-SNAPSHOT.jar:?]
	at org.labkey.search.model.AbstractSearchService.deleteResourcesForPrefix(AbstractSearchService.java:538) ~[search-22.3-SNAPSHOT.jar:?]
	at org.labkey.query.ExternalSchemaDocumentProvider.lambda$enumerateDocuments$0(ExternalSchemaDocumentProvider.java:83) ~[query-22.3-SNAPSHOT.jar:?]
	at org.labkey.search.model.AbstractSearchService.lambda$new$4(AbstractSearchService.java:901) ~[search-22.3-SNAPSHOT.jar:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
```

#### Changes
* Don't attempt to log document counts when search index is not configured
