### PR TITLE
Fix Issue 45275

### DIFF
--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -247,7 +247,8 @@ public class ExperimentUpgradeCode implements UpgradeCode
                 }
             }
 
-            pm.executeBatch();
+            if (count > 0) pm.executeBatch();
+
             tx.commit();
         }
     }

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -228,6 +228,7 @@ public class ExperimentUpgradeCode implements UpgradeCode
             Parameter entityId = new Parameter("entityid", JdbcType.GUID);
             ParameterMapStatement pm = new ParameterMapStatement(protocolApplicationTable.getSchema().getScope(), tx.getConnection(),
                     new SQLFragment("UPDATE " + protocolApplicationTable.getSelectName() + " SET EntityId = ? WHERE RowId = ?", entityId, rowId), null);
+            int count = 0;
 
             for (var application: applications)
             {
@@ -236,6 +237,13 @@ public class ExperimentUpgradeCode implements UpgradeCode
                     rowId.setValue(application.getRowId());
                     entityId.setValue(new GUID());
                     pm.addBatch();
+                    count = count + 1;
+
+                    if (count == 1000)
+                    {
+                        count = 0;
+                        pm.executeBatch();
+                    }
                 }
             }
 


### PR DESCRIPTION
#### Rationale
The upgrade code in question is causing perf problems for large SQL Server installations, this was fixed in a previous PR by @labkey-jeckels, but the issue still needs to be addressed for Postgres. This PR updates the upgrade code to use ParameterMapStatement which should be better perf-wise.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3255

#### Changes
* ExperimentUpgradeCode: Use ParameterMapStatement in generateExpProtocolApplicationEntityIds
