### PR TITLE
45711: Imported study has additional columns in dataset compared to original study

### DIFF
--- a/study/src/org/labkey/study/writer/DatasetDataWriter.java
+++ b/study/src/org/labkey/study/writer/DatasetDataWriter.java
@@ -310,9 +310,17 @@ public class DatasetDataWriter implements InternalStudyWriter
                 if ("ptid".equalsIgnoreCase(in.getName()) && !in.equals(ptidColumn))
                     continue;
 
-                // don't include the sample type alias column for export
-                if (ExpMaterialTable.Column.Alias.name().equalsIgnoreCase(in.getName()) && def.isPublishedData())
-                    continue;
+                if (def.isPublishedData())
+                {
+                    // don't include some published data columns in the export
+                    if (ExpMaterialTable.Column.Alias.name().equalsIgnoreCase(in.getName()) ||
+                            ExpMaterialTable.Column.Flag.name().equalsIgnoreCase(in.getName()) ||
+                            "run".equalsIgnoreCase(in.getName()) ||
+                            "participantVisit/visit".equalsIgnoreCase(in.getName()) ||
+                            "ancestors".equalsIgnoreCase(in.getName()) ||
+                            "rowId".equalsIgnoreCase(in.getName()))
+                        continue;
+                }
 
                 if (in.equals(qcStateColumn))
                 {


### PR DESCRIPTION
#### Rationale
Datasets which are sourced by either linked assay or sample data are joined to the parent assay or sample tables. So when you are viewing the data from a study we are viewing the underlying tables. A very different thing happens when you export and then import one of these studies because the datasets are no longer linked to the source assay or sample tables, but are instead now regular datasets with most of the columns copied over.

For this reason, we don't want to export all fields of a published dataset because fields such as run, ancestor, alias only make sense in the context of either an assay or sample table. 

This PR expands the list of columns that we filter out during export so that they don't cause confusion when those datasets are later imported. I decided to filter out the flag column as well since in datasets flag columns are not supported in the same way as they are in samples or assays with the special renderer, but are essentially just treated like a text field.

[Related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45711)
