### PR TITLE
Switch "Body" column from hidden to simply not shown in default view

### DIFF
--- a/announcements/resources/schemas/comm.xml
+++ b/announcements/resources/schemas/comm.xml
@@ -367,7 +367,7 @@
     <versionColumnName>Modified</versionColumnName>
     <titleColumn>EntityId</titleColumn>
   </table>
-  <table tableName="CurrentWikiVersions" tableDbType="VIEW">
+  <table tableName="CurrentWikiVersions" tableDbType="VIEW" useColumnOrder="true">
     <description>Contains one row per wiki page joined to its most current wiki version</description>
     <tableUrl>/wiki/page.view?name=${Name}</tableUrl>
     <columns>
@@ -400,9 +400,6 @@
       <column columnName="Version">
         <url>/wiki/version.view?name=${Name}&amp;version=${Version}</url>
       </column>
-      <column columnName="Body">
-        <isHidden>true</isHidden>
-      </column>
       <column columnName="RendererType"/>
       <column columnName="CreatedBy"/>
       <column columnName="Created">
@@ -412,9 +409,10 @@
       <column columnName="Modified">
         <formatString>DateTime</formatString>
       </column>
+      <column columnName="Body"/>
     </columns>
   </table>
-  <table tableName="AllWikiVersions" tableDbType="VIEW">
+  <table tableName="AllWikiVersions" tableDbType="VIEW" useColumnOrder="true">
     <description>Contains one row per wiki version joined to its parent wiki page, providing the full version history of all pages</description>
     <tableUrl>/wiki/version.view?name=${Name}&amp;version=${Version}</tableUrl>
     <columns>
@@ -447,9 +445,6 @@
       <column columnName="Version">
         <url>/wiki/version.view?name=${Name}&amp;version=${Version}</url>
       </column>
-      <column columnName="Body">
-        <isHidden>true</isHidden>
-      </column>
       <column columnName="RendererType"/>
       <column columnName="CreatedBy"/>
       <column columnName="Created">
@@ -459,6 +454,7 @@
       <column columnName="Modified">
         <formatString>DateTime</formatString>
       </column>
+      <column columnName="Body"/>
     </columns>
   </table>
   <table tableName="UserList" tableDbType="TABLE">

--- a/api/schemas/tableInfo.xsd
+++ b/api/schemas/tableInfo.xsd
@@ -499,7 +499,7 @@
             <xs:element name="shownInInsertView" type="xs:boolean" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
-                        Defaults to true. Set to false if the column should not shown in insert views.
+                        Defaults to true. Set to false if the column should not be shown in insert views.
                         Supported for SQL metadata, dataset import/export and list import/export.
                     </xs:documentation>
                 </xs:annotation>
@@ -507,7 +507,7 @@
             <xs:element name="shownInUpdateView" type="xs:boolean" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
-                        Defaults to true. Set to false if the column should not shown in update views.
+                        Defaults to true. Set to false if the column should not be shown in update views.
                         Supported for SQL metadata, dataset import/export and list import/export.
                     </xs:documentation>
                 </xs:annotation>
@@ -515,7 +515,7 @@
             <xs:element name="shownInDetailsView" type="xs:boolean" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
-                        Defaults to true. Set to false if the column should not shown in details views.
+                        Defaults to true. Set to false if the column should not be shown in details views.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/internal/src/org/labkey/api/query/SimpleUserSchema.java
+++ b/internal/src/org/labkey/api/query/SimpleUserSchema.java
@@ -27,7 +27,6 @@ import org.labkey.api.collections.CaseInsensitiveTreeSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.ContainerForeignKey;
 import org.labkey.api.data.ContainerType;
 import org.labkey.api.data.DatabaseTableType;
 import org.labkey.api.data.DbSchema;

--- a/wiki/src/org/labkey/wiki/query/WikiSchema.java
+++ b/wiki/src/org/labkey/wiki/query/WikiSchema.java
@@ -100,6 +100,9 @@ public class WikiSchema extends UserSchema
             table.setDeleteURL(AbstractTableInfo.LINK_DISABLER);
             table.init();
 
+            // Don't show Body column by default
+            table.setDefaultVisibleColumns(table.getDefaultVisibleColumns().stream().filter(col->!col.getName().equals("Body")).toList());
+
             // Change default sort to newest->oldest
             var pk = table.getMutableColumn("RowId");
             pk.setSortDirection(Sort.SortDirection.DESC);


### PR DESCRIPTION
#### Rationale
The `Body` column of the `wiki.CurrentWikiVersions` and `wiki.AllWikiVersions` queries has been marked hidden to keep it out of the default view, since it doesn't format very well in a grid column. But hidden makes it too hard for most users to find, so switch to simply not showing it in the default view.
