### PR TITLE
Issue 45561: Perf slowdown in DatasetUpdateService.getRow() in EHR scenarios

### DIFF
--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -150,6 +150,9 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
         List.of("Container","Datasets","DatasetId","Dataset","Folder","ParticipantSequenceNum").forEach(nameset::remove);
         List<ColumnInfo> columns = getQueryTable().getColumns(nameset.toArray(new String[0]));
 
+        // filter out calculated columns which can be expensive to reselect
+        columns.removeIf(ColumnInfo::isCalculated);
+
         // This is a general version of DatasetDefinition.canonicalizeDatasetRow()
         // The caller needs to make sure names are unique.  Not suitable for use w/ lookups etc where there can be name collisions.
         // CONSIDER: might be nice to make this a TableSelector method.

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -148,7 +148,7 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
         // Mostly this is harmless, but there is some noise.
         HashSet<String> nameset = new HashSet<>(getQueryTable().getColumnNameSet());
         List.of("Container","Datasets","DatasetId","Dataset","Folder","ParticipantSequenceNum").forEach(nameset::remove);
-        List<ColumnInfo> columns = getQueryTable().getColumns(nameset.toArray(new String[0]));
+        List<ColumnInfo> columns = new ArrayList<>(getQueryTable().getColumns(nameset.toArray(new String[0])));
 
         // filter out calculated columns which can be expensive to reselect
         columns.removeIf(ColumnInfo::isCalculated);


### PR DESCRIPTION
#### Rationale
22.3 changes to DatasetUpdateService.getRow() have caused significant perf degradation for EHR data entry scenarios. 

The primary difference is that we used to call DatasetDefinition.getDatasetRow() that did a query against the dataset's schema TableInfo. That's a very lean query. Now we're using the query TableInfo and pulling almost all of its columns, which for the EHR includes all sorts of calculated values. That's a lot slower, and this method is called multiple times for each row during an update operation. Multiply that by dozens or hundreds of rows and we're getting deadlocks and timeouts.

#### Changes
* Filter out calculated columns before reselecting