### PR TITLE
Consistently sort folder types by case-insensitive label (not name)

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -465,7 +465,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
     @SafeVarargs
     public final boolean hasOneOf(@NotNull User user, @NotNull Class<? extends Permission>... perms)
     {
-        return SecurityManager.hasAnyPermissions(null, getPolicy(), user, new HashSet(Arrays.asList(perms)), Set.of());
+        return SecurityManager.hasAnyPermissions(null, getPolicy(), user, new HashSet<>(Arrays.asList(perms)), Set.of());
     }
 
     public boolean isForbiddenProject(User user)
@@ -899,24 +899,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
         return _defaultModule;
     }
 
-    public void setFolderType(FolderType folderType, Set<Module> ensureModules)
-    {
-        BindException errors = new BindException(new Object(), "dummy");
-        setFolderType(folderType, ensureModules, errors);
-    }
-
-    public void setFolderType(FolderType folderType, Set<Module> ensureModules, User user)
-    {
-        BindException errors = new BindException(new Object(), "dummy");
-        setFolderType(folderType, ensureModules, user, errors);
-    }
-
-    public void setFolderType(FolderType folderType, Set<Module> ensureModules, BindException errors)
-    {
-        setFolderType(folderType, ensureModules, null, errors);
-    }
-
-    public void setFolderType(FolderType folderType, Set<Module> ensureModules, User user, BindException errors)
+    public void setFolderType(FolderType folderType, User user, BindException errors, Set<Module> ensureModules)
     {
         setFolderType(folderType, user, errors);
         if (!errors.hasErrors())
@@ -1217,11 +1200,9 @@ public class Container implements Serializable, Comparable<Container>, Securable
             propsWritable.save();
         }
 
-        Set<Module> modules = new HashSet<>();
-
         // always put the required modules in the set
         // note that this will pickup the modules from the folder type's getActiveModules()
-        modules.addAll(getRequiredModules());
+        Set<Module> modules = new HashSet<>(getRequiredModules());
 
         // add all modules found in user preferences:
         for (String moduleName : props.keySet())

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -781,7 +781,7 @@ public class CoreController extends SpringActionController
                 Container newContainer = ContainerManager.createContainer(getContainer(), name, title, description, typeName, getUser());
                 if (folderType != null)
                 {
-                    newContainer.setFolderType(folderType, getUser());
+                    newContainer.setFolderType(folderType, getUser(), errors);
                 }
                 if (!ensureModules.isEmpty())
                 {

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -5137,7 +5137,7 @@ public class AdminController extends SpringActionController
 
             if (null == StringUtils.trimToNull(form.getFolderType()) || FolderType.NONE.getName().equals(form.getFolderType()))
             {
-                container.setFolderType(FolderType.NONE, activeModules, getUser(), errors);
+                container.setFolderType(FolderType.NONE, getUser(), errors, activeModules);
                 Module defaultModule = ModuleLoader.getInstance().getModule(form.getDefaultModule());
                 container.setDefaultModule(defaultModule);
             }
@@ -5147,7 +5147,7 @@ public class AdminController extends SpringActionController
                 if (container.isContainerTab() && folderType.hasContainerTabs())
                     errors.reject(null, "You cannot set a tab folder to a folder type that also has tab folders");
                 else
-                    container.setFolderType(folderType, activeModules, getUser(), errors);
+                    container.setFolderType(folderType, getUser(), errors, activeModules);
             }
             if (errors.hasErrors())
                 return false;
@@ -7024,7 +7024,7 @@ public class AdminController extends SpringActionController
 
                         newContainer = ContainerManager.createContainer(parent, folderName, folderTitle, null, NormalContainerType.NAME, getUser());
                         afterCreateHandler.accept(newContainer);
-                        newContainer.setFolderType(type, getUser());
+                        newContainer.setFolderType(type, getUser(), errors);
 
                         if (null == StringUtils.trimToNull(folderType) || FolderType.NONE.getName().equals(folderType))
                         {
@@ -7036,7 +7036,7 @@ public class AdminController extends SpringActionController
                                     activeModules.add(module);
                             }
 
-                            newContainer.setFolderType(FolderType.NONE, activeModules, getUser());
+                            newContainer.setFolderType(FolderType.NONE, getUser(), errors, activeModules);
                             Module defaultModule = ModuleLoader.getInstance().getModule(form.getDefaultModule());
                             newContainer.setDefaultModule(defaultModule);
                         }

--- a/core/src/org/labkey/core/admin/createFolder.jsp
+++ b/core/src/org/labkey/core/admin/createFolder.jsp
@@ -94,8 +94,8 @@
                     //force custom to appear at end
                     return b.label == 'Custom' ? -1
                         : a.label == 'Custom' ? 1
-                        : (a.label > b.label) ? 1
-                        : (a.label < b.label) ? -1
+                        : (a.label.toLowerCase() > b.label.toLowerCase()) ? 1
+                        : (a.label.toLowerCase() < b.label.toLowerCase()) ? -1
                         : 0
                 });
                 

--- a/core/src/org/labkey/core/admin/folderType.jsp
+++ b/core/src/org/labkey/core/admin/folderType.jsp
@@ -51,7 +51,7 @@ var defaultModules = {};  <% // This is used... Java code below generates JavaSc
     final ViewContext context = getViewContext();
     Container c = getContainer();
     boolean userHasEnableRestrictedModulesPermission = c.hasEnableRestrictedModules(getUser());
-    Collection<FolderType> allFolderTypes = FolderTypeManager.get().getEnabledFolderTypes(userHasEnableRestrictedModulesPermission);
+    List<FolderType> allFolderTypes = new ArrayList<>(FolderTypeManager.get().getEnabledFolderTypes(userHasEnableRestrictedModulesPermission));
     List<Module> allModules = new ArrayList<>(ModuleLoader.getInstance().getModules(userHasEnableRestrictedModulesPermission));
     allModules.sort(Comparator.comparing(module -> module.getTabName(context), String.CASE_INSENSITIVE_ORDER));
     Set<Module> activeModules = c.getActiveModules();
@@ -67,6 +67,9 @@ var defaultModules = {};  <% // This is used... Java code below generates JavaSc
     FolderType folderType = c.getFolderType();
     String path = c.getPath();
     boolean includeProjectLevelTypes = c.isProject();       // Only include Dataspace as an option if container is a project
+
+    // Sort by label, which may not match with the official name
+    allFolderTypes.sort(Comparator.comparing(x -> x.getLabel().toLowerCase()));
 
     for (FolderType ft : allFolderTypes)
     {

--- a/core/src/org/labkey/core/admin/importer/FolderTypeImporterFactory.java
+++ b/core/src/org/labkey/core/admin/importer/FolderTypeImporterFactory.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.core.admin.importer;
 
-import org.jetbrains.annotations.NotNull;
 import org.labkey.api.admin.AbstractFolderImportFactory;
 import org.labkey.api.admin.FolderArchiveDataTypes;
 import org.labkey.api.admin.FolderImportContext;
@@ -27,15 +26,12 @@ import org.labkey.api.module.FolderTypeManager;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.PipelineJob;
-import org.labkey.api.pipeline.PipelineJobWarning;
 import org.labkey.api.settings.WriteableFolderLookAndFeelProperties;
 import org.labkey.api.writer.VirtualFile;
 import org.labkey.folder.xml.FolderDocument.Folder;
 import org.springframework.validation.BindException;
 import org.springframework.validation.ObjectError;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -168,7 +164,7 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
                     ctx.getLogger().debug("[" + c.getPath() + "] Active modules: " + activeModules.stream().map(Module::getName).collect(Collectors.joining(", ")));
                     // It's sorta BrandNew, but not really; say it's not and SubImporter will handle container tabs correctly
                     BindException errors = new BindException(new Object(), "dummy");
-                    c.setFolderType(folderType, activeModules, ctx.getUser(), errors);
+                    c.setFolderType(folderType, ctx.getUser(), errors, activeModules);
                     for (ObjectError error : errors.getAllErrors())
                     {
                         ctx.getLogger().error(error.getDefaultMessage());

--- a/query/webapp/query/browser/Caches.js
+++ b/query/webapp/query/browser/Caches.js
@@ -328,7 +328,10 @@ Ext4.define('LABKEY.query.browser.cache.QueryDependencies', {
                                 fixupJsonResponse.call(this, null, resp, options, c);
                             }
                         },
-                        failure: LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnFailure(config), this, true)
+                        failure: function(resp, options) {
+                            fixupJsonResponse.call(this, null, resp, options, c);
+                            // LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnFailure(config), this, true)
+                        }
                     });
                 }, this);
             },

--- a/query/webapp/query/browser/Caches.js
+++ b/query/webapp/query/browser/Caches.js
@@ -328,10 +328,7 @@ Ext4.define('LABKEY.query.browser.cache.QueryDependencies', {
                                 fixupJsonResponse.call(this, null, resp, options, c);
                             }
                         },
-                        failure: function(resp, options) {
-                            fixupJsonResponse.call(this, null, resp, options, c);
-                            // LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnFailure(config), this, true)
-                        }
+                        failure: LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnFailure(config), this, true)
                     });
                 }, this);
             },


### PR DESCRIPTION
#### Rationale
It's better to sort a list by the thing we're using to label entries. And users generally don't like case-sensitive sorts.

#### Changes
* Sort by folder type label instead of name in the folder management page.
* Do a case-insensitive ordering of folder types in both the creation UI and the management of existing containers
* Consolidate our many Container.setFolderType() overloads