### PR TITLE
Remove .lastfilter=true param on issue webpart titles

### DIFF
--- a/issues/src/org/labkey/issue/view/IssuesListView.java
+++ b/issues/src/org/labkey/issue/view/IssuesListView.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.issue.view;
 
-import org.labkey.api.data.DataRegion;
 import org.labkey.api.query.QueryParam;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
@@ -69,8 +68,7 @@ public class IssuesListView extends VBox
         addView(queryView);
 
         setTitleHref(new ActionURL(IssuesController.ListAction.class, getViewContext().getContainer()).
-                addParameter(IssuesListView.ISSUE_LIST_DEF_NAME, issueDefName).
-                addParameter(DataRegion.LAST_FILTER_PARAM, true));
+                addParameter(IssuesListView.ISSUE_LIST_DEF_NAME, issueDefName));
     }
 
 

--- a/issues/src/org/labkey/issue/view/SummaryWebPart.java
+++ b/issues/src/org/labkey/issue/view/SummaryWebPart.java
@@ -16,7 +16,6 @@
 package org.labkey.issue.view;
 
 import org.labkey.api.data.Container;
-import org.labkey.api.data.DataRegion;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.view.ActionURL;
@@ -54,8 +53,7 @@ public class SummaryWebPart extends JspView<IssuesController.SummaryBean>
             return;
 
         ActionURL listUrl = new ActionURL(IssuesController.ListAction.class, getViewContext().getContainer()).
-                addParameter(IssuesListView.ISSUE_LIST_DEF_NAME, issueDefName).
-                addParameter(DataRegion.LAST_FILTER_PARAM, true);
+                addParameter(IssuesListView.ISSUE_LIST_DEF_NAME, issueDefName);
 
         setTitleHref(listUrl);
 


### PR DESCRIPTION
#### Rationale
There were some recent automation test failures induced by the crawler. The failures were being caused because clicking on the issues `SummaryWebPart` title was pulling in an injected invalid `returnUrl` param from a previous request through the `.lastfilter` param.

This behavior has been there for a long time although it is a little unusual to have a top level view or link using that parameter. Typically it's used more from a `navTrail` link to tie together a detail view to the parent grid to maintain filtering behavior as the `issues-detail.view` does. 