### PR TITLE
Issue 45058: Test and refresh Postgres passthrough JSON functions

### DIFF
--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -82,6 +82,9 @@ public abstract class PostgreSql91Dialect extends SqlDialect
 
     private HtmlString _adminWarning = null;
 
+    // Default to 9 and let newer versions be refreshed later
+    private int _majorVersion = 9;
+
     protected InClauseGenerator _inClauseGenerator = null;
 
     // Specifies if this PostgreSQL server treats backslashes in string literals as normal characters (as per the SQL
@@ -253,6 +256,15 @@ public abstract class PostgreSql91Dialect extends SqlDialect
         }
     }
 
+    public int getMajorVersion()
+    {
+        return _majorVersion;
+    }
+
+    public void setMajorVersion(int majorVersion)
+    {
+        _majorVersion = majorVersion;
+    }
 
     @Override
     public String addReselect(SQLFragment sql, ColumnInfo column, @Nullable String proposedVariable)

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -103,6 +103,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
         Map<String, String> parameterStatuses = (conn instanceof PgConnection ? ((PgConnection) conn).getParameterStatuses() : Collections.emptyMap());
         PostgreSqlServerType serverType = PostgreSqlServerType.getFromParameterStatuses(parameterStatuses);
         dialect.setServerType(serverType);
+        dialect.setMajorVersion(versionNumber.getMajor());
 
         if (logWarnings)
         {

--- a/query/src/org/labkey/query/sql/Method.java
+++ b/query/src/org/labkey/query/sql/Method.java
@@ -1440,8 +1440,9 @@ public abstract class Method
         postgresMethods.put("to_date",new PassthroughMethod("to_date",JdbcType.DATE,2,2));
         postgresMethods.put("to_timestamp",new PassthroughMethod("to_timestamp",JdbcType.TIMESTAMP,2,2));
         postgresMethods.put("to_number",new PassthroughMethod("to_number",JdbcType.DECIMAL,2,2));
-        postgresMethods.put("string_to_array",new PassthroughMethod("string_to_array",JdbcType.VARCHAR,2,2));
+        postgresMethods.put("string_to_array",new PassthroughMethod("string_to_array",JdbcType.VARCHAR,2,3));
         postgresMethods.put("unnest",new PassthroughMethod("unnest",JdbcType.VARCHAR,1,1));
+        postgresMethods.put("row",new PassthroughMethod("row",JdbcType.VARCHAR,1, Integer.MAX_VALUE));
 
         addPostgresJsonMethods();
     }
@@ -1502,23 +1503,47 @@ public abstract class Method
         addJsonPassthroughMethod("object", JdbcType.OTHER, 1, 2);
 
         addJsonPassthroughMethod("array_length", JdbcType.INTEGER, 1, 1);
-        addJsonPassthroughMethod("each", JdbcType.OTHER, 1, 1);
-        addJsonPassthroughMethod("each_text", JdbcType.OTHER, 1, 1);
         addJsonPassthroughMethod("extract_path", JdbcType.OTHER, 2, Integer.MAX_VALUE);
         addJsonPassthroughMethod("extract_path_text", JdbcType.VARCHAR, 2, Integer.MAX_VALUE);
         addJsonPassthroughMethod("object_keys", JdbcType.OTHER, 1, 1);
-        addJsonPassthroughMethod("populate_record", JdbcType.OTHER, 2, 2);
-        addJsonPassthroughMethod("populate_recordset", JdbcType.OTHER, 2, 2);
         addJsonPassthroughMethod("array_elements", JdbcType.OTHER, 1, 1);
         addJsonPassthroughMethod("array_elements_text", JdbcType.VARCHAR, 1, 1);
         addJsonPassthroughMethod("typeof", JdbcType.VARCHAR, 1, 1);
-        addJsonPassthroughMethod("to_record", JdbcType.OTHER, 1, 1);
-        addJsonPassthroughMethod("to_recordset", JdbcType.OTHER, 1, 1);
         addJsonPassthroughMethod("strip_nulls", JdbcType.OTHER, 1, 1);
 
+        // Not fully supported because they can't be used in the FROM clause of a query, and they produce more than
+        // one column as an output, but leaving because they work in other contexts
+        addJsonPassthroughMethod("each", JdbcType.OTHER, 1, 1);
+        addJsonPassthroughMethod("each_text", JdbcType.OTHER, 1, 1);
+
+
+        // Not supported because they require an AS clause that LabKey SQL doesn't handle
+        // Example: select * from json_to_record('{"a":1,"b":[1,2,3],"c":[1,2,3],"e":"bar","r": {"a": 123, "b": "a b c"}}') as x(a int, b text, c int[], d text, r myrowtype)
+//        addJsonPassthroughMethod("to_record", JdbcType.OTHER, 1, 1);
+//        addJsonPassthroughMethod("to_recordset", JdbcType.OTHER, 1, 1);
+
+        // Not supported because they require a first argument (base/type) that LabKey SQL doesn't handle
+        // Example: select * from json_populate_record(null::myrowtype, '{"a": 1, "b": ["2", "a b"], "c": {"d": 4, "e": "a b c"}, "x": "foo"}')
+//        addJsonPassthroughMethod("populate_record", JdbcType.OTHER, 2, 2);
+//        addJsonPassthroughMethod("populate_recordset", JdbcType.OTHER, 2, 2);
+
+
         postgresMethods.put("jsonb_set", new PassthroughMethod("jsonb_set", JdbcType.OTHER, 3, 4));
-        postgresMethods.put("jsonb_insert", new PassthroughMethod("jsonb_set", JdbcType.OTHER, 3, 4));
+        postgresMethods.put("jsonb_set_lax", new PassthroughMethod("jsonb_set_lax", JdbcType.OTHER, 3, 5));
+        postgresMethods.put("jsonb_insert", new PassthroughMethod("jsonb_insert", JdbcType.OTHER, 3, 4));
         postgresMethods.put("jsonb_pretty", new PassthroughMethod("jsonb_pretty", JdbcType.VARCHAR, 1, 1));
+
+        // New in Postgres 12, 13, and 14
+        postgresMethods.put("jsonb_path_exists", new PassthroughMethod("jsonb_path_exists", JdbcType.VARCHAR, 2, 4));
+        postgresMethods.put("jsonb_path_match", new PassthroughMethod("jsonb_path_match", JdbcType.VARCHAR, 2, 4));
+        postgresMethods.put("jsonb_path_query", new PassthroughMethod("jsonb_path_query", JdbcType.VARCHAR, 2, 4));
+        postgresMethods.put("jsonb_path_query_array", new PassthroughMethod("jsonb_path_query_array", JdbcType.VARCHAR, 2, 4));
+        postgresMethods.put("jsonb_path_query_first", new PassthroughMethod("jsonb_path_query_first", JdbcType.VARCHAR, 2, 4));
+        postgresMethods.put("jsonb_path_exists_tz", new PassthroughMethod("jsonb_path_exists_tz", JdbcType.VARCHAR, 2, 4));
+        postgresMethods.put("jsonb_path_match_tz", new PassthroughMethod("jsonb_path_match_tz", JdbcType.VARCHAR, 2, 4));
+        postgresMethods.put("jsonb_path_query_tz", new PassthroughMethod("jsonb_path_query_tz", JdbcType.VARCHAR, 2, 4));
+        postgresMethods.put("jsonb_path_query_array_tz", new PassthroughMethod("jsonb_path_query_array_tz", JdbcType.VARCHAR, 2, 4));
+        postgresMethods.put("jsonb_path_query_first_tz", new PassthroughMethod("jsonb_path_query_first_tz", JdbcType.VARCHAR, 2, 4));
     }
 
     private static void addJsonPassthroughMethod(String name, JdbcType type, int minArgs, int maxArgs)

--- a/query/src/org/labkey/query/sql/Query.java
+++ b/query/src/org/labkey/query/sql/Query.java
@@ -1887,119 +1887,220 @@ d,seven,twelve,day,month,date,duration,guid
     };
 
 
-    static SqlTest[] postgresOnlyFunctions = new SqlTest[]
+    static List<SqlTest> postgresOnlyFunctions()
     {
-        new SqlTest("SELECT stddev_samp(d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT var_samp(d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT bool_and((d < 0)), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT bool_or((d < 0)), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT every((d > 0)), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT bit_or(seven), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT bit_and(seven), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT mode(seven), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT corr(seven, d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT corr(seven, d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT covar_pop(seven, d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT covar_samp(seven, d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT regr_avgx(seven, d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT regr_avgy(seven, d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT regr_count(seven, d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT regr_intercept(seven, d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT regr_r2(seven, d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT regr_slope(seven, d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT regr_sxx(seven, d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT regr_sxy(seven, d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT regr_syy(seven, d), day FROM R GROUP BY day", 2, 7),
-        new SqlTest("SELECT 'similar' WHERE similar_to('abc','abc')", 1, 1),
-        new SqlTest("SELECT 'similar' WHERE similar_to('abc','a')", 1, 0),
-        new SqlTest("SELECT 'similar' WHERE similar_to('abc','%(b|d)%')", 1, 1),
-        new SqlTest("SELECT 'similar' WHERE similar_to('abc','(b|c)%')", 1, 0),
-        new SqlTest("SELECT 'similar' WHERE similar_to('abc|','abc\\|', '\\')", 1, 1),
-        new SqlTest("SELECT parse_jsonb('{\"a\":1, \"b\":null}')", 1, 1),
-        new SqlTest("SELECT json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a')", 1, 1),
-        // Postgres 9.6 doesn't support direct JSONB and JSON to INTEGER casting, so use VARCHAR for our simple purposes
-        new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f != '1'", 1, 0),
-        new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f = '1'", 1, 1),
-        new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_json('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f != '1'", 1, 0),
-        new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_json('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f = '1'", 1, 1),
-    };
+        return List.of(
+            new SqlTest("SELECT stddev_samp(d), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT var_samp(d), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT bool_and((d < 0)), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT bool_or((d < 0)), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT every((d > 0)), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT bit_or(seven), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT bit_and(seven), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT mode(seven), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT corr(seven, d), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT corr(seven, d), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT covar_pop(seven, d), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT covar_samp(seven, d), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT regr_avgx(seven, d), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT regr_avgy(seven, d), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT regr_count(seven, d), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT regr_intercept(seven, d), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT regr_r2(seven, d), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT regr_slope(seven, d), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT regr_sxx(seven, d), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT regr_sxy(seven, d), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT regr_syy(seven, d), day FROM R GROUP BY day", 2, 7),
+            new SqlTest("SELECT 'similar' WHERE similar_to('abc','abc')", 1, 1),
+            new SqlTest("SELECT 'similar' WHERE similar_to('abc','a')", 1, 0),
+            new SqlTest("SELECT 'similar' WHERE similar_to('abc','%(b|d)%')", 1, 1),
+            new SqlTest("SELECT 'similar' WHERE similar_to('abc','(b|c)%')", 1, 0),
+            new SqlTest("SELECT 'similar' WHERE similar_to('abc|','abc\\|', '\\')", 1, 1),
+
+            // parse_json, parse_jsonb, and json_op
+            new SqlTest("SELECT parse_jsonb('{\"a\":1, \"b\":null}')", 1, 1),
+            new SqlTest("SELECT json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a')", 1, 1),
+            // Postgres 9.6 doesn't support direct JSONB and JSON to INTEGER casting, so use VARCHAR for our simple purposes
+            new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f != '1'", 1, 0),
+            new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f = '1'", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_json('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f != '1'", 1, 0),
+            new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_json('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f = '1'", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_json('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f = '1'", 1, 1),
+
+            // to_json and to_jsonb
+            new SqlTest("SELECT f FROM (SELECT CAST(to_json(CAST('{\"a\":1, \"b\":null}' AS VARCHAR)) AS VARCHAR) AS f) X WHERE f = '\"{\\\"a\\\":1, \\\"b\\\":null}\"'", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(to_jsonb(CAST('{\"a\":1, \"b\":null}' AS VARCHAR)) AS VARCHAR) AS f) X WHERE f = '\"{\\\"a\\\":1, \\\"b\\\":null}\"'", 1, 1),
+
+            // array_to_json
+            new SqlTest("SELECT f FROM (SELECT CAST(array_to_json(string_to_array('xx~^~yy~^~zz', '~^~', 'yy')) AS VARCHAR) AS f) X WHERE f = '[\"xx\",null,\"zz\"]'", 1, 1),
+
+            // row_to_json
+            new SqlTest("SELECT f FROM (SELECT CAST(row_to_json(row(1,'foo')) AS VARCHAR) AS f) X WHERE f = '{\"f1\":1,\"f2\":\"foo\"}'", 1, 1),
+
+            // json_build_array and jsonb_build_array
+            new SqlTest("SELECT f FROM (SELECT CAST(json_build_array(1, 2, 'foo', 4, 5) AS VARCHAR) AS f) X WHERE f = '[1, 2, \"foo\", 4, 5]'", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_build_array(1, 2, 'foo', 4, 5) AS VARCHAR) AS f) X WHERE f = '[1, 2, \"foo\", 4, 5]'", 1, 1),
+
+            // json_build_object and jsonb_build_object
+            new SqlTest("SELECT f FROM (SELECT CAST(json_build_object('foo', 1, 2, row(3,'bar')) AS VARCHAR) AS f) X WHERE f = '{\"foo\" : 1, \"2\" : {\"f1\":3,\"f2\":\"bar\"}}'", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_build_object('foo', 1, 2, row(3,'bar')) AS VARCHAR) AS f) X WHERE f = '{\"2\": {\"f1\": 3, \"f2\": \"bar\"}, \"foo\": 1}'", 1, 1),
+
+            // json_object and jsonb_object
+            new SqlTest("SELECT f FROM (SELECT CAST(json_object('{a, 1, b, \"def\", c, 3.5}') AS VARCHAR) AS f) X WHERE f = '{\"a\" : \"1\", \"b\" : \"def\", \"c\" : \"3.5\"}'", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_object('{a, 1, b, \"def\", c, 3.5}') AS VARCHAR) AS f) X WHERE f = '{\"a\": \"1\", \"b\": \"def\", \"c\": \"3.5\"}'", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(json_object('{a,b}', '{1,2}') AS VARCHAR) AS f) X WHERE f = '{\"a\" : \"1\", \"b\" : \"2\"}'", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_object('{a,b}', '{1,2}') AS VARCHAR) AS f) X WHERE f = '{\"a\": \"1\", \"b\": \"2\"}'", 1, 1),
+
+            // json_array_length and jsonb_array_length
+            new SqlTest("SELECT f FROM (SELECT json_array_length(json_build_array(1, 2, 'foo', 4, 5)) AS f) X WHERE f = 5", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT jsonb_array_length(jsonb_build_array(1, 2, 'foo', 4, 5)) AS f) X WHERE f = 5", 1, 1),
+
+            // json_each and jsonb_each, json_each_text and jsonb_each_text
+            new SqlTest("SELECT json_each(parse_json('{\"a\":\"foo\", \"b\":\"bar\"}'))", 1, 2),
+            new SqlTest("SELECT jsonb_each(parse_jsonb('{\"a\":\"foo\", \"b\":\"bar\"}'))", 1, 2),
+            new SqlTest("SELECT json_each_text(parse_json('{\"a\":\"foo\", \"b\":\"bar\"}'))", 1, 2),
+            new SqlTest("SELECT jsonb_each_text(parse_jsonb('{\"a\":\"foo\", \"b\":\"bar\"}'))", 1, 2),
+
+            // json_extract_path and jsonb_extract_path, json_extract_path_text and jsonb_extract_path_text
+            new SqlTest("SELECT f FROM (SELECT CAST(json_extract_path('{\"f2\":{\"f3\":1},\"f4\":{\"f5\":99,\"f6\":\"foo\"}}', 'f4', 'f6') AS VARCHAR) AS f) X WHERE f = '\"foo\"'", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_extract_path('{\"f2\":{\"f3\":1},\"f4\":{\"f5\":99,\"f6\":\"foo\"}}', 'f4', 'f6') AS VARCHAR) AS f) X WHERE f = '\"foo\"'", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(json_extract_path_text('{\"f2\":{\"f3\":1},\"f4\":{\"f5\":99,\"f6\":\"foo\"}}', 'f4', 'f6') AS VARCHAR) AS f) X WHERE f = 'foo'", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_extract_path_text('{\"f2\":{\"f3\":1},\"f4\":{\"f5\":99,\"f6\":\"foo\"}}', 'f4', 'f6') AS VARCHAR) AS f) X WHERE f = 'foo'", 1, 1),
+
+            // json_object_keys and jsonb_object_keys
+            new SqlTest("SELECT f FROM (SELECT json_object_keys('{\"f1\":\"abc\",\"f2\":{\"f3\":\"a\", \"f4\":\"b\"}}') AS f) X WHERE f IN ('f1', 'f2')", 1, 2),
+            new SqlTest("SELECT f FROM (SELECT jsonb_object_keys('{\"f1\":\"abc\",\"f2\":{\"f3\":\"a\", \"f4\":\"b\"}}') AS f) X WHERE f IN ('f1', 'f2')", 1, 2),
+
+            // json_array_elements and jsonb_array_elements, json_array_elements_text and jsonb_array_elements_text
+            new SqlTest("SELECT f FROM (SELECT CAST(json_array_elements('[1,true, [2,false]]') AS VARCHAR) AS f) X WHERE f IN ('1', 'true', '[2,false]')", 1, 3),
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_array_elements('[1,true, [2,false]]') AS VARCHAR) AS f) X WHERE f IN ('1', 'true', '[2, false]')", 1, 3),
+            new SqlTest("SELECT f FROM (SELECT CAST(json_array_elements_text('[1,true, [2,false]]') AS VARCHAR) AS f) X WHERE f IN ('1', 'true', '[2,false]')", 1, 3),
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_array_elements_text('[1,true, [2,false]]') AS VARCHAR) AS f) X WHERE f IN ('1', 'true', '[2, false]')", 1, 3),
+
+            // json_typeof and jsonb_typeof
+            new SqlTest("SELECT f FROM (SELECT json_typeof('-123.4') AS f) X WHERE f IN ('number')", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT jsonb_typeof('-123.4') AS f) X WHERE f IN ('number')", 1, 1),
+
+            // json_strip_nulls and jsonb_strip_nulls
+            new SqlTest("SELECT f FROM (SELECT CAST(json_strip_nulls('[{\"f1\":1, \"f2\":null}, 2, null, 3]') AS VARCHAR) AS f) X WHERE f IN ('[{\"f1\":1},2,null,3]')", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_strip_nulls('[{\"f1\":1, \"f2\":null}, 2, null, 3]') AS VARCHAR) AS f) X WHERE f IN ('[{\"f1\": 1}, 2, null, 3]')", 1, 1),
+
+            // jsonb_pretty
+            new SqlTest("SELECT f FROM (SELECT jsonb_pretty('[{\"f1\":1,\"f2\":null}, 2]') AS f) X WHERE f LIKE '%        \"f2\": null%'", 1, 1),
+
+            // jsonb_set and jsonb_set_lax
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_set('[{\"f1\":1,\"f2\":null},2,null,3]', '{0,f1}', '[2,3,4]', false) AS VARCHAR) AS f) X WHERE f = '[{\"f1\": [2, 3, 4], \"f2\": null}, 2, null, 3]'", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_set('[{\"f1\":1,\"f2\":null},2,null,3]', '{0,f1}', '[2,3,4]') AS VARCHAR) AS f) X WHERE f = '[{\"f1\": [2, 3, 4], \"f2\": null}, 2, null, 3]'", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_set_lax('[{\"f1\":1,\"f2\":null},2,null,3]', '{0,f1}', null) AS VARCHAR) AS f) X WHERE f = '[{\"f1\": null, \"f2\": null}, 2, null, 3]'", 1, 1),
+
+            // jsonb_insert
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_insert('{\"a\": [0,1,2]}', '{a, 1}', '\"new_value\"') AS VARCHAR) AS f) X WHERE f = '{\"a\": [0, \"new_value\", 1, 2]}'", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_insert('{\"a\": [0,1,2]}', '{a, 1}', '\"new_value\"', true) AS VARCHAR) AS f) X WHERE f = '{\"a\": [0, 1, \"new_value\", 2]}'", 1, 1),
+
+            // jsonb_path_exists
+            new SqlTest("SELECT f FROM (SELECT jsonb_path_exists('{\"a\":[1,2,3,4,5]}', '$.a[*] ? (@ >= $min && @ <= $max)', '{\"min\":2, \"max\":4}') AS f) X WHERE f = true", 1, 1),
+
+            // jsonb_path_match
+            new SqlTest("SELECT f FROM (SELECT jsonb_path_match('{\"a\":[1,2,3,4,5]}', 'exists($.a[*] ? (@ >= $min && @ <= $max))', '{\"min\":2, \"max\":4}') AS f) X WHERE f = true", 1, 1),
+
+            // jsonb_path_query
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query('{\"a\":[1,2,3,4,5]}', '$.a[*] ? (@ >= $min && @ <= $max)', '{\"min\":2, \"max\":4}') AS VARCHAR) AS f) X WHERE f IN ('2', '3', '4')", 1, 3),
+
+            // jsonb_path_query_array
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query_array('{\"a\":[1,2,3,4,5]}', '$.a[*] ? (@ >= $min && @ <= $max)', '{\"min\":2, \"max\":4}') AS VARCHAR) AS f) X WHERE f = '[2, 3, 4]'", 1, 1),
+
+            // jsonb_path_query_first
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query_first('{\"a\":[1,2,3,4,5]}', '$.a[*] ? (@ >= $min && @ <= $max)', '{\"min\":2, \"max\":4}') AS VARCHAR) AS f) X WHERE f = '2'", 1, 1),
+
+            // jsonb_path_exists_tz, jsonb_path_match_tz, jsonb_path_query_tz, jsonb_path_query_array_tz, jsonb_path_query_first_tz
+            new SqlTest("SELECT f FROM (SELECT jsonb_path_exists_tz('[\"2015-08-01 12:00:00 -05\"]', '$[*] ? (@.datetime() < \"2015-08-02\".datetime())') AS f) X WHERE f = false", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT jsonb_path_match_tz('[\"2015-08-01 12:00:00 -05\"]', 'exists($[*] ? (@.datetime() > \"2015-08-02\".datetime()))') AS f) X WHERE f = false", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query_tz('[\"2015-08-01 12:00:00 -05\"]', '$[*] ? (@.datetime() < \"2016-08-02\".datetime())') AS VARCHAR) AS f) X", 1, 0),
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query_array_tz('[\"2015-08-01 12:00:00 -05\"]', '$[*] ? (@.datetime() < \"2016-08-02\".datetime())') AS VARCHAR) AS f) X WHERE f = '[]'", 1, 1),
+            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query_first_tz('[\"2015-08-01 12:00:00 -05\"]', '$[*] ? (@.datetime() < \"2016-08-02\".datetime())') AS VARCHAR) AS f) X WHERE f IS NULL", 1, 1)
+        );
+    }
 
 
-	static SqlTest[] negative = new SqlTest[]
+	static List<SqlTest> negative()
 	{
-        new FailTest("SELECT lists.R.d, lists.R.seven FROM R"),  // Schema-qualified column names work only if FROM specifies schema
-		new FailTest("SELECT S.d, S.seven FROM S"),
-		new FailTest("SELECT S.d, S.seven FROM Folder.S"),
-		new FailTest("SELECT S.d, S.seven FROM Folder.qtest.S"),
-		new FailTest("SELECT S.d, S.seven FROM Folder.qtest.list.S"),
-        new FailTest("SELECT SUM(*) FROM R"),
-        new FailTest("SELECT d FROM R A inner join R B on 1=1"),            // ambiguous
-        new FailTest("SELECT R.d, seven FROM lists.R A"),                    // R is hidden
-        new FailTest("SELECT A.d, B.d FROM lists.R A INNER JOIN lists.R B"),     // ON expected
-        new FailTest("SELECT A.d, B.d FROM lists.R A CROSS JOIN lists.R B ON A.d = B.d"),     // ON unexpected
-        new FailTest("SELECT A.d FROM lists.R A WHERE A.StartsWith('x')"),     // bad method 17128
-        new FailTest("SELECT A.d FROM lists.R A WHERE Z.StartsWith('x')"),     // bad method
-        new FailTest("SELECT A.d FROM lists.R A WHERE A.d.StartsWith('x')"),     // bad method
-        new FailTest("WITH peeps AS (SELECT * FROM R), peeps AS (SELECT * FROM peeps1 UNION ALL SELECT * FROM peeps WHERE (1=0)) SELECT * FROM peeps"),   // Duplicate CTE names
-        new FailTest("WITH peeps AS (SELECT * FROM R), peeps1 AS (SELECT * FROM peeps1 UNION ALL SELECT * FROM peeps WHERE (1=0)) SELECT * FROM peeps"),  // CTE can't reference itself in first clause of UNION
-        new FailTest("WITH peeps AS (SELECT * FROM peeps1), peeps1 AS (SELECT * FROM R) SELECT * FROM peeps"),    // Forward reference
-        new FailTest("WITH peeps1 AS (SELECT * FROM R), peeps AS (SELECT * FROM peeps1 UNION ALL SELECT * FROM peeps WHERE (1=0) UNION ALL SELECT * FROM peeps WHERE (1=0)) SELECT * FROM peeps"),  // Can't have 2 recursive references
-        new FailTest("WITH peeps AS (SELECT * FROM R), peeps2 AS (SELECT seven FROM peeps UNION ALL SELECT date FROM peeps) SELECT * FROM peeps2"),   // Column type mismatch
-        new FailTest("WITH peeps2 AS (SELECT seven FROM R UNION SELECT seven FROM S WHERE S.seven IN (SELECT seven FROM peeps2) ) SELECT * FROM peeps2"),
+        return List.of(
+            new FailTest("SELECT lists.R.d, lists.R.seven FROM R"),  // Schema-qualified column names work only if FROM specifies schema
+            new FailTest("SELECT S.d, S.seven FROM S"),
+            new FailTest("SELECT S.d, S.seven FROM Folder.S"),
+            new FailTest("SELECT S.d, S.seven FROM Folder.qtest.S"),
+            new FailTest("SELECT S.d, S.seven FROM Folder.qtest.list.S"),
+            new FailTest("SELECT SUM(*) FROM R"),
+            new FailTest("SELECT d FROM R A inner join R B on 1=1"),            // ambiguous
+            new FailTest("SELECT R.d, seven FROM lists.R A"),                    // R is hidden
+            new FailTest("SELECT A.d, B.d FROM lists.R A INNER JOIN lists.R B"),     // ON expected
+            new FailTest("SELECT A.d, B.d FROM lists.R A CROSS JOIN lists.R B ON A.d = B.d"),     // ON unexpected
+            new FailTest("SELECT A.d FROM lists.R A WHERE A.StartsWith('x')"),     // bad method 17128
+            new FailTest("SELECT A.d FROM lists.R A WHERE Z.StartsWith('x')"),     // bad method
+            new FailTest("SELECT A.d FROM lists.R A WHERE A.d.StartsWith('x')"),     // bad method
+            new FailTest("WITH peeps AS (SELECT * FROM R), peeps AS (SELECT * FROM peeps1 UNION ALL SELECT * FROM peeps WHERE (1=0)) SELECT * FROM peeps"),   // Duplicate CTE names
+            new FailTest("WITH peeps AS (SELECT * FROM R), peeps1 AS (SELECT * FROM peeps1 UNION ALL SELECT * FROM peeps WHERE (1=0)) SELECT * FROM peeps"),  // CTE can't reference itself in first clause of UNION
+            new FailTest("WITH peeps AS (SELECT * FROM peeps1), peeps1 AS (SELECT * FROM R) SELECT * FROM peeps"),    // Forward reference
+            new FailTest("WITH peeps1 AS (SELECT * FROM R), peeps AS (SELECT * FROM peeps1 UNION ALL SELECT * FROM peeps WHERE (1=0) UNION ALL SELECT * FROM peeps WHERE (1=0)) SELECT * FROM peeps"),  // Can't have 2 recursive references
+            new FailTest("WITH peeps AS (SELECT * FROM R), peeps2 AS (SELECT seven FROM peeps UNION ALL SELECT date FROM peeps) SELECT * FROM peeps2"),   // Column type mismatch
+            new FailTest("WITH peeps2 AS (SELECT seven FROM R UNION SELECT seven FROM S WHERE S.seven IN (SELECT seven FROM peeps2) ) SELECT * FROM peeps2"),
 
-        // UNDONE: should work since R.seven and seven are the same
-        new FailTest("SELECT R.seven, twelve, COUNT(*) as C FROM R GROUP BY seven, twelve PIVOT C BY seven IN (0, 1, 2, 3, 4, 5, 6)"),
+            // UNDONE: should work since R.seven and seven are the same
+            new FailTest("SELECT R.seven, twelve, COUNT(*) as C FROM R GROUP BY seven, twelve PIVOT C BY seven IN (0, 1, 2, 3, 4, 5, 6)"),
 
-        new FailTest("SELECT A.Name FROM core.Modules A FULL JOIN core.Modules B ON B.Name=C.Name FULL JOIN core.Modules C ON A.Name=C.Name"), // Missing from-clause entry
+            new FailTest("SELECT A.Name FROM core.Modules A FULL JOIN core.Modules B ON B.Name=C.Name FULL JOIN core.Modules C ON A.Name=C.Name"), // Missing from-clause entry
 
-        // trailing semicolon in subselect
-        new FailTest("SELECT Parent FROM (SELECT Parent FROM core.containers;) AS X"),
+            // trailing semicolon in subselect
+            new FailTest("SELECT Parent FROM (SELECT Parent FROM core.containers;) AS X"),
 
-        // Regression test for Issue 40618: Generate better error message when PIVOT column list can't be computed due to bad sql
-        new FailTest("SELECT A, B, count(*) As C " +
-            "FROM (SELECT seven as A, twelve/0 AS B FROM lists.R) " +
-            "GROUP BY A, B " +
-            "PIVOT C BY B", false),
+            // Regression test for Issue 40618: Generate better error message when PIVOT column list can't be computed due to bad sql
+            new FailTest("SELECT A, B, count(*) As C " +
+                "FROM (SELECT seven as A, twelve/0 AS B FROM lists.R) " +
+                "GROUP BY A, B " +
+                "PIVOT C BY B", false),
 
-        // VALUES tests
-        new FailTest("SELECT column1, column2 FROM (VALUES (CAST('1' as VARCHAR), CAST('1' as INTEGER)), ('two', 2))"), // require alias
-        new FailTest("SELECT column1, column2 FROM (VALUES (a,b),(1,2)) as x"), // can't use identifiers
+            // VALUES tests
+            new FailTest("SELECT column1, column2 FROM (VALUES (CAST('1' as VARCHAR), CAST('1' as INTEGER)), ('two', 2))"), // require alias
+            new FailTest("SELECT column1, column2 FROM (VALUES (a,b),(1,2)) as x") // can't use identifiers
+        );
     };
 
-    private static final InvolvedColumnsTest[] involvedColumnsTests = new InvolvedColumnsTest[]
+    private static List<InvolvedColumnsTest> involvedColumnsTests()
     {
-        new InvolvedColumnsTest("SELECT R.seven FROM R UNION SELECT S.seven FROM Folder.qtest.lists.S S",
-                                Arrays.asList("R/seven", "S/seven")),
-        new InvolvedColumnsTest("SELECT R.seven FROM R UNION ALL SELECT S.seven FROM Folder.qtest.lists.S S",
-                                Arrays.asList("R/seven", "S/seven")),
-        new InvolvedColumnsTest("SELECT 'R' as x, R.seven FROM R UNION SELECT 'S' as x, S.seven FROM Folder.qtest.lists.S S",
-                Arrays.asList("R/seven", "S/seven")),
-        new InvolvedColumnsTest("SELECT 'R' as x, R.seven FROM R UNION SELECT 'S' as x, S.seven FROM Folder.qtest.lists.S S UNION SELECT 'T' as t, R.twelve FROM R",
-                                Arrays.asList("R/seven", "S/seven", "R/twelve")),
-        new InvolvedColumnsTest("(SELECT 'R' as x, R.seven FROM R) UNION (SELECT 'S' as x, S.seven FROM Folder.qtest.lists.S S UNION SELECT 'T' as t, R.twelve FROM R)",
-                                Arrays.asList("R/seven", "S/seven", "R/twelve")),
-        new InvolvedColumnsTest("(SELECT x, y FROM (SELECT 'S' as x, S.seven as y FROM Folder.qtest.lists.S S UNION SELECT 'T' as t, R.twelve as y FROM R) UNION (SELECT 'R' as x, R.seven as y FROM R))",
-                                Arrays.asList("R/seven", "S/seven", "R/twelve")),
+        return List.of(
+            new InvolvedColumnsTest("SELECT R.seven FROM R UNION SELECT S.seven FROM Folder.qtest.lists.S S",
+                                    Arrays.asList("R/seven", "S/seven")),
+            new InvolvedColumnsTest("SELECT R.seven FROM R UNION ALL SELECT S.seven FROM Folder.qtest.lists.S S",
+                                    Arrays.asList("R/seven", "S/seven")),
+            new InvolvedColumnsTest("SELECT 'R' as x, R.seven FROM R UNION SELECT 'S' as x, S.seven FROM Folder.qtest.lists.S S",
+                    Arrays.asList("R/seven", "S/seven")),
+            new InvolvedColumnsTest("SELECT 'R' as x, R.seven FROM R UNION SELECT 'S' as x, S.seven FROM Folder.qtest.lists.S S UNION SELECT 'T' as t, R.twelve FROM R",
+                                    Arrays.asList("R/seven", "S/seven", "R/twelve")),
+            new InvolvedColumnsTest("(SELECT 'R' as x, R.seven FROM R) UNION (SELECT 'S' as x, S.seven FROM Folder.qtest.lists.S S UNION SELECT 'T' as t, R.twelve FROM R)",
+                                    Arrays.asList("R/seven", "S/seven", "R/twelve")),
+            new InvolvedColumnsTest("(SELECT x, y FROM (SELECT 'S' as x, S.seven as y FROM Folder.qtest.lists.S S UNION SELECT 'T' as t, R.twelve as y FROM R) UNION (SELECT 'R' as x, R.seven as y FROM R))",
+                                    Arrays.asList("R/seven", "S/seven", "R/twelve")),
 
-        new InvolvedColumnsTest("SELECT R.seven FROM R UNION SELECT R.seven FROM R UNION SELECT R.twelve FROM R",
-                                Arrays.asList("R/seven", "R/twelve")),
-        new InvolvedColumnsTest("(SELECT R.seven FROM R UNION SELECT R.seven FROM R) UNION ALL SELECT R.twelve FROM R",
-                                Arrays.asList("R/seven", "R/twelve")),
-        new InvolvedColumnsTest("(SELECT R.seven FROM R UNION ALL SELECT R.seven FROM R) UNION SELECT R.twelve FROM R",
-                                Arrays.asList("R/seven", "R/twelve")),
-        new InvolvedColumnsTest("SELECT R.seven FROM R UNION ALL SELECT R.seven FROM R UNION ALL SELECT R.twelve FROM R",
-                                Arrays.asList("R/seven", "R/twelve")),
-        new InvolvedColumnsTest("SELECT u.seven FROM (SELECT R.seven FROM R UNION SELECT R.seven FROM R UNION SELECT R.twelve FROM R) u WHERE u.seven > 5",
-                                Arrays.asList("R/seven", "R/twelve")),
+            new InvolvedColumnsTest("SELECT R.seven FROM R UNION SELECT R.seven FROM R UNION SELECT R.twelve FROM R",
+                                    Arrays.asList("R/seven", "R/twelve")),
+            new InvolvedColumnsTest("(SELECT R.seven FROM R UNION SELECT R.seven FROM R) UNION ALL SELECT R.twelve FROM R",
+                                    Arrays.asList("R/seven", "R/twelve")),
+            new InvolvedColumnsTest("(SELECT R.seven FROM R UNION ALL SELECT R.seven FROM R) UNION SELECT R.twelve FROM R",
+                                    Arrays.asList("R/seven", "R/twelve")),
+            new InvolvedColumnsTest("SELECT R.seven FROM R UNION ALL SELECT R.seven FROM R UNION ALL SELECT R.twelve FROM R",
+                                    Arrays.asList("R/seven", "R/twelve")),
+            new InvolvedColumnsTest("SELECT u.seven FROM (SELECT R.seven FROM R UNION SELECT R.seven FROM R UNION SELECT R.twelve FROM R) u WHERE u.seven > 5",
+                                    Arrays.asList("R/seven", "R/twelve")),
 
-        new InvolvedColumnsTest("SELECT R.seven FROM R ORDER BY twelve",
-                                Arrays.asList("R/seven", "R/twelve")),
-        new InvolvedColumnsTest("SELECT seven, twelve, COUNT(*) as C FROM R GROUP BY seven, twelve PIVOT C BY seven IN (0, 1, 2, 3, 4, 5, 6) ORDER BY twelve LIMIT 4",
-                                Arrays.asList("R/seven", "R/twelve")),
-        new InvolvedColumnsTest("SELECT MAX(R.seven) FROM R GROUP BY twelve",
-                                   Arrays.asList("R/seven", "R/twelve")),
-        new InvolvedColumnsTest("SELECT MAX(seven) As MaxSeven, twelve FROM R GROUP BY twelve PIVOT MaxSeven BY twelve",
-                                   Arrays.asList("R/seven", "R/twelve")),
+            new InvolvedColumnsTest("SELECT R.seven FROM R ORDER BY twelve",
+                                    Arrays.asList("R/seven", "R/twelve")),
+            new InvolvedColumnsTest("SELECT seven, twelve, COUNT(*) as C FROM R GROUP BY seven, twelve PIVOT C BY seven IN (0, 1, 2, 3, 4, 5, 6) ORDER BY twelve LIMIT 4",
+                                    Arrays.asList("R/seven", "R/twelve")),
+            new InvolvedColumnsTest("SELECT MAX(R.seven) FROM R GROUP BY twelve",
+                                       Arrays.asList("R/seven", "R/twelve")),
+            new InvolvedColumnsTest("SELECT MAX(seven) As MaxSeven, twelve FROM R GROUP BY twelve PIVOT MaxSeven BY twelve",
+                                       Arrays.asList("R/seven", "R/twelve"))
+        );
     };
 
     @TestWhen(TestWhen.When.BVT)
@@ -2225,13 +2326,13 @@ d,seven,twelve,day,month,date,duration,guid
 
 			if (dialect.isPostgreSQL())
 			{
-				for (SqlTest test : postgresOnlyFunctions)
+				for (SqlTest test : postgresOnlyFunctions())
                 {
 					test.validate(this, null);
                 }
 			}
 
-			for (SqlTest test : negative)
+			for (SqlTest test : negative())
 			{
 				test.validate(this, null);
 			}
@@ -2246,7 +2347,7 @@ d,seven,twelve,day,month,date,duration,guid
                 }
             }
 
-            for (InvolvedColumnsTest test : involvedColumnsTests)
+            for (InvolvedColumnsTest test : involvedColumnsTests())
             {
                 test.validate(this, null);
             }

--- a/query/src/org/labkey/query/sql/Query.java
+++ b/query/src/org/labkey/query/sql/Query.java
@@ -36,6 +36,7 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.OORDisplayColumnFactory;
@@ -44,6 +45,7 @@ import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
+import org.labkey.api.data.dialect.PostgreSql91Dialect;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.exp.PropertyType;
@@ -1889,136 +1891,152 @@ d,seven,twelve,day,month,date,duration,guid
 
     static List<SqlTest> postgresOnlyFunctions()
     {
-        return List.of(
-            new SqlTest("SELECT stddev_samp(d), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT var_samp(d), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT bool_and((d < 0)), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT bool_or((d < 0)), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT every((d > 0)), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT bit_or(seven), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT bit_and(seven), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT mode(seven), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT corr(seven, d), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT corr(seven, d), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT covar_pop(seven, d), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT covar_samp(seven, d), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT regr_avgx(seven, d), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT regr_avgy(seven, d), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT regr_count(seven, d), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT regr_intercept(seven, d), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT regr_r2(seven, d), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT regr_slope(seven, d), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT regr_sxx(seven, d), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT regr_sxy(seven, d), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT regr_syy(seven, d), day FROM R GROUP BY day", 2, 7),
-            new SqlTest("SELECT 'similar' WHERE similar_to('abc','abc')", 1, 1),
-            new SqlTest("SELECT 'similar' WHERE similar_to('abc','a')", 1, 0),
-            new SqlTest("SELECT 'similar' WHERE similar_to('abc','%(b|d)%')", 1, 1),
-            new SqlTest("SELECT 'similar' WHERE similar_to('abc','(b|c)%')", 1, 0),
-            new SqlTest("SELECT 'similar' WHERE similar_to('abc|','abc\\|', '\\')", 1, 1),
+        int majorVersion = ((PostgreSql91Dialect)CoreSchema.getInstance().getSqlDialect()).getMajorVersion();
 
-            // parse_json, parse_jsonb, and json_op
-            new SqlTest("SELECT parse_jsonb('{\"a\":1, \"b\":null}')", 1, 1),
-            new SqlTest("SELECT json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a')", 1, 1),
-            // Postgres 9.6 doesn't support direct JSONB and JSON to INTEGER casting, so use VARCHAR for our simple purposes
-            new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f != '1'", 1, 0),
-            new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f = '1'", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_json('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f != '1'", 1, 0),
-            new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_json('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f = '1'", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_json('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f = '1'", 1, 1),
+        List<SqlTest> result = new ArrayList<>(
+            List.of(
+                new SqlTest("SELECT stddev_samp(d), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT var_samp(d), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT bool_and((d < 0)), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT bool_or((d < 0)), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT every((d > 0)), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT bit_or(seven), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT bit_and(seven), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT mode(seven), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT corr(seven, d), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT corr(seven, d), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT covar_pop(seven, d), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT covar_samp(seven, d), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT regr_avgx(seven, d), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT regr_avgy(seven, d), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT regr_count(seven, d), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT regr_intercept(seven, d), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT regr_r2(seven, d), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT regr_slope(seven, d), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT regr_sxx(seven, d), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT regr_sxy(seven, d), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT regr_syy(seven, d), day FROM R GROUP BY day", 2, 7),
+                new SqlTest("SELECT 'similar' WHERE similar_to('abc','abc')", 1, 1),
+                new SqlTest("SELECT 'similar' WHERE similar_to('abc','a')", 1, 0),
+                new SqlTest("SELECT 'similar' WHERE similar_to('abc','%(b|d)%')", 1, 1),
+                new SqlTest("SELECT 'similar' WHERE similar_to('abc','(b|c)%')", 1, 0),
+                new SqlTest("SELECT 'similar' WHERE similar_to('abc|','abc\\|', '\\')", 1, 1),
 
-            // to_json and to_jsonb
-            new SqlTest("SELECT f FROM (SELECT CAST(to_json(CAST('{\"a\":1, \"b\":null}' AS VARCHAR)) AS VARCHAR) AS f) X WHERE f = '\"{\\\"a\\\":1, \\\"b\\\":null}\"'", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(to_jsonb(CAST('{\"a\":1, \"b\":null}' AS VARCHAR)) AS VARCHAR) AS f) X WHERE f = '\"{\\\"a\\\":1, \\\"b\\\":null}\"'", 1, 1),
+                // parse_json, parse_jsonb, and json_op
+                new SqlTest("SELECT parse_jsonb('{\"a\":1, \"b\":null}')", 1, 1),
+                new SqlTest("SELECT json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a')", 1, 1),
+                // Postgres 9.6 doesn't support direct JSONB and JSON to INTEGER casting, so use VARCHAR for our simple purposes
+                new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f != '1'", 1, 0),
+                new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_jsonb('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f = '1'", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_json('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f != '1'", 1, 0),
+                new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_json('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f = '1'", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT CAST(json_op(parse_json('{\"a\":1, \"b\":null}'), '->', 'a') AS VARCHAR) AS f) X WHERE f = '1'", 1, 1),
 
-            // array_to_json
-            new SqlTest("SELECT f FROM (SELECT CAST(array_to_json(string_to_array('xx~^~yy~^~zz', '~^~', 'yy')) AS VARCHAR) AS f) X WHERE f = '[\"xx\",null,\"zz\"]'", 1, 1),
+                // to_json and to_jsonb
+                new SqlTest("SELECT f FROM (SELECT CAST(to_json(CAST('{\"a\":1, \"b\":null}' AS VARCHAR)) AS VARCHAR) AS f) X WHERE f = '\"{\\\"a\\\":1, \\\"b\\\":null}\"'", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT CAST(to_jsonb(CAST('{\"a\":1, \"b\":null}' AS VARCHAR)) AS VARCHAR) AS f) X WHERE f = '\"{\\\"a\\\":1, \\\"b\\\":null}\"'", 1, 1),
 
-            // row_to_json
-            new SqlTest("SELECT f FROM (SELECT CAST(row_to_json(row(1,'foo')) AS VARCHAR) AS f) X WHERE f = '{\"f1\":1,\"f2\":\"foo\"}'", 1, 1),
+                // array_to_json
+                new SqlTest("SELECT f FROM (SELECT CAST(array_to_json(string_to_array('xx~^~yy~^~zz', '~^~', 'yy')) AS VARCHAR) AS f) X WHERE f = '[\"xx\",null,\"zz\"]'", 1, 1),
 
-            // json_build_array and jsonb_build_array
-            new SqlTest("SELECT f FROM (SELECT CAST(json_build_array(1, 2, 'foo', 4, 5) AS VARCHAR) AS f) X WHERE f = '[1, 2, \"foo\", 4, 5]'", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_build_array(1, 2, 'foo', 4, 5) AS VARCHAR) AS f) X WHERE f = '[1, 2, \"foo\", 4, 5]'", 1, 1),
+                // row_to_json
+                new SqlTest("SELECT f FROM (SELECT CAST(row_to_json(row(1,'foo')) AS VARCHAR) AS f) X WHERE f = '{\"f1\":1,\"f2\":\"foo\"}'", 1, 1),
 
-            // json_build_object and jsonb_build_object
-            new SqlTest("SELECT f FROM (SELECT CAST(json_build_object('foo', 1, 2, row(3,'bar')) AS VARCHAR) AS f) X WHERE f = '{\"foo\" : 1, \"2\" : {\"f1\":3,\"f2\":\"bar\"}}'", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_build_object('foo', 1, 2, row(3,'bar')) AS VARCHAR) AS f) X WHERE f = '{\"2\": {\"f1\": 3, \"f2\": \"bar\"}, \"foo\": 1}'", 1, 1),
+                // json_build_array and jsonb_build_array
+                new SqlTest("SELECT f FROM (SELECT CAST(json_build_array(1, 2, 'foo', 4, 5) AS VARCHAR) AS f) X WHERE f = '[1, 2, \"foo\", 4, 5]'", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT CAST(jsonb_build_array(1, 2, 'foo', 4, 5) AS VARCHAR) AS f) X WHERE f = '[1, 2, \"foo\", 4, 5]'", 1, 1),
 
-            // json_object and jsonb_object
-            new SqlTest("SELECT f FROM (SELECT CAST(json_object('{a, 1, b, \"def\", c, 3.5}') AS VARCHAR) AS f) X WHERE f = '{\"a\" : \"1\", \"b\" : \"def\", \"c\" : \"3.5\"}'", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_object('{a, 1, b, \"def\", c, 3.5}') AS VARCHAR) AS f) X WHERE f = '{\"a\": \"1\", \"b\": \"def\", \"c\": \"3.5\"}'", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(json_object('{a,b}', '{1,2}') AS VARCHAR) AS f) X WHERE f = '{\"a\" : \"1\", \"b\" : \"2\"}'", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_object('{a,b}', '{1,2}') AS VARCHAR) AS f) X WHERE f = '{\"a\": \"1\", \"b\": \"2\"}'", 1, 1),
+                // json_build_object and jsonb_build_object
+                new SqlTest("SELECT f FROM (SELECT CAST(json_build_object('foo', 1, 2, row(3,'bar')) AS VARCHAR) AS f) X WHERE f = '{\"foo\" : 1, \"2\" : {\"f1\":3,\"f2\":\"bar\"}}'", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT CAST(jsonb_build_object('foo', 1, 2, row(3,'bar')) AS VARCHAR) AS f) X WHERE f = '{\"2\": {\"f1\": 3, \"f2\": \"bar\"}, \"foo\": 1}'", 1, 1),
 
-            // json_array_length and jsonb_array_length
-            new SqlTest("SELECT f FROM (SELECT json_array_length(json_build_array(1, 2, 'foo', 4, 5)) AS f) X WHERE f = 5", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT jsonb_array_length(jsonb_build_array(1, 2, 'foo', 4, 5)) AS f) X WHERE f = 5", 1, 1),
+                // json_object and jsonb_object
+                new SqlTest("SELECT f FROM (SELECT CAST(json_object('{a, 1, b, \"def\", c, 3.5}') AS VARCHAR) AS f) X WHERE f = '{\"a\" : \"1\", \"b\" : \"def\", \"c\" : \"3.5\"}'", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT CAST(jsonb_object('{a, 1, b, \"def\", c, 3.5}') AS VARCHAR) AS f) X WHERE f = '{\"a\": \"1\", \"b\": \"def\", \"c\": \"3.5\"}'", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT CAST(json_object('{a,b}', '{1,2}') AS VARCHAR) AS f) X WHERE f = '{\"a\" : \"1\", \"b\" : \"2\"}'", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT CAST(jsonb_object('{a,b}', '{1,2}') AS VARCHAR) AS f) X WHERE f = '{\"a\": \"1\", \"b\": \"2\"}'", 1, 1),
 
-            // json_each and jsonb_each, json_each_text and jsonb_each_text
-            new SqlTest("SELECT json_each(parse_json('{\"a\":\"foo\", \"b\":\"bar\"}'))", 1, 2),
-            new SqlTest("SELECT jsonb_each(parse_jsonb('{\"a\":\"foo\", \"b\":\"bar\"}'))", 1, 2),
-            new SqlTest("SELECT json_each_text(parse_json('{\"a\":\"foo\", \"b\":\"bar\"}'))", 1, 2),
-            new SqlTest("SELECT jsonb_each_text(parse_jsonb('{\"a\":\"foo\", \"b\":\"bar\"}'))", 1, 2),
+                // json_array_length and jsonb_array_length
+                new SqlTest("SELECT f FROM (SELECT json_array_length(json_build_array(1, 2, 'foo', 4, 5)) AS f) X WHERE f = 5", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT jsonb_array_length(jsonb_build_array(1, 2, 'foo', 4, 5)) AS f) X WHERE f = 5", 1, 1),
 
-            // json_extract_path and jsonb_extract_path, json_extract_path_text and jsonb_extract_path_text
-            new SqlTest("SELECT f FROM (SELECT CAST(json_extract_path('{\"f2\":{\"f3\":1},\"f4\":{\"f5\":99,\"f6\":\"foo\"}}', 'f4', 'f6') AS VARCHAR) AS f) X WHERE f = '\"foo\"'", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_extract_path('{\"f2\":{\"f3\":1},\"f4\":{\"f5\":99,\"f6\":\"foo\"}}', 'f4', 'f6') AS VARCHAR) AS f) X WHERE f = '\"foo\"'", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(json_extract_path_text('{\"f2\":{\"f3\":1},\"f4\":{\"f5\":99,\"f6\":\"foo\"}}', 'f4', 'f6') AS VARCHAR) AS f) X WHERE f = 'foo'", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_extract_path_text('{\"f2\":{\"f3\":1},\"f4\":{\"f5\":99,\"f6\":\"foo\"}}', 'f4', 'f6') AS VARCHAR) AS f) X WHERE f = 'foo'", 1, 1),
+                // json_each and jsonb_each, json_each_text and jsonb_each_text
+                new SqlTest("SELECT json_each(parse_json('{\"a\":\"foo\", \"b\":\"bar\"}'))", 1, 2),
+                new SqlTest("SELECT jsonb_each(parse_jsonb('{\"a\":\"foo\", \"b\":\"bar\"}'))", 1, 2),
+                new SqlTest("SELECT json_each_text(parse_json('{\"a\":\"foo\", \"b\":\"bar\"}'))", 1, 2),
+                new SqlTest("SELECT jsonb_each_text(parse_jsonb('{\"a\":\"foo\", \"b\":\"bar\"}'))", 1, 2),
 
-            // json_object_keys and jsonb_object_keys
-            new SqlTest("SELECT f FROM (SELECT json_object_keys('{\"f1\":\"abc\",\"f2\":{\"f3\":\"a\", \"f4\":\"b\"}}') AS f) X WHERE f IN ('f1', 'f2')", 1, 2),
-            new SqlTest("SELECT f FROM (SELECT jsonb_object_keys('{\"f1\":\"abc\",\"f2\":{\"f3\":\"a\", \"f4\":\"b\"}}') AS f) X WHERE f IN ('f1', 'f2')", 1, 2),
+                // json_extract_path and jsonb_extract_path, json_extract_path_text and jsonb_extract_path_text
+                new SqlTest("SELECT f FROM (SELECT CAST(json_extract_path('{\"f2\":{\"f3\":1},\"f4\":{\"f5\":99,\"f6\":\"foo\"}}', 'f4', 'f6') AS VARCHAR) AS f) X WHERE f = '\"foo\"'", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT CAST(jsonb_extract_path('{\"f2\":{\"f3\":1},\"f4\":{\"f5\":99,\"f6\":\"foo\"}}', 'f4', 'f6') AS VARCHAR) AS f) X WHERE f = '\"foo\"'", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT CAST(json_extract_path_text('{\"f2\":{\"f3\":1},\"f4\":{\"f5\":99,\"f6\":\"foo\"}}', 'f4', 'f6') AS VARCHAR) AS f) X WHERE f = 'foo'", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT CAST(jsonb_extract_path_text('{\"f2\":{\"f3\":1},\"f4\":{\"f5\":99,\"f6\":\"foo\"}}', 'f4', 'f6') AS VARCHAR) AS f) X WHERE f = 'foo'", 1, 1),
 
-            // json_array_elements and jsonb_array_elements, json_array_elements_text and jsonb_array_elements_text
-            new SqlTest("SELECT f FROM (SELECT CAST(json_array_elements('[1,true, [2,false]]') AS VARCHAR) AS f) X WHERE f IN ('1', 'true', '[2,false]')", 1, 3),
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_array_elements('[1,true, [2,false]]') AS VARCHAR) AS f) X WHERE f IN ('1', 'true', '[2, false]')", 1, 3),
-            new SqlTest("SELECT f FROM (SELECT CAST(json_array_elements_text('[1,true, [2,false]]') AS VARCHAR) AS f) X WHERE f IN ('1', 'true', '[2,false]')", 1, 3),
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_array_elements_text('[1,true, [2,false]]') AS VARCHAR) AS f) X WHERE f IN ('1', 'true', '[2, false]')", 1, 3),
+                // json_object_keys and jsonb_object_keys
+                new SqlTest("SELECT f FROM (SELECT json_object_keys('{\"f1\":\"abc\",\"f2\":{\"f3\":\"a\", \"f4\":\"b\"}}') AS f) X WHERE f IN ('f1', 'f2')", 1, 2),
+                new SqlTest("SELECT f FROM (SELECT jsonb_object_keys('{\"f1\":\"abc\",\"f2\":{\"f3\":\"a\", \"f4\":\"b\"}}') AS f) X WHERE f IN ('f1', 'f2')", 1, 2),
 
-            // json_typeof and jsonb_typeof
-            new SqlTest("SELECT f FROM (SELECT json_typeof('-123.4') AS f) X WHERE f IN ('number')", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT jsonb_typeof('-123.4') AS f) X WHERE f IN ('number')", 1, 1),
+                // json_array_elements and jsonb_array_elements, json_array_elements_text and jsonb_array_elements_text
+                new SqlTest("SELECT f FROM (SELECT CAST(json_array_elements('[1,true, [2,false]]') AS VARCHAR) AS f) X WHERE f IN ('1', 'true', '[2,false]')", 1, 3),
+                new SqlTest("SELECT f FROM (SELECT CAST(jsonb_array_elements('[1,true, [2,false]]') AS VARCHAR) AS f) X WHERE f IN ('1', 'true', '[2, false]')", 1, 3),
+                new SqlTest("SELECT f FROM (SELECT CAST(json_array_elements_text('[1,true, [2,false]]') AS VARCHAR) AS f) X WHERE f IN ('1', 'true', '[2,false]')", 1, 3),
+                new SqlTest("SELECT f FROM (SELECT CAST(jsonb_array_elements_text('[1,true, [2,false]]') AS VARCHAR) AS f) X WHERE f IN ('1', 'true', '[2, false]')", 1, 3),
 
-            // json_strip_nulls and jsonb_strip_nulls
-            new SqlTest("SELECT f FROM (SELECT CAST(json_strip_nulls('[{\"f1\":1, \"f2\":null}, 2, null, 3]') AS VARCHAR) AS f) X WHERE f IN ('[{\"f1\":1},2,null,3]')", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_strip_nulls('[{\"f1\":1, \"f2\":null}, 2, null, 3]') AS VARCHAR) AS f) X WHERE f IN ('[{\"f1\": 1}, 2, null, 3]')", 1, 1),
+                // json_typeof and jsonb_typeof
+                new SqlTest("SELECT f FROM (SELECT json_typeof('-123.4') AS f) X WHERE f IN ('number')", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT jsonb_typeof('-123.4') AS f) X WHERE f IN ('number')", 1, 1),
 
-            // jsonb_pretty
-            new SqlTest("SELECT f FROM (SELECT jsonb_pretty('[{\"f1\":1,\"f2\":null}, 2]') AS f) X WHERE f LIKE '%        \"f2\": null%'", 1, 1),
+                // json_strip_nulls and jsonb_strip_nulls
+                new SqlTest("SELECT f FROM (SELECT CAST(json_strip_nulls('[{\"f1\":1, \"f2\":null}, 2, null, 3]') AS VARCHAR) AS f) X WHERE f IN ('[{\"f1\":1},2,null,3]')", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT CAST(jsonb_strip_nulls('[{\"f1\":1, \"f2\":null}, 2, null, 3]') AS VARCHAR) AS f) X WHERE f IN ('[{\"f1\": 1}, 2, null, 3]')", 1, 1),
 
-            // jsonb_set and jsonb_set_lax
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_set('[{\"f1\":1,\"f2\":null},2,null,3]', '{0,f1}', '[2,3,4]', false) AS VARCHAR) AS f) X WHERE f = '[{\"f1\": [2, 3, 4], \"f2\": null}, 2, null, 3]'", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_set('[{\"f1\":1,\"f2\":null},2,null,3]', '{0,f1}', '[2,3,4]') AS VARCHAR) AS f) X WHERE f = '[{\"f1\": [2, 3, 4], \"f2\": null}, 2, null, 3]'", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_set_lax('[{\"f1\":1,\"f2\":null},2,null,3]', '{0,f1}', null) AS VARCHAR) AS f) X WHERE f = '[{\"f1\": null, \"f2\": null}, 2, null, 3]'", 1, 1),
+                // jsonb_pretty
+                new SqlTest("SELECT f FROM (SELECT jsonb_pretty('[{\"f1\":1,\"f2\":null}, 2]') AS f) X WHERE f LIKE '%        \"f2\": null%'", 1, 1),
 
-            // jsonb_insert
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_insert('{\"a\": [0,1,2]}', '{a, 1}', '\"new_value\"') AS VARCHAR) AS f) X WHERE f = '{\"a\": [0, \"new_value\", 1, 2]}'", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_insert('{\"a\": [0,1,2]}', '{a, 1}', '\"new_value\"', true) AS VARCHAR) AS f) X WHERE f = '{\"a\": [0, 1, \"new_value\", 2]}'", 1, 1),
+                // jsonb_set
+                new SqlTest("SELECT f FROM (SELECT CAST(jsonb_set('[{\"f1\":1,\"f2\":null},2,null,3]', '{0,f1}', '[2,3,4]', false) AS VARCHAR) AS f) X WHERE f = '[{\"f1\": [2, 3, 4], \"f2\": null}, 2, null, 3]'", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT CAST(jsonb_set('[{\"f1\":1,\"f2\":null},2,null,3]', '{0,f1}', '[2,3,4]') AS VARCHAR) AS f) X WHERE f = '[{\"f1\": [2, 3, 4], \"f2\": null}, 2, null, 3]'", 1, 1),
 
-            // jsonb_path_exists
-            new SqlTest("SELECT f FROM (SELECT jsonb_path_exists('{\"a\":[1,2,3,4,5]}', '$.a[*] ? (@ >= $min && @ <= $max)', '{\"min\":2, \"max\":4}') AS f) X WHERE f = true", 1, 1),
+                // jsonb_insert
+                new SqlTest("SELECT f FROM (SELECT CAST(jsonb_insert('{\"a\": [0,1,2]}', '{a, 1}', '\"new_value\"') AS VARCHAR) AS f) X WHERE f = '{\"a\": [0, \"new_value\", 1, 2]}'", 1, 1),
+                new SqlTest("SELECT f FROM (SELECT CAST(jsonb_insert('{\"a\": [0,1,2]}', '{a, 1}', '\"new_value\"', true) AS VARCHAR) AS f) X WHERE f = '{\"a\": [0, 1, \"new_value\", 2]}'", 1, 1)
+            ));
 
-            // jsonb_path_match
-            new SqlTest("SELECT f FROM (SELECT jsonb_path_match('{\"a\":[1,2,3,4,5]}', 'exists($.a[*] ? (@ >= $min && @ <= $max))', '{\"min\":2, \"max\":4}') AS f) X WHERE f = true", 1, 1),
+        if (majorVersion >= 12)
+        {
+            result.addAll(Arrays.asList(
+                    // jsonb_path_exists
+                    new SqlTest("SELECT f FROM (SELECT jsonb_path_exists('{\"a\":[1,2,3,4,5]}', '$.a[*] ? (@ >= $min && @ <= $max)', '{\"min\":2, \"max\":4}') AS f) X WHERE f = true", 1, 1),
 
-            // jsonb_path_query
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query('{\"a\":[1,2,3,4,5]}', '$.a[*] ? (@ >= $min && @ <= $max)', '{\"min\":2, \"max\":4}') AS VARCHAR) AS f) X WHERE f IN ('2', '3', '4')", 1, 3),
+                    // jsonb_path_match
+                    new SqlTest("SELECT f FROM (SELECT jsonb_path_match('{\"a\":[1,2,3,4,5]}', 'exists($.a[*] ? (@ >= $min && @ <= $max))', '{\"min\":2, \"max\":4}') AS f) X WHERE f = true", 1, 1),
 
-            // jsonb_path_query_array
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query_array('{\"a\":[1,2,3,4,5]}', '$.a[*] ? (@ >= $min && @ <= $max)', '{\"min\":2, \"max\":4}') AS VARCHAR) AS f) X WHERE f = '[2, 3, 4]'", 1, 1),
+                    // jsonb_path_query
+                    new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query('{\"a\":[1,2,3,4,5]}', '$.a[*] ? (@ >= $min && @ <= $max)', '{\"min\":2, \"max\":4}') AS VARCHAR) AS f) X WHERE f IN ('2', '3', '4')", 1, 3),
 
-            // jsonb_path_query_first
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query_first('{\"a\":[1,2,3,4,5]}', '$.a[*] ? (@ >= $min && @ <= $max)', '{\"min\":2, \"max\":4}') AS VARCHAR) AS f) X WHERE f = '2'", 1, 1),
+                    // jsonb_path_query_array
+                    new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query_array('{\"a\":[1,2,3,4,5]}', '$.a[*] ? (@ >= $min && @ <= $max)', '{\"min\":2, \"max\":4}') AS VARCHAR) AS f) X WHERE f = '[2, 3, 4]'", 1, 1),
 
-            // jsonb_path_exists_tz, jsonb_path_match_tz, jsonb_path_query_tz, jsonb_path_query_array_tz, jsonb_path_query_first_tz
-            new SqlTest("SELECT f FROM (SELECT jsonb_path_exists_tz('[\"2015-08-01 12:00:00 -05\"]', '$[*] ? (@.datetime() < \"2015-08-02\".datetime())') AS f) X WHERE f = false", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT jsonb_path_match_tz('[\"2015-08-01 12:00:00 -05\"]', 'exists($[*] ? (@.datetime() > \"2015-08-02\".datetime()))') AS f) X WHERE f = false", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query_tz('[\"2015-08-01 12:00:00 -05\"]', '$[*] ? (@.datetime() < \"2016-08-02\".datetime())') AS VARCHAR) AS f) X", 1, 0),
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query_array_tz('[\"2015-08-01 12:00:00 -05\"]', '$[*] ? (@.datetime() < \"2016-08-02\".datetime())') AS VARCHAR) AS f) X WHERE f = '[]'", 1, 1),
-            new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query_first_tz('[\"2015-08-01 12:00:00 -05\"]', '$[*] ? (@.datetime() < \"2016-08-02\".datetime())') AS VARCHAR) AS f) X WHERE f IS NULL", 1, 1)
-        );
+                    // jsonb_path_query_first
+                    new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query_first('{\"a\":[1,2,3,4,5]}', '$.a[*] ? (@ >= $min && @ <= $max)', '{\"min\":2, \"max\":4}') AS VARCHAR) AS f) X WHERE f = '2'", 1, 1)
+            ));
+        }
+
+        if (majorVersion >= 13)
+        {
+            result.addAll(Arrays.asList(
+                    // jsonb_set_lax
+                    new SqlTest("SELECT f FROM (SELECT CAST(jsonb_set_lax('[{\"f1\":1,\"f2\":null},2,null,3]', '{0,f1}', null) AS VARCHAR) AS f) X WHERE f = '[{\"f1\": null, \"f2\": null}, 2, null, 3]'", 1, 1),
+
+                    // jsonb_path_exists_tz, jsonb_path_match_tz, jsonb_path_query_tz, jsonb_path_query_array_tz, jsonb_path_query_first_tz
+                    new SqlTest("SELECT f FROM (SELECT jsonb_path_exists_tz('[\"2015-08-01 12:00:00 -05\"]', '$[*] ? (@.datetime() < \"2015-08-02\".datetime())') AS f) X WHERE f = false", 1, 1),
+                    new SqlTest("SELECT f FROM (SELECT jsonb_path_match_tz('[\"2015-08-01 12:00:00 -05\"]', 'exists($[*] ? (@.datetime() > \"2015-08-02\".datetime()))') AS f) X WHERE f = false", 1, 1),
+                    new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query_tz('[\"2015-08-01 12:00:00 -05\"]', '$[*] ? (@.datetime() < \"2016-08-02\".datetime())') AS VARCHAR) AS f) X", 1, 0),
+                    new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query_array_tz('[\"2015-08-01 12:00:00 -05\"]', '$[*] ? (@.datetime() < \"2016-08-02\".datetime())') AS VARCHAR) AS f) X WHERE f = '[]'", 1, 1),
+                    new SqlTest("SELECT f FROM (SELECT CAST(jsonb_path_query_first_tz('[\"2015-08-01 12:00:00 -05\"]', '$[*] ? (@.datetime() < \"2016-08-02\".datetime())') AS VARCHAR) AS f) X WHERE f IS NULL", 1, 1)
+            ));
+        }
+        return result;
     }
 
 


### PR DESCRIPTION
#### Rationale
A few of the Postgres JSON functions that we added as passthroughs require additional syntax that LabKey SQL doesn't handle yet. Postgres has added new functions too. Plus everyone benefits from automated test coverage

#### Changes
* Remove passthroughs for jsonb_to_record, jsonb_to_recordset, jsonb_populate_record, jsonb_populate_recordset
* Add passthroughs for jsonb_set_lax, jsonb_path_exists, jsonb_path_match, jsonb_path_query, jsonb_path_query_array, jsonb_path_query_first, jsonb_path_exists_tz, jsonb_path_match_tz, jsonb_path_query_tz, jsonb_path_query_array_tz, jsonb_path_query_first_tz
* Add basic test coverage for all JSON functions
* Conditionalize testing based on Postgres version