### PR TITLE
Avoid SQL Server deadlock on pipeline.statusfiles

### DIFF
--- a/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
@@ -631,7 +631,7 @@ public class PipelineServiceImpl implements PipelineService
     }
 
     @Override
-    public PipelineStatusFile getStatusFile(String jobGuid)
+    public PipelineStatusFileImpl getStatusFile(String jobGuid)
     {
         return PipelineStatusManager.getJobStatusFile(jobGuid);
     }
@@ -811,15 +811,12 @@ public class PipelineServiceImpl implements PipelineService
     @Override
     public Integer getJobId(User u, Container c, String jobGUID)
     {
-        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("job"), jobGUID);
-        Collection<Map<String, Object>> selectResults = new TableSelector(PipelineService.get().getJobsTable(u, c), Collections.singleton("RowId"), filter, null).getMapCollection();
-        Integer rowId = null;
-
-        for (Map<String, Object> m : selectResults)
+        PipelineStatusFileImpl statusFile = getStatusFile(jobGUID);
+        if (statusFile == null || !statusFile.getContainerId().equalsIgnoreCase(c.getId()))
         {
-            rowId = (Integer)m.get("RowId");
+            return null;
         }
-        return rowId;
+        return statusFile.getRowId();
     }
 
     @Override

--- a/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
@@ -457,7 +457,7 @@ public class PipelineServiceImpl implements PipelineService
                 if (sf != null)
                 {
                     sf.setActiveHostName(null);  //indicates previous task was complete
-                    PipelineStatusManager.updateStatusFile(sf);
+                    PipelineStatusManager.updateStatusFile(sf, PipelineStatusManager.StatusFileField.activeHostName);
                 }
 
                 EPipelineQueueImpl.dispatchJob(job);
@@ -477,7 +477,7 @@ public class PipelineServiceImpl implements PipelineService
         {
             //Use the absolute Path helper to strip user element
             sf.setFilePath(FileUtil.getAbsolutePath(otherFile));
-            PipelineStatusManager.updateStatusFile(sf);
+            PipelineStatusManager.updateStatusFile(sf, PipelineStatusManager.StatusFileField.filePath);
         }
     }
 

--- a/pipeline/src/org/labkey/pipeline/api/PipelineStatusFileImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineStatusFileImpl.java
@@ -32,13 +32,14 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * @author B. MacLean
  */
 public class PipelineStatusFileImpl extends Entity implements Serializable, PipelineStatusFile
 {
-    private static HashSet<String> _emailStatuses = new HashSet<>(Arrays.asList(
+    private static final HashSet<String> _emailStatuses = new HashSet<>(Arrays.asList(
             PipelineJob.TaskStatus.complete.toString(),
             PipelineJob.TaskStatus.error.toString(),
             PipelineJob.TaskStatus.cancelled.toString()
@@ -81,7 +82,7 @@ public class PipelineStatusFileImpl extends Entity implements Serializable, Pipe
         PipelineStatusFileImpl that = (PipelineStatusFileImpl) o;
 
         if (_rowId != that._rowId) return false;
-        if (!Objects.equals(_taskPipelineId, that._taskPipelineId))
+        if (!Objects.equals(_taskPipelineId, that._taskPipelineId)) return false;
         if (!Objects.equals(_activeTaskId, that._activeTaskId))
             return false;
         if (!Objects.equals(_filePath, that._filePath)) return false;
@@ -207,7 +208,7 @@ public class PipelineStatusFileImpl extends Entity implements Serializable, Pipe
             _jobStore = null;
             _activeTaskId = null;
         }
-        // Otherwise preseve what is currently in the database.
+        // Otherwise, preserve what is currently in the database.
         else
         {
             if (_jobStore == null || _jobStore.length() == 0)
@@ -216,12 +217,42 @@ public class PipelineStatusFileImpl extends Entity implements Serializable, Pipe
                 _activeTaskId = curSF._activeTaskId;
         }
 
-        // We only care about the hostName for RUNNING tasks so they can be requeued properly on remote server restart.
+        // We only care about the hostName for RUNNING tasks so that they can be requeued properly
+        // on remote server restart.
         if (!isActive())
         {
             _activeHostName = null;
         }
     }
+
+    public Set<PipelineStatusManager.StatusFileField> diff(PipelineStatusFileImpl oldSF)
+    {
+        Set<PipelineStatusManager.StatusFileField> changedFields = new HashSet<>();
+        addIfChanged(PipelineStatusManager.StatusFileField.job, oldSF, changedFields);
+        addIfChanged(PipelineStatusManager.StatusFileField.jobParent, oldSF, changedFields);
+        addIfChanged(PipelineStatusManager.StatusFileField.jobStore, oldSF, changedFields);
+        addIfChanged(PipelineStatusManager.StatusFileField.activeTaskId, oldSF, changedFields);
+        addIfChanged(PipelineStatusManager.StatusFileField.provider, oldSF, changedFields);
+        addIfChanged(PipelineStatusManager.StatusFileField.status, oldSF, changedFields);
+        addIfChanged(PipelineStatusManager.StatusFileField.info, oldSF, changedFields);
+        addIfChanged(PipelineStatusManager.StatusFileField.dataUrl, oldSF, changedFields);
+        addIfChanged(PipelineStatusManager.StatusFileField.description, oldSF, changedFields);
+        addIfChanged(PipelineStatusManager.StatusFileField.filePath, oldSF, changedFields);
+        addIfChanged(PipelineStatusManager.StatusFileField.email, oldSF, changedFields);
+        addIfChanged(PipelineStatusManager.StatusFileField.hadError, oldSF, changedFields);
+        addIfChanged(PipelineStatusManager.StatusFileField.activeHostName, oldSF, changedFields);
+        addIfChanged(PipelineStatusManager.StatusFileField.taskPipelineId, oldSF, changedFields);
+        return changedFields;
+    }
+
+    private void addIfChanged(PipelineStatusManager.StatusFileField field, PipelineStatusFileImpl oldSF, Set<PipelineStatusManager.StatusFileField> changedFields)
+    {
+        if (!Objects.equals(field.getValue(oldSF), field.getValue(this)))
+        {
+            changedFields.add(field);
+        }
+    }
+
 
     @Override
     public boolean isActive()

--- a/pipeline/src/org/labkey/pipeline/api/PipelineStatusFileImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineStatusFileImpl.java
@@ -28,7 +28,6 @@ import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -39,12 +38,6 @@ import java.util.Set;
  */
 public class PipelineStatusFileImpl extends Entity implements Serializable, PipelineStatusFile
 {
-    private static final HashSet<String> _emailStatuses = new HashSet<>(Arrays.asList(
-            PipelineJob.TaskStatus.complete.toString(),
-            PipelineJob.TaskStatus.error.toString(),
-            PipelineJob.TaskStatus.cancelled.toString()
-    ));
-
     protected int _rowId;
     protected String _job;
     protected String _jobParent;
@@ -273,19 +266,6 @@ public class PipelineStatusFileImpl extends Entity implements Serializable, Pipe
         return (isActive() && !PipelineJob.TaskStatus.cancelling.matches(_status)) ||
                 PipelineJob.TaskStatus.waitingForFiles.matches(_status) ||
                 PipelineJob.TaskStatus.splitWaiting.matches(_status);
-    }
-
-    // We can retry if the job is in ERROR or CANCELLED and we still have the serialized job info
-    public boolean isRetryable()
-    {
-        return (PipelineJob.TaskStatus.error.matches(_status) ||
-                PipelineJob.TaskStatus.cancelled.matches(_status)) &&
-                getJobStore() != null;
-    }
-
-    public boolean isEmailStatus()
-    {
-        return _jobParent == null && _emailStatuses.contains(_status);
     }
 
     @Override

--- a/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
@@ -259,6 +259,8 @@ public class PipelineStatusManager
         return !job.isAutoRetry();
     }
 
+    /** The individual fields that might have changed on the record. Determine by comparing two different
+     * PipelineStatusFile objects via the diff() method */
     public enum StatusFileField
     {
         activeHostName
@@ -374,6 +376,7 @@ public class PipelineStatusManager
      * Update status on a status file read from the database.
      *
      * @param sf the modified status
+     * @param fields optional - the fields/columns that have been changed, allowing for a more targeted UPDATE statement
      */
     public static void updateStatusFile(PipelineStatusFileImpl sf, StatusFileField ... fields)
     {
@@ -398,6 +401,10 @@ public class PipelineStatusManager
 
             if (fields != null && fields.length > 0)
             {
+                // Copy into a map that only updates the specified fields
+                // This is helpful because SQL Server is prone to deadlocking when there are concurrent update and read
+                // operations around unique indices, even though the updates are almost always setting an indexed value
+                // to its current value
                 Map<String, Object> newRow = new CaseInsensitiveHashMap<>();
                 for (StatusFileField field : fields)
                 {


### PR DESCRIPTION
#### Rationale
Since switching to the Microsoft JDBC driver, we're seeing more frequent test failures with DB deadlocks on SQL Server. The problem is that the pipeline.statusfiles table is being queried and updated on different threads (background pipeline and HTTP request) and its multiple unique constraints (two plus a PK) are prone to taking locks in the wrong order across updates and reads.

TargetedMS and Flow tests were the most common to deadlock, and have passed a number of times on this FB.

#### Changes
* Update only the fields that have changed, meaning that most updates won't touch any of the indices
* Simplify common query against the table