### PR TITLE
allow alternate attachment parents for storing signed snapshots

### DIFF
--- a/api/src/org/labkey/api/compliance/ComplianceService.java
+++ b/api/src/org/labkey/api/compliance/ComplianceService.java
@@ -18,6 +18,7 @@ package org.labkey.api.compliance;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.labkey.api.attachments.AttachmentParent;
+import org.labkey.api.attachments.AttachmentType;
 import org.labkey.api.attachments.ByteArrayAttachmentFile;
 import org.labkey.api.data.Activity;
 import org.labkey.api.data.Container;
@@ -36,6 +37,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Created by davebradlee on 7/27/17.
@@ -86,6 +88,13 @@ public interface ComplianceService
      * @throws org.labkey.api.view.UnauthorizedException if the user doesn't have sufficient permissions.
      */
     void setFolderSettings(@NotNull Container container, @NotNull User user, @NotNull ComplianceFolderSettings settings);
+
+    /**
+     * Register a supplier for an attachment parent for attachment types that should use an attachment parent that differs
+     * from the default one provided (for example: saving the attachment to the file system instead of the DB).
+     * The attachment type will need to be specified on the SignedSnapshot.
+     */
+    void registerAttachmentParentSupplier(AttachmentType type, Function<SignedSnapshot, AttachmentParent> supplier);
 
     /**
      * CRD operations for signed snapshots
@@ -157,6 +166,11 @@ public interface ComplianceService
         public Integer insertSignedSnapshot(Container container, User user, SignedSnapshot snapshot, ByteArrayAttachmentFile file) throws IOException
         {
             return null;
+        }
+
+        @Override
+        public void registerAttachmentParentSupplier(AttachmentType type, Function<SignedSnapshot, AttachmentParent> supplier)
+        {
         }
 
         @Override

--- a/api/src/org/labkey/api/compliance/SignedSnapshot.java
+++ b/api/src/org/labkey/api/compliance/SignedSnapshot.java
@@ -33,6 +33,7 @@ public class SignedSnapshot
     private String _entityId;
     private String _hash;
     private String _ownerEntityId;
+    private String _attachmentType;
 
     public SignedSnapshot()
     {
@@ -189,6 +190,16 @@ public class SignedSnapshot
         _ownerEntityId = ownerEntityId;
     }
 
+    public String getAttachmentType()
+    {
+        return _attachmentType;
+    }
+
+    public void setAttachmentType(String attachmentType)
+    {
+        _attachmentType = attachmentType;
+    }
+
     public Map<String, Object> toMap()
     {
         Map<String, Object> props = new HashMap<>();
@@ -205,6 +216,7 @@ public class SignedSnapshot
         props.put("Container", getContainer());
         props.put("Hash", getHash());
         props.put("OwnerEntityId", getOwnerEntityId());
+        props.put("AttachmentType", getAttachmentType());
         return props;
     }
 }


### PR DESCRIPTION
#### Rationale
The `ComplianceService` stores signed snapshots as attachments in the database using the `SignedSnapshotAttachmentParent`. A client recently encountered an issue where the creation of an ELN snapshot failed because it exceeded the max BLOB size configured for the server instance.

This adds support for ELN signed snapshots, which may be too large to be stored in the DB, to be alternately saved to the file system. To enable this the compliance service needed the ability to register alternate attachment parent suppliers which will be keyed by the `AttachmentType` unique id. Signed snapshots will also be able to record an attachment type so signed snapshots can be retrieved appropriately.

[linked issue](https://github.com/LabKey/labbook/issues/215)

#### Related Pull Requests
- https://github.com/LabKey/compliance/pull/160
- https://github.com/LabKey/labbook/pull/219
