### PR TITLE
Issue 45273: Importing groups during "create from template" can result in unauthorized exceptions

### DIFF
--- a/api/src/org/labkey/api/security/GuestUser.java
+++ b/api/src/org/labkey/api/security/GuestUser.java
@@ -37,6 +37,7 @@ class GuestUser extends User
     }
 
     // For serialization
+    @SuppressWarnings("unused")
     protected GuestUser() { }
 
     @Override
@@ -49,5 +50,11 @@ class GuestUser extends User
     public boolean isActive()
     {
         return true;
+    }
+
+    @Override
+    public void refreshGroups()
+    {
+        // Don't clear out GuestUser's groups since they're set in its constructor
     }
 }

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -215,7 +215,8 @@ public class User extends UserPrincipal implements Serializable, Cloneable
 
     public void refreshGroups()
     {
-        _groups = null;
+        if (!isGuest()) // GuestUser explicitly sets groups in its constructor
+            _groups = null;
     }
 
     public boolean isFirstLogin()

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -213,6 +213,10 @@ public class User extends UserPrincipal implements Serializable, Cloneable
         return _groups;
     }
 
+    public void refreshGroups()
+    {
+        _groups = null;
+    }
 
     public boolean isFirstLogin()
     {

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -215,8 +215,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable
 
     public void refreshGroups()
     {
-        if (!isGuest()) // GuestUser explicitly sets groups in its constructor
-            _groups = null;
+        _groups = null;
     }
 
     public boolean isFirstLogin()

--- a/core/src/org/labkey/core/admin/importer/SecurityGroupImporterFactory.java
+++ b/core/src/org/labkey/core/admin/importer/SecurityGroupImporterFactory.java
@@ -92,7 +92,7 @@ public class SecurityGroupImporterFactory extends AbstractFolderImportFactory
                 GroupManager.importGroupMembers(GroupManager.getGroup(ctx.getContainer(), xmlGroupType.getName(), xmlGroupType.getType()), xmlGroupType, ctx.getLogger(), ctx.getContainer());
             }
 
-            ctx.getUser().refreshGroups(); // The import user's own groups may have changed as the result of this import, #45273
+            ctx.getUser().refreshGroups(); // The import user's own groups may have changed as the result of this import, Issue #45273
         }
 
         @NotNull

--- a/core/src/org/labkey/core/admin/importer/SecurityGroupImporterFactory.java
+++ b/core/src/org/labkey/core/admin/importer/SecurityGroupImporterFactory.java
@@ -85,11 +85,14 @@ public class SecurityGroupImporterFactory extends AbstractFolderImportFactory
                 if (groupId == null)
                     SecurityManager.createGroup(ctx.getContainer(), xmlGroupType.getName());
             }
+
             // now populate the groups with their members
             for (GroupType xmlGroupType : groups.getGroupArray())
             {
                 GroupManager.importGroupMembers(GroupManager.getGroup(ctx.getContainer(), xmlGroupType.getName(), xmlGroupType.getType()), xmlGroupType, ctx.getLogger(), ctx.getContainer());
             }
+
+            ctx.getUser().refreshGroups(); // The import user's own groups may have changed as the result of this import, #45273
         }
 
         @NotNull


### PR DESCRIPTION
#### Rationale
Refresh import user's groups after group import to ensure new memberships for that user are recognized.

[Issue 45273: Importing groups during create from template can result in unauthorized exceptions](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45273)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3138
