### PR TITLE
Relax permissions check on wiki webpart title link to read in target folder

### DIFF
--- a/list/src/org/labkey/list/view/ListsWebPart.java
+++ b/list/src/org/labkey/list/view/ListsWebPart.java
@@ -58,7 +58,7 @@ public class ListsWebPart extends WebPartView<ViewContext>
         _narrow = narrow;
 
         setTitle("Lists");
-        setTitleHref(ListController.getBeginURL(getViewContext().getContainer()));
+        setTitleHref(ListController.getBeginURL(portalCtx.getContainer()));
 
         if (portalCtx.hasPermission(DesignListPermission.class))
         {

--- a/list/src/org/labkey/list/view/ListsWebPart.java
+++ b/list/src/org/labkey/list/view/ListsWebPart.java
@@ -21,7 +21,6 @@ import org.labkey.api.exp.list.ListDefinition;
 import org.labkey.api.exp.list.ListService;
 import org.labkey.api.exp.list.ListUrls;
 import org.labkey.api.lists.permissions.DesignListPermission;
-import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.AlwaysAvailableWebPartFactory;
 import org.labkey.api.view.BaseWebPartFactory;
@@ -44,7 +43,7 @@ public class ListsWebPart extends WebPartView<ViewContext>
     public static final BaseWebPartFactory FACTORY = new AlwaysAvailableWebPartFactory("Lists", LOCATION_BODY, LOCATION_RIGHT)
     {
         @Override
-        public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+        public ListsWebPart getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
         {
             boolean narrow = webPart.getLocation().equals(LOCATION_RIGHT);
             return new ListsWebPart(narrow, portalCtx);
@@ -59,11 +58,7 @@ public class ListsWebPart extends WebPartView<ViewContext>
         _narrow = narrow;
 
         setTitle("Lists");
-
-        if (getModelBean().hasPermission(UpdatePermission.class))
-        {
-            setTitleHref(ListController.getBeginURL(getViewContext().getContainer()));
-        }
+        setTitleHref(ListController.getBeginURL(getViewContext().getContainer()));
 
         if (portalCtx.hasPermission(DesignListPermission.class))
         {

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4265,7 +4265,7 @@ public class QueryController extends SpringActionController
         }
     }
 
-    @RequiresPermission(AdminPermission.class)
+    @RequiresPermission(ReadPermission.class)
     public static class ApiTestAction extends SimpleViewAction<Object>
     {
         @Override
@@ -7209,7 +7209,8 @@ public class QueryController extends SpringActionController
                 new AuditDetailsAction(),
                 new ExportTablesAction(),
                 new SaveNamedSetAction(),
-                new DeleteNamedSetAction()
+                new DeleteNamedSetAction(),
+                new ApiTestAction()
             );
 
 
@@ -7229,7 +7230,6 @@ public class QueryController extends SpringActionController
                 new SaveSourceQueryAction(),
 
                 new TruncateTableAction(),
-                new ApiTestAction(),
                 new AdminAction(),
                 new ManageRemoteConnectionsAction(),
                 new ReloadExternalSchemaAction(),

--- a/wiki/src/org/labkey/wiki/export/WikiImporterFactory.java
+++ b/wiki/src/org/labkey/wiki/export/WikiImporterFactory.java
@@ -117,7 +117,6 @@ public class WikiImporterFactory extends AbstractFolderImportFactory
                         // continue to be indexed by default
                         boolean shouldIndex = !wikiXml.isSetShouldIndex() || wikiXml.getShouldIndex();
                         Collection<String> aliases = wikiXml.isSetAliases() ? Arrays.asList(wikiXml.getAliases().getAliasArray()) : Collections.emptyList();
-                        // TODO: Pass in aliases to importWiki() and persist
 
                         // TODO: We should add VirtualFile.getName()
                         String folderName = new File(wikiSubDir.getLocation()).getName();

--- a/wiki/src/org/labkey/wiki/model/BaseWikiView.java
+++ b/wiki/src/org/labkey/wiki/model/BaseWikiView.java
@@ -183,7 +183,10 @@ public abstract class BaseWikiView extends JspView<Object>
                 customizeURL.addReturnURL(getViewContext().getActionURL());
             }
 
-            setTitleHref(WikiController.getPageURL(wiki, c));
+            if (perms.allowRead(wiki))
+            {
+                setTitleHref(WikiController.getPageURL(wiki, c));
+            }
         }
 
         if (null == context.getRequest().getParameter("_print"))

--- a/wiki/src/org/labkey/wiki/model/BaseWikiView.java
+++ b/wiki/src/org/labkey/wiki/model/BaseWikiView.java
@@ -121,7 +121,7 @@ public abstract class BaseWikiView extends JspView<Object>
                 }
                 catch (Exception e)
                 {
-                    HtmlString.unsafe("<p class=\"labkey-error\">Error rendering page: " + PageFlowUtil.filter(e.getMessage()) + "<p>");
+                    html = HtmlString.unsafe("<p class=\"labkey-error\">Error rendering page: " + PageFlowUtil.filter(e.getMessage()) + "<p>");
                 }
             }
             else
@@ -173,12 +173,15 @@ public abstract class BaseWikiView extends JspView<Object>
             updateContentURL.addParameter("redirect", url.getLocalURIString());
         }
 
-        if (isWebPart() && perms.allowAdmin())
+        if (isWebPart())
         {
-            // the customize URL should always be for the current container (not the wiki webpart's container)
-            customizeURL = PageFlowUtil.urlProvider(ProjectUrls.class).getCustomizeWebPartURL(getViewContext().getContainer());
-            customizeURL.addParameter("webPartId", _webPartId);
-            customizeURL.addReturnURL(getViewContext().getActionURL());
+            if (perms.allowAdmin())
+            {
+                // the customize URL should always be for the current container (not the wiki webpart's container)
+                customizeURL = PageFlowUtil.urlProvider(ProjectUrls.class).getCustomizeWebPartURL(getViewContext().getContainer());
+                customizeURL.addParameter("webPartId", _webPartId);
+                customizeURL.addReturnURL(getViewContext().getActionURL());
+            }
 
             setTitleHref(WikiController.getPageURL(wiki, c));
         }


### PR DESCRIPTION
#### Rationale
The wiki webpart title is linked to the page view of the currently displayed wiki, but only if the user is an admin in the wiki's folder. That seems unnecessarily restrictive... anyone with read permissions in that folder can visit that page.

Permission checks for list webpart title link and query-apiTest action also seem too restrictive.

#### Changes
* Update webpart title link permission check to read in target folder
* Remove obsolete comment
* Fix error message currently getting dropped on the floor
* Relax permissions check on list webpart title link for the same reasons
* Relax permissions to view ApiTest page. Note: Matt & I discussed possibly moving this action to the TestController, but then it wouldn't ship with client distributions. The action could be handy at times and we document it (lightly). So, I left it in query.