### PR TITLE
Issue 45634: Improve cross-folder lineage lookup support in name expressions

### DIFF
--- a/api/src/org/labkey/api/assay/actions/BulkPropertiesUploadForm.java
+++ b/api/src/org/labkey/api/assay/actions/BulkPropertiesUploadForm.java
@@ -185,21 +185,12 @@ public abstract class BulkPropertiesUploadForm<ProviderType extends AssayProvide
         {
             String sampleTypeName = name.substring(0, dotIndex);
             String sampleName = name.substring(dotIndex + 1);
-            // Could easily do some caching here, but probably not a significant perf issue
-            for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(getContainer(), getUser(), true))
+            ExpSampleType sampleType = SampleTypeService.get().getSampleType(getContainer(), getUser(), sampleTypeName);
+            if (sampleType != null)
             {
-                // Look for a sample type with the right name
-                if (sampleTypeName.equals(sampleType.getName()))
-                {
-                    for (ExpMaterial sample : sampleType.getSamples(sampleType.getContainer()))
-                    {
-                        // Look for a sample with the right name
-                        if (sample.getName().equals(sampleName))
-                        {
-                            return sample;
-                        }
-                    }
-                }
+                ExpMaterial sample = sampleType.getSample(getContainer(), sampleName);
+                if (sample != null)
+                    return sample;
             }
         }
 

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -1162,7 +1162,6 @@ public class NameGenerator
         return state.nextName(rowMap, parentDatas, parentSamples, extraPropsFns, altExpression);
     }
 
-
     public class State implements AutoCloseable
     {
         private final boolean _incrementSampleCounts;
@@ -1186,7 +1185,6 @@ public class NameGenerator
             _user = User.getSearchUser();
             _lookupCache = new HashMap<>();
         }
-
 
         @Override
         public void close()
@@ -1347,9 +1345,11 @@ public class NameGenerator
                                             Map<String, ArrayList<Object>> inputLookupValues)
         {
             String inputType = isMaterialParent ? ExpMaterial.MATERIAL_INPUT_PARENT : ExpData.DATA_INPUT_PARENT;
+            String inputCol = inputType + "/" + parentTypeName;
+
             List<String> fieldNames = new ArrayList<>();
-            if (_expLineageLookupFields.containsKey(inputType + "/" + parentTypeName))
-                fieldNames.addAll(_expLineageLookupFields.get(inputType + "/" + parentTypeName));
+            if (_expLineageLookupFields.containsKey(inputCol))
+                fieldNames.addAll(_expLineageLookupFields.get(inputCol));
             if (_expLineageLookupFields.containsKey(inputType))
                 fieldNames.addAll(_expLineageLookupFields.get(inputType));
             if (_expLineageLookupFields.containsKey(INPUT_PARENT))
@@ -1361,37 +1361,24 @@ public class NameGenerator
                 if (lookupValue == null)
                     continue;
 
-                // add to Input/lookupfield
+                // add to Input/<LookupField>
                 inputLookupValues.computeIfAbsent(INPUT_PARENT + "/" + fieldName, (s) -> new ArrayList<>()).add(lookupValue);
 
-                // add to importAlias/lookupfield
+                // add to importAlias/<LookupField>
                 if (parentImportAliases != null)
                 {
-                    String inputCol = (isMaterialParent ? ExpMaterial.MATERIAL_INPUT_PARENT : ExpData.DATA_INPUT_PARENT) + "/" + parentTypeName;
                     parentImportAliases
                             .entrySet()
                             .stream()
-                            .filter(entry -> entry.getValue().equalsIgnoreCase(inputCol))
+                            .filter(entry -> inputCol.equalsIgnoreCase(entry.getValue()))
                             .forEach(entry -> inputLookupValues.computeIfAbsent(entry.getKey() + "/" + fieldName, (s) -> new ArrayList<>()).add(lookupValue));
                 }
 
-                if (isMaterialParent)
-                {
-                    // add to MaterialInputs/lookupfield
-                    inputLookupValues.computeIfAbsent(ExpMaterial.MATERIAL_INPUT_PARENT + "/" + fieldName, (s) -> new ArrayList<>()).add(lookupValue);
-                    // add to MaterialInputs/SampleType/lookupfield
-                    inputLookupValues.computeIfAbsent(ExpMaterial.MATERIAL_INPUT_PARENT + "/" + parentTypeName + "/" + fieldName, (s) -> new ArrayList<>()).add(lookupValue);
-
-                }
-                else
-                {
-                    // add to DataInputs/lookupfield
-                    inputLookupValues.computeIfAbsent(ExpData.DATA_INPUT_PARENT + "/" + fieldName, (s) -> new ArrayList<>()).add(lookupValue);
-                    // add to DataInputs/DataClass/lookupfield
-                    inputLookupValues.computeIfAbsent(ExpData.DATA_INPUT_PARENT + "/" + parentTypeName + "/" + fieldName, (s) -> new ArrayList<>()).add(lookupValue);
-                }
+                // add to <Type>Inputs/<LookupField>
+                inputLookupValues.computeIfAbsent(inputType + "/" + fieldName, (s) -> new ArrayList<>()).add(lookupValue);
+                // add to <Type>Inputs/<TypeName>/<LookupField>
+                inputLookupValues.computeIfAbsent(inputCol + "/" + fieldName, (s) -> new ArrayList<>()).add(lookupValue);
             }
-
         }
 
         private void addLineageLookupContext(String parentTypeName,

--- a/api/src/org/labkey/api/exp/api/ExpObject.java
+++ b/api/src/org/labkey/api/exp/api/ExpObject.java
@@ -75,6 +75,11 @@ public interface ExpObject extends Identifiable, Comparable<ExpObject>
      */
     Map<String, ObjectProperty> getObjectProperties();
 
+    default Map<String, ObjectProperty> getObjectProperties(@Nullable User user)
+    {
+        return getObjectProperties();
+    }
+
     @Override
     @Nullable
     default ExpObject getExpObject()

--- a/api/src/org/labkey/api/exp/api/ExpSampleType.java
+++ b/api/src/org/labkey/api/exp/api/ExpSampleType.java
@@ -234,5 +234,5 @@ public interface ExpSampleType extends ExpObject
 
     long getCurrentGenId();
 
-    void ensureMinGenId(long newSeqValue, Container container) throws ExperimentException;
+    void ensureMinGenId(long newSeqValue) throws ExperimentException;
 }

--- a/experiment/src/org/labkey/experiment/DerivedSamplePropertyHelper.java
+++ b/experiment/src/org/labkey/experiment/DerivedSamplePropertyHelper.java
@@ -76,7 +76,7 @@ public class DerivedSamplePropertyHelper extends SamplePropertyHelper<Lsid>
 
         _sampleType = sampleType;
         if (_sampleType != null)
-            _nameGenerator = _sampleType.getNameGenerator();
+            _nameGenerator = _sampleType.getNameGenerator(c);
         else
             _nameGenerator = null;
 

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -583,6 +583,11 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         return getObjectProperties(getDataClass());
     }
 
+    public Map<String, ObjectProperty> getObjectProperties(@Nullable User user)
+    {
+        return getObjectProperties(getDataClass(user));
+    }
+
     private Map<String, ObjectProperty> getObjectProperties(ExpDataClassImpl dataClass)
     {
         HashMap<String,ObjectProperty> ret = new HashMap<>(super.getObjectProperties());

--- a/experiment/src/org/labkey/experiment/api/ExpIdentifiableBaseImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpIdentifiableBaseImpl.java
@@ -178,13 +178,14 @@ public abstract class ExpIdentifiableBaseImpl<Type extends IdentifiableBase> ext
     protected Function<String, Long> getMaxCounterWithPrefixFunction(TableInfo tableInfo)
     {
         String dataTypeLsid = getLSID();
-        Container container = getContainer();
         return (namePrefix) ->
         {
             long max = 0;
 
-            SimpleFilter filter = SimpleFilter.createContainerFilter(container);
-            filter.addCondition(FieldKey.fromParts("cpastype"), dataTypeLsid);
+            // Here we don't apply a container filter and instead rely on the "CpasType" of the associated data.
+            // This allows for us to process max counter from all matching results within the provided type.
+            SimpleFilter filter = new SimpleFilter();
+            filter.addCondition(FieldKey.fromParts("CpasType"), dataTypeLsid);
             filter.addCondition(FieldKey.fromParts("Name"), namePrefix, STARTS_WITH);
 
             TableSelector selector = new TableSelector(tableInfo, Collections.singleton("Name"), filter, null);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -948,7 +948,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
             // sampleset.createSampleNames() + generate lsid
             // TODO: does not handle insertIgnore
-            DataIterator names = new _GenerateNamesDataIterator(sampleType, DataIteratorUtil.wrapMap(dataIterator, false), context, batchSize)
+            DataIterator names = new _GenerateNamesDataIterator(sampleType, container, DataIteratorUtil.wrapMap(dataIterator, false), context, batchSize)
                     .setAllowUserSpecifiedNames(NameExpressionOptionService.get().allowUserSpecifiedNames(sampleType.getContainer()))
                     .addExtraPropsFn(() -> {
                         if (container != null)
@@ -1023,7 +1023,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
         String generatedName = null;
 
-        _GenerateNamesDataIterator(ExpSampleTypeImpl sampleType, MapDataIterator source, DataIteratorContext context, int batchSize)
+        _GenerateNamesDataIterator(ExpSampleTypeImpl sampleType, Container dataContainer, MapDataIterator source, DataIteratorContext context, int batchSize)
         {
             super(source, context);
             this.sampleType = sampleType;
@@ -1041,8 +1041,8 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             {
                 // do nothing
             }
-            nameGen = sampleType.getNameGenerator();
-            aliquotNameGen = sampleType.getAliquotNameGenerator();
+            nameGen = sampleType.getNameGenerator(dataContainer);
+            aliquotNameGen = sampleType.getAliquotNameGenerator(dataContainer);
             if (nameGen != null)
                 nameState = nameGen.createState(true);
             else

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -7318,7 +7318,7 @@ public class ExperimentController extends SpringActionController
 
                 ExpSampleType sampleType = SampleTypeService.get().getSampleType(form.getRowId());
                 if (sampleType != null)
-                    sampleType.ensureMinGenId(form.getGenId(), getContainer());
+                    sampleType.ensureMinGenId(form.getGenId());
                 else
                 {
                     resp.put("success", false);


### PR DESCRIPTION
#### Rationale
This addresses [Issue 45634](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45634) by passing through the target "data" container to the name generator. Currently, we do a mishmash of sometimes receiving the data container and other times receiving the container where the data type is defined. Additionally, this also updates Data Classes to be able to support lineage lookups and account for the scenario outlined in 45634.

There is also an adjacent scenario I was able to address which is lineage lookup values were failing cross-folder for non "built-in" columns specified on a data class domain. The reason for this failure is that the ExpData objects were not resolving their associated ExpDataClass due to not being provided with a user. As such, the NameGenerator would fail to resolve any properties for cross-folder data types.

#### Changes
* Pass in the "data" container in places that spawn a `NameGenerator`.
* Expose `getObjectProperties(@Nullable User user)` as part of the public interface for `ExpItem` to allow for providing user to an underlying instance retrieving properties.
* Consolidate creation of the name and aliquot name generators for Sample Types.
