### PR TITLE
More consistent error messages from query API actions

### DIFF
--- a/api/src/org/labkey/api/query/QueryForm.java
+++ b/api/src/org/labkey/api/query/QueryForm.java
@@ -83,7 +83,7 @@ public class QueryForm extends ReturnUrlForm implements HasViewContext, HasBindP
         init();
         if (_schema == null)
         {
-            throw new NotFoundException("Could not find schema: " + getSchemaName());
+            throw new NotFoundException("The specified schema does not exist");
         }
 
         if (StringUtils.isEmpty(getQueryName()))
@@ -98,7 +98,7 @@ public class QueryForm extends ReturnUrlForm implements HasViewContext, HasBindP
         // Don't treat a query with errors as if it doesn't exist at all
         if (_queryView.getTable() == null && _queryView.getParseErrors().isEmpty())
         {
-            throw new NotFoundException("Query '" + getQueryName() + "' in schema '" + getSchemaName() + "' doesn't exist.");
+            throw new NotFoundException("The specified query does not exist in schema '" + getSchemaName() + "'");
         }
 
         return _queryView;

--- a/api/src/org/labkey/api/query/QuerySettings.java
+++ b/api/src/org/labkey/api/query/QuerySettings.java
@@ -60,7 +60,7 @@ public class QuerySettings
 {
     public static final String URL_PARAMETER_PREFIX = "param.";
 
-    // Don't echo the user-provided value. See #44528.
+    // Don't echo the user-provided value. See Issue 44528 and Issue 45567
     private static final String parseError = "Could not parse parameter '%s'";
 
     private String _schemaName;
@@ -180,7 +180,7 @@ public class QuerySettings
             }
             catch (IllegalArgumentException ex)
             {
-                throw new BadRequestException(String.format(parseError, QueryParam.showRows.name()), ex);
+                throwParameterParseException(QueryParam.showRows);
             }
         }
     }
@@ -242,7 +242,7 @@ public class QuerySettings
             }
             catch (ConversionException e)
             {
-                throw new BadRequestException(String.format(parseError, "ignoreFilter"), e);
+                throwParameterParseException(QueryParam.ignoreFilter);
             }
 
             String reportId = _getParameter(param(QueryParam.reportId));
@@ -250,7 +250,7 @@ public class QuerySettings
             {
                 var identifier = ReportService.get().getReportIdentifier(reportId, null, null);
                 if (null == identifier)
-                    throw new NotFoundException("Could not find report for reportId: " + reportId);
+                    throw new NotFoundException("Could not find report for the specified reportId");
                 setReportId(identifier);
             }
         }
@@ -269,7 +269,7 @@ public class QuerySettings
                 }
                 catch (NumberFormatException nfe)
                 {
-                    throw new BadRequestException(String.format(parseError, "offset"), nfe);
+                    throwParameterParseException(QueryParam.offset);
                 }
             }
 
@@ -289,7 +289,7 @@ public class QuerySettings
                 }
                 catch (NumberFormatException nfe)
                 {
-                    throw new BadRequestException(String.format(parseError, "maxRows"), nfe);
+                    throwParameterParseException(QueryParam.maxRows);
                 }
             }
         }
@@ -299,7 +299,7 @@ public class QuerySettings
         {
             // fail fast
             if (null == ContainerFilter.getType(containerFilterNameParam))
-                throw new BadRequestException(String.format(parseError, "containerFilterName"));
+                throwParameterParseException(QueryParam.containerFilterName);
 
             setContainerFilterName(containerFilterNameParam);
         }
@@ -327,7 +327,7 @@ public class QuerySettings
             }
             catch (URISyntaxException | IllegalArgumentException use)
             {
-                throw new BadRequestException(String.format(parseError, ActionURL.Param.returnUrl), use);
+                throwParameterParseException(ActionURL.Param.returnUrl);
             }
         }
 
@@ -360,7 +360,7 @@ public class QuerySettings
             }
             catch (ConversionException e)
             {
-                throw new BadRequestException(String.format(parseError, "allowHeaderLock"), e);
+                throwParameterParseException(QueryParam.allowHeaderLock);
             }
         }
     }
@@ -815,5 +815,12 @@ public class QuerySettings
     public void setShowReports(boolean showReports)
     {
         _showReports = showReports;
+    }
+
+    // Always throws BadRequestException with our standard message. Use this for convenience and consistency. Also
+    // helps address Issue 45567.
+    public static void throwParameterParseException(Enum parameterEnum)
+    {
+        throw new BadRequestException(String.format(parseError, parameterEnum.name()));
     }
 }

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -105,14 +105,14 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
         QuerySchema querySchema = DefaultSchema.get(user, container, form.getSchemaName());
         if (!(querySchema instanceof UserSchema))
             // Don't echo the provided schema name. See #44528.
-            throw new NotFoundException("Could not find the specified schema in the folder '" + container.getPath() + "'!");
+            throw new NotFoundException("Could not find the specified schema in the folder '" + container.getPath() + "'");
         UserSchema schema = (UserSchema)querySchema;
 
         QuerySettings settings = schema.getSettings(getViewContext(), QueryView.DATAREGIONNAME_DEFAULT, form.getQueryName());
         QueryDefinition queryDef = settings.getQueryDef(schema);
         if (null == queryDef)
             // Don't echo the provided query name, but schema name is legit since it was found. See #44528.
-            throw new NotFoundException("Could not find the specified query in the schema '" + form.getSchemaName() + "'!");
+            throw new NotFoundException("Could not find the specified query in the schema '" + form.getSchemaName() + "'");
 
         boolean isUserDefined = queryDef.isUserDefined();
 
@@ -127,7 +127,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
         resp.put("canEdit", canEdit);
         resp.put("canDelete", queryDef.canDelete(user));
         resp.put("canEditSharedViews", container.hasPermission(user, EditSharedViewPermission.class));
-        // CONSIDER: do we want to separate the 'canEditMetadata' property and 'isMetadataOverridable' properties to differentiate between cabability and the permission check?
+        // CONSIDER: do we want to separate the 'canEditMetadata' property and 'isMetadataOverridable' properties to differentiate between capability and the permission check?
         resp.put("isMetadataOverrideable", queryDef.isMetadataEditable() && queryDef.canEditMetadata(user));
 
         if (isUserDefined)
@@ -157,7 +157,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
         }
 
         if (null == tinfo)
-            throw new NotFoundException("Could not find the query '" + form.getQueryName() + "' in the schema '" + form.getSchemaName() + "'!");
+            throw new NotFoundException("Could not find the specified query in the schema '" + form.getSchemaName() + "'");
 
         resp.put("supportGroupConcatSubSelect", tinfo.getSqlDialect().supportsGroupConcatSubSelect());
 
@@ -167,10 +167,9 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
             CaseInsensitiveHashSet names = new CaseInsensitiveHashSet(schema.getTableNames());
             if (names.contains(form.getQueryName()))
             {
-                resp.put("warning", "This query has the same name as a built-in table.  This may cause unexpected behavior.");
+                resp.put("warning", "This query has the same name as a built-in table. This may cause unexpected behavior.");
             }
         }
-
 
         ActionURL auditHistoryUrl = QueryService.get().getAuditHistoryURL(user, container, tinfo);
         if (auditHistoryUrl != null)
@@ -238,9 +237,9 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
                 Map<FieldKey,ColumnInfo> colMap = QueryService.get().getColumns(tinfo, Collections.singletonList(fk));
                 ColumnInfo cinfo = colMap.get(fk);
                 if (null == cinfo)
-                    throw new IllegalArgumentException("Could not find the column '" + form.getFk() + "' starting from the query " + form.getSchemaName() + "." + form.getQueryName() + "!");
+                    throw new IllegalArgumentException("Could not find the column '" + form.getFk() + "' starting from the query " + form.getSchemaName() + "." + form.getQueryName() + "");
                 if (null == cinfo.getFk() || null == cinfo.getFkTableInfo())
-                    throw new IllegalArgumentException("The column '" + form.getFk() + "' is not a foreign key!");
+                    throw new IllegalArgumentException("The column '" + form.getFk() + "' is not a foreign key");
                 tinfo = cinfo.getFkTableInfo();
             }
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -3431,9 +3431,22 @@ public class QueryController extends SpringActionController
             QueryService service = QueryService.get();
 
             if (null == getViewContext().getRequest().getParameter(QueryParam.maxRows.toString()))
+            {
                 settings.setMaxRows(DEFAULT_API_MAX_ROWS);
+            }
             else
-                settings.setMaxRows(Integer.parseInt(getViewContext().getRequest().getParameter(QueryParam.maxRows.toString())));
+            {
+                try
+                {
+                    int maxRows = Integer.parseInt(getViewContext().getRequest().getParameter(QueryParam.maxRows.toString()));
+                    settings.setMaxRows(maxRows);
+                }
+                catch (NumberFormatException e)
+                {
+                    // Standard exception message, Issue 45567
+                    QuerySettings.throwParameterParseException(QueryParam.maxRows);
+                }
+            }
 
             List<FieldKey> fieldKeys = settings.getFieldKeys();
             if (null == fieldKeys || fieldKeys.size() != 1)


### PR DESCRIPTION
#### Rationale
More consistent and concise error messages. Fewer exclamation points. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=45567
