### PR TITLE
CacheManager.Sealable interface for cacheable collections

### DIFF
--- a/api/src/org/labkey/api/cache/CacheManager.java
+++ b/api/src/org/labkey/api/cache/CacheManager.java
@@ -182,4 +182,11 @@ public class CacheManager
             LOG.warn(debugName + " attempted to cache " + description + ", which could be mutated by callers!");
         }
     }
+
+
+    /* This interface allows a Collection to declare it self immutable when being added to a cache */
+    public interface Sealable
+    {
+        boolean isSealed();
+    }
 }

--- a/api/src/org/labkey/api/collections/CollectionUtils.java
+++ b/api/src/org/labkey/api/collections/CollectionUtils.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.PropertyManager;
 import org.labkey.api.util.PageFlowUtil;
 
@@ -89,6 +90,9 @@ public class CollectionUtils
     public static @Nullable String getModifiableCollectionMapOrArrayType(@Nullable Object value)
     {
         if (null == value || value instanceof Unmodifiable)
+            return null;
+
+        if (value instanceof CacheManager.Sealable sealable && sealable.isSealed())
             return null;
 
         if (value instanceof PropertyManager.PropertyMap)

--- a/query/src/org/labkey/query/olap/MemberSet.java
+++ b/query/src/org/labkey/query/olap/MemberSet.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.cache.CacheManager;
 import org.labkey.api.collections.SparseBitSet;
 import org.olap4j.OlapException;
 import org.olap4j.metadata.Hierarchy;
@@ -48,9 +49,10 @@ import java.util.Set;
  */
 
 
-public class MemberSet extends AbstractSet<Member>
+public class MemberSet extends AbstractSet<Member> implements CacheManager.Sealable
 {
     Map<String,LevelMemberSet> levelMap = new HashMap<>();
+    boolean sealed = false;
 
 
     public MemberSet()
@@ -94,11 +96,19 @@ public class MemberSet extends AbstractSet<Member>
             LevelMemberSet s = entry.getValue();
             s._set.seal();
         }
+        sealed = true;
     }
+
+
+    public boolean isSealed()
+    {
+        return sealed;
+    }
+
 
     // NOTE : Don't need to do this if the cube is a CachedCube.
     // For olap4j cube we can't hang onto metadata when sitting in a cache (e.g. Level objects)
-    // we need a way to detach and reattch a MemberSet to a cube
+    // we need a way to detach and reattach a MemberSet to a cube
 
     MemberSet detach()
     {


### PR DESCRIPTION
#### Rationale
Create an interface CacheManager.Sealable for collections that want to declare themselves as valid for caching (e.g. readonly)

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
