### PR TITLE
45176: Resolving an issue always reassigns to the opener

### DIFF
--- a/issues/src/org/labkey/issue/IssueServiceImpl.java
+++ b/issues/src/org/labkey/issue/IssueServiceImpl.java
@@ -79,7 +79,6 @@ public class IssueServiceImpl implements IssueService
                         {
                             duplicateOf = IssueManager.getIssue(null, user, issueObject.getDuplicate());
                         }
-                        issueObject.beforeResolve(container, user);
                         issueObject.resolve(user);
                     }
                     case reopen -> issueObject.open(container, user);


### PR DESCRIPTION
#### Rationale
Resolved issues were always getting reassigned to the user who opened the issue, even if a different user was specified. This was a small bug fix and the problem was introduced with the merge of the API endpoint with the legacy UI code (the problem actually came from the API endpoint code)

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45176
