### PR TITLE
Fix for ModuleReportCache test

### DIFF
--- a/query/src/org/labkey/query/reports/ModuleReportCache.java
+++ b/query/src/org/labkey/query/reports/ModuleReportCache.java
@@ -232,8 +232,6 @@ public class ModuleReportCache
             // Make sure the cache retrieves the expected number of report descriptors from a couple test modules, if present
 
             Module simpleTest = ModuleLoader.getInstance().getModule("simpletest");
-            var resources = MODULE_REPORT_DESCRIPTOR_CACHE.getResourceMap(simpleTest);
-
             if (null != simpleTest)
                 assertEquals("Report descriptors from the simpletest module", 5, MODULE_REPORT_DESCRIPTOR_CACHE.getResourceMap(simpleTest).size());
 


### PR DESCRIPTION
#### Rationale
[Test failure ](https://teamcity.labkey.org/buildConfiguration/LabKey_227Release_Internal_TestArtifactoryModules/1889227?hideProblemsFromDependencies=false&expandBuildTestsSection=true&hideTestsFromDependencies=false&expandBuildChangesSection=true)introduced by code which expects the simple module to be present in the distribution.

The code was introduced in the Jupyter report merges. Those resources aren't used by the test, so removing seems appropriate.

