### PR TITLE
Issue 45350: add proper aliasing for container/folder columns to fix property update issues

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -263,7 +263,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
             case Folder:
             {
-                var c = wrapColumn("Container", getRealTable().getColumn("Container"));
+                var c = wrapColumn(alias, getRealTable().getColumn("Container"));
                 c.setLabel("Folder");
                 c.setShownInDetailsView(false);
                 return c;
@@ -330,7 +330,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         addColumn(Column.ModifiedBy);
         addColumn(Column.Flag);
         addColumn(Column.DataClass);
-        addColumn(Column.Folder);
+        addContainerColumn(Column.Folder, null);
         addColumn(Column.Description);
         addColumn(Column.Alias);
 


### PR DESCRIPTION
#### Rationale
Because we have aliased the Folder column as Container, when we try to update the property that stores the text choices, it fails because we have one of these but not the other.

#### Changes
* Use `addContainerColumn` for data set data table so we get the aliases we want
* Update the Folder column to use the alias when wrapping, like the other columns.