### PR TITLE
Label vocabulary domain for SMILES properties

### DIFF
--- a/api/src/org/labkey/api/exp/property/ConceptURIVocabularyDomainProvider.java
+++ b/api/src/org/labkey/api/exp/property/ConceptURIVocabularyDomainProvider.java
@@ -31,6 +31,8 @@ public interface ConceptURIVocabularyDomainProvider
 
     @Nullable String getDomainName(@NotNull String sourceFieldName, @NotNull ExpObject expObject);
 
+    @Nullable String getDomainLabel(@NotNull String sourceFieldName);
+
     @NotNull DataIteratorBuilder getDataIteratorBuilder(@NotNull DataIteratorBuilder data, @NotNull ExpDataClass expDataClass, @NotNull AttachmentParentFactory attachmentParentFactory, Container container, User user);
 
     @NotNull Map<String, Object> getUpdateRowProperties(User user, Container c, @NotNull Map<String, Object> rowStripped, Map<String, Object> oldRow, @NotNull AttachmentParentFactory attachmentParentFactory, @NotNull String sourceFieldName, @NotNull String propertyColumnName, boolean hasMultipleSourceFields);

--- a/experiment/src/org/labkey/experiment/api/DataClassVocabularyProviderProperties.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassVocabularyProviderProperties.java
@@ -2,6 +2,9 @@ package org.labkey.experiment.api;
 
 import org.labkey.api.exp.property.ConceptURIVocabularyDomainProvider;
 
-public record DataClassVocabularyProviderProperties(String sourceColumnName /* the dataclass column that has attached vocabulary*/, String sourceColumnLabel /* the label of the dataclass column */, String vocabularyDomainName /* vocabulary property column field key */, ConceptURIVocabularyDomainProvider conceptURIVocabularyDomainProvider /*the ConceptURIVocabularyDomainProvider that matches the column's conceptURI*/)
+public record DataClassVocabularyProviderProperties(String sourceColumnName /* the dataclass column that has attached vocabulary*/,
+                                                    String sourceColumnLabel /* the label of the dataclass column */,
+                                                    String vocabularyDomainName /* vocabulary property column field key */,
+                                                    ConceptURIVocabularyDomainProvider conceptURIVocabularyDomainProvider /*the ConceptURIVocabularyDomainProvider that matches the column's conceptURI*/)
 {
 }

--- a/experiment/src/org/labkey/experiment/api/DataClassVocabularyProviderProperties.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassVocabularyProviderProperties.java
@@ -1,0 +1,7 @@
+package org.labkey.experiment.api;
+
+import org.labkey.api.exp.property.ConceptURIVocabularyDomainProvider;
+
+public record DataClassVocabularyProviderProperties(String sourceColumnName /* the dataclass column that has attached vocabulary*/, String sourceColumnLabel /* the label of the dataclass column */, String vocabularyDomainName /* vocabulary property column field key */, ConceptURIVocabularyDomainProvider conceptURIVocabularyDomainProvider /*the ConceptURIVocabularyDomainProvider that matches the column's conceptURI*/)
+{
+}

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -139,7 +139,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
     private final @NotNull ExpDataClassImpl _dataClass;
     public static final String DATA_COUNTER_SEQ_PREFIX = "DataNameGenCounter-";
 
-    private Map<String/*domain name*/, Tuple3<String/*column that has attached vocabulary*/, String/*vocabulary property column field key*/, ConceptURIVocabularyDomainProvider>> _vocabularyDomainProviders;
+    private Map<String/*domain name*/, DataClassVocabularyProviderProperties> _vocabularyDomainProviders;
 
     public ExpDataClassDataTableImpl(String name, UserSchema schema, ContainerFilter cf, @NotNull ExpDataClassImpl dataClass)
     {
@@ -489,7 +489,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         addExpObjectMethod();
     }
 
-    private Map<String, Tuple3<String, String, ConceptURIVocabularyDomainProvider>> getVocabularyDomainProviders()
+    private Map<String, DataClassVocabularyProviderProperties> getVocabularyDomainProviders()
     {
         if (_vocabularyDomainProviders != null)
             return _vocabularyDomainProviders;
@@ -515,7 +515,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                         continue;
 
                     String propertyColumnName = getVocabularyDomainColumnName(domain);
-                    _vocabularyDomainProviders.put(domainName, new Tuple3<>(col.getName(), propertyColumnName, conceptURIVocabularyDomainProvider));
+                    _vocabularyDomainProviders.put(domainName, new DataClassVocabularyProviderProperties(col.getName(), col.getLabel(), propertyColumnName, conceptURIVocabularyDomainProvider));
 
                 }
             }
@@ -549,17 +549,17 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
                 }
 
-                Tuple3<String, String, ConceptURIVocabularyDomainProvider> fieldVocabularyDomainProvider = getVocabularyDomainProviders().get(domain.getName());
+                DataClassVocabularyProviderProperties fieldVocabularyDomainProvider = getVocabularyDomainProviders().get(domain.getName());
                 if (fieldVocabularyDomainProvider != null)
-                    fieldVocabularyDomainProvider.third.decorateColumn(columnInfo, pd, _userSchema.getContainer());
+                    fieldVocabularyDomainProvider.conceptURIVocabularyDomainProvider().decorateColumn(columnInfo, pd, _userSchema.getContainer());
             }
 
             @Override
             protected @NotNull FieldKey decideColumnName(@NotNull ColumnInfo parent, @NotNull String displayField, @NotNull PropertyDescriptor pd)
             {
-                Tuple3<String, String, ConceptURIVocabularyDomainProvider> fieldVocabularyDomainProvider = getVocabularyDomainProviders().get(domain.getName());
+                DataClassVocabularyProviderProperties fieldVocabularyDomainProvider = getVocabularyDomainProviders().get(domain.getName());
                 if (fieldVocabularyDomainProvider != null)
-                    return fieldVocabularyDomainProvider.third.getColumnFieldKey(parent, pd);
+                    return fieldVocabularyDomainProvider.conceptURIVocabularyDomainProvider().getColumnFieldKey(parent, pd);
 
                 return super.decideColumnName(parent, displayField, pd);
           }
@@ -584,10 +584,11 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             col.setLabel(domain.getName());
             col.setDescription("Properties from " + domain.getLabel(getContainer()));
 
-            Tuple3<String, String, ConceptURIVocabularyDomainProvider> fieldVocabularyDomainProvider = getVocabularyDomainProviders().get(domain.getName());
+            DataClassVocabularyProviderProperties fieldVocabularyDomainProvider = getVocabularyDomainProviders().get(domain.getName());
             if (fieldVocabularyDomainProvider != null)
             {
-                List<FieldKey> fieldKeys = fieldVocabularyDomainProvider.third.addLookupColumns(_dataClass, this, col, fieldVocabularyDomainProvider.first);
+                col.setLabel(fieldVocabularyDomainProvider.conceptURIVocabularyDomainProvider().getDomainLabel(fieldVocabularyDomainProvider.sourceColumnLabel()));
+                List<FieldKey> fieldKeys = fieldVocabularyDomainProvider.conceptURIVocabularyDomainProvider().addLookupColumns(_dataClass, this, col, fieldVocabularyDomainProvider.sourceColumnName());
                 if (fieldKeys != null)
                     domainFields.addAll(fieldKeys);
             }
@@ -657,10 +658,10 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         Set<String> excludeColumns = new HashSet<>();
         for (String vocabularyDomainName : getVocabularyDomainProviders().keySet())
         {
-            Tuple3<String, String, ConceptURIVocabularyDomainProvider> fieldVocabularyDomainProvider = getVocabularyDomainProviders().get(vocabularyDomainName);
+            DataClassVocabularyProviderProperties fieldVocabularyDomainProvider = getVocabularyDomainProviders().get(vocabularyDomainName);
             if (fieldVocabularyDomainProvider != null)
             {
-                excludeColumns.addAll(fieldVocabularyDomainProvider.third.getImportTemplateExcludeColumns(fieldVocabularyDomainProvider.second));
+                excludeColumns.addAll(fieldVocabularyDomainProvider.conceptURIVocabularyDomainProvider().getImportTemplateExcludeColumns(fieldVocabularyDomainProvider.vocabularyDomainName()));
             }
         }
 
@@ -987,9 +988,9 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
             for (String vocabularyDomainName : getVocabularyDomainProviders().keySet())
             {
-                Tuple3<String, String, ConceptURIVocabularyDomainProvider> fieldVocabularyDomainProvider = getVocabularyDomainProviders().get(vocabularyDomainName);
+                DataClassVocabularyProviderProperties fieldVocabularyDomainProvider = getVocabularyDomainProviders().get(vocabularyDomainName);
                 if (fieldVocabularyDomainProvider != null)
-                    rowStripped.putAll(fieldVocabularyDomainProvider.third.getUpdateRowProperties(user, c, rowStripped, oldRow, getAttachmentParentFactory(), fieldVocabularyDomainProvider.first, fieldVocabularyDomainProvider.second, getVocabularyDomainProviders().size() > 1));
+                    rowStripped.putAll(fieldVocabularyDomainProvider.conceptURIVocabularyDomainProvider().getUpdateRowProperties(user, c, rowStripped, oldRow, getAttachmentParentFactory(), fieldVocabularyDomainProvider.sourceColumnName(), fieldVocabularyDomainProvider.vocabularyDomainName(), getVocabularyDomainProviders().size() > 1));
             }
 
             // update exp.data


### PR DESCRIPTION
#### Rationale
SMILS properties are stored in a vocabulary domain, which uses non user friendly names. When customizing grid labels, we want to display a more user friendly name for those domains.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3473
* https://github.com/LabKey/biologics/pull/1391

#### Related Story
* https://github.com/LabKey/labkey-ui-components/pull/871
* https://github.com/LabKey/platform/pull/3470
* https://github.com/LabKey/sampleManagement/pull/1022
* https://github.com/LabKey/biologics/pull/1389
* https://github.com/LabKey/inventory/pull/466

#### Changes
* Use custom label for smiles vocabulary domain property fields
