### PR TITLE
Remove unique constraint from exp.materialsource

### DIFF
--- a/experiment/resources/schemas/dbscripts/postgresql/exp-22.002-22.003.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-22.002-22.003.sql
@@ -1,1 +1,0 @@
-ALTER TABLE exp.materialsource ADD CONSTRAINT UQ_MaterialSource_Container_Name UNIQUE (Container, Name);

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-22.004-22.005.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-22.004-22.005.sql
@@ -1,0 +1,1 @@
+SELECT core.fn_dropifexists('materialsource', 'exp', 'constraint', 'UQ_MaterialSource_Container_Name');

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-22.002-22.003.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-22.002-22.003.sql
@@ -1,1 +1,0 @@
-ALTER TABLE exp.materialsource ADD CONSTRAINT UQ_MaterialSource_Container_Name UNIQUE (Container, Name);

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-22.004-22.005.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-22.004-22.005.sql
@@ -1,0 +1,1 @@
+EXEC core.fn_dropifexists 'materialsource', 'exp', 'CONSTRAINT', 'UQ_MaterialSource_Container_Name';

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -165,7 +165,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     public Double getSchemaVersion()
     {
-        return 22.004;
+        return 22.005;
     }
 
     @Nullable


### PR DESCRIPTION
#### Rationale
As part of the work to support sample type renaming, a db uniq key is added on exp.materialsource to guarantee unique name per container. For unknown reasons, there have are existing materialsource records in some client's db with duplicate sample names within the same container, resulting in upgrade error. This uniq key adds additional safeguard but is not strictly needed since we explicitly check for duplicates in sample type create and update apis. To avoid similar upgrade error, we are removing the uniq key in this PR. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3256

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
