### PR TITLE
Prevent working Office files (starting with ~) from being indexed

### DIFF
--- a/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
+++ b/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
@@ -598,6 +598,8 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
             return false;
         if (name.equals(".DS_Store")) // mac
             return false;
+        if (name.startsWith("~") || name.startsWith(".~"))  // Office working files
+            return false;
         return true;
     }
 


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45005
previous fix prevented the body, but not the file entire from being indexed. This changes that.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3336

#### Changes
* add check for ~ starting files to shouldIndex
