### PR TITLE
Log Query Analyzer error messages

### DIFF
--- a/query/webapp/query/browser/Caches.js
+++ b/query/webapp/query/browser/Caches.js
@@ -191,13 +191,15 @@ Ext4.define('LABKEY.query.browser.cache.QueryDependencies', {
         if (!this.queries) {
             this.analyzeQueries({
                 containerPath : containerPath,
-                success : function(resp){
+                success : function(resp, opts){
                     this.processDependencies(resp);
                     if (Ext4.isFunction(success)){
-                        success.call(scope || this)
+                        success.call(scope || this, resp, opts);
                     }
                 },
-                failure : failure,
+                failure : function(resp, opts) {
+                    failure.call(scope || this, resp, opts);
+                },
                 scope : this
             });
         }

--- a/query/webapp/query/browser/view/Dependencies.js
+++ b/query/webapp/query/browser/view/Dependencies.js
@@ -80,7 +80,7 @@ Ext4.define('LABKEY.query.browser.view.Dependencies', {
             }
         });
 
-        function loadSuccessHandler() {
+        function loadSuccessHandler(resp, opts) {
             pb.destroy();
             Ext4.TaskManager.stopAll();
             this.parent.getEl().unmask();
@@ -91,13 +91,16 @@ Ext4.define('LABKEY.query.browser.view.Dependencies', {
                     this);
         }
 
+        function loadFailureHandler(resp, opts) {
+            pb.destroy();
+            Ext4.TaskManager.stopAll();
+            this.parent.getEl().unmask();
+            LABKEY.Utils.displayAjaxErrorResponse(resp, opts, true);
+        }
+
         // clear the cache and re-load using the configured path
         this.parent.getEl().mask();
         this.dependencyCache.clear();
-        this.dependencyCache.load(this.analysisPath, loadSuccessHandler, this.onLoadError, this);
-    },
-
-    onLoadError : function() {
-        Ext4.Msg.alert('Cross Folder Dependencies', 'The query analysis failed, check the console log');
+        this.dependencyCache.load(this.analysisPath, loadSuccessHandler, loadFailureHandler, this);
     }
 });


### PR DESCRIPTION
#### Rationale
To help investigate occasional automated test failures a few changes were made to the query analysis tool:
- Instead of displaying a generic error dialog, we will try to show the standard LabKey error dialog with details about the execption.
- For the server side `AnalyzeQueriesAction`, log any exceptions to the error log for the `QueryController` logger.

[Related Issue
](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45908)
