### PR TITLE
Issue 45399: LinkBuilder.style() is ignored when generating HTML

### DIFF
--- a/api/src/org/labkey/api/util/Link.java
+++ b/api/src/org/labkey/api/util/Link.java
@@ -24,9 +24,11 @@ import java.io.Writer;
 import java.util.Collections;
 
 import static org.labkey.api.util.DOM.A;
+import static org.labkey.api.util.DOM.Attribute.name;
 import static org.labkey.api.util.DOM.Attribute.href;
 import static org.labkey.api.util.DOM.Attribute.onclick;
 import static org.labkey.api.util.DOM.Attribute.rel;
+import static org.labkey.api.util.DOM.Attribute.style;
 import static org.labkey.api.util.DOM.Attribute.target;
 import static org.labkey.api.util.DOM.Attribute.title;
 import static org.labkey.api.util.DOM.at;
@@ -60,6 +62,8 @@ public class Link extends DisplayElement implements HasHtmlString
                 .at(lb.usePost, onclick, PageFlowUtil.postOnClickJavaScript(lb.href, lb.confirmMessage), lb.onClick)
                 .at(rel, lb.rel)
                 .at(title, lb.title)
+                .at(style, lb.style)
+                .at(name, lb.name)
                 .data(null != lb.tooltip, "tt", "tooltip")
                 .data(null != lb.tooltip, "placement","top")
                 .data(null != lb.tooltip, "original-title", lb.tooltip),


### PR DESCRIPTION
#### Rationale
LinkBuilder as a couple of properties that it doesn't propagate through to the HTML it generates, style and name.

#### Changes
* Pass 'em through!