### PR TITLE
Issue 45534: Include full +/- 3 SD range for multi-series plots with SD as y-axis range

### DIFF
--- a/internal/webapp/vis/src/plot.js
+++ b/internal/webapp/vis/src/plot.js
@@ -1767,6 +1767,10 @@ boxPlot.render();
                     && config.properties.valueConversion === 'percentDeviation') {
                 maxValue = mean * LABKEY.vis.Stat.MOVING_RANGE_UPPER_LIMIT_WEIGHT;
                 minValue = mean;
+            } else if (config.qcPlotType === LABKEY.vis.TrendingLinePlotType.LeveyJennings
+                        && config.properties.valueConversion === 'standardDeviation') {
+                maxValue = 3.2;
+                minValue = -3.2;
             } else if (include3StdDev && stddev) {
                 maxValue = mean + (3.2 * stddev);
                 minValue = mean - (3.2 * stddev);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45534

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3322

#### Changes
* set min/max value to [-3.2,3.2] for L-J plot with SD as y-axis range
