### PR TITLE
Issue 46086: Add manual export/import of metrics

### DIFF
--- a/api/src/org/labkey/api/action/BaseApiAction.java
+++ b/api/src/org/labkey/api/action/BaseApiAction.java
@@ -513,9 +513,9 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
         }
     }
 
-    private static class JsonPropertyValues extends MutablePropertyValues
+    public static class JsonPropertyValues extends MutablePropertyValues
     {
-        private JsonPropertyValues(JSONObject jsonObj) throws JSONException
+        public JsonPropertyValues(JSONObject jsonObj) throws JSONException
         {
             addPropertyValues(jsonObj);
         }

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -9853,6 +9853,10 @@ public class AdminController extends SpringActionController
                         params.put("upgradeMessage", report.getContent());
                 }
             }
+            if (form.isDownload())
+            {
+                getViewContext().getResponse().setHeader("Content-disposition", "attachment; filename=\"metrics.json\"");
+            }
             return new ApiSimpleResponse(params);
         }
     }
@@ -9863,6 +9867,7 @@ public class AdminController extends SpringActionController
         private String _type = MothershipReport.Type.CheckForUpdates.toString();
         private String _level = UsageReportingLevel.ON.toString();
         private boolean _submit = false;
+        private boolean _download = false;
         private String _forwardedFor = null;
         // indicates action is being invoked for dev/test
         private boolean _testMode = false;
@@ -9915,6 +9920,16 @@ public class AdminController extends SpringActionController
         public void setTestMode(boolean testMode)
         {
             _testMode = testMode;
+        }
+
+        public boolean isDownload()
+        {
+            return _download;
+        }
+
+        public void setDownload(boolean download)
+        {
+            _download = download;
         }
     }
 

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -68,18 +68,27 @@ var enableTestButton = function(el, level) {
     }
 };
 
-var testUsageReport = function() {
-    testMothershipReport('CheckForUpdates', '<%=UsageReportingLevel.ON%>');
+var testUsageReport = function(download) {
+    testMothershipReport('CheckForUpdates', '<%=UsageReportingLevel.ON%>', download);
 };
 
-var testExceptionReport = function() {
+var testExceptionReport = function(download) {
     var level = document.querySelector('input[name="exceptionReportingLevel"]:checked').value;
-    testMothershipReport('ReportException', level);
+    testMothershipReport('ReportException', level, download);
 };
 
-var testMothershipReport = function (type, level) {
-    var url = LABKEY.ActionURL.buildURL("admin", "testMothershipReport", null, { type: type, level: level });
-    window.open(url, '_blank', 'noopener noreferrer');
+var testMothershipReport = function (type, level, download) {
+    var params = { type: type, level: level };
+    if (download) {
+        params.download = true;
+    }
+    var url = LABKEY.ActionURL.buildURL("admin", "testMothershipReport", null, params);
+    if (download) {
+        window.location = url;
+    }
+    else {
+        window.open(url, '_blank', 'noopener noreferrer');
+    }
 };
 </script>
 
@@ -162,7 +171,7 @@ Click the Save button at any time to accept the current settings and continue.</
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
-    <td class="labkey-form-label" valign="top">Check for updates and report usage statistics to the LabKey team.<br>
+    <td class="labkey-form-label" style="vertical-align: top">Check for updates and report usage statistics to the LabKey team.<br>
         LabKey uses this data to prioritize LabKey Server enhancements. Turn this on to ensure the
         features you use are maintained and improved over time.<br>All data is transmitted securely over HTTPS.
     </td>
@@ -186,8 +195,10 @@ Click the Save button at any time to accept the current settings and continue.</
                 </td>
             </tr>
             <tr>
-                <td style="padding: 5px 0 5px;" colspan="2"><%=button("View").id("testUsageReport").onClick("testUsageReport(); return false;")%>
-                    Display an example usage report. <strong>No data will be submitted.</strong></td>
+                <td style="padding: 5px 0 5px;" colspan="2">
+                            <%=button("View").id("testUsageReport").onClick("testUsageReport(false); return false;")%>
+                            <%=button("Download").id("testUsageReportDownload").onClick("testUsageReport(true); return false;")%>
+                    Generate an example usage report. <strong>No data will be submitted.</strong></td>
             </tr>
         </table>
     </td>
@@ -200,7 +211,7 @@ Click the Save button at any time to accept the current settings and continue.</
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
-    <td class="labkey-form-label" valign="top">Report exceptions to the LabKey team who will use this information to identify and fix product issues encountered on your deployment.<br>All data is transmitted securely over HTTPS.</td>
+    <td class="labkey-form-label" style="vertical-align: top">Report exceptions to the LabKey team who will use this information to identify and fix product issues encountered on your deployment.<br>All data is transmitted securely over HTTPS.</td>
     <td>
         <table>
             <tr>
@@ -236,8 +247,10 @@ Click the Save button at any time to accept the current settings and continue.</
                 </td>
             </tr>
             <tr >
-                <td style="padding: 5px 0 5px;" colspan="2"><%=button("View").id("testExceptionReport").onClick("testExceptionReport(); return false;").enabled(appProps.getExceptionReportingLevel() != NONE)%>
-                    Display an example report for the selected level. <strong>No data will be submitted.</strong></td>
+                <td style="padding: 5px 0 5px;" colspan="2">
+                    <%=button("View").id("testExceptionReport").onClick("testExceptionReport(false); return false;").enabled(appProps.getExceptionReportingLevel() != NONE)%>
+                    <%=button("Download").id("testExceptionReportDownload").onClick("testExceptionReport(true); return false;").enabled(appProps.getExceptionReportingLevel() != NONE)%>
+                    Generate an example report for the selected level. <strong>No data will be submitted.</strong></td>
             </tr>
         </table>
     </td>

--- a/mothership/resources/schemas/mothership.xml
+++ b/mothership/resources/schemas/mothership.xml
@@ -82,6 +82,7 @@
             </column>
             <column columnName="Note">
                 <inputLength>80</inputLength>
+                <inputRows>3</inputRows>
             </column>
             <column columnName="Container"/>
             <column columnName="SystemDescription">
@@ -106,7 +107,6 @@
             <column columnName="ServerHostName">
                 <inputLength>60</inputLength>
                 <scale>255</scale>
-                <isReadOnly>true</isReadOnly>
             </column>
             <column columnName="UsedInstaller"/>
             <column columnName="IgnoreExceptions"/>

--- a/mothership/src/org/labkey/mothership/view/linkBar.jsp
+++ b/mothership/src/org/labkey/mothership/view/linkBar.jsp
@@ -21,6 +21,7 @@
 <%@ page import="org.labkey.api.query.FieldKey" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.mothership.MothershipController" %>
+<%@ page import="org.labkey.api.security.permissions.AdminPermission" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
@@ -31,6 +32,9 @@
     <%= link("View All Installations", new ActionURL(MothershipController.ShowInstallationsAction.class, c)) %>
     <%= link("Configure Mothership", new ActionURL(MothershipController.EditUpgradeMessageAction.class, c)) %>
     <%= link("List of Releases", new ActionURL(MothershipController.ShowReleasesAction.class, c)) %>
+    <% if (getContainer().hasPermission(getUser(), AdminPermission.class)) { %>
+    <%= link("Manual Metric Import", new ActionURL(MothershipController.ManualMetricImportAction.class, c)) %>
+    <%}%>
     <% if (getUser() != null && !getUser().isGuest()) {
             ActionURL myExceptions = new ActionURL(MothershipController.ShowExceptionsAction.class, c);
             myExceptions.addFilter("ExceptionSummary", FieldKey.fromParts("BugNumber"), CompareType.ISBLANK, null);

--- a/mothership/test/src/org/labkey/test/pages/mothership/ShowInstallationDetailPage.java
+++ b/mothership/test/src/org/labkey/test/pages/mothership/ShowInstallationDetailPage.java
@@ -15,8 +15,7 @@
  */
 package org.labkey.test.pages.mothership;
 
-import org.apache.commons.lang3.text.WordUtils;
-import org.labkey.test.LabKeySiteWrapper;
+import org.apache.commons.text.WordUtils;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
@@ -56,13 +55,13 @@ public class ShowInstallationDetailPage extends LabKeyPage<ShowInstallationDetai
 
     public String getServerHostName()
     {
-        return getInstallationValue("Server Host Name");
+        return Locator.input("serverHostName").findElement(getDriver()).getAttribute("value");
     }
 
     public String getInstallationValue(String labelText)
     {
         return Locator.tagWithClassContaining("td", "lk-form-label")
-                .withText(WordUtils.capitalize(labelText))  // TODO: WordUtils is deprecated in Commons Lang 3.6; this class is now maintained in Commons Text
+                .withText(WordUtils.capitalize(labelText))
                 .followingSibling("td")
                 .findElement(getDriver()).getText();
     }


### PR DESCRIPTION
#### Rationale
Not all installations are doing automated metric reporting

#### Changes
* Easy export of metric data to a JSON file via Admin Console->Site Settings
* New import form for admins that parses the JSON and treats like an automated submission