### PR TITLE
Issue 45592: remove html encoding of name/value for form submission

### DIFF
--- a/api/webapp/clientapi/dom/Utils.js
+++ b/api/webapp/clientapi/dom/Utils.js
@@ -49,8 +49,8 @@ LABKEY.Utils = new function(impl, $) {
 
             const inputElement = document.createElement('input');
             inputElement.type = 'hidden';
-            inputElement.name = LABKEY.Utils.encodeHtml(name);
-            inputElement.value = LABKEY.Utils.encodeHtml(value);
+            inputElement.name = name;
+            inputElement.value = value;
 
             formElement.appendChild(inputElement);
         });


### PR DESCRIPTION
#### Rationale
This fixes [Issue 45592](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45592). With #3387 the `formSubmit()` utility method was updated to use JavaScript element creation rather than jQuery string processing. In doing so I'd erroneously copied over the encoding of the name/value pairs for each input element to be generated.

#### Related Pull Requests
*  #3387

#### Changes
* Remove HTML encoding of form input "name" and "value" properties.
