### PR TITLE
Experiment: APIs for external use of lineage edges

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExpLineage.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineage.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.exp.api;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -38,12 +39,12 @@ import static java.util.stream.Collectors.toList;
  */
 public class ExpLineage
 {
-    private Set<Identifiable> _seeds;
-    private Set<ExpData> _datas;
-    private Set<ExpMaterial> _materials;
-    private Set<ExpRun> _runs;
-    private Set<Identifiable> _objects;
-    private Set<Edge> _edges;
+    private final Set<Identifiable> _seeds;
+    private final Set<ExpData> _datas;
+    private final Set<ExpMaterial> _materials;
+    private final Set<ExpRun> _runs;
+    private final Set<Identifiable> _objects;
+    private final Set<Edge> _edges;
 
     // constructed in processNodes
     private Map<String, Identifiable> _nodes;
@@ -159,7 +160,8 @@ public class ExpLineage
         return _nodesAndEdges;
     }
 
-    private Pair<Set<ExpLineage.Edge>, Set<ExpLineage.Edge>> nodeEdges(Identifiable node)
+    @Nullable
+    private Pair<Set<ExpLineage.Edge>, Set<ExpLineage.Edge>> nodeEdges(@NotNull Identifiable node)
     {
         Map<String, Identifiable> nodes = processNodes();
         String nodeLsid = node.getLSID();
@@ -167,8 +169,7 @@ public class ExpLineage
             throw new IllegalArgumentException("node not in lineage");
 
         Map<String, Pair<Set<ExpLineage.Edge>, Set<ExpLineage.Edge>>> edges = processNodeEdges();
-        Pair<Set<ExpLineage.Edge>, Set<ExpLineage.Edge>> nodeEdges = edges.get(nodeLsid);
-        return nodeEdges;
+        return edges.get(nodeLsid);
     }
 
     /** Get the set of directly connected parents for the node. */
@@ -300,7 +301,13 @@ public class ExpLineage
         return findNearestParents(null, cpasType, seed, nodes, edges, false);
     }
 
-    private <T extends ExpRunItem> Set<T> findNearestParents(@Nullable Class<T> parentClazz, @Nullable String cpasType, Identifiable seed, Map<String, Identifiable> nodes, Map<String, Pair<Set<Edge>, Set<Edge>>> edges, boolean findBothMaterialAndData)
+    private <T extends ExpRunItem> Set<T> findNearestParents(
+        @Nullable Class<T> parentClazz,
+        @Nullable String cpasType,
+        Identifiable seed,
+        Map<String, Identifiable> nodes, Map<String, Pair<Set<Edge>, Set<Edge>>> edges,
+        boolean findBothMaterialAndData
+    )
     {
         if (edges.size() == 0)
             return Collections.emptySet();

--- a/api/src/org/labkey/api/exp/api/ExpLineageEdge.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineageEdge.java
@@ -1,5 +1,7 @@
 package org.labkey.api.exp.api;
 
+import java.util.Objects;
+
 public class ExpLineageEdge
 {
     private Integer _fromObjectId;
@@ -11,6 +13,15 @@ public class ExpLineageEdge
     // Necessary for database serialization
     public ExpLineageEdge()
     {
+    }
+
+    public ExpLineageEdge(Integer fromObjectId, Integer toObjectId, Integer runId, Integer sourceId, String sourceKey)
+    {
+        _fromObjectId = fromObjectId;
+        _toObjectId = toObjectId;
+        _runId = runId;
+        _sourceId = sourceId;
+        _sourceKey = sourceKey;
     }
 
     public Integer getFromObjectId()
@@ -61,6 +72,36 @@ public class ExpLineageEdge
     public void setToObjectId(Integer toObjectId)
     {
         _toObjectId = toObjectId;
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format(
+            "fromObjectId: %d, toObjectId: %d, runId: %d, sourceId: %d, sourceKey: %s",
+            _fromObjectId, _toObjectId, _runId, _sourceId, _sourceKey
+        );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(_fromObjectId, _toObjectId, _runId, _sourceId, _sourceKey);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (!(obj instanceof ExpLineageEdge edge))
+            return false;
+
+        return (
+            Objects.equals(_fromObjectId, edge.getFromObjectId()) &&
+            Objects.equals(_toObjectId, edge.getToObjectId()) &&
+            Objects.equals(_runId, edge.getRunId()) &&
+            Objects.equals(_sourceId, edge.getSourceId()) &&
+            Objects.equals(_sourceKey, edge.getSourceKey())
+        );
     }
 
     public static class Options

--- a/api/src/org/labkey/api/exp/api/ExpLineageEdge.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineageEdge.java
@@ -1,0 +1,104 @@
+package org.labkey.api.exp.api;
+
+public class ExpLineageEdge
+{
+    private Integer _fromObjectId;
+    private Integer _runId;
+    private Integer _sourceId;
+    private String _sourceKey;
+    private Integer _toObjectId;
+
+    // Necessary for database serialization
+    public ExpLineageEdge()
+    {
+    }
+
+    public Integer getFromObjectId()
+    {
+        return _fromObjectId;
+    }
+
+    public void setFromObjectId(Integer fromObjectId)
+    {
+        _fromObjectId = fromObjectId;
+    }
+
+    public Integer getRunId()
+    {
+        return _runId;
+    }
+
+    public void setRunId(Integer runId)
+    {
+        _runId = runId;
+    }
+
+    public Integer getSourceId()
+    {
+        return _sourceId;
+    }
+
+    public void setSourceId(Integer sourceId)
+    {
+        _sourceId = sourceId;
+    }
+
+    public String getSourceKey()
+    {
+        return _sourceKey;
+    }
+
+    public void setSourceKey(String sourceKey)
+    {
+        _sourceKey = sourceKey;
+    }
+
+    public Integer getToObjectId()
+    {
+        return _toObjectId;
+    }
+
+    public void setToObjectId(Integer toObjectId)
+    {
+        _toObjectId = toObjectId;
+    }
+
+    public static class Options
+    {
+        public Integer fromObjectId;
+        public Integer runId;
+        public Integer sourceId;
+        public String sourceKey;
+        public Integer toObjectId;
+
+        public Options fromObjectId(Integer fromObjectId)
+        {
+            this.fromObjectId = fromObjectId;
+            return this;
+        }
+
+        public Options runId(Integer runId)
+        {
+            this.runId = runId;
+            return this;
+        }
+
+        public Options sourceId(Integer sourceId)
+        {
+            this.sourceId = sourceId;
+            return this;
+        }
+
+        public Options sourceKey(String sourceKey)
+        {
+            this.sourceKey = sourceKey;
+            return this;
+        }
+
+        public Options toObjectId(Integer toObjectId)
+        {
+            this.toObjectId = toObjectId;
+            return this;
+        }
+    }
+}

--- a/api/src/org/labkey/api/exp/api/ExpLineageEdge.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineageEdge.java
@@ -1,6 +1,8 @@
 package org.labkey.api.exp.api;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 public class ExpLineageEdge
 {
@@ -108,7 +110,7 @@ public class ExpLineageEdge
     {
         public Integer fromObjectId;
         public Integer runId;
-        public Integer sourceId;
+        public Set<Integer> sourceIds;
         public String sourceKey;
         public Integer toObjectId;
 
@@ -126,7 +128,13 @@ public class ExpLineageEdge
 
         public Options sourceId(Integer sourceId)
         {
-            this.sourceId = sourceId;
+            this.sourceIds = Set.of(sourceId);
+            return this;
+        }
+
+        public Options sourceIds(Set<Integer> sourceIds)
+        {
+            this.sourceIds = new HashSet<>(sourceIds);
             return this;
         }
 

--- a/api/src/org/labkey/api/exp/api/ExpLineageEdge.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineageEdge.java
@@ -6,18 +6,18 @@ import java.util.Set;
 
 public class ExpLineageEdge
 {
-    private Integer _fromObjectId;
+    private int _fromObjectId; // not nullable
     private Integer _runId;
     private Integer _sourceId;
     private String _sourceKey;
-    private Integer _toObjectId;
+    private int _toObjectId; // not nullable
 
     // Necessary for database serialization
     public ExpLineageEdge()
     {
     }
 
-    public ExpLineageEdge(Integer fromObjectId, Integer toObjectId, Integer runId, Integer sourceId, String sourceKey)
+    public ExpLineageEdge(int fromObjectId, int toObjectId, Integer runId, Integer sourceId, String sourceKey)
     {
         _fromObjectId = fromObjectId;
         _toObjectId = toObjectId;
@@ -26,12 +26,12 @@ public class ExpLineageEdge
         _sourceKey = sourceKey;
     }
 
-    public Integer getFromObjectId()
+    public int getFromObjectId()
     {
         return _fromObjectId;
     }
 
-    public void setFromObjectId(Integer fromObjectId)
+    public void setFromObjectId(int fromObjectId)
     {
         _fromObjectId = fromObjectId;
     }
@@ -66,12 +66,12 @@ public class ExpLineageEdge
         _sourceKey = sourceKey;
     }
 
-    public Integer getToObjectId()
+    public int getToObjectId()
     {
         return _toObjectId;
     }
 
-    public void setToObjectId(Integer toObjectId)
+    public void setToObjectId(int toObjectId)
     {
         _toObjectId = toObjectId;
     }
@@ -106,7 +106,7 @@ public class ExpLineageEdge
         );
     }
 
-    public static class Options
+    public static class FilterOptions
     {
         public Integer fromObjectId;
         public Integer runId;
@@ -114,37 +114,37 @@ public class ExpLineageEdge
         public String sourceKey;
         public Integer toObjectId;
 
-        public Options fromObjectId(Integer fromObjectId)
+        public FilterOptions fromObjectId(Integer fromObjectId)
         {
             this.fromObjectId = fromObjectId;
             return this;
         }
 
-        public Options runId(Integer runId)
+        public FilterOptions runId(Integer runId)
         {
             this.runId = runId;
             return this;
         }
 
-        public Options sourceId(Integer sourceId)
+        public FilterOptions sourceId(Integer sourceId)
         {
             this.sourceIds = Set.of(sourceId);
             return this;
         }
 
-        public Options sourceIds(Set<Integer> sourceIds)
+        public FilterOptions sourceIds(Set<Integer> sourceIds)
         {
             this.sourceIds = new HashSet<>(sourceIds);
             return this;
         }
 
-        public Options sourceKey(String sourceKey)
+        public FilterOptions sourceKey(String sourceKey)
         {
             this.sourceKey = sourceKey;
             return this;
         }
 
-        public Options toObjectId(Integer toObjectId)
+        public FilterOptions toObjectId(Integer toObjectId)
         {
             this.toObjectId = toObjectId;
             return this;

--- a/api/src/org/labkey/api/exp/api/ExpLineageOptions.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineageOptions.java
@@ -16,7 +16,7 @@
 package org.labkey.api.exp.api;
 
 /**
- * Captures options for doing an lineage search
+ * Captures options for doing a lineage search
  * Created by Nick Arnold on 2/12/2016.
  */
 public class ExpLineageOptions extends ResolveLsidsForm

--- a/api/src/org/labkey/api/exp/api/ExpRun.java
+++ b/api/src/org/labkey/api/exp/api/ExpRun.java
@@ -100,7 +100,7 @@ public interface ExpRun extends ExpObject, Identifiable
 
     void deleteProtocolApplications(User user);
 
-    /** Mark this run and its data as being replaced (superceeded) by another, more current run */
+    /** Mark this run and its data as being replaced (superseded) by another, more current run */
     void setReplacedByRun(ExpRun run);
 
     /** @return the run that represents the updated version of this run's data, if any */

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -859,11 +859,43 @@ public interface ExperimentService extends ExperimentRunTypeSource
      */
     Integer getObjectIdWithLegacyName(String name, String dataType, Date effectiveDate, Container c);
 
+    /**
+     * Persists a collection of lineage relationships (a.k.a. "edges") between experiment objects.
+     * Adding edges with a runId is not supported and this method will throw an exception if any run-based edges
+     * are supplied. Use experiment protocol inputs/outputs if run support is necessary.
+     * @param edges Collection of edges to persist.
+     */
     void addEdges(Collection<ExpLineageEdge> edges);
 
+    /**
+     * Fetch a collection of lineage relationships (a.k.a. "edges") between experiment objects. The constraints
+     * for which edges to fetch is provided via the ExpLineageEdge.FilterOptions parameter. Example:
+     *
+     * new ExpLineageEdge.FilterOptions().sourceId(42).sourceKey("happy")
+     *
+     * fetches edges where:
+     *
+     * sourceId = 42 AND sourceKey = "happy"
+     *
+     * @param options Filtering options used to constrain the edge's fetched.
+     * @return The collection of currently persisted lineage relationships matching the supplied filter options.
+     */
     @NotNull
     List<ExpLineageEdge> getEdges(ExpLineageEdge.FilterOptions options);
 
+    /**
+     * Removes lineage relationships (a.k.a. "edges") between experiment objects. The constraints for which edges
+     * are removed is provided via the ExpLineageEdge.FilterOptions parameter. Example:
+     *
+     * new ExpLineageEdge.FilterOptions().sourceId(24).sourceKey("cheerful")
+     *
+     * removes edges where:
+     *
+     * sourceId = 24 AND sourceKey = "cheerful"
+     *
+     * @param options Filtering options used to constrain the edge's removed.
+     * @return The number of edges removed.
+     */
     int removeEdges(ExpLineageEdge.FilterOptions options);
 
     class XarExportOptions

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -191,6 +191,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
     /**
      * Get a Data with name at a specific time.
      */
+    @Nullable
     ExpData getEffectiveData(@NotNull ExpDataClass dataClass, String name, @NotNull Date effectiveDate, @NotNull Container container);
 
     /**
@@ -857,6 +858,13 @@ public interface ExperimentService extends ExperimentRunTypeSource
      * @return The exp.object.rowId with legacy name at the effectiveDate of specified dataType
      */
     Integer getObjectIdWithLegacyName(String name, String dataType, Date effectiveDate, Container c);
+
+    void addEdges(ExpLineageEdge... edges);
+
+    @NotNull
+    List<ExpLineageEdge> getEdges(ExpLineageEdge.Options options);
+
+    int removeEdges(ExpLineageEdge.Options options);
 
     class XarExportOptions
     {

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -859,7 +859,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
      */
     Integer getObjectIdWithLegacyName(String name, String dataType, Date effectiveDate, Container c);
 
-    void addEdges(ExpLineageEdge... edges);
+    void addEdges(Collection<ExpLineageEdge> edges);
 
     @NotNull
     List<ExpLineageEdge> getEdges(ExpLineageEdge.Options options);

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -862,9 +862,9 @@ public interface ExperimentService extends ExperimentRunTypeSource
     void addEdges(Collection<ExpLineageEdge> edges);
 
     @NotNull
-    List<ExpLineageEdge> getEdges(ExpLineageEdge.Options options);
+    List<ExpLineageEdge> getEdges(ExpLineageEdge.FilterOptions options);
 
-    int removeEdges(ExpLineageEdge.Options options);
+    int removeEdges(ExpLineageEdge.FilterOptions options);
 
     class XarExportOptions
     {

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-22.005-22.006.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-22.005-22.006.sql
@@ -8,5 +8,7 @@ ALTER TABLE exp.Edge
     ADD SourceKey VARCHAR(200) NULL,
 
     ADD CONSTRAINT FK_Edge_SourceId_Object FOREIGN KEY (SourceId) REFERENCES exp.Object (Objectid),
-    ADD CONSTRAINT UQ_Edge_FromTo_RunId_SourceIdSourceKey UNIQUE (FromObjectId, ToObjectId, RunId, SourceId, SourceKey),
-    ADD CONSTRAINT UQ_Edge_ToFrom_RunId_SourceIdSourceKey UNIQUE (ToObjectId, FromObjectId, RunId, SourceId, SourceKey);
+    ADD CONSTRAINT UQ_Edge_FromTo_RunId_SourceId_SourceKey UNIQUE (FromObjectId, ToObjectId, RunId, SourceId, SourceKey);
+
+CREATE INDEX IX_Edge_ToObjectId ON exp.Edge(ToObjectId);
+CREATE INDEX IX_Edge_SourceId ON exp.Edge(SourceId);

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-22.005-22.006.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-22.005-22.006.sql
@@ -1,0 +1,12 @@
+ALTER TABLE exp.Edge
+    DROP CONSTRAINT UQ_Edge_FromTo_RunId,
+    DROP CONSTRAINT UQ_Edge_ToFrom_RunId,
+
+    ALTER COLUMN RunId DROP NOT NULL,
+
+    ADD SourceId INT NULL,
+    ADD SourceKey VARCHAR(200) NULL,
+
+    ADD CONSTRAINT FK_Edge_SourceId_Object FOREIGN KEY (SourceId) REFERENCES exp.Object (Objectid),
+    ADD CONSTRAINT UQ_Edge_FromTo_RunId_SourceIdSourceKey UNIQUE (FromObjectId, ToObjectId, RunId, SourceId, SourceKey),
+    ADD CONSTRAINT UQ_Edge_ToFrom_RunId_SourceIdSourceKey UNIQUE (ToObjectId, FromObjectId, RunId, SourceId, SourceKey);

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-22.005-22.006.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-22.005-22.006.sql
@@ -7,6 +7,8 @@ ALTER TABLE exp.Edge ADD SourceId INT NULL;
 ALTER TABLE exp.Edge ADD SourceKey NVARCHAR(200) NULL;
 
 ALTER TABLE exp.Edge ADD CONSTRAINT FK_Edge_SourceId_Object FOREIGN KEY (SourceId) REFERENCES exp.Object (Objectid);
-ALTER TABLE exp.Edge ADD CONSTRAINT UQ_Edge_FromTo_RunId_SourceIdSourceKey UNIQUE (FromObjectId, ToObjectId, RunId, SourceId, SourceKey);
-ALTER TABLE exp.Edge ADD CONSTRAINT UQ_Edge_ToFrom_RunId_SourceIdSourceKey UNIQUE (ToObjectId, FromObjectId, RunId, SourceId, SourceKey);
+ALTER TABLE exp.Edge ADD CONSTRAINT UQ_Edge_FromTo_RunId_SourceId_SourceKey UNIQUE (FromObjectId, ToObjectId, RunId, SourceId, SourceKey);
+
+CREATE INDEX IX_Edge_ToObjectId ON exp.Edge(ToObjectId);
+CREATE INDEX IX_Edge_SourceId ON exp.Edge(SourceId);
 GO

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-22.005-22.006.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-22.005-22.006.sql
@@ -1,0 +1,12 @@
+ALTER TABLE exp.Edge DROP CONSTRAINT UQ_Edge_FromTo_RunId;
+ALTER TABLE exp.Edge DROP CONSTRAINT UQ_Edge_ToFrom_RunId;
+
+ALTER TABLE exp.Edge ALTER COLUMN RunId INT NULL;
+
+ALTER TABLE exp.Edge ADD SourceId INT NULL;
+ALTER TABLE exp.Edge ADD SourceKey NVARCHAR(200) NULL;
+
+ALTER TABLE exp.Edge ADD CONSTRAINT FK_Edge_SourceId_Object FOREIGN KEY (SourceId) REFERENCES exp.Object (Objectid);
+ALTER TABLE exp.Edge ADD CONSTRAINT UQ_Edge_FromTo_RunId_SourceIdSourceKey UNIQUE (FromObjectId, ToObjectId, RunId, SourceId, SourceKey);
+ALTER TABLE exp.Edge ADD CONSTRAINT UQ_Edge_ToFrom_RunId_SourceIdSourceKey UNIQUE (ToObjectId, FromObjectId, RunId, SourceId, SourceKey);
+GO

--- a/experiment/resources/schemas/exp.xml
+++ b/experiment/resources/schemas/exp.xml
@@ -1135,6 +1135,8 @@
             <column columnName="fromObjectId"/>
             <column columnName="toObjectId"/>
             <column columnName="runId"/>
+            <column columnName="sourceId"/>
+            <column columnName="sourceKey"/>
         </columns>
     </table>
     <table tableName="Exclusions" tableDbType="UNKNOWN">

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -165,7 +165,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     public Double getSchemaVersion()
     {
-        return 22.005;
+        return 22.006;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -2383,8 +2383,6 @@ public class ExperimentServiceImpl implements ExperimentService
 
         for (Identifiable seed : seeds)
         {
-            var roughEdges = getEdges(new ExpLineageEdge.Options().sourceId(seed.getExpObject().getObjectId()));
-
             // create additional edges from the run for each ExpMaterial or ExpData seed
             if (seed instanceof ExpRunItem runSeed && !isUnknownMaterial(runSeed))
             {
@@ -8103,7 +8101,7 @@ public class ExperimentServiceImpl implements ExperimentService
         for (var edge : edges)
         {
             if (edge.getRunId() != null)
-                throw new IllegalArgumentException("Failed to add lineage edge. Edges with a runId are not supported. Use experiment protocol inputs/outputs if run support is necessary.");
+                throw new IllegalArgumentException("Failed to add lineage edge. Adding edges with a runId are not supported. Use experiment protocol inputs/outputs if run support is necessary.");
 
             // ignore cycles from and to itself
             if (Objects.equals(edge.getFromObjectId(), edge.getToObjectId()))
@@ -8189,13 +8187,13 @@ public class ExperimentServiceImpl implements ExperimentService
         @Before
         public void setUp()
         {
-            ContainerManager.deleteAll(JunitUtil.getTestContainer(), TestContext.get().getUser());
+            JunitUtil.deleteTestContainer();
         }
 
         @After
         public void tearDown()
         {
-            ContainerManager.deleteAll(JunitUtil.getTestContainer(), TestContext.get().getUser());
+            JunitUtil.deleteTestContainer();
         }
 
         @Test

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -440,7 +440,7 @@ public class ExperimentServiceImpl implements ExperimentService
         try
         {
             ExpProtocol protocol;
-            try (DbScope.Transaction transaction = ExperimentService.get().getSchema().getScope().ensureTransaction(ExperimentService.get().getProtocolImportLock()))
+            try (DbScope.Transaction transaction = getSchema().getScope().ensureTransaction(getProtocolImportLock()))
             {
                 List<String> sequenceProtocols = new ArrayList<>();
                 Map<String, ExpProtocol> protocolCache = new HashMap<>();
@@ -454,10 +454,10 @@ public class ExperimentServiceImpl implements ExperimentService
                     if (!protocolCache.containsKey(stepName))
                     {
                         // Check if it's in the database already
-                        ExpProtocol stepProtocol = ExperimentService.get().getExpProtocol(container, stepName);
+                        ExpProtocol stepProtocol = getExpProtocol(container, stepName);
                         if (stepProtocol == null)
                         {
-                            stepProtocol = ExperimentService.get().createExpProtocol(container, ProtocolApplication, stepName);
+                            stepProtocol = createExpProtocol(container, ProtocolApplication, stepName);
                             stepProtocol.save(user);
                         }
                         protocolCache.put(stepName, stepProtocol);
@@ -531,7 +531,6 @@ public class ExperimentServiceImpl implements ExperimentService
         filter.addCondition(FieldKey.fromParts("classId"), dataClass.getRowId());
 
         return ExpDataImpl.fromDatas(new TableSelector(getTinfoData(), filter, null).getArrayList(Data.class));
-
     }
 
     @Override
@@ -1142,7 +1141,7 @@ public class ExperimentServiceImpl implements ExperimentService
 
         obj.setName(name);
         obj.setObjectType(objectType);
-        obj.setLSID(ExperimentService.get().generateGuidLSID(c, ExpProtocolInput.class));
+        obj.setLSID(generateGuidLSID(c, ExpProtocolInput.class));
         obj.setProtocolId(protocolId);
         obj.setInput(input);
         if (criteria != null)
@@ -1388,7 +1387,7 @@ public class ExperimentServiceImpl implements ExperimentService
     @Override
     public ExpDataClass getEffectiveDataClass(@NotNull Container definitionContainer, @NotNull String dataClassName, @NotNull Date effectiveDate)
     {
-        Integer legacyObjectId = ExperimentService.get().getObjectIdWithLegacyName(dataClassName, ExperimentServiceImpl.getNamespacePrefix(ExpDataClass.class), effectiveDate, definitionContainer);
+        Integer legacyObjectId = getObjectIdWithLegacyName(dataClassName, ExperimentServiceImpl.getNamespacePrefix(ExpDataClass.class), effectiveDate, definitionContainer);
         if (legacyObjectId != null)
             return getDataClassByObjectId(definitionContainer, legacyObjectId);
 
@@ -1534,6 +1533,7 @@ public class ExperimentServiceImpl implements ExperimentService
         return data == null ? null : new ExpDataImpl(data);
     }
 
+    @Nullable
     public ExpDataImpl getDataByObjectId(Container c, Integer objectId)
     {
         SimpleFilter filter = SimpleFilter.createContainerFilter(c);
@@ -1546,9 +1546,10 @@ public class ExperimentServiceImpl implements ExperimentService
     }
 
     @Override
+    @Nullable
     public ExpData getEffectiveData(@NotNull ExpDataClass dataClass, String name, @NotNull Date effectiveDate, @NotNull Container container)
     {
-        Integer legacyObjectId = ExperimentService.get().getObjectIdWithLegacyName(name, ExperimentServiceImpl.getNamespacePrefix(ExpData.class), effectiveDate, dataClass.getContainer());
+        Integer legacyObjectId = getObjectIdWithLegacyName(name, ExperimentServiceImpl.getNamespacePrefix(ExpData.class), effectiveDate, dataClass.getContainer());
         if (legacyObjectId != null)
             return getDataByObjectId(container, legacyObjectId);
 
@@ -1560,6 +1561,7 @@ public class ExperimentServiceImpl implements ExperimentService
     }
 
     @Override
+    @Nullable
     public ExpData findExpData(Container c, User user,
                             @NotNull ExpDataClass dataClass,
                             @NotNull String dataClassName, String dataName,
@@ -1725,17 +1727,16 @@ public class ExperimentServiceImpl implements ExperimentService
         return view;
     }
 
-
     /**
      * export to temp directory
      */
     @Override
     public File exportXarForRuns(
-            User user,
-            Set<Integer> runIds,
-            Integer expRowId,
-            XarExportOptions options)
-            throws NotFoundException, IOException, ExperimentException
+        User user,
+        Set<Integer> runIds,
+        Integer expRowId,
+        XarExportOptions options
+    ) throws NotFoundException, IOException, ExperimentException
     {
         if (runIds.isEmpty())
         {
@@ -1747,7 +1748,7 @@ public class ExperimentServiceImpl implements ExperimentService
             List<ExpRun> runs = new ArrayList<>();
             for (int id : runIds)
             {
-                ExpRun run = ExperimentService.get().getExpRun(id);
+                ExpRun run = getExpRun(id);
                 if (run == null || !run.getContainer().hasPermission(user, ReadPermission.class))
                 {
                     throw new NotFoundException("Could not find run " + id);
@@ -1758,7 +1759,7 @@ public class ExperimentServiceImpl implements ExperimentService
             XarExportSelection selection = new XarExportSelection();
             if (expRowId != null)
             {
-                ExpExperiment experiment = ExperimentService.get().getExpExperiment(expRowId);
+                ExpExperiment experiment = getExpExperiment(expRowId);
                 if (experiment == null || !experiment.getContainer().hasPermission(user, ReadPermission.class))
                 {
                     throw new NotFoundException("Run group " + expRowId);
@@ -1796,7 +1797,6 @@ public class ExperimentServiceImpl implements ExperimentService
             throw new NotFoundException(runIds.toString());
         }
     }
-
 
     @Override
     public DbSchema getSchema()
@@ -1900,7 +1900,7 @@ public class ExperimentServiceImpl implements ExperimentService
     @Nullable
     public ExpDataRunInputImpl getDataInput(int dataId, int targetProtocolApplicationId)
     {
-        TableInfo inputTable = ExperimentServiceImpl.get().getTinfoDataInput();
+        TableInfo inputTable = getTinfoDataInput();
         SimpleFilter filter = new SimpleFilter();
         filter.addCondition(FieldKey.fromParts("dataId"), dataId);
         filter.addCondition(FieldKey.fromParts("targetApplicationId"), targetProtocolApplicationId);
@@ -1915,7 +1915,7 @@ public class ExperimentServiceImpl implements ExperimentService
     @Nullable
     public ExpDataProtocolInputImpl getDataProtocolInput(int rowId)
     {
-        TableInfo inputTable = ExperimentServiceImpl.get().getTinfoProtocolInput();
+        TableInfo inputTable = getTinfoProtocolInput();
 
         SimpleFilter filter = new SimpleFilter();
         filter.addCondition(FieldKey.fromParts("objectType"), ExpData.DEFAULT_CPAS_TYPE);
@@ -1935,7 +1935,7 @@ public class ExperimentServiceImpl implements ExperimentService
         if (!DataProtocolInput.NAMESPACE.equals(namespace))
             return null;
 
-        TableInfo inputTable = ExperimentServiceImpl.get().getTinfoProtocolInput();
+        TableInfo inputTable = getTinfoProtocolInput();
         SimpleFilter filter = new SimpleFilter();
         filter.addCondition(FieldKey.fromParts("objectType"), ExpData.DEFAULT_CPAS_TYPE);
         filter.addCondition(FieldKey.fromParts("lsid"), lsid);
@@ -1950,7 +1950,7 @@ public class ExperimentServiceImpl implements ExperimentService
     @Override
     public List<? extends ExpDataProtocolInput> getDataProtocolInputs(int protocolId, boolean input, @Nullable String name, @Nullable Integer dataClassId)
     {
-        TableInfo inputTable = ExperimentServiceImpl.get().getTinfoProtocolInput();
+        TableInfo inputTable = getTinfoProtocolInput();
         SimpleFilter filter = new SimpleFilter();
         filter.addCondition(FieldKey.fromParts("objectType"), ExpData.DEFAULT_CPAS_TYPE);
         filter.addCondition(FieldKey.fromParts("protocolId"), protocolId);
@@ -1991,7 +1991,7 @@ public class ExperimentServiceImpl implements ExperimentService
     @Nullable
     public ExpMaterialRunInputImpl getMaterialInput(int materialId, int targetProtocolApplicationId)
     {
-        TableInfo inputTable = ExperimentServiceImpl.get().getTinfoMaterialInput();
+        TableInfo inputTable = getTinfoMaterialInput();
         SimpleFilter filter = new SimpleFilter();
         filter.addCondition(FieldKey.fromParts("materialId"), materialId);
         filter.addCondition(FieldKey.fromParts("targetApplicationId"), targetProtocolApplicationId);
@@ -2021,7 +2021,7 @@ public class ExperimentServiceImpl implements ExperimentService
 
     public List<? extends ExpProtocolInputImpl> getProtocolInputs(int protocolId)
     {
-        TableInfo inputTable = ExperimentServiceImpl.get().getTinfoProtocolInput();
+        TableInfo inputTable = getTinfoProtocolInput();
         SimpleFilter filter = new SimpleFilter();
         filter.addCondition(FieldKey.fromParts("protocolId"), protocolId);
         Collection<Map<String, Object>> rows = new TableSelector(inputTable, TableSelector.ALL_COLUMNS, filter, new Sort("rowId")).getMapCollection();
@@ -2031,7 +2031,7 @@ public class ExperimentServiceImpl implements ExperimentService
 
     public ExpProtocolInputImpl getProtocolInput(int rowId)
     {
-        TableInfo inputTable = ExperimentServiceImpl.get().getTinfoProtocolInput();
+        TableInfo inputTable = getTinfoProtocolInput();
         SimpleFilter filter = new SimpleFilter();
         filter.addCondition(FieldKey.fromParts("rowId"), rowId);
         Map<String, Object> row = new TableSelector(inputTable, TableSelector.ALL_COLUMNS, filter, null).getMap();
@@ -2046,7 +2046,7 @@ public class ExperimentServiceImpl implements ExperimentService
         if (!AbstractProtocolInput.NAMESPACE.equals(namespace))
             return null;
 
-        TableInfo inputTable = ExperimentServiceImpl.get().getTinfoProtocolInput();
+        TableInfo inputTable = getTinfoProtocolInput();
         SimpleFilter filter = new SimpleFilter();
         filter.addCondition(FieldKey.fromParts("lsid"), lsid);
         Map<String, Object> row = new TableSelector(inputTable, TableSelector.ALL_COLUMNS, filter, null).getMap();
@@ -2057,7 +2057,7 @@ public class ExperimentServiceImpl implements ExperimentService
     @Nullable
     public ExpMaterialProtocolInputImpl getMaterialProtocolInput(int rowId)
     {
-        TableInfo inputTable = ExperimentServiceImpl.get().getTinfoProtocolInput();
+        TableInfo inputTable = getTinfoProtocolInput();
         SimpleFilter filter = new SimpleFilter();
         filter.addCondition(FieldKey.fromParts("objectType"), ExpMaterial.DEFAULT_CPAS_TYPE);
         filter.addCondition(FieldKey.fromParts("rowId"), rowId);
@@ -2076,7 +2076,7 @@ public class ExperimentServiceImpl implements ExperimentService
         if (!AbstractProtocolInput.NAMESPACE.equals(namespace))
             return null;
 
-        TableInfo inputTable = ExperimentServiceImpl.get().getTinfoProtocolInput();
+        TableInfo inputTable = getTinfoProtocolInput();
         SimpleFilter filter = new SimpleFilter();
         filter.addCondition(FieldKey.fromParts("objectType"), ExpMaterial.DEFAULT_CPAS_TYPE);
         filter.addCondition(FieldKey.fromParts("lsid"), lsid);
@@ -2091,7 +2091,7 @@ public class ExperimentServiceImpl implements ExperimentService
     @Nullable
     public List<? extends ExpMaterialProtocolInput> getMaterialProtocolInputs(int protocolId, boolean input, @Nullable String name, @Nullable Integer materialSourceId)
     {
-        TableInfo inputTable = ExperimentServiceImpl.get().getTinfoProtocolInput();
+        TableInfo inputTable = getTinfoProtocolInput();
         SimpleFilter filter = new SimpleFilter();
         filter.addCondition(FieldKey.fromParts("objectType"), ExpMaterial.DEFAULT_CPAS_TYPE);
         filter.addCondition(FieldKey.fromParts("protocolId"), protocolId);
@@ -2250,9 +2250,9 @@ public class ExperimentServiceImpl implements ExperimentService
         if (down)
         {
             if (start instanceof ExpData)
-                runsToInvestigate.addAll(ExperimentServiceImpl.get().getRunsUsingDataIds(Arrays.asList(start.getRowId())));
+                runsToInvestigate.addAll(getRunsUsingDataIds(Arrays.asList(start.getRowId())));
             else if (start instanceof ExpMaterial)
-                runsToInvestigate.addAll(ExperimentServiceImpl.get().getRunsUsingMaterials(start.getRowId()));
+                runsToInvestigate.addAll(getRunsUsingMaterials(start.getRowId()));
             runsToInvestigate.remove(start.getRun());
         }
         return runsToInvestigate;
@@ -2287,9 +2287,9 @@ public class ExperimentServiceImpl implements ExperimentService
         if (down)
         {
             if (start instanceof ExpData)
-                runsDown.putAll(flattenPairs(ExperimentServiceImpl.get().getRunsAndRolesUsingDataIds(Arrays.asList(start.getRowId()))));
+                runsDown.putAll(flattenPairs(getRunsAndRolesUsingDataIds(Arrays.asList(start.getRowId()))));
             else if (start instanceof ExpMaterial)
-                runsDown.putAll(flattenPairs(ExperimentServiceImpl.get().getRunsAndRolesUsingMaterialIds(Arrays.asList(start.getRowId()))));
+                runsDown.putAll(flattenPairs(getRunsAndRolesUsingMaterialIds(Arrays.asList(start.getRowId()))));
 
             if (parentRun != null)
                 runsDown.remove(parentRun.getLSID());
@@ -2385,10 +2385,12 @@ public class ExperimentServiceImpl implements ExperimentService
 
         for (Identifiable seed : seeds)
         {
+            var roughEdges = getEdges(new ExpLineageEdge.Options().sourceId(seed.getExpObject().getObjectId()));
+
             // create additional edges from the run for each ExpMaterial or ExpData seed
-            if (seed instanceof ExpRunItem && !isUnknownMaterial((ExpRunItem)seed))
+            if (seed instanceof ExpRunItem runSeed && !isUnknownMaterial(runSeed))
             {
-                Pair<Map<String, String>, Map<String, String>> pair = collectRunsAndRolesToInvestigate((ExpRunItem)seed, options);
+                Pair<Map<String, String>, Map<String, String>> pair = collectRunsAndRolesToInvestigate(runSeed, options);
 
                 // add edges for initial runs and roles up
                 for (Map.Entry<String, String> runAndRole : pair.first.entrySet())
@@ -4106,7 +4108,7 @@ public class ExperimentServiceImpl implements ExperimentService
                                 if (input.getDataFileUrl().equals(output.getDataFileUrl()))
                                 {
                                     // Don't delete the exp.data output if it is being used in other runs
-                                    List<? extends ExpRun> otherUsages = ExperimentService.get().getRunsUsingDatas(List.of(output));
+                                    List<? extends ExpRun> otherUsages = getRunsUsingDatas(List.of(output));
                                     otherUsages.remove(run);
                                     if (!otherUsages.isEmpty())
                                     {
@@ -4128,7 +4130,7 @@ public class ExperimentServiceImpl implements ExperimentService
                             }
 
                             // If the file has no other usages, we can delete it.
-                            List<? extends ExpRun> otherUsages = ExperimentService.get().getRunsUsingDatas(List.of(input));
+                            List<? extends ExpRun> otherUsages = getRunsUsingDatas(List.of(input));
                             otherUsages.remove(run);
                             if (otherUsages.isEmpty())
                             {
@@ -5033,11 +5035,11 @@ public class ExperimentServiceImpl implements ExperimentService
                 }
             }
 
-            SqlExecutor executor = new SqlExecutor(ExperimentServiceImpl.get().getExpSchema());
+            SqlExecutor executor = new SqlExecutor(getExpSchema());
 
-            SQLFragment sql = new SQLFragment("DELETE FROM " + ExperimentServiceImpl.get().getTinfoRunList()
+            SQLFragment sql = new SQLFragment("DELETE FROM " + getTinfoRunList()
                     + " WHERE ExperimentId IN ("
-                    + " SELECT E.RowId FROM " + ExperimentServiceImpl.get().getTinfoExperiment() + " E "
+                    + " SELECT E.RowId FROM " + getTinfoExperiment() + " E "
                     + " WHERE E.RowId = " + experiment.getRowId()
                     + " AND E.Container = ? )", experiment.getContainer());
             executor.execute(sql);
@@ -5050,7 +5052,7 @@ public class ExperimentServiceImpl implements ExperimentService
                 listener.beforeExperimentDeleted(c, user, experiment);
             }
 
-            sql = new SQLFragment("DELETE FROM " + ExperimentServiceImpl.get().getTinfoExperiment()
+            sql = new SQLFragment("DELETE FROM " + getTinfoExperiment()
                     + " WHERE RowId = " + experiment.getRowId()
                     + " AND Container = ?", experiment.getContainer());
             executor.execute(sql);
@@ -5257,7 +5259,6 @@ public class ExperimentServiceImpl implements ExperimentService
             materialListener.beforeMaterialDelete(materials, container, user);
         }
     }
-
 
     @Override
     public List<ExpRunImpl> getRunsUsingDatas(List<ExpData> datas)
@@ -5581,7 +5582,7 @@ public class ExperimentServiceImpl implements ExperimentService
         filter.addCondition(FieldKey.fromParts("classId"), dataClass.getRowId());
 
         MultiValuedMap<String, Integer> byContainer = new ArrayListValuedHashMap<>();
-        TableSelector ts = new TableSelector(ExperimentServiceImpl.get().getTinfoData(), Sets.newCaseInsensitiveHashSet("container", "rowid"), filter, null);
+        TableSelector ts = new TableSelector(getTinfoData(), Sets.newCaseInsensitiveHashSet("container", "rowid"), filter, null);
         ts.forEachMap(row -> byContainer.put((String)row.get("container"), (Integer)row.get("rowid")));
 
         int count = 0;
@@ -6713,7 +6714,7 @@ public class ExperimentServiceImpl implements ExperimentService
                     .append(" (ObjectUri, Container) VALUES (?, ?)");
             Table.batchExecute(getExpSchema(), expObjectSql.toString(), expObjectParams);
 
-            StringBuilder sql = new StringBuilder("INSERT INTO ").append(ExperimentServiceImpl.get().getTinfoExperimentRun().toString()).
+            StringBuilder sql = new StringBuilder("INSERT INTO ").append(getTinfoExperimentRun().toString()).
                     append(" (Lsid, ObjectId, Name, ProtocolLsid, FilePathRoot, EntityId, Created, CreatedBy, Modified, ModifiedBy, Container) " +
                             "VALUES (?,(select objectid from exp.object where objecturi = ?),?,?,?,?,?,?,?,?, '").
                     append(c.getId()).append("')");
@@ -6976,7 +6977,7 @@ public class ExperimentServiceImpl implements ExperimentService
         {
             if (!params.isEmpty())
             {
-                String sql = "INSERT INTO " + ExperimentServiceImpl.get().getTinfoMaterialInput().toString() +
+                String sql = "INSERT INTO " + getTinfoMaterialInput().toString() +
                         " (MaterialId, TargetApplicationId, Role)" +
                         " VALUES (?,?,?)";
                 Table.batchExecute(getExpSchema(), sql, params);
@@ -6987,7 +6988,7 @@ public class ExperimentServiceImpl implements ExperimentService
         {
             if (!params.isEmpty())
             {
-                String sql = "INSERT INTO " + ExperimentServiceImpl.get().getTinfoProtocolApplication().toString() +
+                String sql = "INSERT INTO " + getTinfoProtocolApplication().toString() +
                         " (Name, CpasType, ProtocolLsid, ActivityDate, RunId, ActionSequence, Lsid, EntityId)" +
                         " VALUES (?,?,?,?,?,?,?,?)";
                 Table.batchExecute(getExpSchema(), sql, params);
@@ -6998,7 +6999,7 @@ public class ExperimentServiceImpl implements ExperimentService
         {
             if (!params.isEmpty())
             {
-                String sql = "INSERT INTO " + ExperimentServiceImpl.get().getTinfoDataInput().toString() +
+                String sql = "INSERT INTO " + getTinfoDataInput().toString() +
                         " (Role, DataId, TargetApplicationId)" +
                         " VALUES (?,?,?)";
                 Table.batchExecute(getExpSchema(), sql, params);
@@ -7462,7 +7463,7 @@ public class ExperimentServiceImpl implements ExperimentService
             errors = DomainUtil.updateDomainDescriptor(original, update, c, u, hasNameChange);
 
             if (hasNameChange)
-                ExperimentService.get().addObjectLegacyName(dataClass.getObjectId(), ExperimentServiceImpl.getNamespacePrefix(ExpDataClass.class), oldDataClassName, u);
+                addObjectLegacyName(dataClass.getObjectId(), ExperimentServiceImpl.getNamespacePrefix(ExpDataClass.class), oldDataClassName, u);
 
             if (!errors.hasErrors())
             {
@@ -7478,7 +7479,7 @@ public class ExperimentServiceImpl implements ExperimentService
         if (name == null)
             throw new IllegalArgumentException("DataClass name is required.");
 
-        TableInfo dataClassTable = ExperimentService.get().getTinfoDataClass();
+        TableInfo dataClassTable = getTinfoDataClass();
         int nameMax = dataClassTable.getColumn("Name").getScale();
         if (name.length() > nameMax)
             throw new IllegalArgumentException("DataClass name may not exceed " + nameMax + " characters.");
@@ -7494,7 +7495,7 @@ public class ExperimentServiceImpl implements ExperimentService
         if (options == null)
             return;
 
-        TableInfo dataClassTable = ExperimentService.get().getTinfoDataClass();
+        TableInfo dataClassTable = getTinfoDataClass();
         int nameExpMax = dataClassTable.getColumn("NameExpression").getScale();
         if (options.getNameExpression() != null && options.getNameExpression().length() > nameExpMax)
             throw new IllegalArgumentException("Name expression may not exceed " + nameExpMax + " characters.");
@@ -8047,7 +8048,7 @@ public class ExperimentServiceImpl implements ExperimentService
     @Override
     public Integer getObjectIdWithLegacyName(String name, String dataType, Date effectiveDate, Container c)
     {
-        TableInfo tableInfo = ExperimentService.get().getTinfoObjectLegacyNames();
+        TableInfo tableInfo = getTinfoObjectLegacyNames();
 
         // find the last ObjectLegacyNames record with matched name and timestamp
         SQLFragment sql = new SQLFragment("SELECT ObjectId, Created FROM exp.ObjectLegacyNames " +
@@ -8089,6 +8090,98 @@ public class ExperimentServiceImpl implements ExperimentService
         }
 
         return null;
+    }
+
+    @Override
+    public void addEdges(ExpLineageEdge... edges)
+    {
+        if (edges.length == 0)
+            return;
+
+        List<List<?>> params = new ArrayList<>();
+
+        for (var edge : edges)
+        {
+            if (edge.getRunId() != null)
+                throw new IllegalArgumentException("Failed to add lineage edge. Edges with a runId are not supported. Use experiment protocol inputs/outputs if run support is necessary.");
+
+            // ignore cycles from and to itself
+            if (Objects.equals(edge.getFromObjectId(), edge.getToObjectId()))
+                continue;
+
+            params.add(Arrays.asList(
+                edge.getFromObjectId(),
+                edge.getToObjectId(),
+                edge.getSourceId(),
+                StringUtils.trimToNull(edge.getSourceKey())
+            ));
+        }
+
+        if (params.isEmpty())
+            return;
+
+        try (DbScope.Transaction tx = getSchema().getScope().ensureTransaction())
+        {
+            String sql = "INSERT INTO " + getTinfoEdge().toString() +
+                    " (fromObjectId, toObjectId, sourceId, sourceKey) " +
+                    " VALUES (?, ?, ?, ?) ";
+
+            Table.batchExecute(getExpSchema(), sql, params);
+            tx.commit();
+        }
+        catch (SQLException e)
+        {
+            throw new RuntimeSQLException(e);
+        }
+    }
+
+    @Override
+    @NotNull
+    public List<ExpLineageEdge> getEdges(ExpLineageEdge.Options options)
+    {
+        SimpleFilter filter = getEdgeFilterFromOptions(options);
+        return new TableSelector(getTinfoEdge(), filter, null).getArrayList(ExpLineageEdge.class);
+    }
+
+    private SimpleFilter getEdgeFilterFromOptions(ExpLineageEdge.Options options)
+    {
+        SimpleFilter filter = new SimpleFilter();
+
+        if (options.fromObjectId != null)
+            filter.addCondition(FieldKey.fromParts("fromObjectId"), options.fromObjectId);
+        if (options.toObjectId != null)
+            filter.addCondition(FieldKey.fromParts("toObjectId"), options.toObjectId);
+        if (options.runId != null)
+            filter.addCondition(FieldKey.fromParts("runId"), options.runId);
+        if (options.sourceId != null)
+            filter.addCondition(FieldKey.fromParts("sourceId"), options.sourceId);
+        if (StringUtils.trimToNull(options.sourceKey) != null)
+            filter.addCondition(FieldKey.fromParts("sourceKey"), options.sourceKey);
+
+        return filter;
+    }
+
+    @Override
+    public int removeEdges(ExpLineageEdge.Options options)
+    {
+        if (options.runId != null)
+            throw new IllegalArgumentException("Failed to remove lineage edges. Edges with a runId cannot be deleted via removeEdge(). Use experiment protocol inputs/outputs if run support is necessary.");
+
+        int count = 0;
+        SimpleFilter filter = getEdgeFilterFromOptions(options);
+
+        if (filter.getClauses().isEmpty())
+            return count;
+
+        filter.addCondition(FieldKey.fromParts("runId"), null, CompareType.ISBLANK);
+
+        try (DbScope.Transaction tx = ensureTransaction())
+        {
+            count = Table.delete(getTinfoEdge(), filter);
+            tx.commit();
+        }
+
+        return count;
     }
 
     public static class TestCase extends Assert

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8093,9 +8093,9 @@ public class ExperimentServiceImpl implements ExperimentService
     }
 
     @Override
-    public void addEdges(ExpLineageEdge... edges)
+    public void addEdges(Collection<ExpLineageEdge> edges)
     {
-        if (edges.length == 0)
+        if (edges == null || edges.size() == 0)
             return;
 
         List<List<?>> params = new ArrayList<>();

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8118,7 +8118,7 @@ public class ExperimentServiceImpl implements ExperimentService
         if (params.isEmpty())
             return;
 
-        try (DbScope.Transaction tx = getSchema().getScope().ensureTransaction())
+        try (DbScope.Transaction tx = ensureTransaction())
         {
             String sql = "INSERT INTO " + getTinfoEdge().toString() +
                     " (fromObjectId, toObjectId, sourceId, sourceKey) " +
@@ -8151,8 +8151,15 @@ public class ExperimentServiceImpl implements ExperimentService
             filter.addCondition(FieldKey.fromParts("toObjectId"), options.toObjectId);
         if (options.runId != null)
             filter.addCondition(FieldKey.fromParts("runId"), options.runId);
-        if (options.sourceId != null)
-            filter.addCondition(FieldKey.fromParts("sourceId"), options.sourceId);
+        if (options.sourceIds != null)
+        {
+            if (options.sourceIds.isEmpty())
+                filter.addWhereClause("0 = 1", new Object[]{});
+            if (options.sourceIds.size() == 1)
+                filter.addCondition(FieldKey.fromParts("sourceId"), options.sourceIds.stream().findFirst().get());
+            else
+                filter.addCondition(FieldKey.fromParts("sourceId"), options.sourceIds, CompareType.IN);
+        }
         if (StringUtils.trimToNull(options.sourceKey) != null)
             filter.addCondition(FieldKey.fromParts("sourceKey"), options.sourceKey);
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8155,8 +8155,6 @@ public class ExperimentServiceImpl implements ExperimentService
         {
             if (options.sourceIds.isEmpty())
                 filter.addWhereClause("0 = 1", new Object[]{});
-            if (options.sourceIds.size() == 1)
-                filter.addCondition(FieldKey.fromParts("sourceId"), options.sourceIds.stream().findFirst().get());
             else
                 filter.addCondition(FieldKey.fromParts("sourceId"), options.sourceIds, CompareType.IN);
         }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8101,7 +8101,7 @@ public class ExperimentServiceImpl implements ExperimentService
         for (var edge : edges)
         {
             if (edge.getRunId() != null)
-                throw new IllegalArgumentException("Failed to add lineage edge. Adding edges with a runId are not supported. Use experiment protocol inputs/outputs if run support is necessary.");
+                throw new IllegalArgumentException("Failed to add lineage edge. Adding edges with a runId is not supported. Use experiment protocol inputs/outputs if run support is necessary.");
 
             // ignore cycles from and to itself
             if (Objects.equals(edge.getFromObjectId(), edge.getToObjectId()))
@@ -8135,13 +8135,13 @@ public class ExperimentServiceImpl implements ExperimentService
 
     @Override
     @NotNull
-    public List<ExpLineageEdge> getEdges(ExpLineageEdge.Options options)
+    public List<ExpLineageEdge> getEdges(ExpLineageEdge.FilterOptions options)
     {
         SimpleFilter filter = getEdgeFilterFromOptions(options);
         return new TableSelector(getTinfoEdge(), filter, null).getArrayList(ExpLineageEdge.class);
     }
 
-    private SimpleFilter getEdgeFilterFromOptions(ExpLineageEdge.Options options)
+    private SimpleFilter getEdgeFilterFromOptions(ExpLineageEdge.FilterOptions options)
     {
         SimpleFilter filter = new SimpleFilter();
 
@@ -8167,7 +8167,7 @@ public class ExperimentServiceImpl implements ExperimentService
     }
 
     @Override
-    public int removeEdges(ExpLineageEdge.Options options)
+    public int removeEdges(ExpLineageEdge.FilterOptions options)
     {
         if (options.runId != null)
             throw new IllegalArgumentException("Failed to remove lineage edges. Edges with a runId cannot be deleted via removeEdge(). Use experiment protocol inputs/outputs if run support is necessary.");

--- a/experiment/src/org/labkey/experiment/api/LineageTest.java
+++ b/experiment/src/org/labkey/experiment/api/LineageTest.java
@@ -27,6 +27,7 @@ import org.labkey.api.exp.LsidManager;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpLineage;
+import org.labkey.api.exp.api.ExpLineageEdge;
 import org.labkey.api.exp.api.ExpLineageOptions;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -63,6 +64,7 @@ import org.labkey.api.writer.DefaultContainerUser;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -80,17 +82,22 @@ import static org.labkey.api.exp.api.ExperimentService.SAMPLE_DERIVATION_PROTOCO
 public class LineageTest extends ExpProvisionedTableTestHelper
 {
     Container c;
+    Lsid.LsidBuilder lsidBuilder;
 
     @Before
     public void setUp()
     {
         JunitUtil.deleteTestContainer();
         c = JunitUtil.getTestContainer();
+
+        lsidBuilder = new Lsid.LsidBuilder("JUnitTest", null);
+        LsidManager.get().registerHandler("JUnitTest", new LsidManager.OntologyObjectLsidHandler());
     }
 
     @After
     public void tearDown()
     {
+        JunitUtil.deleteTestContainer();
     }
 
     @Test
@@ -234,29 +241,29 @@ public class LineageTest extends ExpProvisionedTableTestHelper
             ctx.getViewContext().setContainer(c);
             ctx.getViewContext().setActionURL(new ActionURL());
 
-            ColumnInfo colName    = rs.getColumn(rs.findColumn(FieldKey.fromParts("Name")));
-            DisplayColumn dcName  = colName.getRenderer();
+            ColumnInfo colName = rs.getColumn(rs.findColumn(FieldKey.fromParts("Name")));
+            DisplayColumn dcName = colName.getRenderer();
 
-            ColumnInfo colInputsAllNames    = rs.getColumn(rs.findColumn(FieldKey.fromParts("InputsAllNames")));
-            LineageDisplayColumn dcInputsAllNames  = (LineageDisplayColumn)colInputsAllNames.getRenderer();
+            ColumnInfo colInputsAllNames = rs.getColumn(rs.findColumn(FieldKey.fromParts("InputsAllNames")));
+            LineageDisplayColumn dcInputsAllNames = (LineageDisplayColumn)colInputsAllNames.getRenderer();
 
-            ColumnInfo colInputsMaterialSampleNames    = rs.getColumn(rs.findColumn(FieldKey.fromParts("InputsMaterialSampleNames")));
-            LineageDisplayColumn dcInputsMaterialSampleNames  = (LineageDisplayColumn)colInputsMaterialSampleNames.getRenderer();
+            ColumnInfo colInputsMaterialSampleNames = rs.getColumn(rs.findColumn(FieldKey.fromParts("InputsMaterialSampleNames")));
+            LineageDisplayColumn dcInputsMaterialSampleNames = (LineageDisplayColumn)colInputsMaterialSampleNames.getRenderer();
 
-            ColumnInfo colInputsDataAllNames    = rs.getColumn(rs.findColumn(FieldKey.fromParts("InputsDataAllNames")));
-            LineageDisplayColumn dcInputsDataAllNames  = (LineageDisplayColumn)colInputsDataAllNames.getRenderer();
+            ColumnInfo colInputsDataAllNames = rs.getColumn(rs.findColumn(FieldKey.fromParts("InputsDataAllNames")));
+            LineageDisplayColumn dcInputsDataAllNames = (LineageDisplayColumn)colInputsDataAllNames.getRenderer();
 
-            ColumnInfo colInputsDataFirstDataClassNames    = rs.getColumn(rs.findColumn(FieldKey.fromParts("InputsDataFirstDataClassNames")));
-            LineageDisplayColumn dcInputsDataFirstDataClassNames  = (LineageDisplayColumn)colInputsDataFirstDataClassNames.getRenderer();
+            ColumnInfo colInputsDataFirstDataClassNames = rs.getColumn(rs.findColumn(FieldKey.fromParts("InputsDataFirstDataClassNames")));
+            LineageDisplayColumn dcInputsDataFirstDataClassNames = (LineageDisplayColumn)colInputsDataFirstDataClassNames.getRenderer();
 
-            ColumnInfo colInputsRunsAllNames    = rs.getColumn(rs.findColumn(FieldKey.fromParts("InputsRunsAllNames")));
-            LineageDisplayColumn dcInputsRunsAllNames  = (LineageDisplayColumn)colInputsRunsAllNames.getRenderer();
+            ColumnInfo colInputsRunsAllNames = rs.getColumn(rs.findColumn(FieldKey.fromParts("InputsRunsAllNames")));
+            LineageDisplayColumn dcInputsRunsAllNames = (LineageDisplayColumn)colInputsRunsAllNames.getRenderer();
 
-            ColumnInfo colInputsRunsDerivationNames    = rs.getColumn(rs.findColumn(FieldKey.fromParts("InputsRunsDerivationNames")));
-            LineageDisplayColumn dcInputsRunsDerivationNames  = (LineageDisplayColumn)colInputsRunsDerivationNames.getRenderer();
+            ColumnInfo colInputsRunsDerivationNames = rs.getColumn(rs.findColumn(FieldKey.fromParts("InputsRunsDerivationNames")));
+            LineageDisplayColumn dcInputsRunsDerivationNames = (LineageDisplayColumn)colInputsRunsDerivationNames.getRenderer();
 
-            ColumnInfo colInputsRunsAliquotNames    = rs.getColumn(rs.findColumn(FieldKey.fromParts("InputsRunsAliquotNames")));
-            LineageDisplayColumn dcInputsRunsAliquotNames  = (LineageDisplayColumn)colInputsRunsAliquotNames.getRenderer();
+            ColumnInfo colInputsRunsAliquotNames = rs.getColumn(rs.findColumn(FieldKey.fromParts("InputsRunsAliquotNames")));
+            LineageDisplayColumn dcInputsRunsAliquotNames = (LineageDisplayColumn)colInputsRunsAliquotNames.getRenderer();
 
             Assert.assertTrue(rs.next());
             ctx.setRow(rs.getRowMap());
@@ -490,32 +497,11 @@ public class LineageTest extends ExpProvisionedTableTestHelper
     @Test
     public void testObjectInputOutput() throws Exception
     {
-        Lsid.LsidBuilder lsidBuilder = new Lsid.LsidBuilder("JUnitTest", null);
-
-        // register a silly LsidHandler for our test namespace
-        LsidManager.get().registerHandler("JUnitTest", new LsidManager.OntologyObjectLsidHandler());
-
         // create some exp.object rows for use as input and outputs
-        Lsid a1Lsid = lsidBuilder.setObjectId("A1").build();
-        int a1ObjectId = OntologyManager.ensureObject(c, a1Lsid.toString());
-        Identifiable a1 = LsidManager.get().getObject(a1Lsid);
-        assertNotNull(a1);
-
-        Lsid a2Lsid = lsidBuilder.setObjectId("A2").build();
-        int a2ObjectId = OntologyManager.ensureObject(c, a2Lsid.toString());
-        Identifiable a2 = LsidManager.get().getObject(a2Lsid);
-        assertNotNull(a2);
-
-        Lsid b1Lsid = lsidBuilder.setObjectId("B1").build();
-        int b1ObjectId = OntologyManager.ensureObject(c, b1Lsid.toString());
-        Identifiable b1 = LsidManager.get().getObject(b1Lsid);
-        assertNotNull(b1);
-
-        Lsid b2Lsid = lsidBuilder.setObjectId("B2").build();
-        int b2ObjectId = OntologyManager.ensureObject(c, b2Lsid.toString());
-        Identifiable b2 = LsidManager.get().getObject(b2Lsid);
-        assertNotNull(b2);
-
+        var a1 = createExpObject("A1");
+        var a2 = createExpObject("A2");
+        var b1 = createExpObject("B1");
+        var b2 = createExpObject("B2");
 
         // create empty run
         ExpRun run = ExperimentService.get().createExperimentRun(c, "testing");
@@ -528,43 +514,42 @@ public class LineageTest extends ExpProvisionedTableTestHelper
         // add A objects as inputs, B objects as outputs
         ViewBackgroundInfo info = new ViewBackgroundInfo(c, user, null);
         run = ExperimentServiceImpl.get().saveSimpleExperimentRun(run, emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), info, null, false);
-        int runObjectId = run.getObjectId();
+        Integer runObjectId = run.getObjectId();
 
         // HACK: Until we have the ability to add provenance information to the run, just insert directly into exp.edge
         TableInfo edgeTable = ExperimentServiceImpl.get().getTinfoEdge();
         Table.insert(null, edgeTable, Map.of(
-                "runId", run.getRowId(), "fromObjectId", a1ObjectId, "toObjectId", runObjectId));
+                "runId", run.getRowId(), "fromObjectId", a1.objectId, "toObjectId", runObjectId));
         Table.insert(null, edgeTable, Map.of(
-                "runId", run.getRowId(), "fromObjectId", a2ObjectId, "toObjectId", runObjectId));
+                "runId", run.getRowId(), "fromObjectId", a2.objectId, "toObjectId", runObjectId));
 
         Table.insert(null, edgeTable, Map.of(
-                "runId", run.getRowId(), "fromObjectId", runObjectId, "toObjectId", b1ObjectId));
+                "runId", run.getRowId(), "fromObjectId", runObjectId, "toObjectId", b1.objectId));
         Table.insert(null, edgeTable, Map.of(
-                "runId", run.getRowId(), "fromObjectId", runObjectId, "toObjectId", b2ObjectId));
+                "runId", run.getRowId(), "fromObjectId", runObjectId, "toObjectId", b2.objectId));
 
         // query the lineage
-        ExpLineageOptions options = new ExpLineageOptions();
-        ExpLineage lineage = ExperimentServiceImpl.get().getLineage(c, user, Set.of(a1), options);
+        ExpLineage lineage = ExperimentServiceImpl.get().getLineage(c, user, Set.of(a1.identifiable), new ExpLineageOptions());
 
         assertTrue(lineage.getRuns().contains(run));
-        assertEquals(Set.of(a1), lineage.getSeeds());
-        assertEquals(Set.of(b1, b2), lineage.getObjects());
+        assertEquals(Set.of(a1.identifiable), lineage.getSeeds());
+        assertEquals(Set.of(b1.identifiable, b2.identifiable), lineage.getObjects());
 
         // verify lineage parent and children
-        assertTrue(lineage.getNodeParents(a1).isEmpty());
-        assertEquals(Set.of(run), lineage.getNodeChildren(a1));
-        assertEquals(Set.of(a1), lineage.getNodeParents(run));
-        assertEquals(Set.of(b1, b2), lineage.getNodeChildren(run));
+        assertTrue(lineage.getNodeParents(a1.identifiable).isEmpty());
+        assertEquals(Set.of(run), lineage.getNodeChildren(a1.identifiable));
+        assertEquals(Set.of(a1.identifiable), lineage.getNodeParents(run));
+        assertEquals(Set.of(b1.identifiable, b2.identifiable), lineage.getNodeChildren(run));
 
         // verify json structure
         JSONObject json = lineage.toJSON(user, true, new ExperimentJSONConverter.Settings(false, false, false));
-        assertEquals(a1Lsid.toString(), json.getString("seed"));
+        assertEquals(a1.identifiable.getLSID(), json.getString("seed"));
 
         JSONObject nodes = json.getJSONObject("nodes");
         assertEquals(4, nodes.size());
-        JSONObject a1json = nodes.getJSONObject(a1Lsid.toString());
+        JSONObject a1json = nodes.getJSONObject(a1.identifiable.getLSID());
         assertEquals("A1", a1json.getString("name"));
-        assertEquals(a1Lsid.toString(), a1json.getString("lsid"));
+        assertEquals(a1.identifiable.getLSID(), a1json.getString("lsid"));
         assertEquals("JUnitTest", a1json.getString("type"));
 
         JSONArray a1parentsJson = a1json.getJSONArray("parents");
@@ -573,6 +558,96 @@ public class LineageTest extends ExpProvisionedTableTestHelper
         JSONArray a1childrenJson = a1json.getJSONArray("children");
         assertEquals(1, a1childrenJson.length());
         assertEquals(run.getLSID(), a1childrenJson.getJSONObject(0).getString("lsid"));
-
     }
+
+    @Test
+    public void testAddEdges()
+    {
+        // Arrange
+        var expSvc = ExperimentServiceImpl.get();
+        var sourceKey = "testAddEdges";
+        var aa = createExpObject("addAA");
+        var bb = createExpObject("addBB");
+        var cc = createExpObject("addCC");
+
+        // Act
+        // Handles null/empty (noop)
+        expSvc.addEdges(null);
+        expSvc.addEdges(Collections.emptyList());
+
+        // Does not allow run-based edge insertion
+        var exceptionThrown = false;
+        try
+        {
+            expSvc.addEdges(List.of(new ExpLineageEdge(aa.objectId, bb.objectId, -1, bb.objectId, sourceKey)));
+        }
+        catch (IllegalArgumentException e)
+        {
+            exceptionThrown = true;
+            assertTrue("Received unexpected error", e.getMessage().contains("Adding edges with a runId are not supported"));
+        }
+        assertTrue("Expected exception when attempting to add run-based lineage edge", exceptionThrown);
+
+        // skips cycles
+        var edge1 = new ExpLineageEdge(aa.objectId, bb.objectId, null, bb.objectId, sourceKey);
+        var cycle = new ExpLineageEdge(bb.objectId, bb.objectId, null, bb.objectId, sourceKey);
+        var edge3 = new ExpLineageEdge(cc.objectId, bb.objectId, null, bb.objectId, sourceKey);
+        expSvc.addEdges(List.of(edge1, cycle, edge3));
+
+        var bbEdges = new HashSet<>(expSvc.getEdges(new ExpLineageEdge.Options().sourceId(bb.objectId)));
+        assertEquals("Unexpected number of edges", 2, bbEdges.size());
+        assertFalse("Add edges inserted a cycle", bbEdges.contains(cycle));
+    }
+
+    @Test
+    public void testRemoveEdges()
+    {
+        // Arrange
+        var expSvc = ExperimentServiceImpl.get();
+        var sourceKey = "testRemoveEdges";
+        var aa = createExpObject("removeAA");
+        var bb = createExpObject("removeBB");
+        var cc = createExpObject("removeCC");
+
+        expSvc.addEdges(List.of(
+            new ExpLineageEdge(aa.objectId, bb.objectId, null, bb.objectId, sourceKey),
+            new ExpLineageEdge(bb.objectId, cc.objectId, null, bb.objectId, sourceKey),
+            new ExpLineageEdge(aa.objectId, cc.objectId, null, bb.objectId, sourceKey)
+        ));
+
+        // Act
+        // Handles empty options
+        assertEquals("Unexpected edges removed", 0, expSvc.removeEdges(new ExpLineageEdge.Options()));
+
+        // Does not allow run-based edge removal
+        var exceptionThrown = false;
+        try
+        {
+            expSvc.removeEdges(new ExpLineageEdge.Options().runId(-1));
+        }
+        catch (IllegalArgumentException e)
+        {
+            exceptionThrown = true;
+            assertTrue("Received unexpected error", e.getMessage().contains("Edges with a runId cannot be deleted via removeEdge()"));
+        }
+        assertTrue("Expected exception when attempting to remove run-based lineage edge", exceptionThrown);
+
+        // Successfully remove edges
+        var actualRemoved = expSvc.removeEdges(new ExpLineageEdge.Options().sourceId(bb.objectId).sourceKey(sourceKey));
+        assertEquals("Unexpected number of edges removed", 3, actualRemoved);
+
+        var edges = expSvc.getEdges(new ExpLineageEdge.Options().sourceId(bb.objectId));
+        assertEquals("Unexpected edges still persisted", 0, edges.size());
+    }
+
+    private _ExpObject createExpObject(String objectName)
+    {
+        Lsid lsid = lsidBuilder.setObjectId(objectName).build();
+        Integer objectId = OntologyManager.ensureObject(c, lsid.toString());
+        Identifiable identifiable = LsidManager.get().getObject(lsid);
+        assertNotNull(identifiable);
+        return new _ExpObject(objectId, identifiable);
+    }
+
+    private record _ExpObject(Integer objectId, Identifiable identifiable) {}
 }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -6726,7 +6726,7 @@ public class ExperimentController extends SpringActionController
             else
             {
                 // should this require site admin permissions?
-                ExperimentServiceImpl.get().rebuildAllEdges();
+                ExperimentServiceImpl.get().rebuildAllRunEdges();
             }
             return success();
         }


### PR DESCRIPTION
#### Rationale
This PR exposes lineage edge APIs on the `ExperimentService` which will allow other features, beyond experiment run derivation, to persist lineage relationships between experiment objects. In support of this the `exp.edge` table has been updated to include a couple of additional columns which can help to identify edges. These columns are:

- `sourceId`: This is the experiment object that is "declaring" or "sourcing" the relationship. Most often this will likely be an object that is also in the relationship (either `toObjectId` or `fromObjectId`), however, that is not a requirement. This column is a foreign key to the `exp.object` table.
- `sourceKey`: This is a string value that can be leveraged to differentiate edges. The use case is that a caller may want to persist two edges that are the same (`toObjectId`, `fromObjectId`, and `sourceId`) but the edges are declared for different reasons. This field can be leveraged to distinctly identify theses edges based on the reason. The value is up to the caller.
- `runId`: This column is not new but the not null constraint has been dropped in order to allow for the table to persist run-less edges (edges not persisted by experiment run derivation).

The `ExperimentService` has a few new methods available on it for mutating and fetching edge relationships. Namely, `addEdges()`, `getEdges()`, and `removeEdges()`. These all model edges via the new `ExpLineageEdge`. Additionally, the get and remove methods make use of `ExpLineageEdge.Options` to allow for users to construct ad-hoc filters for fetching and removing edges. While this options currently look very similar to `ExpLineageEdge` itself (`sourceIds` being the only real difference) I've elected to have them stand on their own so that future divergence doesn't necessitate a refactor of the public APIs.

Lastly, these new APIs explicitly do not allow for run-based edges to be mutated. If a run-based edge mutation is attempted the methods will throw an exception. That said, the `getEdges()` API does allow for fetching of run-based edges.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1456

#### Changes
* Added `addEdges()`, `getEdges()`, and `removeEdges()` API methods to `ExperimentService` for external use.
* Added an `ExpLineageEdge` bean for serialization of rows in the `exp.edge` table.
* Experiment edge deletion expanded to cover `sourceId` column.
* Renamed `rebuildAllEdges` to `rebuildAllRunEdges` and updated implementation to only remove/refresh run-based edges.
* Removed redundant usages of `ExperimentService.get()` from within its own implementation.
* Unit tests for adding and removing edges.