### PR TITLE
45474: Adding an attachment to an issue or ticket does not trigger email notifications

### DIFF
--- a/issues/src/org/labkey/issue/actions/ChangeSummary.java
+++ b/issues/src/org/labkey/issue/actions/ChangeSummary.java
@@ -340,7 +340,7 @@ public class ChangeSummary
         // Skip the email if no comment and no public fields have changed, #17304
         String fieldChanges = getTextChanges();
 
-        if (fieldChanges.isEmpty() && StringUtils.isEmpty(comment))
+        if (fieldChanges.isEmpty() && StringUtils.isEmpty(comment) && attachments.isEmpty())
             return;
 
         final Set<User> allAddresses = getUsersToEmail(container, user, _issue, _prevIssue, _action);


### PR DESCRIPTION
#### Rationale
Updating an issue where the only change was the addition of an attachment was not triggering an email notification. The issue template does normally handle attachments but in this case we were prematurely short circuiting out.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45474

