### PR TITLE
Issue 45132: Semicolon in file name truncates only on download

### DIFF
--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -5052,7 +5052,7 @@ public class DavController extends SpringActionController
                 if (HttpUtil.isChrome(getRequest()))
                 {
                     Path requestPath = new URLHelper(getRequest().getRequestURI()).getParsedPath();
-                    getResponse().setContentDisposition(contentDisposition + "; filename=" + requestPath.getName());
+                    getResponse().setContentDisposition(contentDisposition + "; filename*=" + PageFlowUtil.encode(requestPath.getName()));
                 }
             }
             catch (URISyntaxException x)

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -5052,7 +5052,8 @@ public class DavController extends SpringActionController
                 if (HttpUtil.isChrome(getRequest()))
                 {
                     Path requestPath = new URLHelper(getRequest().getRequestURI()).getParsedPath();
-                    getResponse().setContentDisposition(contentDisposition + "; filename*=" + PageFlowUtil.encode(requestPath.getName()));
+                    getResponse().setContentDisposition(String.format("%1$s;\n filename=\"%2$s;\"\n filename*=%3$s",
+                            contentDisposition, requestPath.getName(), PageFlowUtil.encode(requestPath.getName())));
                 }
             }
             catch (URISyntaxException x)

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -5046,20 +5046,6 @@ public class DavController extends SpringActionController
         if (!StringUtils.isEmpty(contentDisposition))
         {
             getResponse().setContentDisposition(contentDisposition);
-            try
-            {
-                // https://bugs.chromium.org/p/chromium/issues/detail?id=1503
-                if (HttpUtil.isChrome(getRequest()))
-                {
-                    Path requestPath = new URLHelper(getRequest().getRequestURI()).getParsedPath();
-                    getResponse().setContentDisposition(String.format("%1$s;\n filename=\"%2$s;\"\n filename*=%3$s",
-                            contentDisposition, requestPath.getName(), PageFlowUtil.encode(requestPath.getName())));
-                }
-            }
-            catch (URISyntaxException x)
-            {
-               // pass
-            }
         }
 
         // Find content type


### PR DESCRIPTION
#### Rationale
[Issue 45132](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45132): Semicolon in file name truncates only on download
https://httpwg.org/specs/rfc6266.html#examples

#### Changes
* adjusted the header to use the `filename*` encoded value per the RFC
