### PR TITLE
RunDatasetContextualRoles

### DIFF
--- a/api/src/org/labkey/api/study/assay/RunDatasetContextualRoles.java
+++ b/api/src/org/labkey/api/study/assay/RunDatasetContextualRoles.java
@@ -154,8 +154,9 @@ public class RunDatasetContextualRoles implements HasContextualRoles
 
                 Container studyContainer = ((StudyDatasetLinkedColumn)datasetColumn).getStudyContainer();
                 Dataset dataset = StudyService.get().getDataset(studyContainer, datasetId.intValue());
-                SecurityPolicy policy = dataset.getPolicy();
-                if (policy.hasPermission(user, ReadPermission.class))
+                if (null == dataset)
+                    return null;
+                if (dataset.hasPermission(user, ReadPermission.class))
                     return Collections.singleton(new ReaderRole());
             }
         }


### PR DESCRIPTION
#### Rationale
RunDatasetContextualRoles is not completely consistent with Dataset.hasPermission().  This fixes that.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
