### PR TITLE
Specify legacy-peer-deps flag for setup

### DIFF
--- a/assay/package.json
+++ b/assay/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "setup": "npm ci",
+    "setup": "npm ci --legacy-peer-deps",
     "build": "npm run build-dev",
     "start": "cross-env NODE_ENV=development webpack serve --config node_modules/@labkey/build/webpack/watch.config.js",
     "start-link": "cross-env LINK=true npm run start",

--- a/core/package.json
+++ b/core/package.json
@@ -2,7 +2,7 @@
   "name": "labkey-core",
   "version": "0.0.0",
   "scripts": {
-    "setup": "npm ci",
+    "setup": "npm ci --legacy-peer-deps",
     "build": "npm run build-dev",
     "build-dev": "npm run copy-distributions && cross-env NODE_ENV=development webpack --config node_modules/@labkey/build/webpack/dev.config.js --color",
     "build-prod": "npm run copy-distributions && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "setup": "npm ci",
+    "setup": "npm ci --legacy-peer-deps",
     "build": "npm run build-dev",
     "start": "cross-env NODE_ENV=development webpack serve --config node_modules/@labkey/build/webpack/watch.config.js",
     "start-link": "cross-env LINK=true npm run start",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "setup": "npm ci",
+    "setup": "npm ci --legacy-peer-deps",
     "build": "npm run build-dev",
     "clean": "rimraf resources/web/pipeline/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen",
     "lint": "eslint",


### PR DESCRIPTION
#### Rationale
For some unknown reason the `--legacy-peer-deps` flag has become necessary for our `npm ci` setup commands. It is possibly due to an update to the docker node version we use in TC inadvertently making this necessary for our use case (we use `npm install --legacy-peer-deps`). One interesting thing to note is as of 6/6/22 the `--legacy-peer-deps` flag is not a valid parameter to `npm ci` [according to their documentation](https://docs.npmjs.com/cli/v8/commands/npm-ci).

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3418
* https://github.com/LabKey/biologics/pull/1358
* https://github.com/LabKey/sampleManagement/pull/984
* https://github.com/LabKey/inventory/pull/447

#### Changes
* Change the `setup` command to `npm ci --legacy-peer-deps`. This is the command invoked by TeamCity.
