### PR TITLE
Throwing NotFound from a GWT method generates a server error.

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -34,6 +34,7 @@ import org.jfree.chart.ChartUtilities;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.data.category.DefaultCategoryDataset;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -10180,7 +10181,15 @@ public class AdminController extends SpringActionController
         res.put("health", result);
 
         LabKeyScriptEngineManager mgr = LabKeyScriptEngineManager.get();
-        res.put("scriptEngines", mgr.getEngineDefinitions());
+        JSONArray arr = new JSONArray();
+        for (ExternalScriptEngineDefinition def : mgr.getEngineDefinitions())
+        {
+            var m = ((ObjectFactory<ExternalScriptEngineDefinition>)ObjectFactory.Registry.getFactory(def.getClass())).toMap(def, null);
+            m.remove("password");
+            m.remove("configuration");
+            arr.put(m);
+        }
+        res.put("scriptEngines", arr);
 
         return res;
     }

--- a/study/src/org/labkey/study/designer/StudyDefinitionServiceImpl.java
+++ b/study/src/org/labkey/study/designer/StudyDefinitionServiceImpl.java
@@ -130,7 +130,7 @@ public class StudyDefinitionServiceImpl extends BaseRemoteService implements Stu
                 version = StudyDesignManager.get().getStudyDesignVersion(container, studyId);
 
             if (null == version)
-                throw new NotFoundException("Protocol " + studyId + (revision >= 0 ? ", Revision " + revision : "") + " not found!");
+                return null;
 
             GWTStudyDefinition template = getTemplate();
             GWTStudyDefinition def = XMLSerializer.fromXML(version.getXML(), template.getCavdStudyId() == studyId ? null : template, getUser(), container);


### PR DESCRIPTION
#### Rationale
Of course the calling page still won't work, but stop generating  server error.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
