### PR TITLE
44316: Add default selection to "Create related issue" dialog

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.10.0",
-        "@labkey/components": "2.150.0",
+        "@labkey/components": "2.150.1-fb-issue-44316.0",
         "@labkey/themes": "1.2.1"
       },
       "devDependencies": {
@@ -3022,9 +3022,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.150.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.150.0.tgz",
-      "integrity": "sha1-R5Dtd8hk7h2I8wT7+Le5xRzympo=",
+      "version": "2.150.1-fb-issue-44316.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.150.1-fb-issue-44316.0.tgz",
+      "integrity": "sha1-CK4c5Xzj0IWAqwzP6xqNEM7vRuM=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -17358,9 +17358,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.150.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.150.0.tgz",
-      "integrity": "sha1-R5Dtd8hk7h2I8wT7+Le5xRzympo=",
+      "version": "2.150.1-fb-issue-44316.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.150.1-fb-issue-44316.0.tgz",
+      "integrity": "sha1-CK4c5Xzj0IWAqwzP6xqNEM7vRuM=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.10.0",
-        "@labkey/components": "2.150.1-fb-issue-44316.0",
+        "@labkey/components": "2.153.1",
         "@labkey/themes": "1.2.1"
       },
       "devDependencies": {
@@ -3022,9 +3022,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.150.1-fb-issue-44316.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.150.1-fb-issue-44316.0.tgz",
-      "integrity": "sha1-CK4c5Xzj0IWAqwzP6xqNEM7vRuM=",
+      "version": "2.153.1",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.153.1.tgz",
+      "integrity": "sha1-mSozMMxVyZR/bC0cvcZxixyVlGs=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -17358,9 +17358,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.150.1-fb-issue-44316.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.150.1-fb-issue-44316.0.tgz",
-      "integrity": "sha1-CK4c5Xzj0IWAqwzP6xqNEM7vRuM=",
+      "version": "2.153.1",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.153.1.tgz",
+      "integrity": "sha1-mSozMMxVyZR/bC0cvcZxixyVlGs=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package.json
+++ b/core/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.10.0",
-    "@labkey/components": "2.150.1-fb-issue-44316.0",
+    "@labkey/components": "2.153.1",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.10.0",
-    "@labkey/components": "2.150.0",
+    "@labkey/components": "2.150.1-fb-issue-44316.0",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/internal/src/org/labkey/api/issues/IssuesDomainKindProperties.java
+++ b/internal/src/org/labkey/api/issues/IssuesDomainKindProperties.java
@@ -9,11 +9,13 @@ public class IssuesDomainKindProperties
 
     private Integer _assignedToGroup;
     private Integer _assignedToUser;
+    private String _relatedFolderName;
 
     public IssuesDomainKindProperties()
     {}
 
-    public IssuesDomainKindProperties(String name, String singularName, String pluralName, String commentSortDirection, Integer assignedToGroup, Integer assignedToUser)
+    public IssuesDomainKindProperties(String name, String singularName, String pluralName, String commentSortDirection,
+                                      Integer assignedToGroup, Integer assignedToUser, String relatedFolderName)
     {
         _issueDefName = name;
         _singularItemName = singularName;
@@ -21,6 +23,7 @@ public class IssuesDomainKindProperties
         _commentSortDirection = commentSortDirection;
         _assignedToGroup = assignedToGroup;
         _assignedToUser = assignedToUser;
+        _relatedFolderName = relatedFolderName;
     }
 
     public String getIssueDefName()
@@ -81,5 +84,15 @@ public class IssuesDomainKindProperties
     public void setAssignedToUser(Integer assignedToUser)
     {
         _assignedToUser = assignedToUser;
+    }
+
+    public String getRelatedFolderName()
+    {
+        return _relatedFolderName;
+    }
+
+    public void setRelatedFolderName(String relatedFolderName)
+    {
+        _relatedFolderName = relatedFolderName;
     }
 }

--- a/issues/src/org/labkey/issue/actions/GetRelatedFolder.java
+++ b/issues/src/org/labkey/issue/actions/GetRelatedFolder.java
@@ -43,7 +43,6 @@ public class GetRelatedFolder extends ReadOnlyApiAction<IssuesController.IssuesF
         ApiSimpleResponse response = new ApiSimpleResponse();
         LinkedList<Map<String, String>> containers = new LinkedList<>();
 
-        // exclude current container
         IssueManager.getIssueListDefs(null).forEach(def -> {
             Container c = ContainerManager.getForId(def.getContainerId());
             if (c.hasPermission(getUser(), InsertPermission.class))

--- a/issues/src/org/labkey/issue/model/IssueManager.java
+++ b/issues/src/org/labkey/issue/model/IssueManager.java
@@ -132,7 +132,7 @@ public class IssueManager
     // UNDONE: Keywords, Summary, etc.
 
     private static final IssuesSchema _issuesSchema = IssuesSchema.getInstance();
-    
+
     public static final int NOTIFY_ASSIGNEDTO_OPEN = 1;     // if a bug is assigned to me
     public static final int NOTIFY_ASSIGNEDTO_UPDATE = 2;   // if a bug assigned to me is modified
     public static final int NOTIFY_CREATED_UPDATE = 4;      // if a bug I created is modified
@@ -150,23 +150,13 @@ public class IssueManager
     private static final String PROP_ENTRY_TYPE_NAME_SINGULAR = "issueEntryTypeNameSingular";
     private static final String PROP_ENTRY_TYPE_NAME_PLURAL = "issueEntryTypeNamePlural";
 
-    private static final String CAT_ASSIGNED_TO_LIST = "issueAssignedToList";
     private static final String PROP_ASSIGNED_TO_GROUP = "issueAssignedToGroup";
-
-    private static final String CAT_DEFAULT_ASSIGNED_TO_LIST = "issueDefaultAsignedToList";
     private static final String PROP_DEFAULT_ASSIGNED_TO_USER = "issueDefaultAssignedToUser";
-
-    private static final String CAT_DEFAULT_MOVE_TO_LIST = "issueDefaultMoveToList";
-    private static final String PROP_DEFAULT_MOVE_TO_CONTAINER = "issueDefaultMoveToContainer";
-
     private static final String CAT_DEFAULT_INHERIT_FROM_CONTAINER = "issueDefaultInheritFromCategory";
     private static final String PROP_DEFAULT_INHERIT_FROM_CONTAINER = "issueDefaultInheritFromProperty";
-
-    private static final String CAT_DEFAULT_RELATED_ISSUES_LIST = "issueRelatedIssuesList";
-    private static final String PROP_DEFAULT_RELATED_ISSUES_LIST = "issueRelatedIssuesList";
+    private static final String PROP_DEFAULT_RELATED_FOLDER = "issueDefaultsRelatedFolder";
 
     private static final String CAT_COMMENT_SORT = "issueCommentSort";
-    public static final String PICK_LIST_NAME = "pickListColumns";
 
     private IssueManager()
     {
@@ -251,8 +241,8 @@ public class IssueManager
      * Returns a linked list of all comments for the argument Issue together with comments
      * of all related issues sorted by creation date.
      *
-     * @param   issue   an issue to retrieve comments from
-     * @return          the sorted linked list of all related comments
+     * @param issue an issue to retrieve comments from
+     * @return the sorted linked list of all related comments
      */
     public static List<IssueObject.CommentObject> getCommentsForRelatedIssues(IssueObject issue, User user)
     {
@@ -292,8 +282,8 @@ public class IssueManager
      * Determine if the parameter issue has related issues.  Returns true if the issue has related
      * issues and false otherwise.
      *
-     * @param   issue   The issue to query
-     * @return          boolean return value
+     * @param issue The issue to query
+     * @return boolean return value
      */
     public static boolean hasRelatedIssues(IssueObject issue, User user)
     {
@@ -350,8 +340,8 @@ public class IssueManager
                     if (!batchErrors.hasErrors())
                     {
                         assert results.size() == 1;
-                        issue.setIssueId((int)results.get(0).get("IssueId"));
-                        issue.setIssueDefId((Integer)results.get(0).get("issueDefId"));
+                        issue.setIssueId((int) results.get(0).get("IssueId"));
+                        issue.setIssueDefId((Integer) results.get(0).get("issueDefId"));
                     }
                     else
                         throw batchErrors;
@@ -359,7 +349,7 @@ public class IssueManager
                 else
                 {
                     issue.beforeUpdate(user);
-                    qus.updateRows(user, container, Collections.singletonList(row), Collections.singletonList(row) , null, null);
+                    qus.updateRows(user, container, Collections.singletonList(row), Collections.singletonList(row), null, null);
                 }
                 issue.setRelated(related);
                 saveComments(user, issue);
@@ -575,7 +565,7 @@ public class IssueManager
         Container inheritFrom = getInheritFromContainer(c);
 
         //Return the container from which admin settings were inherited from
-        if(inheritFrom != null)
+        if (inheritFrom != null)
             return inheritFrom;
         return c;
     }
@@ -584,10 +574,10 @@ public class IssueManager
     @NotNull
     public static EntryTypeNames getEntryTypeNames(Container container, String issueDefName)
     {
-        Map<String,String> props = PropertyManager.getProperties(container, getPropMapName(issueDefName));
+        Map<String, String> props = PropertyManager.getProperties(container, getPropMapName(issueDefName));
         EntryTypeNames ret = new EntryTypeNames();
         if (props.containsKey(PROP_ENTRY_TYPE_NAME_SINGULAR))
-            ret.singularName =props.get(PROP_ENTRY_TYPE_NAME_SINGULAR);
+            ret.singularName = props.get(PROP_ENTRY_TYPE_NAME_SINGULAR);
         if (props.containsKey(PROP_ENTRY_TYPE_NAME_PLURAL))
             ret.pluralName = props.get(PROP_ENTRY_TYPE_NAME_PLURAL);
         return ret;
@@ -602,7 +592,6 @@ public class IssueManager
     }
 
     /**
-     *
      * @param container
      * @param inheritingVals
      * @return EntryTypeNames of a container with inherited settings, or of current container.
@@ -610,12 +599,12 @@ public class IssueManager
     public static EntryTypeNames getEntryTypeNames(Container container, boolean inheritingVals)
     {
         Container c;
-        if(inheritingVals)
+        if (inheritingVals)
             c = getInheritFromOrCurrentContainer(container);
         else
             c = container;
 
-        Map<String,String> props = PropertyManager.getProperties(c, CAT_ENTRY_TYPE_NAMES);
+        Map<String, String> props = PropertyManager.getProperties(c, CAT_ENTRY_TYPE_NAMES);
         EntryTypeNames ret = new EntryTypeNames();
         if (props.containsKey(PROP_ENTRY_TYPE_NAME_SINGULAR))
             ret.singularName = props.get(PROP_ENTRY_TYPE_NAME_SINGULAR);
@@ -637,12 +626,21 @@ public class IssueManager
         props.save();
     }
 
+    private static String getPropertyValue(Container c, String issueDefName, String key)
+    {
+        return PropertyManager.getProperties(c, getPropMapName(issueDefName)).get(key);
+    }
+
+    private static void setPropertyValue(Container c, String issueDefName, String key, String value)
+    {
+        PropertyManager.PropertyMap props = PropertyManager.getWritableProperties(c, getPropMapName(issueDefName), true);
+        props.put(key, value);
+        props.save();
+    }
+
     public static @Nullable Group getAssignedToGroup(Container c, String issueDefName)
     {
-        Map<String, String> props = PropertyManager.getProperties(c, getPropMapName(issueDefName));
-
-        String groupId = props.get(PROP_ASSIGNED_TO_GROUP);
-
+        String groupId = getPropertyValue(c, issueDefName, PROP_ASSIGNED_TO_GROUP);
         if (null == groupId)
             return null;
 
@@ -651,16 +649,13 @@ public class IssueManager
 
     public static void saveAssignedToGroup(Container c, String issueDefName,  @Nullable Group group)
     {
-        PropertyManager.PropertyMap props = PropertyManager.getWritableProperties(c, getPropMapName(issueDefName), true);
-        props.put(PROP_ASSIGNED_TO_GROUP, null != group ? String.valueOf(group.getUserId()) : "0");
-        props.save();
+        setPropertyValue(c, issueDefName, PROP_ASSIGNED_TO_GROUP, null != group ? String.valueOf(group.getUserId()) : "0");
         uncache();  // uncache the assigned to list
     }
 
     public static @Nullable User getDefaultAssignedToUser(Container c, String issueDefName)
     {
-        Map<String, String> props = PropertyManager.getProperties(c, getPropMapName(issueDefName));
-        String userId = props.get(PROP_DEFAULT_ASSIGNED_TO_USER);
+        String userId = getPropertyValue(c, issueDefName, PROP_DEFAULT_ASSIGNED_TO_USER);
         if (null == userId)
             return null;
         User user = UserManager.getUser(Integer.parseInt(userId));
@@ -673,9 +668,17 @@ public class IssueManager
 
     public static void saveDefaultAssignedToUser(Container c, String issueDefName, @Nullable User user)
     {
-        PropertyManager.PropertyMap props = PropertyManager.getWritableProperties(c, getPropMapName(issueDefName), true);
-        props.put(PROP_DEFAULT_ASSIGNED_TO_USER, null != user ? String.valueOf(user.getUserId()) : null);
-        props.save();
+        setPropertyValue(c, issueDefName, PROP_DEFAULT_ASSIGNED_TO_USER, null != user ? String.valueOf(user.getUserId()) : null);
+    }
+
+    public static String getDefaultRelatedFolder(Container c, String issueDefName)
+    {
+        return getPropertyValue(c, issueDefName, PROP_DEFAULT_RELATED_FOLDER);
+    }
+
+    public static void setPropDefaultRelatedFolder(Container c, String issueDefName, String relatedFolder)
+    {
+        setPropertyValue(c, issueDefName, PROP_DEFAULT_RELATED_FOLDER, relatedFolder);
     }
 
     public static Collection<Container> getMoveDestinationContainers(Container c, User user, String issueDefName)
@@ -794,8 +797,7 @@ public class IssueManager
 
     public static Sort.SortDirection getCommentSortDirection(Container c, String issueDefName)
     {
-        Map<String, String> props = PropertyManager.getProperties(c, getPropMapName(issueDefName));
-        String direction = props.get(CAT_COMMENT_SORT);
+        String direction = getPropertyValue(c, issueDefName, CAT_COMMENT_SORT);
         if (direction != null)
         {
             try
@@ -809,9 +811,7 @@ public class IssueManager
 
     public static void saveCommentSortDirection(Container c, String issueDefName, @NotNull Sort.SortDirection direction)
     {
-        PropertyManager.PropertyMap props = PropertyManager.getWritableProperties(c, getPropMapName(issueDefName), true);
-        props.put(CAT_COMMENT_SORT, direction.toString());
-        props.save();
+        setPropertyValue(c, issueDefName, CAT_COMMENT_SORT, direction.toString());
         uncache();  // uncache the assigned to list
     }
 

--- a/issues/src/org/labkey/issue/model/IssuesListDefServiceImpl.java
+++ b/issues/src/org/labkey/issue/model/IssuesListDefServiceImpl.java
@@ -76,7 +76,9 @@ public class IssuesListDefServiceImpl implements IssuesListDefService
         if (defaultUser != null)
             assignedToUser = defaultUser.getUserId();
 
-        return new IssuesDomainKindProperties(defName, typeNames.singularName, typeNames.pluralName, sortDirection, assignedToGroup, assignedToUser);
+        String relatedFolderName = IssueManager.getDefaultRelatedFolder(container, defName);
+
+        return new IssuesDomainKindProperties(defName, typeNames.singularName, typeNames.pluralName, sortDirection, assignedToGroup, assignedToUser, relatedFolderName);
     }
 
     @Override
@@ -139,6 +141,7 @@ public class IssuesListDefServiceImpl implements IssuesListDefService
         }
 
         IssueManager.saveDefaultAssignedToUser(container, name, user);
+        IssueManager.setPropDefaultRelatedFolder(container, name, properties.getRelatedFolderName());
     }
 
     @Override

--- a/issues/src/org/labkey/issue/view/detailView.jsp
+++ b/issues/src/org/labkey/issue/view/detailView.jsp
@@ -126,7 +126,8 @@
     relatedIssues.append(", assignedTo :").append(issue.getAssignedTo());
     relatedIssues.append(", priority :").append(q(issue.getProperty(IssueObject.Prop.priority)));
     relatedIssues.append(", related :").append(issue.getIssueId());
-    relatedIssues.append(", relatedFolder :").append(q(relatedFolderName));
+    relatedIssues.append(", defaultRelatedFolder :").append(q(relatedFolderName));
+    relatedIssues.append(", currentIssueDef :").append(q(String.join("|", getContainer().getPath(), issueDef.getName())));
     relatedIssues.append("})");
 
     List<NavTree> additionalHeaderLinks = new ArrayList<>();

--- a/issues/src/org/labkey/issue/view/detailView.jsp
+++ b/issues/src/org/labkey/issue/view/detailView.jsp
@@ -71,6 +71,7 @@
     List<IssueObject.CommentObject> commentLinkedList = IssueManager.getCommentsForRelatedIssues(issue, user);
     IssueListDef issueDef = IssueManager.getIssueListDef(issue);
     EntryTypeNames names = IssueManager.getEntryTypeNames(c, issueDef.getName());
+    String relatedFolderName = IssueManager.getDefaultRelatedFolder(c, issueDef.getName());
 
     List<DomainProperty> column1Props = new ArrayList<>();
     List<DomainProperty> column2Props = new ArrayList<>();
@@ -125,6 +126,7 @@
     relatedIssues.append(", assignedTo :").append(issue.getAssignedTo());
     relatedIssues.append(", priority :").append(q(issue.getProperty(IssueObject.Prop.priority)));
     relatedIssues.append(", related :").append(issue.getIssueId());
+    relatedIssues.append(", relatedFolder :").append(q(relatedFolderName));
     relatedIssues.append("})");
 
     List<NavTree> additionalHeaderLinks = new ArrayList<>();


### PR DESCRIPTION
#### Rationale
We want to introduce a new dropdown in the issue definition properties panel to allow administrators to configure the default folder that is offered when a user creates a new related issue.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44316

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/802

#### Changes
- save the default related folder in the prop store
- initialize the selection of the folder in the related issue dialog box
