### PR TITLE
queryinfo element missing from existing usages of the ConvertArraysToExcelAction

### DIFF
--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -2434,9 +2434,9 @@ public class ExperimentController extends SpringActionController
                     ResponseHelper.setPrivate(response);
                     workbook.write(response.getOutputStream());
 
-                    if (rootObject.has("queryinfo"))
+                    JSONObject qInfo = rootObject.has("queryinfo") ? rootObject.getJSONObject("queryinfo") : null;
+                    if (qInfo != null)
                     {
-                        JSONObject qInfo = rootObject.getJSONObject("queryinfo");
                         QueryService.get().addAuditEvent(getUser(), getContainer(), qInfo.getString("schema"),
                                 qInfo.getString("query"), getViewContext().getActionURL(),
                                 rootObject.getString("auditMessage") + filename,

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -2434,9 +2434,9 @@ public class ExperimentController extends SpringActionController
                     ResponseHelper.setPrivate(response);
                     workbook.write(response.getOutputStream());
 
-                    JSONObject qInfo = rootObject.getJSONObject("queryinfo");
-                    if (qInfo != null)
+                    if (rootObject.has("queryinfo"))
                     {
+                        JSONObject qInfo = rootObject.getJSONObject("queryinfo");
                         QueryService.get().addAuditEvent(getUser(), getContainer(), qInfo.getString("schema"),
                                 qInfo.getString("query"), getViewContext().getActionURL(),
                                 rootObject.getString("auditMessage") + filename,


### PR DESCRIPTION
#### Rationale
Fix TargetedMS tests

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3400

#### Changes
* Adjust element check in ConvertArraysToExcelAction
