### PR TITLE
AliquotedFrom is required for updating aliquots

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -644,9 +644,10 @@ public class ExpDataIterators
         }
     }
 
-    static boolean hasAliquots(List<String> names)
+    static boolean hasAliquots(int sampleTypeRowId, List<String> names)
     {
         SimpleFilter f = new SimpleFilter(FieldKey.fromParts("Name"), names, IN);
+        f.addCondition(FieldKey.fromParts("MaterialSourceId"), sampleTypeRowId);
         f.addCondition(FieldKey.fromParts("AliquotedFromLSID"), null, CompareType.NONBLANK);
         return new TableSelector(ExperimentService.get().getTinfoMaterial(), f, null).exists();
     }
@@ -864,7 +865,7 @@ public class ExpDataIterators
                     {
                         if (!_candidateAliquotNames.isEmpty())
                         {
-                            if (hasAliquots(_candidateAliquotNames))
+                            if (hasAliquots(_currentSampleType.getRowId(), _candidateAliquotNames))
                             {
                                 // AliquotedFrom is used to determine if aliquot/meta field value should be retained or discarded
                                 // In the case of merge, one can argue AliquotedFrom can be queried for existing data, instead of making it a required field.

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -644,9 +644,9 @@ public class ExpDataIterators
         }
     }
 
-    static boolean hasAliquots(List<String> lsids)
+    static boolean hasAliquots(List<String> names)
     {
-        SimpleFilter f = new SimpleFilter(FieldKey.fromParts("LSID"), lsids, IN);
+        SimpleFilter f = new SimpleFilter(FieldKey.fromParts("Name"), names, IN);
         f.addCondition(FieldKey.fromParts("AliquotedFromLSID"), null, CompareType.NONBLANK);
         return new TableSelector(ExperimentService.get().getTinfoMaterial(), f, null).exists();
     }
@@ -674,7 +674,7 @@ public class ExpDataIterators
         final boolean _isSample;
         final boolean _skipAliquot; // skip aliquot validation, used for update/updates cases
 
-        final List<String> _candidateAliquotLsids; // used to check if a lsid is an aliquot, with absent "AliquotedFrom". used for merge only
+        final List<String> _candidateAliquotNames; // used to check if a name is an aliquot, with absent "AliquotedFrom". used for merge only
 
         protected DerivationDataIterator(DataIterator di, DataIteratorContext context, Container container, User user, ExpObject currentDataType, boolean isSample, boolean skipAliquot)
         {
@@ -700,7 +700,7 @@ public class ExpDataIterators
             _parentNames = new LinkedHashMap<>();
             _parentCols = new HashMap<>();
             _aliquotParents = new LinkedHashMap<>();
-            _candidateAliquotLsids = new ArrayList<>();
+            _candidateAliquotNames = new ArrayList<>();
             _container = container;
             _user = user;
 
@@ -767,11 +767,11 @@ public class ExpDataIterators
                     }
 
                     if (aliquotParentName == null && _context.getInsertOption().mergeRows)
-                        _candidateAliquotLsids.add(lsid);
+                        _candidateAliquotNames.add(name);
                 }
                 else if (!_skipAliquot && _context.getInsertOption().mergeRows)
                 {
-                    _candidateAliquotLsids.add(lsid);
+                    _candidateAliquotNames.add(name);
                 }
 
                 Set<Pair<String, String>> allParts = new HashSet<>();
@@ -862,9 +862,9 @@ public class ExpDataIterators
 
                     if (_isSample && _context.getInsertOption().mergeRows)
                     {
-                        if (!_candidateAliquotLsids.isEmpty())
+                        if (!_candidateAliquotNames.isEmpty())
                         {
-                            if (hasAliquots(_candidateAliquotLsids))
+                            if (hasAliquots(_candidateAliquotNames))
                             {
                                 // AliquotedFrom is used to determine if aliquot/meta field value should be retained or discarded
                                 // In the case of merge, one can argue AliquotedFrom can be queried for existing data, instead of making it a required field.


### PR DESCRIPTION
#### Rationale
When importing samples with merge, a scan of all samples in the import file to determine if any aliquot is present is done to determine if the absence of AliquotedFrom is acceptable. With LSID no longer deterministic, the check of existing samples needs to query from name, not lsid. 

https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_SampleManagerAPostgres/1852860?buildTab=tests&name=SMAliquotImportExportTest.testInvalidImportCases

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
