### PR TITLE
Issue 45333: Query Edit Metadata page doesn't load with query.queryName param

### DIFF
--- a/core/src/client/QueryMetadataEditor/QueryMetadataEditor.tsx
+++ b/core/src/client/QueryMetadataEditor/QueryMetadataEditor.tsx
@@ -45,7 +45,8 @@ interface IAppState {
     showResetConfirmationModal: boolean,
     showViewDataConfirmationModal: boolean,
     navigateAfterSave: boolean,
-    userDefinedQuery: boolean
+    userDefinedQuery: boolean,
+    error: string,
 }
 
 export class App extends PureComponent<any, Partial<IAppState>> {
@@ -56,27 +57,26 @@ export class App extends PureComponent<any, Partial<IAppState>> {
         super(props);
 
         const { schemaName, queryName, returnUrl } = ActionURL.getParameters();
+        const _queryName = queryName ?? ActionURL.getParameter('query.queryName');
 
-        let messages = List<IBannerMessage>();
-        if ((!schemaName || !queryName)) {
-            let msg =  'Missing required parameter: schemaName and queryName.';
-            let msgType = 'danger';
-            let bannerMsg ={message : msg, messageType : msgType};
-            messages = messages.push(bannerMsg);
+        let error;
+        if (!schemaName || !_queryName) {
+            error = 'Missing required parameter: schemaName and queryName.';
         }
 
         this.state = {
             schemaName,
-            queryName,
+            queryName: _queryName,
             returnUrl,
-            messages,
-            showAlias : false,
+            messages: List<IBannerMessage>(),
+            showAlias: false,
             showSave: true,
             showEditSourceConfirmationModal: false,
             showResetConfirmationModal: false,
             showViewDataConfirmationModal: false,
             navigateAfterSave: false,
-            userDefinedQuery: false
+            userDefinedQuery: false,
+            error,
         };
     }
 
@@ -311,12 +311,24 @@ export class App extends PureComponent<any, Partial<IAppState>> {
     }
 
     render() {
-        const { domain, showAlias, messages, showEditSourceConfirmationModal, showResetConfirmationModal, showViewDataConfirmationModal } = this.state;
+        const {
+            domain,
+            showAlias,
+            messages,
+            showEditSourceConfirmationModal,
+            showResetConfirmationModal,
+            showViewDataConfirmationModal,
+            error,
+        } = this.state;
         const isLoading = domain === undefined;
 
-        if (isLoading) {
-            return <LoadingSpinner/>
+        if (error) {
+            return <Alert>{error}</Alert>;
         }
+        if (isLoading) {
+            return <LoadingSpinner />;
+        }
+
         return (
             <BeforeUnload beforeunload={this.handleWindowBeforeUnload}>
                 {domain &&


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45333

#### Changes
* Update QueryMetadataEditor.tsx to show error on missing param
* Update QueryMetadataEditor.tsx to check for both "queryName" and "query.queryName" params
