### PR TITLE
fix to ensureRequiredColumns

### DIFF
--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -1674,17 +1674,24 @@ public class QueryServiceImpl implements QueryService
     {
         AliasManager manager = new AliasManager(table, columns);
 
+        /* What is the difference between ret and columnMap?
+         *   "ret" is the list of columns that needs to be selected, while columnMap may include some
+         *   additional "intermediate" lookup columns.  For instance, if you select A, and A/B/C,
+         *   then columnMap will end up with A/B.
+         */
+        LinkedHashMap<FieldKey, ColumnInfo> ret = new LinkedHashMap<>();
         for (ColumnInfo column : columns)
-            columnMap.put(column.getFieldKey(), column);
-
-        ArrayList<ColumnInfo> ret = new ArrayList<>(columns);
+        {
+            columnMap.putIfAbsent(column.getFieldKey(), column);
+            ret.putIfAbsent(column.getFieldKey(), column);
+        }
 
         // Add container column if needed
         ColumnInfo containerColumn = table.getColumn("Container");
         if (null != containerColumn && !columnMap.containsKey(containerColumn.getFieldKey()) && containerColumn.isRequired())
         {
-            ret.add(containerColumn);
             columnMap.put(FieldKey.fromString("Container"), containerColumn);
+            ret.putIfAbsent(containerColumn.getFieldKey(), containerColumn);
         }
 
         // foreign keys
@@ -1713,7 +1720,7 @@ public class QueryServiceImpl implements QueryService
             {
                 ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager);
                 if (col != null)
-                    ret.add(col);
+                    ret.putIfAbsent(col.getFieldKey(),col);
             }
         }
 
@@ -1724,9 +1731,7 @@ public class QueryServiceImpl implements QueryService
             {
                 ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager);
                 if (col != null)
-                    ret.add(col);
-                else if (columnMap.containsKey(fieldKey))
-                    ret.add(columnMap.get(fieldKey));
+                    ret.putIfAbsent(col.getFieldKey(),col);
             }
         }
 
@@ -1737,7 +1742,7 @@ public class QueryServiceImpl implements QueryService
                 ColumnInfo col = resolveFieldKey(field.getFieldKey(), table, columnMap, unresolvedColumns, manager);
                 if (col != null)
                 {
-                    ret.add(col);
+                    ret.putIfAbsent(col.getFieldKey(),col);
                     resolveSortColumns(col, columnMap, manager, ret, allInvolvedColumns, false);
                 }
                 //the column might be displayed, but also used as a sort.  if so, we need to ensure we include sortFieldKeys
@@ -1765,13 +1770,13 @@ public class QueryServiceImpl implements QueryService
             }
         }
 
-        allInvolvedColumns.addAll(ret);
-        return ret;
+        allInvolvedColumns.addAll(ret.values());
+        return new ArrayList<>(ret.values());
     }
 
 
-    private ArrayList<ColumnInfo> resolveSortColumns(ColumnInfo col, Map<FieldKey, ColumnInfo> columnMap, AliasManager manager,
-                                                     ArrayList<ColumnInfo> ret, Set<ColumnInfo> allInvolvedColumns, boolean addSortKeysOnly)
+    private void resolveSortColumns(ColumnInfo col, Map<FieldKey, ColumnInfo> columnMap, AliasManager manager,
+                                                     LinkedHashMap<FieldKey,ColumnInfo> ret, Set<ColumnInfo> allInvolvedColumns, boolean addSortKeysOnly)
     {
         if (col.getSortFieldKeys() != null || null != col.getMvColumnName())
         {
@@ -1801,29 +1806,23 @@ public class QueryServiceImpl implements QueryService
                 }
             }
 
-            ret.addAll(toAdd);
+            toAdd.forEach(c -> ret.putIfAbsent(c.getFieldKey(), c));
             allInvolvedColumns.addAll(toAdd);
         }
         else
         {
             if (!addSortKeysOnly)
             {
-                if (!columnMap.containsKey(col.getFieldKey()))
-                    ret.add(col);
+                ret.putIfAbsent(col.getFieldKey(),col);
                 allInvolvedColumns.add(col);
             }
         }
-
-        return ret;
     }
 
 
     private ColumnInfo resolveFieldKey(FieldKey fieldKey, TableInfo table, Map<FieldKey, ColumnInfo> columnMap, Set<FieldKey> unresolvedColumns, AliasManager manager)
     {
         if (fieldKey == null)
-            return null;
-
-        if (columnMap.containsKey(fieldKey))
             return null;
 
         // This could be made more general, but I don't think there's a need.  To reduce testing
@@ -1852,11 +1851,9 @@ public class QueryServiceImpl implements QueryService
             // getColumn() might return a column with a different field key than we asked for!
             if (!column.getFieldKey().equals(fieldKey))
             {
+                LOG.error("WTF: requested " + fieldKey + " got " + column.getFieldKey());
                 if (columnMap.containsKey(column.getFieldKey()))
-                {
                     columnMap.put(fieldKey, columnMap.get(column.getFieldKey()));
-                    return null;
-                }
             }
 
             return column;

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -1851,7 +1851,6 @@ public class QueryServiceImpl implements QueryService
             // getColumn() might return a column with a different field key than we asked for!
             if (!column.getFieldKey().equals(fieldKey))
             {
-                LOG.error("WTF: requested " + fieldKey + " got " + column.getFieldKey());
                 if (columnMap.containsKey(column.getFieldKey()))
                     columnMap.put(fieldKey, columnMap.get(column.getFieldKey()));
             }


### PR DESCRIPTION
#### Rationale
ensureRequiredColumns() has always had weird order of insertion dependent behaviors.  Insertion order into columnMap would change when resolveFieldKey() would return null or not.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
I changed "ret" from a List into a LinkedHashMap so it can handle duplicates itself.
resolveFieldKey() always returns the resolved column instead of trying to be clever and sometimes returning null.
