### PR TITLE
Workflow job creation and update with custom fields

### DIFF
--- a/api/src/org/labkey/api/exp/query/ExpTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpTable.java
@@ -83,6 +83,8 @@ public interface ExpTable<C extends Enum> extends ContainerFilterable, TableInfo
      */
     MutableColumnInfo addColumns(Domain domain, @Nullable String legacyName);
 
+    void setTitle(String title);
+
     void setDescription(String description);
 
     void setDomain(Domain domain);

--- a/internal/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/internal/src/org/labkey/api/exp/property/DomainUtil.java
@@ -336,15 +336,23 @@ public class DomainUtil
 
     public static GWTPropertyDescriptor getPropertyDescriptor(PropertyDescriptor prop)
     {
+        return getPropertyDescriptor(prop, false);
+    }
+
+    public static GWTPropertyDescriptor getPropertyDescriptor(PropertyDescriptor prop, boolean copy)
+    {
         GWTPropertyDescriptor gwtProp = new GWTPropertyDescriptor();
 
-        gwtProp.setPropertyId(prop.getPropertyId());
+        if (!copy)
+        {
+            gwtProp.setPropertyId(prop.getPropertyId());
+            gwtProp.setPropertyURI(prop.getPropertyURI());
+        }
         gwtProp.setDescription(prop.getDescription());
         gwtProp.setFormat(prop.getFormat());
         gwtProp.setLabel(prop.getLabel());
         gwtProp.setConceptURI(prop.getConceptURI());
         gwtProp.setName(prop.getName());
-        gwtProp.setPropertyURI(prop.getPropertyURI());
         gwtProp.setContainer(prop.getContainer().getId());
         gwtProp.setRangeURI(prop.getPropertyType() != null ? prop.getPropertyType().getTypeUri() : prop.getRangeURI());
         gwtProp.setRequired(prop.isRequired());
@@ -380,10 +388,11 @@ public class DomainUtil
             GWTPropertyValidator gpv = new GWTPropertyValidator();
             Lsid lsid = new Lsid(pv.getTypeURI());
 
+            if (!copy)
+                gpv.setRowId(pv.getRowId());
             gpv.setName(pv.getName());
             gpv.setDescription(pv.getDescription());
             gpv.setExpression(pv.getExpressionValue());
-            gpv.setRowId(pv.getRowId());
             gpv.setType(PropertyValidatorType.getType(lsid.getObjectId()));
             gpv.setErrorMessage(pv.getErrorMessage());
 


### PR DESCRIPTION
#### Rationale
As part of the epic to allow for custom fields for workflow jobs, we previously added the ability for an admin to define fields for a job template. This story expands on that so that if you create a job with a template that has custom fields defined, those fields show as form inputs on the job creation page, show the field key/value pairs on the job overview page, and allow the user to update those field values for an active job.

This PR adds a prop to the DomainUtil.getPropertyDescriptor() to make it easier to copy a property (used in this story for the "Save as template" option in job creation).

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/930
* https://github.com/LabKey/platform/pull/3597
* https://github.com/LabKey/sampleManagement/pull/1159
* https://github.com/LabKey/biologics/pull/1507
* https://github.com/LabKey/inventory/pull/515

#### Changes
* DomainUtil.getPropertyDescriptor with prop for copy
