### PR TITLE
Issue 46056: Folder disappears when import is canceled after transform script warning

### DIFF
--- a/api/src/org/labkey/api/assay/PipelineDataCollector.java
+++ b/api/src/org/labkey/api/assay/PipelineDataCollector.java
@@ -159,6 +159,16 @@ public class PipelineDataCollector<ContextType extends AssayRunUploadContext<? e
         return result;
     }
 
+    public static synchronized void clearFileQueue(HttpSession session, Container c, ExpProtocol protocol)
+    {
+        Map<Pair<Container, Integer>, List<Map<String, File>>> collections = (Map<Pair<Container, Integer>, List<Map<String, File>>>) session.getAttribute(PipelineDataCollector.class.getName());
+        if (collections == null)
+            return;
+
+        Pair<Container, Integer> key = new Pair<>(c, protocol.getRowId());
+        collections.remove(key);
+    }
+
     @Override
     @NotNull
     public Map<String, File> createData(ContextType context) throws IOException, ExperimentException


### PR DESCRIPTION
#### Rationale
[issue link](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46056)

We want to modify the behavior so canceling out of transform warning would only delete the working directory if starting from new upload.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Only delete temp folder when canceling out of transform warning
* Clear session file queue for protocol when canceling out of transform warning
