### PR TITLE
45265: Lists: Default to not including project/shared lists

### DIFF
--- a/api/src/org/labkey/api/exp/list/ListDefinition.java
+++ b/api/src/org/labkey/api/exp/list/ListDefinition.java
@@ -333,6 +333,7 @@ public interface ListDefinition extends Comparable<ListDefinition>
     @Nullable TableInfo getTable(User user, Container c, @Nullable ContainerFilter cf);
 
     ActionURL urlShowDefinition();
+    ActionURL urlImport(Container container);
     ActionURL urlUpdate(User user, Container container, @Nullable Object pk, @Nullable URLHelper returnUrl);
     ActionURL urlDetails(@Nullable Object pk);
     ActionURL urlDetails(@Nullable Object pk, Container c);

--- a/list/src/org/labkey/list/PicklistSampleCompareType.java
+++ b/list/src/org/labkey/list/PicklistSampleCompareType.java
@@ -32,7 +32,7 @@ public class PicklistSampleCompareType extends CompareType
         if (user == null || container == null)
             return new SimpleFilter.FalseClause();
 
-        ListDefinition listDef = ListService.get().getList(container, listName);
+        ListDefinition listDef = ListService.get().getList(container, listName, true);
         if (listDef == null || !listDef.isPicklist())
             return new SimpleFilter.FalseClause();
 

--- a/list/src/org/labkey/list/model/ListDefinitionImpl.java
+++ b/list/src/org/labkey/list/model/ListDefinitionImpl.java
@@ -713,6 +713,11 @@ public class ListDefinitionImpl implements ListDefinition
         return table;
     }
 
+    public ActionURL urlImport(Container c)
+    {
+        return urlForName(ListController.UploadListItemsAction.class, c);
+    }
+
     @Override
     public ActionURL urlShowDefinition()
     {
@@ -722,7 +727,7 @@ public class ListDefinitionImpl implements ListDefinition
     @Override
     public ActionURL urlShowData(Container c)
     {
-        return urlFor(ListController.GridAction.class, c);
+        return urlForName(ListController.GridAction.class, c);
     }
 
     @Override
@@ -752,7 +757,7 @@ public class ListDefinitionImpl implements ListDefinition
     @Override
     public ActionURL urlDetails(@Nullable Object pk, Container c)
     {
-        ActionURL url = urlFor(ListController.DetailsAction.class, c);
+        ActionURL url = urlForName(ListController.DetailsAction.class, c);
         // Can be null if caller will be filling in pk (e.g., grid edit column)
 
         if (null != pk)
@@ -784,6 +789,13 @@ public class ListDefinitionImpl implements ListDefinition
     {
         ActionURL ret = new ActionURL(actionClass, c);
         ret.addParameter("listId", getListId());
+        return ret;
+    }
+
+    private ActionURL urlForName(Class<? extends Controller> actionClass, Container c)
+    {
+        ActionURL ret = new ActionURL(actionClass, c);
+        ret.addParameter("name", getName());
         return ret;
     }
 

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -496,7 +496,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
                 {
                     return exception.addGlobalError("List name cannot be longer than " + MAX_NAME_LENGTH + " characters.");
                 }
-                else if (ListService.get().getList(container, update.getName(), false) != null)
+                else if (ListService.get().getList(container, update.getName()) != null)
                 {
                     return exception.addGlobalError("The name '" + update.getName() + "' is already in use.");
                 }

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -496,7 +496,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
                 {
                     return exception.addGlobalError("List name cannot be longer than " + MAX_NAME_LENGTH + " characters.");
                 }
-                else if (ListService.get().getList(container, update.getName()) != null)
+                else if (ListService.get().getList(container, update.getName(), false) != null)
                 {
                     return exception.addGlobalError("The name '" + update.getName() + "' is already in use.");
                 }

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -130,12 +130,12 @@ public class ListManager implements SearchService.DocumentProvider
 
     public Collection<ListDef> getPicklists(Container container)
     {
-        return getLists(container).stream().filter(ListDef::isPicklist).collect(Collectors.toList());
+        return getLists(container, true).stream().filter(ListDef::isPicklist).collect(Collectors.toList());
     }
 
     public Collection<ListDef> getLists(Container container)
     {
-        return getLists(container, true);
+        return getLists(container, false);
     }
 
     public Collection<ListDef> getLists(Container container, boolean includeProjectAndShared)

--- a/list/src/org/labkey/list/model/ListQuerySchema.java
+++ b/list/src/org/labkey/list/model/ListQuerySchema.java
@@ -94,7 +94,7 @@ public class ListQuerySchema extends UserSchema
     public QueryDefinition getQueryDefForTable(String name)
     {
         QueryDefinition qdef = super.getQueryDefForTable(name);
-        ListDefinition list = ListService.get().getList(getContainer(), name);
+        ListDefinition list = ListService.get().getList(getContainer(), name, true);
         if (list != null)
             qdef.setIsIncludedForLookups(!list.isPicklist());
         return qdef;
@@ -104,7 +104,7 @@ public class ListQuerySchema extends UserSchema
     @Nullable
     public TableInfo createTable(String name, ContainerFilter cf)
     {
-        ListDefinition def = ListService.get().getList(getContainer(), name);
+        ListDefinition def = ListService.get().getList(getContainer(), name, true);
         if (def != null)
         {
             Domain domain = def.getDomain();
@@ -126,7 +126,7 @@ public class ListQuerySchema extends UserSchema
     @Override
     public QueryView createView(ViewContext context, @NotNull QuerySettings settings, BindException errors)
     {
-        ListDefinition def = ListService.get().getList(getContainer(), settings.getQueryName());
+        ListDefinition def = ListService.get().getList(getContainer(), settings.getQueryName(), true);
         if (def != null)
         {
             return new ListQueryView(def, this, settings, errors);
@@ -139,7 +139,7 @@ public class ListQuerySchema extends UserSchema
     public String getDomainURI(String queryName)
     {
         Container container = getContainer();
-        ListDefinition listDef = ListService.get().getList(container, queryName);
+        ListDefinition listDef = ListService.get().getList(container, queryName, true);
         if (null == listDef)
             throw new NotFoundException("List '" + queryName + "' was not found in the container '" + container.getPath() + "'.");
         Domain domain = listDef.getDomain();

--- a/list/src/org/labkey/list/model/ListQuerySchema.java
+++ b/list/src/org/labkey/list/model/ListQuerySchema.java
@@ -84,7 +84,7 @@ public class ListQuerySchema extends UserSchema
     @Override
     public Set<String> getTableNames()
     {
-        return ListManager.get().getLists(getContainer(), getUser(), false, true, true)
+        return ListManager.get().getLists(getContainer(), getUser(), false, true, false)
             .stream()
             .map(ListDef::getName)
             .collect(Collectors.toSet());

--- a/list/src/org/labkey/list/model/ListServiceImpl.java
+++ b/list/src/org/labkey/list/model/ListServiceImpl.java
@@ -67,7 +67,7 @@ public class ListServiceImpl implements ListService
     @Override
     public Map<String, ListDefinition> getLists(Container container, @Nullable User user, boolean checkVisibility)
     {
-        return getLists(container, user, checkVisibility, true, true);
+        return getLists(container, user, checkVisibility, true, false);
     }
 
     @Override
@@ -126,7 +126,7 @@ public class ListServiceImpl implements ListService
     @Nullable
     public ListDefinition getList(Container container, String name)
     {
-        return getList(container, name, true);
+        return getList(container, name, false);
     }
 
     @Override

--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -409,7 +409,7 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
         // currently, picklists don't contain PHI and can always be deleted
-        if (_list.isPicklist() && InsertPermission.class.equals(perm) || UpdatePermission.class.equals(perm) || DeletePermission.class.equals(perm))
+        if (_list.isPicklist() && (InsertPermission.class.equals(perm) || UpdatePermission.class.equals(perm) || DeletePermission.class.equals(perm)))
             return getContainer().hasPermission(user, ManagePicklistsPermission.class);
 
         boolean gate = true;

--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -314,8 +314,7 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
             setImportURL(LINK_DISABLER);
         else
         {
-            ActionURL importURL = listDef.urlFor(ListController.UploadListItemsAction.class, _userSchema.getContainer());
-            setImportURL(new DetailsURL(importURL));
+            setImportURL(new DetailsURL(listDef.urlImport(_userSchema.getContainer())));
         }
 
         if (!listDef.getAllowDelete() || !_canAccessPhi)

--- a/list/src/org/labkey/list/view/ListDefinitionForm.java
+++ b/list/src/org/labkey/list/view/ListDefinitionForm.java
@@ -42,7 +42,7 @@ public class ListDefinitionForm extends ViewForm
             }
             else if (null != getName())
             {
-                _listDef = ListService.get().getList(getContainer(), getName());
+                _listDef = ListService.get().getList(getContainer(), getName(), true);
             }
             else
             {

--- a/list/src/org/labkey/list/view/ListQueryForm.java
+++ b/list/src/org/labkey/list/view/ListQueryForm.java
@@ -50,7 +50,7 @@ public class ListQueryForm extends QueryForm
     {
         this();
         setViewContext(context);
-        _primaryDef = ListService.get().getList(getContainer(), listName);
+        _primaryDef = ListService.get().getList(getContainer(), listName, true);
     }
 
     // Set by spring binding reflection
@@ -64,7 +64,7 @@ public class ListQueryForm extends QueryForm
     @SuppressWarnings({"UnusedDeclaration"})
     public void setName(String name)
     {
-        _reflectionBoundDef = ListService.get().getList(getContainer(), name);
+        _reflectionBoundDef = ListService.get().getList(getContainer(), name, true);
     }
 
     private ListDefinition getListDef(int listId)


### PR DESCRIPTION
#### Rationale
This PR addresses [45625](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45265) by switching the default behavior for fetching list definitions to only include definitions from the provided container. List query behavior continues to resolve cross-folder and the `ListQuerySchema` has been updated to explicitly resolve list definitions cross-folder.

Additionally, I've included a couple fixes URL composition for list actions. Namely, when an action resolves a list by `listId` then the scope of list definitions retrieved is for the provided container. If an action resolves a list by `name` then the scope is the provided container plus the container's project and the /Shared folder. This aligns with the underlying data structures since listIds are only unique to a container where as resolving a list by name resolves cross-folder.

#### Related Pull Requests
* #3001 
* #3264

#### Changes
* `ListService` and `ListManager` updated to default to `false` for any implicitly usages of `includeProjectAndShared`.
* `ListQuerySchema` updated to explicitly resolve list definitions cross-folder. Lone exception is `getTableNames` where it defaults to only the current container scope. The latter addresses [45198](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45198).
* Add `urlImport` interface to `ListDefinition` for resolving the import bulk data URL for a list in LKS.
* Resolve import and details URLs for list definitions by "name" so they resolve cross-folder.
*  (Miscellaneous) Fix logic in permissions check for picklists.
