### PR TITLE
Allow 'WhoAmIAction' during upgrade

### DIFF
--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -2623,7 +2623,9 @@ public class LoginController extends SpringActionController
 
     @SuppressWarnings("unused")
     @RequiresNoPermission
+    @IgnoresTermsOfUse
     @IgnoresForbiddenProjectCheck
+    @AllowedDuringUpgrade
     public class WhoAmIAction extends ReadOnlyApiAction
     {
         @Override


### PR DESCRIPTION
#### Rationale
Tests use `WhoAmIAction` during setup. It causes test to fail during upgrade sometimes.
```
java.lang.RuntimeException: Failed to fetch current user info.
	at org.labkey.test.WebDriverWrapper.whoAmI(WebDriverWrapper.java:1196)
	at org.labkey.test.WebDriverWrapper.getCurrentUser(WebDriverWrapper.java:1202)
	at org.labkey.test.LabKeySiteWrapper.simpleSignIn(LabKeySiteWrapper.java:138)
	at org.labkey.test.LabKeySiteWrapper.signIn(LabKeySiteWrapper.java:338)
	at org.labkey.test.BaseWebDriverTest.doPreamble(BaseWebDriverTest.java:587)
```

#### Changes
* Allow `WhoAmIAction` during upgrade, ignoring terms of use.
