### PR TITLE
Fix statistics for transaction caches

### DIFF
--- a/api/src/org/labkey/api/admin/FolderImportContext.java
+++ b/api/src/org/labkey/api/admin/FolderImportContext.java
@@ -43,7 +43,8 @@ import java.util.Set;
 public class FolderImportContext extends AbstractFolderContext
 {
     private Path _folderXml;
-    HashSet<String> _importedReports = new HashSet<>();
+
+    private final HashSet<String> _importedReports = new HashSet<>();
 
     /** Required for xstream serialization on Java 7 */
     @SuppressWarnings({"UnusedDeclaration"})
@@ -53,6 +54,7 @@ public class FolderImportContext extends AbstractFolderContext
     }
 
     @Deprecated //Prefer the Path version -- This will not work for Cloud based archive files
+    // TODO: Delete this... no more usages
     public FolderImportContext(User user, Container c, File folderXml, Set<String> dataTypes, LoggerGetter logger, VirtualFile root)
     {
         this(user, c, folderXml.toPath(), dataTypes, logger, root);
@@ -127,7 +129,8 @@ public class FolderImportContext extends AbstractFolderContext
     @Override
     public Double getArchiveVersion()
     {
-        try {
+        try
+        {
             FolderDocument folderDoc = getDocument();
             return folderDoc.getFolder() != null ? folderDoc.getFolder().getArchiveVersion() : null;
         }

--- a/api/src/org/labkey/api/cache/CacheManager.java
+++ b/api/src/org/labkey/api/cache/CacheManager.java
@@ -163,7 +163,7 @@ public class CacheManager
 
     public static CacheStats getTransactionCacheStats(TrackingCache cache)
     {
-        return new CacheStats(cache.getDebugName(), cache.getCreationStackTrace(), cache.getTransactionStats(), cache.size(), cache.getLimit());
+        return new CacheStats(cache.getDebugName(), cache.getCreationStackTrace(), cache.getTransactionStats(), 0, cache.getLimit());
     }
 
     public static void shutdown()

--- a/api/src/org/labkey/api/cache/CacheStats.java
+++ b/api/src/org/labkey/api/cache/CacheStats.java
@@ -23,30 +23,35 @@ public class CacheStats implements Comparable<CacheStats>
     private final String _description;
     @Nullable
     private final StackTraceElement[] _stackTrace;
+    private final int _limit;
+    private final long _expirations;
+    private final long _evictions;
+
     private final long _gets;
     private final long _misses;
     private final long _puts;
-    private final long _expirations;
     private final long _removes;
     private final long _clears;
-    private final long _size;
     private final long _maxSize;
-    private final int _limit;
 
+    private final long _size;
 
-    public CacheStats(String description, @Nullable StackTraceElement[] stackTrace, Stats stats, int size, int limit)
+    public CacheStats(TrackingCache<?, ?> cache, Stats stats, int size)
     {
-        _description = description;
-        _stackTrace = stackTrace;
+        _description = cache.getDebugName();
+        _stackTrace = cache.getCreationStackTrace();
+        _limit = cache.getLimit();
+        _expirations = cache.getExpirations();
+        _evictions = cache.getEvictions();
+
         _gets = stats.gets.get();
         _misses = stats.misses.get();
         _puts = stats.puts.get();
-        _expirations = stats.expirations.get();
         _removes = stats.removes.get();
         _clears = stats.clears.get();
-        _size = size;
         _maxSize = stats.max_size.get();
-        _limit = limit;
+
+        _size = size;
     }
 
     public String getDescription()
@@ -106,6 +111,11 @@ public class CacheStats implements Comparable<CacheStats>
     public long getExpirations()
     {
         return _expirations;
+    }
+
+    public long getEvictions()
+    {
+        return _evictions;
     }
 
     public double getMissRatio()

--- a/api/src/org/labkey/api/cache/CacheWrapper.java
+++ b/api/src/org/labkey/api/cache/CacheWrapper.java
@@ -32,7 +32,6 @@ import java.util.Set;
  * Time: 9:47:03 AM
  */
 
-// TODO: Track expirations?
 // Wraps a SimpleCache to provide a full Cache implementation. Adds null markers, loaders, statistics gathering and debug name.
 class CacheWrapper<K, V> implements TrackingCache<K, V>, CacheMXBean
 {
@@ -178,6 +177,17 @@ class CacheWrapper<K, V> implements TrackingCache<K, V>, CacheMXBean
         return _cache.size();
     }
 
+    @Override
+    public int getExpirations()
+    {
+        return _cache.getExpirations();
+    }
+
+    @Override
+    public int getEvictions()
+    {
+        return _cache.getEvictions();
+    }
 
     @Override
     public long getDefaultExpires()
@@ -257,11 +267,6 @@ class CacheWrapper<K, V> implements TrackingCache<K, V>, CacheMXBean
         long currentSize = size();
         if (currentSize > maxSize)
             _stats.max_size.compareAndSet(maxSize, currentSize);
-    }
-
-    private void trackExpiration()
-    {
-        _stats.expirations.incrementAndGet();
     }
 
     private void trackRemove()

--- a/api/src/org/labkey/api/cache/NoopCacheProvider.java
+++ b/api/src/org/labkey/api/cache/NoopCacheProvider.java
@@ -93,6 +93,18 @@ public class NoopCacheProvider implements CacheProvider
         }
 
         @Override
+        public int getExpirations()
+        {
+            return 0;
+        }
+
+        @Override
+        public int getEvictions()
+        {
+            return 0;
+        }
+
+        @Override
         public boolean isEmpty()
         {
             return false;

--- a/api/src/org/labkey/api/cache/SimpleCache.java
+++ b/api/src/org/labkey/api/cache/SimpleCache.java
@@ -57,6 +57,16 @@ public interface SimpleCache<K, V>
     // Current number of elements in the cache
     int size();
 
+    /**
+     * @return Number of expired elements
+     */
+    int getExpirations();
+
+    /**
+     * @return Number of evicted elements
+     */
+    int getEvictions();
+
     // Is this cache empty?
     boolean isEmpty();
 

--- a/api/src/org/labkey/api/cache/SimpleCache.java
+++ b/api/src/org/labkey/api/cache/SimpleCache.java
@@ -58,7 +58,7 @@ public interface SimpleCache<K, V>
     int size();
 
     // Is this cache empty?
-    public boolean isEmpty();
+    boolean isEmpty();
 
     long getDefaultExpires();
 

--- a/api/src/org/labkey/api/cache/Stats.java
+++ b/api/src/org/labkey/api/cache/Stats.java
@@ -27,7 +27,8 @@ public class Stats
     public final AtomicLong gets = new AtomicLong(0);
     public final AtomicLong misses = new AtomicLong(0);
     public final AtomicLong puts = new AtomicLong(0);
-    public final AtomicLong expirations = new AtomicLong(0);
+    public final AtomicLong expirations = new AtomicLong(0); // TODO: accrue expiration counts when temp caches are closed
+    public final AtomicLong evictions = new AtomicLong(0);   // TODO: accrue eviction counts when temp caches are closed
     public final AtomicLong removes = new AtomicLong(0);
     public final AtomicLong clears = new AtomicLong(0);
     public final AtomicLong max_size = new AtomicLong(0);

--- a/api/src/org/labkey/api/cache/Tracking.java
+++ b/api/src/org/labkey/api/cache/Tracking.java
@@ -41,5 +41,9 @@ public interface Tracking
     // Current number of elements in the cache
     int size();
 
+    int getExpirations();
+
+    int getEvictions();
+
     long getDefaultExpires();
 }

--- a/api/src/org/labkey/api/cache/ehcache/EhSimpleCache.java
+++ b/api/src/org/labkey/api/cache/ehcache/EhSimpleCache.java
@@ -107,13 +107,25 @@ class EhSimpleCache<K, V> implements SimpleCache<K, V>
     @Override
     public int getLimit()
     {
-        return _cache.getCacheConfiguration().getMaxElementsInMemory();
+        return (int)_cache.getCacheConfiguration().getMaxEntriesLocalHeap();
     }
 
     @Override
     public int size()
     {
         return (int)_cache.getStatistics().getObjectCount();
+    }
+
+    @Override
+    public int getExpirations()
+    {
+        return (int)_cache.getLiveCacheStatistics().getExpiredCount();
+    }
+
+    @Override
+    public int getEvictions()
+    {
+        return (int)_cache.getStatistics().getEvictionCount();
     }
 
     @Override

--- a/api/src/org/labkey/api/collections/CaseInsensitiveLinkedHashMap.java
+++ b/api/src/org/labkey/api/collections/CaseInsensitiveLinkedHashMap.java
@@ -42,7 +42,6 @@ public class CaseInsensitiveLinkedHashMap<V> extends CaseInsensitiveMapWrapper<V
     {
         this(map.size());
 
-        for (Map.Entry<String, V> entry : map.entrySet())
-            put(entry.getKey(), entry.getValue());
+        putAll(map);
     }
 }

--- a/api/src/org/labkey/api/collections/CollectionUtils.java
+++ b/api/src/org/labkey/api/collections/CollectionUtils.java
@@ -141,8 +141,8 @@ public class CollectionUtils
     /**
      * Attempts to determine if the provided Set implementation is stable-ordered, i.e., its iteration order matches its
      * insertion order. Currently, LinkedHashSet, Collections.emptySet(), and Collections.singleton() are considered
-     * stable-ordered, meaning HashSet and TreeSet are not. Sets returned by Set.of() are also not considered stable-
-     * ordered; although they seem to iterate in insertion order in current JVMs, their JavaDoc clearly states that "the
+     * stable-ordered; HashSet and TreeSet are not. Sets returned by Set.of() are also not considered stable-ordered;
+     * although they seem to iterate in insertion order in current JVMs, their JavaDoc clearly states that "the
      * iteration order of set elements is unspecified and is subject to change."
      */
     public static boolean isStableOrderedSet(@NotNull Set<?> set)
@@ -224,7 +224,7 @@ public class CollectionUtils
             assertUnmodifiable(MultiMapUtils.unmodifiableMultiValuedMap(new ArrayListValuedHashMap<>()));
             assertUnmodifiable(MultiMapUtils.emptyMultiValuedMap());
 
-            //  These Collections methods are new to Java 8
+            // These Collections methods are new to Java 8
             assertUnmodifiable(Collections.emptyNavigableSet());
             assertUnmodifiable(Collections.emptySortedSet());
             assertUnmodifiable(Collections.unmodifiableNavigableSet(new TreeSet<>()));
@@ -258,6 +258,7 @@ public class CollectionUtils
             assertFalse(isStableOrderedSet(Set.of("this")));
             assertFalse(isStableOrderedSet(Set.of("this", "that")));
             assertFalse(isStableOrderedSet(new HashSet<>()));
+            assertFalse(isStableOrderedSet(new TreeSet<>()));
         }
     }
 }

--- a/api/src/org/labkey/api/data/DatabaseCache.java
+++ b/api/src/org/labkey/api/data/DatabaseCache.java
@@ -74,7 +74,7 @@ public class DatabaseCache<K, V> implements Cache<K, V>
 
     protected Cache<K, V> createTemporaryCache(TrackingCache<K, V> trackingCache)
     {
-        return CacheManager.getTemporaryCache(trackingCache.getLimit(), trackingCache.getDefaultExpires(), "transaction cache: " + trackingCache.getDebugName(), trackingCache.getStats());
+        return CacheManager.getTemporaryCache(trackingCache.getLimit(), trackingCache.getDefaultExpires(), "transaction cache: " + trackingCache.getDebugName(), trackingCache.getTransactionStats());
     }
 
     private Cache<K, V> getCache()

--- a/api/src/org/labkey/api/data/Sort.java
+++ b/api/src/org/labkey/api/data/Sort.java
@@ -109,7 +109,7 @@ public class Sort
     public static class SortField
     {
         SortDirection _dir = SortDirection.ASC;
-        FieldKey _fieldKey = null;
+        FieldKey _fieldKey;
         boolean _urlClause = false;
 
         public SortField(FieldKey fieldKey, SortDirection dir)
@@ -123,13 +123,6 @@ public class Sort
             {
                 _dir = dir;
             }
-        }
-
-        @Deprecated // Use FieldKey version instead.
-        public SortField(String str, SortDirection dir)
-        {
-            _fieldKey = FieldKey.fromString(str.trim());
-            _dir = dir;
         }
 
         @Deprecated // Use FieldKey version instead.
@@ -527,7 +520,7 @@ public class Sort
 
                             if (mvIndicatorColumn != null)
                             {
-                                SortField mvSortField = new SortField(mvIndicatorColumn.getName(), sf.getSortDirection());
+                                SortField mvSortField = new SortField(mvIndicatorColumn.getFieldKey(), sf.getSortDirection());
                                 appendColumnToSort(mvSortField, dialect, mvIndicatorColumn.getAlias(), distinctKeys, sb);
                             }
                         }

--- a/api/src/org/labkey/api/reports/ReportService.java
+++ b/api/src/org/labkey/api/reports/ReportService.java
@@ -20,7 +20,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.xmlbeans.XmlObject;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.admin.ImportContext;
+import org.labkey.api.admin.FolderImportContext;
 import org.labkey.api.data.Container;
 import org.labkey.api.module.Module;
 import org.labkey.api.query.QuerySettings;
@@ -181,7 +181,7 @@ public interface ReportService
      * parameters. Imported reports are always treated as new reports even if they were exported from
      * the same container.
      */
-    Report importReport(ImportContext ctx, XmlObject reportXml, VirtualFile root, String xmlFileName) throws IOException, SQLException, XmlValidationException;
+    Report importReport(FolderImportContext ctx, XmlObject reportXml, VirtualFile root, String xmlFileName) throws IOException, SQLException, XmlValidationException;
 
     /**
      * Runs maintenance on the report service.

--- a/api/src/org/labkey/api/security/UserCache.java
+++ b/api/src/org/labkey/api/security/UserCache.java
@@ -62,13 +62,11 @@ class UserCache
             return new BlockingCache<>(shared, new UserCollectionsLoader());
         }
 
-
-
         @Override
         protected Cache<String, UserCollections> createTemporaryCache(TrackingCache<String, UserCollections> sharedCache)
         {
             Tracking tracking = sharedCache.getTrackingCache();
-            Cache<String, Wrapper<UserCollections>> temp = CacheManager.getTemporaryCache(tracking.getLimit(), tracking.getDefaultExpires(), "Transaction cache: User Collections", tracking.getStats());
+            Cache<String, Wrapper<UserCollections>> temp = CacheManager.getTemporaryCache(tracking.getLimit(), tracking.getDefaultExpires(), "Transaction cache: User Collections", tracking.getTransactionStats());
             return new BlockingCache<>(temp, new UserCollectionsLoader());
         }
     };

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -249,13 +249,13 @@ import java.util.StringTokenizer;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.labkey.api.data.MultiValuedRenderContext.VALUE_DELIMITER_REGEX;
-import static org.labkey.api.module.DefaultModule.CORE_MODULE_NAME;
 import static org.labkey.api.settings.AdminConsole.SettingsLinkType.Configuration;
 import static org.labkey.api.settings.AdminConsole.SettingsLinkType.Diagnostics;
 import static org.labkey.api.util.DOM.A;
@@ -2834,16 +2834,22 @@ public class AdminController extends SpringActionController
             html.append(PageFlowUtil.textLink("Refresh", getCachesURL(false, false)));
 
             html.append("<br/><br/>\n");
-            appendStats(html, "Caches", cacheStats);
+            appendStats(html, "Caches", cacheStats, false);
 
             html.append("<br/><br/>\n");
-            appendStats(html, "Transaction Caches", transactionStats);
+            appendStats(html, "Transaction Caches", transactionStats, true);
 
             return new HtmlView(html.toString());
         }
 
-        private void appendStats(StringBuilder html, String title, List<CacheStats> stats)
+        private void appendStats(StringBuilder html, String title, List<CacheStats> allStats, boolean skipUnusedCaches)
         {
+            List<CacheStats> stats = skipUnusedCaches ?
+                allStats.stream()
+                    .filter(stat->stat.getMaxSize() > 0)
+                    .collect(Collectors.toCollection((Supplier<List<CacheStats>>) ArrayList::new)) :
+                allStats;
+
             Collections.sort(stats);
 
             html.append("<p><b>");
@@ -2888,11 +2894,10 @@ public class AdminController extends SpringActionController
                 appendDescription(html, stat.getDescription(), stat.getCreationStackTrace());
 
                 Long limit = stat.getLimit();
-                Long maxSize = stat.getMaxSize();
+                long maxSize = stat.getMaxSize();
 
                 appendLongs(html, limit, maxSize, stat.getSize(), stat.getGets(), stat.getMisses(), stat.getPuts(), stat.getExpirations(), stat.getRemoves(), stat.getClears());
                 appendDoubles(html, stat.getMissRatio());
-
 
                 html.append("<td>").append(PageFlowUtil.textLink("Clear", getCacheURL(stat.getDescription()))).append("</td>\n");
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -2803,7 +2803,7 @@ public class AdminController extends SpringActionController
                 throw new RedirectException(redirect);
             }
 
-            List<TrackingCache> caches = CacheManager.getKnownCaches();
+            List<TrackingCache<?, ?>> caches = CacheManager.getKnownCaches();
 
             if (form.getDebugName() != null)
             {
@@ -2865,6 +2865,7 @@ public class AdminController extends SpringActionController
             html.append("<td class=\"labkey-column-header\">Misses</td>");
             html.append("<td class=\"labkey-column-header\">Puts</td>");
             html.append("<td class=\"labkey-column-header\">Expirations</td>");
+            html.append("<td class=\"labkey-column-header\">Evictions</td>");
             html.append("<td class=\"labkey-column-header\">Removes</td>");
             html.append("<td class=\"labkey-column-header\">Clears</td>");
             html.append("<td class=\"labkey-column-header\">Miss Percentage</td>");
@@ -2875,6 +2876,7 @@ public class AdminController extends SpringActionController
             long misses = 0;
             long puts = 0;
             long expirations = 0;
+            long evictions = 0;
             long removes = 0;
             long clears = 0;
             int rowCount = 0;
@@ -2886,6 +2888,7 @@ public class AdminController extends SpringActionController
                 misses += stat.getMisses();
                 puts += stat.getPuts();
                 expirations += stat.getExpirations();
+                evictions += stat.getEvictions();
                 removes += stat.getRemoves();
                 clears += stat.getClears();
 
@@ -2896,7 +2899,7 @@ public class AdminController extends SpringActionController
                 Long limit = stat.getLimit();
                 long maxSize = stat.getMaxSize();
 
-                appendLongs(html, limit, maxSize, stat.getSize(), stat.getGets(), stat.getMisses(), stat.getPuts(), stat.getExpirations(), stat.getRemoves(), stat.getClears());
+                appendLongs(html, limit, maxSize, stat.getSize(), stat.getGets(), stat.getMisses(), stat.getPuts(), stat.getExpirations(), stat.getEvictions(), stat.getRemoves(), stat.getClears());
                 appendDoubles(html, stat.getMissRatio());
 
                 html.append("<td>").append(PageFlowUtil.textLink("Clear", getCacheURL(stat.getDescription()))).append("</td>\n");
@@ -2911,7 +2914,7 @@ public class AdminController extends SpringActionController
             double ratio = 0 != gets ? misses / (double)gets : 0;
             html.append("<tr class=\"labkey-row\"><td><b>Total</b></td>");
 
-            appendLongs(html, null, null, size, gets, misses, puts, expirations, removes, clears);
+            appendLongs(html, null, null, size, gets, misses, puts, expirations, evictions, removes, clears);
             appendDoubles(html, ratio);
 
             html.append("</tr>\n");

--- a/filecontent/src/org/labkey/filecontent/FileImporter.java
+++ b/filecontent/src/org/labkey/filecontent/FileImporter.java
@@ -22,7 +22,6 @@ import org.labkey.api.admin.AbstractFolderImportFactory;
 import org.labkey.api.admin.FolderArchiveDataTypes;
 import org.labkey.api.admin.FolderImportContext;
 import org.labkey.api.admin.FolderImporter;
-import org.labkey.api.admin.ImportContext;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.query.ExpDataTable;
 import org.labkey.api.exp.query.ExpSchema;
@@ -30,7 +29,6 @@ import org.labkey.api.files.FileContentService;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineJobWarning;
 import org.labkey.api.writer.VirtualFile;
-import org.labkey.folder.xml.FolderDocument.Folder;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/query/src/org/labkey/query/reports/ReportServiceImpl.java
+++ b/query/src/org/labkey/query/reports/ReportServiceImpl.java
@@ -27,7 +27,6 @@ import org.apache.xmlbeans.XmlObject;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.admin.FolderImportContext;
-import org.labkey.api.admin.ImportContext;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ContainerManager.AbstractContainerListener;
@@ -884,7 +883,7 @@ public class ReportServiceImpl extends AbstractContainerListener implements Repo
     }
 
     @Override @Nullable
-    public Report importReport(ImportContext ctx, XmlObject reportXml, VirtualFile root, String xmlFileName) throws IOException, XmlValidationException
+    public Report importReport(FolderImportContext ctx, XmlObject reportXml, VirtualFile root, String xmlFileName) throws IOException, XmlValidationException
     {
         Report report = deserialize(ctx.getContainer(), ctx.getUser(), reportXml, root, xmlFileName);
         if (report != null)

--- a/wiki/src/org/labkey/wiki/export/WikiImporterFactory.java
+++ b/wiki/src/org/labkey/wiki/export/WikiImporterFactory.java
@@ -20,7 +20,6 @@ import org.labkey.api.admin.AbstractFolderImportFactory;
 import org.labkey.api.admin.FolderArchiveDataTypes;
 import org.labkey.api.admin.FolderImportContext;
 import org.labkey.api.admin.FolderImporter;
-import org.labkey.api.admin.ImportContext;
 import org.labkey.api.admin.ImportException;
 import org.labkey.api.attachments.Attachment;
 import org.labkey.api.attachments.AttachmentFile;
@@ -35,7 +34,6 @@ import org.labkey.api.writer.VirtualFile;
 import org.labkey.data.xml.wiki.WikiType;
 import org.labkey.data.xml.wiki.WikisDocument;
 import org.labkey.data.xml.wiki.WikisType;
-import org.labkey.folder.xml.FolderDocument.Folder;
 import org.labkey.wiki.WikiManager;
 import org.labkey.wiki.WikiSelectManager;
 import org.labkey.wiki.model.Wiki;
@@ -54,6 +52,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * User: jeckels
@@ -167,7 +166,7 @@ public class WikiImporterFactory extends AbstractFolderImportFactory
             }
         }
 
-        private Wiki importWiki(String name, String title, boolean shouldIndex, boolean showAttachments, VirtualFile wikiSubDir, String folderName, ImportContext<Folder> ctx, int displayOrder, String attachmentOrder) throws IOException, ImportException
+        private Wiki importWiki(String name, String title, boolean shouldIndex, boolean showAttachments, VirtualFile wikiSubDir, String folderName, FolderImportContext ctx, int displayOrder, String attachmentOrder) throws IOException, ImportException
         {
             Wiki existingWiki = WikiSelectManager.getWiki(ctx.getContainer(), name);
             List<String> existingAttachmentNames = new ArrayList<>();
@@ -210,7 +209,7 @@ public class WikiImporterFactory extends AbstractFolderImportFactory
             }
             if (attachmentOrder != null) {
                 AtomicInteger inc = new AtomicInteger();
-                Map<String, Integer> attachmentOrderMap = List.of(attachmentOrder.split(";")).stream().collect(Collectors.toMap(i -> i, i -> inc.getAndIncrement()));
+                Map<String, Integer> attachmentOrderMap = Stream.of(attachmentOrder.split(";")).collect(Collectors.toMap(i -> i, i -> inc.getAndIncrement()));
                 attachments.sort(Comparator.comparing(e -> attachmentOrderMap.get(e.getFilename())));
             }
 


### PR DESCRIPTION
#### Rationale
Our "Caches" admin page displays statistics for all the caches used in the product. The "Transaction Caches" section has been broken for a long time; it's supposed to show cumulative statistics for all the temporary caches we create during transactions, but the stats are all zeros.

#### Changes
* Correctly pass in the transaction stats collector when creating a temporary cache
* Report every transaction cache current size as 0
* Prune the list of transaction caches to those that have seen at least one element
* Attempt to fix expirations & evictions counts... but doesn't seem to be working locally