### PR TITLE
Report type not getting set for module JS reports

### DIFF
--- a/api/src/org/labkey/api/reports/report/ModuleJavaScriptReportDescriptor.java
+++ b/api/src/org/labkey/api/reports/report/ModuleJavaScriptReportDescriptor.java
@@ -45,6 +45,7 @@ public class ModuleJavaScriptReportDescriptor extends JavaScriptReportDescriptor
 
         setReportKey(reportKey);
         setReportName(name);
+        setReportType(JavaScriptReport.TYPE);
         _resource = getModuleReportResource(sourceFile);
         loadMetaData();
         _resource.loadScript();


### PR DESCRIPTION
#### Rationale
The `SimpleModuleTest` is failing due to a javascript report not appearing in the reports menu for the data region. The reason is because the module based descriptor did not have a report type recorded.

The test started to fail after the merge of the Jupyter reports PR. It appears that a line of code was removed inadvertently. 