### PR TITLE
Null check ClientDependency supplier result

### DIFF
--- a/api/src/org/labkey/api/view/template/ClientDependency.java
+++ b/api/src/org/labkey/api/view/template/ClientDependency.java
@@ -429,7 +429,9 @@ public abstract class ClientDependency
     {
         return getDependencySuppliers(c)
             .stream()
-            .map(cd->cd.get().getRequiredModuleContexts(c))
+            .map(Supplier::get)
+            .filter(Objects::nonNull)
+            .map(cd->cd.getRequiredModuleContexts(c))
             .flatMap(Collection::stream)
             .collect(Collectors.toSet());
     }


### PR DESCRIPTION
#### Rationale
Fix exception report NPE. Caused by a bad upgrade (mismatched module versions), but still reasonable to fix.

https://www.labkey.org/_mothership/mothership-showStackTraceDetail.view?exceptionStackTraceId=31913
