### PR TITLE
Issue 45696: Add quotes around parent names containing commas in audit log data

### DIFF
--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -633,7 +633,10 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             }
 
             parentByType.computeIfAbsent(type, k -> new ArrayList<>());
-            parentByType.get(type).add(parent.getName());
+            String parentName = parent.getName();
+            if (parentName.contains(","))
+                parentName = "\"" + parentName + "\"";
+            parentByType.get(type).add(parentName);
         }
 
         for (String type : parentByType.keySet())


### PR DESCRIPTION
#### Rationale
We parse the names of parents from the old and new record data of audit log entries to create links to the parents in our applications, so we need to put quotes around he ones that contain commas so our parsing as comma-separated values works.

#### Related Pull Requests
* #3348 

#### Changes
* Quote parent names in parentByType map
