### PR TITLE
45265: Do not export lists cross-folder

### DIFF
--- a/list/src/org/labkey/list/model/FolderListWriter.java
+++ b/list/src/org/labkey/list/model/FolderListWriter.java
@@ -47,7 +47,7 @@ public class FolderListWriter extends BaseFolderWriter
     {
         Container c = ctx.getContainer();
 
-        if (ListService.get().hasLists(c, true))
+        if (ListService.get().hasLists(c, false))
         {
             VirtualFile listsDir = root.getDir(DEFAULT_DIRECTORY);
 

--- a/list/src/org/labkey/list/model/ListWriter.java
+++ b/list/src/org/labkey/list/model/ListWriter.java
@@ -90,7 +90,7 @@ public class ListWriter
     {
         // We exclude picklists because they contain just sampleIds, which will be different in the new container.
         // Picklists are meant to be transient, so not including them in the export makes sense.
-        Map<String, ListDefinition> lists = ListService.get().getLists(c, user, false, false, true);
+        Map<String, ListDefinition> lists = ListService.get().getLists(c, user, false, false, false);
         PHI exportPhiLevel = (ctx != null) ? ctx.getPhiLevel() : PHI.NotPHI;
 
         if (!lists.isEmpty())


### PR DESCRIPTION
#### Rationale
This PR addresses [45265](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45265) by reverting the behavior of including lists defined in other folders in folder exports. In the future we can consider how to better support cross-folder data in list exports.

#### Related Pull Requests
* #3001

#### Changes
* No longer resolve lists cross-folder in `ListWriter` and `FolderListWriter`.
