### PR TITLE
Fix column sizing for excel exports

### DIFF
--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -2451,6 +2451,7 @@ public class QueryView extends WebPartView<Object>
         excelWriter.setCaptionType(config.getHeaderType() == null ? getColumnHeaderType() : config.getHeaderType());
         excelWriter.setRenameColumnMap(config.getRenamedColumns());
         excelWriter.setShowInsertableColumnsOnly(config.getInsertColumnsOnly(), config.getIncludeColumns(), config.getExcludeColumns());
+        excelWriter.setAutoSize(true);
 
         return excelWriter;
     }
@@ -2765,6 +2766,7 @@ public class QueryView extends WebPartView<Object>
                 ew.setShowInsertableColumnsOnly(config.getInsertColumnsOnly(), config.getIncludeColumns(), config.getExcludeColumns());
                 if (config.getPrefix() != null)
                     ew.setFilenamePrefix(config.getPrefix());
+                ew.setAutoSize(true);
                 ew.renderSheetAndWrite(config.getResponse());
 
                 if (!config.getTemplateOnly())


### PR DESCRIPTION
#### Rationale
[Columns are not resizing correctly](https://teamcity.labkey.org/viewLog.html?buildId=1814453&buildTypeId=bt20&fromExperimentalUI=true#testNameId-6391035446226030044)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3328

#### Changes
* Moved setting autosize flag on columns after field updates.
