### PR TITLE
Don't use HashSet for column lists

### DIFF
--- a/api/src/org/labkey/api/collections/CollectionUtils.java
+++ b/api/src/org/labkey/api/collections/CollectionUtils.java
@@ -140,10 +140,10 @@ public class CollectionUtils
 
     /**
      * Attempts to determine if the provided Set implementation is stable-ordered, i.e., its iteration order matches its
-     * insertion order. Currently, that means a LinkedHashSet, Collections.emptySet(), or Collections.singleton().
-     * HashSet and TreeSet are not considered stable-order. Also note that sets returned by Set.of() are not considered
-     * stable-ordered; although they seem to iterate in insertion order in current JVMs, their JavaDoc clearly states
-     * that "the iteration order of set elements is unspecified and is subject to change."
+     * insertion order. Currently, LinkedHashSet, Collections.emptySet(), and Collections.singleton() are considered
+     * stable-ordered, meaning HashSet and TreeSet are not. Sets returned by Set.of() are also not considered stable-
+     * ordered; although they seem to iterate in insertion order in current JVMs, their JavaDoc clearly states that "the
+     * iteration order of set elements is unspecified and is subject to change."
      */
     public static boolean isStableOrderedSet(@NotNull Set<?> set)
     {

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -161,6 +161,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -4291,7 +4292,7 @@ public class ExperimentServiceImpl implements ExperimentService
             TableInfo tableInfo = userSchema.getTable(sampleType.getName());
 
             // collect up columns of name 'dataset<N>'
-            Set<String> linkedColumnNames = new HashSet<>();
+            Set<String> linkedColumnNames = new LinkedHashSet<>();
             List<ColumnInfo> columns = tableInfo.getColumns();
             for (ColumnInfo column : columns)
             {
@@ -4306,7 +4307,7 @@ public class ExperimentServiceImpl implements ExperimentService
 
                 // Over each selected row
                 SimpleFilter filter = new SimpleFilter().addInClause(FieldKey.fromParts(ExpMaterialTable.Column.RowId.toString()), deletable);
-                TableSelector rowIdsFromTableSelector = new TableSelector(tableInfo, new HashSet<>(linkedColumnNames), filter, null);
+                TableSelector rowIdsFromTableSelector = new TableSelector(tableInfo, linkedColumnNames, filter, null);
                 Collection<Map<String, Object>> selectedRow = rowIdsFromTableSelector.getMapCollection();
 
                 // Over each column of name 'dataset<N>'

--- a/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
+++ b/experiment/src/org/labkey/experiment/samples/UploadSamplesHelper.java
@@ -961,7 +961,7 @@ public abstract class UploadSamplesHelper
             {
                 _existingNames = new HashSet<>();
                 SamplesSchema schema = new SamplesSchema(User.getSearchUser(), _container);
-                TableSelector ts = new TableSelector(schema.getTable(sampletype, null), Set.of("Name")).setMaxRows(1_000_000);
+                TableSelector ts = new TableSelector(schema.getTable(sampletype, null), Collections.singleton("Name")).setMaxRows(1_000_000);
                 ts.fillSet(_existingNames);
             }
             return _existingNames.contains(name);

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -488,7 +488,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
         ListManager.get().deleteIndexedList(_list);
 
         // Delete attachments and discussions associated with a list in batches of 1,000
-        new TableSelector(getDbTable(), Collections.singleton("entityId")).forEachBatch(String.class, 1000, new ForEachBatchBlock<String>()
+        new TableSelector(getDbTable(), Collections.singleton("entityId")).forEachBatch(String.class, 1000, new ForEachBatchBlock<>()
         {
             @Override
             public boolean accept(String entityId)


### PR DESCRIPTION
#### Rationale
We're getting stricter about requiring stable-ordered column lists. See related PR for details.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3158