### PR TITLE
Issue 44797: Update data alignment with custom and standard participant views

### DIFF
--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -4604,7 +4604,11 @@ public class StudyController extends BaseStudyController
             "       /* place the webpart into the 'participantData' div: */\n" +
             "       participantWebPart.render();\n" +
             "   });\n" +
-            "</script>";
+            "</script> \n" +
+            "/* Adjust width of first column: */\n" +
+            "<style>\n" +
+            "  .labkey-data-region tr td:first-child {width: 300px}\n" +
+            "</style>";
 
     public static class CustomizeParticipantViewForm extends ReturnUrlForm
     {

--- a/study/src/org/labkey/study/view/customizeParticipantView.jsp
+++ b/study/src/org/labkey/study/view/customizeParticipantView.jsp
@@ -29,6 +29,14 @@
     boolean useCustomView = bean.isUseCustomView();
     String subjectNoun = StudyService.get().getSubjectNounSingular(getContainer());
 %>
+
+<style type="text/css">
+    .labkey-data-region tr td:first-child
+    {
+        width: 300px;
+    }
+</style>
+
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
     window.onbeforeunload = LABKEY.beforeunload();
 

--- a/study/src/org/labkey/study/view/customizeParticipantView.jsp
+++ b/study/src/org/labkey/study/view/customizeParticipantView.jsp
@@ -29,14 +29,6 @@
     boolean useCustomView = bean.isUseCustomView();
     String subjectNoun = StudyService.get().getSubjectNounSingular(getContainer());
 %>
-
-<style type="text/css">
-    .labkey-data-region tr td:first-child
-    {
-        width: 300px;
-    }
-</style>
-
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
     window.onbeforeunload = LABKEY.beforeunload();
 

--- a/study/src/org/labkey/study/view/participantAll.jsp
+++ b/study/src/org/labkey/study/view/participantAll.jsp
@@ -239,6 +239,11 @@
     .labkey-ptid-remove, .labkey-ptid-add {
         cursor: pointer;
     }
+
+    .labkey-data-region tr td:first-child
+    {
+        width: 300px
+    }
 </style>
 
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">

--- a/study/src/org/labkey/study/view/participantAll.jsp
+++ b/study/src/org/labkey/study/view/participantAll.jsp
@@ -242,7 +242,7 @@
 
     .labkey-data-region tr td:first-child
     {
-        width: 300px
+        width: 300px;
     }
 </style>
 


### PR DESCRIPTION
#### Rationale
When you customize the participant view in a study, our default code is showing a particularly wide first column. By default, the first column should be within a reasonable width for readability.

#### Related Pull Requests
* N/A

#### Changes
* Update styling
