### PR TITLE
Issue 45464: Strict OOXML documents aren't supported - warn 

### DIFF
--- a/api/src/org/labkey/api/reader/ExcelFormatException.java
+++ b/api/src/org/labkey/api/reader/ExcelFormatException.java
@@ -27,6 +27,11 @@ public class ExcelFormatException extends IOException
 {
     public ExcelFormatException(InvalidFormatException e)
     {
-        super("Unable to open Excel file." + (e.getMessage() == null ? "" : " (" + e.getMessage() + ")"));
+        super("Unable to open Excel file." + (e.getMessage() == null ? "" : " (" + e.getMessage() + ")"), e);
+    }
+
+    public ExcelFormatException(String message, Throwable e)
+    {
+        super(message, e);
     }
 }


### PR DESCRIPTION
#### Rationale
There are two flavors of .xlsx files. There are the normal ones that we parse all of the time, and another variant that shows up in Excel's file save dialog near the bottom of the format list, "Strict Open XML Spreadsheet (.xlsx)". 

The latter isn't supported by POI, the library we use for parsing a variety of formats, including .xlsx. This stricter format is clearly not used very often, and POI hasn't made any progress on supporting it since 2016. 

#### Changes
* Give clearer feedback to users about the unsupported variant