### PR TITLE
Issue 45138: Support unzipped xar file for sample type and data class impors

### DIFF
--- a/experiment/src/org/labkey/experiment/samples/SampleStatusFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleStatusFolderImporter.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.DEFAULT_DIRECTORY;
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.XAR_TYPES_NAME;
+import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.XAR_TYPES_XML_NAME;
 
 public class SampleStatusFolderImporter extends SampleTypeAndDataClassFolderImporter
 {
@@ -57,7 +58,7 @@ public class SampleStatusFolderImporter extends SampleTypeAndDataClassFolderImpo
 
             for (String file: xarDir.list())
             {
-                if (file.equalsIgnoreCase(XAR_TYPES_NAME))
+                if (file.equalsIgnoreCase(XAR_TYPES_NAME) || file.equalsIgnoreCase(XAR_TYPES_XML_NAME))
                 {
                     if (typesXarFile == null)
                         typesXarFile = xarDirPath.resolve(file);

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -13,6 +13,7 @@ import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.DetailedAuditLogDataIterator;
 import org.labkey.api.exp.CompressedInputStreamXarSource;
 import org.labkey.api.exp.ExperimentException;
+import org.labkey.api.exp.FileXarSource;
 import org.labkey.api.exp.Identifiable;
 import org.labkey.api.exp.XarSource;
 import org.labkey.api.exp.api.ExperimentService;
@@ -49,7 +50,9 @@ import java.util.stream.Collectors;
 
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.DEFAULT_DIRECTORY;
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.XAR_RUNS_NAME;
+import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.XAR_RUNS_XML_NAME;
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.XAR_TYPES_NAME;
+import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.XAR_TYPES_XML_NAME;
 
 public class SampleTypeAndDataClassFolderImporter implements FolderImporter
 {
@@ -90,14 +93,14 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
 
             for (String file: xarDir.list())
             {
-                if (file.equalsIgnoreCase(XAR_TYPES_NAME))
+                if (file.equalsIgnoreCase(XAR_TYPES_NAME) || file.equalsIgnoreCase(XAR_TYPES_XML_NAME))
                 {
                     if (typesXarFile == null)
                         typesXarFile = xarDirPath.resolve(file);
                     else
                         log.error("More than one types XAR file found in the sample type directory: ", file);
                 }
-                else if (file.equalsIgnoreCase(XAR_RUNS_NAME))
+                else if (file.equalsIgnoreCase(XAR_RUNS_NAME) || file.equalsIgnoreCase(XAR_RUNS_XML_NAME))
                 {
                     if (runsXarFile == null)
                         runsXarFile = xarDirPath.resolve(file);
@@ -143,7 +146,11 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                     // handle wiring up any derivation runs
                     if (runsXarFile != null)
                     {
-                        XarSource runsXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(runsXarFile.getFileName().toString()), runsXarFile, logFile, job, ctx.getUser(), ctx.getContainer(), ctx.getXarJobIdContext());
+                        XarSource runsXarSource;
+                        if (runsXarFile.getFileName().toString().endsWith(".xar.xml"))
+                            runsXarSource = new FileXarSource(runsXarFile, job, ctx.getContainer());
+                        else
+                            runsXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(runsXarFile.getFileName().toString()), runsXarFile, logFile, job, ctx.getUser(), ctx.getContainer(), ctx.getXarJobIdContext());
                         try
                         {
                             runsXarSource.init();
@@ -184,7 +191,12 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
             job = getDummyPipelineJob(ctx);
         }
 
-        XarSource typesXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(typesXarFile.getFileName().toString()), typesXarFile, logFile, job, ctx.getUser(), ctx.getContainer(), ctx.getXarJobIdContext());
+        XarSource typesXarSource;
+
+        if (typesXarFile.getFileName().toString().endsWith(".xar.xml"))
+            typesXarSource = new FileXarSource(typesXarFile, job, ctx.getContainer());
+        else
+            typesXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(typesXarFile.getFileName().toString()), typesXarFile, logFile, job, ctx.getUser(), ctx.getContainer(), ctx.getXarJobIdContext());
         try
         {
             typesXarSource.init();

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -147,7 +147,7 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                     if (runsXarFile != null)
                     {
                         XarSource runsXarSource;
-                        if (runsXarFile.getFileName().toString().endsWith(".xar.xml"))
+                        if (runsXarFile.getFileName().toString().toLowerCase().endsWith(".xar.xml"))
                             runsXarSource = new FileXarSource(runsXarFile, job, ctx.getContainer());
                         else
                             runsXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(runsXarFile.getFileName().toString()), runsXarFile, logFile, job, ctx.getUser(), ctx.getContainer(), ctx.getXarJobIdContext());
@@ -193,7 +193,7 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
 
         XarSource typesXarSource;
 
-        if (typesXarFile.getFileName().toString().endsWith(".xar.xml"))
+        if (typesXarFile.getFileName().toString().toLowerCase().endsWith(".xar.xml"))
             typesXarSource = new FileXarSource(typesXarFile, job, ctx.getContainer());
         else
             typesXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(typesXarFile.getFileName().toString()), typesXarFile, logFile, job, ctx.getUser(), ctx.getContainer(), ctx.getXarJobIdContext());

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
@@ -80,8 +80,8 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter
     public static final String DEFAULT_DIRECTORY = "sample-types";
     public static final String XAR_TYPES_NAME = "sample_types.xar";             // the file which contains the sample type and data class definitions
     public static final String XAR_RUNS_NAME = "runs.xar";                      // the file which contains the derivation runs for sample types and data classes
-    private static final String XAR_TYPES_XML_NAME = XAR_TYPES_NAME + ".xml";
-    private static final String XAR_RUNS_XML_NAME = XAR_RUNS_NAME + ".xml";
+    public static final String XAR_TYPES_XML_NAME = XAR_TYPES_NAME + ".xml";
+    public static final String XAR_RUNS_XML_NAME = XAR_RUNS_NAME + ".xml";
     public static final String SAMPLE_TYPE_PREFIX = "SAMPLE_TYPE_";
     public static final String SAMPLE_STATUS_PREFIX = "SAMPLE_STATUS_";
     public static final String DATA_CLASS_PREFIX = "DATA_CLASS_";

--- a/experiment/src/org/labkey/experiment/xar/FolderXarImporterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarImporterFactory.java
@@ -201,7 +201,7 @@ public class FolderXarImporterFactory extends AbstractFolderImportFactory
         {
             if (_xarSource == null)
             {
-                if (getXarFile().getFileName().toString().endsWith(".xar.xml"))
+                if (getXarFile().getFileName().toString().toLowerCase().endsWith(".xar.xml"))
                 {
                     _xarSource = new FileXarSource(
                             getXarFile(),


### PR DESCRIPTION
#### Rationale
Previous commit updated our xar import processing to recognize unzip `.xar.xml` files within the `xar` directory. Here we update the processing within the `sample_types` directory to also recognize unzip `sample_types.xar` and `runs.xar` files. For folder archives that are checked in, this makes it much easier to maintain.

#### Related Pull Requests
* #3187

#### Changes
* Update processing for Sample Types, Data Classes and Sample Status to also process unzip xar files 
