### PR TITLE
Don't expect error logging from domain editor

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
@@ -166,9 +166,6 @@ public class StudyDatasetsTest extends BaseWebDriverTest
         final String mySubjectId = "MySubjectId";
         final String subjectIdDataset = "SubjectIdTest";
 
-        // Check the number of server errors.
-        int errorCountBefore = getServerErrorCount();
-
         goToManageStudy();
         waitAndClickAndWait(Locator.linkWithText("Change Study Properties"));
         waitForElement(Locator.name("SubjectColumnName"), WAIT_FOR_JAVASCRIPT);
@@ -187,7 +184,6 @@ public class StudyDatasetsTest extends BaseWebDriverTest
         fieldsPanel.removeField(subjectName);
         fieldsPanel.manuallyDefineFields(mySubjectId);
         designerPage.clickSave();
-        checkExpectedErrors(errorCountBefore + 2);
 
         goToManageStudy();
         waitAndClickAndWait(Locator.linkWithText("Change Study Properties"));


### PR DESCRIPTION
#### Rationale
This test was checking for error logs produced by attempting to use a reserved field name. This operation should never have been causing these errors to appear. The product is behaving properly now and the test should be updated.

#### Changes
* Remove check for server errors
