### PR TITLE
Allow dependencies (e.g., biojava) to include log4j2.xml files

### DIFF
--- a/core/src/org/labkey/core/admin/logger/LoggingTestCase.java
+++ b/core/src/org/labkey/core/admin/logger/LoggingTestCase.java
@@ -23,28 +23,38 @@ public class LoggingTestCase extends Assert
     @Test
     public void testXmlFiles() throws IOException
     {
-        test("log4j2.xml", List.of("labkeyWebapp/WEB-INF/classes/log4j2.xml")); // Our standard log4j2.xml file
+        // BioJava jars add log4j2.xml files to the class path. Tolerate them, but verify that LabKey's standard
+        // log4j2.xml file is found first.
+        String filename = "log4j2.xml";
+        String substring = "labkeyWebapp/WEB-INF/classes/log4j2.xml"; // Our standard log4j2.xml file
+
+        List<URL> list = Collections.list(getClass().getClassLoader().getResources(filename));
+        assertFalse("Didn't find expected file: " + filename, list.isEmpty());
+        String first = list.get(0).toString();
+        assertTrue("Did not find substring \"" + substring + "\" in file path of the first " + filename + " file on the class path. Here's what was found: "
+            + list.stream().map(URL::toString).collect(Collectors.joining(", ")), first.contains(substring));
     }
 
     @Test
     public void testPropertiesFiles() throws IOException
     {
-        test("log4j2.properties", Collections.emptyList());
+        strictTest("log4j2.properties", Collections.emptyList());
     }
 
     @Test
     public void testOldXmlFiles() throws IOException
     {
-        test("log4j.xml", List.of("jxl-2.6.3.jar")); // Issue #45119
+        strictTest("log4j.xml", List.of("jxl-2.6.3.jar")); // Issue #45119
     }
 
     @Test
     public void testOldPropertiesFiles() throws IOException
     {
-        test("log4j.properties", List.of("activeio-core-3.1.0-tests.jar")); // Issue #45120
+        strictTest("log4j.properties", List.of("activeio-core-3.1.0-tests.jar")); // Issue #45120
     }
 
-    private void test(String filename, List<String> expectedSubstrings) throws IOException
+    // Must find all expected substrings and no others
+    private void strictTest(String filename, List<String> expectedSubstrings) throws IOException
     {
         List<URL> list = Collections.list(getClass().getClassLoader().getResources(filename));
         assertEquals("Found the wrong number of " + filename + " files on the class path: " + list.stream().map(URL::toString).collect(Collectors.joining(", ")), expectedSubstrings.size(), list.size());


### PR DESCRIPTION
#### Rationale
Relax `log4j2.xml` test to simply verify that the first file found on the class path is LabKey's