### PR TITLE
Issue 45559: displayWidth set in .query.xml for lookup field is ignored

### DIFF
--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -93,7 +93,13 @@ public class DataColumn extends DisplayColumn
             _sortFieldKeys = Collections.singletonList(_displayColumn.getFieldKey());
         _filterColumn = _displayColumn.getFilterField();
 
-        _width = _displayColumn.getWidth();
+        // Issue 45559 - use the width set on the bound column when configured. If not set, use the display column's
+        // width (in non-lookup cases they will be the same)
+        _width = _boundColumn.getWidth();
+        if ("".equals(_width))
+        {
+            _width = _displayColumn.getWidth();
+        }
         StringExpression url = withLookups ?
                 _boundColumn.getEffectiveURL() :
                 _boundColumn.getURL();


### PR DESCRIPTION
#### Rationale
For standard LabKey Server grids, you can customize column widths via .query.xml metadata. 

When you set a width for a column that's a lookup, the value is ignored. That's because we're considering the lookup target's title column as the displayColumn and pulling the width from it. 

This seems like reasonable behavior, as in many cases you'd want to set this centrally instead of every place that uses the lookup. 

However, it also seems reasonable to allow this to be customized on a case-by-case value. I propose that we use any width setting on the field that's doing the lookup by default and fall back to the lookup target column when we don't have a width set (which will be the vast majority of the time).

#### Changes
* Check for explicit width setting on primary column, falling back on the setting for the display column (lookup target)