### PR TITLE
Force reload of SMILES image on modify

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentUrls.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentUrls.java
@@ -118,4 +118,6 @@ public interface ExperimentUrls extends UrlProvider
 
     default ActionURL getInsertMaterialQueryRowAction(Container c, TableInfo table) { return null; }
 
+    default ActionURL getDataClassAttachmentDownloadAction(Container c) { return null; }
+
 }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -6606,6 +6606,12 @@ public class ExperimentController extends SpringActionController
             return url;
         }
 
+        @Override
+        public ActionURL getDataClassAttachmentDownloadAction(Container c)
+        {
+            return new ActionURL(ExperimentController.DataClassAttachmentDownloadAction.class, c);
+        }
+
     }
 
     private static abstract class BaseResolveLsidApiAction<F extends ResolveLsidsForm> extends ReadOnlyApiAction<F>


### PR DESCRIPTION
#### Rationale
When SMILES string is updated, the image content are redrawn while the filename stays the same. The stale structure image will be displayed due to browser cache in those cases. We want to add a cache-buster flag to force browser to reload the image. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3369
* https://github.com/LabKey/biologics/pull/1320

#### Changes
* Expose ExperimentController.DataClassAttachmentDownloadAction ExperimentUrls
