### PR TITLE
45152: Support displaying Data Class data from subfolder

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
@@ -22,10 +22,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.AbstractTableInfo;
-import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.ContainerForeignKey;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.SQLFragment;
@@ -93,8 +91,11 @@ public class ExpDataClassTableImpl extends ExpTableImpl<ExpDataClassTable.Column
 
                 // Since the 'Name' column isn't a real PK column, we can't use the ShowDataClassAction with 'Name' as
                 // a parameter for the table's detailsURL.  However, we can use it as the url for this column.
-                c.setURL(new DetailsURL(new ActionURL(ExperimentController.ShowDataClassAction.class, _userSchema.getContainer()),
-                        Collections.singletonMap("name", "Name")));
+                DetailsURL nameURL = new DetailsURL(new ActionURL(ExperimentController.ShowDataClassAction.class, _userSchema.getContainer()),
+                        Collections.singletonMap("name", "Name"));
+                nameURL.setContainerContext(getContainer());
+                c.setURL(nameURL);
+
                 return c;
             }
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -148,6 +148,7 @@ import org.labkey.api.util.ErrorRenderer;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.ImageUtil;
+import org.labkey.api.util.Link;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
@@ -1025,13 +1026,12 @@ public class ExperimentController extends SpringActionController
         public ModelAndView getView(DataClassForm form, BindException errors)
         {
             _dataClass = form.getDataClass(null);
-            ensureCorrectContainer(getContainer(), _dataClass, getViewContext());
+            return new VBox(getDataClassPropertiesView(), getDataClassContentsView(errors));
+        }
 
-            ExpSchema expSchema = new ExpSchema(getUser(), getContainer());
-            UserSchema dataClassSchema = (UserSchema) expSchema.getSchema(ExpSchema.NestedSchemas.data.toString());
-            if (dataClassSchema == null)
-                throw new NotFoundException("exp.dataclass schema not found");
-            QueryView queryView = dataClassSchema.createView(getViewContext(), QueryView.DATAREGIONNAME_DEFAULT, _dataClass.getName(), errors);
+        private DetailsView getDataClassPropertiesView()
+        {
+            ExpSchema expSchema = new ExpSchema(getUser(), _dataClass.getContainer());
 
             TableInfo table = ExpSchema.TableType.DataClasses.createTable(expSchema, null, null);
             QueryUpdateForm tvf = new QueryUpdateForm(table, getViewContext(), null);
@@ -1041,28 +1041,71 @@ public class ExperimentController extends SpringActionController
 
             ButtonBar bb = new ButtonBar();
             bb.setStyle(ButtonBar.Style.separateButtons);
+            boolean inDefinitionContainer = getContainer().equals(_dataClass.getContainer());
 
-            DomainKind domainKind = _dataClass.getDomain().getDomainKind();
+            DomainKind<?> domainKind = _dataClass.getDomain().getDomainKind();
             if (domainKind != null && domainKind.canEditDefinition(getUser(), _dataClass.getDomain()))
             {
                 ActionURL updateURL = new ActionURL(EditDataClassAction.class, _dataClass.getContainer());
                 updateURL.addParameter("rowId", _dataClass.getRowId());
                 updateURL.addReturnURL(getViewContext().getActionURL());
-                ActionButton updateButton = new ActionButton(updateURL, "Edit", ActionButton.Action.LINK);
-                updateButton.setDisplayPermission(DesignDataClassPermission.class);
-                updateButton.setPrimary(true);
-                bb.add(updateButton);
 
-                ActionURL deleteURL = new ActionURL(ExperimentController.DeleteDataClassAction.class, _dataClass.getContainer());
+                if (inDefinitionContainer)
+                {
+                    ActionButton updateButton = new ActionButton(updateURL, "Edit", ActionButton.Action.LINK);
+                    updateButton.setDisplayPermission(DesignDataClassPermission.class);
+                    updateButton.setPrimary(true);
+                    bb.add(updateButton);
+                }
+                else if (_dataClass.getContainer().hasPermission(getUser(), DesignDataClassPermission.class))
+                {
+                    ActionButton updateButton = new ActionButton("Edit");
+                    updateButton.setURL("javascript:void(0)");
+                    updateButton.setActionType(ActionButton.Action.SCRIPT);
+                    updateButton.setScript("javascript: if (window.confirm('This data class is defined in the " + _dataClass.getContainer().getPath() + " folder. Would you still like to edit it?')) { window.location = '" + updateURL + "' }");
+                    updateButton.setPrimary(true);
+                    bb.add(updateButton);
+                }
+
+                ActionURL deleteURL = new ActionURL(DeleteDataClassAction.class, _dataClass.getContainer());
                 deleteURL.addParameter("singleObjectRowId", _dataClass.getRowId());
                 deleteURL.addReturnURL(ExperimentUrlsImpl.get().getDataClassListURL(getContainer()));
                 ActionButton deleteButton = new ActionButton(deleteURL, "Delete", ActionButton.Action.LINK);
-                deleteButton.setDisplayPermission(DesignDataClassPermission.class);
-                bb.add(deleteButton);
+
+                if (inDefinitionContainer)
+                {
+                    deleteButton.setDisplayPermission(DesignDataClassPermission.class);
+                    bb.add(deleteButton);
+                }
+                else if (_dataClass.getContainer().hasPermission(getUser(), DesignDataClassPermission.class))
+                {
+                    bb.add(deleteButton);
+                }
             }
             detailsView.getDataRegion().setButtonBar(bb);
 
-            return new VBox(detailsView, queryView);
+            if (!inDefinitionContainer)
+            {
+                ActionURL definitionURL = urlProvider(ExperimentUrls.class).getShowDataClassURL(_dataClass.getContainer(), _dataClass.getRowId());
+                Link.LinkBuilder link = PageFlowUtil.link(_dataClass.getContainer().getPath())
+                        .href(definitionURL)
+                        .clearClasses();
+                SimpleDisplayColumn definedInCol = new SimpleDisplayColumn(link.toString());
+                definedInCol.setCaption("Defined In");
+                detailsView.getDataRegion().addDisplayColumn(definedInCol);
+            }
+
+            return detailsView;
+        }
+
+        private QueryView getDataClassContentsView(BindException errors)
+        {
+            ExpSchema expSchema = new ExpSchema(getUser(), getContainer());
+            UserSchema dataClassSchema = (UserSchema) expSchema.getSchema(ExpSchema.NestedSchemas.data.toString());
+            if (dataClassSchema == null)
+                throw new NotFoundException("exp.dataclass schema not found");
+
+            return dataClassSchema.createView(getViewContext(), QueryView.DATAREGIONNAME_DEFAULT, _dataClass.getName(), errors);
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
This allows for Data Class data to be viewed and interacted with from folders that are not the definition folder. This addresses [45152](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45152) so users can now delete data in a Data Class in a subfolder.

#### Changes
* `ShowDataClassAction` now supports the following:
  * Displays Data Class Properties for Data Class cross-folder.
  * Adds a "Defined In: /Folder" if viewed away from definition folder.
  * Provides modal warning when navigating away from folder.
  * Button permissions determined by target folder for action.
* Links from Data Class listing are now folder relative. This allows for data to be browsed in the current folder.
