### PR TITLE
Set protocol status to 'active' for Application Type 'ExperimentRun'

### DIFF
--- a/experiment/resources/schemas/dbscripts/postgresql/exp-22.001-22.002.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-22.001-22.002.sql
@@ -1,1 +1,1 @@
-UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun';
+UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun' WHERE Status IS NULL;

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-22.001-22.002.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-22.001-22.002.sql
@@ -1,1 +1,1 @@
-UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun' WHERE Status IS NULL;
+UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun' AND Status IS NULL;

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-22.001-22.002.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-22.001-22.002.sql
@@ -1,0 +1,1 @@
+UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun';

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-22.001-22.002.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-22.001-22.002.sql
@@ -1,1 +1,1 @@
-UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun';
+UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun' WHERE Status IS NULL;

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-22.001-22.002.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-22.001-22.002.sql
@@ -1,1 +1,1 @@
-UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun' WHERE Status IS NULL;
+UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun' AND Status IS NULL;

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-22.001-22.002.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-22.001-22.002.sql
@@ -1,0 +1,1 @@
+UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun';

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -162,7 +162,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     public Double getSchemaVersion()
     {
-        return 22.001;
+        return 22.002;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -7576,6 +7576,7 @@ public class ExperimentServiceImpl implements ExperimentService
 
             Protocol baseProtocol = ((ExpProtocolImpl)wrappedProtocol).getDataObject();
             wrappedProtocol.setApplicationType(ExpProtocol.ApplicationType.ExperimentRun);
+            wrappedProtocol.setStatus(ExpProtocol.Status.Active);
             baseProtocol.setOutputDataType(ExpData.DEFAULT_CPAS_TYPE);
             baseProtocol.setOutputMaterialType(ExpMaterial.DEFAULT_CPAS_TYPE);
             baseProtocol.setContainer(baseProtocol.getContainer());


### PR DESCRIPTION
#### Rationale
During (Panorama) folder import, running into
"Protocol with LSID 'urn:lsid:labkey.com:Protocol.Folder-20:...' does not match existing protocol"
'Status differs: 'null' vs 'Active'

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/515

#### Changes
* Set protocol status to 'active' for Application Type 'ExperimentRun' in insertSimpleProtocol() to match other areas in the code (Ex. XarReader.java, line 2266 and upgrade script exp-21.016-21.017.sql)
