### PR TITLE
Metrics consistency and usability

### DIFF
--- a/api/src/org/labkey/api/usageMetrics/SimpleMetricsService.java
+++ b/api/src/org/labkey/api/usageMetrics/SimpleMetricsService.java
@@ -23,9 +23,13 @@ public interface SimpleMetricsService
      * Increment the persistent counter associated with the given module, feature area, and metric name combination.
      * The total will be reported to mothership in this module's "simpleMetricCounts" node. Isn't that simple?
      * @param moduleName Module name. Must match a currently deployed module's name, though we'll grudgingly accept
-     *                  casing differences vs. the module's canonical name.
-     * @param featureArea Your name for the feature area. Needs to be unique within this module's simple metrics.
-     * @param metricName Your name for the specific metric within this feature area.
+     *                   casing differences vs. the module's canonical name. But just use the module's name constant so
+     *                   you don't have to worry about it.
+     * @param featureArea Your name for the feature area. Needs to be unique within this module's simple metrics. By
+     *                    convention, we typically use camel case with initial lowercase letter (like method names).
+     * @param metricName Your name for the specific metric within this feature area. Same convention as above (camel
+     *                   case with initial lowercase letter). These are all counts, so no need to include "count" in
+     *                   the name.
      * @return new value for this counter
      */
     long increment(String moduleName, String featureArea, String metricName);

--- a/api/src/org/labkey/api/util/HttpUtil.java
+++ b/api/src/org/labkey/api/util/HttpUtil.java
@@ -290,7 +290,7 @@ public class HttpUtil
     {
         String clientLibrary = getClientLibrary(request);
         if (null != clientLibrary)
-            SimpleMetricsService.get().increment(DefaultModule.CORE_MODULE_NAME, "ClientApiRequests", clientLibrary);
+            SimpleMetricsService.get().increment(DefaultModule.CORE_MODULE_NAME, "clientApiRequests", clientLibrary);
     }
 
     private static @Nullable String getClientLibrary(HttpServletRequest request)

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -50,19 +50,13 @@ var submitSystemMaintenance;
     }
 })();
 
-var enableUsageTest = function() {
-    var el = document.getElementById('testUsageReport');
-    var level = document.querySelector('input[name="usageReportingLevel"]:checked').value;
-    enableTestButtion(el, level);
-};
-
 var enableExceptionTest = function() {
     var el = document.getElementById('testExceptionReport');
     var level = document.querySelector('input[name="exceptionReportingLevel"]:checked').value;
-    enableTestButtion(el, level);
+    enableTestButton(el, level);
 };
 
-var enableTestButtion = function(el, level) {
+var enableTestButton = function(el, level) {
     if ("NONE" == level)
     {
         LABKEY.Utils.addClass(el, 'labkey-disabled-button');
@@ -74,8 +68,7 @@ var enableTestButtion = function(el, level) {
 };
 
 var testUsageReport = function() {
-    var level = document.querySelector('input[name="usageReportingLevel"]:checked').value;
-    testMothershipReport('CheckForUpdates', level);
+    testMothershipReport('CheckForUpdates', '<%=UsageReportingLevel.ON%>');
 };
 
 var testExceptionReport = function() {
@@ -177,7 +170,7 @@ Click the Save button at any time to accept the current settings and continue.</
             <tr>
                 <td style="vertical-align: top">
                     <label>
-                        <input type="radio" name="usageReportingLevel" id="usageReportingLevel1" onchange="enableUsageTest();" value="<%=UsageReportingLevel.NONE%>"<%=checked(appProps.getUsageReportingLevel() == UsageReportingLevel.NONE)%>>
+                        <input type="radio" name="usageReportingLevel" id="usageReportingLevel1" value="<%=UsageReportingLevel.NONE%>"<%=checked(appProps.getUsageReportingLevel() == UsageReportingLevel.NONE)%>>
                         <strong>OFF</strong> - Do not check for updates or report any usage data.
                     </label>
                 </td>
@@ -185,15 +178,15 @@ Click the Save button at any time to accept the current settings and continue.</
             <tr>
                 <td style="vertical-align: top">
                     <label>
-                        <input type="radio" name="usageReportingLevel" id="usageReportingLevel2" onchange="enableUsageTest();"
+                        <input type="radio" name="usageReportingLevel" id="usageReportingLevel2"
                                value="<%=UsageReportingLevel.ON%>"<%=checked(appProps.getUsageReportingLevel() == UsageReportingLevel.ON)%>>
                         <strong>ON</strong> - Check for updates and report system information, usage data, and organization details.
                     </label>
                 </td>
             </tr>
             <tr>
-                <td style="padding: 5px 0 5px;" colspan="2"><%=button("View").id("testUsageReport").onClick("testUsageReport(); return false;").enabled(appProps.getUsageReportingLevel() != UsageReportingLevel.NONE)%>
-                    Display an example report for the selected level. <strong>No data will be submitted.</strong></td>
+                <td style="padding: 5px 0 5px;" colspan="2"><%=button("View").id("testUsageReport").onClick("testUsageReport(); return false;")%>
+                    Display an example usage report. <strong>No data will be submitted.</strong></td>
             </tr>
         </table>
     </td>

--- a/core/src/org/labkey/core/admin/usageMetrics/UsageMetricsServiceImpl.java
+++ b/core/src/org/labkey/core/admin/usageMetrics/UsageMetricsServiceImpl.java
@@ -22,8 +22,6 @@ import org.labkey.api.collections.ConcurrentHashSet;
 import org.labkey.api.usageMetrics.UsageMetricsProvider;
 import org.labkey.api.usageMetrics.UsageMetricsService;
 import org.labkey.api.util.ExceptionUtil;
-import org.labkey.api.util.MinorConfigurationException;
-import org.labkey.api.util.UsageReportingLevel;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -2441,7 +2441,7 @@ public class ExperimentController extends SpringActionController
                                 qInfo.getString("query"), getViewContext().getActionURL(),
                                 rootObject.getString("auditMessage") + filename,
                                 null);
-                        SimpleMetricsService.get().increment(ExperimentService.MODULE_NAME, "ConvertTable", "asExcel");
+                        SimpleMetricsService.get().increment(ExperimentService.MODULE_NAME, "convertTable", "asExcel");
                     }
                 }
             }
@@ -2522,7 +2522,7 @@ public class ExperimentController extends SpringActionController
                             getViewContext().getActionURL(),
                             rootObject.getString("auditMessage") + filename,
                             rowsArray.length());
-                    SimpleMetricsService.get().increment(ExperimentService.MODULE_NAME, "ConvertTable", "asDelimited");
+                    SimpleMetricsService.get().increment(ExperimentService.MODULE_NAME, "convertTable", "asDelimited");
                 }
             }
             catch (JSONException e)


### PR DESCRIPTION
#### Rationale
Casing consistency can reduce headaches at query time. No reason to disable that "view example usages" button

#### Changes
* Update a few metrics "feature area" names for consistency
* Document conventions
* Stop disabling the "view example usage report" button