### PR TITLE
Issue 45498: Show cross-linked peptide sequence info

### DIFF
--- a/api/src/org/labkey/api/protein/ProteinService.java
+++ b/api/src/org/labkey/api/protein/ProteinService.java
@@ -18,6 +18,7 @@ package org.labkey.api.protein;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.QueryViewAction;
 import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.QueryViewProvider;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.util.HtmlString;
@@ -86,6 +87,8 @@ public interface ProteinService
 
     /** Get seqId for the sequence -- there may be more than one if organism matches */
     List<Integer> getProteinSeqId(String sequence);
+
+    TableInfo getSequencesTable();
 
     interface FormViewProvider<FormType>
     {


### PR DESCRIPTION
#### Changes
Expose the prot.sequences table to let TargetedMS module reliably reference it

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/537
