### PR TITLE
D3Renderer.js null check for plot.originalAes

### DIFF
--- a/internal/webapp/vis/src/internal/D3Renderer.js
+++ b/internal/webapp/vis/src/internal/D3Renderer.js
@@ -1922,7 +1922,7 @@ LABKEY.vis.internal.D3Renderer = function(plot) {
                     return 'translate(' + glyphX + ',' + y + ')';
                 });
 
-        if (plot.originalAes.legend && plot.originalAes.legend.mouseOverFn) {
+        if (plot.originalAes && plot.originalAes.legend && plot.originalAes.legend.mouseOverFn) {
             selection.on('mouseover', function (data) {
                 plot.originalAes.legend.mouseOverFn.call(d3.event, data, this);
             });


### PR DESCRIPTION
#### Rationale
Fix for ElisaMultiPlateAssayTest failures caused by changes from the Panorama QC plot updates.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3237

#### Changes
* Add null check in D3Renderer.js before plot.originalAes.legend is used
