### PR TITLE
Remove unsupported lint commands

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -12,11 +12,7 @@
     "start-link": "cross-env LINK=true npm run start",
     "test": "cross-env NODE_ENV=test jest",
     "lint": "eslint",
-    "lint-fix": "eslint --fix",
-    "lint-precommit": "node lint.diff.js",
-    "lint-precommit-fix": "node lint.diff.js --fix",
-    "lint-branch": "node lint.diff.js --currentBranch",
-    "lint-branch-fix": "node lint.diff.js --currentBranch --fix"
+    "lint-fix": "eslint --fix"
   },
   "jest": {
     "globals": {


### PR DESCRIPTION
#### Rationale
Removes unsupported lint commends from this module. These capabilities may be added in the future but how/when that is supported is to be determined.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/788
* https://github.com/LabKey/biologics/pull/1218
* https://github.com/LabKey/platform/pull/3186
* https://github.com/LabKey/moduleEditor/pull/54
* https://github.com/LabKey/provenance/pull/100

#### Changes
* Remove unsupported lint commands.