### PR TITLE
Don't include "Upload XAR" button if assay module is missing

### DIFF
--- a/api/src/org/labkey/api/assay/AssayUrls.java
+++ b/api/src/org/labkey/api/assay/AssayUrls.java
@@ -96,4 +96,5 @@ public interface AssayUrls extends UrlProvider
     ActionURL getSetDefaultValuesAssayURL(Container container, String providerName, Domain domain, ActionURL returnUrl);
     String getBatchIdFilterParam();
     ActionURL getPlateMetadataTemplateURL(Container container, AssayProvider provider);
+    ActionURL getUploadXARURL(Container container);
 }

--- a/api/src/org/labkey/api/exp/api/ExperimentUrls.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentUrls.java
@@ -110,8 +110,6 @@ public interface ExperimentUrls extends UrlProvider
 
     default ActionURL getShowRunGraphURL(ExpRun run) { return null; }
 
-    default ActionURL getUploadXARURL(Container container) { return null; }
-
     default ActionURL getRepairTypeURL(Container container) { return null; }
 
     default ActionURL getUpdateMaterialQueryRowAction(Container c, TableInfo table) { return null; }

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -1291,6 +1291,12 @@ public class AssayController extends SpringActionController
         {
             return provider.getPlateMetadataTemplateURL(container);
         }
+
+        @Override
+        public ActionURL getUploadXARURL(Container container)
+        {
+            return new ActionURL(ChooseAssayTypeAction.class, container).addParameter("tab", "import");
+        }
     }
 
     @RequiresPermission(DesignAssayPermission.class)

--- a/experiment/src/org/labkey/experiment/RunGroupWebPart.java
+++ b/experiment/src/org/labkey/experiment/RunGroupWebPart.java
@@ -15,7 +15,7 @@
  */
 package org.labkey.experiment;
 
-import org.labkey.api.assay.AssayService;
+import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
 import org.labkey.api.data.ContainerFilter;
@@ -25,6 +25,7 @@ import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.DataView;
 import org.labkey.api.view.Portal;
 import org.labkey.api.view.ViewContext;
@@ -121,9 +122,10 @@ public class RunGroupWebPart extends QueryView
         super.populateButtonBar(view, bb);
         if (!_narrow)
         {
-            if (AssayService.get() != null)
+            AssayUrls assayUrls = PageFlowUtil.urlProvider(AssayUrls.class);
+            if (assayUrls != null)
             {
-                ActionButton addXarFile = new ActionButton(ExperimentController.ExperimentUrlsImpl.get().getUploadXARURL(getViewContext().getContainer()), "Upload XAR");
+                ActionButton addXarFile = new ActionButton(assayUrls.getUploadXARURL(getViewContext().getContainer()), "Upload XAR");
                 addXarFile.setActionType(ActionButton.Action.LINK);
                 addXarFile.setDisplayPermission(InsertPermission.class);
                 bb.add(addXarFile);

--- a/experiment/src/org/labkey/experiment/RunGroupWebPart.java
+++ b/experiment/src/org/labkey/experiment/RunGroupWebPart.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.experiment;
 
+import org.labkey.api.assay.AssayService;
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
 import org.labkey.api.data.ContainerFilter;
@@ -120,10 +121,13 @@ public class RunGroupWebPart extends QueryView
         super.populateButtonBar(view, bb);
         if (!_narrow)
         {
-            ActionButton addXarFile = new ActionButton(ExperimentController.ExperimentUrlsImpl.get().getUploadXARURL(getViewContext().getContainer()), "Upload XAR");
-            addXarFile.setActionType(ActionButton.Action.LINK);
-            addXarFile.setDisplayPermission(InsertPermission.class);
-            bb.add(addXarFile);
+            if (AssayService.get() != null)
+            {
+                ActionButton addXarFile = new ActionButton(ExperimentController.ExperimentUrlsImpl.get().getUploadXARURL(getViewContext().getContainer()), "Upload XAR");
+                addXarFile.setActionType(ActionButton.Action.LINK);
+                addXarFile.setDisplayPermission(InsertPermission.class);
+                bb.add(addXarFile);
+            }
 
             ActionButton createExperiment = new ActionButton(ExperimentController.ExperimentUrlsImpl.get().getCreateRunGroupURL(getViewContext().getContainer(), getReturnURL(), false), "Create Run Group");
             createExperiment.setActionType(ActionButton.Action.LINK);

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -6590,12 +6590,6 @@ public class ExperimentController extends SpringActionController
         }
 
         @Override
-        public ActionURL getUploadXARURL(Container container)
-        {
-            return new ActionURL("assay", "chooseAssayType", container).addParameter("tab", "import");
-        }
-
-        @Override
         public ActionURL getRepairTypeURL(Container container)
         {
             return new ActionURL(TypesController.RepairAction.class, container);


### PR DESCRIPTION
#### Rationale
Our link crawler found that the experiment begin page links to the assay XAR import page even if the assay module is not installed.
The first commit here just adds a module check before adding the XAR button. The second commit also moves the URL getter from `ExperimentUrls` to `AssayUrls`. If moving the URL getter isn't wanted, I can roll back the second commit.

```
java.lang.AssertionError: /MyStudies%20Test%20Organization/assay-chooseAssayType.view?tab=import
produced response code 404
Originating page: http://localhost:8111/labkey/MyStudies%20Test%20Organization/experiment-begin.view
  at org.junit.Assert.fail(Assert.java:89)
  at org.labkey.test.util.Crawler.crawlLink(Crawler.java:991)
  at org.labkey.test.util.Crawler.crawl(Crawler.java:823)
  at org.labkey.test.util.Crawler.crawlAllLinks(Crawler.java:786)
  at org.labkey.test.BaseWebDriverTest.checkLinks(BaseWebDriverTest.java:1458)
```

#### Changes
* Don't include XAR upload button on run group webpart if the Assay module is not present
