### PR TITLE
Don't persist parameter "pageId" with ".lastFilter=true"

### DIFF
--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -2891,9 +2891,10 @@ public class PageFlowUtil
         for (String paramName : clone.getParameterMap().keySet())
         {
             if (paramName.endsWith("." + QueryParam.offset))
-            {
                 clone.deleteParameter(paramName);
-            }
+            // CONSIDER: Should we whitelist params that don't contain a "."?  They are not usually dataregion related.
+            // We know pageId should not be persisted (Issue 45617)
+            clone.deleteParameter("pageId");
         }
 
         clone.deleteParameter(scope + DataRegion.LAST_FILTER_PARAM);


### PR DESCRIPTION
#### Rationale
.lastFilter remembers too many parameters.  In particular remembering "pageId", messes up navigation on portal pages.
Issue 45617

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
