### PR TITLE
Don't complain when running with Microsoft JDBC driver

### DIFF
--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
@@ -93,8 +93,8 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
 
         String driverName = md.getDriverName();
 
-        if (!driverName.startsWith("jTDS"))
-            LOG.warn("LabKey Server has not been tested against " + driverName + ". Instead, we recommend configuring the jTDS JDBC Driver, which is distributed with LabKey Server.");
+        if (!driverName.startsWith("jTDS") && !driverName.startsWith("Microsoft"))
+            LOG.warn("LabKey Server has not been tested against " + driverName + ". Instead, we recommend configuring the Microsoft SQL Server JDBC Driver, which is distributed with LabKey Server.");
 
         return dialect;
     }


### PR DESCRIPTION
#### Rationale
We've made updates to support the Microsoft SQL Server JDBC driver, but are still warning about it being unsupported.

#### Changes
* Don't warn when running with MS driver, and stop recommending jTDS