### PR TITLE
Create TableSelector tests for MySQL and Oracle. Fix some minor problems raised.

### DIFF
--- a/api/src/org/labkey/api/data/TableSelectorTestCase.java
+++ b/api/src/org/labkey/api/data/TableSelectorTestCase.java
@@ -34,11 +34,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -52,9 +54,117 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
     @Test
     public void testTableSelector() throws SQLException
     {
+//  Calls below can be used to test that Oracle and MySQL dialects behave as expected, following our maxRows, offset,
+//  and other rules. Uncomment these lines and their corresponding bean classes below.
+//        testTableSelector(DbSchema.get("oracle.granite", DbSchemaType.Bare).getTable("account"), Account.class);
+//        testTableSelector(DbSchema.get("mySql.sakila", DbSchemaType.Bare).getTable("country"), Country.class);
         testTableSelector(CoreSchema.getInstance().getTableInfoActiveUsers(), User.class);
         testTableSelector(CoreSchema.getInstance().getTableInfoModules(), ModuleContext.class);
     }
+
+//    public static class Country
+//    {
+//        private int _country_id;
+//        private String _country;
+//        private Date _last_update;
+//
+//        public int getCountry_id()
+//        {
+//            return _country_id;
+//        }
+//
+//        public void setCountry_id(int country_id)
+//        {
+//            _country_id = country_id;
+//        }
+//
+//        public String getCountry()
+//        {
+//            return _country;
+//        }
+//
+//        public void setCountry(String country)
+//        {
+//            _country = country;
+//        }
+//
+//        public Date getLast_update()
+//        {
+//            return _last_update;
+//        }
+//
+//        public void setLast_update(Date last_update)
+//        {
+//            _last_update = last_update;
+//        }
+//
+//        @Override
+//        public boolean equals(Object o)
+//        {
+//            if (this == o) return true;
+//            if (o == null || getClass() != o.getClass()) return false;
+//            Country country = (Country) o;
+//            return _country_id == country._country_id && Objects.equals(_country, country._country) && Objects.equals(_last_update, country._last_update);
+//        }
+//
+//        @Override
+//        public int hashCode()
+//        {
+//            return Objects.hash(_country_id, _country, _last_update);
+//        }
+//    }
+//
+//    public static class Account
+//    {
+//        private int _account_id;
+//        private String _account_number;
+//        private String _account_desc;
+//
+//        public int getAccount_id()
+//        {
+//            return _account_id;
+//        }
+//
+//        public void setAccount_id(int account_id)
+//        {
+//            _account_id = account_id;
+//        }
+//
+//        public String getAccount_number()
+//        {
+//            return _account_number;
+//        }
+//
+//        public void setAccount_number(String account_number)
+//        {
+//            _account_number = account_number;
+//        }
+//
+//        public String getAccount_desc()
+//        {
+//            return _account_desc;
+//        }
+//
+//        public void setAccount_desc(String account_desc)
+//        {
+//            _account_desc = account_desc;
+//        }
+//
+//        @Override
+//        public boolean equals(Object o)
+//        {
+//            if (this == o) return true;
+//            if (o == null || getClass() != o.getClass()) return false;
+//            Account account = (Account) o;
+//            return _account_id == account._account_id && Objects.equals(_account_number, account._account_number) && Objects.equals(_account_desc, account._account_desc);
+//        }
+//
+//        @Override
+//        public int hashCode()
+//        {
+//            return Objects.hash(_account_id, _account_number, _account_desc);
+//        }
+//    }
 
     @Test
     public void testGetObject()
@@ -318,9 +428,12 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
         test(selector, clazz);
         testOffsetAndLimit(selector, clazz);
 
-        // Verify that we can generate some execution plan
-        Collection<String> executionPlan = selector.getExecutionPlan();
-        assertTrue(!executionPlan.isEmpty());
+        // Verify that we can generate an execution plan (if supported)
+        if (table.getSqlDialect().canShowExecutionPlan())
+        {
+            Collection<String> executionPlan = selector.getExecutionPlan();
+            assertTrue(!executionPlan.isEmpty());
+        }
     }
 
     @Override

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -292,13 +292,13 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     @Override
     public SQLFragment limitRows(SQLFragment frag, int maxRows)
     {
-        return LimitRowsSqlGenerator.limitRows(frag, maxRows, 0);
+        return LimitRowsSqlGenerator.limitRows(frag, maxRows, 0, true);
     }
 
     @Override
     public SQLFragment limitRows(SQLFragment select, SQLFragment from, SQLFragment filter, String order, String groupBy, int maxRows, long offset)
     {
-        return LimitRowsSqlGenerator.limitRows(select, from, filter, order, groupBy, maxRows, offset);
+        return LimitRowsSqlGenerator.limitRows(select, from, filter, order, groupBy, maxRows, offset, true);
     }
 
     @Override

--- a/api/src/org/labkey/api/data/dialect/SimpleSqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SimpleSqlDialect.java
@@ -121,7 +121,7 @@ public abstract class SimpleSqlDialect extends SqlDialect
     }
 
     @Override
-    public Collection<String> getQueryExecutionPlan(Connection conn, DbScope scope, SQLFragment sql)
+    protected Collection<String> getQueryExecutionPlan(Connection conn, DbScope scope, SQLFragment sql)
     {
         throw new IllegalStateException("Should not call when canShowExecutionPlan() returns false");
     }

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
@@ -16,7 +16,6 @@
 
 package org.labkey.bigiron.mssql;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -34,6 +33,7 @@ import org.labkey.api.data.dialect.StandardTableResolver;
 import org.labkey.api.data.dialect.TableResolver;
 import org.labkey.api.data.dialect.TestUpgradeCode;
 import org.labkey.api.util.VersionNumber;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
@@ -48,7 +48,7 @@ import java.util.Set;
 */
 public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
 {
-    private static final Logger LOG = LogManager.getLogger(MicrosoftSqlServerDialectFactory.class);
+    private static final Logger LOG = LogHelper.getLogger(MicrosoftSqlServerDialectFactory.class, "Warnings about SQL Server versions");
     public static final String PRODUCT_NAME = "Microsoft SQL Server";
 
     private volatile TableResolver _tableResolver = new StandardTableResolver();
@@ -127,15 +127,7 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
             if (version >= 120)
                 return new MicrosoftSqlServer2014Dialect(_tableResolver);
 
-            if (version >= 110)
-            {
-                if (logWarnings)
-                    LOG.warn("LabKey Server no longer supports " + getProductName() + " version " + databaseProductVersion + ". " + RECOMMENDED);
-
-                return new MicrosoftSqlServer2012Dialect(_tableResolver);
-            }
-
-            // Accept 2008 or 2008R2 as an external/supplemental database, but not as the primary database
+            // Accept 2008, 2008R2, or 2012 as an external/supplemental database, but not as the primary database
             if (!primaryDataSource)
             {
                 if (logWarnings)

--- a/bigiron/src/org/labkey/bigiron/mysql/MySqlDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySqlDialect.java
@@ -193,13 +193,13 @@ public class MySqlDialect extends SimpleSqlDialect
     @Override
     public SQLFragment limitRows(SQLFragment frag, int maxRows)
     {
-        return LimitRowsSqlGenerator.limitRows(frag, maxRows, 0);
+        return LimitRowsSqlGenerator.limitRows(frag, maxRows, 0, false);
     }
 
     @Override
     public SQLFragment limitRows(SQLFragment select, SQLFragment from, SQLFragment filter, String order, String groupBy, int maxRows, long offset)
     {
-        return LimitRowsSqlGenerator.limitRows(select, from, filter, order, groupBy, maxRows, offset);
+        return LimitRowsSqlGenerator.limitRows(select, from, filter, order, groupBy, maxRows, offset, false);
     }
 
     @Override
@@ -276,5 +276,11 @@ public class MySqlDialect extends SimpleSqlDialect
     public boolean supportsRoundDouble()
     {
         return true;
+    }
+
+    @Override
+    public SQLFragment wrapExistsExpression(SQLFragment existsSQL)
+    {
+        return existsSQL;
     }
 }


### PR DESCRIPTION
#### Rationale
When you test your code you sometimes find problems.

#### Changes
* Test MySQL and Oracle tables via the TableSelectorTestCase. Tests are not enabled by default since they're highly dependent on deployment-specific data source and schema names.
* Fix some problems that this testing uncovered:
  * Test execution plan only if it's supported
  * Unlike PostgreSQL, MySQL requires LIMIT if OFFSET is specified. Refine limitRows() to handle this.
  * Support EXISTS expressions on MySQL.
* Remove support for Microsoft SQL Server 2012 as a primary data source.
