### PR TITLE
Fix flaky DataFinderTest "LABKEY.notifications[rowId] is undefined"

### DIFF
--- a/core/webapp/notification/NotificationViewAll.js
+++ b/core/webapp/notification/NotificationViewAll.js
@@ -192,7 +192,7 @@ Ext4.define('LABKEY.core.notification.NotificationViewAll', {
                                 if (notificationRec.get('ReadOn') == null)
                                 {
                                     notificationRec.set('ReadOn', new Date());
-                                    if (Ext4.isDefined(LABKEY.notifications))
+                                    if (Ext4.isDefined(LABKEY.notifications) && LABKEY.notifications[rowId])
                                         LABKEY.notifications[rowId].ReadOn = new Date();
                                 }
                             });


### PR DESCRIPTION
#### Rationale
Intermittent test failure in DataFinderTest looks like a race condition in NotificationViewAll.js:

https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_LabkeyPremiumTrunk_GitModules_ImmportPostgres95/1855691?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true

#### Changes
* Check that we have a notification for the rowId in question