### PR TITLE
Don't index files starting with '~'

### DIFF
--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -1015,12 +1015,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
     private boolean isWorkingFile(@NotNull WebdavResource r)
     {
         // MS Office opens temp/working files with '~', ignore these. Issue #45005
-        if (r.getName().startsWith("~") || r.getName().startsWith(".~"))
-        {
-            return true;
-        }
-
-        return false;
+        return r.getName().startsWith("~") || r.getName().startsWith(".~");
     }
 
     private boolean isTooBig(FileStream fs, String contentType) throws IOException

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -998,6 +998,10 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
                     DocumentParser p = detectParser(r, null);
                     return p != null;
                 }
+                else if (isTempFile(r))
+                {
+                    return false;
+                }
                 return true;
             }
             finally
@@ -1011,6 +1015,16 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
         }
     }
 
+    private boolean isTempFile(@NotNull WebdavResource r)
+    {
+        // MS Office opens temp/working files with '~', ignore these. Issue #45005
+        if (r.getName().startsWith("~"))
+        {
+            return true;
+        }
+
+        return false;
+    }
 
     private boolean isTooBig(FileStream fs, String contentType) throws IOException
     {

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -985,7 +985,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
         try
         {
             String contentType = r.getContentType();
-            if (isImage(contentType) || isZip(contentType))
+            if (isImage(contentType) || isZip(contentType) || isWorkingFile(r))
                 return false;
             FileStream fs = r.getFileStream(User.getSearchUser());
             if (null == fs)
@@ -998,10 +998,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
                     DocumentParser p = detectParser(r, null);
                     return p != null;
                 }
-                else if (isTempFile(r))
-                {
-                    return false;
-                }
+
                 return true;
             }
             finally
@@ -1015,10 +1012,10 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
         }
     }
 
-    private boolean isTempFile(@NotNull WebdavResource r)
+    private boolean isWorkingFile(@NotNull WebdavResource r)
     {
         // MS Office opens temp/working files with '~', ignore these. Issue #45005
-        if (r.getName().startsWith("~"))
+        if (r.getName().startsWith("~") || r.getName().startsWith(".~"))
         {
             return true;
         }


### PR DESCRIPTION
#### Rationale
[Issue 45005: Exclude from search indexing any files that start with ~](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45005)

#### Changes
* Added check to indexer to ignore files starting with '~' 
