### PR TITLE
Fix study designer NPE

### DIFF
--- a/internal/src/org/labkey/api/gwt/server/BaseRemoteService.java
+++ b/internal/src/org/labkey/api/gwt/server/BaseRemoteService.java
@@ -17,8 +17,6 @@
 package org.labkey.api.gwt.server;
 
 import com.google.gwt.user.server.rpc.RemoteServiceServlet;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.module.ModuleLoader;
@@ -43,8 +41,6 @@ import java.util.Vector;
  */
 public abstract class BaseRemoteService extends RemoteServiceServlet
 {
-    private static Logger _log = LogManager.getLogger(BaseRemoteService.class);
-
     protected ViewContext _context;
     public BaseRemoteService(ViewContext context)
     {
@@ -108,7 +104,6 @@ public abstract class BaseRemoteService extends RemoteServiceServlet
     {
         failure = ExceptionUtil.unwrapException(failure);
         ExceptionUtil.logExceptionToMothership(getThreadLocalRequest(), failure);
-        _log.error("GWT Service Error", failure);
 
         HttpServletResponse response = getThreadLocalResponse();
         try

--- a/study/src/org/labkey/study/designer/StudyDefinitionServiceImpl.java
+++ b/study/src/org/labkey/study/designer/StudyDefinitionServiceImpl.java
@@ -36,6 +36,7 @@ import org.labkey.api.study.StudyService;
 import org.labkey.api.study.TimepointType;
 import org.labkey.api.study.Visit;
 import org.labkey.api.util.UnexpectedException;
+import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewContext;
 import org.labkey.study.assay.StudyPublishManager;
@@ -127,6 +128,9 @@ public class StudyDefinitionServiceImpl extends BaseRemoteService implements Stu
                 version = StudyDesignManager.get().getStudyDesignVersion(container, studyId, revision);
             else
                 version = StudyDesignManager.get().getStudyDesignVersion(container, studyId);
+
+            if (null == version)
+                throw new NotFoundException("Protocol " + studyId + (revision >= 0 ? ", Revision " + revision : "") + " not found!");
 
             GWTStudyDefinition template = getTemplate();
             GWTStudyDefinition def = XMLSerializer.fromXML(version.getXML(), template.getCavdStudyId() == studyId ? null : template, getUser(), container);


### PR DESCRIPTION
#### Rationale
Crawler threw garbage at the study designer and saw an NPE stack trace in the log.

Throw a `NotFoundException` instead. Also, get rid of unconditional logging of exceptions in `BaseRemoteService`, otherwise the crawler will balk at not found and other innocuous exceptions. `ExceptionUtil.logExceptionToMothership()` already logs the exceptions we want to see... no need to double log.
