### PR TITLE
Fix test failures related to startup property changes

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -284,7 +284,10 @@ public class ModuleLoader implements Filter, MemTrackerListener
         // make sure ConvertHelper is initialized
         ConvertHelper.getPropertyEditorRegistrar();
 
-        //load module instances using Spring
+        // Populate early so module include/exclude properties are available for loadModules()... and not reloaded when
+        // creating and loading modules using the module editor.
+        ModuleLoaderStartupProperties.populate();
+        // Load module instances using Spring
         List<Module> moduleList = loadModules(explodedModuleDirs);
 
         //sort the modules by dependencies
@@ -932,8 +935,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
             }
         }
 
-        // filter by startup properties if specified
-        ModuleLoaderStartupProperties.populate();
+        // filter by startup properties if they were specified
         LinkedList<String> includeList = ModuleLoaderStartupProperties.include.getList();
         LinkedList<String> excludeList = ModuleLoaderStartupProperties.exclude.getList();
 

--- a/wiki/src/org/labkey/wiki/WikiModule.java
+++ b/wiki/src/org/labkey/wiki/WikiModule.java
@@ -98,8 +98,8 @@ public class WikiModule extends CodeOnlyModule implements SearchService.Document
         ContainerManager.addContainerListener(new WikiContainerListener());
 //        WebdavService.get().addProvider(new WikiWebdavProvider());
 
-        // Don't check ModuleLoader.isNewInstall() here to support blue-green scenario, where _newInstall may be true
-        // even though scripts and bootstrap() have already run
+        // Don't check ModuleLoader.isNewInstall() here to support trial AMIs, where _newInstall may be true even though
+        // scripts and bootstrap() have already run
         if (moduleContext.isNewInstall())
             bootstrap(moduleContext);
 

--- a/wiki/src/org/labkey/wiki/WikiModule.java
+++ b/wiki/src/org/labkey/wiki/WikiModule.java
@@ -27,7 +27,6 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.module.CodeOnlyModule;
 import org.labkey.api.module.ModuleContext;
-import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.util.PageFlowUtil;
@@ -99,7 +98,9 @@ public class WikiModule extends CodeOnlyModule implements SearchService.Document
         ContainerManager.addContainerListener(new WikiContainerListener());
 //        WebdavService.get().addProvider(new WikiWebdavProvider());
 
-        if (ModuleLoader.getInstance().isNewInstall())
+        // Don't check ModuleLoader.isNewInstall() here to support blue-green scenario, where _newInstall may be true
+        // even though scripts and bootstrap() have already run
+        if (moduleContext.isNewInstall())
             bootstrap(moduleContext);
 
         SearchService ss = SearchService.get();


### PR DESCRIPTION
#### Rationale
Tests should pass and trial AMIs should run

#### Changes
* Populate the module include/exclude properties earlier so we don't attempt to load them after startup (i.e., module editing and module loading through the UI)
* Check `ModuleContext.isNewInstall()` instead of `ModuleLoader.isNewInstall()` before invoking `bootstrap()`. ModuleLoader.isNewInstall() returns true if the `newinstall` file exists, but that doesn't make bootstrap() happy... it doesn't want to be invoked twice.