### PR TITLE
Issue 44563: Remove quotes around parents when creating aliquot names and fix parentName parsing with commas

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -41,6 +41,7 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.RuntimeValidationException;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
+import org.labkey.api.reader.TabLoader;
 import org.labkey.api.security.User;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.JunitUtil;
@@ -53,6 +54,7 @@ import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.SubstitutionFormat;
 import org.labkey.api.util.Tuple3;
 
+import java.io.IOException;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -557,7 +559,22 @@ public class NameGenerator
         Stream<String> values;
         if (value instanceof String)
         {
-            values = Arrays.stream(((String)value).split(","));
+            // Issue 44841: The names of the parents may include commas, so we parse the set of parent names
+            // using TabLoader instead of just splitting on the comma.
+            try (TabLoader tabLoader = new TabLoader((String) value))
+            {
+                tabLoader.setDelimiterCharacter(',');
+                tabLoader.setUnescapeBackslashes(false);
+                try
+                {
+                    String[][] parsedValues = tabLoader.getFirstNLines(1);
+                    values = Arrays.stream(parsedValues[0]);
+                }
+                catch (IOException e)
+                {
+                    throw new IllegalStateException("Unable to parse parent names from " + value, e);
+                }
+            }
         }
         else if (value instanceof Collection)
         {
@@ -1369,7 +1386,6 @@ public class NameGenerator
         {
             if (!_exprHasLineageLookup || StringUtils.isEmpty(parentTypeName) || StringUtils.isEmpty(parentName))
                 return;
-
 
             boolean hasTypeLookup = false;
             if (_expLineageLookupFields.containsKey(INPUT_PARENT))

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -87,6 +87,7 @@ import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.study.publish.StudyPublishService;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.experiment.ExpDataIterators;
 import org.labkey.experiment.SampleTypeAuditProvider;
 
@@ -1016,7 +1017,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         @Override
         protected void processNextInput()
         {
-            Map<String,Object> map = ((MapDataIterator)getInput()).getMap();
+            Map<String,Object> map = new HashMap<>(((MapDataIterator)getInput()).getMap());
 
             String aliquotedFrom = null;
             Object aliquotedFromObj = map.get("AliquotedFrom");
@@ -1024,7 +1025,10 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             {
                 if (aliquotedFromObj instanceof String)
                 {
-                    aliquotedFrom = (String) aliquotedFromObj;
+                    // Issue 45563: We need the AliquotedFrom name to be quoted so we can properly find the parent,
+                    // but we don't want to include the quotes in the name we generate using AliquotedFrom
+                    aliquotedFrom = StringUtilsLabKey.unquoteString((String) aliquotedFromObj);
+                    map.put("AliquotedFrom", aliquotedFrom);
                 }
                 else if (aliquotedFromObj instanceof Number)
                 {


### PR DESCRIPTION
#### Rationale
We recently added support for having commas in the names of samples (and other objects). When a sample name contains a comma and we are creating aliquots from that sample within our applications, we add the quotes in the AliquotedFrom input, just as for other parent values, but don't want to include those quotes in the name of the aliquot.

This also fixes the parsing of general parent names used as part of name expressions so we account for the quoted names containing commas.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/3348

#### Changes
* Use `TabLoader` when parsing parent names for use in `NameGenerator`
* Unquote value for `AliquotedFrom` field
