### PR TITLE
Item 10394: Updates for incorporating ELN in LKSM

### DIFF
--- a/core/api-src/org/labkey/api/products/ProductMenuProvider.java
+++ b/core/api-src/org/labkey/api/products/ProductMenuProvider.java
@@ -17,7 +17,9 @@ package org.labkey.api.products;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.Container;
 import org.labkey.api.util.HelpTopic;
+import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
 
 import java.util.ArrayList;
@@ -59,6 +61,9 @@ public abstract class ProductMenuProvider
     {
         return getProductId();
     }
+
+    @NotNull
+    public abstract ActionURL getAppURL(Container container);
 
     @NotNull
     public abstract Collection<String> getSectionNames(@Nullable ViewContext viewContext);

--- a/core/api-src/org/labkey/api/products/ProductRegistry.java
+++ b/core/api-src/org/labkey/api/products/ProductRegistry.java
@@ -27,6 +27,7 @@ import org.labkey.api.collections.ConcurrentCaseInsensitiveSortedMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.module.Module;
 import org.labkey.api.test.TestWhen;
+import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
 
@@ -99,6 +100,13 @@ public class ProductRegistry
         }
 
         return productIds;
+    }
+
+    @Nullable
+    public ProductMenuProvider getPrimaryProductForContainer(@NotNull Container container)
+    {
+        Set<String> modules = container.getActiveModules().stream().map(Module::getName).collect(Collectors.toSet());
+        return getRegisteredProducts().stream().filter(product -> modules.contains(product.getModuleName())).findFirst().orElse(null);
     }
 
     @NotNull
@@ -216,6 +224,12 @@ public class ProductRegistry
             public @NotNull String getProductId()
             {
                 return _productId;
+            }
+
+            @Override
+            public @NotNull ActionURL getAppURL(Container container)
+            {
+                return new ActionURL();
             }
 
             @Override

--- a/core/api-src/org/labkey/api/products/ProductRegistry.java
+++ b/core/api-src/org/labkey/api/products/ProductRegistry.java
@@ -103,10 +103,10 @@ public class ProductRegistry
     }
 
     @Nullable
-    public ProductMenuProvider getPrimaryProductForContainer(@NotNull Container container)
+    public ProductMenuProvider getPrimaryProductMenuForContainer(@NotNull Container container)
     {
-        Set<String> modules = container.getActiveModules().stream().map(Module::getName).collect(Collectors.toSet());
-        return getRegisteredProducts().stream().filter(product -> modules.contains(product.getModuleName())).findFirst().orElse(null);
+        List<String> productIds = getProductIdsForContainer(container);
+        return getRegisteredProducts().stream().filter(product -> productIds.contains(product.getProductId())).findFirst().orElse(null);
     }
 
     @NotNull


### PR DESCRIPTION
#### Rationale
The previous stories to separate the @labkey/eln package and other steps in the epic are complete and we are ready to wire up the ELN related features in LKSM. This will initially be done with an experimental feature. 

This PR adds a getPrimaryProductForContainer() helper for ProductRegistry. This can be used in the labbook module notifications to determine what URL to generate for the app links in the email templates.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/843
* https://github.com/LabKey/labbook/pull/186
* https://github.com/LabKey/biologics/pull/1329
* https://github.com/LabKey/sampleManagement/pull/967
* https://github.com/LabKey/platform/pull/3381
* https://github.com/LabKey/inventory/pull/439

#### Changes
* add getPrimaryProductForContainer() helper for ProductRegistry
