### PR TITLE
Rewrite limit rows implementations to correct behavior and share code

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1608,10 +1608,10 @@ public class DbScope
 
         LOG.info("Attempting to create database \"" + dbName + "\"");
 
-        String masterUrl = StringUtils.replace(url, dbName, dialect.getMasterDataBaseName());
+        String defaultUrl = StringUtils.replace(url, dbName, dialect.getDefaultDatabaseName());
         String createSql = "(undefined)";
 
-        try (Connection conn = getRawConnection(masterUrl, props))
+        try (Connection conn = getRawConnection(defaultUrl, props))
         {
             // Get version-specific dialect; don't log version warnings.
             dialect = SqlDialectManager.getFromMetaData(conn.getMetaData(), false, primaryDataSource);

--- a/api/src/org/labkey/api/data/Table.java
+++ b/api/src/org/labkey/api/data/Table.java
@@ -93,7 +93,7 @@ public class Table
 
     private static final Logger _log = LogHelper.getLogger(Table.class, "SQL generation and execution, some TableInfo-scoped DB operations");
 
-    // Return all rows instead of limiting to the top n
+    // Don't limit the rows returned to a specific count (filters and offsets can still eliminate rows)
     public static final int ALL_ROWS = -1;
     // Return no rows -- useful for query validation or when you need just metadata
     public static final int NO_ROWS = 0;

--- a/api/src/org/labkey/api/data/TableSelectorTestCase.java
+++ b/api/src/org/labkey/api/data/TableSelectorTestCase.java
@@ -371,27 +371,18 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
             List<K> sortedList = new ArrayList<>(selector.getCollection(clazz));
             verifyResultSets(selector, count, true);
 
-            // Set a row count, verify the lengths and contents against the expected array & list subsets
+            // Set just a row count, verify the lengths and contents against the expected array & list subsets
             selector.setMaxRows(rowCount);
-            assertEquals(rowCount, (int) selector.getRowCount());
-            K[] rowCountArray = selector.getArray(clazz);
-            assertEquals(rowCount, rowCountArray.length);
-            assertArrayEquals(Arrays.copyOf(sortedArray, rowCount), rowCountArray);
-            List<K> rowCountList = new ArrayList<>(selector.getCollection(clazz));
-            assertEquals(rowCount, rowCountList.size());
-            assertEquals(sortedList.subList(0, rowCount), rowCountList);
-            verifyResultSets(selector, rowCount, false);
+            test(selector, clazz, 0, rowCount, sortedArray, sortedList, false);
 
-            // Set an offset, verify the lengths and contents against the expected array & list subsets
+            // Set just an offset, verify the lengths and contents against the expected array & list subsets
             selector.setOffset(offset);
-            assertEquals(rowCount, (int) selector.getRowCount());
-            K[] offsetArray = selector.getArray(clazz);
-            assertEquals(rowCount, offsetArray.length);
-            assertArrayEquals(Arrays.copyOfRange(sortedArray, offset, offset + rowCount), offsetArray);
-            List<K> offsetList = new ArrayList<>(selector.getCollection(clazz));
-            assertEquals(rowCount, offsetList.size());
-            assertEquals(sortedList.subList(offset, offset + rowCount), offsetList);
-            verifyResultSets(selector, rowCount, false);
+            selector.setMaxRows(Table.ALL_ROWS);
+            test(selector, clazz, offset, count - offset, sortedArray, sortedList, true);
+
+            // Set an offset and a rowCount, verify the lengths and contents against the expected array & list subsets
+            selector.setMaxRows(rowCount);
+            test(selector, clazz, offset, rowCount, sortedArray, sortedList, false);
 
             // Back to all rows and verify
             selector.setMaxRows(Table.ALL_ROWS);
@@ -401,5 +392,17 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
             assertEquals(count, selector.getCollection(clazz).size());
             verifyResultSets(selector, count, true);
         }
+    }
+
+    private <K> void test(TableSelector selector, Class<K> clazz, int offset, int rowCount, K[] sortedArray, List<K> sortedList, boolean expectedComplete) throws SQLException
+    {
+        assertEquals(rowCount, (int) selector.getRowCount());
+        K[] array = selector.getArray(clazz);
+        assertEquals(rowCount, array.length);
+        assertArrayEquals(Arrays.copyOfRange(sortedArray, offset, offset + rowCount), array);
+        List<K> list = new ArrayList<>(selector.getCollection(clazz));
+        assertEquals(rowCount, list.size());
+        assertEquals(sortedList.subList(offset, offset + rowCount), list);
+        verifyResultSets(selector, rowCount, expectedComplete);
     }
 }

--- a/api/src/org/labkey/api/data/dialect/LimitRowsSqlGenerator.java
+++ b/api/src/org/labkey/api/data/dialect/LimitRowsSqlGenerator.java
@@ -1,0 +1,56 @@
+package org.labkey.api.data.dialect;
+
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.Table;
+
+/**
+ * Implementations of limitRows() and related methods for databases that support standard syntax
+ */
+public class LimitRowsSqlGenerator
+{
+    public static SQLFragment limitRows(SQLFragment frag, int rowCount, long offset)
+    {
+        if (rowCount != Table.ALL_ROWS)
+        {
+            frag.append("\nLIMIT ");
+            frag.append(Integer.toString(Table.NO_ROWS == rowCount ? 0 : rowCount));
+        }
+
+        if (offset > 0)
+        {
+            frag.append("\nOFFSET ");
+            frag.append(Long.toString(offset));
+        }
+
+        return frag;
+    }
+
+    public static SQLFragment limitRows(SQLFragment select, SQLFragment from, SQLFragment filter, String order, String groupBy, int maxRows, long offset)
+    {
+        SQLFragment sql = appendFromFilterOrderAndGroupBy(select, from, filter, order, groupBy);
+
+        return limitRows(sql, maxRows, offset);
+    }
+
+    public static SQLFragment appendFromFilterOrderAndGroupBy(SQLFragment select, SQLFragment from, SQLFragment filter, String order, String groupBy)
+    {
+        if (select == null)
+            throw new IllegalArgumentException("select");
+        if (from == null)
+            throw new IllegalArgumentException("from");
+
+        return appendFromFilterOrderAndGroupByNoValidation(select, from, filter, order, groupBy);
+    }
+
+    public static SQLFragment appendFromFilterOrderAndGroupByNoValidation(SQLFragment select, SQLFragment from, SQLFragment filter, String order, String groupBy)
+    {
+        SQLFragment sql = new SQLFragment();
+        sql.append(select);
+        sql.append("\n").append(from);
+        if (filter != null) sql.append("\n").append(filter);
+        if (groupBy != null) sql.append("\n").append(groupBy);
+        if (order != null) sql.append("\n").append(order);
+
+        return sql;
+    }
+}

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -292,41 +292,13 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     @Override
     public SQLFragment limitRows(SQLFragment frag, int maxRows)
     {
-        return limitRows(frag, maxRows, 0);
-    }
-
-    private SQLFragment limitRows(SQLFragment frag, int rowCount, long offset)
-    {
-        if (rowCount != Table.ALL_ROWS)
-        {
-            frag.append("\nLIMIT ");
-            frag.append(Integer.toString(Table.NO_ROWS == rowCount ? 0 : rowCount));
-
-            if (offset > 0)
-            {
-                frag.append(" OFFSET ");
-                frag.append(Long.toString(offset));
-            }
-        }
-        return frag;
+        return LimitRowsSqlGenerator.limitRows(frag, maxRows, 0);
     }
 
     @Override
     public SQLFragment limitRows(SQLFragment select, SQLFragment from, SQLFragment filter, String order, String groupBy, int maxRows, long offset)
     {
-        if (select == null)
-            throw new IllegalArgumentException("select");
-        if (from == null)
-            throw new IllegalArgumentException("from");
-
-        SQLFragment sql = new SQLFragment();
-        sql.append(select);
-        sql.append("\n").append(from);
-        if (filter != null) sql.append("\n").append(filter);
-        if (groupBy != null) sql.append("\n").append(groupBy);
-        if (order != null) sql.append("\n").append(order);
-
-        return limitRows(sql, maxRows, offset);
+        return LimitRowsSqlGenerator.limitRows(select, from, filter, order, groupBy, maxRows, offset);
     }
 
     @Override
@@ -948,7 +920,7 @@ public abstract class PostgreSql91Dialect extends SqlDialect
 
 
     @Override
-    public String getMasterDataBaseName()
+    public String getDefaultDatabaseName()
     {
         return "template1";
     }

--- a/api/src/org/labkey/api/data/dialect/SimpleSqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SimpleSqlDialect.java
@@ -456,7 +456,7 @@ public abstract class SimpleSqlDialect extends SqlDialect
     }
 
     @Override
-    public String getMasterDataBaseName()
+    public String getDefaultDatabaseName()
     {
         throw new UnsupportedOperationException(getClass().getSimpleName() + " does not implement");
     }

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -608,7 +608,11 @@ public abstract class SqlDialect
      */
     protected abstract @NotNull Pattern getSQLScriptProcPattern();
 
-    public abstract String getMasterDataBaseName();
+    /**
+     * Database that's created by default on this database server. This is the database to which we'll connect if the
+     * specified labkey database doesn't exist and we need to create it.
+     */
+    public abstract String getDefaultDatabaseName();
 
     public abstract String getDefaultDateTimeDataType();
 

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -491,8 +491,8 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
         if (from == null)
             throw new IllegalArgumentException("from");
 
-        // If there's no offset or requesting no rows then we can do use a simple TOP approach for maxRows, which
-        // doesn't require an ORDER BY and allows 0 rows (unlike OFFSET + FETCH)
+        // If there's no offset or requesting no rows then we can use a simple TOP approach for maxRows, which doesn't
+        // require an ORDER BY and allows 0 rows (unlike OFFSET + FETCH)
         if (offset == 0 || maxRows == Table.NO_ROWS)
         {
             SQLFragment sql = LimitRowsSqlGenerator.appendFromFilterOrderAndGroupByNoValidation(select, from, filter, order, groupBy);

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2008R2Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2008R2Dialect.java
@@ -17,6 +17,7 @@ package org.labkey.bigiron.mssql;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.Table;
 import org.labkey.api.data.dialect.TableResolver;
 
 /**
@@ -29,7 +30,7 @@ public class MicrosoftSqlServer2008R2Dialect extends BaseMicrosoftSqlServerDiale
         super(tableResolver);
     }
 
-    // Called only if rowCount and offset are both > 0
+    // Called only if offset is > 0, maxRows is not NO_ROWS, and order is non-blank
     @Override
     protected SQLFragment _limitRows(SQLFragment select, SQLFragment from, SQLFragment filter, @NotNull String order, String groupBy, int maxRows, long offset)
     {
@@ -43,10 +44,19 @@ public class MicrosoftSqlServer2008R2Dialect extends BaseMicrosoftSqlServerDiale
         if (filter != null) sql.append("\n").append(filter);
         if (groupBy != null) sql.append("\n").append(groupBy);
         sql.append("\n) AS z\n");
-        sql.append("WHERE _RowNum BETWEEN ");
-        sql.append(offset + 1);
-        sql.append(" AND ");
-        sql.append(offset + maxRows);
+        sql.append("WHERE _RowNum ");
+
+        if (maxRows == Table.ALL_ROWS)
+        {
+            sql.append(">= ").append(offset + 1);
+        }
+        else
+        {
+            sql.append("BETWEEN ");
+            sql.append(offset + 1);
+            sql.append(" AND ");
+            sql.append(offset + maxRows);
+        }
 
         return sql;
     }

--- a/bigiron/src/org/labkey/bigiron/mysql/MySqlDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySqlDialect.java
@@ -23,11 +23,11 @@ import org.labkey.api.data.DatabaseTableType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlExecutor;
-import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.dialect.ColumnMetaDataReader;
 import org.labkey.api.data.dialect.JdbcHelper;
 import org.labkey.api.data.dialect.JdbcMetaDataLocator;
+import org.labkey.api.data.dialect.LimitRowsSqlGenerator;
 import org.labkey.api.data.dialect.PkMetaDataReader;
 import org.labkey.api.data.dialect.SimpleSqlDialect;
 import org.labkey.api.data.dialect.StandardJdbcHelper;
@@ -190,44 +190,16 @@ public class MySqlDialect extends SimpleSqlDialect
         return new PkMetaDataReader(rs, "COLUMN_NAME", "KEY_SEQ");
     }
 
-    private SQLFragment limitRows(SQLFragment frag, int rowCount, long offset)
+    @Override
+    public SQLFragment limitRows(SQLFragment frag, int maxRows)
     {
-        if (rowCount != Table.ALL_ROWS)
-        {
-            frag.append("\nLIMIT ");
-            frag.append(Integer.toString(Table.NO_ROWS == rowCount ? 0 : rowCount));
-
-            if (offset > 0)
-            {
-                frag.append(" OFFSET ");
-                frag.append(Long.toString(offset));
-            }
-        }
-        return frag;
+        return LimitRowsSqlGenerator.limitRows(frag, maxRows, 0);
     }
 
     @Override
     public SQLFragment limitRows(SQLFragment select, SQLFragment from, SQLFragment filter, String order, String groupBy, int maxRows, long offset)
     {
-        if (select == null)
-            throw new IllegalArgumentException("select");
-        if (from == null)
-            throw new IllegalArgumentException("from");
-
-        SQLFragment sql = new SQLFragment();
-        sql.append(select);
-        sql.append("\n").append(from);
-        if (filter != null) sql.append("\n").append(filter);
-        if (groupBy != null) sql.append("\n").append(groupBy);
-        if (order != null) sql.append("\n").append(order);
-
-        return limitRows(sql, maxRows, offset);
-    }
-
-    @Override
-    public SQLFragment limitRows(SQLFragment frag, int maxRows)
-    {
-        return limitRows(frag, maxRows, 0);
+        return LimitRowsSqlGenerator.limitRows(select, from, filter, order, groupBy, maxRows, offset);
     }
 
     @Override

--- a/bigiron/src/org/labkey/bigiron/oracle/Oracle11gR1Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/oracle/Oracle11gR1Dialect.java
@@ -30,7 +30,7 @@ import java.util.Set;
 public class Oracle11gR1Dialect extends OracleDialect
 {
 
-    /* Reserved and KeyWords for Oracle 11gR1
+    /* Reserved and Keywords for Oracle 11gR1
        See: http://download.oracle.com/docs/cd/B28359_01/server.111/b28286/ap_keywd.htm#SQLRF022
 
        On keywords:

--- a/bigiron/src/org/labkey/bigiron/sas/SasDialect.java
+++ b/bigiron/src/org/labkey/bigiron/sas/SasDialect.java
@@ -28,6 +28,7 @@ import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.dialect.JdbcHelper;
 import org.labkey.api.data.dialect.JdbcMetaDataLocator;
+import org.labkey.api.data.dialect.LimitRowsSqlGenerator;
 import org.labkey.api.data.dialect.SimpleSqlDialect;
 import org.labkey.api.data.dialect.StandardJdbcMetaDataLocator;
 import org.labkey.api.data.dialect.StandardTableResolver;
@@ -100,19 +101,7 @@ public abstract class SasDialect extends SimpleSqlDialect
     @Override
     public SQLFragment limitRows(SQLFragment select, SQLFragment from, SQLFragment filter, String order, String groupBy, int maxRows, long offset)
     {
-        if (select == null)
-            throw new IllegalArgumentException("select");
-        if (from == null)
-            throw new IllegalArgumentException("from");
-
-        SQLFragment sql = new SQLFragment();
-        sql.append(select);
-        sql.append("\n").append(from);
-        if (filter != null) sql.append("\n").append(filter);
-        if (groupBy != null) sql.append("\n").append(groupBy);
-        if (order != null) sql.append("\n").append(order);
-
-        return sql;
+        return LimitRowsSqlGenerator.appendFromFilterOrderAndGroupBy(select, from, filter, order, groupBy);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
When configuring offset with maxRows = ALL_ROWS, existing limit rows methods were generating invalid SQL on SQL Server and incorrect SQL on PostgreSQL. We also had dialects duplicating identical implementation.

[Issue 45482: TableSelector.getRowCount generates invalid SQL when using SQL Server](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45482)

#### Related Pull Requests
* https://github.com/LabKey/redshift/pull/31

#### Changes
* Introduce `LimitRowsSqlGenerator` to share standard implementation
* Shore up the `TableSelectorTestCase` with an additional test case (set an offset plus maxRows = ALL_ROWS) and factor out common test code
* Fix limit rows implementations and use shared code
* "master" -> "default"
* Optimize `getRowCount()` for zero rows and offset cases