### PR TITLE
Make logging of deadlock during next() similar to logging of deadlock during execute()

### DIFF
--- a/api/src/org/labkey/api/data/dialect/StatementWrapper.java
+++ b/api/src/org/labkey/api/data/dialect/StatementWrapper.java
@@ -19,12 +19,14 @@ package org.labkey.api.data.dialect;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.collections.OneBasedList;
 import org.labkey.api.data.ConnectionWrapper;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.QueryLogging;
+import org.labkey.api.data.ResultSetWrapper;
 import org.labkey.api.data.queryprofiler.QueryProfiler;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.DateUtil;
@@ -99,7 +101,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         _stackTrace = stackTrace;
     }
 
-    public @Nullable Boolean isRequestThread()
+    public @NotNull Boolean isRequestThread()
     {
         return null != _requestThread ? _requestThread : ViewServlet.isRequestThread();
     }
@@ -1244,7 +1246,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
 
             ResultSet rs = ((PreparedStatement)_stmt).executeQuery();
             assert MemTracker.getInstance().put(rs);
-            return rs;
+            return wrap(rs);
         }
         catch (SQLException sqlx)
         {
@@ -1279,14 +1281,13 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         }
     }
 
-    private boolean _set(int i, @Nullable Object o)
+    private void _set(int i, @Nullable Object o)
     {
         if (null == _parameters)
             _parameters = new OneBasedList<>(10);
         while (_parameters.size() < i)
             _parameters.add(null);
         _parameters.set(i, o);
-        return true;
     }
 
     @Override
@@ -1832,7 +1833,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         {
             ResultSet rs = _stmt.executeQuery(sql);
             assert MemTracker.getInstance().put(rs);
-            return rs;
+            return wrap(rs);
         }
         catch (SQLException sqlx)
         {
@@ -2069,7 +2070,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         {
             ResultSet rs = _stmt.getResultSet();
             assert MemTracker.getInstance().put(rs);
-            return rs;
+            return wrap(rs);
         }
         catch (SQLException e)
         {
@@ -2268,7 +2269,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         {
             ResultSet rs = _stmt.getGeneratedKeys();
             assert MemTracker.getInstance().put(rs);
-            return rs;
+            return wrap(rs);
         }
         catch (SQLException e)
         {
@@ -2871,6 +2872,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
             _conn.logAndCheckException(x);
         }
 
+        //noinspection ConstantConditions
         if (!_log.isEnabled(Level.DEBUG) && !isAssertEnabled)
             return;
 
@@ -2931,17 +2933,8 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         final String logString = logEntry.toString();
         _log.log(Level.DEBUG, logString);
 
-// modified on trunk, just commenting out for now
-//        MemTracker.getInstance().put(new MemTrackable(){
-//            @Override
-//            public String toMemTrackerString()
-//            {
-//                return logString;
-//            }
-//        });
-
         // check for deadlock or transaction related error
-        if (x != null && SqlDialect.isTransactionException(x))
+        if (SqlDialect.isTransactionException(x))
         {
             DebugInfoDumper.dumpThreads(_log);
         }
@@ -2991,5 +2984,27 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
     public String getDebugSql()
     {
         return _debugSql;
+    }
+
+
+    ResultSet wrap(ResultSet rs)
+    {
+        return new ResultSetWrapper(rs)
+        {
+            @Override
+            public boolean next() throws SQLException
+            {
+                try
+                {
+                    return super.next();
+                }
+                catch (SQLException x)
+                {
+                    if (SqlDialect.isTransactionException(x))
+                        _logStatement(_debugSql, x, -1, getQueryLogging());
+                    throw x;
+                }
+            }
+        };
     }
 }


### PR DESCRIPTION
… 
#### Rationale
Deadlock exceptions can be thrown from Statement.next().  However, our logging in this case is much less detailed than when deadlock is thrown during execute(), making it difficult to troubleshoot.  Hopefully this change helps that.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
