### PR TITLE
Issue 45794: Search API doesn't audit

### DIFF
--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -40,6 +40,7 @@ import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.URLHelper;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.WebPartView;
@@ -72,8 +73,8 @@ import java.util.function.Function;
 public interface SearchService
 {
     // create logger for package which can be set via logger-manage.view
-    Logger _packageLogger = LogManager.getLogger(SearchService.class.getPackage().getName());
-    Logger _log = LogManager.getLogger(SearchService.class);
+    Logger _packageLogger = LogHelper.getLogger(SearchService.class.getPackage(), "Full text search module rollup");
+    Logger _log = LogHelper.getLogger(SearchService.class, "Full text search service");
 
     long DEFAULT_FILE_SIZE_LIMIT = 100L; // 100 MB
 

--- a/api/src/org/labkey/api/util/logging/LogHelper.java
+++ b/api/src/org/labkey/api/util/logging/LogHelper.java
@@ -23,6 +23,13 @@ public class LogHelper
         return LogManager.getLogger(c);
     }
 
+    public static Logger getLogger(Package p, String note)
+    {
+        LOGGER_NOTES.put(p.getName(), note);
+        //noinspection SSBasedInspection
+        return LogManager.getLogger(p.getName());
+    }
+
     public static String getNote(String className)
     {
         return LOGGER_NOTES.get(className);

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -585,6 +585,8 @@ public class SearchController extends SpringActionController
                 throw new NotFoundException();
             }
 
+            audit(form);
+
             final Path contextPath = Path.parse(getViewContext().getContextPath());
             final String query = form.getQueryString();
             final JSONObject response = new JSONObject();


### PR DESCRIPTION
#### Rationale
We should audit search terms whether you're coming through the LKS UI or an API (typically via LKSM or LKB, but not necessarily)

#### Changes
* Add audit record for API based search
* Add metric that counts total searches on a server
* Minor code cleanup
* LogHelper method for package-level logger