### PR TITLE
@NotNull and @Override annotations to eliminate some warnings

### DIFF
--- a/api/src/org/labkey/api/action/ConfirmAction.java
+++ b/api/src/org/labkey/api/action/ConfirmAction.java
@@ -116,7 +116,7 @@ public abstract class ConfirmAction<FORM> extends BaseViewAction<FORM>
     }
 
     /**
-     * View with text and buttons.  Should NOT include &lt;form&gt; 
+     * View with text and buttons. Should NOT include &lt;form&gt;
      */
     public abstract ModelAndView getConfirmView(FORM form, BindException errors) throws Exception;
 

--- a/api/src/org/labkey/api/flow/api/FlowService.java
+++ b/api/src/org/labkey/api/flow/api/FlowService.java
@@ -36,6 +36,4 @@ public interface FlowService extends WebdavResourceExpDataProvider
     {
         ServiceRegistry.get().registerService(FlowService.class, impl);
     }
-
-    int getTempTableCount();
 }


### PR DESCRIPTION
#### Rationale
And remove an unused flow service method
