### PR TITLE
Issue 39538: Update Sample Type container filter options

### DIFF
--- a/experiment/src/org/labkey/experiment/controllers/exp/SampleTypeContentsView.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/SampleTypeContentsView.java
@@ -43,6 +43,12 @@ public class SampleTypeContentsView extends QueryView
         setTitle("Sample Type Contents");
         addClientDependency(ClientDependency.fromPath("Ext4"));
         addClientDependency(ClientDependency.fromPath("experiment/confirmDelete.js"));
+        setAllowableContainerFilterTypes(
+            ContainerFilter.Type.Current,
+            ContainerFilter.Type.CurrentAndSubfoldersPlusShared,
+            ContainerFilter.Type.CurrentPlusProjectAndShared,
+            ContainerFilter.Type.AllFolders
+        );
     }
 
     public static ActionButton getDeriveSamplesButton(@NotNull Container container, @Nullable Integer targetSampleTypeId)


### PR DESCRIPTION
#### Rationale
This adjusts the container filter dropdown for Sample Type data in LKS to correspond to options made available in our applications. This is the final piece of changes made to in support of [Issue 39538](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=39538).

<img width="464" alt="image" src="https://user-images.githubusercontent.com/3926239/178621971-47b0b19e-7ffa-4e1d-bc91-7e2eb308a658.png">

#### Changes
* Explictly declare allowable container filter types on Sample Type data table view.
