### PR TITLE
Move exclusion closure to proper dependency

### DIFF
--- a/query/build.gradle
+++ b/query/build.gradle
@@ -13,6 +13,18 @@ dependencies {
    antlr "org.antlr:antlr:${antlrVersion}"
     jspImplementation "org.olap4j:olap4j:${olap4jVersion}"
     implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
+    BuildUtils.addExternalDependency(
+            project,
+            new ExternalDependency(
+                    "org.apache.logging.log4j:log4j-1.2-api:${log4j2Version}",
+                    "Log4j",
+                    "Apache",
+                    "https://logging.apache.org/log4j/2.x/",
+                    ExternalDependency.APACHE_2_LICENSE_NAME,
+                    ExternalDependency.APACHE_2_LICENSE_URL,
+                    "Logging"
+            )
+    )
 
     BuildUtils.addExternalDependency(
         project,

--- a/query/build.gradle
+++ b/query/build.gradle
@@ -63,7 +63,14 @@ dependencies {
             "Eclipse Public License - v 1.0",
             "http://www.eclipse.org/legal/epl-v10.html",
             "Part of Mondrian distribution"
-        )
+        ),
+            {
+                // exclude these because they cause interference with the tomcat versions
+                exclude group: "javax.servlet", module:"jsp-api"
+                exclude group: "javax.servlet", module:"servlet-api"
+                // exclude this because it brings older version of log4j
+                exclude group: "log4j", module:"log4j"
+            }
     )
 
     BuildUtils.addExternalDependency(
@@ -77,14 +84,7 @@ dependencies {
             ExternalDependency.APACHE_2_LICENSE_URL,
             "Part of Mondrian distribution",
 
-        ),
-        {
-            // exclude these because they cause interference with the tomcat versions
-            exclude group: "javax.servlet", module:"jsp-api"
-            exclude group: "javax.servlet", module:"servlet-api"
-            // exclude this because it brings older version of log4j
-            exclude group: "log4j", module:"log4j"
-        }
+        )
     )
 }
 

--- a/query/build.gradle
+++ b/query/build.gradle
@@ -13,6 +13,7 @@ dependencies {
    antlr "org.antlr:antlr:${antlrVersion}"
     jspImplementation "org.olap4j:olap4j:${olap4jVersion}"
     implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
+    // we add this bridge jar because certain Mondrian classes require the log4j interface
     BuildUtils.addExternalDependency(
             project,
             new ExternalDependency(

--- a/query/build.gradle
+++ b/query/build.gradle
@@ -47,8 +47,8 @@ dependencies {
             "Mondrian",
             "Pentaho",
             "http://mondrian.pentaho.com/",
-            ExternalDependency.APACHE_2_LICENSE_NAME,  //From Maven
-            ExternalDependency.APACHE_2_LICENSE_URL,   //From Maven
+            ExternalDependency.APACHE_2_LICENSE_NAME,
+            ExternalDependency.APACHE_2_LICENSE_URL,
             "Part of Mondrian distribution"
         )
     )


### PR DESCRIPTION
#### Rationale
Exclusion closure got attached to the wrong dependency so we're pulling in jars that we don't want. Because Mondrian does have dependencies on log4j, we include the log4j-1.2-api bridge jar here to avoid vulnerabilities but allow for usage of the log4j interface.  This has the unfortunate side effect of getting this interface back in the classpath, but perhaps we can find a way to configure IntelliJ to not offer this as a suggestion.

#### Changes
* Move exclusions to proper dependency
