### PR TITLE
More consistency for audit record map display

### DIFF
--- a/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
@@ -36,6 +36,7 @@ import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.ExistingRecordDataIterator;
 import org.labkey.api.exp.ChangePropertyDescriptorException;
 import org.labkey.api.exp.PropertyDescriptor;
+import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.Domain;
@@ -65,6 +66,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.labkey.api.audit.query.AbstractAuditDomainKind.AUDIT_RECORD_DATA_MAP_CONCEPT_URI;
+import static org.labkey.api.audit.query.AbstractAuditDomainKind.NEW_RECORD_PROP_NAME;
+import static org.labkey.api.audit.query.AbstractAuditDomainKind.OLD_RECORD_PROP_NAME;
+
 /**
  * User: klum
  * Date: 7/11/13
@@ -86,9 +91,7 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
     public static final String COLUMN_NAME_TRANSACTION_ID = "TransactionID";
     public static final String COLUMN_NAME_DATA_CHANGES = "DataChanges";
 
-    public static final String OLD_RECORD_PROP_NAME = "oldRecordMap";
     public static final String OLD_RECORD_PROP_CAPTION = "Old Record Values";
-    public static final String NEW_RECORD_PROP_NAME = "newRecordMap";
     public static final String NEW_RECORD_PROP_CAPTION = "New Record Values";
 
     final AbstractAuditDomainKind domainKind;
@@ -349,6 +352,7 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
             var added = table.addColumn(new AliasedColumn(table, "OldValues", oldCol));
             added.setDisplayColumnFactory(DataMapColumn::new);
             added.setLabel(OLD_RECORD_PROP_CAPTION);
+            added.setConceptURI(AUDIT_RECORD_DATA_MAP_CONCEPT_URI);
             oldCol.setHidden(true);
         }
 
@@ -357,6 +361,7 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
             var added = table.addColumn(new AliasedColumn(table, "NewValues", newCol));
             added.setDisplayColumnFactory(DataMapColumn::new);
             added.setLabel(NEW_RECORD_PROP_CAPTION);
+            added.setConceptURI(AUDIT_RECORD_DATA_MAP_CONCEPT_URI);
             newCol.setHidden(true);
         }
 

--- a/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
@@ -36,7 +36,6 @@ import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.ExistingRecordDataIterator;
 import org.labkey.api.exp.ChangePropertyDescriptorException;
 import org.labkey.api.exp.PropertyDescriptor;
-import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.Domain;
@@ -90,9 +89,6 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
     public static final String COLUMN_NAME_PROJECT_ID = "ProjectId";
     public static final String COLUMN_NAME_TRANSACTION_ID = "TransactionID";
     public static final String COLUMN_NAME_DATA_CHANGES = "DataChanges";
-
-    public static final String OLD_RECORD_PROP_CAPTION = "Old Record Values";
-    public static final String NEW_RECORD_PROP_CAPTION = "New Record Values";
 
     final AbstractAuditDomainKind domainKind;
 
@@ -351,7 +347,7 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
         {
             var added = table.addColumn(new AliasedColumn(table, "OldValues", oldCol));
             added.setDisplayColumnFactory(DataMapColumn::new);
-            added.setLabel(OLD_RECORD_PROP_CAPTION);
+            added.setLabel(AbstractAuditDomainKind.OLD_RECORD_PROP_CAPTION);
             added.setConceptURI(AUDIT_RECORD_DATA_MAP_CONCEPT_URI);
             oldCol.setHidden(true);
         }
@@ -360,7 +356,7 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
         {
             var added = table.addColumn(new AliasedColumn(table, "NewValues", newCol));
             added.setDisplayColumnFactory(DataMapColumn::new);
-            added.setLabel(NEW_RECORD_PROP_CAPTION);
+            added.setLabel(AbstractAuditDomainKind.NEW_RECORD_PROP_CAPTION);
             added.setConceptURI(AUDIT_RECORD_DATA_MAP_CONCEPT_URI);
             newCol.setHidden(true);
         }

--- a/api/src/org/labkey/api/audit/data/DataMapColumn.java
+++ b/api/src/org/labkey/api/audit/data/DataMapColumn.java
@@ -21,6 +21,8 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.AbstractAuditTypeProvider;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
@@ -91,5 +93,14 @@ public class DataMapColumn extends DataColumn
             return result;
         }
         return Collections.emptyList();
+    }
+
+    public static class Factory implements DisplayColumnFactory
+    {
+        @Override
+        public DisplayColumn createRenderer(ColumnInfo colInfo)
+        {
+            return new DataMapColumn(colInfo);
+        }
     }
 }

--- a/api/src/org/labkey/api/audit/query/AbstractAuditDomainKind.java
+++ b/api/src/org/labkey/api/audit/query/AbstractAuditDomainKind.java
@@ -54,15 +54,13 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import static org.labkey.api.audit.AbstractAuditTypeProvider.NEW_RECORD_PROP_CAPTION;
-import static org.labkey.api.audit.AbstractAuditTypeProvider.OLD_RECORD_PROP_CAPTION;
-
 /**
  * User: klum
  * Date: 7/8/13
  */
 public abstract class AbstractAuditDomainKind extends DomainKind<JSONObject>
 {
+
     private static String XAR_SUBSTITUTION_SCHEMA_NAME = "SchemaName";
     private static String XAR_SUBSTITUTION_TABLE_NAME = "TableName";
 
@@ -74,6 +72,8 @@ public abstract class AbstractAuditDomainKind extends DomainKind<JSONObject>
 
     public static final String OLD_RECORD_PROP_NAME = "oldRecordMap";
     public static final String NEW_RECORD_PROP_NAME = "newRecordMap";
+    public static final String OLD_RECORD_PROP_CAPTION = "Old Record Values";
+    public static final String NEW_RECORD_PROP_CAPTION = "New Record Values";
 
     public static final String AUDIT_RECORD_DATA_MAP_CONCEPT_URI = "http://www.labkey.org/types#auditRecordDataMap";
 

--- a/api/src/org/labkey/api/audit/query/AbstractAuditDomainKind.java
+++ b/api/src/org/labkey/api/audit/query/AbstractAuditDomainKind.java
@@ -54,6 +54,9 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import static org.labkey.api.audit.AbstractAuditTypeProvider.NEW_RECORD_PROP_CAPTION;
+import static org.labkey.api.audit.AbstractAuditTypeProvider.OLD_RECORD_PROP_CAPTION;
+
 /**
  * User: klum
  * Date: 7/8/13
@@ -71,6 +74,8 @@ public abstract class AbstractAuditDomainKind extends DomainKind<JSONObject>
 
     public static final String OLD_RECORD_PROP_NAME = "oldRecordMap";
     public static final String NEW_RECORD_PROP_NAME = "newRecordMap";
+
+    public static final String AUDIT_RECORD_DATA_MAP_CONCEPT_URI = "http://www.labkey.org/types#auditRecordDataMap";
 
     static
     {
@@ -360,6 +365,22 @@ public abstract class AbstractAuditDomainKind extends DomainKind<JSONObject>
         pd.setRequired(required);
 
         return pd;
+    }
+
+    protected PropertyDescriptor createOldDataMapPropertyDescriptor()
+    {
+        PropertyDescriptor d = createPropertyDescriptor(OLD_RECORD_PROP_NAME, PropertyType.STRING, -1); // varchar max
+        d.setConceptURI(AUDIT_RECORD_DATA_MAP_CONCEPT_URI);
+        d.setLabel(OLD_RECORD_PROP_CAPTION);
+        return d;
+    }
+
+    protected PropertyDescriptor createNewDataMapPropertyDescriptor()
+    {
+        PropertyDescriptor d = createPropertyDescriptor(NEW_RECORD_PROP_NAME, PropertyType.STRING, -1); // varchar max
+        d.setConceptURI(AUDIT_RECORD_DATA_MAP_CONCEPT_URI);
+        d.setLabel(NEW_RECORD_PROP_CAPTION);
+        return d;
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
@@ -155,8 +155,8 @@ public class SampleTimelineAuditProvider extends AbstractAuditTypeProvider
             fields.add(createPropertyDescriptor(IS_LINEAGE_UPDATE_COLUMN_NAME, PropertyType.BOOLEAN));
             fields.add(createPropertyDescriptor(INVENTORY_UPDATE_TYPE_COLUMN_NAME, PropertyType.STRING));
             fields.add(createPropertyDescriptor(METADATA_COLUMN_NAME, PropertyType.STRING, -1));        // varchar max
-            fields.add(createPropertyDescriptor(OLD_RECORD_PROP_NAME, PropertyType.STRING, -1));        // varchar max
-            fields.add(createPropertyDescriptor(NEW_RECORD_PROP_NAME, PropertyType.STRING, -1));        // varchar max
+            fields.add(createOldDataMapPropertyDescriptor());
+            fields.add(createNewDataMapPropertyDescriptor());
             fields.add(createPropertyDescriptor(COLUMN_NAME_TRANSACTION_ID, PropertyType.BIGINT));        // varchar max
             _fields = Collections.unmodifiableSet(fields);
         }

--- a/list/src/org/labkey/list/model/ListAuditProvider.java
+++ b/list/src/org/labkey/list/model/ListAuditProvider.java
@@ -242,8 +242,8 @@ public class ListAuditProvider extends AbstractAuditTypeProvider implements Audi
             // to be indexed
             fields.add(createPropertyDescriptor(COLUMN_NAME_LIST_ITEM_ENTITY_ID, PropertyType.STRING, 300)); // UNDONE: is needed ? .setEntityId(true));
             fields.add(createPropertyDescriptor(COLUMN_NAME_LIST_NAME, PropertyType.STRING));
-            fields.add(createPropertyDescriptor(OLD_RECORD_PROP_NAME, PropertyType.STRING, -1));        // varchar max
-            fields.add(createPropertyDescriptor(NEW_RECORD_PROP_NAME, PropertyType.STRING, -1));        // varchar max
+            fields.add(createOldDataMapPropertyDescriptor());
+            fields.add(createNewDataMapPropertyDescriptor());
             _fields = Collections.unmodifiableSet(fields);
         }
 

--- a/list/src/org/labkey/list/model/ListAuditProvider.java
+++ b/list/src/org/labkey/list/model/ListAuditProvider.java
@@ -117,6 +117,7 @@ public class ListAuditProvider extends AbstractAuditTypeProvider implements Audi
                 }
             }
         };
+        appendValueMapColumns(table);
 
         // Render a details URL only for rows that have a listItemEntityId
         DetailsURL url = DetailsURL.fromString("list/listItemDetails.view?listId=${listId}&entityId=${listItemEntityId}&rowId=${rowId}", null, StringExpressionFactory.AbstractStringExpression.NullValueBehavior.NullResult);

--- a/query/src/org/labkey/query/audit/QueryUpdateAuditProvider.java
+++ b/query/src/org/labkey/query/audit/QueryUpdateAuditProvider.java
@@ -273,8 +273,8 @@ public class QueryUpdateAuditProvider extends AbstractAuditTypeProvider implemen
             fields.add(createPropertyDescriptor(COLUMN_NAME_ROW_PK, PropertyType.STRING));
             fields.add(createPropertyDescriptor(COLUMN_NAME_SCHEMA_NAME, PropertyType.STRING));
             fields.add(createPropertyDescriptor(COLUMN_NAME_QUERY_NAME, PropertyType.STRING));
-            fields.add(createPropertyDescriptor(OLD_RECORD_PROP_NAME, PropertyType.STRING, -1));        // varchar max
-            fields.add(createPropertyDescriptor(NEW_RECORD_PROP_NAME, PropertyType.STRING, -1));        // varchar max
+            fields.add(createOldDataMapPropertyDescriptor());
+            fields.add(createNewDataMapPropertyDescriptor());
             fields.add(createPropertyDescriptor(COLUMN_NAME_TRANSACTION_ID, PropertyType.BIGINT));
             _fields = Collections.unmodifiableSet(fields);
         }

--- a/study/src/org/labkey/study/audit/ParticipantGroupAuditProvider.java
+++ b/study/src/org/labkey/study/audit/ParticipantGroupAuditProvider.java
@@ -176,8 +176,8 @@ public class ParticipantGroupAuditProvider extends AbstractAuditTypeProvider imp
             fields = new LinkedHashSet<>();
             fields.add(createPropertyDescriptor(PARTICIPANT_CATEGORY_ID_COLUMN_NAME, PropertyType.INTEGER, PARTICIPANT_CATEGORY_ID_COLUMN_NAME, null, true));
             fields.add(createPropertyDescriptor(PARTICIPANT_GROUP_ID_COLUMN_NAME, PropertyType.STRING, PARTICIPANT_GROUP_ID_COLUMN_NAME, null, false));
-            fields.add(createPropertyDescriptor(OLD_RECORD_PROP_NAME, PropertyType.STRING, -1));
-            fields.add(createPropertyDescriptor(NEW_RECORD_PROP_NAME, PropertyType.STRING, -1));
+            fields.add(createOldDataMapPropertyDescriptor());
+            fields.add(createNewDataMapPropertyDescriptor());
         }
 
         @Override

--- a/study/src/org/labkey/study/dataset/DatasetAuditProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetAuditProvider.java
@@ -258,8 +258,8 @@ public class DatasetAuditProvider extends AbstractAuditTypeProvider implements A
             fields.add(createPropertyDescriptor(COLUMN_NAME_DATASET_ID, PropertyType.INTEGER));
             fields.add(createPropertyDescriptor(COLUMN_NAME_HAS_DETAILS, PropertyType.BOOLEAN));
             fields.add(createPropertyDescriptor(COLUMN_NAME_LSID, PropertyType.STRING));
-            fields.add(createPropertyDescriptor(OLD_RECORD_PROP_NAME, PropertyType.STRING, -1));        // varchar max
-            fields.add(createPropertyDescriptor(NEW_RECORD_PROP_NAME, PropertyType.STRING, -1));        // varchar max
+            fields.add(createOldDataMapPropertyDescriptor());
+            fields.add(createNewDataMapPropertyDescriptor());
             _fields = Collections.unmodifiableSet(fields);
         }
 


### PR DESCRIPTION
#### Rationale
Many audit tables add the `oldDataMap` and `newDataMap` columns, so a helper method to do that promotes consistency. Also, we have considered making a nicer display of this data for our applications. Adding a conceptURI to the fields makes it easier to do that customization.

#### Related Pull Requests
https://github.com/LabKey/inventory/pull/472
https://github.com/LabKey/sampleManagement/pull/1063

#### Changes
* Add `conceptURI` for the audit record data map fields (not required at this time, but provides a way to customize the display in our applications if we choose to do that).
* Add utility methods to centralize creation of the fields for the `oldDataMap` and `newDataMap`
* Add `Factory` class to `DataMapColumn`
* In `ListAuditProvider`, add the dataMap columns in the standard way so they get the display column factory

