### PR TITLE
Improve AttachmentFile implementations & add WikiService.getAllContent

### DIFF
--- a/api/src/org/labkey/api/attachments/ByteArrayAttachmentFile.java
+++ b/api/src/org/labkey/api/attachments/ByteArrayAttachmentFile.java
@@ -74,6 +74,7 @@ public class ByteArrayAttachmentFile implements AttachmentFile
         if (_inputStream == null)
             throw new IllegalStateException("No input stream is active for this ByteArrayAttachmentFile");
         _inputStream.close();
+        _inputStream = null;
     }
 
     @Override

--- a/api/src/org/labkey/api/attachments/ByteArrayAttachmentFile.java
+++ b/api/src/org/labkey/api/attachments/ByteArrayAttachmentFile.java
@@ -64,6 +64,7 @@ public class ByteArrayAttachmentFile implements AttachmentFile
     {
         if (_inputStream != null)
             throw new IllegalStateException("An unclosed input stream is already active for this ByteArrayAttachmentFile");
+
         _inputStream = new BufferedInputStream(new ByteArrayInputStream(_content));
         return _inputStream;
     }
@@ -73,6 +74,7 @@ public class ByteArrayAttachmentFile implements AttachmentFile
     {
         if (_inputStream == null)
             throw new IllegalStateException("No input stream is active for this ByteArrayAttachmentFile");
+
         _inputStream.close();
         _inputStream = null;
     }

--- a/api/src/org/labkey/api/attachments/FileAttachmentFile.java
+++ b/api/src/org/labkey/api/attachments/FileAttachmentFile.java
@@ -71,6 +71,9 @@ public class FileAttachmentFile implements AttachmentFile
     @Override
     public InputStream openInputStream() throws IOException
     {
+        if (_in != null)
+            throw new IllegalStateException("An unclosed input stream is already active for this FileAttachmentFile");
+
         _in = new FileInputStream(_file);
         return _in;
     }
@@ -78,8 +81,11 @@ public class FileAttachmentFile implements AttachmentFile
     @Override
     public void closeInputStream() throws IOException
     {
-        if (null != _in)
-            _in.close();
+        if (_in == null)
+            throw new IllegalStateException("No input stream is active for this FileAttachmentFile");
+
+        _in.close();
+        _in = null;
     }
 
     @Override

--- a/api/src/org/labkey/api/attachments/SpringAttachmentFile.java
+++ b/api/src/org/labkey/api/attachments/SpringAttachmentFile.java
@@ -90,6 +90,9 @@ public class SpringAttachmentFile implements AttachmentFile
     @Override
     public InputStream openInputStream() throws IOException
     {
+        if (_in != null)
+            throw new IllegalStateException("An unclosed input stream is already active for this SpringAttachmentFile");
+
         _in = _file.getInputStream();
         return _in;
     }
@@ -97,8 +100,11 @@ public class SpringAttachmentFile implements AttachmentFile
     @Override
     public void closeInputStream() throws IOException
     {
-        if (null != _in)
-            _in.close();
+        if (_in == null)
+            throw new IllegalStateException("No input stream is active for this SpringAttachmentFile");
+
+        _in.close();
+        _in = null;
     }
 
     public static List<AttachmentFile> createList(Map<String, MultipartFile> fileMap)

--- a/api/src/org/labkey/api/dataiterator/AttachmentDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/AttachmentDataIterator.java
@@ -158,7 +158,8 @@ public class AttachmentDataIterator extends WrapperDataIterator
             {
                 for (AttachmentFile attachmentFile : attachmentFiles)
                 {
-                    try { attachmentFile.closeInputStream(); } catch (IOException ignored) {}
+                    try { attachmentFile.closeInputStream(); }
+                    catch (IOException | IllegalStateException ignored) {}
                 }
             }
         }

--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -574,7 +574,17 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
             if (loader != null)
                 loader.close();
             if (null != file)
-                file.closeInputStream();
+            {
+                try
+                {
+                    file.closeInputStream();
+                }
+                catch (IllegalStateException e)
+                {
+                    // This is fine, this means that the exception that we caught above was thrown before we ever opened
+                    // the InputStream for the file.
+                }
+            }
             if (null != dataFile && !Boolean.parseBoolean(saveToPipeline) && !_useAsync)
                 dataFile.delete();
         }

--- a/api/src/org/labkey/api/wiki/WikiService.java
+++ b/api/src/org/labkey/api/wiki/WikiService.java
@@ -70,6 +70,11 @@ public interface WikiService
     String getContent(Container c, String wikiName);
 
     /**
+     * Returns the raw (unformatted) content for every version of the wiki
+     */
+    List<String> getAllContent(Container c, String wikiName);
+
+    /**
      * Update the content of a wiki
      *
      * @param wikiName The name of the wiki to update

--- a/api/src/org/labkey/api/wiki/WikiService.java
+++ b/api/src/org/labkey/api/wiki/WikiService.java
@@ -67,12 +67,12 @@ public interface WikiService
     /**
      * Returns the raw (unformatted) content
      */
-    String getContent(Container c, String wikiName);
+    @Nullable String getContent(Container c, String wikiName);
 
     /**
      * Returns the raw (unformatted) content for every version of the wiki
      */
-    List<String> getAllContent(Container c, String wikiName);
+    @Nullable List<String> getAllContent(Container c, String wikiName);
 
     /**
      * Update the content of a wiki

--- a/core/src/org/labkey/core/attachment/DatabaseAttachmentFile.java
+++ b/core/src/org/labkey/core/attachment/DatabaseAttachmentFile.java
@@ -119,6 +119,9 @@ public class DatabaseAttachmentFile implements AttachmentFile
     @Override
     public void closeInputStream()
     {
+        if (_is == null)
+            throw new IllegalStateException("No input stream is active for this DatabaseAttachmentFile");
+
         IOUtils.closeQuietly(_is);
         _is = null;
         _rs = ResultSetUtil.close(_rs);

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -999,6 +999,22 @@ public class WikiManager implements WikiService
     }
 
     @Override
+    public List<String> getAllContent(Container c, String wikiName)
+    {
+        Wiki wiki = WikiSelectManager.getWiki(c, wikiName);
+
+        if (null == wiki)
+            return null;
+
+        List<String> allContent = new ArrayList<>();
+
+        for (WikiVersion version : WikiSelectManager.getAllVersions(wiki))
+            allContent.add(version.getBody());
+
+        return allContent;
+    }
+
+    @Override
     public boolean updateContent(Container c, User user, String wikiName, String content, @Nullable Integer newVersionThreshold)
     {
         if (content != null)


### PR DESCRIPTION
#### Rationale
This PR does a few things that are needed for the improved embedded attachment behavior in ELN (see changes below).

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1239
* https://github.com/LabKey/labbook/pull/155

#### Changes
* Make the behavior for openInputStream and closeInputStream consistent across all AttachmentFile implementations
  * InputStreamAttachmentFile is the one exception, because it cannot be re-opened.
* Adds getAllContent to WikiService so modules can fetch the content for every version of a given wiki
  * This is needed so we can search previous versions for attachments and remove any attachments that do not exist in any version of a wiki.
