### PR TITLE
Issue 45138: Adjust FolderXarImporterFactory to support unzipped XARs

### DIFF
--- a/api/src/org/labkey/api/exp/XarSource.java
+++ b/api/src/org/labkey/api/exp/XarSource.java
@@ -31,7 +31,6 @@ import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.security.User;
 import org.labkey.api.util.FileUtil;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
@@ -73,9 +72,6 @@ public abstract class XarSource implements Serializable
 
     public abstract ExperimentArchiveDocument getDocument() throws XmlException, IOException;
 
-    @Deprecated
-    public abstract File getRoot();
-
     public abstract Path getRootPath();
 
     /**
@@ -104,8 +100,7 @@ public abstract class XarSource implements Serializable
                     urlToLookup = FileUtil.uriToString(uri);
                 }
             }
-            catch (IllegalArgumentException ignored) {}
-            catch (URISyntaxException ignored) {}
+            catch (IllegalArgumentException | URISyntaxException ignored) {}
             result = canonicalizeDataFileURL(urlToLookup);
             _dataFileURLs.put(dataFileURL, result);
             _dataFileURLs.put(urlToLookup, result);
@@ -115,13 +110,7 @@ public abstract class XarSource implements Serializable
 
     protected abstract String canonicalizeDataFileURL(String dataFileURL) throws XarFormatException;
 
-    @Deprecated //Prefer the getLogFilePath version
-    public abstract File getLogFile() throws IOException;       // Log file always local file
-    public Path getLogFilePath() throws IOException
-    {
-        //TODO This should be overridden in inherited classes
-        return getLogFile().toPath();
-    }
+    public abstract Path getLogFilePath() throws IOException;
 
     /**
      * Called before trying to import this XAR to let the source set up any resources that are required 

--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -1089,7 +1089,8 @@ quickScan:
      * Returns the absolute path to a file. On Windows and Mac, corrects casing in file paths to match the
      * canonical path.
      */
-    public static File getAbsoluteCaseSensitiveFile(File file)
+    @NotNull
+    public static File getAbsoluteCaseSensitiveFile(@NotNull File file)
     {
         file = resolveFile(file.getAbsoluteFile());
         if (isCaseInsensitiveFileSystem())

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -878,10 +878,15 @@ public class XarReader extends AbstractXarImporter
 
             // Clear out any existing runs with the same LSID
             ExpRun existingRun = ExperimentService.get().getExpRun(runLSID);
-            if (existingRun != null && (_reloadExistingRuns || !Objects.equals(existingRun.getFilePathRoot() == null ? null : FileUtil.getAbsoluteCaseSensitiveFile(existingRun.getFilePathRoot()), _xarSource.getRoot() == null ? null : FileUtil.getAbsoluteCaseSensitiveFile(_xarSource.getRoot()))))
+            if (existingRun != null)
             {
-                getLog().debug("Deleting existing experiment run with LSID'" + runLSID + "' so that the run specified in the file can be uploaded");
-                existingRun.delete(getUser());
+                Path existingFilePathRoot = existingRun.getFilePathRoot() == null ? null : FileUtil.getAbsoluteCaseSensitivePath(getRootContext().getContainer(), existingRun.getFilePathRootPath());
+                Path newFilePathRoot = _xarSource.getRootPath() == null ? null : FileUtil.getAbsoluteCaseSensitivePath(getRootContext().getContainer(), _xarSource.getRootPath());
+                if (_reloadExistingRuns || !Objects.equals(existingFilePathRoot, newFilePathRoot))
+                {
+                    getLog().debug("Deleting existing experiment run with LSID'" + runLSID + "' so that the run specified in the file can be uploaded");
+                    existingRun.delete(getUser());
+                }
             }
         }
     }
@@ -1403,7 +1408,7 @@ public class XarReader extends AbstractXarImporter
     private ExpMaterial loadMaterial(MaterialBaseType xbMaterial,
                                   @Nullable ExperimentRun run,
                                   Integer sourceApplicationId,
-                                  XarContext context) throws XarFormatException, ExperimentException
+                                  XarContext context) throws ExperimentException
     {
         TableInfo tiMaterial = ExperimentServiceImpl.get().getTinfoMaterial();
 

--- a/experiment/src/org/labkey/experiment/pipeline/ExpGeneratorHelper.java
+++ b/experiment/src/org/labkey/experiment/pipeline/ExpGeneratorHelper.java
@@ -298,7 +298,7 @@ public class ExpGeneratorHelper
         ProvenanceService pvs = ProvenanceService.get();
         run.setProtocol(protocol);
         if (null != source)
-            run.setFilePathRoot(source.getRoot());
+            run.setFilePathRootPath(source.getRootPath());
         if (null != runJobId)
             run.setJobId(runJobId);
 

--- a/experiment/src/org/labkey/experiment/pipeline/MoveRunsTask.java
+++ b/experiment/src/org/labkey/experiment/pipeline/MoveRunsTask.java
@@ -208,14 +208,6 @@ public class MoveRunsTask extends PipelineJob.Task<MoveRunsTaskFactory>
         }
 
         @Override
-        public File getRoot()
-        {
-            if (FileUtil.hasCloudScheme(_root))
-                throw new RuntimeException("Root is in cloud.");
-            return getRootPath().toFile();
-        }
-
-        @Override
         public Path getRootPath()
         {
             return FileUtil.stringToPath(_sourceContainer, _root);
@@ -244,9 +236,9 @@ public class MoveRunsTask extends PipelineJob.Task<MoveRunsTaskFactory>
         }
 
         @Override
-        public File getLogFile()
+        public Path getLogFilePath()
         {
-            return _logFile;
+            return _logFile.toPath();
         }
 
         public String toString()

--- a/experiment/src/org/labkey/experiment/pipeline/XarGeneratorSource.java
+++ b/experiment/src/org/labkey/experiment/pipeline/XarGeneratorSource.java
@@ -19,7 +19,6 @@ import org.fhcrc.cpas.exp.xml.ExperimentArchiveDocument;
 import org.labkey.api.exp.AbstractFileXarSource;
 import org.labkey.api.pipeline.PipelineJob;
 
-import java.io.File;
 import java.nio.file.Path;
 
 /*
@@ -35,13 +34,13 @@ public class XarGeneratorSource extends AbstractFileXarSource
     }
 
     @Override
-    public ExperimentArchiveDocument getDocument()
+    public Path getLogFilePath()
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public File getLogFile()
+    public ExperimentArchiveDocument getDocument()
     {
         throw new UnsupportedOperationException();
     }

--- a/experiment/src/org/labkey/experiment/xar/XarExpander.java
+++ b/experiment/src/org/labkey/experiment/xar/XarExpander.java
@@ -55,6 +55,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -598,19 +599,14 @@ public class XarExpander extends AbstractXarImporter
         {
             try
             {
-                File f = new File(new URI(inputDir)).getParentFile();
-
-                File xarDir = _xarSource.getRoot();
+                Path f = new File(new URI(inputDir)).getParentFile().toPath();
+                Path xarDir = _xarSource.getRootPath();
 
                 inputDir = FileUtil.relativizeUnix(xarDir, f, true);
 
                 context.addSubstitution("InputDir", inputDir);
             }
-            catch (IOException e)
-            {
-                throw new XarFormatException(e);
-            }
-            catch (URISyntaxException e)
+            catch (IOException | URISyntaxException e)
             {
                 throw new XarFormatException(e);
             }
@@ -638,7 +634,7 @@ public class XarExpander extends AbstractXarImporter
                             XarContext context,
                             ExperimentRunType xbRun) throws ExperimentException
     {
-        FileResolver resolver = new FileResolver(_xarSource.getRoot());
+        FileResolver resolver = new FileResolver(_xarSource.getRootPath().toFile());
         for (ExperimentLogEntryType step : steps)
         {
             if (null == step.getStepCompleted())

--- a/internal/src/org/labkey/api/exp/AbstractFileXarSource.java
+++ b/internal/src/org/labkey/api/exp/AbstractFileXarSource.java
@@ -89,14 +89,6 @@ public abstract class AbstractFileXarSource extends XarSource
 
     @Override
     @Nullable
-    @Deprecated
-    public File getRoot()
-    {
-        return null != getRootPath()? getRootPath().toFile() : null;
-    }
-
-    @Override
-    @Nullable
     public Path getRootPath()
     {
         return null != getXmlFile()? getXmlFile().getParent(): null;

--- a/internal/src/org/labkey/api/exp/CompressedInputStreamXarSource.java
+++ b/internal/src/org/labkey/api/exp/CompressedInputStreamXarSource.java
@@ -82,13 +82,6 @@ public class CompressedInputStreamXarSource extends AbstractFileXarSource
     }
 
     @Override
-    public File getLogFile()
-    {
-        return _logFile.toFile();
-    }
-
-
-    @Override
     public Path getLogFilePath()
     {
         return _logFile;

--- a/internal/src/org/labkey/api/exp/CompressedXarSource.java
+++ b/internal/src/org/labkey/api/exp/CompressedXarSource.java
@@ -96,12 +96,6 @@ public class CompressedXarSource extends AbstractFileXarSource
     }
 
     @Override
-    public File getLogFile()
-    {
-        return getLogFilePath().toFile();
-    }
-
-    @Override
     public Path getLogFilePath()
     {
         try

--- a/internal/src/org/labkey/api/exp/FileXarSource.java
+++ b/internal/src/org/labkey/api/exp/FileXarSource.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.exp;
 
+import org.labkey.api.data.Container;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.util.FileUtil;
 
@@ -29,23 +30,16 @@ import java.nio.file.Path;
  */
 public class FileXarSource extends AbstractFileXarSource
 {
-    @Deprecated
-    public FileXarSource(File file, PipelineJob job)
-    {
-        super(job);
-        _xmlFile = file.toPath().normalize();
-    }
-
     public FileXarSource(Path file, PipelineJob job)
     {
         super(job);
         _xmlFile = file.normalize();
     }
 
-    @Deprecated
-    public File getLogFile() throws IOException
+    public FileXarSource(Path file, PipelineJob job, Container targetContainer)
     {
-        return getLogFilePath().toFile();
+        super(job.getDescription(), targetContainer, job.getUser(), job);
+        _xmlFile = file;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Checking in zipped files (like .xar files) makes it hard to edit and view diffs. We can easily handle importing .xar.xml files in folder archives, even if we always export in the compressed form

#### Changes
* Check for both .xar and .xar.xml files in folder archives
* Remove deprecated File method variants in favor of Path