### PR TITLE
Issue 45132: Semicolon in file name truncates name upon download (#3183)

### DIFF
--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -5046,19 +5046,6 @@ public class DavController extends SpringActionController
         if (!StringUtils.isEmpty(contentDisposition))
         {
             getResponse().setContentDisposition(contentDisposition);
-            try
-            {
-                // https://bugs.chromium.org/p/chromium/issues/detail?id=1503
-                if (HttpUtil.isChrome(getRequest()))
-                {
-                    Path requestPath = new URLHelper(getRequest().getRequestURI()).getParsedPath();
-                    getResponse().setContentDisposition(contentDisposition + "; filename=" + requestPath.getName());
-                }
-            }
-            catch (URISyntaxException x)
-            {
-               // pass
-            }
         }
 
         // Find content type


### PR DESCRIPTION
#### Rationale
Back port the change to the download files Content-Disposition to 22.3
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45132

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3183

#### Changes
* Cherry-picked https://github.com/LabKey/platform/commit/8664045796d42b9b609a183af885fb5acacf333f
  * Removed the filename parameter from the Content-Dispostion header 
