### PR TITLE
update tests for link name change

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
@@ -536,10 +536,10 @@ public class StudySimpleExportTest extends StudyBaseTest
         _fileBrowserHelper.selectFileBrowserItem("export/folder.xml");
 
         log("Study Properties: import study into subfolder");
-        createSubfolderAndImportStudyFromPipeline("Study Properties");
+        createSubfolderAndImportStudyFromPipeline("Study Properties Folder");
 
         log("Study Properties: verify imported settings");
-        clickFolder("Study Properties");
+        clickFolder("Study Properties Folder");
         goToManageStudy();
         waitAndClickAndWait(Locator.linkWithText("Study Properties"));
         waitForElement(Locator.name("Investigator"));


### PR DESCRIPTION
#### Rationale
With the related PR to rename the link on the manage study page from `Change Study Properties` to `Study Properties`, the test was clicking on the wrong link because the folder name and manage link were now the same. Instead of fiddling with the selector, I just made the easy change to the folder name.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/3397