### PR TITLE
close attachment file input stream

### DIFF
--- a/core/src/org/labkey/core/query/UsersTable.java
+++ b/core/src/org/labkey/core/query/UsersTable.java
@@ -557,6 +557,7 @@ public class UsersTable extends SimpleUserSchema.SimpleTable<UserSchema>
                 try (InputStream is = file.openInputStream())
                 {
                     BufferedImage image = ImageIO.read(is);
+                    file.closeInputStream();
                     float desiredSize = ThumbnailService.ImageType.Large.getHeight();
 
                     if (image == null)
@@ -589,6 +590,7 @@ public class UsersTable extends SimpleUserSchema.SimpleTable<UserSchema>
                     {
                         ImageStreamThumbnailProvider wrapper = new ImageStreamThumbnailProvider(new AvatarThumbnailProvider(user), is, file.getContentType(), imageType, true);
                         svc.replaceThumbnail(wrapper, imageType, null, null);
+                        file.closeInputStream();
                     }
                     catch (IOException e)
                     {


### PR DESCRIPTION
#### Rationale
Another failure related to this [merge](https://github.com/LabKey/platform/pull/3231). The code was wrapping the returned  `InputStream` in a `try with resources` block but wasn't aware that the `AttachmentFile` also tracks the `InputStream`. Maybe in the future we should consider not having `AttachmentFile` manage `InputStreams` and have anyone who asks for an `InputStream` manage it on their own.

#### Changes
- invoke `AttachmentFile.closeInputStream`