### PR TITLE
PdLookupForeignKey: support passing ContainerFilter

### DIFF
--- a/api/src/org/labkey/api/data/AbstractForeignKey.java
+++ b/api/src/org/labkey/api/data/AbstractForeignKey.java
@@ -16,6 +16,7 @@
 package org.labkey.api.data;
 
 import org.apache.logging.log4j.LogManager;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.NamedObjectList;
 import org.labkey.api.query.FieldKey;
@@ -233,7 +234,7 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
     }
 
     @Override
-    public NamedObjectList getSelectList(RenderContext ctx)
+    public @NotNull NamedObjectList getSelectList(RenderContext ctx)
     {
         TableInfo lookupTable = getLookupTableInfo();
         if (lookupTable == null)

--- a/api/src/org/labkey/api/exp/PropertyColumn.java
+++ b/api/src/org/labkey/api/exp/PropertyColumn.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.LookupColumn;
 import org.labkey.api.data.MutableColumnInfo;
@@ -81,7 +82,19 @@ public class PropertyColumn extends LookupColumn
     // TODO handle pd.copyTo(MutableColumnInfo)
     public static void copyAttributes(User user, MutableColumnInfo to, DomainProperty dp, Container container, @Nullable FieldKey lsidColumnFieldKey)
     {
-        copyAttributes(user, (BaseColumnInfo)to, dp.getPropertyDescriptor(), container, null, null, null, lsidColumnFieldKey);
+        copyAttributes(user, to, dp, container, lsidColumnFieldKey, null);
+    }
+
+    public static void copyAttributes(
+        User user,
+        MutableColumnInfo to,
+        DomainProperty dp,
+        Container container,
+        @Nullable FieldKey lsidColumnFieldKey,
+        @Nullable final ContainerFilter cf
+    )
+    {
+        copyAttributes(user, to, dp.getPropertyDescriptor(), container, null, null, null, lsidColumnFieldKey, cf);
         Map<DomainProperty, Object> map = DefaultValueService.get().getDefaultValues(container, dp.getDomain(), user);
 
         Object value = map.get(dp);
@@ -92,28 +105,35 @@ public class PropertyColumn extends LookupColumn
 
     public static void copyAttributes(User user, MutableColumnInfo to, PropertyDescriptor pd, Container container, FieldKey lsidColumnFieldKey)
     {
-        copyAttributes(user, (BaseColumnInfo)to, pd, container, null, null, null, lsidColumnFieldKey);
+        copyAttributes(user, to, pd, container, null, null, null, lsidColumnFieldKey, null);
     }
 
     public static void copyAttributes(User user, MutableColumnInfo to, PropertyDescriptor pd, Container container, SchemaKey schemaKey, String queryName, FieldKey pkFieldKey)
     {
-        copyAttributes(user, (BaseColumnInfo)to, pd, container, schemaKey, queryName, pkFieldKey, null);
+        copyAttributes(user, to, pd, container, schemaKey, queryName, pkFieldKey, null, null);
+    }
+
+    public static void copyAttributes(User user, MutableColumnInfo to, PropertyDescriptor pd, Container container, SchemaKey schemaKey, String queryName, FieldKey pkFieldKey, @Nullable ContainerFilter cf)
+    {
+        copyAttributes(user, to, pd, container, schemaKey, queryName, pkFieldKey, null, cf);
     }
 
     // TODO handle pd.copyTo(MutableColumnInfo)
+    // TODO: Refactor to builder pattern
     private static void copyAttributes(
         User user,
-        BaseColumnInfo to,
-        final PropertyDescriptor pd,
+        @NotNull MutableColumnInfo to,
+        @NotNull final PropertyDescriptor pd,
         final Container container,
-        final SchemaKey schemaKey,
-        final String queryName,
-        final FieldKey pkFieldKey,
-        @Nullable final FieldKey lsidColumnFieldKey
+        @Nullable final SchemaKey schemaKey,
+        @Nullable final String queryName,
+        @Nullable final FieldKey pkFieldKey,
+        @Nullable final FieldKey lsidColumnFieldKey,
+        @Nullable final ContainerFilter cf
     )
     {
         // ColumnRenderProperties
-        pd.copyTo(to);
+        pd.copyTo((BaseColumnInfo) to);
 
         to.setPropertyType(pd.getPropertyType());
         to.setRequired(pd.isRequired());
@@ -143,7 +163,7 @@ public class PropertyColumn extends LookupColumn
         }
 
         if (user != null && ((pd.getLookupSchema() != null && pd.getLookupQuery() != null) || pd.getConceptURI() != null))
-            to.setFk(PdLookupForeignKey.create(to.getParentTable().getUserSchema(), user, container, pd));
+            to.setFk(PdLookupForeignKey.create(to.getParentTable().getUserSchema(), user, container, pd, cf));
 
         to.setDefaultValueType(pd.getDefaultValueTypeEnum());
         to.setConditionalFormats(PropertyService.get().getConditionalFormats(pd));
@@ -159,13 +179,11 @@ public class PropertyColumn extends LookupColumn
         setSqlTypeName(getSqlDialect().getSqlTypeName(JdbcType.VARCHAR));
     }
 
-
     public void setParentIsObjectId(boolean id)
     {
         _parentIsObjectId = id;
     }
     
-
     @Override
     public SQLFragment getValueSql(String tableAlias)
     {
@@ -206,7 +224,6 @@ public class PropertyColumn extends LookupColumn
             super.declareJoins(baseAlias, map);
     }
 
-
     static private String getPropertyCol(@NotNull PropertyDescriptor pd)
     {
         if (pd.getPropertyType() == null)
@@ -225,7 +242,6 @@ public class PropertyColumn extends LookupColumn
         }
     }
 
-
     private String getPropertySqlCastType()
     {
         if (isMvIndicatorColumn())
@@ -240,7 +256,6 @@ public class PropertyColumn extends LookupColumn
         else
             return getParentTable().getSqlDialect().getSqlTypeName(JdbcType.VARCHAR) + "(" + PropertyStorageSpec.DEFAULT_SIZE + ")";
     }
-
 
     public PropertyDescriptor getPropertyDescriptor()
     {

--- a/api/src/org/labkey/api/exp/PropertyDescriptor.java
+++ b/api/src/org/labkey/api/exp/PropertyDescriptor.java
@@ -38,6 +38,7 @@ import org.labkey.api.exp.property.Lookup;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.query.PdLookupForeignKey;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringExpression;
@@ -391,9 +392,15 @@ public class PropertyDescriptor extends ColumnRenderPropertiesImpl implements Pa
         var info = new PropertyColumn(this, baseTable, lsidCol, container, user, false);
         if (getLookupQuery() != null || getConceptURI() != null)
         {
-            assert null==baseTable.getUserSchema() || baseTable.getUserSchema().getUser() == user;
-            assert null==baseTable.getUserSchema() || baseTable.getUserSchema().getContainer() == container;
-            info.setFk(PdLookupForeignKey.create(baseTable.getUserSchema(), user, container, this));
+            UserSchema schema = baseTable.getUserSchema();
+            if (schema == null)
+                info.setFk(PdLookupForeignKey.create(null, user, container, this));
+            else
+            {
+                assert schema.getUser() == user;
+                assert schema.getContainer() == container;
+                info.setFk(PdLookupForeignKey.create(schema, this));
+            }
         }
         return info;
     }

--- a/api/src/org/labkey/api/query/PdLookupForeignKey.java
+++ b/api/src/org/labkey/api/query/PdLookupForeignKey.java
@@ -42,9 +42,9 @@ import org.labkey.api.util.StringExpression;
 
 public class PdLookupForeignKey extends AbstractForeignKey
 {
-    User _user;
-    PropertyDescriptor _pd;
-    Container _currentContainer;
+    final User _user;
+    final PropertyDescriptor _pd;
+    final Container _currentContainer;
     private Container _targetContainer;
     private TableInfo _tableInfo = null;
 
@@ -54,7 +54,7 @@ public class PdLookupForeignKey extends AbstractForeignKey
     }
 
     static public PdLookupForeignKey create(
-        @NotNull QuerySchema sourceSchema,
+        @Nullable QuerySchema sourceSchema,
         @NotNull User user,
         @NotNull Container container,
         @NotNull PropertyDescriptor pd
@@ -64,7 +64,7 @@ public class PdLookupForeignKey extends AbstractForeignKey
     }
 
     static public PdLookupForeignKey create(
-        @NotNull QuerySchema sourceSchema,
+        @Nullable QuerySchema sourceSchema,
         @NotNull User user,
         @NotNull Container container,
         @NotNull PropertyDescriptor pd,
@@ -73,8 +73,8 @@ public class PdLookupForeignKey extends AbstractForeignKey
     {
         assert container != null : "Container cannot be null";
 
-        Container targetContainer = pd.getLookupContainer() == null ? null : ContainerManager.getForId(pd.getLookupContainer());
-        SchemaKey lookupSchemaKey = null == pd.getLookupSchema() ? null : SchemaKey.fromString(pd.getLookupSchema());
+        Container targetContainer = getLookupContainer(pd);
+        SchemaKey lookupSchemaKey = getLookupSchemaKey(pd);
         String lookupQuery = pd.getLookupQuery();
 
         // check for conceptURI if the lookup container/schema/query are not already specified
@@ -98,15 +98,25 @@ public class PdLookupForeignKey extends AbstractForeignKey
     }
 
     protected PdLookupForeignKey(
-        @NotNull QuerySchema sourceSchema,
-        Container currentContainer,
+        @Nullable QuerySchema sourceSchema,
+        @NotNull Container currentContainer,
         @NotNull User user,
         @Nullable ContainerFilter cf,
-        PropertyDescriptor pd,
-        SchemaKey lookupSchemaKey,
-        String lookupQuery,
-        // TODO: This parameter is not respected! Missed in a previous refactor.
-        Container targetContainer
+        @NotNull PropertyDescriptor pd
+    )
+    {
+        this(sourceSchema, currentContainer, user, cf, pd, getLookupSchemaKey(pd), pd.getLookupQuery(), getLookupContainer(pd));
+    }
+
+    private PdLookupForeignKey(
+        @Nullable QuerySchema sourceSchema,
+        @NotNull Container currentContainer,
+        @NotNull User user,
+        @Nullable ContainerFilter cf,
+        @NotNull PropertyDescriptor pd,
+        @Nullable SchemaKey lookupSchemaKey,
+        @Nullable String lookupQuery,
+        @Nullable Container targetContainer
     )
     {
         super(sourceSchema, cf, lookupSchemaKey, lookupQuery, null, null);
@@ -114,7 +124,7 @@ public class PdLookupForeignKey extends AbstractForeignKey
         _user = user;
         assert currentContainer != null : "Container cannot be null";
         _currentContainer = currentContainer;
-        _targetContainer = _pd.getLookupContainer() == null ? null : ContainerManager.getForId(_pd.getLookupContainer());
+        _targetContainer = targetContainer;
     }
 
     @Override
@@ -136,6 +146,7 @@ public class PdLookupForeignKey extends AbstractForeignKey
     }
 
     @Override
+    @Nullable
     public TableInfo getLookupTableInfo()
     {
         if (_lookupSchemaKey == null || _tableName == null)
@@ -173,6 +184,7 @@ public class PdLookupForeignKey extends AbstractForeignKey
         return table;
     }
 
+    @Nullable
     private TableInfo findTableInfo(Container container)
     {
         if (container == null)
@@ -257,5 +269,15 @@ public class PdLookupForeignKey extends AbstractForeignKey
         if (null == columnName)
             return null;
         return LookupForeignKey.getDetailsURL(parent, lookupTable, columnName);
+    }
+
+    private static @Nullable Container getLookupContainer(@NotNull PropertyDescriptor pd)
+    {
+        return pd.getLookupContainer() == null ? null : ContainerManager.getForId(pd.getLookupContainer());
+    }
+
+    private static @Nullable SchemaKey getLookupSchemaKey(@NotNull PropertyDescriptor pd)
+    {
+        return pd.getLookupSchema() == null ? null : SchemaKey.fromString(pd.getLookupSchema());
     }
 }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -74,7 +74,6 @@ import org.labkey.api.query.DefaultQueryUpdateService;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.InvalidKeyException;
-import org.labkey.api.query.PdLookupForeignKey;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
@@ -380,7 +379,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             PropertyDescriptor pd = (null==dp) ? null : dp.getPropertyDescriptor();
             if (dp != null && pd != null)
             {
-                PropertyColumn.copyAttributes(_userSchema.getUser(), wrapped, dp, getContainer(), lsidFieldKey);
+                PropertyColumn.copyAttributes(_userSchema.getUser(), wrapped, dp, getContainer(), lsidFieldKey, getContainerFilter());
                 wrapped.setFieldKey(FieldKey.fromParts(dp.getName()));
 
                 if (pd.getPropertyType() == PropertyType.ATTACHMENT)
@@ -405,10 +404,6 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                     wrappedMvCol.getFieldKey();
                     wrapped.setMvColumnName(wrappedMvCol.getFieldKey());
                 }
-
-                boolean isTargetLookup = dp.getLookup() != null && dp.getLookup().getContainer() != null;
-                if (!isTargetLookup && wrapped.getFk() instanceof PdLookupForeignKey)
-                    ((PdLookupForeignKey) wrapped.getFk()).setContainerFilter(getContainerFilter());
             }
 
             addColumn(wrapped);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -758,7 +758,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             if (null != dp)
             {
                 PropertyColumn.copyAttributes(schema.getUser(), propColumn, dp.getPropertyDescriptor(), schema.getContainer(),
-                    SchemaKey.fromParts("samples"), st.getName(), FieldKey.fromParts("RowId"));
+                    SchemaKey.fromParts("samples"), st.getName(), FieldKey.fromParts("RowId"), getContainerFilter());
 
                 if (idCols.contains(dp))
                 {
@@ -789,10 +789,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                     addColumn(mvColumn);
                     propColumn.setMvColumnName(FieldKey.fromParts(dp.getName() + MvColumn.MV_INDICATOR_SUFFIX));
                 }
-
-                boolean isTargetLookup = dp.getLookup() != null && dp.getLookup().getContainer() != null;
-                if (!isTargetLookup && propColumn.getFk() instanceof PdLookupForeignKey)
-                    ((PdLookupForeignKey) propColumn.getFk()).setContainerFilter(getContainerFilter());
             }
 
             if (!mvColumns.contains(propColumn.getFieldKey()))

--- a/issues/src/org/labkey/issue/query/IssuesTable.java
+++ b/issues/src/org/labkey/issue/query/IssuesTable.java
@@ -721,7 +721,7 @@ public class IssuesTable extends FilteredTable<IssuesQuerySchema> implements Upd
 
         public IssuesPdLookupForeignKey(IssuesQuerySchema schema, PropertyDescriptor pd)
         {
-            super(schema, schema.getContainer(), schema.getUser(), null, pd, null==pd.getLookupSchema()?null:SchemaKey.fromString(pd.getLookupSchema()), pd.getLookupQuery(), pd.getContainer());
+            super(schema, schema.getContainer(), schema.getUser(), null, pd);
             _user = schema.getUser();
             _container = schema.getContainer();
             _propName = pd.getName();

--- a/issues/src/org/labkey/issue/query/IssuesTable.java
+++ b/issues/src/org/labkey/issue/query/IssuesTable.java
@@ -715,9 +715,9 @@ public class IssuesTable extends FilteredTable<IssuesQuerySchema> implements Upd
      */
     static class IssuesPdLookupForeignKey extends PdLookupForeignKey
     {
-        private User _user;
-        private Container _container;
-        private String _propName;
+        private final User _user;
+        private final Container _container;
+        private final String _propName;
 
         public IssuesPdLookupForeignKey(IssuesQuerySchema schema, PropertyDescriptor pd)
         {
@@ -728,7 +728,7 @@ public class IssuesTable extends FilteredTable<IssuesQuerySchema> implements Upd
         }
 
         @Override
-        public NamedObjectList getSelectList(RenderContext ctx)
+        public @NotNull NamedObjectList getSelectList(RenderContext ctx)
         {
             NamedObjectList objectList = super.getSelectList(ctx);
             Integer issueId = ctx.get(FieldKey.fromParts("IssueId"), Integer.class);

--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -65,7 +65,6 @@ import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.util.ContainerContext;
 import org.labkey.api.util.StringExpressionFactory;
-import org.labkey.api.view.ActionURL;
 import org.labkey.list.controllers.ListController;
 
 import java.sql.Connection;
@@ -224,7 +223,7 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
                     if (null != pd)
                     {
                         col.setFieldKey(new FieldKey(null,pd.getName()));
-                        PropertyColumn.copyAttributes(schema.getUser(), col, dp, schema.getContainer(), FieldKey.fromParts("EntityId"));
+                        PropertyColumn.copyAttributes(schema.getUser(), col, dp, schema.getContainer(), FieldKey.fromParts("EntityId"), getContainerFilter());
 
                         if (pd.isMvEnabled())
                         {
@@ -261,12 +260,6 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
                             col.setURL(StringExpressionFactory.createURL(
                                 ListController.getDownloadURL(listDef, "${EntityId}", "${" + col.getName() + "}")
                             ));
-                        }
-
-                        if (_list.isPicklist() && PICKLIST_SAMPLE_ID.equalsIgnoreCase(pd.getName()))
-                        {
-                            if (col.getFk() instanceof PdLookupForeignKey)
-                                ((PdLookupForeignKey) col.getFk()).setContainerFilter(getContainerFilter());
                         }
                     }
 
@@ -503,7 +496,6 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
                 .setKeyColumns(new CaseInsensitiveHashSet(getPkColumnNames()));
     }
 
-
     public class _DataIteratorBuilder implements DataIteratorBuilder
     {
         DataIteratorContext _context;
@@ -557,13 +549,11 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
         }
     }
 
-
     @Override
     public ParameterMapStatement insertStatement(Connection conn, User user) throws SQLException
     {
         return StatementUtils.insertStatement(conn, this, getContainer(), user, false, true);
     }
-
 
     @Override
     public ParameterMapStatement updateStatement(Connection conn, User user, Set<String> columns)


### PR DESCRIPTION
#### Rationale
This addresses [Issue 45453](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45453) by adding support for passing a `ContainerFilter` to a `PdLookupForeignKey`. This allows these lookups to properly respect the container filter applied on the table info when available. If an explicit target container is set on the lookup that will still take preference over the supplied container filter.

I've been fairly aggressive with adding this support in places where I had previously had to "work around" this behavior by inspecting the foreign key in certain relationships. Namely, samples, lists, and data classes. There are likely other usages of `PdLookupForeignKey.create()` that should have their usage updated to pass in the container filter, however, I'm leaving that to future work.

#### Changes
* Update `PdLookupForeignKey` to take a `ContainerFilter` and apply iff a target container is not supplied.
* Update `PropertyColumn.copyAttritbutes()` signatures to support passing a `ContainerFilter`.
* Remove explicit application of container filters for `ExpMaterial`, `ExpDataClassData` and `Lists` as theses behaviors should be encapsulated by these changes.
