### PR TITLE
Issue 45298: Optimize notification count retrieval

### DIFF
--- a/api/src/org/labkey/api/admin/notification/NotificationService.java
+++ b/api/src/org/labkey/api/admin/notification/NotificationService.java
@@ -72,7 +72,7 @@ public interface NotificationService
      * Returns just the count of notifications for a specific user. At any given instant, will match the length of the
      * list returned by getNotificationsByUser(), and is significantly more efficient to query.
      */
-    long getNotificationCountByUser(Container container, int notifyUserId, boolean unreadOnly);
+    long getUnreadNotificationCountByUser(Container container, int notifyUserId);
 
     /*
      * Returns a list of notifications for a specific user based on the specified type.
@@ -140,13 +140,13 @@ public interface NotificationService
     /*
      * send event to browser
      */
-    void sendServerEvent(int userId, Class clazz);
+    void sendServerEvent(int userId, Class<?> clazz);
     /*
      * send event to browser
      */
-    void sendServerEvent(int userId, Enum e);
+    void sendServerEvent(int userId, Enum<?> e);
 
-    void sendServerEvent(List<Integer> userIds, Enum e);
+    void sendServerEvent(List<Integer> userIds, Enum<?> e);
 
-    void sendServerEvent(List<Integer> userIds, Class clazz);
+    void sendServerEvent(List<Integer> userIds, Class<?> clazz);
 }

--- a/api/src/org/labkey/api/admin/notification/NotificationService.java
+++ b/api/src/org/labkey/api/admin/notification/NotificationService.java
@@ -72,7 +72,7 @@ public interface NotificationService
      * Returns just the count of notifications for a specific user. At any given instant, will match the length of the
      * list returned by getNotificationsByUser(), and is significantly more efficient to query.
      */
-    long getUnreadNotificationCountByUser(Container container, int notifyUserId);
+    long getUnreadNotificationCountByUser(@Nullable Container container, int notifyUserId);
 
     /*
      * Returns a list of notifications for a specific user based on the specified type.

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -2352,7 +2352,7 @@ public class PageFlowUtil
         json.put("jdkJavaDocLinkPrefix", HelpTopic.getJdkJavaDocLinkPrefix());
 
         if (AppProps.getInstance().isExperimentalFeatureEnabled(NotificationMenuView.EXPERIMENTAL_NOTIFICATION_MENU))
-            json.put("notifications", Map.of("unreadCount", NotificationService.get().getNotificationCountByUser(null, user.getUserId(), true)));
+            json.put("notifications", Map.of("unreadCount", NotificationService.get().getUnreadNotificationCountByUser(null, user.getUserId())));
 
         JSONObject defaultHeaders = new JSONObject();
         defaultHeaders.put("X-ONUNAUTHORIZED", "UNAUTHORIZED");


### PR DESCRIPTION
#### Rationale
When the notification menu is turned on, it adds a DB query to every page load. While 10-20ms extra isn't terrible, it's a lot of time to add to every single page.

#### Changes
* Cache unread notification count on a per-user basis
* Clear cache when notifications come and go