### PR TITLE
Issue 46060: Excel exports are leaving permanent 'temporary poifiles'

### DIFF
--- a/api/src/org/labkey/api/data/ExcelColumn.java
+++ b/api/src/org/labkey/api/data/ExcelColumn.java
@@ -896,7 +896,7 @@ public class ExcelColumn extends RenderColumn
             {
                 try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
                 {
-                    excel.renderSheetAndWrite(baos);
+                    excel.renderWorkbook(baos);
                     Sheet wb = WorkbookFactory.create(new ByteArrayInputStream(baos.toByteArray())).getSheetAt(0);
                     DataFormatter formatter = new DataFormatter();
                     for (int rowIdx = 0; rowIdx < DATA.length; rowIdx++)

--- a/api/src/org/labkey/api/data/ExcelColumn.java
+++ b/api/src/org/labkey/api/data/ExcelColumn.java
@@ -19,7 +19,6 @@ package org.labkey.api.data;
 import jxl.format.Colour;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.poi.hssf.usermodel.HSSFClientAnchor;
 import org.apache.poi.hssf.usermodel.HSSFPicture;
@@ -63,6 +62,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.TestContext;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ViewContext;
 import org.springframework.validation.BindException;
 
@@ -92,7 +92,7 @@ import java.util.stream.Collectors;
 
 public class ExcelColumn extends RenderColumn
 {
-    private static Logger _log = LogManager.getLogger(ExcelColumn.class);
+    private static final Logger _log = LogHelper.getLogger(ExcelColumn.class, "Excel column rendering");
 
     private static final int TYPE_UNKNOWN = 0;
     private static final int TYPE_INT = 1;
@@ -892,31 +892,29 @@ public class ExcelColumn extends RenderColumn
 
             BindException errors = new NullSafeBindException(new Object(), "command");
             QueryView view = us.createView(qf, errors);
-            try (ExcelWriter excel = view.getExcelWriter(ExcelWriter.ExcelDocumentType.xlsx))
+            ExcelWriter excel = view.getExcelWriter(ExcelWriter.ExcelDocumentType.xlsx);
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
             {
-                try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
+                excel.renderWorkbook(baos);
+                Sheet wb = WorkbookFactory.create(new ByteArrayInputStream(baos.toByteArray())).getSheetAt(0);
+                DataFormatter formatter = new DataFormatter();
+                for (int rowIdx = 0; rowIdx < DATA.length; rowIdx++)
                 {
-                    excel.renderWorkbook(baos);
-                    Sheet wb = WorkbookFactory.create(new ByteArrayInputStream(baos.toByteArray())).getSheetAt(0);
-                    DataFormatter formatter = new DataFormatter();
-                    for (int rowIdx = 0; rowIdx < DATA.length; rowIdx++)
+                    Object[] expectedData = DATA[rowIdx];
+                    Row excelRow = wb.getRow(rowIdx + 1);
+                    for (int fieldIdx = 0; fieldIdx < FIELDS.length; fieldIdx++)
                     {
-                        Object[] expectedData = DATA[rowIdx];
-                        Row excelRow = wb.getRow(rowIdx + 1);
-                        for (int fieldIdx = 0; fieldIdx < FIELDS.length; fieldIdx++)
-                        {
-                            Object[] fieldDef = FIELDS[fieldIdx];
-                            ColumnInfo ci = ti.getColumn((String) fieldDef[0]);
+                        Object[] fieldDef = FIELDS[fieldIdx];
+                        ColumnInfo ci = ti.getColumn((String) fieldDef[0]);
 
-                            String expected = parseAndFormatExpected(expectedData[fieldIdx], ci);
-                            Cell cell = excelRow.getCell(fieldIdx);
-                            String actual = formatter.formatCellValue(cell);
-                            assertEquals("Incorrect Excel Value", expected, actual);
+                        String expected = parseAndFormatExpected(expectedData[fieldIdx], ci);
+                        Cell cell = excelRow.getCell(fieldIdx);
+                        String actual = formatter.formatCellValue(cell);
+                        assertEquals("Incorrect Excel Value", expected, actual);
 
-                            Object expectedObj = ConvertHelper.convert(expected, ci.getJavaClass());
-                            Object actualObj = ConvertHelper.convert(actual, ci.getJavaClass());
-                            assertEquals("Incorrect Parsed Excel Value", expectedObj, actualObj);
-                        }
+                        Object expectedObj = ConvertHelper.convert(expected, ci.getJavaClass());
+                        Object actualObj = ConvertHelper.convert(actual, ci.getJavaClass());
+                        assertEquals("Incorrect Parsed Excel Value", expectedObj, actualObj);
                     }
                 }
             }

--- a/api/src/org/labkey/api/data/ExcelWriter.java
+++ b/api/src/org/labkey/api/data/ExcelWriter.java
@@ -389,30 +389,10 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
         _captionRowVisible = captionRowVisible;
     }
 
-
-    public ExcelColumn getExcelColumn(int index)
-    {
-        return _columns.get(index);
-    }
-
-
-    public ExcelColumn getExcelColumn(String columnName)
-    {
-        for (ExcelColumn column : _columns)
-        {
-            if (column.getName().equalsIgnoreCase(columnName))
-                return column;
-        }
-
-        return null;
-    }
-
-
     private void addColumn(DisplayColumn col)
     {
         _columns.add(new ExcelColumn(col, _formatters, _workbook));
     }
-
 
     private void addDisplayColumns(List<DisplayColumn> columns)
     {
@@ -424,7 +404,6 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
         }
     }
 
-
     private void addColumns(List<ColumnInfo> cols)
     {
         for (ColumnInfo col : cols)
@@ -435,13 +414,11 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
         }
     }
 
-
     public void setDisplayColumns(List<DisplayColumn> columns)
     {
         _columns = new ArrayList<>(10);
         addDisplayColumns(columns);
     }
-
 
     public void setColumns(List<ColumnInfo> columns)
     {
@@ -454,7 +431,6 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
     {
         return _columns;
     }
-
 
     public List<ExcelColumn> getVisibleColumns(RenderContext ctx)
     {
@@ -476,7 +452,6 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
 
         return visibleColumns;
     }
-
 
     // Sets AutoSize property on all columns
     public void setAutoSize(boolean autoSize)

--- a/api/src/org/labkey/api/data/ExcelWriter.java
+++ b/api/src/org/labkey/api/data/ExcelWriter.java
@@ -650,12 +650,6 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
         return null;
     }
 
-    @Deprecated
-    public void renderNewSheet()
-    {
-        renderNewSheet(_workbook);
-    }
-
     public int getCurrentRow()
     {
         return _currentRow;

--- a/api/src/org/labkey/api/data/ExcelWriter.java
+++ b/api/src/org/labkey/api/data/ExcelWriter.java
@@ -212,7 +212,7 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
     private int _currentRow = 0;
     private int _currentSheet = -1;
 
-    protected final Workbook _workbook;
+    private final Workbook _workbook;
 
     // Some columns may need to be Aliased (e.g., Name -> Sample ID)
     private Map<String, String> _renameColumnMap;
@@ -654,50 +654,6 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
     public void renderNewSheet()
     {
         renderNewSheet(_workbook);
-    }
-
-    /**
-     * Writes out the workbook to the response stream
-     * @param response to write to
-     */
-    @Deprecated
-    public void writeWorkbook(HttpServletResponse response)
-    {
-        writeWorkbook(_workbook, response, getFilenamePrefix());
-    }
-
-    @Deprecated
-    public Workbook getWorkbook()
-    {
-        return _workbook;
-    }
-
-    /**
-     * Write workbook out to supplied response
-     * @param response to write to
-     * @param filenamePrefix string to prepend to a time stamp as filename
-     */
-    @Deprecated
-    private void writeWorkbook(Workbook workbook, HttpServletResponse response, String filenamePrefix)
-    {
-        try (ServletOutputStream outputStream = getOutputStream(response, filenamePrefix, _docType))
-        {
-            _write(workbook, outputStream);
-        }
-        catch (IOException e)
-        {
-            ExceptionUtil.logExceptionToMothership(null, e);
-        }
-        catch (OpenXML4JRuntimeException e)
-        {
-            // We can get this message if there's an IOException when writing out the document to the stream.
-            // It happens because the browser has disconnected before receiving the full file. We can safely ignore it.
-            // Otherwise, rethrow. See issue #14987
-            if (e.getMessage() == null || e.getMessage().contains("to be saved in the stream with marshaller"))
-            {
-                throw e;
-            }
-        }
     }
 
     public int getCurrentRow()

--- a/api/src/org/labkey/api/data/ExcelWriter.java
+++ b/api/src/org/labkey/api/data/ExcelWriter.java
@@ -408,7 +408,7 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
         addColumns(columns);
     }
 
-    // ColumnModifier will be invoked on each visible ExcelColumn at creation time
+    // Column modifier will be invoked on each visible ExcelColumn at creation time
     public void setColumnModifier(Consumer<ExcelColumn> columnModifier)
     {
         _columnModifier = columnModifier;

--- a/api/src/org/labkey/api/data/ExcelWriter.java
+++ b/api/src/org/labkey/api/data/ExcelWriter.java
@@ -619,6 +619,12 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
         writeWorkbook(_workbook, response, getFilenamePrefix());
     }
 
+    @Deprecated
+    public Workbook getWorkbook()
+    {
+        return _workbook;
+    }
+
     /**
      * Write workbook out to supplied response
      * @param response to write to
@@ -852,7 +858,6 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
         }
     }
 
-
     public void renderColumnCaptions(Sheet sheet, List<ExcelColumn> visibleColumns) throws MaxRowsExceededException
     {
         if (_currentRow <= _docType.getMaxRows())
@@ -939,11 +944,6 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
         incrementRow();
     }
 
-    public Workbook getWorkbook()
-    {
-        return _workbook;
-    }
-
     public ExcelDocumentType getDocumentType()
     {
         return _docType;
@@ -974,6 +974,6 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
 
     public void setRenameColumnMap(Map<String, String> renameColumnMap)
     {
-        this._renameColumnMap = Collections.unmodifiableMap(renameColumnMap);
+        _renameColumnMap = Collections.unmodifiableMap(renameColumnMap);
     }
 }

--- a/api/src/org/labkey/api/data/ExcelWriter.java
+++ b/api/src/org/labkey/api/data/ExcelWriter.java
@@ -65,7 +65,7 @@ import java.util.regex.Pattern;
 /**
  * Knows how to create an Excel file (of various formats) based on the {@link Results} of a database query.
  */
-public class ExcelWriter implements ExportWriter, AutoCloseable
+public class ExcelWriter implements ExportWriter
 {
     /** Flavors of supported Excel file formats */
     public enum ExcelDocumentType
@@ -861,12 +861,6 @@ public class ExcelWriter implements ExportWriter, AutoCloseable
     public int getDataRowCount()
     {
         return _totalDataRows;
-    }
-
-    @Override
-    public void close()
-    {
-        // No-op: Results are closed via try-with-resources at render time
     }
 
     public void setRenameColumnMap(Map<String, String> renameColumnMap)

--- a/api/src/org/labkey/api/query/CrosstabExcelWriter.java
+++ b/api/src/org/labkey/api/query/CrosstabExcelWriter.java
@@ -63,7 +63,7 @@ public class CrosstabExcelWriter extends ExcelWriter
         {
             Row dimensionRow = sheet.createRow(getCurrentRow());
             Cell dimensionCell = dimensionRow.getCell(column, MissingCellPolicy.CREATE_NULL_AS_BLANK);
-            dimensionCell.setCellStyle(getBoldFormat());
+            dimensionCell.setCellStyle(getBoldFormat(sheet.getWorkbook()));
             dimensionCell.setCellValue(_table.getSettings().getColumnAxis().getCaption());
 
             incrementRow();
@@ -86,7 +86,7 @@ public class CrosstabExcelWriter extends ExcelWriter
             if (currentMember != null)
             {
                 Cell cell = row.getCell(column, MissingCellPolicy.CREATE_NULL_AS_BLANK);
-                cell.setCellStyle(getBoldFormat());
+                cell.setCellStyle(getBoldFormat(sheet.getWorkbook()));
                 cell.setCellValue(currentMember.getCaption());
                 column += memberColumns.size();
                 if (column >= _docType.getMaxColumns())

--- a/api/src/org/labkey/api/query/CrosstabView.java
+++ b/api/src/org/labkey/api/query/CrosstabView.java
@@ -244,7 +244,7 @@ public class CrosstabView extends QueryView
     }
 
     @Override
-    public ExcelWriter getExcelWriter(ExcelWriter.ExcelDocumentType docType) throws IOException
+    public ExcelWriter getExcelWriter(ExcelWriter.ExcelDocumentType docType)
     {
         DataView view = createDataView();
         DataRegion rgn = view.getDataRegion();

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -368,7 +368,7 @@ public class QueryView extends WebPartView<Object>
      * @param config settings to apply to writer prior to sheet export
           * @param sheetName Name to give to sheet, if not unique within workbook existing sheet will be overwritten
      */
-    public void exportToExcelSheet(ExcelWriter writer, ExcelExportConfig config, @Nullable String sheetName)
+    public void exportToExcelSheet(ExcelWriter writer, Workbook workbook, ExcelExportConfig config, @Nullable String sheetName)
     {
         configureExcelWriter(writer, config);
         String name = StringUtils.isNotBlank(sheetName)? sheetName : getQueryDef().getName();

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -362,28 +362,10 @@ public class QueryView extends WebPartView<Object>
         }
     }
 
-    /**
-     * Writes this query view as a sheet in the provided ExcelWriter (CALLER MUST CLOSE)
-     * @param writer to write to
-     * @param config settings to apply to writer prior to sheet export
-          * @param sheetName Name to give to sheet, if not unique within workbook existing sheet will be overwritten
-     */
-    public void exportToExcelSheet(ExcelWriter writer, Workbook workbook, ExcelExportConfig config, @Nullable String sheetName)
-    {
-        configureExcelWriter(writer, config);
-        String name = StringUtils.isNotBlank(sheetName)? sheetName : getQueryDef().getName();
-        name = StringUtils.isNotBlank(name)? name : StringUtils.isNotBlank(getDataRegionName()) ? getDataRegionName() : "Data";
-        writer.setSheetName(name);
-        writer.setAutoSize(true);
-        writer.renderNewSheet();
-        logAuditEvent("Exported to Excel", writer.getDataRowCount());
-    }
-
-
     /* delay load menu, because it is usually visible==false */
     private class QueryNavTreeMenuButton extends MenuButton
     {
-        boolean populated = false;
+        private boolean populated = false;
 
         QueryNavTreeMenuButton(String label)
         {
@@ -2965,7 +2947,7 @@ public class QueryView extends WebPartView<Object>
         return DataRegionSelection.setSelectionForAll(this, this.getSelectionKey(), true);
     }
 
-    protected void logAuditEvent(String comment, int dataRowCount)
+    public void logAuditEvent(String comment, int dataRowCount)
     {
         QueryService.get().addAuditEvent(this, comment, dataRowCount);
     }

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -2764,7 +2764,7 @@ public class QueryView extends WebPartView<Object>
                 if (config.getPrefix() != null)
                     ew.setFilenamePrefix(config.getPrefix());
                 ew.setAutoSize(true);
-                ew.renderSheetAndWrite(config.getResponse());
+                ew.renderWorkbook(config.getResponse());
 
                 if (!config.getTemplateOnly())
                     logAuditEvent("Exported to Excel", ew.getDataRowCount());
@@ -2793,7 +2793,7 @@ public class QueryView extends WebPartView<Object>
                 ew.setCaptionType(headerType);
                 ew.setShowInsertableColumnsOnly(false, null);
                 ew.setMetadata(metadata);
-                ew.renderSheetAndWrite(stream);
+                ew.renderWorkbook(stream);
                 stream.flush();
                 String extension = docType.name();
                 String filename = includeTimestamp ?

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -2739,18 +2739,16 @@ public class QueryView extends WebPartView<Object>
         TableInfo table = getTable();
         if (table != null)
         {
-            try (ExcelWriter ew = config.getTemplateOnly() ? getExcelTemplateWriter(config) : getExcelWriter(config))
-            {
-                ew.setCaptionType(config.getHeaderType() == null ? getColumnHeaderType() : config.getHeaderType());
-                ew.setShowInsertableColumnsOnly(config.getInsertColumnsOnly(), config.getIncludeColumns(), config.getExcludeColumns());
-                if (config.getPrefix() != null)
-                    ew.setFilenamePrefix(config.getPrefix());
-                ew.setAutoSize(true);
-                ew.renderWorkbook(config.getResponse());
+            ExcelWriter ew = config.getTemplateOnly() ? getExcelTemplateWriter(config) : getExcelWriter(config);
+            ew.setCaptionType(config.getHeaderType() == null ? getColumnHeaderType() : config.getHeaderType());
+            ew.setShowInsertableColumnsOnly(config.getInsertColumnsOnly(), config.getIncludeColumns(), config.getExcludeColumns());
+            if (config.getPrefix() != null)
+                ew.setFilenamePrefix(config.getPrefix());
+            ew.setAutoSize(true);
+            ew.renderWorkbook(config.getResponse());
 
-                if (!config.getTemplateOnly())
-                    logAuditEvent("Exported to Excel", ew.getDataRowCount());
-            }
+            if (!config.getTemplateOnly())
+                logAuditEvent("Exported to Excel", ew.getDataRowCount());
         }
     }
 
@@ -2770,8 +2768,9 @@ public class QueryView extends WebPartView<Object>
         if (table != null)
         {
             ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
-            try (OutputStream stream = new BufferedOutputStream(byteStream); ExcelWriter ew = getExcelWriter(docType))
+            try (OutputStream stream = new BufferedOutputStream(byteStream))
             {
+                ExcelWriter ew = getExcelWriter(docType);
                 ew.setCaptionType(headerType);
                 ew.setShowInsertableColumnsOnly(false, null);
                 ew.setMetadata(metadata);

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -2776,7 +2776,6 @@ public class QueryView extends WebPartView<Object>
                 ew.setShowInsertableColumnsOnly(false, null);
                 ew.setMetadata(metadata);
                 ew.renderWorkbook(stream);
-                stream.flush();
                 String extension = docType.name();
                 String filename = includeTimestamp ?
                                     FileUtil.makeFileNameWithTimestamp(ew.getFilenamePrefix(), extension) :

--- a/api/src/org/labkey/api/study/reports/Crosstab.java
+++ b/api/src/org/labkey/api/study/reports/Crosstab.java
@@ -21,6 +21,7 @@ import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.HorizontalAlignment;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.VerticalAlignment;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DisplayColumn;
@@ -364,9 +365,9 @@ public class Crosstab
         }
 
         @Override
-        protected CellStyle getWrappingTextFormat()
+        protected CellStyle getWrappingTextFormat(Workbook workbook)
         {
-            CellStyle format = _workbook.createCellStyle();
+            CellStyle format = workbook.createCellStyle();
             format.setWrapText(true);
             format.setVerticalAlignment(VerticalAlignment.TOP);
             format.setAlignment(HorizontalAlignment.CENTER);

--- a/api/src/org/labkey/api/study/reports/Crosstab.java
+++ b/api/src/org/labkey/api/study/reports/Crosstab.java
@@ -326,7 +326,7 @@ public class Crosstab
 
     public static class CrosstabExcelWriter extends ExcelWriter
     {
-        private Crosstab _crosstab;
+        private final Crosstab _crosstab;
         private static final String STAT_COLUMN = "Stat";
 
         public CrosstabExcelWriter(Crosstab crosstab)

--- a/assay/src/org/labkey/assay/actions/TemplateAction.java
+++ b/assay/src/org/labkey/assay/actions/TemplateAction.java
@@ -69,7 +69,7 @@ public class TemplateAction extends BaseAssayAction<ProtocolIdForm>
 
         try (ExcelWriter xl = new ExcelWriter(()->dr.getResults(ctx), dr.getDisplayColumns(), ExcelWriter.ExcelDocumentType.xlsx))
         {
-            xl.renderSheetAndWrite(getViewContext().getResponse());
+            xl.renderWorkbook(getViewContext().getResponse());
         }
         return null;
     }

--- a/assay/src/org/labkey/assay/actions/TemplateAction.java
+++ b/assay/src/org/labkey/assay/actions/TemplateAction.java
@@ -67,10 +67,8 @@ public class TemplateAction extends BaseAssayAction<ProtocolIdForm>
         ctx.setContainer(getContainer());
         ctx.setBaseFilter(filter);
 
-        try (ExcelWriter xl = new ExcelWriter(()->dr.getResults(ctx), dr.getDisplayColumns(), ExcelWriter.ExcelDocumentType.xlsx))
-        {
-            xl.renderWorkbook(getViewContext().getResponse());
-        }
+        ExcelWriter xl = new ExcelWriter(()->dr.getResults(ctx), dr.getDisplayColumns(), ExcelWriter.ExcelDocumentType.xlsx);
+        xl.renderWorkbook(getViewContext().getResponse());
         return null;
     }
 

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -1078,7 +1078,7 @@ public class SecurityController extends SpringActionController
                 ew.setAutoSize(true);
                 ew.setSheetName(group + " Members");
                 ew.setFooter(group + " Members");
-                ew.renderSheetAndWrite(response);
+                ew.renderWorkbook(response);
             }
         }
     }

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -1058,28 +1058,26 @@ public class SecurityController extends SpringActionController
                 filter.addCondition(FieldKey.fromParts("Active"), true);
             ctx.setBaseFilter(filter);
             rgn.prepareDisplayColumns(c);
-            try (ExcelWriter ew = new ExcelWriter(()->rgn.getResults(ctx), rgn.getDisplayColumns())
-                {
-                    @Override
-                    public void renderGrid(RenderContext ctx, Sheet sheet, List<ExcelColumn> visibleColumns) throws MaxRowsExceededException, SQLException, IOException
-                    {
-                        for (Pair<Integer, String> memberGroup : memberGroups)
-                        {
-                            Map<String, Object> row = new CaseInsensitiveHashMap<>();
-                            row.put("displayName", memberGroup.getValue());
-                            row.put("userId", memberGroup.getKey());
-                            ctx.setRow(row);
-                            renderGridRow(sheet, ctx, visibleColumns);
-                        }
-                        super.renderGrid(ctx, sheet, visibleColumns);
-                    }
-                })
+            ExcelWriter ew = new ExcelWriter(()->rgn.getResults(ctx), rgn.getDisplayColumns())
             {
-                ew.setAutoSize(true);
-                ew.setSheetName(group + " Members");
-                ew.setFooter(group + " Members");
-                ew.renderWorkbook(response);
-            }
+                @Override
+                public void renderGrid(RenderContext ctx, Sheet sheet, List<ExcelColumn> visibleColumns) throws MaxRowsExceededException, SQLException, IOException
+                {
+                    for (Pair<Integer, String> memberGroup : memberGroups)
+                    {
+                        Map<String, Object> row = new CaseInsensitiveHashMap<>();
+                        row.put("displayName", memberGroup.getValue());
+                        row.put("userId", memberGroup.getKey());
+                        ctx.setRow(row);
+                        renderGridRow(sheet, ctx, visibleColumns);
+                    }
+                    super.renderGrid(ctx, sheet, visibleColumns);
+                }
+            };
+            ew.setAutoSize(true);
+            ew.setSheetName(group + " Members");
+            ew.setFooter(group + " Members");
+            ew.renderWorkbook(response);
         }
     }
 

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -1083,7 +1083,6 @@ public class SecurityController extends SpringActionController
         }
     }
 
-
     @RequiresPermission(AdminPermission.class)
     public class GroupPermissionAction extends SimpleViewAction<GroupAccessForm>
     {

--- a/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
@@ -949,10 +949,9 @@ public class ExpDataTableImpl extends ExpRunItemTableImpl<ExpDataTable.Column> i
                 assertEquals("Incorrect WebDavUrlRelative", tc.getUrlRelative(), webDavUrlRelative);
                 assertEquals("Incorrect WebDavUrl", tc.getUrl(), webDavUrl);
 
-                try (ExcelWriter excel = view.getExcelWriter(ExcelWriter.ExcelDocumentType.xlsx))
+                ExcelWriter excel = view.getExcelWriter(ExcelWriter.ExcelDocumentType.xlsx);
+                try (VirtualFile f = new MemoryVirtualFile())
                 {
-                    VirtualFile f = new MemoryVirtualFile();
-
                     try (OutputStream os = f.getOutputStream("excel.xlsx"))
                     {
                         excel.renderWorkbook(os);

--- a/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
@@ -955,7 +955,7 @@ public class ExpDataTableImpl extends ExpRunItemTableImpl<ExpDataTable.Column> i
 
                     try (OutputStream os = f.getOutputStream("excel.xlsx"))
                     {
-                        excel.renderSheetAndWrite(os);
+                        excel.renderWorkbook(os);
                     }
 
                     try (ExcelLoader loader = new ExcelLoader(f.getInputStream("excel.xlsx"), true, getProject()))

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1847,7 +1847,7 @@ public class QueryController extends SpringActionController
 
         public void setIncludeColumn(FieldKey[] includeColumn)
         {
-            includeColumn = includeColumn;
+            this.includeColumn = includeColumn;
         }
 
         public String getFilenamePrefix()
@@ -1867,7 +1867,7 @@ public class QueryController extends SpringActionController
 
         public void setFileType(String fileType)
         {
-            fileType = fileType;
+            this.fileType = fileType;
         }
     }
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1786,10 +1786,10 @@ public class QueryController extends SpringActionController
 
                     QueryView qv = qf.getQueryView();
                     qv.exportToExcelSheet(writer,
-                            new QueryView.ExcelExportConfig(response, qf.getHeaderType())
-                                .setExcludeColumns(qf.getExcludeColumns())
-                                .setRenamedColumns(qf.getRenameColumnMap()),
-                            qf.getSheetName()
+                        new QueryView.ExcelExportConfig(response, qf.getHeaderType())
+                            .setExcludeColumns(qf.getExcludeColumns())
+                            .setRenamedColumns(qf.getRenameColumnMap()),
+                        qf.getSheetName()
                     );
                 }
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1692,7 +1692,7 @@ public class QueryController extends SpringActionController
 
         public String getFilename()
         {
-            return this.filename;
+            return filename;
         }
 
         public void setQueryForms(List<ExportQueryForm> queryForms)
@@ -1702,7 +1702,7 @@ public class QueryController extends SpringActionController
 
         public List<ExportQueryForm> getQueryForms()
         {
-            return this.queryForms;
+            return queryForms;
         }
 
         /**
@@ -1751,7 +1751,7 @@ public class QueryController extends SpringActionController
             for (JSONObject queryModel : models.toJSONObjectArray())
             {
                 ExportQueryForm qf = new ExportQueryForm();
-                qf.setViewContext(this.getViewContext());
+                qf.setViewContext(getViewContext());
 
                 qf.bindParameters(getPropertyValues(queryModel));
                 forms.add(qf);
@@ -1775,10 +1775,9 @@ public class QueryController extends SpringActionController
             HttpServletResponse response = getViewContext().getResponse();
             response.setHeader("X-Robots-Tag", "noindex");
             response.setHeader("Content-Disposition", "attachment");
-
             ViewContext viewContext = getViewContext();
 
-            try (ExcelWriter writer = new ExcelWriter(ExcelWriter.ExcelDocumentType.xlsx){
+            try (ExcelWriter writer = new ExcelWriter(ExcelWriter.ExcelDocumentType.xlsx) {
                 @Override
                 protected void renderSheets(Workbook workbook)
                 {
@@ -1788,12 +1787,17 @@ public class QueryController extends SpringActionController
                         qf.getSchema();
 
                         QueryView qv = qf.getQueryView();
-                        qv.exportToExcelSheet(this, workbook,
-                            new QueryView.ExcelExportConfig(response, qf.getHeaderType())
-                                .setExcludeColumns(qf.getExcludeColumns())
-                                .setRenamedColumns(qf.getRenameColumnMap()),
-                            qf.getSheetName()
-                        );
+                        QueryView.ExcelExportConfig config = new QueryView.ExcelExportConfig(response, qf.getHeaderType())
+                            .setExcludeColumns(qf.getExcludeColumns())
+                            .setRenamedColumns(qf.getRenameColumnMap());
+                        String sheetName = qf.getSheetName();
+                        qv.configureExcelWriter(this, config);
+                        String name = StringUtils.isNotBlank(sheetName)? sheetName : qv.getQueryDef().getName();
+                        name = StringUtils.isNotBlank(name)? name : StringUtils.isNotBlank(qv.getDataRegionName()) ? qv.getDataRegionName() : "Data";
+                        setSheetName(name);
+                        setAutoSize(true);
+                        renderNewSheet(workbook);
+                        qv.logAuditEvent("Exported to Excel", getDataRowCount());
                     }
 
                     workbook.setActiveSheet(0);
@@ -1840,12 +1844,12 @@ public class QueryController extends SpringActionController
 
         public FieldKey[] getIncludeColumn()
         {
-            return this.includeColumn;
+            return includeColumn;
         }
 
         public void setIncludeColumn(FieldKey[] includeColumn)
         {
-            this.includeColumn = includeColumn;
+            includeColumn = includeColumn;
         }
 
         public String getFilenamePrefix()
@@ -1855,7 +1859,7 @@ public class QueryController extends SpringActionController
 
         public void setFilenamePrefix(String prefix)
         {
-            this.filenamePrefix = prefix;
+            filenamePrefix = prefix;
         }
 
         public String getFileType()
@@ -1865,7 +1869,7 @@ public class QueryController extends SpringActionController
 
         public void setFileType(String fileType)
         {
-            this.fileType = fileType;
+            fileType = fileType;
         }
     }
 
@@ -1951,7 +1955,7 @@ public class QueryController extends SpringActionController
 
         public String getSheetName()
         {
-            return this.sheetName;
+            return sheetName;
         }
 
         public ColumnHeaderType getHeaderType()
@@ -2449,7 +2453,6 @@ public class QueryController extends SpringActionController
         {
             this.newName = newName;
         }
-
     }
 
     @RequiresPermission(ReadPermission.class)
@@ -5493,7 +5496,6 @@ public class QueryController extends SpringActionController
         {
             this.replace = replace;
         }
-
     }
 
     // Moves a session view into the database.
@@ -5992,7 +5994,6 @@ public class QueryController extends SpringActionController
         {
             this.validateIds = validateIds;
         }
-
     }
 
     @RequiresPermission(ReadPermission.class)
@@ -7383,7 +7384,7 @@ public class QueryController extends SpringActionController
         @Override
         protected ObjectMapper createResponseObjectMapper()
         {
-            return this.createRequestObjectMapper();
+            return createRequestObjectMapper();
         }
 
         @Override
@@ -7417,7 +7418,7 @@ public class QueryController extends SpringActionController
         @Override
         protected ObjectMapper createResponseObjectMapper()
         {
-            return this.createRequestObjectMapper();
+            return createRequestObjectMapper();
         }
 
         @Override

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1777,7 +1777,7 @@ public class QueryController extends SpringActionController
             response.setHeader("Content-Disposition", "attachment");
             ViewContext viewContext = getViewContext();
 
-            try (ExcelWriter writer = new ExcelWriter(ExcelWriter.ExcelDocumentType.xlsx) {
+            ExcelWriter writer = new ExcelWriter(ExcelWriter.ExcelDocumentType.xlsx) {
                 @Override
                 protected void renderSheets(Workbook workbook)
                 {
@@ -1802,12 +1802,10 @@ public class QueryController extends SpringActionController
 
                     workbook.setActiveSheet(0);
                 }
-            })
-            {
-                writer.setFilenamePrefix(form.getFilename());
-                writer.renderWorkbook(response);
-                return null; //Returning anything here will cause error as excel writer will close the response stream
-            }
+            };
+            writer.setFilenamePrefix(form.getFilename());
+            writer.renderWorkbook(response);
+            return null; //Returning anything here will cause error as excel writer will close the response stream
         }
     }
 

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -2495,7 +2495,7 @@ public class ReportsController extends SpringActionController
                 if (report instanceof CrosstabReport)
                 {
                     ExcelWriter writer = ((CrosstabReport)report).getExcelWriter(getViewContext());
-                    writer.renderSheetAndWrite(getViewContext().getResponse());
+                    writer.renderWorkbook(getViewContext().getResponse());
                 }
             }
             return null;

--- a/specimen/src/org/labkey/specimen/actions/SpecimenController.java
+++ b/specimen/src/org/labkey/specimen/actions/SpecimenController.java
@@ -1127,9 +1127,11 @@ public class SpecimenController extends SpringActionController
             List<Map<String,Object>> defaultSpecimens = new ArrayList<>();
             SimpleSpecimenImporter importer = new SimpleSpecimenImporter(getContainer(), getUser(),
                     getStudyRedirectIfNull().getTimepointType(), StudyService.get().getSubjectNounSingular(getContainer()));
-            MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(defaultSpecimens, importer.getSimpleSpecimenColumns());
-            xlWriter.setColumnModifier(col -> col.setCaption(importer.label(col.getName())));
-            xlWriter.renderWorkbook(getViewContext().getResponse());
+            try (MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(defaultSpecimens, importer.getSimpleSpecimenColumns()))
+            {
+                xlWriter.setColumnModifier(col -> col.setCaption(importer.label(col.getName())));
+                xlWriter.renderWorkbook(getViewContext().getResponse());
+            }
 
             return null;
         }

--- a/specimen/src/org/labkey/specimen/actions/SpecimenController.java
+++ b/specimen/src/org/labkey/specimen/actions/SpecimenController.java
@@ -1131,7 +1131,7 @@ public class SpecimenController extends SpringActionController
             for (ExcelColumn col : xlWriter.getColumns())
                 col.setCaption(importer.label(col.getName()));
 
-            xlWriter.renderSheetAndWrite(getViewContext().getResponse());
+            xlWriter.renderWorkbook(getViewContext().getResponse());
 
             return null;
         }
@@ -5045,7 +5045,7 @@ public class SpecimenController extends SpringActionController
                 {
                     try (ExcelWriter writer = getSpecimenListXlsWriter(specimenRequest, sourceLocation, destLocation, type))
                     {
-                        writer.renderSheetAndWrite(getViewContext().getResponse());
+                        writer.renderWorkbook(getViewContext().getResponse());
                     }
                 }
             }
@@ -5198,7 +5198,7 @@ public class SpecimenController extends SpringActionController
                     {
                         try (ByteArrayOutputStream byteStream = new ByteArrayOutputStream(); OutputStream ostream = new BufferedOutputStream(byteStream); ExcelWriter xlsWriter = getSpecimenListXlsWriter(request, originatingOrProvidingLocation, receivingLocation, type))
                         {
-                            xlsWriter.renderSheetAndWrite(ostream);
+                            xlsWriter.renderWorkbook(ostream);
                             ostream.flush();
                             formFiles.add(new ByteArrayAttachmentFile(xlsWriter.getFilenamePrefix() + "." + xlsWriter.getDocumentType().name(), byteStream.toByteArray(), xlsWriter.getDocumentType().getMimeType()));
                         }

--- a/specimen/src/org/labkey/specimen/actions/SpecimenController.java
+++ b/specimen/src/org/labkey/specimen/actions/SpecimenController.java
@@ -1128,9 +1128,7 @@ public class SpecimenController extends SpringActionController
             SimpleSpecimenImporter importer = new SimpleSpecimenImporter(getContainer(), getUser(),
                     getStudyRedirectIfNull().getTimepointType(), StudyService.get().getSubjectNounSingular(getContainer()));
             MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(defaultSpecimens, importer.getSimpleSpecimenColumns());
-            for (ExcelColumn col : xlWriter.getColumns())
-                col.setCaption(importer.label(col.getName()));
-
+            xlWriter.setColumnModifier(col -> col.setCaption(importer.label(col.getName())));
             xlWriter.renderWorkbook(getViewContext().getResponse());
 
             return null;

--- a/specimen/src/org/labkey/specimen/actions/SpecimenController.java
+++ b/specimen/src/org/labkey/specimen/actions/SpecimenController.java
@@ -1129,6 +1129,8 @@ public class SpecimenController extends SpringActionController
                     getStudyRedirectIfNull().getTimepointType(), StudyService.get().getSubjectNounSingular(getContainer()));
             try (MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(defaultSpecimens, importer.getSimpleSpecimenColumns()))
             {
+                // Note: I don't think this is having any effect on the output because ExcelColumn.renderCaption() uses
+                // the DisplayColumn's caption, not its own caption. That seems wrong...
                 xlWriter.setColumnModifier(col -> col.setCaption(importer.label(col.getName())));
                 xlWriter.renderWorkbook(getViewContext().getResponse());
             }

--- a/specimen/src/org/labkey/specimen/actions/SpecimenController.java
+++ b/specimen/src/org/labkey/specimen/actions/SpecimenController.java
@@ -5199,7 +5199,6 @@ public class SpecimenController extends SpringActionController
                         try (ByteArrayOutputStream byteStream = new ByteArrayOutputStream(); OutputStream ostream = new BufferedOutputStream(byteStream); ExcelWriter xlsWriter = getSpecimenListXlsWriter(request, originatingOrProvidingLocation, receivingLocation, type))
                         {
                             xlsWriter.renderWorkbook(ostream);
-                            ostream.flush();
                             formFiles.add(new ByteArrayAttachmentFile(xlsWriter.getFilenamePrefix() + "." + xlsWriter.getDocumentType().name(), byteStream.toByteArray(), xlsWriter.getDocumentType().getMimeType()));
                         }
                     }

--- a/specimen/src/org/labkey/specimen/actions/SpecimenController.java
+++ b/specimen/src/org/labkey/specimen/actions/SpecimenController.java
@@ -1127,13 +1127,11 @@ public class SpecimenController extends SpringActionController
             List<Map<String,Object>> defaultSpecimens = new ArrayList<>();
             SimpleSpecimenImporter importer = new SimpleSpecimenImporter(getContainer(), getUser(),
                     getStudyRedirectIfNull().getTimepointType(), StudyService.get().getSubjectNounSingular(getContainer()));
-            try (MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(defaultSpecimens, importer.getSimpleSpecimenColumns()))
-            {
-                // Note: I don't think this is having any effect on the output because ExcelColumn.renderCaption() uses
-                // the DisplayColumn's caption, not its own caption. That seems wrong...
-                xlWriter.setColumnModifier(col -> col.setCaption(importer.label(col.getName())));
-                xlWriter.renderWorkbook(getViewContext().getResponse());
-            }
+            MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(defaultSpecimens, importer.getSimpleSpecimenColumns());
+            // Note: I don't think this is having any effect on the output because ExcelColumn.renderCaption() uses
+            // the DisplayColumn's caption, not its own caption. That seems wrong...
+            xlWriter.setColumnModifier(col -> col.setCaption(importer.label(col.getName())));
+            xlWriter.renderWorkbook(getViewContext().getResponse());
 
             return null;
         }
@@ -5045,10 +5043,8 @@ public class SpecimenController extends SpringActionController
                 }
                 else if (EXPORT_XLS.equals(form.getExport()))
                 {
-                    try (ExcelWriter writer = getSpecimenListXlsWriter(specimenRequest, sourceLocation, destLocation, type))
-                    {
-                        writer.renderWorkbook(getViewContext().getResponse());
-                    }
+                    ExcelWriter writer = getSpecimenListXlsWriter(specimenRequest, sourceLocation, destLocation, type);
+                    writer.renderWorkbook(getViewContext().getResponse());
                 }
             }
             return null;
@@ -5198,8 +5194,9 @@ public class SpecimenController extends SpringActionController
 
                     if (form.isSendXls())
                     {
-                        try (ByteArrayOutputStream byteStream = new ByteArrayOutputStream(); OutputStream ostream = new BufferedOutputStream(byteStream); ExcelWriter xlsWriter = getSpecimenListXlsWriter(request, originatingOrProvidingLocation, receivingLocation, type))
+                        try (ByteArrayOutputStream byteStream = new ByteArrayOutputStream(); OutputStream ostream = new BufferedOutputStream(byteStream))
                         {
+                            ExcelWriter xlsWriter = getSpecimenListXlsWriter(request, originatingOrProvidingLocation, receivingLocation, type);
                             xlsWriter.renderWorkbook(ostream);
                             formFiles.add(new ByteArrayAttachmentFile(xlsWriter.getFilenamePrefix() + "." + xlsWriter.getDocumentType().name(), byteStream.toByteArray(), xlsWriter.getDocumentType().getMimeType()));
                         }

--- a/specimen/src/org/labkey/specimen/report/SpecimenReportExcelWriter.java
+++ b/specimen/src/org/labkey/specimen/report/SpecimenReportExcelWriter.java
@@ -67,7 +67,7 @@ public class SpecimenReportExcelWriter
             settings.setArrayGrowSize(300000);
             workbook = Workbook.createWorkbook(ostream, settings);
 
-            for (SpecimenVisitReport report : _parameters.getReports())
+            for (SpecimenVisitReport<?> report : _parameters.getReports())
                 writeReport(workbook, report);
         }
         catch (WriteException | IOException e)

--- a/study/src/org/labkey/study/controllers/designer/DesignerController.java
+++ b/study/src/org/labkey/study/controllers/designer/DesignerController.java
@@ -421,6 +421,8 @@ public class DesignerController extends SpringActionController
             List<Map<String,Object>> defaultSpecimens = StudyDesignManager.get().generateSampleList(getStudyDefinition(form), getParticipants(), form.getBeginDate());
             try (MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(defaultSpecimens, importer.getSimpleSpecimenColumns()))
             {
+                // Note: I don't think this is having any effect on the output because ExcelColumn.renderCaption() uses
+                // the DisplayColumn's caption, not its own caption. That seems wrong...
                 xlWriter.setColumnModifier(col -> col.setCaption(importer.label(col.getName())));
                 xlWriter.renderWorkbook(response);
             }

--- a/study/src/org/labkey/study/controllers/designer/DesignerController.java
+++ b/study/src/org/labkey/study/controllers/designer/DesignerController.java
@@ -345,9 +345,12 @@ public class DesignerController extends SpringActionController
             xlCols[0] = new ColumnDescriptor("SubjectId", Integer.class);
             xlCols[1] = new ColumnDescriptor("Cohort", String.class);
             xlCols[2] = new ColumnDescriptor("StartDate", Date.class);
-            MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(participantGroup, xlCols);
-            xlWriter.setHeaders(Arrays.asList("#Update the SubjectId column of this spreadsheet to the identifiers used when sending a sample to labs", "#"));
-            xlWriter.renderWorkbook(response);
+
+            try (MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(participantGroup, xlCols))
+            {
+                xlWriter.setHeaders(Arrays.asList("#Update the SubjectId column of this spreadsheet to the identifiers used when sending a sample to labs", "#"));
+                xlWriter.renderWorkbook(response);
+            }
         }
     }
 

--- a/study/src/org/labkey/study/controllers/designer/DesignerController.java
+++ b/study/src/org/labkey/study/controllers/designer/DesignerController.java
@@ -346,11 +346,9 @@ public class DesignerController extends SpringActionController
             xlCols[1] = new ColumnDescriptor("Cohort", String.class);
             xlCols[2] = new ColumnDescriptor("StartDate", Date.class);
 
-            try (MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(participantGroup, xlCols))
-            {
-                xlWriter.setHeaders(Arrays.asList("#Update the SubjectId column of this spreadsheet to the identifiers used when sending a sample to labs", "#"));
-                xlWriter.renderWorkbook(response);
-            }
+            MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(participantGroup, xlCols);
+            xlWriter.setHeaders(Arrays.asList("#Update the SubjectId column of this spreadsheet to the identifiers used when sending a sample to labs", "#"));
+            xlWriter.renderWorkbook(response);
         }
     }
 
@@ -419,13 +417,11 @@ public class DesignerController extends SpringActionController
             //Search for a template in all folders up to root.
             SimpleSpecimenImporter importer = new SimpleSpecimenImporter(getContainer(), getUser(), TimepointType.DATE, "Subject");
             List<Map<String,Object>> defaultSpecimens = StudyDesignManager.get().generateSampleList(getStudyDefinition(form), getParticipants(), form.getBeginDate());
-            try (MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(defaultSpecimens, importer.getSimpleSpecimenColumns()))
-            {
-                // Note: I don't think this is having any effect on the output because ExcelColumn.renderCaption() uses
-                // the DisplayColumn's caption, not its own caption. That seems wrong...
-                xlWriter.setColumnModifier(col -> col.setCaption(importer.label(col.getName())));
-                xlWriter.renderWorkbook(response);
-            }
+            MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(defaultSpecimens, importer.getSimpleSpecimenColumns());
+            // Note: I don't think this is having any effect on the output because ExcelColumn.renderCaption() uses
+            // the DisplayColumn's caption, not its own caption. That seems wrong...
+            xlWriter.setColumnModifier(col -> col.setCaption(importer.label(col.getName())));
+            xlWriter.renderWorkbook(response);
         }
     }
 

--- a/study/src/org/labkey/study/controllers/designer/DesignerController.java
+++ b/study/src/org/labkey/study/controllers/designer/DesignerController.java
@@ -37,7 +37,6 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DataRegionSelection;
-import org.labkey.api.data.ExcelColumn;
 import org.labkey.api.gwt.server.BaseRemoteService;
 import org.labkey.api.portal.ProjectUrls;
 import org.labkey.api.reader.ColumnDescriptor;
@@ -417,13 +416,11 @@ public class DesignerController extends SpringActionController
             //Search for a template in all folders up to root.
             SimpleSpecimenImporter importer = new SimpleSpecimenImporter(getContainer(), getUser(), TimepointType.DATE, "Subject");
             List<Map<String,Object>> defaultSpecimens = StudyDesignManager.get().generateSampleList(getStudyDefinition(form), getParticipants(), form.getBeginDate());
-            MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(defaultSpecimens, importer.getSimpleSpecimenColumns());
-            for (ExcelColumn col : xlWriter.getColumns())
+            try (MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(defaultSpecimens, importer.getSimpleSpecimenColumns()))
             {
-                col.setCaption(importer.label(col.getName()));
+                xlWriter.setColumnModifier(col -> col.setCaption(importer.label(col.getName())));
+                xlWriter.renderWorkbook(response);
             }
-
-            xlWriter.renderWorkbook(response);
         }
     }
 

--- a/study/src/org/labkey/study/controllers/designer/DesignerController.java
+++ b/study/src/org/labkey/study/controllers/designer/DesignerController.java
@@ -348,7 +348,7 @@ public class DesignerController extends SpringActionController
             xlCols[2] = new ColumnDescriptor("StartDate", Date.class);
             MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(participantGroup, xlCols);
             xlWriter.setHeaders(Arrays.asList("#Update the SubjectId column of this spreadsheet to the identifiers used when sending a sample to labs", "#"));
-            xlWriter.renderSheetAndWrite(response);
+            xlWriter.renderWorkbook(response);
         }
     }
 
@@ -423,7 +423,7 @@ public class DesignerController extends SpringActionController
                 col.setCaption(importer.label(col.getName()));
             }
 
-            xlWriter.renderSheetAndWrite(response);
+            xlWriter.renderWorkbook(response);
         }
     }
 

--- a/study/src/org/labkey/study/controllers/reports/ReportsController.java
+++ b/study/src/org/labkey/study/controllers/reports/ReportsController.java
@@ -1649,7 +1649,7 @@ public class ReportsController extends BaseStudyController
 
                         MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(rows, cols.toArray(new ColumnDescriptor[cols.size()]));
                         xlWriter.setHeaders(Arrays.asList("#Progress Report for Assay: " + assayData.get("name"), "#"));
-                        xlWriter.renderSheetAndWrite(response);
+                        xlWriter.renderWorkbook(response);
                     }
                 }
             }

--- a/study/src/org/labkey/study/controllers/reports/ReportsController.java
+++ b/study/src/org/labkey/study/controllers/reports/ReportsController.java
@@ -1647,11 +1647,9 @@ public class ReportsController extends BaseStudyController
                             rows.add(row);
                         }
 
-                        try (MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(rows, cols.toArray(new ColumnDescriptor[cols.size()])))
-                        {
-                            xlWriter.setHeaders(Arrays.asList("#Progress Report for Assay: " + assayData.get("name"), "#"));
-                            xlWriter.renderWorkbook(response);
-                        }
+                        MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(rows, cols.toArray(new ColumnDescriptor[cols.size()]));
+                        xlWriter.setHeaders(Arrays.asList("#Progress Report for Assay: " + assayData.get("name"), "#"));
+                        xlWriter.renderWorkbook(response);
                     }
                 }
             }

--- a/study/src/org/labkey/study/controllers/reports/ReportsController.java
+++ b/study/src/org/labkey/study/controllers/reports/ReportsController.java
@@ -1647,9 +1647,11 @@ public class ReportsController extends BaseStudyController
                             rows.add(row);
                         }
 
-                        MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(rows, cols.toArray(new ColumnDescriptor[cols.size()]));
-                        xlWriter.setHeaders(Arrays.asList("#Progress Report for Assay: " + assayData.get("name"), "#"));
-                        xlWriter.renderWorkbook(response);
+                        try (MapArrayExcelWriter xlWriter = new MapArrayExcelWriter(rows, cols.toArray(new ColumnDescriptor[cols.size()])))
+                        {
+                            xlWriter.setHeaders(Arrays.asList("#Progress Report for Assay: " + assayData.get("name"), "#"));
+                            xlWriter.renderWorkbook(response);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
#### Rationale
We aren't closing `Workbook` instances and we aren't calling `SXSSFWorkbook.dispose()`. We're getting what we deserve.

#### Changes
* Refactor `ExcelWriter` for the jillionth time. Now, `renderWorkbook()` is the key method that all callers invoke. Privatize, protectorize, or eliminate all other render methods. Code paths that need special handling (multiple sheets, special workbook settings) can subclass and override `renderSheets()`. This enables us to create the Workbook in a try-with-resources to ensure resources are closed in all scenarios.
