### PR TITLE
Remove report label -> name fix-up for imported reports & views

### DIFF
--- a/core/src/org/labkey/core/admin/importer/SubfolderImporterFactory.java
+++ b/core/src/org/labkey/core/admin/importer/SubfolderImporterFactory.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.core.admin.importer;
 
-import org.jetbrains.annotations.NotNull;
 import org.labkey.api.admin.AbstractFolderImportFactory;
 import org.labkey.api.admin.FolderImportContext;
 import org.labkey.api.admin.FolderImporter;
@@ -25,7 +24,6 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.NormalContainerType;
 import org.labkey.api.pipeline.PipelineJob;
-import org.labkey.api.pipeline.PipelineJobWarning;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.view.UnauthorizedException;
@@ -35,8 +33,6 @@ import org.labkey.folder.xml.SubfolderType;
 import org.labkey.folder.xml.SubfoldersDocument;
 
 import java.io.InputStream;
-import java.util.Collection;
-import java.util.Collections;
 
 /**
  * User: cnathe
@@ -128,13 +124,13 @@ public class SubfolderImporterFactory extends AbstractFolderImportFactory
 
                             // set the child container to inherit permissions from the parent by default
                             SecurityManager.setInheritPermissions(childContainer);
-                            ctx.getLogger().info("New container created with inherited permissions for " + subfolderName);
+                            ctx.getLogger().info("New folder created with inherited permissions: " + childContainer.getPath());
                         }
                         else
                         {
                             if (!childContainer.hasPermission(ctx.getUser(), AdminPermission.class))
                             {
-                                ctx.getLogger().error("You must have admin permissions to replace the subfolder: " + getFilePath(subfoldersDir, subfolderName));
+                                ctx.getLogger().error("You must have admin permissions to replace this subfolder: " + childContainer.getPath());
                                 continue;
                             }
                         }

--- a/query/src/org/labkey/query/reports/ReportImporter.java
+++ b/query/src/org/labkey/query/reports/ReportImporter.java
@@ -104,44 +104,6 @@ public class ReportImporter implements FolderImporter
     }
 
     @Override
-    @NotNull
-    public Collection<PipelineJobWarning> postProcess(FolderImportContext ctx, VirtualFile root)
-    {
-        // in 13.2, there was a change to use dataset names instead of label for query references in reports, views, etc.
-        // fire the query change listeners for older archives to fix-up these dataset label references
-        if (ctx.getArchiveVersion() != null && ctx.getArchiveVersion() < 13.11)
-        {
-            StudyService svc = StudyService.get();
-            Study study = svc != null ? svc.getStudy(ctx.getContainer()) : null;
-            if (study != null)
-            {
-                List<QueryChangeListener.QueryPropertyChange> queryPropertyChanges = new ArrayList<>();
-                for (Dataset dataset : study.getDatasets())
-                {
-                    if (!dataset.getName().equals(dataset.getLabel()))
-                    {
-                        queryPropertyChanges.add(new QueryChangeListener.QueryPropertyChange<>(
-                                QueryService.get().getUserSchema(ctx.getUser(), ctx.getContainer(), "study").getQueryDefForTable(dataset.getName()),
-                                QueryChangeListener.QueryProperty.Name,
-                                dataset.getLabel(),
-                                dataset.getName()
-                        ));
-                    }
-                }
-
-                if (queryPropertyChanges.size() > 0)
-                {
-                    ctx.getLogger().info("Post-processing reports, custom views, and query snapshots to use dataset name instead of label");
-                    QueryService.get().fireQueryChanged(ctx.getUser(), ctx.getContainer(), null, new SchemaKey(null, "study"), QueryChangeListener.QueryProperty.Name, queryPropertyChanges);
-                    ctx.getLogger().info("Done post-processing dataset label to name conversion");
-                }
-            }
-        }
-
-        return Collections.emptyList();
-    }
-
-    @Override
     public boolean isValidForImportArchive(FolderImportContext ctx) throws ImportException
     {
         return ctx.getDir("reports") != null;

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
@@ -68,18 +68,19 @@ public class StudyDatasetsTest extends BaseWebDriverTest
     private static final String TIME_CHART_REPORT_NAME = "Time Chart: Body Temp + Pulse For Group 2";
     private static final String SCATTER_PLOT_REPORT_NAME = "Scatter: Systolic vs Diastolic";
     private static final String PTID_REPORT_NAME = "Mouse Report: 2 Dem Vars + 3 Other Vars";
-    private static Map<String, String> EXPECTED_REPORTS = new HashMap<>();
-    private static Map<String, String> EXPECTED_CUSTOM_VIEWS = new HashMap<>();
+    private static final Map<String, String> EXPECTED_REPORTS = new HashMap<>();
+    private static final Map<String, String> EXPECTED_CUSTOM_VIEWS = new HashMap<>();
     private static final String DATASET_HEADER = "mouseId\tsequenceNum\tXTest\tYTest\tZTest\n";
     private static final String DATASET_B_DATA =
-            "a1\t1\tx1\ty1\tz1\n" +
-            "a2\t2\tx2\ty2\tz2\n" +
-            "a3\t3\tx3\ty3\tz3\n" +
-            "a4\t4\tx4\ty4\tz4\n" +
-            "a5\t5\tx5\ty5\tz5\n" +
-            "a6\t6\tx6\ty6\tz6\n";
-    private static final String DATASET_B_MERGE =
-            "a4\t4\tx4_merged\ty4_merged\tz4_merged\n";
+        """
+        a1\t1\tx1\ty1\tz1
+        a2\t2\tx2\ty2\tz2
+        a3\t3\tx3\ty3\tz3
+        a4\t4\tx4\ty4\tz4
+        a5\t5\tx5\ty5\tz5
+        a6\t6\tx6\ty6\tz6
+        """;
+    private static final String DATASET_B_MERGE = "a4\t4\tx4_merged\ty4_merged\tz4_merged\n";
 
     @Override
     protected BrowserType bestBrowser()
@@ -215,12 +216,12 @@ public class StudyDatasetsTest extends BaseWebDriverTest
     protected void renameDataset(String orgName, String newName, String orgLabel, String newLabel, String... fieldNames)
     {
         DatasetDesignerPage editDatasetPage = _studyHelper.goToManageDatasets()
-                .selectDatasetByName(orgName)
-                .clickEditDefinition();
+            .selectDatasetByName(orgName)
+            .clickEditDefinition();
 
         editDatasetPage
-                .setName(newName)
-                .setDatasetLabel(newLabel);
+            .setName(newName)
+            .setDatasetLabel(newLabel);
 
         for (String fieldName : fieldNames)
         {
@@ -251,8 +252,8 @@ public class StudyDatasetsTest extends BaseWebDriverTest
     protected void importDatasetData(String datasetName, String header, String tsv, boolean checkMergeOption, String msg)
     {
         _studyHelper.goToManageDatasets()
-                .selectDatasetByName(datasetName)
-                .clickViewData();
+            .selectDatasetByName(datasetName)
+            .clickViewData();
         waitForText("All data");
         new DataRegionTable("Dataset", getDriver()).clickImportBulkData();
         waitForText("Copy/paste text");
@@ -277,13 +278,13 @@ public class StudyDatasetsTest extends BaseWebDriverTest
     protected void deleteFields(String name)
     {
         DatasetDesignerPage editDatasetPage = _studyHelper.goToManageDatasets()
-                .selectDatasetByName(name)
-                .clickEditDefinition();
+            .selectDatasetByName(name)
+            .clickEditDefinition();
 
         editDatasetPage.getFieldsPanel()
-                .getField("ZTest").clickRemoveField(true);
+            .getField("ZTest").clickRemoveField(true);
         editDatasetPage.getFieldsPanel()
-                .getField("YTest").clickRemoveField(true);
+            .getField("YTest").clickRemoveField(true);
 
         List<String> remainingFields = editDatasetPage.getFieldsPanel().fieldNames();
         assertEquals(Arrays.asList("XTest"), remainingFields);
@@ -294,9 +295,9 @@ public class StudyDatasetsTest extends BaseWebDriverTest
     @LogMethod
     protected void checkFieldsPresent(String name, String... items)
     {
-        DatasetDesignerPage editDatasetPage = _studyHelper.goToManageDatasets()
-                .selectDatasetByName(name)
-                .clickEditDefinition();
+        _studyHelper.goToManageDatasets()
+            .selectDatasetByName(name)
+            .clickEditDefinition();
 
         for (String item : items)
         {
@@ -309,8 +310,8 @@ public class StudyDatasetsTest extends BaseWebDriverTest
     {
         navigateToFolder(getProjectName(), getFolderName());
         _studyHelper.goToManageDatasets()
-                .selectDatasetByName(name)
-                .clickViewData();
+            .selectDatasetByName(name)
+            .clickViewData();
         waitForText(items);
     }
 
@@ -430,9 +431,9 @@ public class StudyDatasetsTest extends BaseWebDriverTest
         assertFalse("Facet panel failed to reflect opposite filter", facetPanel.getGroupCheckbox(GROUP2A).isChecked());
     }
 
-    // in 13.2 Sprint 1 we changed reports and views so that they are associated with query name instead of label (i.e. dataset name instead of label)
-    // there is also a migration step that happens when importing study archives with version < 13.11 to fixup these report/view references
-    // this method verifies that migration on import for a handful of reports and views
+    // This used to test 13.2 "fixup" code where imported reports & views attached to dataset labels were migrated to
+    // the corresponding name. In 22.7, this migration code was removed and the reports in test folder archives were
+    // updated to modern standards. But this is still a reasonable test case to ensure report import acts as expected.
     @LogMethod
     private void verifyReportAndViewDatasetReferences()
     {


### PR DESCRIPTION
#### Rationale
Long ago (13.2) we made a change to migrate report & view binding to use dataset names instead of labels. We left migration code behind to handle folder archives that hadn't yet gotten the memo. It's now time to remove the migration code and update any old test archives that still use dataset labels. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45080

#### Changes
* Remove all dataset label → name migration code. For now, log an error when detecting an imported report that's attempting to bind to a dataset label. We'll remove this error logging in the future.
