### PR TITLE
Handle empty string for parent names in name generator

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -559,6 +559,9 @@ public class NameGenerator
         Stream<String> values;
         if (value instanceof String)
         {
+            if (StringUtils.isEmpty(((String) value).trim()))
+                return Stream.empty();
+
             // Issue 44841: The names of the parents may include commas, so we parse the set of parent names
             // using TabLoader instead of just splitting on the comma.
             try (TabLoader tabLoader = new TabLoader((String) value))


### PR DESCRIPTION
#### Rationale
Sometimes the parents might not be there, even if he naming pattern wants them to be.

#### Related Pull Requests
#3396 

#### Changes
* Check for empty string
