### PR TITLE
Remove default container filter override for data classes

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -128,12 +128,6 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
     private final @NotNull ExpDataClassImpl _dataClass;
     public static final String DATA_COUNTER_SEQ_PREFIX = "DataNameGenCounter-";
 
-    @Override
-    protected ContainerFilter getDefaultContainerFilter()
-    {
-        return ContainerFilter.Type.CurrentPlusProjectAndShared.create(_userSchema);
-    }
-
     public ExpDataClassDataTableImpl(String name, UserSchema schema, ContainerFilter cf, @NotNull ExpDataClassImpl dataClass)
     {
         super(name, ExperimentService.get().getTinfoData(), schema, cf);


### PR DESCRIPTION
#### Rationale
The override of the default container filer for the `ExpDataClassDataTable` to use `CurrentPlusProjectAndShared` is causing inconsistent behavior for samples and data class data in our applications.  I'm not finding a good reason for this table to have a different default container filter.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/929
* https://github.com/LabKey/biologics/pull/1263
* https://github.com/LabKey/labkey-ui-components/pull/816

#### Changes
* Remove default container filter override for data classes
