### PR TITLE
Render titles for wiki links to aliases

### DIFF
--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -514,7 +514,8 @@ public class WikiManager implements WikiService
         if (null != wiki.getEntityId())
             attachPrefix = WikiController.getDownloadURL(wiki.lookupContainer(), wiki, "").getLocalURIString();
 
-        Map<String, String> nameTitleMap = WikiSelectManager.getNameTitleMap(c);
+        // When rendering wikis, we want aliases to resolve to their titles as well
+        Map<String, String> nameTitleMap = WikiSelectManager.getNameAndAliasTitleMap(c);
 
         //get formatter specified for this version
         WikiRenderer w = wikiversion.getRenderer(hrefPrefix, attachPrefix, nameTitleMap, wiki.getAttachments());

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -514,7 +514,7 @@ public class WikiManager implements WikiService
         if (null != wiki.getEntityId())
             attachPrefix = WikiController.getDownloadURL(wiki.lookupContainer(), wiki, "").getLocalURIString();
 
-        // When rendering wikis, we want aliases to resolve to their titles as well
+        // When rendering wikis, we want aliases to resolve to their titles as well, Issue 45497
         Map<String, String> nameTitleMap = WikiSelectManager.getNameAndAliasTitleMap(c);
 
         //get formatter specified for this version

--- a/wiki/src/org/labkey/wiki/WikiSelectManager.java
+++ b/wiki/src/org/labkey/wiki/WikiSelectManager.java
@@ -76,6 +76,10 @@ public class WikiSelectManager
         return getWikiCollections(c).getNameTitleMap();
     }
 
+    public static Map<String, String> getNameAndAliasTitleMap(Container c)
+    {
+        return getWikiCollections(c).getNameAndAliasTitleMap();
+    }
 
     // Get a single wiki by rowId
     public static Wiki getWiki(Container c, int rowId)
@@ -151,11 +155,11 @@ public class WikiSelectManager
         if (null == wiki)
         {
             //Didn't find it with case-sensitive lookup, try case-sensitive (in case the
-            //underlying database is case sensitive)
+            //underlying database is case-sensitive)
             //Bug 2225
             wiki = new TableSelector(CommSchema.getInstance().getTableInfoPages(),
-                    SimpleFilter.createContainerFilter(c).addWhereClause("LOWER(name) = LOWER(?)", new Object[] { name }),
-                    null).getObject(Wiki.class);
+                SimpleFilter.createContainerFilter(c).addWhereClause("LOWER(name) = LOWER(?)", new Object[] { name }),
+                null).getObject(Wiki.class);
         }
 
         return wiki;


### PR DESCRIPTION
#### Rationale
Rendering titles when linking to aliases will ease the transition to more appropriate wiki names.

[Issue 45497: Inter-wiki link to a wiki alias does not display page title as the real/old page name does](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45497)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3165
