### PR TITLE
Issue 45079: Prevent double encoding of permissions page folder tree root

### DIFF
--- a/core/webapp/Security/panel/PermissionEditor.js
+++ b/core/webapp/Security/panel/PermissionEditor.js
@@ -51,8 +51,8 @@ Ext4.define('Security.panel.PermissionEditor', {
                         id : this.treeConfig.project.id,
                         expanded   : true,
                         expandable : true,
-                        text       : Ext4.String.htmlEncode(this.treeConfig.project.name),
-                        href       : Ext4.String.htmlEncode(this.treeConfig.project.securityHref)
+                        text       : this.treeConfig.project.name,
+                        href       : this.treeConfig.project.securityHref
                     }
                 },
                 enableDrag : false,


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=45079

Note that we don't need to use Ext4.String.htmlEncode() here in the Ext4 TreePanel root display because of the override added to ext-patch.js (see `Ext4.override(Ext4.tree.Column, {...})` which now does the encoding for us.

#### Changes
* remove unneeded calls to Ext4.String.htmlEncode()
