### PR TITLE
Ensure requested file name/path is under the root

### DIFF
--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -35,6 +35,7 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DataRegion;
 import org.labkey.api.data.DataRegionSelection;
 import org.labkey.api.pipeline.NoSuchJobException;
+import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.pipeline.PipelineProvider;
@@ -567,7 +568,9 @@ public class StatusController extends SpringActionController
                         fileShow = null;
                     }
 
-                    if (NetworkDrive.exists(fileShow))
+                    // Ensure that the requested file is under the root for this container
+                    PipeRoot root = PipelineService.get().findPipelineRoot(c);
+                    if (root != null && root.isUnderRoot(fileShow) && NetworkDrive.exists(fileShow))
                     {
                         boolean visible = isVisibleFile(fileName, basename);
 


### PR DESCRIPTION
#### Rationale
When requesting a log file, ensure that it's from the expected place on the file system

#### Changes
* Check file path to ensure it's under the root directory for the container