### PR TITLE
Defensive check in searchUsingIndex

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.146.0"
+        "@labkey/components": "2.149.5"
       },
       "devDependencies": {
         "@labkey/build": "6.0.0"
@@ -2181,9 +2181,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.146.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.146.0.tgz",
-      "integrity": "sha1-PgemZV3qc97PJDliySQs3uNUTUU=",
+      "version": "2.149.5",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.149.5.tgz",
+      "integrity": "sha1-i47tSjHSldM+dZeb2d3hzkTJeEY=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -10326,9 +10326,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.146.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.146.0.tgz",
-      "integrity": "sha1-PgemZV3qc97PJDliySQs3uNUTUU=",
+      "version": "2.149.5",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.149.5.tgz",
+      "integrity": "sha1-i47tSjHSldM+dZeb2d3hzkTJeEY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.146.0"
+    "@labkey/components": "2.149.5"
   },
   "devDependencies": {
     "@labkey/build": "6.0.0"

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.10.0",
-        "@labkey/components": "2.149.0",
+        "@labkey/components": "2.149.5",
         "@labkey/themes": "1.2.1"
       },
       "devDependencies": {
@@ -3022,9 +3022,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.149.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.149.0.tgz",
-      "integrity": "sha1-Wdxsp0Kdd38RHwL29Amf5HDzyt8=",
+      "version": "2.149.5",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.149.5.tgz",
+      "integrity": "sha1-i47tSjHSldM+dZeb2d3hzkTJeEY=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -17358,9 +17358,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.149.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.149.0.tgz",
-      "integrity": "sha1-Wdxsp0Kdd38RHwL29Amf5HDzyt8=",
+      "version": "2.149.5",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.149.5.tgz",
+      "integrity": "sha1-i47tSjHSldM+dZeb2d3hzkTJeEY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package.json
+++ b/core/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.10.0",
-    "@labkey/components": "2.149.0",
+    "@labkey/components": "2.149.5",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.149.3"
+        "@labkey/components": "2.149.5"
       },
       "devDependencies": {
         "@labkey/build": "6.0.0"
@@ -2181,9 +2181,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.149.3",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.149.3.tgz",
-      "integrity": "sha1-J6sODisb4sscoYE8n8jFx3fyJsg=",
+      "version": "2.149.5",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.149.5.tgz",
+      "integrity": "sha1-i47tSjHSldM+dZeb2d3hzkTJeEY=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -10326,9 +10326,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.149.3",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.149.3.tgz",
-      "integrity": "sha1-J6sODisb4sscoYE8n8jFx3fyJsg=",
+      "version": "2.149.5",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.149.5.tgz",
+      "integrity": "sha1-i47tSjHSldM+dZeb2d3hzkTJeEY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.149.3"
+    "@labkey/components": "2.149.5"
   },
   "devDependencies": {
     "@labkey/build": "6.0.0"

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.146.0"
+        "@labkey/components": "2.149.5"
       },
       "devDependencies": {
         "@labkey/build": "6.0.0",
@@ -2246,9 +2246,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.146.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.146.0.tgz",
-      "integrity": "sha1-PgemZV3qc97PJDliySQs3uNUTUU=",
+      "version": "2.149.5",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.149.5.tgz",
+      "integrity": "sha1-i47tSjHSldM+dZeb2d3hzkTJeEY=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -12331,9 +12331,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.146.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.146.0.tgz",
-      "integrity": "sha1-PgemZV3qc97PJDliySQs3uNUTUU=",
+      "version": "2.149.5",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.149.5.tgz",
+      "integrity": "sha1-i47tSjHSldM+dZeb2d3hzkTJeEY=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "2.146.0"
+    "@labkey/components": "2.149.5"
   },
   "devDependencies": {
     "@labkey/build": "6.0.0",


### PR DESCRIPTION
#### Rationale
This fixes an inadvertent failure in the concept picker for ontologies from a domain. The defensive check was added in `@labkey/components` with https://github.com/LabKey/labkey-ui-components/pull/792/commits/21cfa1a.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/789
* https://github.com/LabKey/platform/pull/3205
* https://github.com/LabKey/ontology/pull/81

#### Changes
* Bump `@labkey/components`.
