### PR TITLE
Issue 45275: SQL Server upgrade very slow in exp-21.013-21.014.sql

### DIFF
--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-21.013-21.014.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-21.013-21.014.sql
@@ -16,6 +16,8 @@
 
 ALTER TABLE exp.ProtocolApplication ADD EntityId ENTITYID;
 
-EXEC core.executeJavaUpgradeCode 'generateExpProtocolApplicationEntityIds';
+GO
+
+UPDATE exp.ProtocolApplication SET EntityId = NEWID();
 
 ALTER TABLE exp.ProtocolApplication ALTER COLUMN EntityId ENTITYID NOT NULL;


### PR DESCRIPTION
#### Rationale
exp-21.013-21.014.sql is populating the exp.ProtocolApplication.EntityId column by updating the rows one Table.update() call at a time. That's slow when you have more than a million rows.

#### Changes
* For SQL Server, use NEWID() via a bulk UPDATE call instead of Java upgrade code