### PR TITLE
Issue 45802: Remove double encoded from project/folder names in Admin Console > Files > File Directories list box

### DIFF
--- a/core/src/org/labkey/core/admin/view/filesSiteSettings.jsp
+++ b/core/src/org/labkey/core/admin/view/filesSiteSettings.jsp
@@ -165,9 +165,6 @@
                     header:'Project',
                     width:330,
                     dataIndex:'name',
-                    renderer: function(val){
-                        return Ext4.util.Format.htmlEncode(val);
-                    }
                 },{
                     header:'Directory',
                     width:420,


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45802

Note that we don't need to use Ext4.util.Format.htmlEncode() here in the Ext4 TreePanel root display because of the override added to ext-patch.js (see `Ext4.override(Ext4.tree.Column, {...})` which now does the encoding for us.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3469

#### Changes
* Remove `treecolumn` renderer
