### PR TITLE
Issue 45340: Use alias instead of "Container" as with all other columns

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -269,7 +269,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
             case Folder:
             {
-                var c = wrapColumn("Container", getRealTable().getColumn("Container"));
+                var c = wrapColumn(alias, getRealTable().getColumn("Container"));
                 c.setLabel("Folder");
                 c.setShownInDetailsView(false);
                 return c;


### PR DESCRIPTION
#### Rationale
Using "Container" instead of the alias "Folder" for the Folder column alias causes problems when trying to retrieve the Folder column.  This has manifested currently when trying to [update text choice field values](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45350), but would likely show up elsewhere as well.

#### Changes
* Don't use "Container" as alias when a different alias is provided.
