### PR TITLE
Survey panels do not auto-resize

### DIFF
--- a/survey/src/org/labkey/survey/view/surveyWizard.jsp
+++ b/survey/src/org/labkey/survey/view/surveyWizard.jsp
@@ -99,6 +99,11 @@
             autosaveInterval: 60000
         });
 
+        var _resize = function() {
+            if (panel && panel.doLayout) { panel.doLayout(); }
+        };
+
+        Ext4.EventManager.onWindowResize(_resize);
     });
 
 </script>

--- a/survey/webapp/survey/SurveyPanel.js
+++ b/survey/webapp/survey/SurveyPanel.js
@@ -18,6 +18,7 @@ Ext4.define('LABKEY.ext4.SurveyDisplayPanel', {
             border      : false,
             bodyStyle   : 'background-color: transparent;',
             autoHeight  : true,
+            autoScroll  : true,
             items       : []
         });
 


### PR DESCRIPTION
#### Rationale
When creating or updating a survey, window resizing will not re-layout the panels. Additionally, while vertical scroll bars were supported, the panel is configure to truncate content when the window gets too narrow. 

[Related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45837)

#### Changes
- Support the standard panel resizer and force it to re-layout on size changes
- Add support for `autoScroll` in the main panel