### PR TITLE
fix inadvertently causing full reindexing

### DIFF
--- a/search/src/org/labkey/search/model/DavCrawler.java
+++ b/search/src/org/labkey/search/model/DavCrawler.java
@@ -230,7 +230,8 @@ public class DavCrawler implements ShutdownListener
         if (null != start)
         {
             _log.debug("START CONTINUOUS " + start.toString());
-            _paths.updatePath(start, null, nextCrawl, true);
+            // make sure path exists, don't update if it already exists.
+            _paths.insertPath(start, nextCrawl);
         }
 
         pingCrawler();
@@ -292,6 +293,8 @@ public class DavCrawler implements ShutdownListener
             // CONSIDER: delete previously indexed resources in child containers as well
             if (null == _directory || !_directory.isCollection() || !_directory.shouldIndex() || skipContainer(_directory))
             {
+                if (Path.rootPath.equals(_path))
+                    return;
                 if (_path.startsWith(getResolver().getRootPath()))
                     _paths.deletePath(_path);
                 return;
@@ -563,7 +566,8 @@ public class DavCrawler implements ShutdownListener
                 Date nextCrawl = e.getValue().second;
 
                 _log.debug("add to queue: " + path.toString());
-                crawlQueue.add(new IndexDirectoryJob(path, lastCrawl, nextCrawl));
+                if (!Path.rootPath.equals(path))
+                    crawlQueue.add(new IndexDirectoryJob(path, lastCrawl, nextCrawl));
             }
         }
         return crawlQueue.isEmpty() ? null : crawlQueue.removeFirst();


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45066
If a folder is not supposed to be indexed, then we don't index it's children either. However we need to make an exception for the root container, where we don't want to index it, but we do want to index it's children. 

#### Changes
* Adjusted index path enumeration to check for "/" root folder.
