### PR TITLE
Add rel noopener in action button

### DIFF
--- a/api/src/org/labkey/api/data/ActionButton.java
+++ b/api/src/org/labkey/api/data/ActionButton.java
@@ -420,6 +420,11 @@ public class ActionButton extends DisplayElement implements Cloneable
         if (_noFollow)
             button.nofollow();
 
+        if (_target.equalsIgnoreCase("_blank"))
+        {
+            button.noOpener();
+        }
+
         if (_actionType.equals(Action.POST) || _actionType.equals(Action.GET))
         {
             StringBuilder onClickScript = new StringBuilder();

--- a/api/src/org/labkey/api/data/ActionButton.java
+++ b/api/src/org/labkey/api/data/ActionButton.java
@@ -420,7 +420,7 @@ public class ActionButton extends DisplayElement implements Cloneable
         if (_noFollow)
             button.nofollow();
 
-        if (_target.equalsIgnoreCase("_blank"))
+        if (_target != null && _target.equalsIgnoreCase("_blank"))
         {
             button.noOpener();
         }

--- a/api/src/org/labkey/api/util/DisplayElementBuilder.java
+++ b/api/src/org/labkey/api/util/DisplayElementBuilder.java
@@ -137,6 +137,12 @@ public abstract class DisplayElementBuilder<T extends DisplayElement & HasHtmlSt
         return rel("nofollow");
     }
 
+    public BUILDER noOpener()
+    {
+        return rel("noopener noreferrer");
+    }
+
+
     public BUILDER rel(String rel)
     {
         this.rel = rel;


### PR DESCRIPTION
#### Rationale
Recent change to catch security issues with anchor tags referencing an outside server and having target="_blank" but no rel="noopener noreferrer" attribute is detecting such URLs in code base and doing great job. 

#### Changes
* Add rel="noopener noreferrer" in ActionButton when target="_blank"
