### PR TITLE
Adjust admin page routing

### DIFF
--- a/core/src/org/labkey/core/admin/admin.jsp
+++ b/core/src/org/labkey/core/admin/admin.jsp
@@ -242,18 +242,23 @@
 </div>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
     +function($) {
-
-        var defaultRoute = "links";
-
         function loadRoute(hash) {
-            if (!hash || hash === '#') {
-                hash = '#' + defaultRoute;
+            var adminNav = $('#lk-admin-nav');
+            adminNav.find('a').removeClass('active');
+
+            var activeSection = adminNav.find('a[href=\'' + $.escapeSelector(hash) + '\']');
+
+            // Section does not exist -- default to default route
+            if (activeSection.length === 0) {
+                hash = '#links';
+                activeSection = adminNav.find('a[href=\'' + $.escapeSelector(hash) + '\']');
             }
 
-            $('#lk-admin-nav').find('a').removeClass('active');
-            $('#lk-admin-nav').find('a[href=\'' + hash + '\']').addClass('active');
-            $('.lk-admin-section').hide();
-            $('.lk-admin-section[id=\'' + hash.replace('#', '') + '\']').show();
+            if (activeSection.length) {
+                activeSection.addClass('active');
+                $('.lk-admin-section').hide();
+                $('.lk-admin-section[id=\'' + hash.replace('#', '') + '\']').show();
+            }
         }
 
         $(window).on('hashchange', function() {


### PR DESCRIPTION
#### Rationale
Fixes the route loading for the admin page to avoid erroring out when processing URL hash contents. Fixes [test failure of the AppAdminRouteTest](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyCPostgres/1816302?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true).

#### Changes
- escape hash contents to avoid invalid processing
- fallback to default route if associated section not found
