### PR TITLE
Avoid blocking alerts on initial page load

### DIFF
--- a/pipeline/src/org/labkey/pipeline/startPipelineImport.jsp
+++ b/pipeline/src/org/labkey/pipeline/startPipelineImport.jsp
@@ -97,7 +97,7 @@ Ext4.onReady(function()
         },
         failure: function(response)
         {
-            alert('Failed to get folder import info. Folder XML file may be invalid.');
+            Ext4.Msg.alert('Failed to get folder import info. Folder XML file may be invalid.');
 
         }
     });

--- a/pipeline/src/org/labkey/pipeline/startPipelineImport.jsp
+++ b/pipeline/src/org/labkey/pipeline/startPipelineImport.jsp
@@ -97,8 +97,7 @@ Ext4.onReady(function()
         },
         failure: function(response)
         {
-            Ext4.Msg.alert('Failed to get folder import info. Folder XML file may be invalid.');
-
+            LABKEY.Utils.alert('Error', 'Failed to get folder import info. Folder XML file may be invalid.');
         }
     });
 });


### PR DESCRIPTION
#### Rationale
Blocking JavaScript alerts cause trouble for the crawler.

#### Related Pull Requests
* #3476 

#### Changes
* Use `LABKEY.Utils.alert` instead of plain JavaScript alert
