### PR TITLE
Issue 45740: Ensure container filter context for insertion in product projects

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -55,6 +55,7 @@ import org.labkey.api.qc.DataLoaderSettings;
 import org.labkey.api.qc.ValidationDataHandler;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.PropertyValidationError;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.query.ValidationError;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.ColumnDescriptor;
@@ -288,9 +289,6 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         Map<ExpRun, List<ExpData>> grouping = new HashMap<>();
         for (ExpData d : data)
         {
-            String protocolLsid;
-            Container runContainer;
-
             ExpProtocolApplication sourceApplication = d.getSourceApplication();
             if (sourceApplication != null)
             {
@@ -442,9 +440,10 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                 }
             }
 
-            final TableInfo dataTable = provider.createProtocolSchema(user, container, protocol, null).createDataTable(null);
+            final ContainerFilter cf = QueryService.get().getProductProjectsInsertContainerFilter(container, user);
+            final TableInfo dataTable = provider.createProtocolSchema(user, container, protocol, null).createDataTable(cf);
 
-            Map<ExpMaterial, String> inputMaterials = checkData(container, user, protocol, provider, dataTable, dataDomain, rawData, settings, resolver);
+            Map<ExpMaterial, String> inputMaterials = checkData(container, user, dataTable, dataDomain, rawData, settings, resolver);
 
             List<Map<String, Object>> fileData = convertPropertyNamesToURIs(rawData, dataDomain);
 
@@ -702,11 +701,16 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
      * NOTE: Mutates the rawData list in-place
      * @return the set of materials that are inputs to this run
      */
-    private Map<ExpMaterial, String> checkData(Container container, User user, ExpProtocol protocol, AssayProvider provider, TableInfo dataTable, Domain dataDomain, List<Map<String, Object>> rawData, DataLoaderSettings settings, ParticipantVisitResolver resolver)
+    private Map<ExpMaterial, String> checkData(Container container,
+                                               User user,
+                                               TableInfo dataTable,
+                                               Domain dataDomain,
+                                               List<Map<String, Object>> rawData,
+                                               DataLoaderSettings settings,
+                                               ParticipantVisitResolver resolver)
             throws ValidationException, ExperimentException
     {
         final ExperimentService exp = ExperimentService.get();
-        final ProvenanceService pvs = ProvenanceService.get();
 
         List<String> missing = new ArrayList<>();
         List<String> unexpected = new ArrayList<>();
@@ -930,9 +934,8 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                 {
                     valueMissing = true;
                 }
-                else if (o instanceof MvFieldWrapper)
+                else if (o instanceof MvFieldWrapper mvWrapper)
                 {
-                    MvFieldWrapper mvWrapper = (MvFieldWrapper)o;
                     if (mvWrapper.isEmpty())
                         valueMissing = true;
                     else
@@ -1073,9 +1076,8 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
             var provenanceInputs = map.get(ProvenanceService.PROVENANCE_INPUT_PROPERTY);
             if (null != provenanceInputs)
             {
-                if (provenanceInputs instanceof JSONArray)
+                if (provenanceInputs instanceof JSONArray inputJSONArr)
                 {
-                    JSONArray inputJSONArr = (JSONArray) provenanceInputs;
                     Object[] inputArr = inputJSONArr.toArray();
                     for (Object lsid: inputArr)
                     {

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -440,7 +440,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                 }
             }
 
-            final ContainerFilter cf = QueryService.get().getProductProjectsInsertContainerFilter(container, user);
+            final ContainerFilter cf = QueryService.get().getContainerFilterForLookups(container, user);
             final TableInfo dataTable = provider.createProtocolSchema(user, container, protocol, null).createDataTable(cf);
 
             Map<ExpMaterial, String> inputMaterials = checkData(container, user, dataTable, dataDomain, rawData, settings, resolver);

--- a/api/src/org/labkey/api/data/validator/PropertyValidator.java
+++ b/api/src/org/labkey/api/data/validator/PropertyValidator.java
@@ -32,7 +32,7 @@ public class PropertyValidator implements ColumnValidator
     final String columnName;
     final ValidatorKind kind;
     final IPropertyValidator propertyValidator;
-    private ColumnRenderProperties _columnRenderProperties;
+    private final ColumnRenderProperties _columnRenderProperties;
     final List<ValidationError> errors = new ArrayList<>(1);
 
     public PropertyValidator(String columnName, ColumnRenderProperties crp, IPropertyValidator propertyValidator)

--- a/api/src/org/labkey/api/exp/list/ListDefinition.java
+++ b/api/src/org/labkey/api/exp/list/ListDefinition.java
@@ -331,6 +331,7 @@ public interface ListDefinition extends Comparable<ListDefinition>
     @Nullable TableInfo getTable(User user);
     @Nullable TableInfo getTable(User user, Container c);
     @Nullable TableInfo getTable(User user, Container c, @Nullable ContainerFilter cf);
+    @Nullable TableInfo getTableForInsert(User user, Container c);
 
     ActionURL urlShowDefinition();
     ActionURL urlImport(Container container);

--- a/api/src/org/labkey/api/exp/property/ValidatorContext.java
+++ b/api/src/org/labkey/api/exp/property/ValidatorContext.java
@@ -28,10 +28,9 @@ import java.util.Map;
  */
 public class ValidatorContext
 {
-    private Map<Pair<Class<? extends ValidatorKind>, Object>, Object> _map = new HashMap<>();
-
-    private Container _container;
-    private User _user;
+    private final Map<Pair<Class<? extends ValidatorKind>, Object>, Object> _map = new HashMap<>();
+    private final Container _container;
+    private final User _user;
 
     public ValidatorContext(Container container, User user)
     {

--- a/api/src/org/labkey/api/query/QuerySchema.java
+++ b/api/src/org/labkey/api/query/QuerySchema.java
@@ -53,6 +53,11 @@ public interface QuerySchema extends SchemaTreeNode, ContainerUser
     /** Consider using getTableWithFactory(String, ContainerFilter.Factory) instead */
     TableInfo getTable(String name, @Nullable ContainerFilter cf);
 
+    default TableInfo getTableForInsert(String name)
+    {
+        return getTable(name, QueryService.get().getProductProjectsInsertContainerFilter(getContainer(), getUser()));
+    }
+
     @NotNull
     default TableInfo getTableOrThrow(String name)
     {

--- a/api/src/org/labkey/api/query/QuerySchema.java
+++ b/api/src/org/labkey/api/query/QuerySchema.java
@@ -55,7 +55,7 @@ public interface QuerySchema extends SchemaTreeNode, ContainerUser
 
     default TableInfo getTableForInsert(String name)
     {
-        return getTable(name, QueryService.get().getProductProjectsInsertContainerFilter(getContainer(), getUser()));
+        return getTable(name, QueryService.get().getContainerFilterForLookups(getContainer(), getUser()));
     }
 
     @NotNull

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -615,24 +615,15 @@ public interface QueryService
         return col;
     }
 
-    default boolean isProductProjectsEnabled(Container container)
-    {
-        if (container == null || container.isRoot() || container.isWorkbook())
-            return false;
+    /**
+     * Resolves the ContainerFilter to be used during insert/update of data in product projects.
+     * Defaults to null if product projects are not enabled in container scope.
+     */
+    @Nullable
+    ContainerFilter getProductProjectsInsertContainerFilter(Container container, User user);
 
-        Container project;
-        if (container.isProject())
-            project = container;
-        else
-            project = container.getProject();
-
-        if (project == null)
-            return false;
-
-        // It is less than ideal to reference the folder type but for the time being
-        // this is how we recognize the appropriate container context.
-        // 1. The provided container is a LKB top-level LKB folder.
-        // 2. The provided container's top-level parent is a LKB folder.
-        return "Biologics".equals(project.getFolderType().getName());
-    }
+    /**
+     * Resolves if the product projects feature is enabled in the supplied container scope.
+     */
+    boolean isProductProjectsEnabled(Container container);
 }

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -616,11 +616,11 @@ public interface QueryService
     }
 
     /**
-     * Resolves the ContainerFilter to be used during insert/update of data in product projects.
+     * Resolves the ContainerFilter to be used for lookups during insert/update of data in product projects.
      * Defaults to null if product projects are not enabled in container scope.
      */
     @Nullable
-    ContainerFilter getProductProjectsInsertContainerFilter(Container container, User user);
+    ContainerFilter getContainerFilterForLookups(Container container, User user);
 
     /**
      * Resolves if the product projects feature is enabled in the supplied container scope.

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -187,7 +187,7 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
     public TableInfo getTable(String name, @Nullable ContainerFilter cf, boolean includeExtraMetadata, boolean forWrite, boolean skipSuggestedColumns)
     {
         TableInfo table = null;
-        String cacheKey = cacheKey(name,cf,includeExtraMetadata,forWrite);
+        String cacheKey = cacheKey(name, cf, includeExtraMetadata, forWrite);
 
         // NOTE: _getTableOrQuery() does not cache TableInfo for QueryDefinition, so check here before calling
         if (null != cacheKey)
@@ -197,17 +197,17 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
 
         ArrayList<QueryException> errors = new ArrayList<>();
         Object o = _getTableOrQuery(name, cf, includeExtraMetadata, forWrite, errors);
-        if (o instanceof TableInfo)
+        if (o instanceof TableInfo ti)
         {
-            table = (TableInfo)o;
+            table = ti;
         }
-        else if (o instanceof QueryDefinition)
+        else if (o instanceof QueryDefinition qd)
         {
-            table = ((QueryDefinition)o).getTable(this, errors, true, skipSuggestedColumns);
+            table = qd.getTable(this, errors, true, skipSuggestedColumns);
             // throw if there are any non-warning errors
             for (QueryException ex : errors)
             {
-                if (ex instanceof QueryParseException && ((QueryParseException)ex).isWarning())
+                if (ex instanceof QueryParseException qpe && qpe.isWarning())
                     continue;
                 throw ex;
             }
@@ -225,9 +225,6 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
         assert null==cacheKey || table.isLocked();
         return table;
     }
-
-
-
 
     private boolean validateTableInfo(TableInfo t)
     {
@@ -326,14 +323,6 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
     {
         table.overlayMetadata(name, this, errors);
     }
-
-    @Override
-    @Nullable
-    public final TableInfo getTable(String name)
-    {
-        return getTable(name, null, true, false);
-    }
-
 
     @Deprecated // TODO ContainerFilter - remove. Schemas that still override or call this method have not been converted yet.
     public final @Nullable TableInfo createTable(String name)

--- a/assay/api-src/org/labkey/api/assay/AssayResultTable.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultTable.java
@@ -147,7 +147,7 @@ public class AssayResultTable extends FilteredTable<AssayProtocolSchema> impleme
                     col.setFieldKey(new FieldKey(null, domainProperty.getName()));
                     PropertyDescriptor pd = domainProperty.getPropertyDescriptor();
                     FieldKey pkFieldKey = new FieldKey(null, AbstractTsvAssayProvider.ROW_ID_COLUMN_NAME);
-                    PropertyColumn.copyAttributes(_userSchema.getUser(), col, pd, schema.getContainer(), _userSchema.getSchemaPath(), getPublicName(), pkFieldKey);
+                    PropertyColumn.copyAttributes(_userSchema.getUser(), col, pd, schema.getContainer(), _userSchema.getSchemaPath(), getPublicName(), pkFieldKey, cf);
 
                     ExpSampleType st = DefaultAssayRunCreator.getLookupSampleType(domainProperty, getContainer(), getUserSchema().getUser());
                     if (st != null || DefaultAssayRunCreator.isLookupToMaterials(domainProperty))

--- a/experiment/src/org/labkey/experiment/api/property/LookupValidator.java
+++ b/experiment/src/org/labkey/experiment/api/property/LookupValidator.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ColumnRenderProperties;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.ForeignKey;
@@ -32,6 +33,7 @@ import org.labkey.api.exp.property.ValidatorContext;
 import org.labkey.api.exp.property.ValidatorKind;
 import org.labkey.api.gwt.client.model.PropertyValidatorType;
 import org.labkey.api.query.PropertyValidationError;
+import org.labkey.api.query.QuerySchema;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SimpleValidationError;
 import org.labkey.api.query.UserSchema;
@@ -134,7 +136,7 @@ public class LookupValidator extends DefaultPropertyValidator implements Validat
     {
         final private Container _container;
 
-        public LookupValues(ColumnInfo field, Container defaultContainer, User user, List<ValidationError> errors)
+        public LookupValues(ColumnInfo field, Container defaultContainer, List<ValidationError> errors)
         {
             if (field.getFk().getLookupContainer() != null)
             {
@@ -170,14 +172,14 @@ public class LookupValidator extends DefaultPropertyValidator implements Validat
             }
             else
             {
-                UserSchema userSchema = QueryService.get().getUserSchema(user, _container, field.getLookupSchema());
+                QuerySchema userSchema = QueryService.get().getUserSchema(user, _container, field.getLookupSchema());
                 if (userSchema == null)
                 {
                     errors.add(new SimpleValidationError("Could not find the lookup's target schema ('" + field.getLookupSchema() + "') for field '" + field.getNonBlankCaption() + "'"));
                 }
                 else
                 {
-                    processTableInfo(userSchema.getTable(field.getLookupQuery()), field.getJdbcType(), field.getLookupQuery(), field.getNonBlankCaption(), errors);
+                    processTableInfo(userSchema.getTableForInsert(field.getLookupQuery()), field.getJdbcType(), field.getLookupQuery(), field.getNonBlankCaption(), errors);
                 }
             }
         }
@@ -258,7 +260,7 @@ public class LookupValidator extends DefaultPropertyValidator implements Validat
 
                 if (validValues == null)
                 {
-                    validValues = new LookupValues(field, validatorCache.getContainer(), validatorCache.getUser(), errors);
+                    validValues = new LookupValues(field, validatorCache.getContainer(), errors);
                 }
                 return isLookupValid(value, errors, validatorCache, key, field.getFk().getLookupSchemaName(),
                         field.getFk().getLookupTableName(), field.getNonBlankCaption(), validValues);
@@ -281,7 +283,6 @@ public class LookupValidator extends DefaultPropertyValidator implements Validat
                                   String label,
                                   LookupValues validValues)
     {
-
         validatorCache.put(LookupValidator.class, key, validValues);
 
         if (validValues.contains(value))

--- a/experiment/src/org/labkey/experiment/api/property/LookupValidator.java
+++ b/experiment/src/org/labkey/experiment/api/property/LookupValidator.java
@@ -130,9 +130,8 @@ public class LookupValidator extends DefaultPropertyValidator implements Validat
         }
     }
 
-    private class LookupValues extends HashSet<Object>
+    private static class LookupValues extends HashSet<Object>
     {
-        private TableInfo _tableInfo;
         final private Container _container;
 
         public LookupValues(ColumnInfo field, Container defaultContainer, User user, List<ValidationError> errors)
@@ -183,17 +182,15 @@ public class LookupValidator extends DefaultPropertyValidator implements Validat
             }
         }
 
-        private void processTableInfo(TableInfo ti, JdbcType jdbcType, String queryName, String label, List<ValidationError> errors)
+        private void processTableInfo(TableInfo tableInfo, JdbcType jdbcType, String queryName, String label, List<ValidationError> errors)
         {
-            _tableInfo = ti;
-            if (_tableInfo == null)
+            if (tableInfo == null)
             {
                 errors.add(new SimpleValidationError("Could not find the lookup's target query ('" + queryName + "') for field '" + label + "'"));
             }
             else
             {
-
-                List<ColumnInfo> keyCols = _tableInfo.getPkColumns();
+                List<ColumnInfo> keyCols = tableInfo.getPkColumns();
 
                 if (keyCols.size() != 1)
                 {
@@ -203,9 +200,9 @@ public class LookupValidator extends DefaultPropertyValidator implements Validat
                 {
                     ColumnInfo lookupTargetCol = keyCols.get(0);
                     // Hack for sample types - see also revision 37612
-                    if (lookupTargetCol.getJdbcType() != jdbcType && jdbcType.isText() && _tableInfo instanceof ExpMaterialTableImpl)
+                    if (lookupTargetCol.getJdbcType() != jdbcType && jdbcType.isText() && tableInfo instanceof ExpMaterialTableImpl)
                     {
-                        ColumnInfo nameCol = _tableInfo.getColumn(ExpMaterialTableImpl.Column.Name.toString());
+                        ColumnInfo nameCol = tableInfo.getColumn(ExpMaterialTableImpl.Column.Name.toString());
                         assert nameCol != null : "Could not find Name column in SampleType table";
                         if (nameCol != null)
                         {
@@ -225,7 +222,11 @@ public class LookupValidator extends DefaultPropertyValidator implements Validat
     }
 
     @Override
-    public boolean validate(IPropertyValidator validator, ColumnRenderProperties crpField, @NotNull Object value, List<ValidationError> errors, ValidatorContext validatorCache)
+    public boolean validate(IPropertyValidator validator,
+                            ColumnRenderProperties crpField,
+                            @NotNull Object value,
+                            List<ValidationError> errors,
+                            ValidatorContext validatorCache)
     {
         //noinspection ConstantConditions
         assert value != null : "Shouldn't be validating a null value";
@@ -233,10 +234,8 @@ public class LookupValidator extends DefaultPropertyValidator implements Validat
         if (value != null)
             value = ConvertHelper.convert(value, crpField.getJavaObjectClass());
 
-        if (crpField instanceof PropertyDescriptor)
+        if (crpField instanceof PropertyDescriptor field)
         {
-            PropertyDescriptor field = (PropertyDescriptor) crpField;
-
             if (field.getLookupQuery() != null && field.getLookupSchema() != null)
             {
                 LookupKey key = new LookupKey(field);
@@ -250,10 +249,8 @@ public class LookupValidator extends DefaultPropertyValidator implements Validat
                         field.getLookupQuery(), field.getNonBlankCaption(), validValues);
             }
         }
-        else if (crpField instanceof ColumnInfo)
+        else if (crpField instanceof ColumnInfo field)
         {
-            ColumnInfo field = (ColumnInfo) crpField;
-
             if (field.getFk() != null)
             {
                 LookupKey key = new LookupKey(field.getFk(), field.getJdbcType());
@@ -275,9 +272,14 @@ public class LookupValidator extends DefaultPropertyValidator implements Validat
         return true;
     }
 
-    private boolean isLookupValid(@NotNull Object value, List<ValidationError> errors,
-                                           ValidatorContext validatorCache, LookupKey key,
-                                           String schemaName, String queryName, String label, LookupValues validValues)
+    private boolean isLookupValid(@NotNull Object value,
+                                  List<ValidationError> errors,
+                                  ValidatorContext validatorCache,
+                                  LookupKey key,
+                                  String schemaName,
+                                  String queryName,
+                                  String label,
+                                  LookupValues validValues)
     {
 
         validatorCache.put(LookupValidator.class, key, validValues);

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3953,7 +3953,7 @@ public class ExperimentController extends SpringActionController
             QueryDefinition query = form.getQueryDef();
             if (query.getContainerFilter() == null)
             {
-                ContainerFilter cf = QueryService.get().getProductProjectsInsertContainerFilter(getContainer(), getUser());
+                ContainerFilter cf = QueryService.get().getContainerFilterForLookups(getContainer(), getUser());
                 if (cf != null)
                     query.setContainerFilter(cf);
             }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3951,6 +3951,12 @@ public class ExperimentController extends SpringActionController
         protected void initRequest(QueryForm form) throws ServletException
         {
             QueryDefinition query = form.getQueryDef();
+            if (query.getContainerFilter() == null)
+            {
+                ContainerFilter cf = QueryService.get().getProductProjectsInsertContainerFilter(getContainer(), getUser());
+                if (cf != null)
+                    query.setContainerFilter(cf);
+            }
             List<QueryException> qpe = new ArrayList<>();
             TableInfo t = query.getTable(form.getSchema(), qpe, true);
             if (!qpe.isEmpty())

--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -702,7 +702,7 @@ public class ListController extends SpringActionController
         {
             _list = form.getList();
             _insertOption = form.getInsertOption();
-            setTarget(_list.getTable(getUser(), getContainer()));
+            setTarget(_list.getTableForInsert(getUser(), getContainer()));
         }
 
         @Override

--- a/list/src/org/labkey/list/model/ListDefinitionImpl.java
+++ b/list/src/org/labkey/list/model/ListDefinitionImpl.java
@@ -715,7 +715,7 @@ public class ListDefinitionImpl implements ListDefinition
 
     public TableInfo getTableForInsert(User user, Container c)
     {
-        return getTable(user, c, QueryService.get().getProductProjectsInsertContainerFilter(c, user));
+        return getTable(user, c, QueryService.get().getContainerFilterForLookups(c, user));
     }
 
     public ActionURL urlImport(Container c)

--- a/list/src/org/labkey/list/model/ListDefinitionImpl.java
+++ b/list/src/org/labkey/list/model/ListDefinitionImpl.java
@@ -713,6 +713,11 @@ public class ListDefinitionImpl implements ListDefinition
         return table;
     }
 
+    public TableInfo getTableForInsert(User user, Container c)
+    {
+        return getTable(user, c, QueryService.get().getProductProjectsInsertContainerFilter(c, user));
+    }
+
     public ActionURL urlImport(Container c)
     {
         return urlForName(ListController.UploadListItemsAction.class, c);

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3041,7 +3041,7 @@ public class QueryServiceImpl implements QueryService
 
     @Override
     @Nullable
-    public ContainerFilter getProductProjectsInsertContainerFilter(Container container, User user)
+    public ContainerFilter getContainerFilterForLookups(Container container, User user)
     {
         // Issue 45740: When inserting into a product project ensure the correct ContainerFilter scope
         if (QueryService.get().isProductProjectsEnabled(container))

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3039,6 +3039,37 @@ public class QueryServiceImpl implements QueryService
         return columnTransformerMap.get(conceptURI);
     }
 
+    @Override
+    @Nullable
+    public ContainerFilter getProductProjectsInsertContainerFilter(Container container, User user)
+    {
+        // Issue 45740: When inserting into a product project ensure the correct ContainerFilter scope
+        if (QueryService.get().isProductProjectsEnabled(container))
+            return ContainerFilter.Type.CurrentPlusProjectAndShared.create(container, user);
+        return null;
+    }
+
+    @Override
+    public boolean isProductProjectsEnabled(Container container)
+    {
+        if (container == null || container.isRoot() || container.isWorkbook())
+            return false;
+
+        Container project;
+        if (container.isProject())
+            project = container;
+        else
+            project = container.getProject();
+
+        if (project == null)
+            return false;
+
+        // It is less than ideal to reference the folder type but for the time being
+        // this is how we recognize the appropriate container context.
+        // 1. The provided container is a LKB top-level LKB folder.
+        // 2. The provided container's top-level parent is a LKB folder.
+        return "Biologics".equals(project.getFolderType().getName());
+    }
 
     public static class TestCase extends Assert
     {

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4306,17 +4306,6 @@ public class QueryController extends SpringActionController
             return getRequestedApiVersion() >= 13.2;
         }
 
-        @Nullable
-        private ContainerFilter getInsertContainerFilter(Container container, User user)
-        {
-            // Issue 45740: When inserting into a product project ensure the correct ContainerFilter scope
-            if (QueryService.get().isProductProjectsEnabled(container))
-                return ContainerFilter.Type.CurrentPlusProjectAndShared.create(container, user);
-
-            // Return null here so resolved TableInfo falls back to its own default ContainerFilter
-            return null;
-        }
-
         @NotNull
         protected TableInfo getTableInfo(Container container, User user, String schemaName, String queryName)
         {
@@ -4327,7 +4316,7 @@ public class QueryController extends SpringActionController
             if (null == schema)
                 throw new IllegalArgumentException("The schema '" + schemaName + "' does not exist.");
 
-            TableInfo table = schema.getTable(queryName, getInsertContainerFilter(container, user));
+            TableInfo table = schema.getTableForInsert(queryName);
             if (table == null)
                 throw new IllegalArgumentException("The query '" + queryName + "' in the schema '" + schemaName + "' does not exist.");
             return table;

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4306,6 +4306,17 @@ public class QueryController extends SpringActionController
             return getRequestedApiVersion() >= 13.2;
         }
 
+        @Nullable
+        private ContainerFilter getInsertContainerFilter(Container container, User user)
+        {
+            // Issue 45740: When inserting into a product project ensure the correct ContainerFilter scope
+            if (QueryService.get().isProductProjectsEnabled(container))
+                return ContainerFilter.Type.CurrentPlusProjectAndShared.create(container, user);
+
+            // Return null here so resolved TableInfo falls back to its own default ContainerFilter
+            return null;
+        }
+
         @NotNull
         protected TableInfo getTableInfo(Container container, User user, String schemaName, String queryName)
         {
@@ -4316,7 +4327,7 @@ public class QueryController extends SpringActionController
             if (null == schema)
                 throw new IllegalArgumentException("The schema '" + schemaName + "' does not exist.");
 
-            TableInfo table = schema.getTable(queryName, null);
+            TableInfo table = schema.getTable(queryName, getInsertContainerFilter(container, user));
             if (table == null)
                 throw new IllegalArgumentException("The query '" + queryName + "' in the schema '" + schemaName + "' does not exist.");
             return table;


### PR DESCRIPTION
#### Rationale
This addresses [Issue 45740](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45740) by ensuring the correct container filter, `ContainerFilter.Types.CurrentPlusProjectAndShared`, is applied during insertion of rows in product projects. With this, the lookup validator is able to find the correct data to validate against when a field has been marked as "Ensure Value Exists in Lookup Target". This work covers Assays, Data Classes, Transform Tasks, Lists, and Sample Types.

**Opinion**
The crux of the implementation is that in order for a `TableInfo` and all of its subsequently generated bits (foreign key lookups, lookup validators, etc) to have the correct container scope it must be initialized with the expected Container Filter. This effectively means that the container filter to be used depends on _how_ the `TableInfo` is being used (read, insert/update, delete). I've attempted to encapsulate this in the notion of `schema.getTableForInsert()` where that implementation applies the container filter. This isn't ideal as it doesn't prevent someone from using just `schema.getTable()` when doing an insert. I could imagine having a `getTable` that takes something akin to a `QueryUpdateService.InsertOption` where it defaults to `READ` but allows the user to specify otherwise. That also doesn't enforce that the correct parameters are passed but does encapsulate everything in the same method(s) for hydrating a `TableInfo`. I'm open to other ideas as well.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3479
* https://github.com/LabKey/dataintegration/pull/171
* https://github.com/LabKey/biologics/pull/1396

#### Changes
* Introduce `QueryService.getProductProjectsInsertContainerFilter(Container)` which resolves the `ContainerFilter` to be used during insert/update of data in product projects.
* Call `getProductProjectsInsertContainerFilter` when spawning `TableInfo`s used for insertion.
* Miscellaneous nit improvements.
