### PR TITLE
Show the "Manage Remote Connections" button only if dataintegration is present

### DIFF
--- a/internal/src/org/labkey/remoteapi/RemoteConnections.java
+++ b/internal/src/org/labkey/remoteapi/RemoteConnections.java
@@ -45,6 +45,14 @@ public class RemoteConnections
     public static String CONNECTION_KIND_QUERY = "query";
     public static String CONNECTION_KIND_FILE = "file";
 
+    // Instructions/warning displayed on both manage and edit pages
+    public static String MANAGEMENT_PAGE_INSTRUCTIONS =
+        """
+        Administrators can define remote connections to other LabKey Server instances and then use them in ETLs to move
+        data between instances. This feature should be used with care since all schemas in the remote folder will be
+        available to anyone writing or running ETLs.";
+        """;
+
     public static @NotNull Map<String, String> getRemoteConnection(String connectionCategory, String name, Container container)
     {
         return PropertyManager.getEncryptedStore().getProperties(container,

--- a/internal/src/org/labkey/remoteapi/RemoteConnections.java
+++ b/internal/src/org/labkey/remoteapi/RemoteConnections.java
@@ -50,7 +50,7 @@ public class RemoteConnections
         """
         Administrators can define remote connections to other LabKey Server instances and then use them in ETLs to move
         data between instances. This feature should be used with care since all schemas in the remote folder will be
-        available to anyone writing or running ETLs.";
+        available to anyone writing or running ETLs.
         """;
 
     public static @NotNull Map<String, String> getRemoteConnection(String connectionCategory, String name, Container container)

--- a/query/src/org/labkey/query/view/createRemoteConnection.jsp
+++ b/query/src/org/labkey/query/view/createRemoteConnection.jsp
@@ -36,11 +36,7 @@
     boolean editConnection = StringUtils.isNotEmpty(name);
     String nameToShow = editConnection ? name : remoteConnectionForm.getNewConnectionName();
 %>
-<p>
-    Administrators can define external remote connections to alternate LabKey servers.
-    This feature should be used with care since, depending
-    on your configuration, any user with access to the remote site could view arbitrary data in your remote server.
-</p>
+<p><%=h(RemoteConnections.MANAGEMENT_PAGE_INSTRUCTIONS)%></p>
 <labkey:errors/>
 <br>
 <labkey:form name="editConnection" action="<%=QueryController.RemoteQueryConnectionUrls.urlSaveRemoteConnection(c) %>" method="post" layout="horizontal">

--- a/query/src/org/labkey/query/view/manageRemoteConnections.jsp
+++ b/query/src/org/labkey/query/view/manageRemoteConnections.jsp
@@ -21,14 +21,11 @@
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.query.controllers.QueryController.RemoteQueryConnectionUrls" %>
+<%@ page import="org.labkey.remoteapi.RemoteConnections" %>
 <%@ page import="java.util.Map" %>
 <%@ page extends="org.labkey.api.jsp.FormPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
-<p>
-    Administrators can define external remote connections to alternate LabKey servers.
-    This feature should be used with care since, depending
-    on your configuration, any user with access to the remote site could view arbitrary data in your remote server.
-</p>
+<p><%=h(RemoteConnections.MANAGEMENT_PAGE_INSTRUCTIONS)%></p>
 <%
     Container c = getContainer();
     boolean hasAdminOpsPerm = c.hasPermission(getUser(), AdminOperationsPermission.class);

--- a/query/webapp/query/browser/Browser.js
+++ b/query/webapp/query/browser/Browser.js
@@ -175,17 +175,19 @@ Ext4.define('LABKEY.query.browser.Browser', {
             });
         }
         if (LABKEY.Security.currentUser.isAdmin) {
-            tbar.push({
-                xtype: 'querybutton',
-                text: 'Manage Remote Connections',
-                tooltip: 'Manage remote connection credentials for remote LabKey server authentication.',
-                fontCls: 'fa-server',
-                stacked: true,
-                handler: function() {
-                    window.location = LABKEY.ActionURL.buildURL('query', 'manageRemoteConnections');
-                },
-                scope: this
-            });
+            if ("dataintegration" in LABKEY.moduleContext) {
+                tbar.push({
+                    xtype: 'querybutton',
+                    text: 'Manage Remote Connections',
+                    tooltip: 'Manage configurations for remote connections to other LabKey Server instances.',
+                    fontCls: 'fa-server',
+                    stacked: true,
+                    handler: function () {
+                        window.location = LABKEY.ActionURL.buildURL('query', 'manageRemoteConnections');
+                    },
+                    scope: this
+                });
+            }
             if (LABKEY.Security.currentUser.isSystemAdmin) {
                 tbar.push({
                     xtype: 'querybutton',

--- a/query/webapp/query/browser/Browser.js
+++ b/query/webapp/query/browser/Browser.js
@@ -179,7 +179,8 @@ Ext4.define('LABKEY.query.browser.Browser', {
                 tbar.push({
                     xtype: 'querybutton',
                     text: 'Manage Remote Connections',
-                    tooltip: 'Manage configurations for remote connections to other LabKey Server instances.',
+                    tooltip: 'Manage configurations for ETL connections to other LabKey Server instances.',
+
                     fontCls: 'fa-server',
                     stacked: true,
                     handler: function () {


### PR DESCRIPTION
#### Rationale
Remote connections can only be used from an ETL, so the management button should be hidden when the dataintegration module isn't available. We may eventually move the management code to the dataintegration module, but this simple approach is good enough for now.

This also updates the message at the top of the manage pages for accuracy. In particular, the previous warning seemed wrong and unnecessarily scary:

`This feature should be used with care since, depending on your configuration, any user with access to the remote site could view arbitrary data in your remote server.`

Please review the new message for accuracy.