### PR TITLE
Issue 45888: Backport SQLServer exception deadlock retry fetching JDBC metadata

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -843,7 +843,7 @@ public class ExperimentServiceImpl implements ExperimentService
                     }
                     catch (DeadlockLoserDataAccessException dldae)
                     {
-                        // if we're not in an transaction just keep going...
+                        // if we're not in a transaction just keep going...
                         if (dbscope.isTransactionActive())
                             throw dldae;
                     }


### PR DESCRIPTION
#### Rationale
We're seeing deadlocks on SQL Server when fetching JDBC table metadata after switching to the Microsoft driver. This fix has been working well in develop for a week or so.

#### Changes
* Backport https://github.com/LabKey/platform/pull/3509