### PR TITLE
LSIDRelativizer: support /Shared folder substitution

### DIFF
--- a/api/src/org/labkey/api/exp/XarContext.java
+++ b/api/src/org/labkey/api/exp/XarContext.java
@@ -19,6 +19,7 @@ package org.labkey.api.exp;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.pipeline.PipelineJob;
@@ -57,6 +58,7 @@ public class XarContext
     private static final String XAR_FILE_ID_NAME = "XarFileId";
     private static final String EXPERIMENT_RUN_ID_NAME = "ExperimentRun.RowId";
     private static final String CONTAINER_ID_NAME = "Container.RowId";
+    private static final String SHARED_CONTAINER_ID_NAME = "SharedContainer.RowId";
     private static final String FOLDER_LSID_BASE_NAME = "FolderLSIDBase";
     private static final String RUN_LSID_BASE_NAME = "RunLSIDBase";
     private static final String LSID_AUTHORITY_NAME = "LSIDAuthority";
@@ -64,6 +66,7 @@ public class XarContext
     public static final String XAR_FILE_ID_SUBSTITUTION = createSubstitution(XAR_FILE_ID_NAME);
     public static final String EXPERIMENT_RUN_ID_SUBSTITUTION = createSubstitution(EXPERIMENT_RUN_ID_NAME);
     public static final String CONTAINER_ID_SUBSTITUTION = createSubstitution(CONTAINER_ID_NAME);
+    public static final String SHARED_CONTAINER_ID_SUBSTITUTION = createSubstitution(SHARED_CONTAINER_ID_NAME);
     public static final String FOLDER_LSID_BASE_SUBSTITUTION = createSubstitution(FOLDER_LSID_BASE_NAME);
     public static final String RUN_LSID_BASE_SUBSTITUTION = createSubstitution(RUN_LSID_BASE_NAME);
     public static final String LSID_AUTHORITY_SUBSTITUTION = createSubstitution(LSID_AUTHORITY_NAME);
@@ -113,6 +116,7 @@ public class XarContext
 
         _substitutions.put("Container.path", path);
         _substitutions.put(CONTAINER_ID_NAME, Integer.toString(c.getRowId()));
+        _substitutions.put(SHARED_CONTAINER_ID_NAME, Integer.toString(ContainerManager.getSharedContainer().getRowId()));
 
         _substitutions.put(XAR_FILE_ID_NAME, "Xar-" + GUID.makeGUID());
         if (user != null)

--- a/experiment/src/org/labkey/experiment/LSIDRelativizer.java
+++ b/experiment/src/org/labkey/experiment/LSIDRelativizer.java
@@ -19,6 +19,7 @@ package org.labkey.experiment;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.api.ExpData;
@@ -94,7 +95,9 @@ public enum LSIDRelativizer implements SafeToRenderEnum
             }
             else if (suffix != null && SUFFIX_PATTERN.matcher(suffix).matches())
             {
-                return lsids.uniquifyRelativizedLSID("urn:lsid:" + XarContext.LSID_AUTHORITY_SUBSTITUTION + ":" + prefix + ".Folder-" + XarContext.CONTAINER_ID_SUBSTITUTION + "", lsid.getObjectId(), lsid.getVersion());
+                String sharedFolderSuffix = "Folder-" + ContainerManager.getSharedContainer().getRowId();
+                String containerSubstitution = sharedFolderSuffix.equals(suffix) ? XarContext.SHARED_CONTAINER_ID_SUBSTITUTION : XarContext.CONTAINER_ID_SUBSTITUTION;
+                return lsids.uniquifyRelativizedLSID("urn:lsid:" + XarContext.LSID_AUTHORITY_SUBSTITUTION + ":" + prefix + ".Folder-" + containerSubstitution + "", lsid.getObjectId(), lsid.getVersion());
             }
 
             return lsid.toString();
@@ -190,15 +193,15 @@ public enum LSIDRelativizer implements SafeToRenderEnum
     {
         private final LSIDRelativizer _relativizer;
 
-        private Map<String, String> _originalToRelative = new HashMap<>();
+        private final Map<String, String> _originalToRelative = new HashMap<>();
 
         // Maintain a separate set of values so we can quickly determine if one is already in use instead of having
         // to traverse the whole map. See issue 39260
-        private Set<String> _relativized = new HashSet<>();
+        private final Set<String> _relativized = new HashSet<>();
 
         // Also keep track of the next suffix to append for a given LSID prefix so we don't have to run through the full
         // sequence of values we already scanned the last time. See issue 39260
-        private Map<String, Integer> _nextExportVersion = new HashMap<>();
+        private final Map<String, Integer> _nextExportVersion = new HashMap<>();
 
         private int _nextDataId = 1;
         private int _nextSampleId = 1;


### PR DESCRIPTION
#### Rationale
Adds support for explicitly differentiating the /Shared folder from other folders when processing LSIDs. Previously, an LSID for an entity declared in the /Shared folder would result in an LSID substiution for the target container. Something like:
```
urn:lsid:${LSIDAuthority}:SamplesWorkflow.Folder-${Container.RowId}:WorkflowTask#Ordinal
```
With this change it will now provide a different substitution syntax for entities declared in /Shared:
```
urn:lsid:${LSIDAuthority}:SamplesWorkflow.Folder-${SharedContainer.RowId}:WorkflowTask#Ordinal
```
Note, I have decided to not extend this to all processing for all "relativized" LSIDs. Future work could open up this substitution syntax for data types we process LSIDS for explicitly (i.e. "ExperimentRun", "ProtocolApplication", etc.).

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/766
* https://github.com/LabKey/biologics/pull/1194
* https://github.com/LabKey/sampleManagement/pull/874
* https://github.com/LabKey/inventory/pull/393
* https://github.com/LabKey/platform/pull/3176

#### Changes
* LSIDRelativizer: support `${SharedContainer.RowId}` substitution
