### PR TITLE
Issue 45581: Field editor LookupFieldOptions shouldn't diabled target table selection for alias fields in metadata editor

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,8 +8,8 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/api": "1.14.2",
-        "@labkey/components": "2.181.1",
+        "@labkey/api": "1.15.0",
+        "@labkey/components": "2.184.0-fb-queryMetadata45581.0",
         "@labkey/themes": "1.2.2"
       },
       "devDependencies": {
@@ -2991,9 +2991,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.14.2",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.14.2.tgz",
-      "integrity": "sha1-4n+NlvLrIzbaU7gUYlm4lOdQ5Mk=",
+      "version": "1.15.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.15.0.tgz",
+      "integrity": "sha1-OZEawkPKPCranyrgekMhPokH4A0=",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3032,9 +3032,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.181.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.181.1.tgz",
-      "integrity": "sha1-VaUkqcGOLMT5dumtG6a8E7TrGU0=",
+      "version": "2.184.0-fb-queryMetadata45581.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.184.0-fb-queryMetadata45581.0.tgz",
+      "integrity": "sha1-qty7qr2ustl7j6EUJ/vswnJCD3w=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -3042,7 +3042,7 @@
         "@fortawesome/free-regular-svg-icons": "5.15.4",
         "@fortawesome/free-solid-svg-icons": "5.15.4",
         "@fortawesome/react-fontawesome": "0.1.15",
-        "@labkey/api": "1.14.2",
+        "@labkey/api": "1.15.0",
         "bootstrap": "3.4.1",
         "classnames": "2.3.1",
         "font-awesome": "4.7.0",
@@ -17373,9 +17373,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.14.2",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.14.2.tgz",
-      "integrity": "sha1-4n+NlvLrIzbaU7gUYlm4lOdQ5Mk="
+      "version": "1.15.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.15.0.tgz",
+      "integrity": "sha1-OZEawkPKPCranyrgekMhPokH4A0="
     },
     "@labkey/build": {
       "version": "6.1.3",
@@ -17412,16 +17412,16 @@
       }
     },
     "@labkey/components": {
-      "version": "2.181.1",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.181.1.tgz",
-      "integrity": "sha1-VaUkqcGOLMT5dumtG6a8E7TrGU0=",
+      "version": "2.184.0-fb-queryMetadata45581.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.184.0-fb-queryMetadata45581.0.tgz",
+      "integrity": "sha1-qty7qr2ustl7j6EUJ/vswnJCD3w=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-regular-svg-icons": "5.15.4",
         "@fortawesome/free-solid-svg-icons": "5.15.4",
         "@fortawesome/react-fontawesome": "0.1.15",
-        "@labkey/api": "1.14.2",
+        "@labkey/api": "1.15.0",
         "bootstrap": "3.4.1",
         "classnames": "2.3.1",
         "font-awesome": "4.7.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.15.0",
-        "@labkey/components": "2.185.0-fb-queryMetadata45581.0",
+        "@labkey/components": "2.185.1",
         "@labkey/themes": "1.2.2"
       },
       "devDependencies": {
@@ -3032,9 +3032,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.185.0-fb-queryMetadata45581.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.185.0-fb-queryMetadata45581.0.tgz",
-      "integrity": "sha1-EtALBjJdUZyLEnUKBEZi/uheeJs=",
+      "version": "2.185.1",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.185.1.tgz",
+      "integrity": "sha1-K9qsk+DGG63C4At9F8MOzTcZGmg=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -17412,9 +17412,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.185.0-fb-queryMetadata45581.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.185.0-fb-queryMetadata45581.0.tgz",
-      "integrity": "sha1-EtALBjJdUZyLEnUKBEZi/uheeJs=",
+      "version": "2.185.1",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.185.1.tgz",
+      "integrity": "sha1-K9qsk+DGG63C4At9F8MOzTcZGmg=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.15.0",
-        "@labkey/components": "2.184.0-fb-queryMetadata45581.0",
+        "@labkey/components": "2.185.0-fb-queryMetadata45581.0",
         "@labkey/themes": "1.2.2"
       },
       "devDependencies": {
@@ -3032,9 +3032,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.184.0-fb-queryMetadata45581.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.184.0-fb-queryMetadata45581.0.tgz",
-      "integrity": "sha1-qty7qr2ustl7j6EUJ/vswnJCD3w=",
+      "version": "2.185.0-fb-queryMetadata45581.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.185.0-fb-queryMetadata45581.0.tgz",
+      "integrity": "sha1-EtALBjJdUZyLEnUKBEZi/uheeJs=",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -17412,9 +17412,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.184.0-fb-queryMetadata45581.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.184.0-fb-queryMetadata45581.0.tgz",
-      "integrity": "sha1-qty7qr2ustl7j6EUJ/vswnJCD3w=",
+      "version": "2.185.0-fb-queryMetadata45581.0",
+      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.185.0-fb-queryMetadata45581.0.tgz",
+      "integrity": "sha1-EtALBjJdUZyLEnUKBEZi/uheeJs=",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package.json
+++ b/core/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.15.0",
-    "@labkey/components": "2.184.0-fb-queryMetadata45581.0",
+    "@labkey/components": "2.185.0-fb-queryMetadata45581.0",
     "@labkey/themes": "1.2.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -50,8 +50,8 @@
     "testResultsProcessor": "jest-teamcity-reporter"
   },
   "dependencies": {
-    "@labkey/api": "1.14.2",
-    "@labkey/components": "2.181.1",
+    "@labkey/api": "1.15.0",
+    "@labkey/components": "2.184.0-fb-queryMetadata45581.0",
     "@labkey/themes": "1.2.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.15.0",
-    "@labkey/components": "2.185.0-fb-queryMetadata45581.0",
+    "@labkey/components": "2.185.1",
     "@labkey/themes": "1.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45581

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/867

#### Changes
* update @labkey/api and @labkey/components package version
