### PR TITLE
Fix recursive getColumn call

### DIFF
--- a/api/src/org/labkey/api/exp/property/ConceptURIVocabularyDomainProvider.java
+++ b/api/src/org/labkey/api/exp/property/ConceptURIVocabularyDomainProvider.java
@@ -38,4 +38,6 @@ public interface ConceptURIVocabularyDomainProvider
     @NotNull Collection<String> getImportTemplateExcludeColumns(@NotNull String propertyColumnName);
 
     @NotNull FieldKey getColumnFieldKey(@NotNull ColumnInfo parent, @NotNull PropertyDescriptor pd);
+
+    void decorateColumn(MutableColumnInfo columnInfo, PropertyDescriptor pd, Container container);
 }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -526,6 +526,10 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                                     .addParameter("name", "${" + columnInfo.getFieldKey() + "}")));
 
                 }
+
+                Tuple3<String, String, ConceptURIVocabularyDomainProvider> fieldVocabularyDomainProvider = getVocabularyDomainProviders().get(domain.getName());
+                if (fieldVocabularyDomainProvider != null)
+                    fieldVocabularyDomainProvider.third.decorateColumn(columnInfo, pd, _userSchema.getContainer());
             }
 
             @Override

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -1566,11 +1566,6 @@ public class QueryServiceImpl implements QueryService
         // When determining the alias, use the field key with the canonical casing for this column name, not the one
         // that was passed in. This makes sure that we generate the exact same JOIN SQL.
         AliasedColumn ret = new QAliasedColumn(key, manager.decideAlias(lookup.getFieldKey().toString()), lookup, true);
-
-        ColumnInfo columnInfo = table.getColumn(key.toString());
-        if (columnInfo != null && columnInfo.getDisplayColumnFactory() != null)
-            ret.setDisplayColumnFactory(columnInfo.getDisplayColumnFactory());
-
         columnMap.put(key, ret);
 
         return ret;


### PR DESCRIPTION
#### Rationale
The table.getColumn code snippet added in QueryServiceImpl is causing stackoverflow exception for a few tests (NabAssayTest.runUITests, LuminexUploadAndLinkTest.testUploadAndLink). The code was added to get the custom  DisplayColumnFactory for SMILES property columns. This PR removes the change from QueryServiceImpl and configures SMILES property columns in a different way.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3364
* https://github.com/LabKey/biologics/pull/1313

#### Changes
* remove getColumn call in QueryServiceImpl.getColumn to avoid recursive call
* use decorateColumn to set DisplayColumnFactory for SMIELS columns
