### PR TITLE
Rename activeUserCount->recentUserCount, add new total login metric

### DIFF
--- a/api/src/org/labkey/api/audit/AuditLogService.java
+++ b/api/src/org/labkey/api/audit/AuditLogService.java
@@ -109,10 +109,6 @@ public interface AuditLogService
 
     <K extends AuditTypeEvent> List<K> getAuditEvents(Container container, User user, String eventType, @Nullable SimpleFilter filter, @Nullable Sort sort, @Nullable ContainerFilter cf);
 
-    String getTableName();
-
-    TableInfo getTable(ViewContext context, String name);
-
     UserSchema createSchema(User user, Container container);
 
     ActionURL getAuditUrl();

--- a/api/src/org/labkey/api/audit/DefaultAuditProvider.java
+++ b/api/src/org/labkey/api/audit/DefaultAuditProvider.java
@@ -77,18 +77,6 @@ public class DefaultAuditProvider implements AuditLogService, AuditLogService.Re
     }
 
     @Override
-    public String getTableName()
-    {
-        return "default";
-    }
-
-    @Override
-    public TableInfo getTable(ViewContext context, String name)
-    {
-        return null;
-    }
-
-    @Override
     public UserSchema createSchema(User user, Container container)
     {
         return new DefaultAuditSchema(user, container);

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -608,6 +608,7 @@ public class UserManager
         return (int)new TableSelector(CORE.getTableInfoUsersData(), filter, null).getRowCount();
     }
 
+    /** @return the number of user accounts, not including deactivated users */
     public static int getActiveUserCount()
     {
         return UserCache.getActiveUserCount();

--- a/api/src/org/labkey/api/util/UsageReportingLevel.java
+++ b/api/src/org/labkey/api/util/UsageReportingLevel.java
@@ -101,7 +101,7 @@ public enum UsageReportingLevel implements SafeToRenderEnum
             Calendar cal = new GregorianCalendar();
             cal.add(Calendar.DATE, -30);
             Date startDate = cal.getTime();
-            report.addParam("activeUserCount", UserManager.getRecentUserCount(startDate));
+            report.addParam("recentUserCount", UserManager.getRecentUserCount(startDate));
             // Other counts within the last 30 days
             metrics.put("recentLoginCount", UserManager.getRecentLoginCount(startDate));
             metrics.put("recentLogoutCount", UserManager.getRecentLogOutCount(startDate));

--- a/audit/src/org/labkey/audit/AuditLogImpl.java
+++ b/audit/src/org/labkey/audit/AuditLogImpl.java
@@ -200,19 +200,6 @@ public class AuditLogImpl implements AuditLogService, StartupListener
     }
 
     @Override
-    public String getTableName()
-    {
-        return AuditQuerySchema.AUDIT_TABLE_NAME;
-    }
-
-    @Override
-    public TableInfo getTable(ViewContext context, String name)
-    {
-        UserSchema schema = createSchema(context.getUser(), context.getContainer());
-        return schema.getTable(name);
-    }
-
-    @Override
     public UserSchema createSchema(User user, Container container)
     {
         return new AuditQuerySchema(user, container);

--- a/mothership/resources/schemas/dbscripts/postgresql/mothership-22.001-22.002.sql
+++ b/mothership/resources/schemas/dbscripts/postgresql/mothership-22.001-22.002.sql
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE mothership.ServerSession RENAME COLUMN ActiveUserCount TO RecentUserCount;

--- a/mothership/resources/schemas/mothership.xml
+++ b/mothership/resources/schemas/mothership.xml
@@ -157,7 +157,7 @@
             <column columnName="JavaVersion"/>
             <column columnName="EnterprisePipelineEnabled"/>
             <column columnName="UserCount"/>
-            <column columnName="ActiveUserCount"/>
+            <column columnName="RecentUserCount"/>
             <column columnName="ProjectCount"/>
             <column columnName="ContainerCount"/>
             <column columnName="HeapSize">

--- a/mothership/src/org/labkey/mothership/MothershipController.java
+++ b/mothership/src/org/labkey/mothership/MothershipController.java
@@ -777,7 +777,7 @@ public class MothershipController extends SpringActionController
         private String _serverGUID;
 
         private Integer _userCount;
-        private Integer _activeUserCount;
+        private Integer _recentUserCount;
         private Integer _projectCount;
         private Integer _containerCount;
         private Integer _heapSize;
@@ -903,14 +903,24 @@ public class MothershipController extends SpringActionController
             _userCount = userCount;
         }
 
+        // retained for backwards compatibility with 22.5 and earlier
         public Integer getActiveUserCount()
         {
-            return _activeUserCount;
+            return _recentUserCount;
+        }
+        public void setActiveUserCount(Integer recentUserCount)
+        {
+            _recentUserCount = recentUserCount;
         }
 
-        public void setActiveUserCount(Integer activeUserCount)
+        public Integer getRecentUserCount()
         {
-            _activeUserCount = activeUserCount;
+            return _recentUserCount;
+        }
+
+        public void setRecentUserCount(Integer recentUserCount)
+        {
+            _recentUserCount = recentUserCount;
         }
 
         public Integer getProjectCount()
@@ -1044,7 +1054,7 @@ public class MothershipController extends SpringActionController
             session.setRuntimeOS(getRuntimeOS());
             session.setJavaVersion(getJavaVersion());
             session.setContainer(container.getId());
-            session.setActiveUserCount(getActiveUserCount());
+            session.setRecentUserCount(getActiveUserCount());
             session.setUserCount(getUserCount());
             session.setProjectCount(getProjectCount());
             session.setContainerCount(getContainerCount());

--- a/mothership/src/org/labkey/mothership/MothershipController.java
+++ b/mothership/src/org/labkey/mothership/MothershipController.java
@@ -1054,7 +1054,7 @@ public class MothershipController extends SpringActionController
             session.setRuntimeOS(getRuntimeOS());
             session.setJavaVersion(getJavaVersion());
             session.setContainer(container.getId());
-            session.setRecentUserCount(getActiveUserCount());
+            session.setRecentUserCount(getRecentUserCount());
             session.setUserCount(getUserCount());
             session.setProjectCount(getProjectCount());
             session.setContainerCount(getContainerCount());

--- a/mothership/src/org/labkey/mothership/MothershipManager.java
+++ b/mothership/src/org/labkey/mothership/MothershipManager.java
@@ -372,7 +372,7 @@ public class MothershipManager
                 existingSession.setServerHostName(hostName);
                 existingSession.setContainerCount(getBestInteger(existingSession.getContainerCount(), session.getContainerCount()));
                 existingSession.setProjectCount(getBestInteger(existingSession.getProjectCount(), session.getProjectCount()));
-                existingSession.setActiveUserCount(getBestInteger(existingSession.getActiveUserCount(), session.getActiveUserCount()));
+                existingSession.setRecentUserCount(getBestInteger(existingSession.getRecentUserCount(), session.getRecentUserCount()));
                 existingSession.setUserCount(getBestInteger(existingSession.getUserCount(), session.getUserCount()));
                 existingSession.setAdministratorEmail(getBestString(existingSession.getAdministratorEmail(), session.getAdministratorEmail()));
                 existingSession.setEnterprisePipelineEnabled(getBestBoolean(existingSession.isEnterprisePipelineEnabled(), session.isEnterprisePipelineEnabled()));

--- a/mothership/src/org/labkey/mothership/MothershipModule.java
+++ b/mothership/src/org/labkey/mothership/MothershipModule.java
@@ -74,7 +74,7 @@ public class MothershipModule extends DefaultModule
     @Override
     public Double getSchemaVersion()
     {
-        return 22.001;
+        return 22.002;
     }
 
     @Override

--- a/mothership/src/org/labkey/mothership/ServerSession.java
+++ b/mothership/src/org/labkey/mothership/ServerSession.java
@@ -43,7 +43,7 @@ public class ServerSession
     private Boolean _enterprisePipelineEnabled;
 
     private Integer _userCount;
-    private Integer _activeUserCount;
+    private Integer _recentUserCount;
     private Integer _projectCount;
     private Integer _containerCount;
     private Integer _heapSize;
@@ -208,14 +208,14 @@ public class ServerSession
         _userCount = userCount;
     }
 
-    public Integer getActiveUserCount()
+    public Integer getRecentUserCount()
     {
-        return _activeUserCount;
+        return _recentUserCount;
     }
 
-    public void setActiveUserCount(Integer activeUserCount)
+    public void setRecentUserCount(Integer recentUserCount)
     {
-        _activeUserCount = activeUserCount;
+        _recentUserCount = recentUserCount;
     }
 
     public Integer getProjectCount()

--- a/mothership/src/org/labkey/mothership/query/MothershipSchema.java
+++ b/mothership/src/org/labkey/mothership/query/MothershipSchema.java
@@ -19,6 +19,7 @@ package org.labkey.mothership.query;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.AbstractTableInfo;
+import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerForeignKey;
@@ -186,7 +187,18 @@ public class MothershipSchema extends UserSchema
 
     public FilteredTable<MothershipSchema> createServerSessionTable(ContainerFilter cf)
     {
-        FilteredTable<MothershipSchema> result = new FilteredTable<>(MothershipManager.get().getTableInfoServerSession(), this, cf);
+        FilteredTable<MothershipSchema> result = new FilteredTable<>(MothershipManager.get().getTableInfoServerSession(), this, cf)
+        {
+            @Override
+            protected ColumnInfo resolveColumn(String name)
+            {
+                if ("activeUserCount".equalsIgnoreCase(name))
+                {
+                    return getColumn("recentUserCount");
+                }
+                return super.resolveColumn(name);
+            }
+        };
         result.wrapAllColumns(true);
         result.setTitleColumn("RowId");
 
@@ -215,7 +227,7 @@ public class MothershipSchema extends UserSchema
         defaultCols.add(FieldKey.fromString("RuntimeOS"));
         defaultCols.add(FieldKey.fromString("JavaVersion"));
         defaultCols.add(FieldKey.fromString("UserCount"));
-        defaultCols.add(FieldKey.fromString("ActiveUserCount"));
+        defaultCols.add(FieldKey.fromString("RecentUserCount"));
         defaultCols.add(FieldKey.fromString("ContainerCount"));
         defaultCols.add(FieldKey.fromString("HeapSize"));
         defaultCols.add(FieldKey.fromString("ServletContainer"));


### PR DESCRIPTION
#### Rationale
We've overloaded "active" users for metric purposes, so time to disambiguate. Also, good to know the total number of logins, not just recent ones

#### Changes
* Rename activeUserCount -> recentUserCount, with backwards compatibility
* Add new total login count for all logins for history of server
* Delete some dead code