### PR TITLE
44784: IssueAPI should handle missing priority param in validation

### DIFF
--- a/issues/src/org/labkey/issue/IssueServiceImpl.java
+++ b/issues/src/org/labkey/issue/IssueServiceImpl.java
@@ -233,6 +233,7 @@ public class IssueServiceImpl implements IssueService
         if (issueListDef == null)
         {
             issueObject.setIssueDefId(defaultIssueListDef.getRowId());
+            issueListDef = defaultIssueListDef;
         }
 
         if (action == Issue.action.reopen)

--- a/issues/src/org/labkey/issue/model/IssueObject.java
+++ b/issues/src/org/labkey/issue/model/IssueObject.java
@@ -152,7 +152,10 @@ public class IssueObject extends Entity implements Serializable, Cloneable, Issu
         setAssignedTo(IssueManager.validateAssignedTo(c, getAssignedTo()));
     }
 
-
+    /**
+     * This method should be called before the form is initially shown to automatically
+     * populate some fields affected by issue resolution
+     */
     public void beforeResolve(Container c, User u)
     {
         setStatus(statusRESOLVED);


### PR DESCRIPTION
#### Rationale
Requests using the issue API can differ from those submitted from the UI in that the properties can be sparse. The previous validation assumed that all properties were specified in the request (even if they were null). This meant that we were missing some required checks during validation but it would be caught further down when we tried to save the issue to the DB (although this resulted in an error getting logged).

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44784

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/1094

#### Changes
- Handle validation for required fields even if they aren't specified in the request.
