### PR TITLE
Split mothership sessions by calendar month

### DIFF
--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -532,6 +532,19 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         return getMutableColumn(colName, true);
     }
 
+    /** @return a BaseColumnInfo, will throw if column doesn't exist or exists and is locked */
+    @NotNull
+    public MutableColumnInfo getMutableColumnOrThrow(@NotNull String colName)
+    {
+        MutableColumnInfo result = getMutableColumn(colName, true);
+        if (result == null)
+        {
+            UserSchema schema = getUserSchema();
+            throw new IllegalArgumentException("Could not find column '" + colName + "' in " + (schema == null ? "" : (schema.getName() + ".")) + getName() + (schema == null ? "" : (" in " + schema.getContainer().getPath())));
+        }
+        return result;
+    }
+
     /**
      * @param resolveIfNeeded false if only the already-added columns should be checked, and resolveColumn() should
      *                        not be called. Useful because some implementations may have expensive checks they

--- a/api/src/org/labkey/api/query/QuerySchema.java
+++ b/api/src/org/labkey/api/query/QuerySchema.java
@@ -53,6 +53,28 @@ public interface QuerySchema extends SchemaTreeNode, ContainerUser
     /** Consider using getTableWithFactory(String, ContainerFilter.Factory) instead */
     TableInfo getTable(String name, @Nullable ContainerFilter cf);
 
+    @NotNull
+    default TableInfo getTableOrThrow(String name)
+    {
+        TableInfo result = getTable(name);
+        if (result == null)
+        {
+            throw new IllegalArgumentException("Could not find table '" + name + "' in schema '" + getSchemaName() + "'");
+        }
+        return result;
+    }
+
+    @NotNull
+    default TableInfo getTableOrThrow(String name, @Nullable ContainerFilter cf)
+    {
+        TableInfo result = getTable(name, cf);
+        if (result == null)
+        {
+            throw new IllegalArgumentException("Could not find table '" + name + "' in schema '" + getSchemaName() + "'");
+        }
+        return result;
+    }
+
     /**
      * The schema already knows its container and user, we don't need to redundantly create a ContainerFilter with the
      * same info.

--- a/mothership/resources/schemas/dbscripts/postgresql/mothership-22.000-22.001.sql
+++ b/mothership/resources/schemas/dbscripts/postgresql/mothership-22.000-22.001.sql
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE mothership.ServerSession ADD COLUMN ServerHostName VARCHAR(256);
+UPDATE mothership.ServerSession SET ServerHostName = (SELECT ServerHostName FROM mothership.ServerInstallation si WHERE si.serverinstallationid = ServerSession.serverinstallationid);
+
+ALTER TABLE mothership.ServerSession ADD COLUMN ServerIP VARCHAR(20);
+UPDATE mothership.ServerSession SET ServerIP = (SELECT ServerIP FROM mothership.ServerInstallation si WHERE si.serverinstallationid = ServerSession.serverinstallationid);
+
+ALTER TABLE mothership.ServerSession ADD COLUMN OriginalServerSessionId INT;
+CREATE INDEX IX_ServerSession_OriginalServerSessionId ON mothership.ServerSession(OriginalServerSessionId);
+ALTER TABLE mothership.ServerSession
+    ADD CONSTRAINT FK_ServerSession_OriginalServerSessionId FOREIGN KEY (OriginalServerSessionId)
+        REFERENCES mothership.ServerSession (ServerSessionId);

--- a/mothership/resources/schemas/mothership.xml
+++ b/mothership/resources/schemas/mothership.xml
@@ -169,6 +169,9 @@
             <column columnName="JsonMetrics"/>
             <column columnName="UsageReportingLevel"/>
             <column columnName="ExceptionReportingLevel"/>
+            <column columnName="ServerHostName"/>
+            <column columnName="ServerIP"/>
+            <column columnName="OriginalServerSessionId"/>
         </columns>
     </table>
 

--- a/mothership/src/org/labkey/mothership/MothershipManager.java
+++ b/mothership/src/org/labkey/mothership/MothershipManager.java
@@ -19,7 +19,6 @@ package org.labkey.mothership;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -29,10 +28,8 @@ import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.PropertyManager;
-import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SqlExecutor;
-import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
@@ -40,7 +37,9 @@ import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 import org.labkey.api.util.DateUtil;
+import org.labkey.api.util.GUID;
 import org.labkey.api.util.MothershipReport;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -48,7 +47,6 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -72,7 +70,7 @@ public class MothershipManager
     private static final String ISSUES_CONTAINER_PROP = "issuesContainer";
     private static final ReentrantLock INSERT_EXCEPTION_LOCK = new ReentrantLock();
 
-    private static final Logger log = LogManager.getLogger(MothershipManager.class);
+    private static final Logger log = LogHelper.getLogger(MothershipManager.class, "Persists mothership records like sessions and installs");
 
     public static MothershipManager get()
     {
@@ -338,16 +336,40 @@ public class MothershipManager
 
             Date now = new Date();
             ServerSession existingSession = getServerSession(session.getServerSessionGUID(), container);
+            if (existingSession != null)
+            {
+                Calendar existingCal = Calendar.getInstance();
+                existingCal.setTime(existingSession.getLastKnownTime());
+                Calendar nowCal = Calendar.getInstance();
+
+                // Check if this session is straddling months. If so, break it into two so that we
+                // retain metrics with month level granularity
+                if (existingCal.get(Calendar.MONTH) != nowCal.get(Calendar.MONTH))
+                {
+                    // Chain the two sessions together
+                    session.setOriginalServerSessionId(existingSession.getServerSessionId());
+
+                    // Update the GUID for the old one as we're capturing in a new record going forward
+                    existingSession.setServerSessionGUID(GUID.makeGUID());
+                    Table.update(null, getTableInfoServerSession(), existingSession, existingSession.getServerSessionId());
+                    existingSession = null;
+                }
+            }
+
             if (existingSession == null)
             {
                 session.setEarliestKnownTime(now);
                 session.setLastKnownTime(now);
                 session.setServerInstallationId(installation.getServerInstallationId());
+                session.setServerIP(installation.getServerIP());
+                session.setServerHostName(hostName);
                 session = Table.insert(null, getTableInfoServerSession(), session);
             }
             else
             {
                 existingSession.setLastKnownTime(now);
+                existingSession.setServerIP(installation.getServerIP());
+                existingSession.setServerHostName(hostName);
                 existingSession.setContainerCount(getBestInteger(existingSession.getContainerCount(), session.getContainerCount()));
                 existingSession.setProjectCount(getBestInteger(existingSession.getProjectCount(), session.getProjectCount()));
                 existingSession.setActiveUserCount(getBestInteger(existingSession.getActiveUserCount(), session.getActiveUserCount()));
@@ -419,9 +441,9 @@ public class MothershipManager
         ObjectMapper mapper = new ObjectMapper();
         try
         {
-            Map currentMap = mapper.readValue(currentValue, Map.class);
+            Map<String, Object> currentMap = mapper.readValue(currentValue, Map.class);
             ObjectReader updater = mapper.readerForUpdating(currentMap);
-            Map merged = updater.readValue(newValue);
+            Map<String, Object> merged = updater.readValue(newValue);
             return mapper.writeValueAsString(merged);
         }
         catch (IOException e)
@@ -545,33 +567,6 @@ public class MothershipManager
     {
         bean.setContainer(container.getId());
         Table.update(user, getTableInfoSoftwareRelease(), bean, bean.getSoftwareReleaseId());
-    }
-
-    public Collection<ServerInstallation> getServerInstallationsActiveOn(Calendar cal)
-    {
-        SQLFragment sql = new SQLFragment();
-        sql.append("SELECT si.* FROM ");
-        sql.append(getTableInfoServerInstallation(), "si");
-        sql.append(" WHERE si.serverinstallationid IN (SELECT serverinstallationid FROM ");
-        sql.append(getTableInfoServerSession(), "ss");
-        sql.append(" WHERE earliestknowntime <= ? AND lastknowntime >= ?)");
-        sql.add(cal.getTime());
-        sql.add(cal.getTime());
-
-        return new SqlSelector(getSchema(), sql).getCollection(ServerInstallation.class);
-    }
-
-    public Collection<ServerInstallation> getServerInstallationsActiveBefore(Calendar cal)
-    {
-        SQLFragment sql = new SQLFragment();
-        sql.append("SELECT si.* FROM ");
-        sql.append(getTableInfoServerInstallation(), "si");
-        sql.append(" WHERE si.serverinstallationid IN (SELECT serverinstallationid FROM ");
-        sql.append(getTableInfoServerSession(), "ss");
-        sql.append(" WHERE earliestknowntime <= ?)");
-        sql.add(cal.getTime());
-
-        return new SqlSelector(getSchema(), sql).getCollection(ServerInstallation.class);
     }
 
     public ServerInstallation getServerInstallation(int id, Container c)

--- a/mothership/src/org/labkey/mothership/MothershipModule.java
+++ b/mothership/src/org/labkey/mothership/MothershipModule.java
@@ -74,7 +74,7 @@ public class MothershipModule extends DefaultModule
     @Override
     public Double getSchemaVersion()
     {
-        return 22.000;
+        return 22.001;
     }
 
     @Override

--- a/mothership/src/org/labkey/mothership/ServerSession.java
+++ b/mothership/src/org/labkey/mothership/ServerSession.java
@@ -54,6 +54,9 @@ public class ServerSession
     private String _usageReportingLevel;
     private String _exceptionReportingLevel;
     private String _jsonMetrics;
+    private String _serverHostName;
+    private String _serverIP;
+    private Integer _originalServerSessionId;
 
     public String getDatabaseProductVersion()
     {
@@ -313,5 +316,35 @@ public class ServerSession
     public void setJsonMetrics(String jsonMetrics)
     {
         _jsonMetrics = jsonMetrics;
+    }
+
+    public String getServerHostName()
+    {
+        return _serverHostName;
+    }
+
+    public void setServerHostName(String serverHostName)
+    {
+        _serverHostName = serverHostName;
+    }
+
+    public String getServerIP()
+    {
+        return _serverIP;
+    }
+
+    public void setServerIP(String serverIP)
+    {
+        _serverIP = serverIP;
+    }
+
+    public Integer getOriginalServerSessionId()
+    {
+        return _originalServerSessionId;
+    }
+
+    public void setOriginalServerSessionId(Integer originalServerSessionId)
+    {
+        _originalServerSessionId = originalServerSessionId;
     }
 }

--- a/mothership/src/org/labkey/mothership/query/MothershipSchema.java
+++ b/mothership/src/org/labkey/mothership/query/MothershipSchema.java
@@ -154,7 +154,7 @@ public class MothershipSchema extends UserSchema
         FilteredTable<MothershipSchema> result = new FilteredTable<>(MothershipManager.get().getTableInfoSoftwareRelease(), this, cf);
         result.wrapAllColumns(true);
 
-        result.getMutableColumn("Container").setFk(new ContainerForeignKey(this));
+        result.getMutableColumnOrThrow("Container").setFk(new ContainerForeignKey(this));
 
         SQLFragment descriptionSQL = new SQLFragment("CASE WHEN " +
                 ExprColumn.STR_TABLE_ALIAS + ".VcsBranch IS NULL OR " + ExprColumn.STR_TABLE_ALIAS + ".BuildTime IS NULL THEN " +
@@ -190,11 +190,12 @@ public class MothershipSchema extends UserSchema
         result.wrapAllColumns(true);
         result.setTitleColumn("RowId");
 
-        result.getMutableColumn("Container").setFk(new ContainerForeignKey(this));
-        result.getMutableColumn("SoftwareReleaseId").setFk(new QueryForeignKey.Builder(this, cf).table(SOFTWARE_RELEASE_TABLE_NAME));
+        result.getMutableColumnOrThrow("Container").setFk(new ContainerForeignKey(this));
+        result.getMutableColumnOrThrow("SoftwareReleaseId").setFk(new QueryForeignKey.Builder(this, cf).table(SOFTWARE_RELEASE_TABLE_NAME));
+        result.getMutableColumnOrThrow("OriginalServerSessionId").setFk(new QueryForeignKey.Builder(this, cf).table(SERVER_SESSION_TABLE_NAME));
 
-        result.getMutableColumn("ServerInstallationId").setFk(new QueryForeignKey.Builder(this, cf).table(SERVER_INSTALLATION_TABLE_NAME));
-        result.getMutableColumn("ServerInstallationId").setLabel("Server");
+        result.getMutableColumnOrThrow("ServerInstallationId").setFk(new QueryForeignKey.Builder(this, cf).table(SERVER_INSTALLATION_TABLE_NAME));
+        result.getMutableColumnOrThrow("ServerInstallationId").setLabel("Server");
 
         var earliestCol = result.getColumn("EarliestKnownTime");
         var latestCol = result.getColumn("LastKnownTime");
@@ -207,7 +208,7 @@ public class MothershipSchema extends UserSchema
         result.addColumn(exceptionCountCol);
 
         List<FieldKey> defaultCols = new ArrayList<>();
-        defaultCols.add(FieldKey.fromString("VcsRevision"));
+        defaultCols.add(FieldKey.fromString("SoftwareReleaseId/Description"));
         defaultCols.add(FieldKey.fromString("Duration"));
         defaultCols.add(FieldKey.fromString("LastKnownTime"));
         defaultCols.add(FieldKey.fromString("DatabaseProductName"));
@@ -218,7 +219,6 @@ public class MothershipSchema extends UserSchema
         defaultCols.add(FieldKey.fromString("ContainerCount"));
         defaultCols.add(FieldKey.fromString("HeapSize"));
         defaultCols.add(FieldKey.fromString("ServletContainer"));
-        defaultCols.add(FieldKey.fromString("BuildTime"));
         result.setDefaultVisibleColumns(defaultCols);
 
         ActionURL base = new ActionURL(MothershipController.ShowServerSessionDetailAction.class, getContainer());
@@ -236,9 +236,9 @@ public class MothershipSchema extends UserSchema
 
         ActionURL url = new ActionURL(MothershipController.ShowInstallationDetailAction.class, getContainer());
         url.addParameter("serverInstallationId","${ServerInstallationId}");
-        result.getMutableColumn("ServerHostName").setURL(StringExpressionFactory.createURL(url));
+        result.getMutableColumnOrThrow("ServerHostName").setURL(StringExpressionFactory.createURL(url));
 
-        result.getMutableColumn("Container").setFk(new ContainerForeignKey(this));
+        result.getMutableColumnOrThrow("Container").setFk(new ContainerForeignKey(this));
 
         result.setTitleColumn("ServerHostName");
 
@@ -318,25 +318,25 @@ public class MothershipSchema extends UserSchema
         result.setInsertURL(AbstractTableInfo.LINK_DISABLER);
         result.setImportURL(AbstractTableInfo.LINK_DISABLER);
         result.wrapAllColumns(true);
-        result.getMutableColumn("StackTrace").setDisplayColumnFactory(StackTraceDisplayColumn::new);
+        result.getMutableColumnOrThrow("StackTrace").setDisplayColumnFactory(StackTraceDisplayColumn::new);
 
         String path = MothershipManager.get().getIssuesContainer(getContainer());
         ActionURL issueURL = PageFlowUtil.urlProvider(IssuesUrls.class).getDetailsURL(ContainerManager.getForPath(path));
         issueURL.addParameter("issueId", "${BugNumber}");
-        result.getMutableColumn("BugNumber").setURL(StringExpressionFactory.createURL(issueURL));
+        result.getMutableColumnOrThrow("BugNumber").setURL(StringExpressionFactory.createURL(issueURL));
 
         result.setTitleColumn("ExceptionStackTraceId");
         DetailsURL url = new DetailsURL(new ActionURL(MothershipController.ShowStackTraceDetailAction.class, getContainer()), Collections.singletonMap("exceptionStackTraceId", "ExceptionStackTraceId"));
         result.setDetailsURL(url);
 
-        result.getMutableColumn("ExceptionStackTraceId").setURL(url);
-        result.getMutableColumn("ExceptionStackTraceId").setLabel("Exception");
-        result.getMutableColumn("ExceptionStackTraceId").setFormat("'#'0");
-        result.getMutableColumn("ExceptionStackTraceId").setExcelFormatString("0");
+        result.getMutableColumnOrThrow("ExceptionStackTraceId").setURL(url);
+        result.getMutableColumnOrThrow("ExceptionStackTraceId").setLabel("Exception");
+        result.getMutableColumnOrThrow("ExceptionStackTraceId").setFormat("'#'0");
+        result.getMutableColumnOrThrow("ExceptionStackTraceId").setExcelFormatString("0");
 
-        result.getMutableColumn("Container").setFk(new ContainerForeignKey(this, cf));
-        result.getMutableColumn("AssignedTo").setFk(new UserIdQueryForeignKey(this, true));
-        result.getMutableColumn("ModifiedBy").setFk(new UserIdQueryForeignKey(this, true));
+        result.getMutableColumnOrThrow("Container").setFk(new ContainerForeignKey(this, cf));
+        result.getMutableColumnOrThrow("AssignedTo").setFk(new UserIdQueryForeignKey(this, true));
+        result.getMutableColumnOrThrow("ModifiedBy").setFk(new UserIdQueryForeignKey(this, true));
 
         List<FieldKey> defaultCols = new ArrayList<>();
         defaultCols.add(FieldKey.fromParts("ExceptionStackTraceId"));
@@ -369,13 +369,13 @@ public class MothershipSchema extends UserSchema
         FilteredTable<MothershipSchema> result = new FilteredTable<>(MothershipManager.get().getTableInfoExceptionReport(), this, cf);
         result.setDetailsURL(AbstractTableInfo.LINK_DISABLER);
         result.wrapAllColumns(true);
-        result.getMutableColumn("URL").setDisplayColumnFactory(colInfo ->
+        result.getMutableColumnOrThrow("URL").setDisplayColumnFactory(colInfo ->
         {
             DataColumn result1 = new DataColumn(colInfo);
             result1.setURLExpression(StringExpressionFactory.create("${URL}", false));
             return result1;
         });
-        result.getMutableColumn("ReferrerURL").setDisplayColumnFactory(colInfo ->
+        result.getMutableColumnOrThrow("ReferrerURL").setDisplayColumnFactory(colInfo ->
         {
             DataColumn result12 = new DataColumn(colInfo);
             result12.setURLExpression(StringExpressionFactory.create("${ReferrerURL}", false));
@@ -390,20 +390,20 @@ public class MothershipSchema extends UserSchema
         result.addCondition(containerSQL);
 
         // Decorate the stack trace id column and make it a lookup
-        var stackTraceIdColumn = result.getMutableColumn("ExceptionStackTraceId");
+        var stackTraceIdColumn = result.getMutableColumnOrThrow("ExceptionStackTraceId");
         stackTraceIdColumn.setLabel("Exception");
         stackTraceIdColumn.setURL(new DetailsURL(new ActionURL(MothershipController.ShowStackTraceDetailAction.class, getContainer()), "exceptionStackTraceId", FieldKey.fromParts("ExceptionStackTraceId")));
         stackTraceIdColumn.setFk(new QueryForeignKey.Builder(this, null).schema(this).table(EXCEPTION_STACK_TRACE_TABLE_NAME).build());
 
-        result.getMutableColumn("PageflowName").setLabel("Controller");
-        result.getMutableColumn("PageflowAction").setLabel("Action");
+        result.getMutableColumnOrThrow("PageflowName").setLabel("Controller");
+        result.getMutableColumnOrThrow("PageflowAction").setLabel("Action");
 
-        result.getMutableColumn("ServerSessionId").setURL(StringExpressionFactory.createURL("/mothership/showServerSessionDetail.view?serverSessionId=${ServerSessionId}"));
-        result.getMutableColumn("ServerSessionId").setLabel("Session");
-        result.getMutableColumn("ServerSessionId").setFormat("'#'0");
-        result.getMutableColumn("ServerSessionId").setExcelFormatString("0");
+        result.getMutableColumnOrThrow("ServerSessionId").setURL(StringExpressionFactory.createURL("/mothership/showServerSessionDetail.view?serverSessionId=${ServerSessionId}"));
+        result.getMutableColumnOrThrow("ServerSessionId").setLabel("Session");
+        result.getMutableColumnOrThrow("ServerSessionId").setFormat("'#'0");
+        result.getMutableColumnOrThrow("ServerSessionId").setExcelFormatString("0");
         ForeignKey fk = new QueryForeignKey.Builder(this, null).schema(this).table(SERVER_SESSION_TABLE_NAME).build();
-        result.getMutableColumn("ServerSessionId").setFk(fk);
+        result.getMutableColumnOrThrow("ServerSessionId").setFk(fk);
 
         List<FieldKey> defaultCols = new ArrayList<>();
         defaultCols.add(FieldKey.fromParts("ServerSessionId"));


### PR DESCRIPTION
#### Rationale
Current mothership session tracking is based on how long a web server is running before it restarts. If a server restarts only to deploy a major release (like 21.11->22.3) it'll have a session that lasts four months. We want to ensure that we get at least month-level granularity so we can do more time-based reporting.

That also means we need to do a better job of separating out servers that are reporting with the same ServerGUID. Stashing the hostname and IP at the session level may help.

#### Changes
* Store hostname and IP at the session level as well as continuing to stash the most recent values at the installation level
* Split server sessions when it rolls into the next calendar month
* Chain together the sessions that are split so we can still tell their total duration if needed
* Introduce method variants to get non-null ColumnInfos and TableInfos
* Minor code cleanup