### PR TITLE
Render wiki comparisons in a more compact view

### DIFF
--- a/internal/src/org/labkey/api/util/DiffMatchPatch.java
+++ b/internal/src/org/labkey/api/util/DiffMatchPatch.java
@@ -19,6 +19,8 @@
 
 package org.labkey.api.util;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -1273,6 +1275,47 @@ public class DiffMatchPatch
         html.append("<SPAN TITLE=\"i=").append(i).append("\">").append(text)
             .append("</SPAN>");
         break;
+      }
+      if (aDiff.operation != Operation.DELETE) {
+        i += aDiff.text.length();
+      }
+    }
+    return html.toString();
+  }
+
+  private static final String LB = "&para;<BR>";
+
+  /**
+   * Convert a Diff list into a "compact" pretty HTML report. The output is identical to that of diff_prettyHtml()
+   * except that, to highlight the actual changes, this method outputs EQUAL diffs that are more than four lines long
+   * with a shortened summary (first two lines + count of omitted lines + last two lines).
+   * @param diffs List of Diff objects.
+   * @return Compact HTML representation.
+   */
+  public String diff_prettyHtmlCompact(List<Diff> diffs) {
+    StringBuilder html = new StringBuilder();
+    int i = 0;
+    for (Diff aDiff : diffs) {
+      String text = aDiff.text.replace("&", "&amp;").replace("<", "&lt;")
+          .replace(">", "&gt;").replace("\n", LB);
+      switch (aDiff.operation)
+      {
+        case INSERT -> html.append("<INS STYLE=\"background:#E6FFE6;\" TITLE=\"i=").append(i)
+                .append("\">").append(text).append("</INS>");
+        case DELETE -> html.append("<DEL STYLE=\"background:#FFE6E6;\" TITLE=\"i=").append(i)
+                .append("\">").append(text).append("</DEL>");
+        case EQUAL -> {
+                int lines = StringUtils.countMatches(text, LB);
+                if (lines > 4)
+                {
+                    // Compute start and end of the section we want to omit
+                    int start = text.indexOf(LB, text.indexOf(LB) + LB.length()) + LB.length();
+                    int end = text.lastIndexOf(LB,text.lastIndexOf(LB, text.lastIndexOf(LB) - LB.length()) - LB.length()) + LB.length();
+
+                    text = text.substring(0, start) + "<BR><SPAN STYLE=\"color:#808080;\">[" + (lines - 4) + " unchanged lines]</SPAN><BR><BR>" + text.substring(end);
+                }
+                html.append("<SPAN TITLE=\"i=").append(i).append("\">").append(text).append("</SPAN>");
+        }
       }
       if (aDiff.operation != Operation.DELETE) {
         i += aDiff.text.length();

--- a/internal/src/org/labkey/api/util/DiffMatchPatch.java
+++ b/internal/src/org/labkey/api/util/DiffMatchPatch.java
@@ -1288,7 +1288,7 @@ public class DiffMatchPatch
   /**
    * Convert a Diff list into a "compact" pretty HTML report. The output is identical to that of diff_prettyHtml()
    * except that, to highlight the actual changes, this method outputs EQUAL diffs that are more than four lines long
-   * with a shortened summary (first two lines + count of omitted lines + last two lines).
+   * with a shortened summary (first two lines + summary including count of omitted lines + last two lines).
    * @param diffs List of Diff objects.
    * @return Compact HTML representation.
    */

--- a/wiki/src/org/labkey/wiki/WikiController.java
+++ b/wiki/src/org/labkey/wiki/WikiController.java
@@ -60,6 +60,7 @@ import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.ContainerTreeSelected;
 import org.labkey.api.util.DiffMatchPatch;
+import org.labkey.api.util.DiffMatchPatch.Diff;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
@@ -1433,15 +1434,15 @@ public class WikiController extends SpringActionController
                 throw new NotFoundException();
 
             DiffMatchPatch diffTool = new DiffMatchPatch();
-            LinkedList<DiffMatchPatch.Diff> diffs = diffTool.diff_main(StringUtils.trimToEmpty(_wikiVersion1.getBody()), StringUtils.trimToEmpty(_wikiVersion2.getBody()));
-            String htmlDiffs = diffTool.diff_prettyHtml(diffs);
+            List<Diff> diffs = diffTool.diff_main(StringUtils.trimToEmpty(_wikiVersion1.getBody()), StringUtils.trimToEmpty(_wikiVersion2.getBody()));
+            String htmlDiffs = diffTool.diff_prettyHtmlCompact(diffs);
             HtmlView htmlView = new HtmlView(htmlDiffs);
             htmlView.setTitle("Source Differences");
 
             TextExtractor te1 = new TextExtractor(_wikiVersion1.getHtml(getContainer(), _wiki));
             TextExtractor te2 = new TextExtractor(_wikiVersion2.getHtml(getContainer(), _wiki));
             diffs = diffTool.diff_main(te1.extract(), te2.extract());
-            String textDiffs = diffTool.diff_prettyHtml(diffs);
+            String textDiffs = diffTool.diff_prettyHtmlCompact(diffs);
             HtmlView textView = new HtmlView(textDiffs);
             textView.setTitle("Text Differences");
 


### PR DESCRIPTION
#### Rationale
Our documentation team and others use the wiki comparison view to review changes made to wiki content over time. The current view, however, can be difficult to use because it shows a full diff that often includes a large amount of unchanged text along with a small number of changes. Despite color highlighting of inserts and deletes, the changes can be very difficult to spot. The new approach replaces large swaths of unchanged text, if present, with a single line placeholder that states the number of unchanged lines that were omitted. This effectively highlights the changes. For example:

![image](https://user-images.githubusercontent.com/5107383/160504951-08190eae-d860-4828-9124-dae3d475cd22.png)
