### PR TITLE
Validate and canonicalize module names for all usage metrics providers

### DIFF
--- a/api/src/org/labkey/api/usageMetrics/UsageMetricsService.java
+++ b/api/src/org/labkey/api/usageMetrics/UsageMetricsService.java
@@ -17,7 +17,6 @@ package org.labkey.api.usageMetrics;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.services.ServiceRegistry;
-import org.labkey.api.util.UsageReportingLevel;
 
 import java.util.Map;
 
@@ -29,7 +28,7 @@ import java.util.Map;
  *         UsageMetricsService svc = UsageMetricsService.get();
  *         if (null != svc)
  *         {
- *             svc.registerUsageMetrics(moduleName, () -> {
+ *             svc.registerUsageMetrics(DataIntegrationModule.NAME, () -> {
  *                 Map<String, Object> metric = new HashMap<>();
  *                 metric.put("etlRunCount", new SqlSelector(DbSchema.get("dataintegration", DbSchemaType.Module), "SELECT COUNT(*) FROM dataintegration.TransformRun").getObject(Long.class));
  *                 return metric;
@@ -58,8 +57,9 @@ public interface UsageMetricsService
      *  Metrics can be included at UsageReportingLevel OFF or ON. Usage metrics will only be sent for ON.
      *
      * @param moduleName The name of the module
-     * @param metrics Implementation of the functional interface UsageMetricsProvider.getUsageMetrics() method. Typically
+     * @param metrics Implementation of the functional interface UsageMetricsProvider.getUsageMetrics() method. Typically,
      *                this will return a map of metric name -> value pairs.
+     * @throws IllegalArgumentException if moduleName doesn't correspond to an existing module
      */
     void registerUsageMetrics(String moduleName, UsageMetricsProvider metrics);
 }

--- a/core/src/org/labkey/core/admin/usageMetrics/UsageMetricsServiceImpl.java
+++ b/core/src/org/labkey/core/admin/usageMetrics/UsageMetricsServiceImpl.java
@@ -15,13 +15,15 @@
  */
 package org.labkey.core.admin.usageMetrics;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.ConcurrentHashSet;
+import org.labkey.api.module.Module;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.usageMetrics.UsageMetricsProvider;
 import org.labkey.api.usageMetrics.UsageMetricsService;
 import org.labkey.api.util.ExceptionUtil;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,14 +37,20 @@ import java.util.stream.Collectors;
  */
 public class UsageMetricsServiceImpl implements UsageMetricsService
 {
-    private static final Logger LOG = LogManager.getLogger(UsageMetricsServiceImpl.class);
+    private static final Logger LOG = LogHelper.getLogger(UsageMetricsServiceImpl.class, "Usage metrics errors");
 
     private final Map<String, Set<UsageMetricsProvider>> moduleUsageReports = new ConcurrentHashMap<>();
 
     @Override
     public void registerUsageMetrics(String moduleName, UsageMetricsProvider metrics)
     {
-        moduleUsageReports.computeIfAbsent(moduleName, k -> new ConcurrentHashSet<>()).add(metrics);
+        // Check that module exists and use canonical name for consistency
+        if (null == moduleName)
+            throw new IllegalArgumentException("Module name is null");
+        Module module = ModuleLoader.getInstance().getModule(moduleName);
+        if (null == module)
+            throw new IllegalArgumentException("Unknown module: " + moduleName);
+        moduleUsageReports.computeIfAbsent(module.getName(), k -> new ConcurrentHashSet<>()).add(metrics);
     }
 
     @Override
@@ -59,9 +67,9 @@ public class UsageMetricsServiceImpl implements UsageMetricsService
                 {
                     Map<String, Object> providerMetrics = provider.getUsageMetrics();
                     Set<String> duplicateKeys = providerMetrics.keySet()
-                            .stream()
-                            .filter(moduleMetrics::containsKey)
-                            .collect(Collectors.toSet());
+                        .stream()
+                        .filter(moduleMetrics::containsKey)
+                        .collect(Collectors.toSet());
                     if (duplicateKeys.isEmpty())
                         moduleMetrics.putAll(providerMetrics);
                     else

--- a/core/src/org/labkey/core/metrics/SimpleMetricsServiceImpl.java
+++ b/core/src/org/labkey/core/metrics/SimpleMetricsServiceImpl.java
@@ -33,7 +33,7 @@ public class SimpleMetricsServiceImpl implements SimpleMetricsService
     private static final Logger LOG = LogHelper.getLogger(SimpleMetricsServiceImpl.class, "Tallies and persists simple counter metrics");
 
     /** Organized by module, featureArea, and metricName */
-    private final Map<String, Map<String, Map<String, AtomicLong>>> _counts = new ConcurrentHashMap<>();
+    private final Map<Module, Map<String, Map<String, AtomicLong>>> _counts = new ConcurrentHashMap<>();
 
     /** Timestamp when we last saved the counts to the DB */
     private Runnable _saver;
@@ -62,23 +62,23 @@ public class SimpleMetricsServiceImpl implements SimpleMetricsService
 
     private class SimpleMetricsProvider implements UsageMetricsProvider
     {
-        private final String _moduleName;
+        private final Module _module;
 
-        public SimpleMetricsProvider(String moduleName)
+        public SimpleMetricsProvider(Module module)
         {
-            _moduleName = moduleName;
+            _module = module;
         }
 
         @Override
         public Map<String, Object> getUsageMetrics()
         {
-            return Collections.singletonMap("simpleMetricCounts", _counts.get(_moduleName));
+            return Collections.singletonMap("simpleMetricCounts", _counts.get(_module));
         }
     }
 
-    private String getScoping(String moduleName, String featureArea)
+    private String getScoping(@NotNull Module module, String featureArea)
     {
-        return SimpleMetricsServiceImpl.class.getName() + "." + moduleName + "." + featureArea;
+        return SimpleMetricsServiceImpl.class.getName() + "." + module.getName() + "." + featureArea;
     }
 
     private String getRootScoping()
@@ -93,13 +93,17 @@ public class SimpleMetricsServiceImpl implements SimpleMetricsService
         for (Map.Entry<String, String> entry : map.entrySet())
         {
             String moduleName = entry.getKey();
-            Map<String, Map<String, AtomicLong>> moduleMetrics = getModuleMetrics(moduleName);
+            Module module = ModuleLoader.getInstance().getModule(moduleName);
+            // Skip these metrics if module doesn't exist. (Perhaps the module been removed from this deployment.)
+            if (null == module)
+                continue;
+            Map<String, Map<String, AtomicLong>> moduleMetrics = getModuleMetrics(module);
             String featureAreas = entry.getValue();
             if (featureAreas != null)
             {
                 for (String featureArea : featureAreas.split(","))
                 {
-                    String scoping = getScoping(moduleName, featureArea);
+                    String scoping = getScoping(module, featureArea);
 
                     // Load from the properties stored in the DB
                     PropertyManager.PropertyMap storedProps = PropertyManager.getProperties(scoping);
@@ -119,12 +123,12 @@ public class SimpleMetricsServiceImpl implements SimpleMetricsService
         }
     }
 
-    private Map<String, Map<String, AtomicLong>> getModuleMetrics(String moduleName)
+    private Map<String, Map<String, AtomicLong>> getModuleMetrics(Module module)
     {
-        return _counts.computeIfAbsent(moduleName, (k) ->
+        return _counts.computeIfAbsent(module, (k) ->
         {
             // The first time a module is referenced, register a new provider
-            UsageMetricsService.get().registerUsageMetrics(moduleName, new SimpleMetricsProvider(moduleName));
+            UsageMetricsService.get().registerUsageMetrics(module.getName(), new SimpleMetricsProvider(module));
             return new ConcurrentHashMap<>();
         });
     }
@@ -136,15 +140,16 @@ public class SimpleMetricsServiceImpl implements SimpleMetricsService
         {
             throw new IllegalArgumentException("Feature area names cannot contain commas");
         }
+
         Module module = ModuleLoader.getInstance().getModule(requestedModuleName);
         if (null == module)
         {
             throw new IllegalArgumentException("Unknown module: " + requestedModuleName);
         }
-        String moduleName = module.getName();  // Use canonical name to ensure consistent casing
-        String scoping = getScoping(moduleName, featureArea);
 
-        Map<String, Map<String, AtomicLong>> moduleMetrics = getModuleMetrics(moduleName);
+        String scoping = getScoping(module, featureArea);
+        Map<String, Map<String, AtomicLong>> moduleMetrics = getModuleMetrics(module);
+        String moduleName = module.getName();  // Use canonical name to ensure consistent casing
 
         Map<String, AtomicLong> counts = moduleMetrics.computeIfAbsent(featureArea, k ->
         {


### PR DESCRIPTION
#### Rationale
Ensure that all usage metrics are reported using the canonical version of an existing module. This aligns the behavior of simple metrics vs. non-simple metrics.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3533

#### Changes
* Validate and canonicalize module name for non-simple metrics (like we're already doing for simple metrics)
* Move simple metrics to track by `Module` and skip reporting metrics for non-existent modules (more consistent with non-simple)
