### PR TITLE
Startup properties for experimental features

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -86,6 +86,7 @@ import org.labkey.api.security.PasswordExpiration;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.ValidEmail;
 import org.labkey.api.settings.AppPropsTestCase;
+import org.labkey.api.settings.ExperimentalFeatureStartupListener;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.settings.WriteableLookAndFeelProperties;
 import org.labkey.api.util.*;
@@ -140,6 +141,8 @@ public class ApiModule extends CodeOnlyModule
         AuthenticationManager.registerMetricsProvider();
         ApiKeyManager.get().handleStartupProperties();
         MailHelper.init();
+        // Handle experimental feature startup properties as late as possible; we want all experimental features to be registered first
+        ContextListener.addStartupListener(new ExperimentalFeatureStartupListener());
         ContextListener.addStartupListener(new StartupPropertyStartupListener());
     }
 

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -25,6 +25,7 @@ import org.labkey.api.Constants;
 import org.labkey.api.action.UrlProvider;
 import org.labkey.api.action.UrlProviderService;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.CaseInsensitiveHashSetValuedMap;
 import org.labkey.api.collections.CaseInsensitiveTreeMap;
 import org.labkey.api.collections.CaseInsensitiveTreeSet;
@@ -58,7 +59,7 @@ import org.labkey.api.security.UserManager;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.LenientStartupPropertyHandler;
-import org.labkey.api.settings.StandardStartupPropertyHandler;
+import org.labkey.api.settings.MapBasedStartupPropertyHandler;
 import org.labkey.api.settings.StartupProperty;
 import org.labkey.api.settings.StartupPropertyEntry;
 import org.labkey.api.settings.StartupPropertyHandler;
@@ -206,7 +207,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
     private final Map<String, Module> _moduleMap = new CaseInsensitiveHashMap<>();
     private final Map<Class<? extends Module>, Module> _moduleClassMap = new HashMap<>();
     // Allow multiple StartupPropertyHandlers with the same scope as long as the StartupProperty impl class is different.
-    private final Set<StartupPropertyHandler<? extends StartupProperty>> _startupPropertyHandlers = new ConcurrentSkipListSet<>(Comparator.comparing((StartupPropertyHandler sph)->sph.getScope(), String.CASE_INSENSITIVE_ORDER).thenComparing(sph->sph.getStartupPropertyClassName()));
+    private final Set<StartupPropertyHandler<? extends StartupProperty>> _startupPropertyHandlers = new ConcurrentSkipListSet<>(Comparator.comparing((StartupPropertyHandler<?> sph)->sph.getScope(), String.CASE_INSENSITIVE_ORDER).thenComparing(StartupPropertyHandler::getStartupPropertyClassName));
     private final MultiValuedMap<String, StartupPropertyEntry> _startupPropertyMap = new CaseInsensitiveHashSetValuedMap<>();
 
     private List<Module> _modules;
@@ -2158,7 +2159,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
         return unknownContexts;
     }
 
-    public <T extends Enum<T> & StartupProperty> void handleStartupProperties(StandardStartupPropertyHandler<T> handler)
+    public <T extends StartupProperty> void handleStartupProperties(MapBasedStartupPropertyHandler<T> handler)
     {
         if (handler.performChecks())
             startupPropertyChecks(handler);
@@ -2222,7 +2223,14 @@ public class ModuleLoader implements Filter, MemTrackerListener
         ModuleLoader.getInstance().getStartupPropertyHandlers()
             .forEach(handler -> handler.getProperties().values().forEach(sp -> {
                 String previousScope = propertyScopeMap.put(sp, handler.getScope());
-                assert previousScope == null : "Two scopes (\"" + previousScope + "\" and \"" + handler.getScope() + "\") both used the same StartupProperty (" + sp + "\")!";
+                assert previousScope == null : "Two scopes (\"" + previousScope + "\" and \"" + handler.getScope() + "\") both used the same StartupProperty (\"" + sp + "\")!";
+            }));
+
+        Set<String> scopeNameMap = new CaseInsensitiveHashSet();
+        ModuleLoader.getInstance().getStartupPropertyHandlers()
+            .forEach(handler -> handler.getProperties().values().forEach(sp -> {
+                boolean notPresent = scopeNameMap.add(handler.getScope() + ":" + sp.getPropertyName());
+                assert notPresent : "Startup property \"" + handler.getScope() + "." + sp.getPropertyName() + "\" is handled by two separate code paths!";
             }));
 
         return true;

--- a/api/src/org/labkey/api/settings/AdminConsole.java
+++ b/api/src/org/labkey/api/settings/AdminConsole.java
@@ -149,7 +149,7 @@ public class AdminConsole
         return Collections.unmodifiableSet(_experimentalFlags);
     }
 
-    public static class ExperimentalFeatureFlag implements Comparable<ExperimentalFeatureFlag>
+    public static class ExperimentalFeatureFlag implements Comparable<ExperimentalFeatureFlag>, StartupProperty
     {
         private final String _flag;
         private final String _title;
@@ -193,6 +193,15 @@ public class AdminConsole
         public boolean isEnabled()
         {
             return AppProps.getInstance().isExperimentalFeatureEnabled(getFlag());
+        }
+
+        // StartupProperty implementation
+
+        @NotNull
+        @Override
+        public String getPropertyName()
+        {
+            return getFlag();
         }
     }
 }

--- a/api/src/org/labkey/api/settings/AppProps.java
+++ b/api/src/org/labkey/api/settings/AppProps.java
@@ -43,7 +43,7 @@ public interface AppProps
     String SCOPE_SITE_SETTINGS = "SiteSettings";
 
     String EXPERIMENTAL_FEATURE = "experimentalFeature";
-    String SCOPE_EXPERIMENTAL_FEATURE = EXPERIMENTAL_FEATURE;
+    String SCOPE_EXPERIMENTAL_FEATURE = "ExperimentalFeature";
     String EXPERIMENTAL_JAVASCRIPT_MOTHERSHIP = "javascriptMothership";
     String EXPERIMENTAL_JAVASCRIPT_SERVER = "javascriptErrorServerLogging";
     String EXPERIMENTAL_USER_FOLDERS = "userFolders";

--- a/api/src/org/labkey/api/settings/ExperimentalFeatureStartupListener.java
+++ b/api/src/org/labkey/api/settings/ExperimentalFeatureStartupListener.java
@@ -1,0 +1,46 @@
+package org.labkey.api.settings;
+
+import org.apache.commons.lang3.BooleanUtils;
+import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.settings.AdminConsole.ExperimentalFeatureFlag;
+import org.labkey.api.util.StartupListener;
+
+import javax.servlet.ServletContext;
+import java.util.Comparator;
+import java.util.Map;
+
+import static org.labkey.api.settings.AppProps.SCOPE_EXPERIMENTAL_FEATURE;
+
+public class ExperimentalFeatureStartupListener implements StartupListener
+{
+    @Override
+    public String getName()
+    {
+        return "Experimental feature startup property handler";
+    }
+
+    @Override
+    public void moduleStartupComplete(ServletContext servletContext)
+    {
+        ModuleLoader.getInstance().handleStartupProperties(new ExperimentalFeatureStartupPropertyHandler());
+    }
+
+    private static class ExperimentalFeatureStartupPropertyHandler extends MapBasedStartupPropertyHandler<ExperimentalFeatureFlag>
+    {
+        public ExperimentalFeatureStartupPropertyHandler()
+        {
+            super(
+                SCOPE_EXPERIMENTAL_FEATURE,
+                ExperimentalFeatureFlag.class.getName(),
+                AdminConsole.getExperimentalFeatureFlags().stream().sorted(Comparator.comparing(ExperimentalFeatureFlag::getPropertyName, String.CASE_INSENSITIVE_ORDER))
+            );
+        }
+
+        @Override
+        public void handle(Map<ExperimentalFeatureFlag, StartupPropertyEntry> properties)
+        {
+            ExperimentalFeatureService svc = ExperimentalFeatureService.get();
+            properties.forEach((sp, entry) -> svc.setFeatureEnabled(sp.getFlag(), BooleanUtils.toBoolean(entry.getValue()), null));
+        }
+    }
+}

--- a/api/src/org/labkey/api/settings/MapBasedStartupPropertyHandler.java
+++ b/api/src/org/labkey/api/settings/MapBasedStartupPropertyHandler.java
@@ -1,0 +1,23 @@
+package org.labkey.api.settings;
+
+import org.labkey.api.collections.LabKeyCollectors;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+// Base class for startup property handlers that want to work with a map of property entries. Extracted from
+// StandardStartupPropertyHandler to allow ExperimentalFeatureStartupPropertyHandler (which can't use an enum
+// to provide its startup properties) to share implementation and use the existing handleStartupProperties()
+// method. Note that we want StandardStartupPropertyHandler's type parameter (T) to extend Enum<T>, which is
+// why we can't just throw a new constructor on that class.
+public abstract class MapBasedStartupPropertyHandler<T extends StartupProperty> extends StartupPropertyHandler<T>
+{
+    public MapBasedStartupPropertyHandler(String scope, String startupPropertyClassName, Stream<T> properties)
+    {
+        super(scope, startupPropertyClassName, properties
+            .filter(sp -> null != sp.getPropertyName())
+            .collect(LabKeyCollectors.toCaseInsensitiveLinkedMap(StartupProperty::getPropertyName, sp->sp)));
+    }
+
+    public abstract void handle(Map<T, StartupPropertyEntry> properties);
+}

--- a/api/src/org/labkey/api/settings/StandardStartupPropertyHandler.java
+++ b/api/src/org/labkey/api/settings/StandardStartupPropertyHandler.java
@@ -1,11 +1,8 @@
 package org.labkey.api.settings;
 
-import org.labkey.api.collections.LabKeyCollectors;
-
 import java.util.Arrays;
-import java.util.Map;
 
-public abstract class StandardStartupPropertyHandler<T extends Enum<T> & StartupProperty> extends StartupPropertyHandler<T>
+public abstract class StandardStartupPropertyHandler<T extends Enum<T> & StartupProperty> extends MapBasedStartupPropertyHandler<T>
 {
     /**
      * @param scope The scope name
@@ -15,10 +12,6 @@ public abstract class StandardStartupPropertyHandler<T extends Enum<T> & Startup
      */
     protected StandardStartupPropertyHandler(String scope, Class<T> type)
     {
-        super(scope, type.getName(), Arrays.stream(type.getEnumConstants())
-            .filter(sp -> null != sp.getPropertyName())
-            .collect(LabKeyCollectors.toCaseInsensitiveLinkedMap(StartupProperty::getPropertyName, sp->sp)));
+        super(scope, type.getName(), Arrays.stream(type.getEnumConstants()));
     }
-
-    public abstract void handle(Map<T, StartupPropertyEntry> properties);
 }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=45842 requests a new option for startup properties that can enable/disable experimental features.

#### Changes
* Update startup property infrastructure to allow for a handler with a fixed-set of properties that aren't provided via an enum (see `MapBasedStartupPropertyHandler`)
* Add `ExperimentalFeatureStartupPropertyHandler` which provides all registered experimental feature flags as valid startup properties and handles enabling/disabling the requested features. Handling is invoked via a StartupListener to ensure all experimental feature flags have been registered before reading the startup properties.