### PR TITLE
Issue 45375: Add index to speed common queries against core.notifications

### DIFF
--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 22.002
+SchemaVersion: 22.003
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/core-22.002-22.003.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-22.002-22.003.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IX_Notification_User ON core.Notifications(UserId);

--- a/core/resources/schemas/dbscripts/sqlserver/core-22.002-22.003.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-22.002-22.003.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IX_Notification_User ON core.Notifications(UserId);


### PR DESCRIPTION
#### Rationale
There are a handful of reasonably frequent queries against core.notifications that are taking >20ms to complete. An index should help.

#### Changes
* Add index on UserId column, which is a common WHERE clause filter on all the queries