### PR TITLE
Fixes for over-agressive input stream closing

### DIFF
--- a/api/src/org/labkey/api/attachments/ByteArrayAttachmentFile.java
+++ b/api/src/org/labkey/api/attachments/ByteArrayAttachmentFile.java
@@ -16,6 +16,9 @@
 
 package org.labkey.api.attachments;
 
+import org.apache.logging.log4j.Logger;
+import org.labkey.api.util.logging.LogHelper;
+
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -28,6 +31,7 @@ import java.io.InputStream;
  */
 public class ByteArrayAttachmentFile implements AttachmentFile
 {
+    private static final Logger LOG = LogHelper.getLogger(ByteArrayAttachmentFile.class, "Attachment file for byte arrays");
     private final String _contentType;
     private final byte[] _content;
     private final String _fileName;
@@ -72,11 +76,13 @@ public class ByteArrayAttachmentFile implements AttachmentFile
     @Override
     public void closeInputStream() throws IOException
     {
-        if (_inputStream == null)
-            throw new IllegalStateException("No input stream is active for this ByteArrayAttachmentFile");
-
-        _inputStream.close();
-        _inputStream = null;
+        if (_inputStream != null)
+        {
+            _inputStream.close();
+            _inputStream = null;
+        }
+        else
+            LOG.warn("No input stream is active for this ByteArrayAttachmentFile");
     }
 
     @Override

--- a/api/src/org/labkey/api/attachments/FileAttachmentFile.java
+++ b/api/src/org/labkey/api/attachments/FileAttachmentFile.java
@@ -16,8 +16,10 @@
 
 package org.labkey.api.attachments;
 
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -31,6 +33,7 @@ import java.io.InputStream;
  */
 public class FileAttachmentFile implements AttachmentFile
 {
+    private static final Logger LOG = LogHelper.getLogger(FileAttachmentFile.class, "Attachment file for file system files");
     private final File _file;
     private final String _filename;
 
@@ -81,11 +84,13 @@ public class FileAttachmentFile implements AttachmentFile
     @Override
     public void closeInputStream() throws IOException
     {
-        if (_in == null)
-            throw new IllegalStateException("No input stream is active for this FileAttachmentFile");
-
-        _in.close();
-        _in = null;
+        if (_in != null)
+        {
+            _in.close();
+            _in = null;
+        }
+        else
+            LOG.warn("No input stream is active for this FileAttachmentFile");
     }
 
     @Override

--- a/api/src/org/labkey/api/attachments/SpringAttachmentFile.java
+++ b/api/src/org/labkey/api/attachments/SpringAttachmentFile.java
@@ -16,8 +16,10 @@
 
 package org.labkey.api.attachments;
 
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.logging.LogHelper;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -36,6 +38,7 @@ import java.util.Map;
  */
 public class SpringAttachmentFile implements AttachmentFile
 {
+    private static final Logger LOG = LogHelper.getLogger(SpringAttachmentFile.class, "Attachment file for uploaded files");
     private final MultipartFile _file;
     private final String _filename;
 
@@ -100,11 +103,13 @@ public class SpringAttachmentFile implements AttachmentFile
     @Override
     public void closeInputStream() throws IOException
     {
-        if (_in == null)
-            throw new IllegalStateException("No input stream is active for this SpringAttachmentFile");
-
-        _in.close();
-        _in = null;
+        if (_in != null)
+        {
+            _in.close();
+            _in = null;
+        }
+        else
+            LOG.warn("No input stream is active for this SpringAttachmentFile");
     }
 
     public static List<AttachmentFile> createList(Map<String, MultipartFile> fileMap)

--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -574,17 +574,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
             if (loader != null)
                 loader.close();
             if (null != file)
-            {
-                try
-                {
-                    file.closeInputStream();
-                }
-                catch (IllegalStateException e)
-                {
-                    // This is fine, this means that the exception that we caught above was thrown before we ever opened
-                    // the InputStream for the file.
-                }
-            }
+                file.closeInputStream();
             if (null != dataFile && !Boolean.parseBoolean(saveToPipeline) && !_useAsync)
                 dataFile.delete();
         }

--- a/core/src/org/labkey/core/attachment/DatabaseAttachmentFile.java
+++ b/core/src/org/labkey/core/attachment/DatabaseAttachmentFile.java
@@ -17,12 +17,14 @@
 package org.labkey.core.attachment;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.Logger;
 import org.labkey.api.attachments.Attachment;
 import org.labkey.api.attachments.AttachmentFile;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.util.ResultSetUtil;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -38,6 +40,7 @@ import java.util.Map;
  */
 public class DatabaseAttachmentFile implements AttachmentFile
 {
+    private static final Logger LOG = LogHelper.getLogger(DatabaseAttachmentFile.class, "Attachment file stored in the DB");
     private final Attachment _attachment;
     private final String _contentType;
     private final int _fileSize;
@@ -119,11 +122,13 @@ public class DatabaseAttachmentFile implements AttachmentFile
     @Override
     public void closeInputStream()
     {
-        if (_is == null)
-            throw new IllegalStateException("No input stream is active for this DatabaseAttachmentFile");
-
-        IOUtils.closeQuietly(_is);
-        _is = null;
-        _rs = ResultSetUtil.close(_rs);
+        if (_is != null)
+        {
+            IOUtils.closeQuietly(_is);
+            _is = null;
+            _rs = ResultSetUtil.close(_rs);
+        }
+        else
+            LOG.warn("No input stream is active for this DatabaseAttachmentFile");
     }
 }


### PR DESCRIPTION
#### Rationale
A recent [merge ](https://github.com/LabKey/platform/pull/3231) updated how attachment file input streams are handled and essentially made it illegal to close the `InputStream` more than once. This caused a number of automated test failures with exceptions that looked similar to this:

```
java.lang.IllegalStateException: No input stream is active for this SpringAttachmentFile
	at org.labkey.api.attachments.SpringAttachmentFile.closeInputStream(SpringAttachmentFile.java:104) ~[api-22.5-SNAPSHOT.jar:?]
	at org.labkey.core.webdav.DavController$PutAction$1.closeInputStream(DavController.java:3073) ~[core-22.5-SNAPSHOT.jar:?]
	at org.labkey.core.webdav.DavController$PutAction.doMethod(DavController.java:3276) ~[core-22.5-SNAPSHOT.jar:?]
	at org.labkey.core.webdav.DavController$PostAction.doMethod(DavController.java:1250) ~[core-22.5-SNAPSHOT.jar:?]
	at org.labkey.core.webdav.DavController$DavAction.handleRequest(DavController.java:735) ~[core-22.5-SNAPSHOT.jar:?]
	at org.labkey.core.webdav.DavController$PutAction.handleRequest(DavController.java:3020) ~[core-22.5-SNAPSHOT.jar:?]
	at org.labkey.core.webdav.DavController.handleRequest(DavController.java:331) [core-22.5-SNAPSHOT.jar:?]
	at org.labkey.core.webdav.WebdavServlet.service(WebdavServlet.java:145) [core-22.5-SNAPSHOT.jar:?]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:741) [servlet-api.jar:?]
```
This change was overaggressive since we obviously have code paths which attempt to close input streams more than once.  This change reverts back to the previous behavior of allowing multiple closes but logs a warning which will allow the team to evaluate which code paths and attachment files this happens in and to decide whether to fix them and then apply stricter rules.

