### PR TITLE
Issue 45272: Update AssayProvider.getDescription() to not return HTML

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProvider.java
+++ b/api/src/org/labkey/api/assay/AssayProvider.java
@@ -291,7 +291,6 @@ public interface AssayProvider extends Handler<ExpProtocol>
 
     /**
      * @return a short description of this assay type - what kinds of data it can be used to analyze, etc.
-     * HTML is allowed, so the string will not be HTML encoded at render time
      */
     String getDescription();
 

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -35,6 +35,7 @@ import org.labkey.api.action.SimpleApiJsonForm;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.assay.AbstractAssayProvider;
+import org.labkey.api.assay.AssayDataType;
 import org.labkey.api.assay.AssayFileWriter;
 import org.labkey.api.assay.AssayProtocolSchema;
 import org.labkey.api.assay.AssayProvider;
@@ -691,7 +692,8 @@ public class AssayController extends SpringActionController
                 bean = new AssayProviderBean();
                 bean.setName(provider.getName());
                 bean.setDescription(provider.getDescription());
-                bean.setFileTypes(provider.getDataType().getFileType().getSuffixes());
+                AssayDataType dataType = provider.getDataType();
+                bean.setFileTypes(dataType == null ? Collections.emptyList() : dataType.getFileType().getSuffixes());
                 beans.add(bean);
             }
 


### PR DESCRIPTION
#### Rationale
We don't want to return HTML via JSON APIs

#### Changes
* Remove comment giving the all-clear for HTML in the description