### PR TITLE
Issue 45439: Revert change to use absolute value for std dev plots

### DIFF
--- a/internal/webapp/vis/src/plot.js
+++ b/internal/webapp/vis/src/plot.js
@@ -1721,7 +1721,7 @@ boxPlot.render();
             if (isNaN(calc))
                 return 100;
 
-            return Math.abs(calc);
+            return calc;
         };
 
         var convertToStandardDeviation = function(value, mean, stddev) {
@@ -1729,7 +1729,7 @@ boxPlot.render();
             if (isNaN(calc))
                 return 0;
 
-            return Math.abs(calc);
+            return calc;
         };
 
         var convertValues = function(conversion) {


### PR DESCRIPTION
#### Rationale
After further review, the change to use absolute value for standard deviation-based QC plots causes more headaches than it solves. While some use cases may be focused primarily on the magnitude of the standard deviation, it's generally important to know if it's positive or negative.

This undoes https://github.com/LabKey/platform/pull/3052

#### Changes
* Use the value directly instead of its absolute value