### PR TITLE
Item 10239: Panorama QC Plot improvements/cleanup (part 1)

### DIFF
--- a/internal/webapp/vis/src/internal/D3Renderer.js
+++ b/internal/webapp/vis/src/internal/D3Renderer.js
@@ -13,7 +13,7 @@ LABKEY.vis.internal.Axis = function() {
     // different colored tick & gridlines, etc.
     var scale, orientation, tickFormat = function(v) {return v}, tickHover, tickCls, ticks, tickMouseOver, tickMouseOut,
         tickRectCls, tickRectHeightOffset = 12, tickRectWidthOffset = 8, tickClick, axisSel, tickSel, textSel, gridLineSel,
-        borderSel, grid, scalesList = [], gridLinesVisible = 'both', tickDigits, tickValues, tickLabelMax,
+        borderSel, grid, scalesList = [], gridLinesVisible = 'both', tickDigits, tickValues, tickMax, tickLabelMax,
         tickColor = '#000000', tickTextColor = '#000000', gridLineColor = '#DDDDDD', borderColor = '#000000',
         tickPadding = 0, tickLength = 8, tickWidth = 1, tickOverlapRotation = 15, gridLineWidth = 1, borderWidth = 1,
         fontFamily = 'Roboto, arial, helvetica, sans-serif', fontSize = 11, adjustedStarts, adjustedEnds, xLogGutterBorder = 0, yLogGutterBorder = 0,
@@ -31,6 +31,15 @@ LABKEY.vis.internal.Axis = function() {
             data = scale.ticks(ticks);
         } else {
             data = scale.domain();
+        }
+
+        if (tickMax && data.length > tickMax) {
+            var nthDataArr = [];
+            var nth = Math.max(Math.floor( data.length / tickMax), 1);
+            for (var i = 0; i < data.length; i=i+nth) {
+                nthDataArr.push(data[i]);
+            }
+            data = nthDataArr;
         }
 
         // issue 22297: axis values can end up with rounding issues (i.e. 1.4000000000000001)
@@ -496,6 +505,7 @@ LABKEY.vis.internal.Axis = function() {
     axis.tickFormat = function(f) {tickFormat = f; return axis;};
     axis.tickDigits = function(h) {tickDigits = h; return axis;};
     axis.tickValues = function(h) {tickValues = h; return axis;};
+    axis.tickMax = function(h) {tickMax = h; return axis;};
     axis.tickLabelMax = function(h) {tickLabelMax = h; return axis;};
     axis.tickHover = function(h) {tickHover = h; return axis;};
     axis.tickCls = function(c) {tickCls = c; return axis;};
@@ -833,6 +843,10 @@ LABKEY.vis.internal.D3Renderer = function(plot) {
 
             if (plot.scales[name].tickDigits) {
                 indAxis.tickDigits(plot.scales[name].tickDigits);
+            }
+
+            if (plot.scales[name].tickMax) {
+                indAxis.tickMax(plot.scales[name].tickMax);
             }
 
             if (plot.scales[name].tickLabelMax) {

--- a/internal/webapp/vis/src/internal/D3Renderer.js
+++ b/internal/webapp/vis/src/internal/D3Renderer.js
@@ -1907,6 +1907,18 @@ LABKEY.vis.internal.D3Renderer = function(plot) {
                         y = Math.floor(parseInt(sibling.getAttribute('y'))) - 3.5;
                     return 'translate(' + glyphX + ',' + y + ')';
                 });
+
+        if (plot.originalAes.legend && plot.originalAes.legend.mouseOverFn) {
+            selection.on('mouseover', function (data) {
+                plot.originalAes.legend.mouseOverFn.call(d3.event, data, this);
+            });
+
+            if (plot.originalAes.legend.mouseOutFn) {
+                selection.on('mouseout', function(data) {
+                    plot.originalAes.legend.mouseOutFn.call(d3.event, data, this);
+                });
+            }
+        }
     };
 
     var setLegendData = function(legendData) {

--- a/internal/webapp/vis/src/plot.js
+++ b/internal/webapp/vis/src/plot.js
@@ -1627,14 +1627,18 @@ boxPlot.render();
  * @param {Array} [config.properties.yAxisDomain] (Optional) Y-axis min/max values. Example: [0,20].
  * @param {String} [config.properties.color] (Optional) The data property name for the color to be used for the data point.
  * @param {Array} [config.properties.colorRange] (Optional) The array of color values to use for the data points.
+ * @param {Function} [config.properties.pointSize] (Optional) The LABKEY.vis.Geom.Point size.
  * @param {Function} [config.properties.pointOpacityFn] (Optional) A function to be called with the point data to
  *                  return an opacity value for that point.
  * @param {String} [config.groupBy] (optional) The data property name used to group plot lines and points.
  * @param {Function} [config.properties.hoverTextFn] (Optional) The hover text to display for each data point. The parameter
  *                  to that function will be a row of data with access to all values for that row.
  * @param {Function} [config.properties.mouseOverFn] (Optional) The function to call on data point mouse over. The parameters to
- *                  that function will be the click event, the point data, the selection layer, and the DOM element for the point itself.
+ *                  that function will be the mouse event, the point data, the selection layer, and the DOM element for the point itself.
  * @param {Object} [config.properties.mouseOverFnScope] (Optional) The scope to use for the call to mouseOverFn.
+ * @param {Function} [config.properties.mouseOutFn] (Optional) The function to call on data point mouse out. The parameters to
+ *                  that function will be the mouse event, the point data, and the selection layer.
+ * @param {Object} [config.properties.mouseOutFnScope] (Optional) The scope to use for the call to mouseOutFn.
  * @param {Function} [config.properties.pointClickFn] (Optional) The function to call on data point click. The parameters to
  *                  that function will be the click event and the row of data for the selected point.
  * @param {String} [config.properties.lineColor] (Optional) The color to be used for the trend line connecting data points.
@@ -2186,8 +2190,8 @@ boxPlot.render();
             {
                 var pathLayerConfig = {
                     geom: new LABKEY.vis.Geom.Path({
-                        opacity: .6,
-                        size: 2,
+                        opacity: 1,
+                        size: 1,
                         dashed: config.qcPlotType == LABKEY.vis.TrendingLinePlotType.CUSUM && !negativeCusum,
                         color: config.properties.lineColor
                     }),
@@ -2279,7 +2283,7 @@ boxPlot.render();
                 geom: new LABKEY.vis.Geom.Point({
                     position: config.properties.position,
                     opacity: config.properties.pointOpacityFn,
-                    size: 3
+                    size: config.properties.pointSize ? config.properties.pointSize : 3
                 }),
                 aes: {}
             };
@@ -2321,11 +2325,16 @@ boxPlot.render();
                 d3.select(event.srcElement).transition().duration(800).attr("stroke-width", 5).ease("elastic");
 
                 if (config.properties.mouseOverFn) {
-                    config.properties.mouseOverFn.call(config.properties.mouseOverFnScope || this, event, pointData, layerSel, point, valueName);
+                    config.properties.mouseOverFn.call(config.properties.mouseOverFnScope || this, event, pointData, layerSel, point, valueName, config);
                 }
             };
+
             pointLayerConfig.aes.mouseOutFn = function(event, pointData, layerSel) {
                 d3.select(event.srcElement).transition().duration(800).attr("stroke-width", 1).ease("elastic");
+
+                if (config.properties.mouseOutFn) {
+                    config.properties.mouseOutFn.call(config.properties.mouseOutFnScope || this, event, pointData, layerSel, valueName, config);
+                }
             };
 
             if (config.properties.pointIdAttr) {

--- a/internal/webapp/vis/src/plot.js
+++ b/internal/webapp/vis/src/plot.js
@@ -1642,6 +1642,12 @@ boxPlot.render();
  * @param {Function} [config.properties.pointClickFn] (Optional) The function to call on data point click. The parameters to
  *                  that function will be the click event and the row of data for the selected point.
  * @param {String} [config.properties.lineColor] (Optional) The color to be used for the trend line connecting data points.
+ * @param {Function} [config.properties.legendMouseOverFn] (Optional) The function to call on legend item mouse over. The parameters to
+ *                  that function will be the mouse event, legend data, and the DOM element for the legend itself.
+ * @param {Object} [config.properties.legendMouseOverFnScope] (Optional) The scope to use for the call to legendMouseOverFn.
+ * @param {Function} [config.properties.legendMouseOutFn] (Optional) The function to call on legend item mouse out. The parameters to
+ *                  that function will be the mouse event, and the legend data.
+ * @param {Object} [config.properties.legendMouseOutFnScope] (Optional) The scope to use for the call to legendMouseOutFn.
  */
 (function(){
     LABKEY.vis.TrendingLinePlotType = {
@@ -2084,6 +2090,23 @@ boxPlot.render();
             }
         }
 
+        config.aes = {
+            x: 'seqValue'
+        };
+
+        if (config.properties.legendMouseOverFn) {
+            config.aes.legend = {};
+            config.aes.legend.mouseOverFn = function(data, item) {
+                config.properties.legendMouseOverFn.call(config.properties.legendMouseOverFnScope || this, data, item);
+            };
+
+            if (config.properties.legendMouseOutFn) {
+                config.aes.legend.mouseOutFn = function(data, item) {
+                    config.properties.legendMouseOutFn.call(config.properties.legendMouseOutFnScope || this, data, item);
+                };
+            }
+        }
+
         if(!config.margins) {
             config.margins = {};
         }
@@ -2104,10 +2127,6 @@ boxPlot.render();
         if(!config.margins.left) {
             config.margins.left = config.labels && config.labels.y ? 75 : 55;
         }
-
-        config.aes = {
-            x: 'seqValue'
-        };
 
         // determine the width the error bars
         if (config.properties.disableRangeDisplay) {

--- a/internal/webapp/vis/src/plot.js
+++ b/internal/webapp/vis/src/plot.js
@@ -2014,6 +2014,8 @@ boxPlot.render();
             yAxisScaleOverride = 'linear';
         }
 
+        var tickMax = Math.floor(config.width / 50);
+
         config.scales = {
             color: {
                 scaleType: 'discrete',
@@ -2025,15 +2027,9 @@ boxPlot.render();
             },
             x: {
                 scaleType: 'discrete',
-                tickMax: config.width ? Math.floor(config.width / 5) : undefined,
+                tickMax: tickMax,
                 tickFormat: function(index) {
-                    // only show a max of 35 labels on the x-axis to avoid overlap
-                    if (index % Math.ceil(config.data[config.data.length-1].seqValue / 35) == 0) {
-                        return tickLabelMap[index];
-                    }
-                    else {
-                        return "";
-                    }
+                    return tickLabelMap[index];
                 },
                 tickCls: function(index) {
                     var baseTag = 'ticklabel';

--- a/internal/webapp/vis/src/plot.js
+++ b/internal/webapp/vis/src/plot.js
@@ -2025,7 +2025,7 @@ boxPlot.render();
             },
             x: {
                 scaleType: 'discrete',
-                tickMax: 250,
+                tickMax: config.width ? Math.floor(config.width / 5) : undefined,
                 tickFormat: function(index) {
                     // only show a max of 35 labels on the x-axis to avoid overlap
                     if (index % Math.ceil(config.data[config.data.length-1].seqValue / 35) == 0) {

--- a/internal/webapp/vis/src/plot.js
+++ b/internal/webapp/vis/src/plot.js
@@ -1629,6 +1629,7 @@ boxPlot.render();
  * @param {Array} [config.properties.yAxisDomain] (Optional) Y-axis min/max values. Example: [0,20].
  * @param {String} [config.properties.color] (Optional) The data property name for the color to be used for the data point.
  * @param {Array} [config.properties.colorRange] (Optional) The array of color values to use for the data points.
+ * @param {Array} [config.properties.shapeRange] (Optional) The array of shape values to use for the data points.
  * @param {Function} [config.properties.pointSize] (Optional) The LABKEY.vis.Geom.Point size.
  * @param {Function} [config.properties.pointOpacityFn] (Optional) A function to be called with the point data to
  *                  return an opacity value for that point.
@@ -2017,6 +2018,10 @@ boxPlot.render();
             color: {
                 scaleType: 'discrete',
                 range: config.properties.colorRange
+            },
+            shape: {
+                scaleType: 'discrete',
+                range: config.properties.shapeRange
             },
             x: {
                 scaleType: 'discrete',

--- a/internal/webapp/vis/src/plot.js
+++ b/internal/webapp/vis/src/plot.js
@@ -60,6 +60,7 @@
  *          <li><strong>tickFormat:</strong> Add axis label formatting.</li>
  *          <li><strong>tickValues:</strong> Define the axis tick values. Array of values.</li>
  *          <li><strong>tickDigits:</strong> Convert axis tick to exponential form if equal or greater than number of digits</li>
+ *          <li><strong>tickMax:</strong> Maximum number of tick marks to show for an axis.</li>
  *          <li><strong>tickLabelMax:</strong> Maximum number of tick labels to show for a categorical axis.</li>
  *          <li><strong>tickHoverText:</strong>: Adds hover text for axis labels.</li>
  *          <li><strong>tickCls:</strong> Add class to axis label.</li>
@@ -383,6 +384,7 @@ boxPlot.render();
                 newScale.tickValues = origScale.tickValues ? origScale.tickValues : null;
                 newScale.tickFormat = origScale.tickFormat ? origScale.tickFormat : null;
                 newScale.tickDigits = origScale.tickDigits ? origScale.tickDigits : null;
+                newScale.tickMax = origScale.tickMax ? origScale.tickMax : null;
                 newScale.tickLabelMax = origScale.tickLabelMax ? origScale.tickLabelMax : null;
                 newScale.tickHoverText = origScale.tickHoverText ? origScale.tickHoverText : null;
                 newScale.tickCls = origScale.tickCls ? origScale.tickCls : null;
@@ -2018,6 +2020,7 @@ boxPlot.render();
             },
             x: {
                 scaleType: 'discrete',
+                tickMax: 250,
                 tickFormat: function(index) {
                     // only show a max of 35 labels on the x-axis to avoid overlap
                     if (index % Math.ceil(config.data[config.data.length-1].seqValue / 35) == 0) {


### PR DESCRIPTION
#### Rationale
We want to make the QC plots as useful as possible in their default configuration, optimize them for readability, make their reportings actionable by the user, keep them performant, and more. This PR updates the LABKEY.vis.TrendingLinePlot and the related plot configurations to support the changes mentioned in the targetedms PR.

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/518
* https://github.com/LabKey/platform/pull/3237
* https://github.com/LabKey/PanoramaPremiumModules/pull/89

#### Changes
* add tickMax property to control the maximum number of tick marks to show on the x-axis
* add legend mouseOverFn and mouseOutFn
* add shapeRange and plotSize plot config props for trendline plot type
