### PR TITLE
Issue 45861: When sample types are renamed, the custom views associated with the original name are lost

### DIFF
--- a/api/src/org/labkey/api/query/QueryChangeListener.java
+++ b/api/src/org/labkey/api/query/QueryChangeListener.java
@@ -23,6 +23,7 @@ import org.labkey.api.event.PropertyChange;
 import org.labkey.api.security.User;
 
 import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Listener for table and query events that fires when the structure/schema changes, but not when individual data
@@ -135,6 +136,22 @@ public interface QueryChangeListener
             _property = property;
             _oldValue = oldValue;
             _newValue = newValue;
+        }
+
+        public static void handleQueryNameChange(@NotNull String oldValue, String newValue, @NotNull SchemaKey schemaPath, User user, Container container)
+        {
+            if (oldValue.equals(newValue))
+                return;
+
+            QueryChangeListener.QueryPropertyChange change = new QueryChangeListener.QueryPropertyChange<>(
+                    QueryService.get().getUserSchema(user, container, schemaPath).getQueryDefForTable(newValue),
+                    QueryChangeListener.QueryProperty.Name,
+                    oldValue,
+                    newValue
+            );
+
+            QueryService.get().fireQueryChanged(user, container, null, schemaPath,
+                    QueryChangeListener.QueryProperty.Name, Collections.singleton(change));
         }
 
         public QueryDefinition getSource() { return _queryDef; }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -79,6 +79,7 @@ import org.labkey.api.miniprofiler.Timing;
 import org.labkey.api.qc.DataState;
 import org.labkey.api.qc.DataStateManager;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QueryChangeListener;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.SimpleValidationError;
@@ -1020,6 +1021,9 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         try (DbScope.Transaction transaction = ensureTransaction())
         {
             st.save(user);
+            if (hasNameChange)
+                QueryChangeListener.QueryPropertyChange.handleQueryNameChange(oldSampleTypeName, newName, new SchemaKey(null, SamplesSchema.SCHEMA_NAME), user, container);
+
             errors = DomainUtil.updateDomainDescriptor(original, update, container, user, hasNameChange);
             if (hasNameChange)
                 ExperimentService.get().addObjectLegacyName(st.getObjectId(), ExperimentServiceImpl.getNamespacePrefix(ExpSampleType.class), oldSampleTypeName, user);

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -334,18 +334,7 @@ public class ListManager implements SearchService.DocumentProvider
     private void queryChangeUpdate(User user, Container c, String oldName, String updatedName)
     {
         _listDefCache.remove(c.getId());
-        if (!oldName.equals(updatedName))
-        {
-            QueryChangeListener.QueryPropertyChange change = new QueryChangeListener.QueryPropertyChange<>(
-                    QueryService.get().getUserSchema(user, c, ListQuerySchema.NAME).getQueryDefForTable(updatedName),
-                    QueryChangeListener.QueryProperty.Name,
-                    oldName,
-                    updatedName
-            );
-
-            QueryService.get().fireQueryChanged(user, c, null, new SchemaKey(null, ListQuerySchema.NAME),
-                    QueryChangeListener.QueryProperty.Name, Collections.singleton(change));
-        }
+        QueryChangeListener.QueryPropertyChange.handleQueryNameChange(oldName, updatedName, new SchemaKey(null, ListQuerySchema.NAME), user, c);
     }
 
     // CONSIDER: move "list delete" from  ListDefinitionImpl.delete() implementation to ListManager for consistency


### PR DESCRIPTION
#### Rationale
[Issue 45861](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45861)

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* update queryName references when sample type or dataclass is renamed
