### PR TITLE
Custom fields on Workflow Jobs - Job type field definition

### DIFF
--- a/api/gwtsrc/org/labkey/api/gwt/client/model/GWTDomain.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/model/GWTDomain.java
@@ -44,6 +44,7 @@ public class GWTDomain<FieldType extends GWTPropertyDescriptor> implements IsSer
     private boolean allowAttachmentProperties;
     private boolean allowFlagProperties;
     private boolean allowTextChoiceProperties;
+    private boolean allowSampleSubjectProperties;
     private boolean allowTimepointProperties;
     private boolean showDefaultValueSettings;
     private DefaultValueType defaultDefaultValueType = null;
@@ -88,6 +89,7 @@ public class GWTDomain<FieldType extends GWTPropertyDescriptor> implements IsSer
         this.allowAttachmentProperties = src.allowAttachmentProperties;
         this.allowFlagProperties = src.allowFlagProperties;
         this.allowTextChoiceProperties = src.allowTextChoiceProperties;
+        this.allowSampleSubjectProperties = src.allowSampleSubjectProperties;
         this.allowTimepointProperties = src.allowTimepointProperties;
         this.showDefaultValueSettings = src.showDefaultValueSettings;
         this.defaultDefaultValueType = src.defaultDefaultValueType;
@@ -310,6 +312,16 @@ public class GWTDomain<FieldType extends GWTPropertyDescriptor> implements IsSer
     public void setAllowTextChoiceProperties(boolean allowTextChoiceProperties)
     {
         this.allowTextChoiceProperties = allowTextChoiceProperties;
+    }
+
+    public boolean isAllowSampleSubjectProperties()
+    {
+        return allowSampleSubjectProperties;
+    }
+
+    public void setAllowSampleSubjectProperties(boolean allowSampleSubjectProperties)
+    {
+        this.allowSampleSubjectProperties = allowSampleSubjectProperties;
     }
 
     public boolean isAllowTimepointProperties()

--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -308,6 +308,7 @@ abstract public class DomainKind<T>  implements Handler<String>
     public boolean allowAttachmentProperties() { return false; }
     public boolean allowFlagProperties() { return true; }
     public boolean allowTextChoiceProperties() { return true; }
+    public boolean allowSampleSubjectProperties() { return true; }
     public boolean allowTimepointProperties() { return false; }
     public boolean showDefaultValueSettings() { return false; }
 

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.15.0",
-        "@labkey/components": "2.202.5-fb-workflowJobTypeFieldDef.1",
+        "@labkey/components": "2.203.0",
         "@labkey/themes": "1.2.4"
       },
       "devDependencies": {
@@ -2957,9 +2957,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.202.5-fb-workflowJobTypeFieldDef.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.202.5-fb-workflowJobTypeFieldDef.1.tgz",
-      "integrity": "sha512-ToMOQdcOIirRiX6PYNZeTGFhqzV71N5em/+ThiOKlDVmlZmNd+5iODsmM49KEn0twjcOEhrp28D1L/+H4QWtXQ==",
+      "version": "2.203.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.203.0.tgz",
+      "integrity": "sha512-gi8cuH37dXbizBma/Wo1EguZ1ksV1TNyrl3vmi7wmE7L915cLXxPhBVnAvImkBRMQ9qmWPp7MMUl7fAQoBv8yg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
@@ -16705,9 +16705,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.202.5-fb-workflowJobTypeFieldDef.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.202.5-fb-workflowJobTypeFieldDef.1.tgz",
-      "integrity": "sha512-ToMOQdcOIirRiX6PYNZeTGFhqzV71N5em/+ThiOKlDVmlZmNd+5iODsmM49KEn0twjcOEhrp28D1L/+H4QWtXQ==",
+      "version": "2.203.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.203.0.tgz",
+      "integrity": "sha512-gi8cuH37dXbizBma/Wo1EguZ1ksV1TNyrl3vmi7wmE7L915cLXxPhBVnAvImkBRMQ9qmWPp7MMUl7fAQoBv8yg==",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.15.0",
-        "@labkey/components": "2.202.1",
+        "@labkey/components": "2.202.5-fb-workflowJobTypeFieldDef.1",
         "@labkey/themes": "1.2.4"
       },
       "devDependencies": {
@@ -2957,9 +2957,10 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.202.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.202.1.tgz",
-      "integrity": "sha512-Tfc8BU4Ua5+5qPVcjgbJOMfO8gzERSm6P2l5Lcl+n8ZroQsLJOc37Kg0EwbaQyGZVYpFTg2jm++JWIVkCB7oFg==",
+      "version": "2.202.5-fb-workflowJobTypeFieldDef.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.202.5-fb-workflowJobTypeFieldDef.1.tgz",
+      "integrity": "sha512-ToMOQdcOIirRiX6PYNZeTGFhqzV71N5em/+ThiOKlDVmlZmNd+5iODsmM49KEn0twjcOEhrp28D1L/+H4QWtXQ==",
+      "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -16704,9 +16705,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.202.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.202.1.tgz",
-      "integrity": "sha512-Tfc8BU4Ua5+5qPVcjgbJOMfO8gzERSm6P2l5Lcl+n8ZroQsLJOc37Kg0EwbaQyGZVYpFTg2jm++JWIVkCB7oFg==",
+      "version": "2.202.5-fb-workflowJobTypeFieldDef.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.202.5-fb-workflowJobTypeFieldDef.1.tgz",
+      "integrity": "sha512-ToMOQdcOIirRiX6PYNZeTGFhqzV71N5em/+ThiOKlDVmlZmNd+5iODsmM49KEn0twjcOEhrp28D1L/+H4QWtXQ==",
       "requires": {
         "@fortawesome/fontawesome-free": "5.15.4",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.15.0",
-    "@labkey/components": "2.202.5-fb-workflowJobTypeFieldDef.1",
+    "@labkey/components": "2.203.0",
     "@labkey/themes": "1.2.4"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.15.0",
-    "@labkey/components": "2.202.1",
+    "@labkey/components": "2.202.5-fb-workflowJobTypeFieldDef.1",
     "@labkey/themes": "1.2.4"
   },
   "devDependencies": {

--- a/internal/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/internal/src/org/labkey/api/exp/property/DomainUtil.java
@@ -305,6 +305,7 @@ public class DomainUtil
             gwtDomain.setAllowFileLinkProperties(kind.allowFileLinkProperties());
             gwtDomain.setAllowFlagProperties(kind.allowFlagProperties());
             gwtDomain.setAllowTextChoiceProperties(kind.allowTextChoiceProperties());
+            gwtDomain.setAllowSampleSubjectProperties(kind.allowSampleSubjectProperties());
             gwtDomain.setAllowTimepointProperties(kind.allowTimepointProperties());
             gwtDomain.setShowDefaultValueSettings(kind.showDefaultValueSettings());
             gwtDomain.setInstructions(kind.getDomainEditorInstructions());
@@ -320,6 +321,7 @@ public class DomainUtil
         gwtDomain.setAllowFileLinkProperties(kind.allowFileLinkProperties());
         gwtDomain.setAllowFlagProperties(kind.allowFlagProperties());
         gwtDomain.setAllowTextChoiceProperties(kind.allowTextChoiceProperties());
+        gwtDomain.setAllowSampleSubjectProperties(kind.allowSampleSubjectProperties());
         gwtDomain.setAllowTimepointProperties(kind.allowTimepointProperties());
         gwtDomain.setShowDefaultValueSettings(kind.showDefaultValueSettings());
         gwtDomain.setInstructions(kind.getDomainEditorInstructions());


### PR DESCRIPTION
#### Rationale
We want to support workflow jobs to replace the work of the issue tracker by supporting teams’ needs to use Workflow as a tool for requesting work or assays to be performed on samples. One thing that has been called out as a primary blocker is the ability to standardize fields captured around a specific request.

This PR adds the domain kind allowSampleSubjectProperties option so that we can disable/override it in the new workflow job template domain kind.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/922
* https://github.com/LabKey/sampleManagement/pull/1137
* https://github.com/LabKey/biologics/pull/1487
* https://github.com/LabKey/inventory/pull/507
* https://github.com/LabKey/platform/pull/3570

#### Changes
* add domain kind allowSampleSubjectProperties option
