### PR TITLE
Issue 45554: Dataset rows returned from saveRows API return ClobImp toString()

### DIFF
--- a/api/src/org/labkey/api/collections/ResultSetRowMapFactory.java
+++ b/api/src/org/labkey/api/collections/ResultSetRowMapFactory.java
@@ -110,22 +110,7 @@ public class ResultSetRowMapFactory extends RowMapFactory<Object> implements Ser
         {
             Object o = rs.getObject(i);
 
-            if (o instanceof Clob)
-            {
-                o = ConvertHelper.convertClobToString((Clob)o);
-            }
-            // BigDecimal objects are rare, and almost always are converted immediately
-            // to doubles for ease of use in Java code; we can take care of this centrally here.
-            else if (o instanceof BigDecimal && _convertBigDecimalToDouble)
-            {
-                BigDecimal dec = (BigDecimal) o;
-                o = dec.doubleValue();
-            }
-            else if (o instanceof Double)
-            { 
-                double value = ((Number) o).doubleValue();
-                o = ResultSetUtil.mapDatabaseDoubleToJavaDouble(value);
-            }
+            o = translateResultSetObject(o, _convertBigDecimalToDouble);
 
             if (i == _list.size())
                 _list.add(o);
@@ -134,5 +119,25 @@ public class ResultSetRowMapFactory extends RowMapFactory<Object> implements Ser
         }
 
         return map;
+    }
+
+    public static Object translateResultSetObject(Object o, boolean convertBigDecimalToDouble) throws SQLException
+    {
+        if (o instanceof Clob)
+        {
+            o = ConvertHelper.convertClobToString((Clob) o);
+        }
+        // BigDecimal objects are rare, and almost always are converted immediately
+        // to doubles for ease of use in Java code; we can take care of this centrally here.
+        else if (o instanceof BigDecimal dec && convertBigDecimalToDouble)
+        {
+            o = dec.doubleValue();
+        }
+        else if (o instanceof Double)
+        {
+            double value = ((Number) o).doubleValue();
+            o = ResultSetUtil.mapDatabaseDoubleToJavaDouble(value);
+        }
+        return o;
     }
 }

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.collections.ResultSetRowMapFactory;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
@@ -160,7 +161,9 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
                 {
                     for (int i = 0; i < columns.size(); i++)
                     {
-                        map.put(columns.get(i).getName(), rs.getObject(i + 1));
+                        Object o = rs.getObject(i + 1);
+                        o = ResultSetRowMapFactory.translateResultSetObject(o, false);
+                        map.put(columns.get(i).getName(), o);
                     }
                 }
                 catch (SQLException x)


### PR DESCRIPTION
#### Rationale
Calls to saveRows and similar Query APIs are returning values like "net.sourceforge.jtds.jdbc.ClobImpl@430948be" instead of the actual text of the column

Broken by https://github.com/LabKey/platform/commit/5ba6ac3335167802490177f91f5025cdd2b82c12

#### Changes
* Do the same translation that we used to do via the TableSelector.getObject() codepath