### PR TITLE
ensure the study publish protocol is created in the shared folder

### DIFF
--- a/api/src/org/labkey/api/study/publish/StudyPublishService.java
+++ b/api/src/org/labkey/api/study/publish/StudyPublishService.java
@@ -139,7 +139,7 @@ public interface StudyPublishService
     /** Checks if the assay and specimen participant/visit/dates don't match based on the specimen id and target study */
     boolean hasMismatchedInfo(List<Integer> dataRowPKs, AssayProtocolSchema schema);
 
-    ExpProtocol ensureStudyPublishProtocol(User user, Container container, @Nullable String name, @Nullable String lsid) throws ExperimentException;
+    ExpProtocol ensureStudyPublishProtocol(User user) throws ExperimentException;
 
     /**
      * Returns the set of datasets which have ever had data linked from the provided protocol

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -24,33 +24,7 @@ import org.apache.xmlbeans.XmlError;
 import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlObject;
 import org.apache.xmlbeans.XmlOptions;
-import org.fhcrc.cpas.exp.xml.ContactType;
-import org.fhcrc.cpas.exp.xml.DataBaseType;
-import org.fhcrc.cpas.exp.xml.DataClassType;
-import org.fhcrc.cpas.exp.xml.DataProtocolInputType;
-import org.fhcrc.cpas.exp.xml.DataType;
-import org.fhcrc.cpas.exp.xml.DomainDescriptorType;
-import org.fhcrc.cpas.exp.xml.ExperimentArchiveDocument;
-import org.fhcrc.cpas.exp.xml.ExperimentArchiveType;
-import org.fhcrc.cpas.exp.xml.ExperimentLogEntryType;
-import org.fhcrc.cpas.exp.xml.ExperimentRunType;
-import org.fhcrc.cpas.exp.xml.ExperimentType;
-import org.fhcrc.cpas.exp.xml.ImportAlias;
-import org.fhcrc.cpas.exp.xml.InputOutputRefsType;
-import org.fhcrc.cpas.exp.xml.MaterialBaseType;
-import org.fhcrc.cpas.exp.xml.MaterialProtocolInputType;
-import org.fhcrc.cpas.exp.xml.MaterialType;
-import org.fhcrc.cpas.exp.xml.PropertyCollectionType;
-import org.fhcrc.cpas.exp.xml.PropertyObjectDeclarationType;
-import org.fhcrc.cpas.exp.xml.PropertyObjectType;
-import org.fhcrc.cpas.exp.xml.ProtocolActionSetType;
-import org.fhcrc.cpas.exp.xml.ProtocolActionType;
-import org.fhcrc.cpas.exp.xml.ProtocolApplicationBaseType;
-import org.fhcrc.cpas.exp.xml.ProtocolBaseType;
-import org.fhcrc.cpas.exp.xml.SampleSetType;
-import org.fhcrc.cpas.exp.xml.SimpleTypeNames;
-import org.fhcrc.cpas.exp.xml.SimpleValueCollectionType;
-import org.fhcrc.cpas.exp.xml.SimpleValueType;
+import org.fhcrc.cpas.exp.xml.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayProvider;
@@ -114,30 +88,7 @@ import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.logging.LogHelper;
-import org.labkey.experiment.api.AliasInsertHelper;
-import org.labkey.experiment.api.Data;
-import org.labkey.experiment.api.DataClass;
-import org.labkey.experiment.api.DataInput;
-import org.labkey.experiment.api.ExpDataClassImpl;
-import org.labkey.experiment.api.ExpDataImpl;
-import org.labkey.experiment.api.ExpMaterialImpl;
-import org.labkey.experiment.api.ExpProtocolApplicationImpl;
-import org.labkey.experiment.api.ExpProtocolImpl;
-import org.labkey.experiment.api.ExpRunImpl;
-import org.labkey.experiment.api.ExpSampleTypeImpl;
-import org.labkey.experiment.api.Experiment;
-import org.labkey.experiment.api.ExperimentRun;
-import org.labkey.experiment.api.ExperimentServiceImpl;
-import org.labkey.experiment.api.IdentifiableEntity;
-import org.labkey.experiment.api.Material;
-import org.labkey.experiment.api.MaterialInput;
-import org.labkey.experiment.api.Protocol;
-import org.labkey.experiment.api.ProtocolAction;
-import org.labkey.experiment.api.ProtocolActionPredecessor;
-import org.labkey.experiment.api.ProtocolActionStepDetail;
-import org.labkey.experiment.api.ProtocolApplication;
-import org.labkey.experiment.api.RunItem;
-import org.labkey.experiment.api.SampleTypeServiceImpl;
+import org.labkey.experiment.api.*;
 import org.labkey.experiment.api.property.DomainImpl;
 import org.labkey.experiment.pipeline.MoveRunsPipelineJob;
 import org.labkey.experiment.xar.AbstractXarImporter;
@@ -172,6 +123,7 @@ import java.util.stream.Collectors;
 
 import static org.labkey.api.exp.api.ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_LSID;
 import static org.labkey.api.exp.api.ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID;
+import static org.labkey.api.study.publish.StudyPublishService.STUDY_PUBLISH_PROTOCOL_LSID;
 
 public class XarReader extends AbstractXarImporter
 {
@@ -2088,14 +2040,18 @@ public class XarReader extends AbstractXarImporter
         }
         else
         {
-            if (xarProtocol.getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID) || xarProtocol.getLSID().equals(SAMPLE_ALIQUOT_PROTOCOL_LSID))
+            final String xarProtocolLSID = xarProtocol.getLSID();
+            if (xarProtocolLSID.equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID) ||
+                    xarProtocolLSID.equals(SAMPLE_ALIQUOT_PROTOCOL_LSID) ||
+                    xarProtocolLSID.equals(STUDY_PUBLISH_PROTOCOL_LSID))
             {
-                // create derivation and aliquot protocol using shared folder
-                if (xarProtocol.getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID))
-                    ExperimentServiceImpl.get().ensureSampleDerivationProtocol(getUser());
-                else
-                    ExperimentServiceImpl.get().ensureSampleAliquotProtocol(getUser());
-
+                // derivation, aliquot, and publish protocols are created in the shared folder
+                switch (xarProtocolLSID)
+                {
+                    case SAMPLE_DERIVATION_PROTOCOL_LSID -> ExperimentService.get().ensureSampleDerivationProtocol(getUser());
+                    case SAMPLE_ALIQUOT_PROTOCOL_LSID -> ExperimentServiceImpl.get().ensureSampleAliquotProtocol(getUser());
+                    case STUDY_PUBLISH_PROTOCOL_LSID -> StudyPublishService.get().ensureStudyPublishProtocol(getUser());
+                }
                 ExpProtocolImpl ensuredExpProtocol = ExperimentServiceImpl.get().getExpProtocol(protocolLSID);
 
                 if (ensuredExpProtocol == null)

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -551,7 +551,7 @@ public class StudyPublishManager implements StudyPublishService
 
         try
         {
-            studyPublishProtocol = ensureStudyPublishProtocol(user, targetContainer, null, null);
+            studyPublishProtocol = ensureStudyPublishProtocol(user);
 
             run.setProtocol(studyPublishProtocol);
             ViewBackgroundInfo info = new ViewBackgroundInfo(targetContainer, user, null);
@@ -1398,10 +1398,10 @@ public class StudyPublishManager implements StudyPublishService
     }
 
     @Override
-    public ExpProtocol ensureStudyPublishProtocol(User user, Container container, String name, String lsid) throws ExperimentException
+    public ExpProtocol ensureStudyPublishProtocol(User user) throws ExperimentException
     {
-        String protocolName = null != name ? name : STUDY_PUBLISH_PROTOCOL_NAME;
-        String protocolLsid = null != lsid ? lsid : STUDY_PUBLISH_PROTOCOL_LSID;
+        String protocolName = STUDY_PUBLISH_PROTOCOL_NAME;
+        String protocolLsid = STUDY_PUBLISH_PROTOCOL_LSID;
         ExpProtocol protocol = ExperimentService.get().getExpProtocol(protocolLsid);
 
         if (protocol == null)


### PR DESCRIPTION
#### Rationale
In a previous commit we expect the `studyPublishProtocol` to be created in the shared folder and this is certainly the case when data is linked to a study. However, if a folder export (with linked to study data) is imported before the `studyPublishProtocol` is created, this can result in an improperly scoped protocol, causing subsequent imports to fail.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45236

#### Changes
- ensure the study publish protocol is created in the shared folder during `XarImport`