### PR TITLE
use mbeans to look for tomcat webapps

### DIFF
--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -209,7 +209,7 @@ public class CoreWarningProvider implements WarningProvider
         {
             boolean defaultTomcatWebappFound = false;
             Set<String> deployedWebapps = collectAllDeployedApps();
-            deployedWebapps.remove(AppProps.getInstance().getContextPath());
+            deployedWebapps.remove(StringUtils.strip(AppProps.getInstance().getContextPath(),"/"));
             defaultTomcatWebappFound |= deployedWebapps.contains("docs");
             defaultTomcatWebappFound |= deployedWebapps.contains("HOST_MANAGER_");
             defaultTomcatWebappFound |= deployedWebapps.contains("EXAMPLES_");


### PR DESCRIPTION
#### Rationale
Mbeans is a more reliable way to check for tomcat webapps

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
