### PR TITLE
Add analytics metric. Fix mothership preview on Safari

### DIFF
--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -339,6 +339,7 @@ public class ExceptionUtil
     }
 
     /** Figure out exactly what text for the stack trace and other details we should submit */
+    @Nullable
     public static MothershipReport createReportFromThrowable(@Nullable HttpServletRequest request, Throwable ex, String requestURL, MothershipReport.Target target, ExceptionReportingLevel level, @Nullable String errorCode, @Nullable String sqlState, @Nullable String extraInfo)
     {
         if (!shouldSend(level, target.isLocal()))
@@ -453,6 +454,7 @@ public class ExceptionUtil
         return send;
     }
 
+    @NotNull
     private static MothershipReport createReportFromStacktrace(String stackTrace, String exceptionMessage, String browser, String sqlState, String requestURL, String referrerURL, String username, MothershipReport.Target target, ExceptionReportingLevel level, @Nullable String errorCode)
     {
         try

--- a/api/src/org/labkey/api/util/MothershipReport.java
+++ b/api/src/org/labkey/api/util/MothershipReport.java
@@ -80,6 +80,8 @@ public class MothershipReport implements Runnable
     private static boolean showSelfReportExceptions = false;
     private static int _droppedExceptionCount = 0;
 
+    public final static String JSON_METRICS_KEY = "jsonMetrics";
+
     /** @return true if this server can self-report exceptions (that is, has the Mothership module installed) */
     public static boolean isShowSelfReportExceptions()
     {
@@ -465,13 +467,12 @@ public class MothershipReport implements Runnable
             try
             {
                 serializedMetrics = mapper.writeValueAsString(metrics);
+                addParam(JSON_METRICS_KEY, serializedMetrics);
             }
             catch (JsonProcessingException e)
             {
-                // TODO: Where to report, what to do?
-                serializedMetrics = "Exception serializing json metrics. " + e.getMessage();
+                LOG.error("Failed to serialize JSON metrics", e);
             }
-            addParam("jsonMetrics", serializedMetrics);
         }
     }
 }

--- a/api/src/org/labkey/api/util/UsageReportingLevel.java
+++ b/api/src/org/labkey/api/util/UsageReportingLevel.java
@@ -173,6 +173,7 @@ public enum UsageReportingLevel implements SafeToRenderEnum
         return _upgradeMessage;
     }
 
+    @Nullable
     public static MothershipReport generateReport(UsageReportingLevel level, MothershipReport.Target target)
     {
         if (level.doGeneration())

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -992,6 +992,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                 .filter(AdminConsole.ExperimentalFeatureFlag::isEnabled)
                 .map(AdminConsole.ExperimentalFeatureFlag::getFlag)
                 .collect(Collectors.toList()));
+            results.put("analyticsTrackingStatus", AnalyticsServiceImpl.get().getTrackingStatus().toString());
             return results;
         });
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -9785,19 +9785,27 @@ public class AdminController extends SpringActionController
                         target,
                         ExceptionReportingLevel.valueOf(form.getLevel()), null, null, null);
             }
-            Map<String, Object> result = new LinkedHashMap<>();
-            if (null != report)
+
+            Map<String, Object> params = new LinkedHashMap<>();
+            if (report != null)
             {
-                result.put("report", report.getParams());
+                params.putAll(report.getParams());
+                // Hack to make the JSON more readable for preview, as the Mothership report is a String->String map
+                Object jsonMetrics = params.get(MothershipReport.JSON_METRICS_KEY);
+                if (jsonMetrics instanceof String)
+                {
+                    JSONObject o = new JSONObject((String)jsonMetrics);
+                    params.put(MothershipReport.JSON_METRICS_KEY, o);
+                }
                 if (form.isSubmit())
                 {
                     report.setForwardedFor(form.getForwardedFor());
                     report.run();
                     if (null != report.getContent())
-                        result.put("upgradeMessage", report.getContent());
+                        params.put("upgradeMessage", report.getContent());
                 }
             }
-            return new ObjectMapper().writeValueAsString(result);
+            return new ApiSimpleResponse(params);
         }
     }
 

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -75,22 +75,17 @@ var enableTestButtion = function(el, level) {
 
 var testUsageReport = function() {
     var level = document.querySelector('input[name="usageReportingLevel"]:checked').value;
-    testMothershipReport('CheckForUpdates', level, 'Usage');
+    testMothershipReport('CheckForUpdates', level);
 };
 
 var testExceptionReport = function() {
     var level = document.querySelector('input[name="exceptionReportingLevel"]:checked').value;
-    testMothershipReport('ReportException', level, 'Exception');
+    testMothershipReport('ReportException', level);
 };
 
-var testMothershipReport = function(type, level, title) {
-
+var testMothershipReport = function (type, level) {
     var url = LABKEY.ActionURL.buildURL("admin", "testMothershipReport", null, { type: type, level: level });
-    var sampleTab = window.open(url, '_blank');
-
-    if (!sampleTab) {
-        window.alert('Failed to open test report - see browser console for details');
-    }
+    window.open(url, '_blank', 'noopener noreferrer');
 };
 </script>
 

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -84,42 +84,13 @@ var testExceptionReport = function() {
 };
 
 var testMothershipReport = function(type, level, title) {
-    LABKEY.Ajax.request({
-        url: LABKEY.ActionURL.buildURL("admin", "testMothershipReport"),
-        method: "POST",
-        params: {
-            type: type,
-            level: level
-        },
-        success: LABKEY.Utils.getCallbackWrapper(function(response)
-        {
-            var report = JSON.parse(response).report;
-            var reportStr = '';
-            if (report != undefined)
-            {
-                var indent = 4;
-                if (report.jsonMetrics != undefined)
-                {
-                    report.jsonMetrics = JSON.parse(report.jsonMetrics);
-                }
-                else if (report.stackTrace != undefined)
-                {
-                    report.stackTrace = report.stackTrace.replace(/(?:\r\n|\r|\n)/g, '<br/>').replace(/\t/g, '&nbsp;'.repeat(indent * 8));
-                }
-                reportStr = JSON.stringify(report, null, indent);
-            }
-            else {
-                reportStr = 'An error occurred generating the sample report.';
-            }
-            // Use setTimeout() because Safari doesn't let you call window.open in an async callback
-            setTimeout(() => {
-                var sampleTab = window.open('about:blank', '_blank');
-                sampleTab.document.write('<span style="white-space: pre-wrap;">Sample ' + title + ' Report for Level ' + level + '</span><br/><br/>');
-                sampleTab.document.write('<span style="white-space: pre-wrap;">' + reportStr + '</span>');
-                sampleTab.document.close();
-            });
-        })
-    });
+
+    var url = LABKEY.ActionURL.buildURL("admin", "testMothershipReport", null, { type: type, level: level });
+    var sampleTab = window.open(url, '_blank');
+
+    if (!sampleTab) {
+        window.alert('Failed to open test report - see browser console for details');
+    }
 };
 </script>
 
@@ -209,7 +180,7 @@ Click the Save button at any time to accept the current settings and continue.</
     <td>
         <table>
             <tr>
-                <td valign="top">
+                <td style="vertical-align: top">
                     <label>
                         <input type="radio" name="usageReportingLevel" id="usageReportingLevel1" onchange="enableUsageTest();" value="<%=UsageReportingLevel.NONE%>"<%=checked(appProps.getUsageReportingLevel() == UsageReportingLevel.NONE)%>>
                         <strong>OFF</strong> - Do not check for updates or report any usage data.
@@ -217,7 +188,7 @@ Click the Save button at any time to accept the current settings and continue.</
                 </td>
             </tr>
             <tr>
-                <td valign="top">
+                <td style="vertical-align: top">
                     <label>
                         <input type="radio" name="usageReportingLevel" id="usageReportingLevel2" onchange="enableUsageTest();"
                                value="<%=UsageReportingLevel.ON%>"<%=checked(appProps.getUsageReportingLevel() == UsageReportingLevel.ON)%>>

--- a/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
+++ b/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
@@ -17,6 +17,7 @@ package org.labkey.core.analytics;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.analytics.AnalyticsService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -159,6 +160,7 @@ public class AnalyticsServiceImpl implements AnalyticsService
         }
     }
 
+    @NotNull
     public TrackingStatus getTrackingStatus()
     {
         String strStatus = getProperty(AnalyticsProperty.trackingStatus);


### PR DESCRIPTION
#### Rationale
It'll be helpful to know what servers are using analytics (typically Google Analytics) to prioritize improvements properly. Also, the mothership report preview in Site Settings has been problematic on Safari.

#### Changes
* Add a new metric for analytics setting
* When previewing metrics, do a simple GET request and show the server-generated JSON instead of AJAXing and trying to open it in a new tab