### PR TITLE
Stop treating "user limit" exception as unexpected

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -18,7 +18,6 @@ package org.labkey.api.security;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -85,6 +84,7 @@ import org.labkey.api.util.Rate;
 import org.labkey.api.util.RateLimiter;
 import org.labkey.api.util.SessionHelper;
 import org.labkey.api.util.URLHelper;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.NavTree;
@@ -124,7 +124,7 @@ public class AuthenticationManager
 {
     public static final String ALL_DOMAINS = "*";
 
-    private static final Logger _log = LogManager.getLogger(AuthenticationManager.class);
+    private static final Logger _log = LogHelper.getLogger(AuthenticationManager.class, "Authentication warnings and configuration problems");
     // All registered authentication providers (DbLogin, LDAP, SSO, etc.)
     private static final List<AuthenticationProvider> _allProviders = new CopyOnWriteArrayList<>();
 
@@ -157,11 +157,6 @@ public class AuthenticationManager
         public String getHeight()
         {
             return _height;
-        }
-
-        public String getOldPrefix()
-        {
-            return _fileName + "_";
         }
 
         public static @NotNull AuthLogoType getForFilename(String fileName)
@@ -1024,9 +1019,13 @@ public class AuthenticationManager
         }
         catch (SecurityManager.UserManagementException e)
         {
-            // Make sure we record any unexpected problems during user creation; one goal is to help track down cause of #20712
-            ExceptionUtil.decorateException(e, ExceptionUtil.ExceptionInfo.ExtraMessage, email.getEmailAddress(), true);
-            ExceptionUtil.logExceptionToMothership(request, e);
+            // "User limit" exception is expected. Log other exceptions.
+            if (!e.getMessage().startsWith("User limit has been reached"))
+            {
+                // Make sure we record any unexpected problems during user creation; one goal is to help track down cause of #20712
+                ExceptionUtil.decorateException(e, ExceptionUtil.ExceptionInfo.ExtraMessage, email.getEmailAddress(), true);
+                ExceptionUtil.logExceptionToMothership(request, e);
+            }
 
             return new PrimaryAuthenticationResult(AuthenticationStatus.UserCreationError);
         }

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -1006,7 +1006,6 @@ public class SecurityManager
         if (LimitActiveUsersService.get().isUserLimitReached())
             throw new UserManagementException(email, "User limit has been reached so no more users can be added to this deployment.");
 
-
         NewUserStatus status = new NewUserStatus(email);
 
         if (UserManager.userExists(email))


### PR DESCRIPTION
#### Rationale
Auto-create (for first-time LDAP and SSO users) has been logging all `UserManagementException`s since they weren't ever expected. User limit exceptions are now expected, so ignore those for logging purposes. Logging an error exception stack trace was causing a new test to fail.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3334
* https://github.com/LabKey/ldap/pull/57
