### PR TITLE
Issue 45376: Migrate from Universal Analytics to Google Analytics 4

### DIFF
--- a/api/src/org/labkey/api/jsp/taglib/CheckboxTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/CheckboxTag.java
@@ -27,6 +27,9 @@ public class CheckboxTag extends SimpleTagBase
     protected String _name;
     protected String _value;
     protected Boolean _checked;
+    protected Boolean _disabled;
+    protected String _onChange;
+
 
     @Override
     public void doTag() throws IOException
@@ -40,6 +43,12 @@ public class CheckboxTag extends SimpleTagBase
 
         if (_checked != null && _checked)
             checkbox.checked(true);
+
+        if (_disabled != null && _disabled)
+            checkbox.disabled(true);
+
+        if (_onChange != null)
+            checkbox.onChange(_onChange);
 
         getOut().print(checkbox);
 
@@ -68,5 +77,15 @@ public class CheckboxTag extends SimpleTagBase
     public void setChecked(Boolean checked)
     {
         _checked = checked;
+    }
+
+    public void setDisabled(Boolean disabled)
+    {
+        _disabled = disabled;
+    }
+
+    public void setOnChange(String onChange)
+    {
+        _onChange = onChange;
     }
 }

--- a/api/webapp/WEB-INF/labkey.tld
+++ b/api/webapp/WEB-INF/labkey.tld
@@ -108,6 +108,14 @@
             <name>checkedSet</name>
             <rtexprvalue>true</rtexprvalue>
         </attribute>
+        <attribute>
+            <name>disabled</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <name>onChange</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
     </tag>
     <tag>
         <name>radio</name>

--- a/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
+++ b/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
@@ -68,7 +68,7 @@ public class AnalyticsServiceImpl implements AnalyticsService
                         return "";
                     }
                 },
-        /** Use GA with URL sanitization */
+        /** Use old GA with URL sanitization */
         enabled(true)
                 {
                     @Override
@@ -77,7 +77,7 @@ public class AnalyticsServiceImpl implements AnalyticsService
                         return TRACKING_SCRIPT_TEMPLATE_ASYNC;
                     }
                 },
-        /** Use GA without replacing container paths */
+        /** Use old GA without replacing container paths */
         enabledFullURL(true)
                 {
                     @Override
@@ -86,6 +86,7 @@ public class AnalyticsServiceImpl implements AnalyticsService
                         return TRACKING_SCRIPT_TEMPLATE_ASYNC;
                     }
                 },
+        /** Use GA4 with the full URL */
         ga4FullUrl(true)
                 {
                     @Override
@@ -221,7 +222,7 @@ public class AnalyticsServiceImpl implements AnalyticsService
         Container container = context.getContainer();
 
         // Adding a null check for container as on rendering the error page, container can be null for a not found page
-        if (getTrackingStatus().contains(TrackingStatus.enabledFullURL) && null != container && !container.hasPermission(UserManager.getGuestUser(), ReadPermission.class))
+        if (getTrackingStatus().contains(TrackingStatus.enabled) && null != container && !container.hasPermission(UserManager.getGuestUser(), ReadPermission.class))
         {
             actionUrl.deleteParameters();
             actionUrl.setExtraPath(container.getId());

--- a/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
+++ b/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
@@ -34,11 +34,16 @@ import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public class AnalyticsServiceImpl implements AnalyticsService
 {
+    private static final String SEPARATOR = ",";
+
     static public AnalyticsServiceImpl get()
     {
         return (AnalyticsServiceImpl) AnalyticsService.get();
@@ -81,6 +86,14 @@ public class AnalyticsServiceImpl implements AnalyticsService
                         return TRACKING_SCRIPT_TEMPLATE_ASYNC;
                     }
                 },
+        ga4FullUrl(true)
+                {
+                    @Override
+                    public String getRawScript()
+                    {
+                        return GA4_TRACKING_SCRIPT_TEMPLATE;
+                    }
+                },
         /** Custom tracking script */
         script(true)
                 {
@@ -110,6 +123,8 @@ public class AnalyticsServiceImpl implements AnalyticsService
     {
         trackingStatus,
         accountId,
+        // For GA 4
+        measurementId,
         trackingScript,
     }
 
@@ -119,10 +134,10 @@ public class AnalyticsServiceImpl implements AnalyticsService
         return properties.get(property.toString());
     }
 
-    public void setSettings(TrackingStatus trackingStatus, String accountId, String script, User user)
+    public void setSettings(Set<TrackingStatus> trackingStatus, String accountId, String measurementId, String script, User user)
     {
         AnalyticsSettingsGroup g = new AnalyticsSettingsGroup();
-        g.store(trackingStatus, accountId, script, user);
+        g.store(trackingStatus, accountId, measurementId, script, user);
     }
 
     /** Issue 36870 - an admittedly clunky way to hook into audit behavior */
@@ -146,13 +161,15 @@ public class AnalyticsServiceImpl implements AnalyticsService
             return PropertyManager.SHARED_USER;
         }
 
-        public void store(TrackingStatus trackingStatus, String accountId, String script, User user)
+        public void store(Set<TrackingStatus> trackingStatus, String accountId, String measurementId, String script, User user)
         {
             Container c = ContainerManager.getRoot();
             makeWriteable(c);
 
-            storeStringValue(AnalyticsProperty.trackingStatus.toString(), trackingStatus.toString());
+            String statusString = StringUtils.trimToNull(StringUtils.join(trackingStatus.toArray(), SEPARATOR));
+            storeStringValue(AnalyticsProperty.trackingStatus.toString(), statusString);
             storeStringValue(AnalyticsProperty.accountId.toString(), StringUtils.trimToNull(accountId));
+            storeStringValue(AnalyticsProperty.measurementId.toString(), StringUtils.trimToNull(measurementId));
             storeStringValue(AnalyticsProperty.trackingScript.toString(), StringUtils.trimToNull(script));
 
             save();
@@ -161,27 +178,36 @@ public class AnalyticsServiceImpl implements AnalyticsService
     }
 
     @NotNull
-    public TrackingStatus getTrackingStatus()
+    public Set<TrackingStatus> getTrackingStatus()
     {
-        String strStatus = getProperty(AnalyticsProperty.trackingStatus);
-        if (strStatus == null)
+        String allStatuses = getProperty(AnalyticsProperty.trackingStatus);
+        if (allStatuses == null)
         {
-            return TrackingStatus.disabled;
+            return Collections.emptySet();
         }
-        try
+
+        Set<TrackingStatus> result = new HashSet<>();
+
+        for (String status : allStatuses.split(SEPARATOR))
         {
-            return TrackingStatus.valueOf(strStatus);
+            try
+            {
+                result.add(TrackingStatus.valueOf(status));
+            }
+            catch (IllegalArgumentException ignored) {}
         }
-        catch (IllegalArgumentException iae)
-        {
-            return TrackingStatus.disabled;
-        }
+        return result;
     }
 
     public String getAccountId()
     {
         String accountId = getProperty(AnalyticsProperty.accountId);
         return Objects.requireNonNullElse(accountId, DEFAULT_ACCOUNT_ID);
+    }
+
+    public String getMeasurementId()
+    {
+        return getProperty(AnalyticsProperty.measurementId);
     }
 
     /**
@@ -195,7 +221,7 @@ public class AnalyticsServiceImpl implements AnalyticsService
         Container container = context.getContainer();
 
         // Adding a null check for container as on rendering the error page, container can be null for a not found page
-        if (getTrackingStatus() != TrackingStatus.enabledFullURL && null != container && !container.hasPermission(UserManager.getGuestUser(), ReadPermission.class))
+        if (getTrackingStatus().contains(TrackingStatus.enabledFullURL) && null != container && !container.hasPermission(UserManager.getGuestUser(), ReadPermission.class))
         {
             actionUrl.deleteParameters();
             actionUrl.setExtraPath(container.getId());
@@ -214,15 +240,29 @@ public class AnalyticsServiceImpl implements AnalyticsService
      * <p>For an explanation of what settings are available on the pageTracker object, see
      * <a href="http://code.google.com/apis/analytics/docs/gaJSApi.html">Google Analytics Tracking API</a>
      */
-    // new style (async)
     static final private String TRACKING_SCRIPT_TEMPLATE_ASYNC =
-        "<script type=\"text/javascript\">\n"+
-        "var _gaq = _gaq || [];\n" +
-        "_gaq.push(['_setAccount', ${ACCOUNT_ID:jsString}]);\n" +
-        "_gaq.push(['_setDetectTitle', false]);\n" +
-        "_gaq.push(['_trackPageview', ${PAGE_URL:jsString}]);\n" +
-        "</script>\n"+
-        "<script async=\"async\" type=\"text/javascript\" src=\"${GA_JS:htmlEncode}\"></script>\n";
+            """
+                    <script type="text/javascript">
+                    var _gaq = _gaq || [];
+                    _gaq.push(['_setAccount', ${ACCOUNT_ID:jsString}]);
+                    _gaq.push(['_setDetectTitle', false]);
+                    _gaq.push(['_trackPageview', ${PAGE_URL:jsString}]);
+                    </script>
+                    <script async="async" type="text/javascript" src="${GA_JS:htmlEncode}"></script>
+                    """;
+
+    static final private String GA4_TRACKING_SCRIPT_TEMPLATE =
+            """
+                    <!-- Global site tag (gtag.js) - Google Analytics -->
+                    <script async src="${GA4_JS:htmlEncode}"></script>
+                    <script>
+                      window.dataLayer = window.dataLayer || [];
+                      function gtag(){dataLayer.push(arguments);}
+                      gtag('js', new Date());
+                    
+                      gtag('config', ${MEASUREMENT_ID:jsString});
+                    </script>
+                    """;
 
 
     public String getSavedScript()
@@ -234,7 +274,7 @@ public class AnalyticsServiceImpl implements AnalyticsService
     @Override
     public String getTrackingScript(ViewContext context)
     {
-        if (!getTrackingStatus().showTrackingScript())
+        if (getTrackingStatus().isEmpty())
             return "";
 
         ActionURL url = context.getActionURL();
@@ -244,12 +284,20 @@ public class AnalyticsServiceImpl implements AnalyticsService
         boolean isSecure = context.getActionURL().getScheme().startsWith("https");
         String gaJS = (isSecure ? "https://ssl" : "http://www") + ".google-analytics.com/ga.js";
 
-        StringExpression se = StringExpressionFactory.create(getTrackingStatus().getRawScript());
-        return se.eval(PageFlowUtil.map(
-                "ACCOUNT_ID", getAccountId(),
-                "PAGE_URL", getSanitizedUrl(context),
-                "GA_JS", gaJS
-                ));
+        String ga4JS = "https://www.googletagmanager.com/gtag/js?id=" + getMeasurementId();
+
+        StringBuilder sb = new StringBuilder();
+        for (TrackingStatus trackingStatus : getTrackingStatus())
+        {
+            StringExpression se = StringExpressionFactory.create(trackingStatus.getRawScript());
+            sb.append(se.eval(PageFlowUtil.map(
+                    "ACCOUNT_ID", getAccountId(),
+                    "PAGE_URL", getSanitizedUrl(context),
+                    "GA_JS", gaJS,
+                    "GA4_JS", ga4JS,
+                    "MEASUREMENT_ID", getMeasurementId())));
+        }
+        return sb.toString();
     }
 
     static public void populateSettingsWithStartupProps()

--- a/core/src/org/labkey/core/analytics/analyticsSettings.jsp
+++ b/core/src/org/labkey/core/analytics/analyticsSettings.jsp
@@ -31,25 +31,49 @@
     boolean hasAdminOpsPerms = getContainer().hasPermission(getUser(), AdminOperationsPermission.class);
 %>
 <%=getTroubleshooterWarning(hasAdminOpsPerms, HtmlString.unsafe("<br>"))%>
-<p>Your LabKey Server can be configured to add JavaScript to your web site so that usage information will be sent to a web analytics system.</p>
+<p>You can configure your LabKey Server to include JavaScript that reports usage information to a web analytics system.</p>
 
 <labkey:errors/>
 <labkey:form action="<%=new ActionURL(AnalyticsController.BeginAction.class, ContainerManager.getRoot())%>" method="POST">
-    <table>
+    <table style="width: 60em;">
         <tr>
-            <td style="vertical-align: top; white-space: nowrap">
-                <strong><label><labkey:radio name="ff_trackingStatus" value="<%=AnalyticsServiceImpl.TrackingStatus.disabled%>" currentValue="<%=settingsForm.ff_trackingStatus%>"/> Off</label></strong>
+            <td style="vertical-align: top;">
+                <labkey:checkbox onChange="disableCheckboxes()" name="ff_trackingStatus" checked="<%= settingsForm.ff_trackingStatus.contains(AnalyticsServiceImpl.TrackingStatus.ga4FullUrl)%>" value="<%= AnalyticsServiceImpl.TrackingStatus.ga4FullUrl.toString() %>" id="ga4fullURL" />
             </td>
-            <td style="padding-left: 1em;"><p>Do not use analytics tracking on this server.</p></td>
+            <td style="padding-left: 1em;"><strong><label for="ga4fullURL">Google Analytics 4</label></strong>
+                <p>
+                    This is the most recent version of Google Analytics directly supported by LabKey Server.
+                    It always reports the full page URL, regardless of the folder's permissions.
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <td></td>
+            <td style="padding-left: 1em;">
+                <p>
+                    GA4 reporting is based on a Measurement ID, which typically start with <code>G-</code>.
+                    Create your own Measurement ID by signing up with Google Analytics.
+                </p>
+                <p>
+                    <label for="ff_accountId">Measurement ID</label>:
+                    <input <%=unsafe(hasAdminOpsPerms?"":"disabled=\"disabled\"")%> type="text" id="ff_measurementId" name="ff_measurementId" value="<%=h(settingsForm.ff_measurementId)%>"/>
+                </p>
+            </td>
         </tr>
 
+        <tr><td>&nbsp;</td></tr>
+
         <tr>
-            <td style="vertical-align: top; white-space: nowrap; padding-top: 2em;">
-                <strong><label><labkey:radio name="ff_trackingStatus" value="<%=AnalyticsServiceImpl.TrackingStatus.enabled%>" currentValue="<%=settingsForm.ff_trackingStatus%>"/> Google Analytics with modified URL</label></strong>
+            <td style="vertical-align: top;">
+                <labkey:checkbox onChange="disableCheckboxes()" name="ff_trackingStatus" checked="<%= settingsForm.ff_trackingStatus.contains(AnalyticsServiceImpl.TrackingStatus.enabled)%>" value="<%= AnalyticsServiceImpl.TrackingStatus.enabled.toString() %>" id="modifiedURL" />
             </td>
 
-            <td style="padding-left: 1em; padding-top: 2em;">
-                <p style="width: 60em;">
+            <td style="padding-left: 1em;">
+                <strong><label for="modifiedURL">Universal Google Analytics, with redacted URL</label></strong>
+                <p >
+                    Google has deprecated this version of Google Analytics. It stops accepting new data on July 1, 2023.
+                </p>
+                <p>
                     The full page URL will only be reported when it is accessible to Guest users.
                     When a project/folder is secured, LabKey Server will report a unique identifier
                     (the folder's EntityId, available through Admin->Folder->Management->Information)
@@ -59,53 +83,78 @@
             </td>
         </tr>
         <tr>
-            <td style="vertical-align: top; white-space: nowrap">
-                <strong><label><labkey:radio name="ff_trackingStatus" value="<%=AnalyticsServiceImpl.TrackingStatus.enabledFullURL%>" currentValue="<%=settingsForm.ff_trackingStatus%>"/> Google Analytics with full URL</label></strong>
+            <td style="vertical-align: top">
+                <strong><label><labkey:checkbox onChange="disableCheckboxes()" name="ff_trackingStatus" checked="<%= settingsForm.ff_trackingStatus.contains(AnalyticsServiceImpl.TrackingStatus.enabledFullURL)%>" value="<%= AnalyticsServiceImpl.TrackingStatus.enabledFullURL.toString() %>" id="fullURL" />
             </td>
 
-            <td style="padding-left: 1em;"><p>Always report the full page URL, regardless of the folder's permissions.</p></td>
+            <td style="padding-left: 1em;">
+                <strong><label for="fullURL">Universal Google Analytics, with full URL</label></strong>
+                <p>
+                    Google has deprecated this version of Google Analytics. It stops accepting new data on July 1, 2023.
+                </p>
+                <p>Always report the full page URL, regardless of the folder's permissions.</p></td>
         </tr>
         <tr>
             <td></td>
             <td style="padding-left: 1em;">
-                <p style="width: 60em;">
-                    <a href="https://www.google.com/analytics">Google Analytics</a> reporting is based on an Account
+                <p>
+                    Universal Google Analytics reporting is based on an Account
                     ID. LabKey monitors the Account ID
                     <code><%=h(AnalyticsServiceImpl.DEFAULT_ACCOUNT_ID)%></code> to understand usage and prioritize
                     development efforts. You can get own Account ID by signing up with Google Analytics.
                 </p>
-                <p style="width: 60em;">
+                <p>
                     <label for="ff_accountId">Account ID</label>:
-                    <input <%=text(hasAdminOpsPerms?"":"disabled=\"disabled\"")%> type="text" id="ff_accountId" name="ff_accountId" value="<%=h(settingsForm.ff_accountId)%>"/>
+                    <input <%=unsafe(hasAdminOpsPerms?"":"disabled=\"disabled\"")%> type="text" id="ff_accountId" name="ff_accountId" value="<%=h(settingsForm.ff_accountId)%>"/>
                 </p>
             </td>
         </tr>
 
+        <tr><td>&nbsp;</td></tr>
+
         <tr>
-            <td style="vertical-align: top; white-space: nowrap; padding-top: 2em">
-                <strong><label><labkey:radio name="ff_trackingStatus" value="<%=AnalyticsServiceImpl.TrackingStatus.script%>" currentValue="<%=settingsForm.ff_trackingStatus%>"/>&nbsp;Custom</label></strong>
+            <td style="vertical-align: top">
+                <labkey:checkbox name="ff_trackingStatus" checked="<%= settingsForm.ff_trackingStatus.contains(AnalyticsServiceImpl.TrackingStatus.script)%>" value="<%= AnalyticsServiceImpl.TrackingStatus.script.toString() %>" id="customScript" />
             </td>
-            <td style="padding-left: 1em; padding-top: 2em;">
-                <p style="width: 60em;">
+            <td style="padding-left: 1em;">
+                <strong><label for="customScript">Custom JavaScript Analytics></label></strong>
+                <p>
                     Add <label for="ff_trackingScript">custom analytics script</label> to the <code>&lt;head&gt;</code> of every page.  Include required <code>&lt;script&gt;</code> tags.
                 </p>
-                <p style="width: 60em;">
+                <p>
                     <strong>NOTE:</strong> You can mess up your site if you make a mistake here.  You may want to bookmark this page to aid in making corrections, just in case.
                 </p>
-                <textarea <%=text(hasAdminOpsPerms?"":"disabled=\"disabled\"")%> style="width:100%; height:15em;" id="ff_trackingScript" name="ff_trackingScript"><%=h(settingsForm.ff_trackingScript)%></textarea>
+                <textarea <%=unsafe(hasAdminOpsPerms?"":"disabled=\"disabled\"")%> style="width:100%; height:15em;" id="ff_trackingScript" name="ff_trackingScript"><%=h(settingsForm.ff_trackingScript)%></textarea>
+            </td>
+        </tr>
+
+        <tr><td>&nbsp;</td></tr>
+
+        <tr>
+            <td></td>
+            <td style="padding-left: 1em;">
+                <%
+                    String doneBtnText = "done";
+                    if(hasAdminOpsPerms)
+                    {
+                        doneBtnText = "cancel";
+                %>
+                <labkey:button text="submit"/>
+                <%
+                    }
+                %>
+                <labkey:button text="<%=doneBtnText%>" href="<%=urlProvider(AdminUrls.class).getAdminConsoleURL()%>" />
             </td>
         </tr>
     </table>
 
-    <%
-        String doneBtnText = "done";
-        if(hasAdminOpsPerms)
-        {
-            doneBtnText = "cancel";
-    %>
-        <labkey:button text="submit"/>
-    <%
-        }
-    %>
-    <labkey:button text="<%=doneBtnText%>" href="<%=urlProvider(AdminUrls.class).getAdminConsoleURL()%>" />
 </labkey:form>
+
+<script>
+    function disableCheckboxes() {
+        document.getElementById('fullURL').disabled = document.getElementById('modifiedURL').checked;
+        document.getElementById('modifiedURL').disabled = document.getElementById('fullURL').checked;
+    }
+
+    disableCheckboxes();
+</script>

--- a/core/src/org/labkey/core/analytics/analyticsSettings.jsp
+++ b/core/src/org/labkey/core/analytics/analyticsSettings.jsp
@@ -117,7 +117,7 @@
                 <labkey:checkbox name="ff_trackingStatus" checked="<%= settingsForm.ff_trackingStatus.contains(AnalyticsServiceImpl.TrackingStatus.script)%>" value="<%= AnalyticsServiceImpl.TrackingStatus.script.toString() %>" id="customScript" />
             </td>
             <td style="padding-left: 1em;">
-                <strong><label for="customScript">Custom JavaScript Analytics></label></strong>
+                <strong><label for="customScript">Custom JavaScript Analytics</label></strong>
                 <p>
                     Add <label for="ff_trackingScript">custom analytics script</label> to the <code>&lt;head&gt;</code> of every page.  Include required <code>&lt;script&gt;</code> tags.
                 </p>


### PR DESCRIPTION
#### Rationale
Google has deprecated "Universal" analytics, which is the only variant we support directly. GA4 is the version. Sites are also interested in being able to configure multiple styles of reporting for a transition period.

#### Changes
* Add basic support for enabling and reporting to GA4
* Allow multi-select across GA4, Universal, and custom
* Disallow selecting both Universal variants
* A few more passthroughs for the checkbox tagline
*
<img width="777" alt="Screen Shot 2022-06-24 at 3 11 37 PM" src="https://user-images.githubusercontent.com/5114642/175699557-b66553bc-0bd4-4fd6-91b5-d175756b4b8d.png">