### PR TITLE
Issue 45642: Flag column in run grids is very wide now

### DIFF
--- a/internal/src/org/labkey/api/exp/flag/FlagColumnRenderer.java
+++ b/internal/src/org/labkey/api/exp/flag/FlagColumnRenderer.java
@@ -47,6 +47,7 @@ public class FlagColumnRenderer extends DataColumn
         {
             setInputType(displayField.getInputType());
         }
+        setWidth(null);
     }
 
 


### PR DESCRIPTION
#### Rationale
My recent change to how lookup columns choose their widths has an unintended side effect for the quirky Flag column on run grids. Behind the scenes it's a lookup to the exp.FlagComment table (not exposed as a top-level table in the schema browser). It's displaying the Comment column, which is configured with a width of 200 pixels. But FlagColumnRenderer isn't rendering the comment text into the cell - it's just showing the flag icon. 

The custom rendering code should handle the override of configuring the desired width, which is just wide enough to show the flag icon and column heading.

#### Changes
* Unset width to make the column behave like it used to