### PR TITLE
Conditionalize display of "Upload XAR" button

### DIFF
--- a/api/src/org/labkey/api/assay/AssayUrls.java
+++ b/api/src/org/labkey/api/assay/AssayUrls.java
@@ -91,6 +91,7 @@ public interface AssayUrls extends UrlProvider
     ActionURL getSummaryRedirectURL(Container container);
     ActionURL getSetResultFlagURL(Container container);
     ActionURL getChooseAssayTypeURL(Container container);
+    ActionURL getImportAssayDesignURL(Container container);
     ActionURL getShowSelectedDataURL(Container container, ExpProtocol protocol);
     ActionURL getShowSelectedRunsURL(Container container, ExpProtocol protocol, @Nullable ContainerFilter containerFilter);
     ActionURL getSetDefaultValuesAssayURL(Container container, String providerName, Domain domain, ActionURL returnUrl);

--- a/api/src/org/labkey/api/exp/api/ExperimentUrls.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentUrls.java
@@ -110,8 +110,6 @@ public interface ExperimentUrls extends UrlProvider
 
     default ActionURL getShowRunGraphURL(ExpRun run) { return null; }
 
-    default ActionURL getUploadXARURL(Container container) { return null; }
-
     default ActionURL getRepairTypeURL(Container container) { return null; }
 
     default ActionURL getUpdateMaterialQueryRowAction(Container c, TableInfo table) { return null; }

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -1250,6 +1250,12 @@ public class AssayController extends SpringActionController
         }
 
         @Override
+        public ActionURL getImportAssayDesignURL(Container container)
+        {
+            return getChooseAssayTypeURL(container).addParameter("tab", "import");
+        }
+
+        @Override
         public ActionURL getShowSelectedDataURL(Container container, ExpProtocol protocol)
         {
             return getProtocolURL(container, protocol, ShowSelectedDataAction.class);

--- a/core/resources/scripts/labkey/Ajax.js
+++ b/core/resources/scripts/labkey/Ajax.js
@@ -17,7 +17,7 @@ LABKEY.Ajax = new function () {
     var DEFAULT_HEADERS = LABKEY.defaultHeaders;
 
     // Download the file from the ajax response.
-    // For now, we assume we are in a browser enviornment and use the browser's download
+    // For now, we assume we are in a browser environment and use the browser's download
     // file prompt by clicking an <a> element or navigating by updating window.location.
     var downloadFile = function (xhr, config) {
         var filename = "";

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -2838,9 +2838,7 @@ public class CoreController extends SpringActionController
                 int v = (int) (Math.random() * verbs.length);
                 log.info(" that " + verbs[v] + " ");
             }
-
         }
-
 
         @Override
         protected ModelAndView handleGet()

--- a/experiment/src/org/labkey/experiment/RunGroupWebPart.java
+++ b/experiment/src/org/labkey/experiment/RunGroupWebPart.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.experiment;
 
+import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
 import org.labkey.api.data.ContainerFilter;
@@ -24,6 +25,7 @@ import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.DataView;
 import org.labkey.api.view.Portal;
 import org.labkey.api.view.ViewContext;
@@ -120,10 +122,14 @@ public class RunGroupWebPart extends QueryView
         super.populateButtonBar(view, bb);
         if (!_narrow)
         {
-            ActionButton addXarFile = new ActionButton(ExperimentController.ExperimentUrlsImpl.get().getUploadXARURL(getViewContext().getContainer()), "Upload XAR");
-            addXarFile.setActionType(ActionButton.Action.LINK);
-            addXarFile.setDisplayPermission(InsertPermission.class);
-            bb.add(addXarFile);
+            AssayUrls urls = PageFlowUtil.urlProvider(AssayUrls.class);
+            if (null != urls)
+            {
+                ActionButton addXarFile = new ActionButton(urls.getImportAssayDesignURL(getViewContext().getContainer()), "Upload XAR");
+                addXarFile.setActionType(ActionButton.Action.LINK);
+                addXarFile.setDisplayPermission(InsertPermission.class);
+                bb.add(addXarFile);
+            }
 
             ActionButton createExperiment = new ActionButton(ExperimentController.ExperimentUrlsImpl.get().getCreateRunGroupURL(getViewContext().getContainer(), getReturnURL(), false), "Create Run Group");
             createExperiment.setActionType(ActionButton.Action.LINK);

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -6590,12 +6590,6 @@ public class ExperimentController extends SpringActionController
         }
 
         @Override
-        public ActionURL getUploadXARURL(Container container)
-        {
-            return new ActionURL("assay", "chooseAssayType", container).addParameter("tab", "import");
-        }
-
-        @Override
         public ActionURL getRepairTypeURL(Container container)
         {
             return new ActionURL(TypesController.RepairAction.class, container);


### PR DESCRIPTION
#### Rationale
String-based ActionURLs are bad. Cross-module string-based ActionURLs are especially bad. In this case, `RunGroupWebPart` was displaying an "Upload XAR" button when the `assay` module wasn't present, which meant a nice 404.

Thank you, LabKey Crawler, for your service.

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/472