### PR TITLE
Issue 45522: GridPanel search does not find extended characters in MSSQL

### DIFF
--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -897,7 +897,7 @@ public abstract class CompareType
 
                 sql.append(dialect.getColumnSelectName(mappedColumn.getAlias()));
                 sql.append(" ").append(dialect.getCaseInsensitiveLikeOperator()).append(" ");
-                sql.append("'%").append(LikeClause.escapeLikePattern(escapedValue)).append("%'");
+                sql.append(dialect.concatenate(" '%'", "?", "'%' ")).add(LikeClause.escapeLikePattern(escapedValue));
                 sql.append(LikeClause.sqlEscape());
             }
 

--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -849,17 +849,14 @@ public abstract class CompareType
         @Override
         public SQLFragment toSQLFragment(Map<FieldKey, ? extends ColumnInfo> columnMap, SqlDialect dialect)
         {
-            final Object param = getParamVals()[0];
-            final String escapedValue = escapeLabKeySqlValue(param, JdbcType.VARCHAR, true);
-            if (_selectColumns == null || _selectColumns.isEmpty() || escapedValue.isEmpty())
+            final String param = Objects.toString(getParamVals()[0], null) ;
+            if (_selectColumns == null || _selectColumns.isEmpty() || null == param)
                 return new SQLFragment("1=1");
 
             Integer paramNum = null;
             try
             {
-                String paramString = Objects.toString(param, null);
-                if (paramString != null)
-                    paramNum = Integer.parseInt(paramString);
+                paramNum = Integer.parseInt(param);
             }
             catch (NumberFormatException ex)
             {
@@ -897,7 +894,7 @@ public abstract class CompareType
 
                 sql.append(dialect.getColumnSelectName(mappedColumn.getAlias()));
                 sql.append(" ").append(dialect.getCaseInsensitiveLikeOperator()).append(" ");
-                sql.append(dialect.concatenate(" '%'", "?", "'%' ")).add(LikeClause.escapeLikePattern(escapedValue));
+                sql.append(dialect.concatenate(" '%'", "?", "'%' ")).add(LikeClause.escapeLikePattern(param));
                 sql.append(LikeClause.sqlEscape());
             }
 


### PR DESCRIPTION
#### Rationale
MSSQL doesn't recognize extended character set by default like PG does. Using JDBC parameters will set the necessary metadata. Need to create the like value expression string in query to use JDBC parameter.

#### Changes
* Update QClause like value expression to use JDBC parameter.
