### PR TITLE
Add "Clear All Objects" and "Reset" buttons to folder export page

### DIFF
--- a/core/src/org/labkey/core/admin/exportFolder.jsp
+++ b/core/src/org/labkey/core/admin/exportFolder.jsp
@@ -92,7 +92,7 @@ Ext4.onReady(function(){
                 hideLabel: true,
                 boxLabel: parentName,
                 name: "types",
-                itemId: parentName,
+                itemId: parentName.replaceAll(',', ''),
                 inputValue: parentName,
                 checked: checked,
                 objectType: "parent"
@@ -108,7 +108,7 @@ Ext4.onReady(function(){
                         hideLabel: true,
                         boxLabel: childName,
                         name: "types",
-                        itemId: childName,
+                        itemId: childName.replaceAll(',', ''),
                         inputValue: childName,
                         checked: checked,
                         objectType: "child",
@@ -231,7 +231,7 @@ Ext4.onReady(function(){
                 text:'Reset',
                 handler: function(btn) {
                     document.getElementById('exportForm').innerHTML = '';
-                    initializeForm(initExportForm, <%=q(form.getExportType().toString())%>)
+                    initializeForm(initExportForm);
                 }
             }],
             buttonAlign:'left',
@@ -261,16 +261,16 @@ Ext4.onReady(function(){
                 'NotPHI';
     };
 
-    initializeForm(initExportForm, <%=q(form.getExportType().toString())%>);
+    initializeForm(initExportForm);
 });
 
-function initializeForm(initExportForm, exportType)
+function initializeForm(initExportForm)
 {
     LABKEY.Ajax.request({
         url: LABKEY.ActionURL.buildURL("core", "getRegisteredFolderWriters"),
         method: 'POST',
         jsonData: {
-            exportType: exportType
+            exportType: <%=q(form.getExportType().toString())%>
         },
         scope: this,
         success: function (response) {

--- a/core/src/org/labkey/core/admin/exportFolder.jsp
+++ b/core/src/org/labkey/core/admin/exportFolder.jsp
@@ -219,6 +219,20 @@ Ext4.onReady(function(){
 
                     exportForm.getForm().submit();
                 }
+            }, {
+                text:'Clear All Objects',
+                handler: function(btn) {
+                    const leftColumnItems = exportForm.items.items[0].items.items;
+                    for (const item of leftColumnItems)
+                        if (item.xtype === 'checkbox')
+                            item.setValue(false);
+                }
+            }, {
+                text:'Reset',
+                handler: function(btn) {
+                    document.getElementById('exportForm').innerHTML = '';
+                    initializeForm(initExportForm, <%=q(form.getExportType().toString())%>)
+                }
             }],
             buttonAlign:'left',
             listeners : {
@@ -233,7 +247,6 @@ Ext4.onReady(function(){
                                     child.setDisabled(!checked);
                                 });
                             });
-
                         });
                     }
                 }
@@ -248,19 +261,24 @@ Ext4.onReady(function(){
                 'NotPHI';
     };
 
+    initializeForm(initExportForm, <%=q(form.getExportType().toString())%>);
+});
+
+function initializeForm(initExportForm, exportType)
+{
     LABKEY.Ajax.request({
         url: LABKEY.ActionURL.buildURL("core", "getRegisteredFolderWriters"),
         method: 'POST',
         jsonData: {
-            exportType: <%=q(form.getExportType().toString())%>
+            exportType: exportType
         },
         scope: this,
         success: function (response) {
-            var responseText = Ext4.decode(response.responseText);
+            const responseText = Ext4.decode(response.responseText);
             initExportForm(responseText['writers']);
         }
     });
-});
+}
 
 </script>
 


### PR DESCRIPTION
#### Rationale
I'm tired of unchecking boxes on the export page. A simple "clear" button makes it much easier to export a single object type (or a small number of them).

<img width="626" alt="image" src="https://user-images.githubusercontent.com/5107383/167925117-f3344a7f-0fe5-48bb-89f9-ba244484a3fc.png">

#### Changes
* Add "Clear All Objects" and "Reset" buttons at the bottom of the folder/study export page
* Also, an unrelated refactor of to reduce `TSVGridWriter`'s reliance on holding a `Results` member variable