### PR TITLE
Issue 45344: experiment-showMaterial.view fetches ProtocolApplications too often

### DIFF
--- a/api/src/org/labkey/api/exp/query/ExpRunTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpRunTable.java
@@ -23,7 +23,7 @@ import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 
-import java.util.List;
+import java.util.Collection;
 
 public interface ExpRunTable extends ExpTable<ExpRunTable.Column>
 {
@@ -75,7 +75,7 @@ public interface ExpRunTable extends ExpTable<ExpRunTable.Column>
     void setInputData(ExpData expData);
     ExpData getInputData();
 
-    void setRuns(List<ExpRun> runs);
+    void setRuns(Collection<ExpRun> runs);
 
     /**
      * Returns a column which links to a data input of the specified type.

--- a/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
@@ -69,6 +69,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -182,7 +183,7 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
     }
 
     @Override
-    public void setRuns(List<ExpRun> runs)
+    public void setRuns(Collection<ExpRun> runs)
     {
         checkLocked();
         if (runs.isEmpty())
@@ -192,7 +193,6 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
         else
         {
             SQLFragment sql = new SQLFragment();
-            //sql.append(ExperimentServiceImpl.get().getTinfoExperimentRun());
             sql.append("RowID IN (");
             String separator = "";
             for (ExpRun run : runs)

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -5631,8 +5631,7 @@ public class ExperimentServiceImpl implements ExperimentService
         for (ExpMaterialImpl mat : materials)
         {
             runMaterialMap.put(mat.getRowId(), mat);
-            ExpProtocolApplication sourceApplication = mat.getSourceApplication();
-            Integer srcAppId = sourceApplication == null ? null : sourceApplication.getRowId();
+            Integer srcAppId = mat.getDataObject().getSourceApplicationId();
             ExpProtocolApplicationImpl protApp = resolveProtApp(expRun, protStepMap, srcAppId);
             protApp.getOutputMaterials().add(mat);
             mat.markAsPopulated(protApp);

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -237,6 +237,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -887,7 +888,7 @@ public class ExperimentController extends SpringActionController
             VBox vbox = super.getView(form, errors);
 
             List<ExpMaterial> materialsToInvestigate = new ArrayList<>();
-            final List<ExpRun> successorRuns = new ArrayList<>();
+            final Set<ExpRun> successorRuns = new HashSet<>();
             materialsToInvestigate.add(_material);
             Set<ExpMaterial> investigatedMaterials = new HashSet<>();
             while (!materialsToInvestigate.isEmpty())
@@ -897,8 +898,11 @@ public class ExperimentController extends SpringActionController
                 {
                     for (ExpRun r : ExperimentService.get().getRunsUsingMaterials(m.getRowId()))
                     {
-                        successorRuns.add(r);
-                        materialsToInvestigate.addAll(r.getMaterialOutputs());
+                        // Only expand the material outputs of the run if it's our first time looking at the run
+                        if (successorRuns.add(r))
+                        {
+                            materialsToInvestigate.addAll(r.getMaterialOutputs());
+                        }
                     }
                 }
                 if (successorRuns.size() > 1000)


### PR DESCRIPTION
#### Rationale
When a sample has derivations and other downstream usages, rendering its showMaterial page can take tens of seconds because we're firing off tens of thousands of redundant DB queries

#### Changes
* Don't query the exp.ProtocolApplication table based on the RowId, only to use the RowId value for downstream work
* Use a set instead of a list to track which runs have been visited