### PR TITLE
Folder Export: support context override of folder.xml behavior

### DIFF
--- a/api/src/org/labkey/api/admin/FolderExportContext.java
+++ b/api/src/org/labkey/api/admin/FolderExportContext.java
@@ -38,6 +38,7 @@ public class FolderExportContext extends AbstractFolderContext
     private final boolean _alternateIds;
     private final boolean _maskClinic;
 
+    private boolean _includeFolderXml;
     private boolean _includeSubfolders;
     private Set<String> _viewIds;
     private Set<String> _reportIds;
@@ -63,6 +64,7 @@ public class FolderExportContext extends AbstractFolderContext
         }
 
         _format = format;
+        _includeFolderXml = true;
         _includeSubfolders = includeSubfolders;
         _phiLevel = phiLevel;
         _shiftDates = shiftDates;
@@ -74,6 +76,16 @@ public class FolderExportContext extends AbstractFolderContext
     public String getFormat()
     {
         return _format;
+    }
+
+    public void setIncludeFolderXml(boolean includeFolderXml)
+    {
+        _includeFolderXml = includeFolderXml;
+    }
+
+    public boolean isIncludeFolderXml()
+    {
+        return _includeFolderXml;
     }
 
     @Override

--- a/api/src/org/labkey/api/admin/FolderWriterImpl.java
+++ b/api/src/org/labkey/api/admin/FolderWriterImpl.java
@@ -89,7 +89,8 @@ public class FolderWriterImpl extends BaseFolderWriter
             subfolderWriter.write(c, ctx, vf);
         }
 
-        writeFolderXml(c, ctx, vf);
+        if (ctx.isIncludeFolderXml())
+            writeFolderXml(c, ctx, vf);
 
         LOG.info("Done exporting folder to " + vf.getLocation());
     }


### PR DESCRIPTION
#### Rationale
In support of alternative use cases for folder archive writers this PR makes writing of the "folder.xml" to the archive configurable based on the supplied FolderExportContext.

#### Related Pull Requests
* https://github.com/LabKey/labbook/pull/163

#### Changes
* Folder Export: support context override of folder.xml behavior
