### PR TITLE
Track client API requests

### DIFF
--- a/api/src/org/labkey/api/usageMetrics/SimpleMetricsService.java
+++ b/api/src/org/labkey/api/usageMetrics/SimpleMetricsService.java
@@ -19,5 +19,14 @@ public interface SimpleMetricsService
         ServiceRegistry.get().registerService(SimpleMetricsService.class, impl);
     }
 
+    /**
+     * Increment the persistent counter associated with the given module, feature area, and metric name combination.
+     * The total will be reported to mothership in this module's "simpleMetricCounts" node. Isn't that simple?
+     * @param moduleName Module name. Must match a currently deployed module's name, though we'll grudgingly accept
+     *                  casing differences vs. the module's canonical name.
+     * @param featureArea Your name for the feature area. Needs to be unique within this module's simple metrics.
+     * @param metricName Your name for the specific metric within this feature area.
+     * @return new value for this counter
+     */
     long increment(String moduleName, String featureArea, String metricName);
 }

--- a/api/src/org/labkey/api/util/HttpUtil.java
+++ b/api/src/org/labkey/api/util/HttpUtil.java
@@ -298,14 +298,18 @@ public class HttpUtil
         String userAgent = getUserAgent(request);
         if (null != userAgent)
         {
-            if (userAgent.startsWith("Apache-HttpClient/")) // Can't distinguish between SAS, Java, and JDBC right now
+            if (userAgent.startsWith("Apache-HttpClient/") /* Note: This could be older SAS or JDBC access */ || userAgent.startsWith("LabKey Java API"))
                 return "Java";
-            else if (userAgent.startsWith("Rlabkey"))
+            else if (userAgent.startsWith("Rlabkey")|| userAgent.startsWith("LabKey R API"))
                 return "R";
-            else if (userAgent.startsWith("python-requests/"))
+            else if (userAgent.startsWith("python-requests/")|| userAgent.startsWith("LabKey Python API"))
                 return "Python";
-            else if (userAgent.startsWith("Perl API Client/"))
+            else if (userAgent.startsWith("LabKey JDBC API"))
+                return "JDBC";
+            else if (userAgent.startsWith("Perl API Client/") || userAgent.startsWith("LabKey Perl API"))
                 return "Perl";
+            else if (userAgent.startsWith("LabKey SAS API"))
+                return "SAS";
         }
 
         return null;

--- a/core/src/org/labkey/core/metrics/SimpleMetricsServiceImpl.java
+++ b/core/src/org/labkey/core/metrics/SimpleMetricsServiceImpl.java
@@ -4,6 +4,8 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.data.PropertyManager;
+import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.module.Module;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.usageMetrics.SimpleMetricsService;
 import org.labkey.api.usageMetrics.UsageMetricsProvider;
@@ -128,12 +130,18 @@ public class SimpleMetricsServiceImpl implements SimpleMetricsService
     }
 
     @Override
-    public long increment(@NotNull String moduleName, @NotNull String featureArea, @NotNull String metricName)
+    public long increment(@NotNull String requestedModuleName, @NotNull String featureArea, @NotNull String metricName)
     {
         if (featureArea.contains(","))
         {
             throw new IllegalArgumentException("Feature area names cannot contain commas");
         }
+        Module module = ModuleLoader.getInstance().getModule(requestedModuleName);
+        if (null == module)
+        {
+            throw new IllegalArgumentException("Unknown module: " + requestedModuleName);
+        }
+        String moduleName = module.getName();  // Use canonical name to ensure consistent casing
         String scoping = getScoping(moduleName, featureArea);
 
         Map<String, Map<String, AtomicLong>> moduleMetrics = getModuleMetrics(moduleName);

--- a/internal/src/org/labkey/api/security/AuthFilter.java
+++ b/internal/src/org/labkey/api/security/AuthFilter.java
@@ -27,6 +27,7 @@ import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.CSRFUtil;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.GUID;
+import org.labkey.api.util.HttpUtil;
 import org.labkey.api.util.HttpsUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.ViewServlet;
@@ -235,6 +236,7 @@ public class AuthFilter implements Filter
         {
             SecurityLogger.pushSecurityContext("AuthFilter " + req.getRequestURI(), user);
             addRandomHeader(req, resp);
+            HttpUtil.trackClientApiRequests(req);
             chain.doFilter(req, resp);
         }
         finally
@@ -254,7 +256,6 @@ public class AuthFilter implements Filter
         }
     }
 
-
     private void addRandomHeader(HttpServletRequest req, HttpServletResponse resp)
     {
         // make response size  a bit random (compressed or not)
@@ -264,6 +265,7 @@ public class AuthFilter implements Filter
             sb.append((char)('A' + r.nextInt(26)));
         resp.addHeader("X-LK-NONCE", sb.toString());
     }
+
 
 
     private boolean clearRequestAttributes(HttpServletRequest request)


### PR DESCRIPTION
#### Rationale
Metrics are helpful. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45844

#### Changes
* Detect requests from client libraries. Count them.
* Make `SimpleMetricsServiceImpl` canonicalize module name and flag unknown modules.