### PR TITLE
Get mutable copy of webparts before trying to edit

### DIFF
--- a/api/src/org/labkey/api/module/DefaultFolderType.java
+++ b/api/src/org/labkey/api/module/DefaultFolderType.java
@@ -237,7 +237,7 @@ public class DefaultFolderType implements FolderType
             if (null != portalPage)
             {
                 // Mark any actual permanent parts not permanent, since we're switching to another folder type
-                List<WebPart> parts = Portal.getParts(c, portalPage.getPageId());
+                List<WebPart> parts = Portal.getEditableParts(c, portalPage.getPageId());
                 boolean saveRequired = false;
 
                 for (WebPart part : parts)


### PR DESCRIPTION
#### Rationale
From an exception report:

```
java.lang.UnsupportedOperationException
	at org.labkey.api.view.Portal$WebPart$1.setPermanent(Portal.java:527)
	at org.labkey.api.module.DefaultFolderType.unconfigureContainer(DefaultFolderType.java:247)
	at org.labkey.api.data.ContainerManager.setFolderType(ContainerManager.java:433)
	at org.labkey.api.data.ContainerManager.setFolderType(ContainerManager.java:380)
	at org.labkey.api.data.Container.setFolderType(Container.java:960)
	at org.labkey.api.data.Container.setFolderType(Container.java:922)
```

#### Changes
* Don't try to modify the cached definition of the web parts, which is now immutable