### PR TITLE
query.queryName -> queryName

### DIFF
--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -626,7 +626,7 @@ public class QueryServiceImpl implements QueryService
         if (schema != null)
             ret.addParameter(QueryParam.schemaName.toString(), schema);
         if (query != null)
-            ret.addParameter(QueryView.DATAREGIONNAME_DEFAULT + "." + QueryParam.queryName, query);
+            ret.addParameter(QueryParam.queryName, query);
         return ret;
     }
 


### PR DESCRIPTION
#### Rationale
Most usages of QueryForm should support "queryName=" instead of "query.queryName=".  And at least some usages of "query.queryName" no longer work (see issue 45333).

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
