### PR TITLE
Data generator for Experiment objects

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -35,11 +35,6 @@ List apache = [
         "org.apache.pdfbox:pdfbox:${pdfboxVersion}"
 ]
 
-
-List gwt = [
-        "com.google.gwt:gwt-servlet:${gwtServletVersion}"
-]
-
 List jackson = [
         "com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}",
         "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",
@@ -47,54 +42,6 @@ List jackson = [
         // added because otherwise we get this error: Java 8 date/time type `java.time.LocalDate` not supported by default
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}",
 //        "com.fasterxml.jackson.datatype:jackson-datatype-json-org:${jacksonVersion}" // included separately below so we can exclude the json jar it brings in
-]
-
-List charting = [
-        "org.jfree:jfreechart:${jfreechartVersion}"
-]
-
-List caching = [
-        "net.sf.ehcache:ehcache-core:${ehcacheCoreVersion}"
-]
-
-List logging = [
-        "org.apache.logging.log4j:log4j-core:${log4j2Version}",
-        "org.apache.logging.log4j:log4j-api:${log4j2Version}",
-        "commons-logging:commons-logging:${commonsLoggingVersion}"
-]
-
-List r = [
-        "net.rforge:rengine:${rforgeVersion}",
-        "net.rforge:rserve:${rforgeVersion}"
-]
-
-List test = [
-        "org.jmock:jmock:${jmockVersion}",
-        "org.jmock:jmock-legacy:${jmockVersion}",
-        "junit:junit:${junitVersion}"
-]
-
-List others = [
-        "gov.nist.math:jama:${jamaVersion}",
-        "org.jetbrains:annotations:${annotationsVersion}",
-        "org.apache.xmlgraphics:batik-codec:${batikVersion}",
-        "org.apache.xmlgraphics:batik-transcoder:${batikVersion}",
-        "org.apache.xmlgraphics:fop:${fopVersion}",
-        "flyingsaucer:core-renderer:${flyingsaucerVersion}",
-        "com.google.guava:guava:${guavaVersion}",
-        "net.sf.jtidy:jtidy:${jtidyVersion}",
-        "org.quartz-scheduler:quartz:${quartzVersion}",
-        "net.coobird:thumbnailator:${thumbnailatorVersion}",
-        "org.apache.tika:tika-core:${tikaVersion}",
-        "cglib:cglib-nodep:${cglibNodepVersion}",
-        "xerces:xercesImpl:${xercesImplVersion}",
-        "org.imca_cat.pollingwatchservice:pollingwatchservice:${pollingWatchVersion}",
-        "org.postgresql:postgresql:${postgresqlDriverVersion}",
-        "org.hamcrest:hamcrest-core:${hamcrestVersion}"
-]
-
-List javax = [
-        "javax.validation:validation-api:${validationApiVersion}",
 ]
 
 List runtime = [

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -451,11 +451,13 @@ public class DataGenerator<T extends DataGenerator.Config>
             }
             ListofMapsDataIterator rowsDI = new ListofMapsDataIterator(rows.get(0).keySet(), rows);
             numImported += service.importRows(_user, _container, rowsDI, errors, null, null);
-            if (errors.hasErrors())
-                throw errors;
+
             _log.info("... " + numImported);
         }
         timer.stop();
+        if (errors.hasErrors())
+           _log.error("There were problems importing the samples", errors);
+
         _log.info(String.format("Generating %d '%s' samples derived from '%s/%s' took %s.", quantity, sampleType.getName(), parentInput, parentQueryName, timer.getDuration()));
 
     }

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -1,0 +1,151 @@
+package org.labkey.api.data.generator;
+
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.exp.ExperimentException;
+import org.labkey.api.exp.api.ExpDataClass;
+import org.labkey.api.exp.api.ExpSampleType;
+import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.SampleTypeService;
+import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.exp.query.SamplesSchema;
+import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
+import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.DuplicateKeyException;
+import org.labkey.api.query.QueryService;
+import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.QueryUpdateServiceException;
+import org.labkey.api.query.SchemaKey;
+import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.User;
+
+import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class DataGenerator
+{
+    protected Container _container;
+    protected User _user;
+
+    public DataGenerator(Container container, User user)
+    {
+        _container = container;
+        _user = user;
+    }
+    record FieldPrefix(String uri, String namePrefix) { }
+
+    private static final List<FieldPrefix> fieldPrefixes = new ArrayList<>();
+    static {
+        fieldPrefixes.add(new FieldPrefix("string", "TextField"));
+        fieldPrefixes.add(new FieldPrefix("int", "IntField"));
+        fieldPrefixes.add(new FieldPrefix("float", "FloatField"));
+        fieldPrefixes.add(new FieldPrefix("date", "DateField"));
+    }
+
+    public ExpSampleType generateSampleType(String sampleTypeName, @Nullable String namingPattern, int numFields, Logger log) throws ExperimentException, SQLException
+    {
+        List<GWTPropertyDescriptor> props = new ArrayList<>();
+        props.add(new GWTPropertyDescriptor("Name", "string"));
+        addDomainProperties(props, numFields);
+
+        SampleTypeService service = SampleTypeService.get();
+        log.info(String.format("Creating Sample Type '%s' with %d fields", sampleTypeName, numFields));
+        return service.createSampleType(_container, _user, sampleTypeName,
+                "Generated sample type", props, List.of(),
+                namingPattern);
+    }
+
+    public void generateSamples(ExpSampleType sampleType, int numSamples) throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException
+    {
+        UserSchema schema = QueryService.get().getUserSchema(_user, _container, SchemaKey.fromParts(SamplesSchema.SCHEMA_NAME));
+        TableInfo table = schema.getTable(sampleType.getName());
+        QueryUpdateService svc = table.getUpdateService();
+
+        List<Map<String, Object>> rows = new ArrayList<>();
+        for (int i = 1; i <= numSamples; i++)
+        {
+            Map<String, Object> row = new CaseInsensitiveHashMap<>();
+            row.put("Description", "Sample " + i);
+            Domain domain = sampleType.getDomain();
+            List<? extends DomainProperty> properties = domain.getProperties();
+            for (int p = 0; p < properties.size(); p++)
+            {
+                DomainProperty property = properties.get(p);
+                int dataNum = p + (i % 15);
+                Object value = switch (property.getRangeURI())
+                        {
+                            case "string" -> "Text " + dataNum;
+                            case "int" -> dataNum;
+                            case "float" -> dataNum * 1.5;
+                            case "date" -> randomDate();
+                            default -> null;
+                        };
+                row.put(property.getName(), value);
+            }
+            rows.add(row);
+        }
+        BatchValidationException errors = new BatchValidationException();
+        svc.insertRows(_user, _container, rows, errors, null, null);
+        if (errors.hasErrors())
+            throw errors;
+    }
+
+   public ExpDataClass generateDataClass(String dataClassName, @Nullable String namingPattern, int numFields, Logger log) throws ExperimentException, SQLException
+    {
+        List<GWTPropertyDescriptor> props = new ArrayList<>();
+        addDomainProperties(props, numFields);
+
+        ExperimentService service = ExperimentService.get();
+
+        log.info(String.format("Creating Data Class '%s' with %d fields", dataClassName, numFields));
+        return service.createDataClass(_container, _user, dataClassName, "Custom data class with " + numFields + " fields",
+                    props, List.of(), null,
+                    namingPattern, null, null);
+    }
+
+    private void addDomainProperties(List<GWTPropertyDescriptor> props, int numFields)
+    {
+        for (int i = 0; i < numFields; i++)
+        {
+            var fieldPrefix = fieldPrefixes.get(i % fieldPrefixes.size());
+            props.add(new GWTPropertyDescriptor(fieldPrefix.namePrefix() + "_" + i, fieldPrefix.uri()));
+        }
+    }
+
+    protected String randomDate()
+    {
+        var startDate = new Date(112 /* 2012 */, Calendar.JANUARY, 1);
+        var endDate = new Date();
+
+        var random = new Date(ThreadLocalRandom.current().nextLong(startDate.getTime(), endDate.getTime()));
+        return new SimpleDateFormat("dd-MMM-yy").format(random);
+    }
+
+    protected String randomDouble(int min, int max)
+    {
+        double random = Math.random() < 0.5 ? ((1-Math.random()) * (max-min) + min) : (Math.random() * (max-min) + min);
+        return String.format("%.2f", random);
+    }
+
+    protected <T> T randomIndex(T[] array)
+    {
+        return array[randomInt(0, array.length)];
+    }
+
+    protected int randomInt(int min, int max)
+    {
+        // The maximum is exclusive and the minimum is inclusive
+        return (int) Math.round(Math.floor(Math.random() * (max - min) + min));
+    }
+
+}

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -3,8 +3,12 @@ package org.labkey.api.data.generator;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.dataiterator.ListofMapsDataIterator;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpDataClass;
 import org.labkey.api.exp.api.ExpSampleType;
@@ -17,32 +21,53 @@ import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.DuplicateKeyException;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
+import org.labkey.api.util.CPUTimer;
+import org.labkey.api.util.DateUtil;
+import org.labkey.api.util.Pair;
 
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class DataGenerator
 {
-    protected Container _container;
-    protected User _user;
+    private Container _container;
+    private final User _user;
+    private final Logger _log;
+    private Config _config;
 
-    public DataGenerator(Container container, User user)
-    {
-        _container = container;
-        _user = user;
-    }
+    private List<ExpSampleType> _sampleTypes = new ArrayList<>();
+    private final Map<String, Pair<String, Long>> _nameData = new HashMap<>();
+
+    private List<ExpDataClass> _customDataClasses = new ArrayList<>();
+
+    // map from rowId to # of generations (including the root)
+    private final Map<Integer, Integer> _sampleGenerations = new HashMap<>();
+    // Map from rowId to # of aliquots.
+    private final Map<Integer, Integer> _numAliquotsPerParent = new HashMap<>();
+
+    private UserSchema _samplesSchema;
+    private UserSchema _dataClassSchema;
+
+    private final BatchValidationException _errors = new BatchValidationException();
+
+
     record FieldPrefix(String uri, String namePrefix) { }
 
     private static final List<FieldPrefix> fieldPrefixes = new ArrayList<>();
@@ -53,22 +78,348 @@ public class DataGenerator
         fieldPrefixes.add(new FieldPrefix("date", "DateField"));
     }
 
-    public ExpSampleType generateSampleType(String sampleTypeName, @Nullable String namingPattern, int numFields, Logger log) throws ExperimentException, SQLException
+    public DataGenerator(Container container, User user, Map<String, String> parameters, Logger log)
+    {
+        _container = container;
+        _user = user;
+        _log = log;
+        _config = new Config(parameters);
+        _samplesSchema = QueryService.get().getUserSchema(_user, _container, SchemaKey.fromParts(SamplesSchema.SCHEMA_NAME));
+        _dataClassSchema = QueryService.get().getUserSchema(_user, _container, ExpSchema.SCHEMA_EXP_DATA);
+    }
+
+    public Container getContainer()
+    {
+        return _container;
+    }
+
+    public void setContainer(Container container)
+    {
+        _container = container;
+    }
+
+    public Config getConfig()
+    {
+        return _config;
+    }
+
+    public void setConfig(Config config)
+    {
+        _config = config;
+    }
+
+    public List<ExpSampleType> getSampleTypes()
+    {
+        return _sampleTypes;
+    }
+
+    public void setSampleTypes(List<ExpSampleType> sampleTypes)
+    {
+        _sampleTypes = sampleTypes;
+    }
+
+    public List<ExpDataClass> getCustomDataClasses()
+    {
+        return _customDataClasses;
+    }
+
+    public void setCustomDataClasses(List<ExpDataClass> customDataClasses)
+    {
+        _customDataClasses = customDataClasses;
+    }
+
+    public void generateSampleTypes(String namePrefix, String namingPatternPrefix) throws ExperimentException, SQLException
+    {
+        int numSampleTypes = _config.getNumSampleTypes();
+        int minFields = _config.getMinFields();
+        int maxFields = _config.getMaxFields();
+
+        int fieldIncrement = numSampleTypes <= 1 ? 0 : (maxFields - minFields)/(numSampleTypes-1);
+
+        CPUTimer timer = new CPUTimer("Sample Type Generation");
+        timer.start();
+        int numFields = minFields;
+        int typeIndex = 0;
+        for (int i = 0; i < numSampleTypes; i++)
+        {
+            String sampleTypeName;
+            do {
+                typeIndex++;
+                sampleTypeName = namePrefix + typeIndex;
+            } while (SampleTypeService.get().getSampleType(_container, _user, sampleTypeName) != null);
+            String prefixWithIndex = namingPatternPrefix + typeIndex + "_";
+            String namingPattern = prefixWithIndex + "${genId}";
+            ExpSampleType sampleType = generateSampleType(sampleTypeName, namingPattern, numFields);
+            Pair<String, Long> nameData = new Pair<>(prefixWithIndex, sampleType.getCurrentGenId());
+            _nameData.put(sampleTypeName, nameData);
+            _sampleTypes.add(sampleType);
+            numFields = Math.min(numFields + fieldIncrement, maxFields);
+        }
+        timer.stop();
+
+        _log.info(String.format("Generating %d sample types took %s", numSampleTypes, timer.getDuration() + "."));
+    }
+
+    public ExpSampleType generateSampleType(String sampleTypeName, @Nullable String namingPattern, int numFields) throws ExperimentException, SQLException
     {
         List<GWTPropertyDescriptor> props = new ArrayList<>();
         props.add(new GWTPropertyDescriptor("Name", "string"));
         addDomainProperties(props, numFields);
 
         SampleTypeService service = SampleTypeService.get();
-        log.info(String.format("Creating Sample Type '%s' with %d fields", sampleTypeName, numFields));
+        _log.info(String.format("Creating Sample Type '%s' with %d fields", sampleTypeName, numFields));
         return service.createSampleType(_container, _user, sampleTypeName,
                 "Generated sample type", props, List.of(), namingPattern);
     }
 
-    public void generateSamples(ExpSampleType sampleType, int numSamples) throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException
+    public void generateSamplesForAllTypes() throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException, InvalidKeyException
     {
-        UserSchema schema = QueryService.get().getUserSchema(_user, _container, SchemaKey.fromParts(SamplesSchema.SCHEMA_NAME));
-        generateExpData(numSamples, schema, sampleType.getName(), sampleType.getDomain());
+        DataGenerator.Config config = getConfig();
+
+        int sampleIncrement = config.getNumSampleTypes() <= 1 ? 0 : (config.getMaxSamples() - config.getMinSamples())/(config.getNumSampleTypes()-1);
+        int numSamples = config.getMinSamples();
+        for (int i = 0; i < config.getNumSampleTypes(); i++)
+        {
+            ExpSampleType sampleType = _sampleTypes.get(i);
+            _log.info(String.format("Generating %d samples for sample type %s.", numSamples, sampleType.getName()));
+            CPUTimer timer = new CPUTimer("Generate samples " + i);
+            timer.start();
+            generateSamples(_sampleTypes.get(i), numSamples);
+            timer.stop();
+            _log.info(String.format("Generating %d samples for sample type %s took %s.", numSamples, sampleType.getName(), timer.getDuration()));
+
+            numSamples = Math.min(numSamples+sampleIncrement, config.getMaxSamples());
+        }
+    }
+
+    public void generateSamples(ExpSampleType sampleType, int numSamplesAndAliquots) throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException
+    {
+        TableInfo tableInfo = _samplesSchema.getTable(sampleType.getName());
+        QueryUpdateService svc = tableInfo.getUpdateService();
+        int numAliquots = Math.round(numSamplesAndAliquots * _config.getPctAliquots());
+        int numPooled = Math.round(numSamplesAndAliquots * _config.getPctPooled());
+        int numSamples = numSamplesAndAliquots - numAliquots - numPooled;
+
+        generateDomainData(numSamples, svc, sampleType.getDomain());
+        // TODO create 75% of the pooled samples
+        int aliquotCount = generateAliquots(sampleType, svc, numAliquots);
+        // TODO create the other ppooled samples from aliquots
+//      poolSamples(samples, svc, sampleType.getName(), Math.round(numSamplesAndAliquots * _config.getPctPooled()));
+    }
+
+    public int generateAliquots(ExpSampleType sampleType, QueryUpdateService svc, int quantity) throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException
+    {
+        _log.info(String.format("Generating %d aliquots for sample type %s.", quantity, sampleType.getName()));
+        CPUTimer timer = new CPUTimer(sampleType.getName() + " aliquots");
+        timer.start();
+        int totalAliquots = 0;
+        int iterations = 0;
+        int numGenerated;
+        do
+        {
+            List<Map<String, Object>> parents = getRandomSamples(sampleType, Math.min(100, quantity/10));
+            numGenerated = generateAliquotsForParents(parents, svc, quantity);
+            totalAliquots += numGenerated;
+            iterations++;
+        } while (totalAliquots < quantity && numGenerated > 0);
+        timer.stop();
+        if (totalAliquots < quantity)
+            _log.warn(String.format("Generated only %d aliquots after %d iterations", totalAliquots, iterations));
+        _log.info(String.format("Generating %d aliquots for sample type %s in %d iterations took %s.", totalAliquots, sampleType.getName(), iterations, timer.getDuration()));
+        return totalAliquots;
+    }
+
+    private int generateAliquotsForParents(List<Map<String, Object>> parents, QueryUpdateService svc, int quantity) throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException
+    {
+        int generatedCount = 0;
+        List<Map<String, Object>> allAliquots = new ArrayList<>();
+        for (int p = 0; p < parents.size() && generatedCount < quantity; p++)
+        {
+            List<Map<String, Object>> rows = new ArrayList<>();
+
+            Map<String, Object> parent = parents.get(p);
+            Integer parentId = (Integer) parent.get("rowId");
+            // skip any parents that already are at the max depth
+            if (_sampleGenerations.getOrDefault(parentId, 1) > _config.getMaxGenerations())
+                continue;
+
+            // choose a number of aliquots to create
+            int currentAliquots = _numAliquotsPerParent.getOrDefault(parentId, 0);
+            int numAliquots = Math.min(randomInt(0, _config.getMaxAliquotsPerParent()), _config.getMaxGenerations() - currentAliquots);
+            numAliquots = Math.min(numAliquots, quantity - generatedCount);
+            // generate that number of aliquots
+            for (int i = 0; i < numAliquots; i++)
+            {
+                Map<String, Object> row = new CaseInsensitiveHashMap<>();
+                row.put("AliquotedFrom", parent.get("Name"));
+                rows.add(row);
+            }
+            if (!rows.isEmpty())
+            {
+                BatchValidationException errors = new BatchValidationException();
+                List<Map<String, Object>> aliquots = svc.insertRows(_user, _container, rows, errors, null, null);
+                if (errors.hasErrors())
+                    throw errors;
+
+                // record generation number for the aliquots
+                int parentGen = _sampleGenerations.getOrDefault(parentId, 1);
+                aliquots.forEach(aliquot -> _sampleGenerations.put((Integer) aliquot.get("RowId"), parentGen + 1));
+                _numAliquotsPerParent.put(parentId, currentAliquots + numAliquots);
+                generatedCount += numAliquots;
+                allAliquots.addAll(aliquots);
+            }
+        }
+        // for each of the aliquots, possibly generate further aliquot generations
+        if (generatedCount < quantity)
+        {
+            generatedCount += generateAliquotsForParents(allAliquots, svc, quantity-generatedCount);
+        }
+        return generatedCount;
+    }
+
+    private List<Map<String, Object>> getRandomSamples(ExpSampleType sampleType, int quantity)
+    {
+        TableInfo tableInfo = _samplesSchema.getTable(sampleType.getName());
+        SimpleFilter filter = SimpleFilter.createContainerFilter(_container);
+        var nameGenData = _nameData.get(sampleType.getName());
+        filter.addCondition(FieldKey.fromParts("Name"),
+                getRandomNames(nameGenData.first, nameGenData.second, sampleType.getCurrentGenId(), quantity), CompareType.IN);
+        TableSelector selector = new TableSelector(tableInfo, Set.of("Name", "RowId", "AliquotedFrom", "AliquotedFrom/Name", "IsAliquot"), filter, null);
+        return Arrays.asList(selector.getMapArray());
+    }
+
+//    public List<Map<String, Object>> poolSamples(ExpSampleType sampleType, QueryUpdateService service, int numPooled) throws SQLException, BatchValidationException, QueryUpdateServiceException, InvalidKeyException
+//    {
+//        // TODO This can pool samples from different generations, which seems a little odd, but we'll go with it for now.
+//        List<Map<String, Object>> rows = new ArrayList<>();
+//        List<Map<String, Object>> oldKeys = new ArrayList<>();
+//        // choose a random set of child samples to.
+//        List<Integer> possibleParents = new ArrayList<>(samples.stream().map(sample -> (Integer) sample.get("RowId")).toList());
+//        List<Integer> possibleChildren = new ArrayList<>(getRandomSamples(sampleType, numPooled).stream().map(sample -> (Integer) sample.get("RowId")).toList());
+//        for (int i = 0;  i < possibleChildren.size() ; i++)
+//        {
+//            Map<String, Object> row = new CaseInsensitiveHashMap<>();
+//            Map<String, Object> keys = new CaseInsensitiveHashMap<>();
+//            // choose a random sample
+//            int childIndex = randomInt(0, possibleChildren.size());
+//            Integer childId = possibleChildren.get(childIndex);
+//            keys.put("RowId", childId);
+//            possibleChildren.remove(childIndex);
+//            // choose a random pool size
+//            int poolSize = randomInt(0, _config.getMaxPoolSize());
+//            List<Integer> parentIds = new ArrayList<>();
+//            int childAsParentIndex = possibleParents.indexOf(childId);
+//            while (parentIds.size() < poolSize && possibleParents.size() > 0)
+//            {
+//                int parentIndex = randomInt(0, possibleParents.size());
+//                if (parentIndex != childAsParentIndex)
+//                {
+//                    parentIds.add(possibleParents.get(parentIndex));
+//                    possibleParents.remove(parentIndex);
+//                }
+//            }
+//            if (parentIds.size() > 2)
+//            {
+//                row.put("MaterialInputs/" + sampleType.getName(), parentIds);
+//                rows.add(row);
+//                oldKeys.add(keys);
+//            }
+//            else
+//            {
+//                _log.info(String.format("Generated %d pooled sample and then ran out of parents.", i+1));
+//            }
+//        }
+//        return service.updateRows(_user, _container, rows, oldKeys, null, null);
+//    }
+
+
+    private List<String> getRandomNames(String namePrefix, long startIndex, long endIndex, int quantity)
+    {
+        List<String> names = new ArrayList<>();
+        for (int i = 0; i < quantity; i++)
+            names.add(namePrefix + randomLong(startIndex, endIndex));
+        return names;
+    }
+
+    public void generateCustomDataClasses(String typeNamePrefix, String namingPatternPrefix) throws ExperimentException, SQLException
+    {
+        DataGenerator.Config config = getConfig();
+
+        int fieldIncrement = config.getNumDataClasses() <= 1 ? 0 : (config.getMaxFields() - config.getMinFields())/(config.getNumDataClasses()-1);
+
+        CPUTimer timer = new CPUTimer("Custom Data Classes");
+        timer.start();
+        int numFields = config.getMinFields();
+        for (int i = 1; i <= config.getNumDataClasses(); i++)
+        {
+            String dataClassName = typeNamePrefix + i;
+            String namingPattern = namingPatternPrefix + i + "_${genId}";
+            _customDataClasses.add(generateDataClass(dataClassName, namingPattern, numFields, _log, null));
+            numFields = Math.min(numFields + fieldIncrement, config.getMaxFields());
+        }
+        timer.stop();
+
+        _log.info(String.format("Generating %d data classes took %s.", config.getNumDataClasses(), timer.getDuration()));
+    }
+
+   public ExpDataClass generateDataClass(String dataClassName, @Nullable String namingPattern, int numFields, Logger log, @Nullable String category) throws ExperimentException
+    {
+        List<GWTPropertyDescriptor> props = new ArrayList<>();
+        addDomainProperties(props, numFields);
+
+        ExperimentService service = ExperimentService.get();
+
+        log.info(String.format("Creating Data Class '%s' with %d fields", dataClassName, numFields));
+        return service.createDataClass(_container, _user, dataClassName, "Custom data class with " + numFields + " fields",
+                    props, List.of(), null,
+                    namingPattern, null, category);
+    }
+
+    public void generateCustomDataClassObjects() throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException
+    {
+        DataGenerator.Config config = getConfig();
+
+        int increment = config.getMaxDataClassObjects() <= 1 ? 0 : (config.getMaxDataClassObjects() - config.getMinDataClassObjects())/(config.getNumDataClasses()-1);
+        int numObjects = config.getMinDataClassObjects();
+        for (int i = 0; i < config.getNumDataClasses(); i++)
+        {
+            var startTime = System.currentTimeMillis();
+            ExpDataClass dataClass = _customDataClasses.get(i);
+            _log.info(String.format("Generating %d data class objects for data class %s.", numObjects, dataClass.getName()));
+            generateDataClassObjects(dataClass, numObjects);
+            var endTime = System.currentTimeMillis();
+            _log.info(String.format("Generating %d data class objects for data class %s took %s.", numObjects, dataClass.getName(), DateUtil.formatDuration(endTime - startTime)));
+
+            numObjects = Math.min(numObjects+increment, config.getMaxDataClassObjects());
+        }
+    }
+
+    public void generateDataClassObjects(ExpDataClass dataClass, int numObjects) throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException
+    {
+        QueryUpdateService svc = _dataClassSchema.getTable(dataClass.getName()).getUpdateService();
+        generateDomainData(numObjects, svc, dataClass.getDomain());
+    }
+
+
+    private void generateDomainData(int totalRows, QueryUpdateService service, Domain domain) throws DuplicateKeyException, BatchValidationException, QueryUpdateServiceException, SQLException
+    {
+        // TODO batch it up
+        List<Map<String, Object>> rows = createRows(totalRows, domain);
+        BatchValidationException errors = new BatchValidationException();
+        ListofMapsDataIterator rowDI = new ListofMapsDataIterator(rows.get(0).keySet(), rows);
+        service.importRows(_user, _container, rowDI, errors, null, null);
+        if (errors.hasErrors())
+            throw errors;
+    }
+
+    private void addDomainProperties(List<GWTPropertyDescriptor> props, int numFields)
+    {
+        for (int i = 0; i < numFields; i++)
+        {
+            int suffix = i / fieldPrefixes.size() + 1;
+            var fieldPrefix = fieldPrefixes.get(i % fieldPrefixes.size());
+            props.add(new GWTPropertyDescriptor(fieldPrefix.namePrefix() + "_" + suffix, fieldPrefix.uri()));
+        }
     }
 
     private List<Map<String, Object>> createRows(int numRows, Domain domain)
@@ -97,48 +448,6 @@ public class DataGenerator
         return rows;
     }
 
-   public ExpDataClass generateDataClass(String dataClassName, @Nullable String namingPattern, int numFields, Logger log, @Nullable String category) throws ExperimentException, SQLException
-    {
-        List<GWTPropertyDescriptor> props = new ArrayList<>();
-        addDomainProperties(props, numFields);
-
-        ExperimentService service = ExperimentService.get();
-
-        log.info(String.format("Creating Data Class '%s' with %d fields", dataClassName, numFields));
-        return service.createDataClass(_container, _user, dataClassName, "Custom data class with " + numFields + " fields",
-                    props, List.of(), null,
-                    namingPattern, null, category);
-    }
-
-    public void generateDataClassObjects(ExpDataClass dataClass, int numObjects) throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException
-    {
-        UserSchema schema = QueryService.get().getUserSchema(_user, _container, ExpSchema.SCHEMA_EXP_DATA);
-        generateExpData(numObjects, schema, dataClass.getName(), dataClass.getDomain());
-    }
-
-
-    private void generateExpData(int numRows, UserSchema schema, String name, Domain domain) throws DuplicateKeyException, BatchValidationException, QueryUpdateServiceException, SQLException
-    {
-        TableInfo table = schema.getTable(name);
-        QueryUpdateService svc = table.getUpdateService();
-
-        List<Map<String, Object>> rows = createRows(numRows, domain);
-        BatchValidationException errors = new BatchValidationException();
-        svc.insertRows(_user, _container, rows, errors, null, null);
-        if (errors.hasErrors())
-            throw errors;
-    }
-
-    private void addDomainProperties(List<GWTPropertyDescriptor> props, int numFields)
-    {
-        for (int i = 0; i < numFields; i++)
-        {
-            int suffix = i / fieldPrefixes.size() + 1;
-            var fieldPrefix = fieldPrefixes.get(i % fieldPrefixes.size());
-            props.add(new GWTPropertyDescriptor(fieldPrefix.namePrefix() + "_" + suffix, fieldPrefix.uri()));
-        }
-    }
-
     public static String randomDate()
     {
         var startDate = new Date(112 /* 2012 */, Calendar.JANUARY, 1);
@@ -163,6 +472,205 @@ public class DataGenerator
     {
         // The maximum is exclusive and the minimum is inclusive
         return (int) Math.round(Math.floor(Math.random() * (max - min) + min));
+    }
+
+    public static long randomLong(long startIndex, long endIndex)
+    {
+        return Math.round(Math.floor(Math.random() * (endIndex - startIndex) + startIndex));
+    }
+
+    public static class Config
+    {
+        public static final String NUM_SAMPLE_TYPES = "numSampleTypes";
+        public static final String PCT_ALIQUOTS = "percentAliquots";
+        public static final String PCT_DERIVED = "percentDerived";
+        public static final String PCT_POOLED = "percentPooled";
+        public static final String MAX_POOL_SIZE = "maxPoolSize";
+        public static final String MIN_SAMPLES = "minSamples";
+        public static final String MAX_SAMPLES = "maxSamples";
+        private static final String MAX_ALIQUOTS_PER_SAMPLE = "maxAliquotsPerSample";
+        private static final String MAX_GENERATIONS = "maxGenerations";
+        public static final String NUM_CUSTOM_DATA_CLASSES = "numCustomDataClasses";
+        public static final String MIN_NUM_FIELDS = "minFields";
+        public static final String MAX_NUM_FIELDS = "maxFields";
+        public static final String MIN_DATA_CLASS_OBJECTS = "minDataClassObjects";
+        public static final String MAX_DATA_CLASS_OBJECTS = "maxDataClassObjects";
+
+        int _numSampleTypes = 0;
+        int _minSamples = 0;
+        int _maxSamples = 0;
+        float _pctAliquots = 0;
+        float _pctPooled = 0;
+        float _pctDerived = 0;
+        int _maxPoolSize = 2;
+        int _maxGenerations = 1;
+        int _maxAliquotsPerParent = 0;
+
+        int _numDataClasses = 0;
+        int _minDataClassObjects = 0;
+        int _maxDataClassObjects = 0;
+
+        int _minFields = 1;
+        int _maxFields = 1;
+
+        public Config(Map<String, String> parameters)
+        {
+            _numSampleTypes = Integer.parseInt(parameters.getOrDefault(NUM_SAMPLE_TYPES, "0"));
+            _minSamples = Integer.parseInt(parameters.getOrDefault(MIN_SAMPLES, "0"));
+            _maxSamples = Math.max(Integer.parseInt(parameters.getOrDefault(DataGenerator.Config.MAX_SAMPLES, "0")), _minSamples);
+            _pctAliquots = Float.parseFloat(parameters.getOrDefault(PCT_ALIQUOTS, "0.0"));
+            _pctDerived = Float.parseFloat(parameters.getOrDefault(PCT_DERIVED, "0.0"));
+            _pctPooled = Float.parseFloat(parameters.getOrDefault(PCT_POOLED, "0.0"));
+            _maxPoolSize = Integer.parseInt(parameters.getOrDefault(MAX_POOL_SIZE, "2"));
+            _maxGenerations = Integer.parseInt(parameters.getOrDefault(MAX_GENERATIONS, "1"));
+            _maxAliquotsPerParent = Integer.parseInt(parameters.getOrDefault(MAX_ALIQUOTS_PER_SAMPLE, "0"));
+            _numDataClasses = Integer.parseInt(parameters.getOrDefault(NUM_CUSTOM_DATA_CLASSES, "0"));
+            _minDataClassObjects = Integer.parseInt(parameters.getOrDefault(MIN_DATA_CLASS_OBJECTS, "0"));
+            _maxDataClassObjects = Math.max(Integer.parseInt(parameters.getOrDefault(MAX_DATA_CLASS_OBJECTS, "0")), _minDataClassObjects);
+
+            _minFields = Integer.parseInt(parameters.getOrDefault(MIN_NUM_FIELDS, "1"));
+            _maxFields = Math.max(Integer.parseInt(parameters.getOrDefault(MAX_NUM_FIELDS, "1")), _minFields);
+        }
+
+        public int getNumSampleTypes()
+        {
+            return _numSampleTypes;
+        }
+
+        public void setNumSampleTypes(int numSampleTypes)
+        {
+            _numSampleTypes = numSampleTypes;
+        }
+
+        public int getMinSamples()
+        {
+            return _minSamples;
+        }
+
+        public void setMinSamples(int minSamples)
+        {
+            _minSamples = minSamples;
+        }
+
+        public int getMaxSamples()
+        {
+            return _maxSamples;
+        }
+
+        public void setMaxSamples(int maxSamples)
+        {
+            _maxSamples = maxSamples;
+        }
+
+        public float getPctAliquots()
+        {
+            return _pctAliquots;
+        }
+
+        public void setPctAliquots(float pctAliquots)
+        {
+            _pctAliquots = pctAliquots;
+        }
+
+        public float getPctPooled()
+        {
+            return _pctPooled;
+        }
+
+        public void setPctPooled(float pctPooled)
+        {
+            _pctPooled = pctPooled;
+        }
+
+        public float getPctDerived()
+        {
+            return _pctDerived;
+        }
+
+        public void setPctDerived(float pctDerived)
+        {
+            _pctDerived = pctDerived;
+        }
+
+        public int getMaxPoolSize()
+        {
+            return _maxPoolSize;
+        }
+
+        public void setMaxPoolSize(int maxPoolSize)
+        {
+            _maxPoolSize = maxPoolSize;
+        }
+
+        public int getMaxGenerations()
+        {
+            return _maxGenerations;
+        }
+
+        public void setMaxGenerations(int maxGenerations)
+        {
+            _maxGenerations = maxGenerations;
+        }
+
+        public int getMaxAliquotsPerParent()
+        {
+            return _maxAliquotsPerParent;
+        }
+
+        public void setMaxAliquotsPerParent(int maxAliquotsPerParent)
+        {
+            _maxAliquotsPerParent = maxAliquotsPerParent;
+        }
+
+        public int getNumDataClasses()
+        {
+            return _numDataClasses;
+        }
+
+        public void setNumDataClasses(int numDataClasses)
+        {
+            _numDataClasses = numDataClasses;
+        }
+
+        public int getMinDataClassObjects()
+        {
+            return _minDataClassObjects;
+        }
+
+        public void setMinDataClassObjects(int minDataClassObjects)
+        {
+            _minDataClassObjects = minDataClassObjects;
+        }
+
+        public int getMaxDataClassObjects()
+        {
+            return _maxDataClassObjects;
+        }
+
+        public void setMaxDataClassObjects(int maxDataClassObjects)
+        {
+            _maxDataClassObjects = maxDataClassObjects;
+        }
+
+        public int getMinFields()
+        {
+            return _minFields;
+        }
+
+        public void setMinFields(int minFields)
+        {
+            _minFields = minFields;
+        }
+
+        public int getMaxFields()
+        {
+            return _maxFields;
+        }
+
+        public void setMaxFields(int maxFields)
+        {
+            _maxFields = maxFields;
+        }
     }
 
 }

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -98,6 +98,10 @@ public interface SampleTypeService
     ExpSampleType createSampleType(Container container, User user, String name, String description, List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, int idCol1, int idCol2, int idCol3, int parentCol, String nameExpression)
             throws ExperimentException, SQLException;
 
+    @NotNull
+    ExpSampleType createSampleType(Container container, User user, String name, String description, List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, String nameExpression)
+            throws ExperimentException, SQLException;
+
     /**
      * (MAB) todo need a builder interface, or at least  parameter bean
      */

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -7580,7 +7580,7 @@ public class ExperimentServiceImpl implements ExperimentService
     @Override
     public PipelineJob importXarAsync(ViewBackgroundInfo info, File file, String description, PipeRoot root) throws IOException
     {
-        ExperimentPipelineJob job = new ExperimentPipelineJob(info, file, description, false, root);
+        ExperimentPipelineJob job = new ExperimentPipelineJob(info, file.toPath(), description, false, root);
         try
         {
             PipelineService.get().queueJob(job);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -621,7 +621,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     public ExpSampleTypeImpl createSampleType(Container c, User u, String name, String description, List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, int idCol1, int idCol2, int idCol3, int parentCol, String nameExpression)
             throws ExperimentException
     {
-        return createSampleType(c,u,name,description,properties,indices,idCol1,idCol2,idCol3,parentCol,null, null);
+        return createSampleType(c,u,name,description,properties,indices,idCol1,idCol2,idCol3,parentCol,nameExpression, null);
     }
 
     @NotNull

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -626,6 +626,14 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
     @NotNull
     @Override
+    public ExpSampleTypeImpl createSampleType(Container c, User u, String name, String description, List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, String nameExpression)
+            throws ExperimentException
+    {
+        return createSampleType(c,u,name,description,properties,indices,-1,-1,-1, -1, nameExpression, null);
+    }
+
+    @NotNull
+    @Override
     public ExpSampleTypeImpl createSampleType(Container c, User u, String name, String description, List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, int idCol1, int idCol2, int idCol3, int parentCol,
                                               String nameExpression, @Nullable TemplateInfo templateInfo)
             throws ExperimentException

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -6167,13 +6167,13 @@ public class ExperimentController extends SpringActionController
             {
                 if (f.isFile())
                 {
-                    ExperimentPipelineJob job = new ExperimentPipelineJob(getViewBackgroundInfo(), f, "Experiment Import", false, form.getPipeRoot(getContainer()));
+                    ExperimentPipelineJob job = new ExperimentPipelineJob(getViewBackgroundInfo(), f.toPath(), "Experiment Import", false, form.getPipeRoot(getContainer()));
 
                     // TODO: Configure module resources with the appropriate log location per container
                     if (form.getModule() != null)
                     {
                         File logFile = new File(form.getPipeRoot(getContainer()).getRootPath(), "module-resource-xar.log");
-                        job.setLogFile(logFile);
+                        job.setLogFile(logFile.toPath());
                     }
 
                     PipelineService.get().queueJob(job);
@@ -6207,7 +6207,7 @@ public class ExperimentController extends SpringActionController
             for (File f : form.getValidatedFiles(getContainer()))
             {
                 Map<String, String> archive = new HashMap<>();
-                ExperimentPipelineJob job = new ExperimentPipelineJob(getViewBackgroundInfo(), f, "Experiment Import", false, form.getPipeRoot(getContainer()));
+                ExperimentPipelineJob job = new ExperimentPipelineJob(getViewBackgroundInfo(), f.toPath(), "Experiment Import", false, form.getPipeRoot(getContainer()));
 
                 // TODO: Configure module resources with the appropriate log location per container
                 if (form.getModule() != null)


### PR DESCRIPTION
#### Rationale
We want to be able to exercise our applications that use Experiment object with data at scale. This PR provides a DataGenerator class that can be used to generate random, realistic data for sample types and data classes (other Exp types will likely come later), including the ability to add lineage relationships between objects and create aliquots.  The data generation is driven by a pipeline job that reads a `.properties` file that specifies how many sample types, samples, data classes, etc. as well as the percentage of samples that are to be derived, aliquots, etc.  There are lots of parameters, and likely to be more. Perhaps using a more structured JSON object will work better as we add even more kinds of data to be generated, but simple properties is where we start.

Much of the generation of relationships between the objects relies on the use of the genId values in the names of the entities and the ability to query for the current genId value so we can generate random names known to be valid that can be used to choose random objects.  This is not robust against all interactions, of course, and possibly the use of the IN clauses for the selection of the random samples is going to be too inefficient as we try to generate larger  data, so a different mechanism may be required in the end, but all data generation is batched to prevent overwhelming with the number of inserts or the amount of data being inserted at once. 

As currently set up, the sample types and custom data classes that are generated are added to the ones that already exist. This was easiest for testing purposes, but also allows for the possibility of choosing multiple `.properties` files when running the pipeline job to generate samples using different percentages of aliquots, number of fields, etc.

There is some code commented out (e.g., the code for creating pooled samples), and some methods that are not used, but are left for possible future needs.

**TODO** (perhaps not all in this PR)
- [x] Some accounting is not quite right when generating samples
- [x] The distribution of aliquots across generations still makes for a very wide tree with little chance of generating a deep tree
- Pooling samples - both regular samples and aliquots can be pooled

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1462

#### Changes
* Add `DataGenerator` class that can be used to generate sample types and data classes 
* add `createSampleType` method that does not use the deprecated idCol values
* Use some non-deprecated methods for Experiment pipeline job
