### PR TITLE
Issue 45238: NPE when importing sample type with auto-link study via pipeline job

### DIFF
--- a/api/src/org/labkey/api/admin/FolderImportContext.java
+++ b/api/src/org/labkey/api/admin/FolderImportContext.java
@@ -67,8 +67,6 @@ public class FolderImportContext extends AbstractFolderContext
     {
         super(user, c, null, dataTypes, logger, root);
         _folderXml = folderXml;
-        DbSequence newSequence = DbSequenceManager.getPreallocatingSequence(c, FOLDER_IMPORT_DB_SEQUENCE_PREFIX, 0, 1);
-        _xarJobId = "Xar-" + newSequence.next();
     }
 
     public FolderImportContext(User user, Container c, FolderDocument folderDoc, Set<String> dataTypes, LoggerGetter logger, VirtualFile root)
@@ -152,6 +150,12 @@ public class FolderImportContext extends AbstractFolderContext
 
     public Map<String, String> getXarJobIdContext()
     {
+        if (_xarJobId == null)
+        {
+            DbSequence newSequence = DbSequenceManager.getPreallocatingSequence(getContainer(), FOLDER_IMPORT_DB_SEQUENCE_PREFIX, 0, 1);
+            _xarJobId = "Xar-" + newSequence.next();
+        }
+
         return new HashMap<>()
         {{
             put(XAR_JOB_ID_NAME, _xarJobId);

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -3095,6 +3095,11 @@ public class QueryView extends WebPartView<Object>
         return _apiResponseView;
     }
 
+    public void setApiResponseView(boolean apiResponseView)
+    {
+        _apiResponseView = apiResponseView;
+    }
+
     public boolean isUseQueryViewActionExportURLs()
     {
         return _useQueryViewActionExportURLs;

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -143,7 +143,7 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                     // handle wiring up any derivation runs
                     if (runsXarFile != null)
                     {
-                        XarSource runsXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(runsXarFile.getFileName().toString()), runsXarFile, logFile, job, ctx.getContainer(), ctx.getXarJobIdContext());
+                        XarSource runsXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(runsXarFile.getFileName().toString()), runsXarFile, logFile, job, ctx.getUser(), ctx.getContainer(), ctx.getXarJobIdContext());
                         try
                         {
                             runsXarSource.init();
@@ -184,7 +184,7 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
             job = getDummyPipelineJob(ctx);
         }
 
-        XarSource typesXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(typesXarFile.getFileName().toString()), typesXarFile, logFile, job, ctx.getContainer(), ctx.getXarJobIdContext());
+        XarSource typesXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(typesXarFile.getFileName().toString()), typesXarFile, logFile, job, ctx.getUser(), ctx.getContainer(), ctx.getXarJobIdContext());
         try
         {
             typesXarSource.init();

--- a/experiment/src/org/labkey/experiment/xar/AbstractXarImporter.java
+++ b/experiment/src/org/labkey/experiment/xar/AbstractXarImporter.java
@@ -18,6 +18,7 @@ package org.labkey.experiment.xar;
 
 import org.apache.logging.log4j.Logger;
 import org.fhcrc.cpas.exp.xml.ExperimentArchiveType;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.XarContext;
@@ -30,6 +31,7 @@ import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.security.User;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.experiment.api.SampleTypeServiceImpl;
 
 /**
@@ -38,11 +40,14 @@ import org.labkey.experiment.api.SampleTypeServiceImpl;
  */
 public abstract class AbstractXarImporter
 {
+    private static final Logger LOG = LogHelper.getLogger(AbstractXarImporter.class, "XAR imports");
+
     protected final XarSource _xarSource;
+    @Nullable
     protected final PipelineJob _job;
     protected ExperimentArchiveType _experimentArchive;
 
-    public AbstractXarImporter(XarSource source, PipelineJob job)
+    public AbstractXarImporter(XarSource source, @Nullable PipelineJob job)
     {
         _xarSource = source;
         _job = job;
@@ -91,8 +96,8 @@ public abstract class AbstractXarImporter
         }
     }
 
-    protected User getUser() { return _job.getUser(); }
-    protected Logger getLog() { return _job.getLogger(); }
-    protected Container getContainer() { return _job.getContainer(); }
+    protected User getUser() { return _job == null ? _xarSource.getXarContext().getUser() : _job.getUser(); }
+    protected Logger getLog() { return _job == null ? LOG : _job.getLogger(); }
+    protected Container getContainer() { return _job == null ? _xarSource.getXarContext().getContainer() : _job.getContainer(); }
     protected XarContext getRootContext() { return _xarSource.getXarContext(); }
 }

--- a/internal/src/org/labkey/api/exp/CompressedInputStreamXarSource.java
+++ b/internal/src/org/labkey/api/exp/CompressedInputStreamXarSource.java
@@ -5,6 +5,7 @@ import org.fhcrc.cpas.exp.xml.ExperimentArchiveDocument;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.security.User;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.XmlBeansUtil;
 
@@ -12,7 +13,6 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -33,9 +33,9 @@ public class CompressedInputStreamXarSource extends AbstractFileXarSource
     private final Path _logFile;
     private String _xml;
 
-    public CompressedInputStreamXarSource(InputStream xarInputStream, Path xarFile, Path logFile, PipelineJob job, Container container, @Nullable Map<String, String> substitutions)
+    public CompressedInputStreamXarSource(InputStream xarInputStream, Path xarFile, Path logFile, @Nullable PipelineJob job, User user, Container container, @Nullable Map<String, String> substitutions)
     {
-        super(job.getDescription(), container, job.getUser(), job, substitutions);
+        super(job == null ? null : job.getDescription(), container, user, job, substitutions);
         _xarInputStream = xarInputStream;
         _xmlFile = xarFile;
         _logFile = logFile;

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -1693,6 +1693,9 @@ public class StudyPublishManager implements StudyPublishService
             if (qs != null)
             {
                 QueryView view = new QueryView(userSchema, qs, null);
+                // Issue 45238 - configure as API style invocation to skip setting up buttons and other items that
+                // rely on being invoked inside an HTTP request/ViewContext
+                view.setApiResponseView(true);
                 DataView dataView = view.createDataView();
                 for (Map.Entry<FieldKey, ColumnInfo> entry : dataView.getDataRegion().getSelectColumns().entrySet())
                 {


### PR DESCRIPTION
#### Rationale
We want full-fidelity round tripping of sample types regardless of the import mechanism

#### Changes
* Don't assume we have a PipelineJob driving the import
* Don't assume we have an HTTP request with a URL when auto-linking samples to a target study
* Always populate xarJobId substitution, regardless of which constructor is used