### PR TITLE
Issue 41515: Provide Editors with links/buttons to access dataset details and import history pages

### DIFF
--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -547,8 +547,8 @@ public class StudyController extends BaseStudyController
         public void addNavTrail(NavTree root)
         {
             setHelpTopic("datasetProperties");
-            _addNavTrailDatasetAdmin(root);
-            root.addChild(_def.getLabel() + " Dataset Properties");
+            root.addChild(_def.getLabel(), urlProvider(StudyUrls.class).getDatasetURL(getContainer(), _def.getDatasetId()));
+            root.addChild("Dataset Properties");
         }
     }
 

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -473,7 +473,7 @@ public class DatasetQueryView extends StudyQueryView
                 // Anyone with read permissions can see the dataset details page, #41515
                 ActionButton manageButton = new ActionButton(new ActionURL(StudyController.DatasetDetailsAction.class, getContainer()).addParameter("id", _dataset.getDatasetId()), canManage ? "Manage" : "Details");
                 manageButton.setActionType(ActionButton.Action.LINK);
-                manageButton.setDisplayPermission(InsertPermission.class);
+                manageButton.setDisplayPermission(ReadPermission.class);
                 bar.add(manageButton);
             }
             else

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -470,14 +470,11 @@ public class DatasetQueryView extends StudyQueryView
                     }
                 }
 
-                if (canManage)
-                {
-                    // manage dataset
-                    ActionButton manageButton = new ActionButton(new ActionURL(StudyController.DatasetDetailsAction.class, getContainer()).addParameter("id", _dataset.getDatasetId()), "Manage");
-                    manageButton.setActionType(ActionButton.Action.LINK);
-                    manageButton.setDisplayPermission(InsertPermission.class);
-                    bar.add(manageButton);
-                }
+                // Anyone with read permissions can see the dataset details page, #41515
+                ActionButton manageButton = new ActionButton(new ActionURL(StudyController.DatasetDetailsAction.class, getContainer()).addParameter("id", _dataset.getDatasetId()), canManage ? "Manage" : "Details");
+                manageButton.setActionType(ActionButton.Action.LINK);
+                manageButton.setDisplayPermission(InsertPermission.class);
+                bar.add(manageButton);
             }
             else
             {

--- a/study/src/org/labkey/study/view/datasetDetails.jsp
+++ b/study/src/org/labkey/study/view/datasetDetails.jsp
@@ -16,10 +16,12 @@
  */
 %>
 <%@ page import="org.labkey.api.data.Container"%>
+<%@ page import="org.labkey.api.data.TableInfo"%>
 <%@ page import="org.labkey.api.pipeline.PipelineService"%>
 <%@ page import="org.labkey.api.security.SecurityManager"%>
 <%@ page import="org.labkey.api.security.User" %>
 <%@ page import="org.labkey.api.security.permissions.AdminPermission" %>
+<%@ page import="org.labkey.api.security.permissions.DeletePermission" %>
 <%@ page import="org.labkey.api.security.permissions.Permission" %>
 <%@ page import="org.labkey.api.security.permissions.UpdatePermission" %>
 <%@ page import="org.labkey.api.study.Dataset" %>
@@ -47,8 +49,6 @@
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Set" %>
 <%@ page import="static org.labkey.study.model.DatasetDomainKindProperties.TIME_KEY_FIELD_DISPLAY" %>
-<%@ page import="org.labkey.api.data.TableInfo" %>
-<%@ page import="org.labkey.api.security.permissions.DeletePermission" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -130,17 +130,20 @@ if (permissions.contains(AdminPermission.class))
         buttons.add(button("Delete All Rows").onClick("truncateTable();"));
     }
 }
+
 if (permissions.contains(UpdatePermission.class) && !isDatasetInherited)
 {
     ActionURL showHistoryURL = new ActionURL(StudyController.ShowUploadHistoryAction.class, c);
     showHistoryURL.addParameter("id", dataset.getDatasetId());
-
-    ActionURL editTypeURL = new ActionURL(StudyController.EditTypeAction.class, c);
-    editTypeURL.addParameter("datasetId", dataset.getDatasetId());
-
     buttons.add(button("Show Import History").href(showHistoryURL));
+}
+
+if (permissions.contains(AdminPermission.class) && !isDatasetInherited)
+{
     if (dataset.getType().equals(Dataset.TYPE_STANDARD))
     {
+        ActionURL editTypeURL = new ActionURL(StudyController.EditTypeAction.class, c);
+        editTypeURL.addParameter("datasetId", dataset.getDatasetId());
         buttons.add(button("Edit Definition").href(editTypeURL));
     }
     else if(dataset.getType().equals(Dataset.TYPE_PLACEHOLDER))


### PR DESCRIPTION
#### Rationale
Missing buttons and inconsistent permission checking can lead to user frustration

[Issue 41515: Provide Editors with links/buttons to access dataset details and import history pages](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41515)

#### Changes
* Non-admins now get a "Details" button on non-inherited datasets to take them to the dataset details page. This page has always required only read permissions, but we've never provided non-admins a way to navigate to it.
* Don't show "Edit Definition" button to non-admins
* Fix "Dataset Details" navtrail