### PR TITLE
Better error message formatting

### DIFF
--- a/api/src/org/labkey/api/action/LabKeyErrorWithLink.java
+++ b/api/src/org/labkey/api/action/LabKeyErrorWithLink.java
@@ -2,7 +2,7 @@ package org.labkey.api.action;
 
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
-import org.labkey.api.util.Link;
+import org.labkey.api.util.Link.LinkBuilder;
 import org.labkey.api.view.ViewContext;
 
 public class LabKeyErrorWithLink extends LabKeyError
@@ -21,7 +21,8 @@ public class LabKeyErrorWithLink extends LabKeyError
     public HtmlString renderToHTML(ViewContext context)
     {
         HtmlStringBuilder builder = HtmlStringBuilder.of(super.renderToHTML(context));
-        builder.append(new Link.LinkBuilder(getAdviceText()).href(getAdviceHref()));
+        builder.append(" ");
+        builder.append(new LinkBuilder(getAdviceText()).href(getAdviceHref()).clearClasses());
 
         return builder.getHtmlString();
     }


### PR DESCRIPTION
#### Rationale
Current HTML rendering of `LabKeyErrorWithLink` is not quite up to our usual standards:

![image](https://user-images.githubusercontent.com/5107383/173121216-d006748d-1c55-413f-8b35-d9ff5da1af84.png)

New rendering:

![image](https://user-images.githubusercontent.com/5107383/173121407-6f345a1c-84af-49be-9712-86181cec0865.png)

