### PR TITLE
cast will fail if data iterator logging is enabled

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -224,8 +224,8 @@ public class ExpDataIterators
         {
             if (_aliquotedFromColInd == null)
             {
-                Map<String, Integer> columnNameMap = ((SimpleTranslator) data).getColumnNameMap();
-                if (columnNameMap != null && columnNameMap.containsKey("AliquotedFrom"))
+                Map<String, Integer> columnNameMap = DataIteratorUtil.createColumnNameMap(data);
+                if (columnNameMap.containsKey("AliquotedFrom"))
                     _aliquotedFromColInd = columnNameMap.get("AliquotedFrom");
                 else
                     _aliquotedFromColInd = -1;


### PR DESCRIPTION
#### Rationale
Can use DataIteratorUtil.createColumnNameMap() directly.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
