### PR TITLE
Avoid HTML-encoding HTML on contextContent attributes

### DIFF
--- a/api/src/org/labkey/api/security/PasswordRule.java
+++ b/api/src/org/labkey/api/security/PasswordRule.java
@@ -19,6 +19,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.util.DOM;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.view.HttpView;
 
 import java.util.Collection;
@@ -38,16 +40,16 @@ public enum PasswordRule
 
         @NotNull
         @Override
-        public String getFullRuleHTML()
+        public HtmlString getFullRuleHTML()
         {
-            return "Passwords must be six non-whitespace characters or more and must not match your email address.";
+            return HtmlString.of("Passwords must be six non-whitespace characters or more and must not match your email address.");
         }
 
         @NotNull
         @Override
-        public String getSummaryRuleHTML()
+        public HtmlString getSummaryRuleHTML()
         {
-            return "Your password must be at least six characters and cannot contain spaces or match your email address.";
+            return HtmlString.of("Your password must be at least six characters and cannot contain spaces or match your email address.");
         }
         
         @Override
@@ -91,20 +93,23 @@ public enum PasswordRule
 
         @NotNull
         @Override
-        public String getFullRuleHTML()
+        public HtmlString getFullRuleHTML()
         {
-            return "Passwords follow these rules:<ul>\n" +
-                    "<li>Must be eight characters or more.</li>\n" +
-                    "<li>Must contain three of the following: lowercase letter (a-z), uppercase letter (A-Z), digit (0-9), or symbol (e.g., ! # $ % & / < = > ? @).</li>\n" +
-                    "<li>Must not contain a sequence of three or more characters from your email address, display name, first name, or last name.</li>\n" +
-                    "<li>Must not match any of your 10 previously used passwords.</li>\n</ul>\n";
+            return DOM.createHtml(DOM.createHtmlFragment(
+                    "Passwords follow these rules:",
+                    DOM.UL(
+                            DOM.LI("Must be eight characters or more."),
+                            DOM.LI("Must contain three of the following: lowercase letter (a-z), uppercase letter (A-Z), digit (0-9), or symbol (e.g., ! # $ % & / < = > ? @)."),
+                            DOM.LI("Must not contain a sequence of three or more characters from your email address, display name, first name, or last name."),
+                            DOM.LI("Must not match any of your 10 previously used passwords.")
+                    )));
         }
 
         @NotNull
         @Override
-        public String getSummaryRuleHTML()
+        public HtmlString getSummaryRuleHTML()
         {
-            return "Your password must be at least eight characters, include a mix of letters, digits, and symbols, and cannot include your email address.";
+            return HtmlString.of("Your password must be at least eight characters, include a mix of letters, digits, and symbols, and cannot include your email address.");
         }
 
         @Override
@@ -220,9 +225,9 @@ public enum PasswordRule
 
     abstract boolean isValidToStore(@NotNull String password, @NotNull User user, @Nullable Collection<String> messages);
 
-    public abstract @NotNull String getFullRuleHTML();
+    public abstract @NotNull HtmlString getFullRuleHTML();
 
-    public abstract @NotNull String getSummaryRuleHTML();
+    public abstract @NotNull HtmlString getSummaryRuleHTML();
 
     // 100 most-used passwords on RockYou
     private static final String weakPasswords = "123456\n"+

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -709,8 +709,8 @@ public class LoginController extends SpringActionController
             ApiSimpleResponse response = new ApiSimpleResponse();
             PasswordRule passwordRule = DbLoginManager.getPasswordRule();
 
-            response.put("full", passwordRule.getFullRuleHTML());
-            response.put("summary", passwordRule.getSummaryRuleHTML());
+            response.put("full", passwordRule.getFullRuleHTML().toString());
+            response.put("summary", passwordRule.getSummaryRuleHTML().toString());
             return response;
         }
     }

--- a/core/src/org/labkey/core/login/setPassword.jsp
+++ b/core/src/org/labkey/core/login/setPassword.jsp
@@ -29,6 +29,7 @@
 <%@ page import="org.labkey.core.login.LoginController.SetPasswordBean" %>
 <%@ page import="org.labkey.core.portal.ProjectController.HomeAction" %>
 <%@ page import="org.labkey.core.portal.ProjectController.StartAction" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
     @Override
@@ -73,8 +74,8 @@
         <% } %>
 
         <% for (NamedObject input : bean.passwordInputs) {
-            String contextContent = LoginController.PASSWORD1_TEXT_FIELD_NAME.equals(input.getObject())
-                    ? DbLoginManager.getPasswordRule().getSummaryRuleHTML() : "";
+            HtmlString contextContent = LoginController.PASSWORD1_TEXT_FIELD_NAME.equals(input.getObject())
+                    ? DbLoginManager.getPasswordRule().getSummaryRuleHTML() : null;
         %>
             <p>
                 <%=h(contextContent)%>

--- a/core/src/org/labkey/core/user/changeEmail.jsp
+++ b/core/src/org/labkey/core/user/changeEmail.jsp
@@ -24,6 +24,9 @@
 <%@ page import="org.labkey.core.user.UserController.ChangeEmailAction" %>
 <%@ page import="org.labkey.core.user.UserController.DetailsAction" %>
 <%@ page import="org.labkey.core.user.UserController.UserForm" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
+<%@ page import="org.labkey.api.util.DOM" %>
+<%@ page import="org.labkey.api.util.HtmlStringBuilder" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     String errors = formatMissedErrorsStr("form");
@@ -60,7 +63,7 @@
     }
     else if (form.getIsPasswordPrompt())
     {
-        String resetPasswordLink = "<a href=" + h(urlFor(ResetPasswordAction.class)) + ">forgot password</a>";
+        HtmlString resetPasswordLink = DOM.createHtml(DOM.A(DOM.at(DOM.Attribute.href, urlFor(ResetPasswordAction.class)), "forgot password"));
 %>
         <p>For security purposes, please enter your password.</p>
         <labkey:form action="<%=urlFor(ChangeEmailAction.class)%>" method="POST" layout="horizontal">

--- a/core/src/org/labkey/core/user/changeEmail.jsp
+++ b/core/src/org/labkey/core/user/changeEmail.jsp
@@ -63,7 +63,7 @@
     }
     else if (form.getIsPasswordPrompt())
     {
-        HtmlString resetPasswordLink = DOM.createHtml(DOM.A(DOM.at(DOM.Attribute.href, urlFor(ResetPasswordAction.class)), "forgot password"));
+        HtmlString resetPasswordLink = link("forgot password", urlFor(ResetPasswordAction.class)).getHtmlString();
 %>
         <p>For security purposes, please enter your password.</p>
         <labkey:form action="<%=urlFor(ChangeEmailAction.class)%>" method="POST" layout="horizontal">

--- a/core/src/org/labkey/core/view/styleGuide.jsp
+++ b/core/src/org/labkey/core/view/styleGuide.jsp
@@ -20,6 +20,8 @@
 <%@ page import="org.labkey.api.util.element.Select" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
+<%@ page import="org.labkey.api.util.DOM" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
@@ -276,7 +278,8 @@
         </div>
         <br>
         <h2>Context Content</h2>
-        <% String helpText = "Go to home: <a href=" + ActionURL.getBaseServerURL() + ">Server Home</a>";%>
+        <% HtmlString helpText = DOM.createHtml(DOM.createHtmlFragment("Go to home: ", DOM.A(DOM.at(DOM.Attribute.href, ActionURL.getBaseServerURL()), "Server Home"))); %>
+
         <labkey:form action="some-action" layout="horizontal">
             <labkey:input name="name" label="Rich Content" placeholder="URL of page" contextContent="<%= helpText %>" id="exampleRichContext"/>
         </labkey:form>


### PR DESCRIPTION
#### Rationale
We're HTML-encoding the "forgot password" link when a user is changing their own email address. We've got a couple of other places that are passing HTML as a string to contextContent.

#### Changes
* Use HtmlString to avoid showing raw HTML to user