### PR TITLE
PageConfig: support injecting container permissions on page

### DIFF
--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -58,6 +58,7 @@ import org.labkey.api.query.QueryParam;
 import org.labkey.api.reader.Readers;
 import org.labkey.api.security.AuthenticationManager;
 import org.labkey.api.security.SecurityLogger;
+import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.settings.AppProps;
@@ -1705,23 +1706,20 @@ public class PageFlowUtil
         }
     }
 
-
-    public static SafeToRender getAppIncludes(ViewContext context, @Nullable  LinkedHashSet<ClientDependency> resources)
+    public static SafeToRender getAppIncludes(ViewContext context, @NotNull PageConfig config)
     {
-        return _getStandardIncludes(context, null, resources, false, false);
+        return _getStandardIncludes(context, config, config.getClientDependencies(), false, false);
     }
-
 
     public static SafeToRender getStandardIncludes(ViewContext context, @Nullable LinkedHashSet<ClientDependency> resources, boolean includePostParameters)
     {
         return _getStandardIncludes(context, null, resources, true, includePostParameters);
     }
 
-    public static SafeToRender getStandardIncludes(ViewContext context, PageConfig config)
+    public static SafeToRender getStandardIncludes(ViewContext context, @NotNull PageConfig config)
     {
         return _getStandardIncludes(context, config, config.getClientDependencies(), true, config.shouldIncludePostParameters());
     }
-
 
     private static SafeToRender _getStandardIncludes(ViewContext context, @Nullable PageConfig config, @Nullable LinkedHashSet<ClientDependency> extraResources,
             boolean includeDefaultResources, boolean includePostParameters)
@@ -2330,7 +2328,7 @@ public class PageFlowUtil
 
         if (null != container)
         {
-            json.put("container", container.toJSON(user, false));
+            json.put("container", container.toJSON(user, config != null && config.isIncludePermissions()));
             json.put("demoMode", DemoMode.isDemoMode(container, user));
         }
 

--- a/api/src/org/labkey/api/view/template/PageConfig.java
+++ b/api/src/org/labkey/api/view/template/PageConfig.java
@@ -148,6 +148,7 @@ public class PageConfig
     private boolean _trackingScript = true;
     private String _canonicalLink = null;
     private boolean _includePostParameters = false;
+    private boolean _includePermissions = false;
 
     public final Date createTime = new Date();
     public final Throwable createThrowable = new Throwable();
@@ -352,6 +353,16 @@ public class PageConfig
     public void setIncludePostParameters(boolean includePostParameters)
     {
         _includePostParameters = includePostParameters;
+    }
+
+    public boolean isIncludePermissions()
+    {
+        return _includePermissions;
+    }
+
+    public void setIncludePermissions(boolean includePermissions)
+    {
+        _includePermissions = includePermissions;
     }
 
     public void addMetaTag(String name, String value)

--- a/core/src/org/labkey/core/view/template/bootstrap/AppTemplate.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/AppTemplate.java
@@ -46,6 +46,7 @@ public class AppTemplate extends PageTemplate
 
         // don't show the header on body template
         page.setShowHeader(false);
+        page.setIncludePermissions(true);
 
         setBody(body);
         setView("bodyTemplate", getBodyTemplate(page, body));

--- a/core/src/org/labkey/core/view/template/bootstrap/pageTemplate.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/pageTemplate.jsp
@@ -44,7 +44,7 @@
     <%= model.getPreloadTags() %>
     <title><%= h(model.getTitle()) %></title>
     <% if (me.isAppTemplate()) { %>
-    <%= PageFlowUtil.getAppIncludes(getViewContext(), model.getClientDependencies()) %>
+    <%= PageFlowUtil.getAppIncludes(getViewContext(), model) %>
     <% } else { %>
     <%= PageFlowUtil.getStandardIncludes(getViewContext(), model) %>
     <% } %>


### PR DESCRIPTION
#### Rationale
Adds support to `PageConfig` for injecting container permissions on the page for the current user. Pages using the "app" template default to injecting these permissions. This avoids our applications having to wait/delay on load out on the client where an immediate check is simpler to follow.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3323
* https://github.com/LabKey/labkey-ui-components/pull/831
* https://github.com/LabKey/biologics/pull/1286
* https://github.com/LabKey/sampleManagement/pull/946
* https://github.com/LabKey/inventory/pull/429

#### Changes
* Add `includePermissions` bit to the `PageConfig` class and wire up to include permissions of the container into the injected JS page object.
* Update `AppTemplate` to always include container permissions.
