### PR TITLE
Fix layout of Jupyter report output

### DIFF
--- a/api/src/org/labkey/api/docker/DockerService.java
+++ b/api/src/org/labkey/api/docker/DockerService.java
@@ -464,6 +464,10 @@ public interface DockerService
 
     boolean pingDocker();
 
+    void start(DockerContainer dc);
+
+    void start(String containerId);
+
     void stop(String containerId, Map<String, String> archivesFromContainer, boolean delete);
 
     void stop(DockerContainer dc);

--- a/api/src/org/labkey/api/reports/report/python/IpynbReport.java
+++ b/api/src/org/labkey/api/reports/report/python/IpynbReport.java
@@ -24,7 +24,6 @@ import org.labkey.api.reports.report.r.view.ConsoleOutput;
 import org.labkey.api.reports.report.r.view.IpynbOutput;
 import org.labkey.api.security.SessionApiKeyManager;
 import org.labkey.api.util.FileUtil;
-import org.labkey.api.util.GUID;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.UnexpectedException;
@@ -175,11 +174,13 @@ public class IpynbReport extends DockerScriptReport
 
         ExecuteStrategy ex = new DockerRunTarStdinStdout();
         int exitCode = ex.execute(context, apikey, workingDirectory, scriptFile);
+        LOG.trace("EXIT: " + exitCode);
         File outputFile = ex.getOutputDocument();
+        LOG.trace("OUTPUT: " + outputFile);
 
         Set<File> afterExecute = new HashSet<>(FileUtils.listFiles(workingDirectory, null, true));
         LOG.trace("wd:    " + workingDirectory.getPath());
-        LOG.trace("AFTER: " + StringUtils.join(afterExecute.stream().map(File::getName).toArray(), "\n\t"));
+        LOG.trace("AFTER: " + StringUtils.join(afterExecute.stream().map(f -> f.getName() + " : " + f.length()).toArray(), "\n\t"));
 
         try
         {

--- a/api/src/org/labkey/api/reports/report/python/IpynbReport.java
+++ b/api/src/org/labkey/api/reports/report/python/IpynbReport.java
@@ -219,6 +219,7 @@ public class IpynbReport extends DockerScriptReport
             if (error.isFile() && error.length() > 0)
                 vbox.addView(new ConsoleOutput(error).getView(context));
 
+            LOG.trace("VIEWS: " + vbox.getViews().size());
             return vbox;
         }
         catch (Exception x)

--- a/api/src/org/labkey/api/reports/report/python/IpynbReport.java
+++ b/api/src/org/labkey/api/reports/report/python/IpynbReport.java
@@ -170,7 +170,8 @@ public class IpynbReport extends DockerScriptReport
         IOUtil.copyCompletely(new StringReader(script), new FileWriter(scriptFile, StringUtilsLabKey.DEFAULT_CHARSET));
 
         Set<File> beforeExecute = new HashSet<>(FileUtils.listFiles(workingDirectory, null, true));
-        LOG.trace("BEFORE: " + StringUtils.join(beforeExecute.stream().map(File::getName).toArray(), "\n\t"));
+        LOG.trace("BEFORE: " + workingDirectory.getPath() + "\n\t" +
+                StringUtils.join(beforeExecute.stream().map(f -> f.getName() + " : " + f.length()).toArray(), "\n\t"));
 
         ExecuteStrategy ex = new DockerRunTarStdinStdout();
         int exitCode = ex.execute(context, apikey, workingDirectory, scriptFile);
@@ -179,8 +180,8 @@ public class IpynbReport extends DockerScriptReport
         LOG.trace("OUTPUT: " + outputFile);
 
         Set<File> afterExecute = new HashSet<>(FileUtils.listFiles(workingDirectory, null, true));
-        LOG.trace("wd:    " + workingDirectory.getPath());
-        LOG.trace("AFTER: " + StringUtils.join(afterExecute.stream().map(f -> f.getName() + " : " + f.length()).toArray(), "\n\t"));
+        LOG.trace("AFTER: " + workingDirectory.getPath() + "\n\t" +
+                StringUtils.join(afterExecute.stream().map(f -> f.getName() + " : " + f.length()).toArray(), "\n\t"));
 
         try
         {
@@ -216,7 +217,7 @@ public class IpynbReport extends DockerScriptReport
         }
         catch (Exception x)
         {
-            x.printStackTrace();
+            LOG.error("Error rendering report", x);
             throw x;
         }
     }

--- a/api/src/org/labkey/api/reports/report/r/view/IpynbOutput.java
+++ b/api/src/org/labkey/api/reports/report/r/view/IpynbOutput.java
@@ -19,6 +19,7 @@ package org.labkey.api.reports.report.r.view;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.markdown.MarkdownService;
@@ -148,7 +149,7 @@ public class IpynbOutput extends HtmlOutput
         @Override
         protected String renderInternalAsString(File file) throws Exception
         {
-            String result = super.renderInternalAsString(file);
+            String result = StringUtils.trimToEmpty(super.renderInternalAsString(file));
             try
             {
                 final JSONObject obj = new JSONObject(result);
@@ -224,6 +225,12 @@ public class IpynbOutput extends HtmlOutput
                 sb.append(HtmlString.unsafe("<div class=\"labkey-error\">"));
                 sb.append(HtmlString.of(ex.getMessage()));
                 sb.append(HtmlString.unsafe("</div>"));
+                if (ex instanceof JSONException)
+                {
+                    sb.append(HtmlString.unsafe("<div>"));
+                    sb.append(HtmlString.of(result));
+                    sb.append(HtmlString.unsafe("</div>"));
+                }
                 return sb.toString();
             }
         }

--- a/api/src/org/labkey/api/reports/report/r/view/IpynbOutput.java
+++ b/api/src/org/labkey/api/reports/report/r/view/IpynbOutput.java
@@ -16,11 +16,9 @@
 
 package org.labkey.api.reports.report.r.view;
 
-import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.markdown.MarkdownService;
@@ -151,87 +149,83 @@ public class IpynbOutput extends HtmlOutput
         protected String renderInternalAsString(File file) throws Exception
         {
             String result = super.renderInternalAsString(file);
-            JSONObject obj;
             try
             {
-                obj = new JSONObject(result);
-            }
-            catch (JSONException ex)
-            {
-                return null;
-            }
-            HtmlStringBuilder sb = HtmlStringBuilder.of();
-            sb.append(HtmlString.unsafe("<div class=labkey-wiki>"));
+                final JSONObject obj = new JSONObject(result);
+                HtmlStringBuilder sb = HtmlStringBuilder.of();
+                sb.append(HtmlString.unsafe("<div class=labkey-wiki>"));
 
-            JSONArray arr = (JSONArray) obj.get("cells");
-            if (null == arr)
-            {
-                JSONArray worksheets = (JSONArray)obj.get("worksheets");
-                if (null != worksheets && worksheets.length() > 0)
-                    arr = (JSONArray)((JSONObject)worksheets.get(0)).get("cells");
-            }
-
-            // TODO move to stylesheet
-            renderStylesheet(sb);
-
-            for (int cellindex = 0; null != arr && cellindex < arr.length(); cellindex++)
-            {
-                JSONObject cell = (JSONObject)arr.get(cellindex);
-                String cell_type = String.valueOf(cell.get("cell_type"));
-                int execution_count = -1;
-                try
+                JSONArray arr = (JSONArray) obj.get("cells");
+                if (null == arr)
                 {
+                    JSONArray worksheets = (JSONArray) obj.get("worksheets");
+                    if (null != worksheets && worksheets.length() > 0)
+                        arr = (JSONArray) ((JSONObject) worksheets.get(0)).get("cells");
+                }
+
+                // TODO move to stylesheet
+                renderStylesheet(sb);
+
+                for (int cellindex = 0; null != arr && cellindex < arr.length(); cellindex++)
+                {
+                    JSONObject cell = (JSONObject) arr.get(cellindex);
+                    String cell_type = String.valueOf(cell.get("cell_type"));
+                    String execution_count = null;
                     if (null != cell.get("execution_count"))
-                        execution_count = ((Integer) JdbcType.INTEGER.convert(cell.get("execution_count")));
+                        execution_count = String.valueOf(cell.get("execution_count"));
                     else if (null != cell.get("prompt_number"))
-                        execution_count = ((Integer) JdbcType.INTEGER.convert(cell.get("prompt_number")));
-                }
-                catch (ConversionException x)
-                {
-                    // pass
-                }
+                        execution_count = String.valueOf(cell.get("prompt_number"));
 
-                HtmlString executionCountDiv = HtmlString.unsafe("<div class='ipynb-cell-index'>" + (execution_count > 0 ? "[ " + execution_count + " ]" : "") + "</div>");
-                sb.append(HtmlString.unsafe("<div class='ipynb-cell'>"));
-                sb.append(executionCountDiv);
-
-                sb.append(HtmlString.unsafe("<div class='ipynb-cell-source'>"));
-
-                switch (cell_type)
-                {
-                    case "markdown":
-                        renderMarkdownSource(sb, cell);
-                        break;
-                    case "raw":
-                        renderRawSource(sb, cell);
-                        break;
-                    case "code":
-                        renderCodeSource(sb, cell);
-                        break;
-                    case "header": // old format
-                        renderHeaderCell(sb, cell);
-                        break;
-                }
-
-                sb.append(HtmlString.unsafe("</div>")); // ipynb-cell-source
-
-                JSONArray outputs = (JSONArray) cell.get("outputs");
-                if (outputs != null && outputs.length() > 0)
-                {
+                    HtmlString executionCountDiv = HtmlString.unsafe("<div class='ipynb-cell-index'>" + (execution_count != null ? "[ " + execution_count + " ]" : "") + "</div>");
+                    sb.append(HtmlString.unsafe("<div class='ipynb-cell'>"));
                     sb.append(executionCountDiv);
-                    sb.append(HtmlString.unsafe("<div class='ipynb-cell-outputs'>"));
 
-                    for (int outputindex=0 ; outputindex<outputs.length() ; outputindex++)
+                    sb.append(HtmlString.unsafe("<div class='ipynb-cell-source'>"));
+
+                    switch (cell_type)
                     {
-                        renderOutput(sb, (JSONObject)outputs.get(outputindex));
+                        case "markdown":
+                            renderMarkdownSource(sb, cell);
+                            break;
+                        case "raw":
+                            renderRawSource(sb, cell);
+                            break;
+                        case "code":
+                            renderCodeSource(sb, cell);
+                            break;
+                        case "header": // old format
+                            renderHeaderCell(sb, cell);
+                            break;
                     }
 
-                    sb.append(HtmlString.unsafe("</div>")); // ipynb-cell-outputs
+                    sb.append(HtmlString.unsafe("</div>")); // ipynb-cell-source
+
+                    JSONArray outputs = (JSONArray) cell.get("outputs");
+                    if (outputs != null && outputs.length() > 0)
+                    {
+                        sb.append(executionCountDiv);
+                        sb.append(HtmlString.unsafe("<div class='ipynb-cell-outputs'>"));
+
+                        for (int outputindex = 0; outputindex < outputs.length(); outputindex++)
+                        {
+                            renderOutput(sb, (JSONObject) outputs.get(outputindex));
+                        }
+
+                        sb.append(HtmlString.unsafe("</div>")); // ipynb-cell-outputs
+                    }
+                    sb.append(HtmlString.unsafe("</div>")); // ipynb-cell
                 }
-                sb.append(HtmlString.unsafe("</div>")); // ipynb-cell
+                sb.append(HtmlString.unsafe("</div>")); // labkey-wiki
+                return sb.toString();
             }
-            sb.append(HtmlString.unsafe("</div>")); // labkey-wiki
-            return sb.toString();
+            catch (Exception ex)
+            {
+                HtmlStringBuilder sb = HtmlStringBuilder.of();
+                sb.append(HtmlString.unsafe("<div class=\"labkey-error\">"));
+                sb.append(HtmlString.of(ex.getMessage()));
+                sb.append(HtmlString.unsafe("</div>"));
+                return sb.toString();
+            }
         }
 
         private void renderStylesheet(HtmlStringBuilder sb)

--- a/api/src/org/labkey/api/reports/report/r/view/IpynbOutput.java
+++ b/api/src/org/labkey/api/reports/report/r/view/IpynbOutput.java
@@ -347,7 +347,7 @@ public class IpynbOutput extends HtmlOutput
                         {
                             boolean isError = "stderr".equals(data.get("name"));
                             var textArray = (JSONArray) Objects.requireNonNullElse(data.get("text/plain"), data.get("text"));
-                            sb.append(HtmlString.unsafe("<div class=\"ipynb-output\"><div class=\"" + (isError ? "ipnyb-error" : "ipynb-text") + "\">"));
+                            sb.append(HtmlString.unsafe("<div class=\"ipynb-output\"><div class=\"" + (isError ? "ipynb-error" : "ipynb-text") + "\">"));
                             sb.append(HtmlString.unsafe("<pre>\n"));
                             for (int i=0 ; i<textArray.length() ; i++)
                                 sb.append((String)textArray.get(i));

--- a/api/src/org/labkey/api/reports/report/r/view/IpynbOutput.java
+++ b/api/src/org/labkey/api/reports/report/r/view/IpynbOutput.java
@@ -239,11 +239,11 @@ public class IpynbOutput extends HtmlOutput
             sb.append(HtmlString.unsafe(
                 """
                 <style type="text/css">
-                div.ipynb-cell { }
+                div.ipynb-cell { display:grid; grid-template-columns: 50px auto; }
                 
                 div.ipynb-cell-index {
                     padding:5px; color:rgb(100,100,100); font-size:small;
-                    width:50px; float:left; clear:both; text-align:right; text-overflow:ellipsis, overflow-x:hidden; border:solid blue 0px;
+                    clear:both; text-align:right; text-overflow:ellipsis, overflow-x:hidden; border:solid blue 0px;
                 }
                 
                 div.ipynb-cell-source { border:solid red 0px;}
@@ -338,7 +338,7 @@ public class IpynbOutput extends HtmlOutput
                             var textArray = (JSONArray)data.get("image/svg+xml");
                             sb.append(HtmlString.unsafe("<div class=\"ipynb-svg\">"));
                             for (int i=0 ; i<textArray.length() ; i++)
-                                sb.append((String)textArray.get(i));
+                                sb.append(HtmlString.unsafe((String)textArray.get(i)));
                             sb.append(HtmlString.unsafe("</div>"));
                             sbOutput.append(sb);
                             return;

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -881,7 +881,7 @@ public class ReportsController extends SpringActionController
                 var script = sw.toString();
                 if (!script.isBlank())
                 {
-                    _log.trace("Prepending report end of body script.");
+                    _log.trace("Append end of body script.");
                     var out = mr.getWriter();
                     out.print("<script type=\"text/javascript\" nonce=\"" + config.getScriptNonce() + "\">");
                     out.print(script);

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -897,7 +897,7 @@ public class ReportsController extends SpringActionController
             }
 
             final String html = mr.getContentAsString();
-            _log.trace("Report success. Size: " + html.length());
+            _log.trace("Report rendered. Size: " + html.length());
             resultProperties.put("html", html);
             resultProperties.put("requiredJsScripts", includes);
             resultProperties.put("requiredCssScripts", cssScripts);

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -190,9 +190,11 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.labkey.api.reports.model.ViewCategoryManager.UNCATEGORIZED_ROWID;
+import static org.labkey.api.util.DOM.DIV;
 import static org.labkey.api.util.DOM.SPAN;
 import static org.labkey.api.util.DOM.cl;
 
@@ -833,6 +835,7 @@ public class ReportsController extends SpringActionController
             Report report = bean.getReport(getViewContext());
             if (report != null)
             {
+                _log.trace("Executing report: " + report.getClass().getSimpleName());
                 if (bean.getIsDirty())
                     report.clearCache();
 
@@ -841,9 +844,16 @@ public class ReportsController extends SpringActionController
                 {
                     if (report instanceof RReport)
                         resultsView.addView(new RenderBackgroundRReportView((RReport)report));
+                    else
+                        resultsView.addView(new HtmlView(DIV(cl("labkey-error"), "Report type not support background execution: " + report.getClass().getSimpleName())));
                 }
                 else
-                    resultsView.addView(report.renderReport(getViewContext()));
+                {
+                    HttpView<?> renderedReport = report.renderReport(getViewContext());
+                    _log.trace("Report views: " + (renderedReport != null ? renderedReport.getViews().stream()
+                            .map(mv -> mv.getClass().getSimpleName()).collect(Collectors.joining(", ")) : null));
+                    resultsView.addView(renderedReport);
+                }
             }
 
             Map<String, Object> resultProperties = new HashMap<>();
@@ -863,6 +873,7 @@ public class ReportsController extends SpringActionController
             nested.setResponse(mr);
             try (var init = HttpView.initForRequest(nested, getViewContext().getRequest(), mr))
             {
+                _log.trace("Rendering report");
                 resultsView.render(getViewContext().getRequest(), mr);
                 var config = HttpView.currentPageConfig();
                 var sw = new StringWriter();
@@ -870,6 +881,7 @@ public class ReportsController extends SpringActionController
                 var script = sw.toString();
                 if (!script.isBlank())
                 {
+                    _log.trace("Prepending report end of body script.");
                     var out = mr.getWriter();
                     out.print("<script type=\"text/javascript\" nonce=\"" + config.getScriptNonce() + "\">");
                     out.print(script);
@@ -884,7 +896,9 @@ public class ReportsController extends SpringActionController
                 return null;
             }
 
-            resultProperties.put("html", mr.getContentAsString());
+            final String html = mr.getContentAsString();
+            _log.trace("Report success. Size: " + html.length());
+            resultProperties.put("html", html);
             resultProperties.put("requiredJsScripts", includes);
             resultProperties.put("requiredCssScripts", cssScripts);
             resultProperties.put("implicitJsIncludes", implicitIncludes);

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -879,6 +879,7 @@ public class ReportsController extends SpringActionController
 
             if (mr.getStatus() != HttpServletResponse.SC_OK)
             {
+                _log.trace("Report error. Status: " + mr.getStatus());
                 resultsView.render(getViewContext().getRequest(), getViewContext().getResponse());
                 return null;
             }

--- a/query/webapp/reports/ScriptReportPanel.js
+++ b/query/webapp/reports/ScriptReportPanel.js
@@ -143,7 +143,7 @@ Ext4.define('LABKEY.ext4.ScriptReportPanel', {
 
     viewFailure : function(cmp, resp, exp) {
 
-        var error = LABKEY.Utils.getMsgFromError(resp, exp, {msgPrefix : 'Failed to retrieve report results:\n'});
+        var error = null;
         if (resp && resp.responseText && resp.getResponseHeader('Content-Type'))
         {
             var contentType = resp.getResponseHeader('Content-Type');
@@ -152,6 +152,9 @@ Ext4.define('LABKEY.ext4.ScriptReportPanel', {
                 var json = LABKEY.Utils.decode(resp.responseText);
                 error = this.errorTpl.apply(json);
             }
+        }
+        if (!error) {
+            error = this.errorTpl.apply({exception: LABKEY.Utils.getMsgFromError(resp, exp)});
         }
         Ext4.get(cmp.getEl()).update(error);
         cmp.getEl().unmask();

--- a/query/webapp/reports/ScriptReportPanel.js
+++ b/query/webapp/reports/ScriptReportPanel.js
@@ -143,7 +143,7 @@ Ext4.define('LABKEY.ext4.ScriptReportPanel', {
 
     viewFailure : function(cmp, resp, exp) {
 
-        var error = LABKEY.Utils.getMsgFromError(resp, exp, {msgPrefix : 'Failed to retrieve report results'});
+        var error = LABKEY.Utils.getMsgFromError(resp, exp, {msgPrefix : 'Failed to retrieve report results:\n'});
         if (resp && resp.responseText && resp.getResponseHeader('Content-Type'))
         {
             var contentType = resp.getResponseHeader('Content-Type');


### PR DESCRIPTION
#### Rationale
Markdown cells and "Output" blocks after the first aren't aligned properly.
![image](https://user-images.githubusercontent.com/5263798/179589762-564f34a5-afbd-48f2-873f-4daaf818460e.png)

Using a grid layout aligns all of the source and output cells as expected:
![image](https://user-images.githubusercontent.com/5263798/179592949-ecce0fa3-f28d-4e29-be7c-54f6665fce8e.png)

SVG outputs are getting encoded and are displayed as plain text instead of an image.

#### Related Pull Requests
* #3474 

#### Changes
* Use 'grid' layout for Jupyter report cells
* Don't encode SVG output
* Fix typo in CSS class for `stderr` stream output
