### PR TITLE
Issue 45857: Add header locking for dataset security page table

### DIFF
--- a/study/src/org/labkey/study/security/datasets.jsp
+++ b/study/src/org/labkey/study/security/datasets.jsp
@@ -191,7 +191,7 @@ set on the alternate ID dataset will affect who can edit other datasets. Hover o
 
     tr.header-lock {
         position: sticky;
-        top: 0;
+        top: -1px;
     }
 </style>
 <labkey:form id="datasetSecurityForm" action="<%=urlFor(ApplyDatasetPermissionsAction.class)%>" onsubmit="LABKEY.setSubmit(true);" method="POST">

--- a/study/src/org/labkey/study/security/datasets.jsp
+++ b/study/src/org/labkey/study/security/datasets.jsp
@@ -188,6 +188,11 @@ set on the alternate ID dataset will affect who can edit other datasets. Hover o
     td.dataset-permission {
         padding: 5px 5px 0 5px !important;
     }
+
+    tr.header-lock {
+        position: sticky;
+        top: 0;
+    }
 </style>
 <labkey:form id="datasetSecurityForm" action="<%=urlFor(ApplyDatasetPermissionsAction.class)%>" onsubmit="LABKEY.setSubmit(true);" method="POST">
 <%
@@ -202,7 +207,7 @@ set on the alternate ID dataset will affect who can edit other datasets. Hover o
         %><col><%
     }
     %></colgroup>
-    <tr class="<%=getShadeRowClass(row++)%>"><th>&nbsp;</th><%
+    <tr class="header-lock <%=getShadeRowClass(row++)%>"><th>&nbsp;</th><%
     for (Group g : restrictedGroups)
     {
         %><th style="padding: 0 5px 0 5px;"><%=h(groupName(g))%></th><%


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45857

#### Changes
* Add CSS for `position: sticky` to table header row for study dataset security page
