### PR TITLE
Issue 45067: Configure AssayUploadPipelineJob via pipeline tasks

### DIFF
--- a/api/src/org/labkey/api/assay/pipeline/AssayUploadPipelineJob.java
+++ b/api/src/org/labkey/api/assay/pipeline/AssayUploadPipelineJob.java
@@ -17,7 +17,7 @@ package org.labkey.api.assay.pipeline;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.assay.AssayFileWriter;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.AssayUrls;
@@ -28,7 +28,10 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineJobNotificationProvider;
+import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.pipeline.PipelineService;
+import org.labkey.api.pipeline.TaskId;
+import org.labkey.api.pipeline.TaskPipeline;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ViewBackgroundInfo;
@@ -87,6 +90,12 @@ public class AssayUploadPipelineJob<ProviderType extends AssayProvider> extends 
     }
 
     @Override
+    public @Nullable TaskPipeline<?> getTaskPipeline()
+    {
+        return PipelineJobService.get().getTaskPipeline(new TaskId(AssayUploadPipelineJob.class));
+    }
+
+    @Override
     public String getDescription()
     {
         // Generate a description that matches what the run's name/ID will be
@@ -105,8 +114,7 @@ public class AssayUploadPipelineJob<ProviderType extends AssayProvider> extends 
         return "Assay upload";
     }
 
-    @Override
-    public void run()
+    public void doWork()
     {
         PipelineJobNotificationProvider notificationProvider = getNotificationProvider();
 
@@ -114,7 +122,6 @@ public class AssayUploadPipelineJob<ProviderType extends AssayProvider> extends 
         {
             _context.setLogger(getLogger());
 
-            setStatus(TaskStatus.running);
             getLogger().info("Starting assay upload");
 
             if (notificationProvider != null)

--- a/api/src/org/labkey/api/assay/pipeline/AssayUploadPipelineTask.java
+++ b/api/src/org/labkey/api/assay/pipeline/AssayUploadPipelineTask.java
@@ -1,0 +1,82 @@
+package org.labkey.api.assay.pipeline;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.pipeline.AbstractTaskFactory;
+import org.labkey.api.pipeline.AbstractTaskFactorySettings;
+import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.pipeline.PipelineJobException;
+import org.labkey.api.pipeline.RecordedActionSet;
+import org.labkey.api.util.FileType;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A tiny task definition that allows configuration of the execution location of this work. It defers back to
+ * AssayUploadPipelineJob to do the real work.
+ */
+public class AssayUploadPipelineTask extends PipelineJob.Task<AssayUploadPipelineTask.Factory>
+{
+    public AssayUploadPipelineTask(Factory factory, PipelineJob job)
+    {
+        super(factory, job);
+    }
+
+    @Override
+    public @NotNull RecordedActionSet run() throws PipelineJobException
+    {
+        ((AssayUploadPipelineJob<?>)getJob()).doWork();
+        return new RecordedActionSet();
+    }
+
+    public static class Factory extends AbstractTaskFactory<AbstractTaskFactorySettings, Factory>
+    {
+        private String _executionLocation;
+
+        public Factory()
+        {
+            super(AssayUploadPipelineTask.class);
+        }
+
+        @Override
+        public List<FileType> getInputTypes()
+        {
+            return Collections.emptyList();
+        }
+
+        public void setExecutionLocation(String executionLocation)
+        {
+            _executionLocation = executionLocation;
+        }
+
+        @Override
+        public String getExecutionLocation()
+        {
+            return _executionLocation == null ? super.getExecutionLocation() : _executionLocation;
+        }
+
+        @Override
+        public String getStatusName()
+        {
+            return "Assay upload";
+        }
+
+        @Override
+        public List<String> getProtocolActionNames()
+        {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public AssayUploadPipelineTask createTask(PipelineJob job)
+        {
+            return new AssayUploadPipelineTask(this, job);
+        }
+
+        @Override
+        public boolean isJobComplete(PipelineJob job)
+        {
+            return false;
+        }
+    }
+}

--- a/api/src/org/labkey/api/module/SpringModule.java
+++ b/api/src/org/labkey/api/module/SpringModule.java
@@ -128,7 +128,7 @@ public abstract class SpringModule extends DefaultModule
 
     /**
      * A module may define a pipeline configuration file in the deployed webapp at /WEB-INF/[lower_case_module_name]Context.xml.
-     * Context may be overridden outside the the module after installation, by specifying a path to
+     * Context may be overridden outside the module after installation, by specifying a path to
      * the configuration files in the <code>ServletContext</code> parameter
      * <code>INIT_PARAMETER_CONFIG_PATH</code>.
      * <p/>

--- a/api/src/org/labkey/api/pipeline/TaskFactory.java
+++ b/api/src/org/labkey/api/pipeline/TaskFactory.java
@@ -98,4 +98,5 @@ public interface TaskFactory<SettingsType extends TaskFactorySettings>
      * Location name for task to run on the LabKey Server itself (inside the Tomcat process).
      */
     String WEBSERVER = "webserver";
+    String WEBSERVER_HIGH_PRIORITY = "webserver-high-priority";
 }

--- a/assay/webapp/WEB-INF/assay/assayContext.xml
+++ b/assay/webapp/WEB-INF/assay/assayContext.xml
@@ -8,11 +8,24 @@
             <list>
                 <bean class="org.labkey.assay.pipeline.AssayImportRunTask$Factory"/>
                 <bean class="org.labkey.assay.pipeline.AssayImportRunTask$FileAnalysisFactory"/>
+                <bean class="org.labkey.api.assay.pipeline.AssayUploadPipelineTask$Factory"/>
             </list>
         </property>
 
         <property name="pipelines">
             <list>
+                <!-- Assay upload job pipeline -->
+                <bean class="org.labkey.api.pipeline.TaskPipelineSettings">
+                    <constructor-arg type="java.lang.Class" value="org.labkey.api.assay.pipeline.AssayUploadPipelineJob"/>
+                    <property name="taskProgressionSpec">
+                        <list>
+                            <bean id="assayUploadTask" class="org.labkey.api.pipeline.TaskId">
+                                <constructor-arg><value type="java.lang.Class">org.labkey.api.assay.pipeline.AssayUploadPipelineTask</value></constructor-arg>
+                            </bean>
+                        </list>
+                    </property>
+                </bean>
+
                 <!-- assay import file watcher -->
                 <bean class="org.labkey.api.pipeline.file.FileAnalysisTaskPipelineSettings">
                     <constructor-arg value="AssayImportTask"/>

--- a/pipeline/src/org/labkey/pipeline/mule/EPipelineContextListener.java
+++ b/pipeline/src/org/labkey/pipeline/mule/EPipelineContextListener.java
@@ -43,8 +43,7 @@ public class EPipelineContextListener implements StartupListener, ShutdownListen
         // so don't initialize if it is not in use.
         if (PipelineService.get().isEnterprisePipeline())
         {
-            _muleListenerHelper = new MuleListenerHelper(servletContext,
-                    "org/labkey/pipeline/mule/config/webserverMuleConfig.xml");
+            _muleListenerHelper = new MuleListenerHelper(servletContext);
         }
     }
 


### PR DESCRIPTION
#### Rationale
Admins value being able to customize the threading behavior of key pipeline tasks. We'd like to let them define various thread pools on the web server via a Mule XML config file, as well as have a hook to assign assay imports to a non-default thread pool.

#### Changes
* Check for an alternative webserverMuleConfig.xml file from what we include in the Pipeline module.
* Create a one-task pipeline definition for AssayUploadPipelineJob so that its execution can be customized.
* Minor cleanup and typo fixes. 