### PR TITLE
Indexer continuously revisiting materials

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -835,7 +835,7 @@ public class ExperimentServiceImpl implements ExperimentService
                     ts.setValue(new Timestamp(p.second));
                     pm.addBatch();
                 }
-                pm.execute();
+                pm.executeBatch();
             });
         }
         catch (SQLException x)


### PR DESCRIPTION
#### Rationale
Update LastIndexed batching for materials is broken because calling `ParameterMapStatement.execute()` updates a single row. `executeBatch()` is the better choice.

https://www.labkey.org/home/Developer/issues/Secure/issues-update.view?issueId=45502

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2319
