### PR TITLE
QuerySelect: remove "componentId" prop

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.10.0",
-        "@labkey/components": "2.156.1-fb-query-select-imp.0",
+        "@labkey/components": "2.157.0",
         "@labkey/themes": "1.2.1"
       },
       "devDependencies": {
@@ -3022,9 +3022,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.156.1-fb-query-select-imp.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.156.1-fb-query-select-imp.0.tgz",
-      "integrity": "sha1-DTNEGDPY9Xv9oEBHqCH9Ox3fXRw=",
+      "version": "2.157.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.157.0.tgz",
+      "integrity": "sha1-N5gCKlitMFruewPoYB/28/8cX8A=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -17346,9 +17346,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.156.1-fb-query-select-imp.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.156.1-fb-query-select-imp.0.tgz",
-      "integrity": "sha1-DTNEGDPY9Xv9oEBHqCH9Ox3fXRw=",
+      "version": "2.157.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.157.0.tgz",
+      "integrity": "sha1-N5gCKlitMFruewPoYB/28/8cX8A=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.10.0",
-        "@labkey/components": "2.156.0",
+        "@labkey/components": "2.156.1-fb-query-select-imp.0",
         "@labkey/themes": "1.2.1"
       },
       "devDependencies": {
@@ -3022,9 +3022,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.156.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.156.0.tgz",
-      "integrity": "sha1-uiIOo73hRTtdMe+jkKK/hYbr5Kw=",
+      "version": "2.156.1-fb-query-select-imp.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.156.1-fb-query-select-imp.0.tgz",
+      "integrity": "sha1-DTNEGDPY9Xv9oEBHqCH9Ox3fXRw=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -17346,9 +17346,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.156.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.156.0.tgz",
-      "integrity": "sha1-uiIOo73hRTtdMe+jkKK/hYbr5Kw=",
+      "version": "2.156.1-fb-query-select-imp.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.156.1-fb-query-select-imp.0.tgz",
+      "integrity": "sha1-DTNEGDPY9Xv9oEBHqCH9Ox3fXRw=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package.json
+++ b/core/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.10.0",
-    "@labkey/components": "2.156.1-fb-query-select-imp.0",
+    "@labkey/components": "2.157.0",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.10.0",
-    "@labkey/components": "2.156.0",
+    "@labkey/components": "2.156.1-fb-query-select-imp.0",
     "@labkey/themes": "1.2.1"
   },
   "devDependencies": {

--- a/core/src/client/QuerySelectInput/QuerySelectInput.tsx
+++ b/core/src/client/QuerySelectInput/QuerySelectInput.tsx
@@ -22,7 +22,7 @@ export const QuerySelectInput: FC<Props> = memo(props => {
 
     return (
         <QuerySelect
-            componentId={'query-select' + name}
+            key={'query-select' + name}
             inputClass={'col-sm-8 col-xs-12'}
             name={name}
             schemaQuery={SchemaQuery.create(schemaName, queryName)}


### PR DESCRIPTION
#### Rationale
This PR factors out the `componentId` prop on `QuerySelect`.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/811
* https://github.com/LabKey/biologics/pull/1261
* https://github.com/LabKey/sampleManagement/pull/925
* https://github.com/LabKey/inventory/pull/421
* https://github.com/LabKey/platform/pull/3267

#### Changes
* Factor out `componentId` prop on `QuerySelect`.
