### PR TITLE
Fix NPE in `DeleteForm.getIds`

### DIFF
--- a/internal/src/org/labkey/api/exp/form/DeleteForm.java
+++ b/internal/src/org/labkey/api/exp/form/DeleteForm.java
@@ -18,7 +18,6 @@ package org.labkey.api.exp.form;
 import org.labkey.api.assay.actions.ProtocolIdForm;
 import org.labkey.api.data.DataRegionSelection;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -41,12 +40,10 @@ public class DeleteForm extends ProtocolIdForm implements DataRegionSelection.Da
         {
             return singleton(_singleObjectRowId);
         }
-        else if (_dataRegionSelectionKey != null)
-            return DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
         else if (_rowIds != null)
             return new HashSet<>(_rowIds);
         else
-            return Collections.emptySet();
+            return DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
     }
 
     public Integer getSingleObjectRowId()

--- a/internal/src/org/labkey/api/exp/form/DeleteForm.java
+++ b/internal/src/org/labkey/api/exp/form/DeleteForm.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.exp.form;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.actions.ProtocolIdForm;
 import org.labkey.api.data.DataRegionSelection;
 
@@ -35,16 +36,15 @@ public class DeleteForm extends ProtocolIdForm implements DataRegionSelection.Da
     private Integer _singleObjectRowId;
     private List<Integer> _rowIds;
 
+    @NotNull
     public Set<Integer> getIds(boolean clear)
     {
-        if (_singleObjectRowId != null)
-        {
-            return singleton(_singleObjectRowId);
-        }
-        else if (_dataRegionSelectionKey != null)
+        if (getSingleObjectRowId() != null)
+            return singleton(getSingleObjectRowId());
+        else if (getDataRegionSelectionKey() != null)
             return DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
-        else if (_rowIds != null)
-            return new HashSet<>(_rowIds);
+        else if (getRowIds() != null)
+            return new HashSet<>(getRowIds());
         else
             return Collections.emptySet();
     }

--- a/internal/src/org/labkey/api/exp/form/DeleteForm.java
+++ b/internal/src/org/labkey/api/exp/form/DeleteForm.java
@@ -18,6 +18,7 @@ package org.labkey.api.exp.form;
 import org.labkey.api.assay.actions.ProtocolIdForm;
 import org.labkey.api.data.DataRegionSelection;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -40,10 +41,12 @@ public class DeleteForm extends ProtocolIdForm implements DataRegionSelection.Da
         {
             return singleton(_singleObjectRowId);
         }
+        else if (_dataRegionSelectionKey != null)
+            return DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
         else if (_rowIds != null)
             return new HashSet<>(_rowIds);
         else
-            return DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
+            return Collections.emptySet();
     }
 
     public Integer getSingleObjectRowId()

--- a/internal/src/org/labkey/api/exp/form/DeleteForm.java
+++ b/internal/src/org/labkey/api/exp/form/DeleteForm.java
@@ -18,6 +18,7 @@ package org.labkey.api.exp.form;
 import org.labkey.api.assay.actions.ProtocolIdForm;
 import org.labkey.api.data.DataRegionSelection;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -42,8 +43,10 @@ public class DeleteForm extends ProtocolIdForm implements DataRegionSelection.Da
         }
         else if (_dataRegionSelectionKey != null)
             return DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
-        else
+        else if (_rowIds != null)
             return new HashSet<>(_rowIds);
+        else
+            return Collections.emptySet();
     }
 
     public Integer getSingleObjectRowId()


### PR DESCRIPTION
#### Rationale
The crawler hit an NPE on `experiment-deleteProtocolByRowIds`
```
java.lang.NullPointerException: Cannot invoke "java.util.Collection.size()" because "c" is null
	at java.util.HashSet.<init>(HashSet.java:120) ~[?:?]
	at org.labkey.api.exp.form.DeleteForm.getIds(DeleteForm.java:46) ~[internal-22.9-SNAPSHOT.jar:?]
	at org.labkey.experiment.controllers.exp.ExperimentController$DeleteProtocolByRowIdsAction.getView(ExperimentController.java:3341) ~[experiment-22.9-SNAPSHOT.jar:?]
	at org.labkey.experiment.controllers.exp.ExperimentController$DeleteProtocolByRowIdsAction.getView(ExperimentController.java:3327) ~[experiment-22.9-SNAPSHOT.jar:?]
```

#### Related Pull Requests
* #3589 

#### Changes
* Add null check to `DeleteForm.getIds`
