### PR TITLE
Cross-Folder - Remove Experimental Flag

### DIFF
--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -618,6 +618,7 @@ public interface QueryService
 
     default boolean isProductSubfolderDataEnabled()
     {
-        return ExperimentalFeatureService.get().isFeatureEnabled(EXPERIMENTAL_SUBFOLDER_DATA_ENABLED);
+        return true;
+        // return ExperimentalFeatureService.get().isFeatureEnabled(EXPERIMENTAL_SUBFOLDER_DATA_ENABLED);
     }
 }

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -69,7 +69,7 @@ import java.util.Set;
 public interface QueryService
 {
     String EXPERIMENTAL_LAST_MODIFIED = "queryMetadataLastModified";
-    String PRODUCT_PROJECTS_ENABLED = "isSubfolderDataEnabled";
+    String PRODUCT_PROJECTS_ENABLED = "isProductProjectsEnabled";
 
     String MODULE_QUERIES_DIRECTORY = "queries";
     Path MODULE_QUERIES_PATH = Path.parse(MODULE_QUERIES_DIRECTORY);

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -48,7 +48,6 @@ import org.labkey.api.query.column.ConceptURIColumnInfoTransformer;
 import org.labkey.api.query.snapshot.QuerySnapshotDefinition;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
-import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.util.Path;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
@@ -70,7 +69,7 @@ import java.util.Set;
 public interface QueryService
 {
     String EXPERIMENTAL_LAST_MODIFIED = "queryMetadataLastModified";
-    String EXPERIMENTAL_SUBFOLDER_DATA_ENABLED = "isSubfolderDataEnabled";
+    String PRODUCT_PROJECTS_ENABLED = "isSubfolderDataEnabled";
 
     String MODULE_QUERIES_DIRECTORY = "queries";
     Path MODULE_QUERIES_PATH = Path.parse(MODULE_QUERIES_DIRECTORY);
@@ -616,9 +615,24 @@ public interface QueryService
         return col;
     }
 
-    default boolean isProductSubfolderDataEnabled()
+    default boolean isProductProjectsEnabled(Container container)
     {
-        return true;
-        // return ExperimentalFeatureService.get().isFeatureEnabled(EXPERIMENTAL_SUBFOLDER_DATA_ENABLED);
+        if (container == null || container.isRoot() || container.isWorkbook())
+            return false;
+
+        Container project;
+        if (container.isProject())
+            project = container;
+        else
+            project = container.getProject();
+
+        if (project == null)
+            return false;
+
+        // It is less than ideal to reference the folder type but for the time being
+        // this is how we recognize the appropriate container context.
+        // 1. The provided container is a LKB top-level LKB folder.
+        // 2. The provided container's top-level parent is a LKB folder.
+        return "Biologics".equals(project.getFolderType().getName());
     }
 }

--- a/list/src/org/labkey/list/model/ListServiceImpl.java
+++ b/list/src/org/labkey/list/model/ListServiceImpl.java
@@ -196,7 +196,7 @@ public class ListServiceImpl implements ListService
     @Nullable
     public ContainerFilter getPicklistContainerFilter(Container container, User user, @NotNull ListDefinition list)
     {
-        if (!QueryService.get().isProductSubfolderDataEnabled())
+        if (!QueryService.get().isProductProjectsEnabled(container))
             return null;
 
         if (container == null || user == null || !list.isPicklist() || container.isRoot())

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -220,8 +220,6 @@ public class QueryModule extends DefaultModule
         AdminConsole.addExperimentalFeatureFlag(QueryServiceImpl.EXPERIMENTAL_LAST_MODIFIED, "Include Last-Modified header on query metadata requests",
                 "For schema, query, and view metadata requests include a Last-Modified header such that the browser can cache the response. " +
                 "The metadata is invalidated when performing actions such as creating a new List or modifying the columns on a custom view", false);
-        AdminConsole.addExperimentalFeatureFlag(QueryServiceImpl.EXPERIMENTAL_SUBFOLDER_DATA_ENABLED, "Subfolder data in LabKey Products",
-                "View and interact with data from subfolders of a Product Project.", false);
         AdminConsole.addExperimentalFeatureFlag(QueryView.EXPERIMENTAL_CUSTOMIZE_VIEWS_IN_APPS, "Customizing Grid view in LabKey Products",
                 "Customize grid views from within Biologics and Sample Manager applications.", false);
     }
@@ -393,7 +391,7 @@ public class QueryModule extends DefaultModule
         JSONObject json = super.getPageContextJson(context);
         boolean hasEditQueriesPermission = context.getContainer().hasPermission(context.getUser(), EditQueriesPermission.class);
         json.put("hasEditQueriesPermission", hasEditQueriesPermission);
-        json.put(QueryServiceImpl.EXPERIMENTAL_SUBFOLDER_DATA_ENABLED, QueryService.get().isProductSubfolderDataEnabled());
+        json.put(QueryServiceImpl.PRODUCT_PROJECTS_ENABLED, QueryService.get().isProductProjectsEnabled(context.getContainer()));
         json.put(QueryView.EXPERIMENTAL_CUSTOMIZE_VIEWS_IN_APPS, ExperimentalFeatureService.get().isFeatureEnabled(QueryView.EXPERIMENTAL_CUSTOMIZE_VIEWS_IN_APPS));
 
         return json;


### PR DESCRIPTION
#### Rationale
This brings the cross-folder features for our applications out from under an experimental flag and makes it the default functionality for LKB.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3443
* https://github.com/LabKey/biologics/pull/1371
* https://github.com/LabKey/sampleManagement/pull/997
* https://github.com/LabKey/recipe/pull/67
* https://github.com/LabKey/inventory/pull/457
* https://github.com/LabKey/labkey-ui-components/pull/860

#### Changes
* Rename `isProductSubfolderDataEnabled` to `isProductProjectsEnabled` and accept a `Container` parameter to check container context.
* Update `isProductProjectsEnabled` to respect container context for determining if projects is enabled within a given container.
* Remove experimental flag.
