### PR TITLE
Various 22.5 bugs for LKSM

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -717,7 +717,7 @@ public class NameGenerator
 
         }
 
-        if ((isCurrentDataType || inputDataType == null) && !_domainProperties.isEmpty())
+        if ((isCurrentDataType || inputDataType == null) && _domainProperties != null && !_domainProperties.isEmpty())
         {
             Map<String, GWTPropertyDescriptor> domainFields = new CaseInsensitiveHashMap<>();
             _domainProperties.forEach(prop -> domainFields.put(prop.getName(), prop));

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -168,6 +168,9 @@ public interface ExperimentService extends ExperimentRunTypeSource
     @NotNull
     List<? extends ExpData> getExpDatas(Collection<Integer> rowid);
 
+    @NotNull
+    List<? extends ExpData> getExpDatas(ExpDataClass dataClass, Collection<Integer> rowIds);
+
     List<? extends ExpData> getExpDatas(Container container, @Nullable DataType type, @Nullable String name);
 
     @NotNull

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -55,6 +55,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -227,6 +228,15 @@ public interface SearchService
         default WebdavResource resolve(@NotNull String resourceIdentifier) { return null; }
         default HttpView getCustomSearchResult(User user, @NotNull String resourceIdentifier) { return null; }
         default Map<String, Object> getCustomSearchJson(User user, @NotNull String resourceIdentifier) { return null; }
+        default Map<String, Map<String, Object>> getCustomSearchJsonMap(User user, @NotNull Collection<String> resourceIdentifiers)
+        {
+            Map<String, Map<String, Object>> results = new HashMap<>();
+            for (String resourceIdentifier : resourceIdentifiers)
+            {
+                results.put(resourceIdentifier, getCustomSearchJson(user, resourceIdentifier));
+            }
+            return results;
+        }
     }
 
 
@@ -426,6 +436,7 @@ public interface SearchService
     WebdavResource resolveResource(@NotNull String resourceIdentifier);
     HttpView getCustomSearchResult(User user, @NotNull String resourceIdentifier);
     Map<String, Object> getCustomSearchJson(User user, @NotNull String resourceIdentifier);
+    Map<String, Map<String, Object>> getCustomSearchJsonMap(User user, @NotNull Collection<String> resourceIdentifiers);
 
     void addSearchResultTemplate(@NotNull SearchResultTemplate template);
     @Nullable SearchResultTemplate getSearchResultTemplate(@Nullable String name);

--- a/core/src/org/labkey/core/search/NoopSearchService.java
+++ b/core/src/org/labkey/core/search/NoopSearchService.java
@@ -248,6 +248,12 @@ public class NoopSearchService implements SearchService
     }
 
     @Override
+    public Map<String, Map<String, Object>> getCustomSearchJsonMap(User user, @NotNull Collection<String> resourceIdentifiers)
+    {
+        return null;
+    }
+
+    @Override
     public void addSearchResultTemplate(@NotNull SearchResultTemplate template)
     {
     }

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -38,6 +38,7 @@ import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.DefaultExperimentDataHandler;
+import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpDataClass;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -132,6 +133,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -332,6 +334,19 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
 
                 return ExperimentJSONConverter.serializeData(data, user, ExperimentJSONConverter.DEFAULT_SETTINGS);
             }
+
+            @Override
+            public Map<String, Map<String, Object>> getCustomSearchJsonMap(User user, @NotNull Collection<String> resourceIdentifiers)
+            {
+                Map<String, ExpData> idDataMap = ExpDataImpl.fromDocumentIds(resourceIdentifiers);
+                if (idDataMap == null)
+                    return null;
+
+                Map<String, Map<String, Object>> searchJsonMap = new HashMap<>();
+                for (String resourceIdentifier : idDataMap.keySet())
+                    searchJsonMap.put(resourceIdentifier, ExperimentJSONConverter.serializeData(idDataMap.get(resourceIdentifier), user, ExperimentJSONConverter.DEFAULT_SETTINGS));
+                return searchJsonMap;
+            }
         });
     }
 
@@ -411,6 +426,32 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
 
                 return ExperimentJSONConverter.serializeMaterial(material, ExperimentJSONConverter.DEFAULT_SETTINGS);
             }
+
+            @Override
+            public Map<String, Map<String, Object>> getCustomSearchJsonMap(User user, @NotNull Collection<String> resourceIdentifiers)
+            {
+                Set<Integer> rowIds = new HashSet<>();
+                Map<Integer, String> rowIdIdentifierMap = new HashMap<>();
+                for (String resourceIdentifier : resourceIdentifiers)
+                {
+                    int rowId = NumberUtils.toInt(resourceIdentifier.replace(categoryName + ":", ""));
+                    if (rowId != 0)
+                    {
+                        rowIds.add(rowId);
+                        rowIdIdentifierMap.put(rowId, resourceIdentifier);
+                    }
+
+                }
+
+                Map<String, Map<String, Object>> searchJsonMap = new HashMap<>();
+                for (ExpMaterial material : ExperimentService.get().getExpMaterials(rowIds))
+                {
+                    searchJsonMap.put(rowIdIdentifierMap.get(material.getRowId()), ExperimentJSONConverter.serializeMaterial(material, ExperimentJSONConverter.DEFAULT_SETTINGS));
+                }
+
+                return searchJsonMap;
+            }
+
         });
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -519,6 +519,18 @@ public class ExperimentServiceImpl implements ExperimentService
     }
 
     @Override
+    public @NotNull List<? extends ExpData> getExpDatas(ExpDataClass dataClass, Collection<Integer> rowIds)
+    {
+        if (rowIds.size() == 0)
+            return Collections.emptyList();
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("RowId"), rowIds, IN);
+        filter.addCondition(FieldKey.fromParts("classId"), dataClass.getRowId());
+
+        return ExpDataImpl.fromDatas(new TableSelector(getTinfoData(), filter, null).getArrayList(Data.class));
+
+    }
+
+    @Override
     public List<ExpDataImpl> getExpDatas(Container container, @Nullable DataType type, @Nullable String name)
     {
         SimpleFilter filter = SimpleFilter.createContainerFilter(container);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -361,7 +361,9 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
             if (isAliquot && isSampleMetaField)
             {
-                LOG.warn("Sample metadata update has been skipped for an aliquot");
+                Object oldMetaValue = oldRow.get(updateField);
+                if (!Objects.equals(oldMetaValue, updateValue))
+                    LOG.warn("Sample metadata update has been skipped for an aliquot");
             }
             else if (!isAliquot && isAliquotField)
             {


### PR DESCRIPTION
#### Rationale
Issue 45215: Performance issues with Search for Sample Manager
The getCustomSearchJson call in search action fetches each hit's custom data individually, which means at least one DB query per hit. When the number of hits is large, the DB overhead is resulting in poor performance for LKSM, who needs to getCustomSearchJson for each hit to support its advanced search function. Instead of fetching row by row, a change is made to fetch at 1,000 a batch.
Issue 45180: LKSM: Naming patterns with parents always add with square brackets
when the parent size is 1, return the object instead of the array
Issue 45007: Cannot create a new sample type with a naming pattern that references a field in the sample type
Look at draft fields in addition to DB fields

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/803
* https://github.com/LabKey/platform/pull/3244
* https://github.com/LabKey/sampleManagement/pull/916
* https://github.com/LabKey/testAutomation/pull/1072

#### Changes
* See details in Rationale section
