### PR TITLE
Set help topic to new External Tool Access page

### DIFF
--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -2100,6 +2100,7 @@ public class SecurityController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
+            setHelpTopic("externalTools");
             root.addChild("External Tool Access");
         }
     }

--- a/core/src/org/labkey/core/security/nothingEnabled.jsp
+++ b/core/src/org/labkey/core/security/nothingEnabled.jsp
@@ -18,3 +18,4 @@
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 This server does not have any configurations enabled that show settings here. An administrator can configure tool access via the Admin Console.
+<br/><br/>


### PR DESCRIPTION
#### Rationale
Better than landing on the default page.

Also, restore critical whitespace.
