### PR TITLE
Always capture thread name for connection leak logging

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1002,7 +1002,7 @@ public class DbScope
 
             if (_transaction.isEmpty())
             {
-                log.info("There are no threads holding connections for the data source '" + this + "'");
+                log.info("There are no threads holding transactions for the data source '" + this + "'");
             }
             else
             {

--- a/api/src/org/labkey/api/data/ResultSetImpl.java
+++ b/api/src/org/labkey/api/data/ResultSetImpl.java
@@ -51,7 +51,7 @@ public class ResultSetImpl extends LoggingResultSetWrapper implements TableResul
     protected int _size;
 
     // for resource tracking
-    private StackTraceElement[] _debugCreated;
+    private final StackTraceElement[] _debugCreated;
     protected boolean _wasClosed = false;
 
 

--- a/api/src/org/labkey/api/formSchema/FormSchema.java
+++ b/api/src/org/labkey/api/formSchema/FormSchema.java
@@ -24,14 +24,14 @@ import java.util.List;
  */
 public class FormSchema
 {
-    private final List<Field> _fields; // The fields to render on the client
+    private final List<Field<?>> _fields; // The fields to render on the client
 
-    public FormSchema (List<Field> fields)
+    public FormSchema (List<Field<?>> fields)
     {
         _fields = fields;
     }
 
-    public List<Field> getFields()
+    public List<Field<?>> getFields()
     {
         return _fields;
     }

--- a/api/src/org/labkey/api/pipeline/file/FileAnalysisTaskPipelineSettings.java
+++ b/api/src/org/labkey/api/pipeline/file/FileAnalysisTaskPipelineSettings.java
@@ -102,14 +102,14 @@ public class FileAnalysisTaskPipelineSettings extends TaskPipelineSettings
     /**
      * The custom fields to render when configuring a FileAnalysisTaskPipeline
      */
-    private List<Field> _customFields;
+    private List<Field<?>> _customFields;
 
     public FileAnalysisTaskPipelineSettings(String name)
     {
         super(FileAnalysisTaskPipeline.class, name);
     }
 
-    public FileAnalysisTaskPipelineSettings(Class namespaceClass, String name)
+    public FileAnalysisTaskPipelineSettings(Class<?> namespaceClass, String name)
     {
         super(namespaceClass, name);
     }
@@ -246,12 +246,12 @@ public class FileAnalysisTaskPipelineSettings extends TaskPipelineSettings
         _moveAvailable = moveAvailable;
     }
 
-    public List<Field> getCustomFields()
+    public List<Field<?>> getCustomFields()
     {
         return _customFields;
     }
 
-    public void setCustomFields(List<Field> customFields)
+    public void setCustomFields(List<Field<?>> customFields)
     {
         _customFields = customFields;
     }

--- a/pipeline/src/org/labkey/pipeline/analysis/FileAnalysisTaskPipelineImpl.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/FileAnalysisTaskPipelineImpl.java
@@ -156,10 +156,11 @@ public class FileAnalysisTaskPipelineImpl extends TaskPipelineImpl<FileAnalysisT
                 _initialFileTypesFromTask = false;
                 _initialFileTypes = inputFilterExts;
             }
-            else if (_initialFileTypesFromTask)
+            else if (_initialFileTypesFromTask || getInitialFileTypes() == null)
             {
+                _initialFileTypesFromTask = true;
                 TaskId tid = getTaskProgression()[0];
-                TaskFactory<?> factory = PipelineJobService.get().getTaskFactory(tid);
+                TaskFactory factory = PipelineJobService.get().getTaskFactory(tid);
                 _initialFileTypes = factory.getInputTypes();
             }
 

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -101,7 +101,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
 {
     public static final String MODULE_PIPELINE_DIR = "pipeline";
 
-    private static final Logger LOG = LogManager.getLogger(PipelineJobServiceImpl.class);
+    public static final Logger LOG = LogManager.getLogger(PipelineJobServiceImpl.class);
     private static final String PIPELINE_TOOLS_ERROR = "Failed to locate %s. Use the site pipeline tools settings to specify where it can be found. (Currently '%s')";
     private static final String INSTALLED_PIPELINE_TOOL_ERROR = "Failed to locate %s. Check tool install location defined in pipelineConfig.xml. (Currently '%s')";
     private static final String MODULE_TASKS_DIR = "tasks";
@@ -361,7 +361,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
     {
         synchronized (_taskFactoryStore)
         {
-            TaskFactory factory = _taskFactoryStore.get(id);
+            TaskFactory<?> factory = _taskFactoryStore.get(id);
             if (factory != null)
                 return factory;
         }
@@ -424,8 +424,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
         synchronized (_taskFactoryStore)
         {
             factories.addAll(_taskFactoryStore.values().stream()
-                .filter(factory -> module.equals(factory.getDeclaringModule()))
-                .collect(Collectors.toList()));
+                    .filter(factory -> module.equals(factory.getDeclaringModule())).toList());
         }
 
         factories.addAll(TASK_FACTORY_CACHE.getResourceMap(module).values());
@@ -547,7 +546,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
     public FormSchema getFormSchema(Container container)
     {
         List<Option<String>> typeOptions = new ArrayList<>();
-        for (PipelineTriggerType pipelineTriggerType : PipelineTriggerRegistry.get().getTypes())
+        for (PipelineTriggerType<?> pipelineTriggerType : PipelineTriggerRegistry.get().getTypes())
         {
             typeOptions.add(new Option<>(pipelineTriggerType.getName(), pipelineTriggerType.getName()));
         }
@@ -563,8 +562,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
                 .filter(FileAnalysisTaskPipeline.class::isInstance)
                 .map(FileAnalysisTaskPipeline.class::cast)
                 .filter(FileAnalysisTaskPipeline::isAllowForTriggerConfiguration)
-                .sorted((tp1, tp2) -> tp1.getDescription().compareToIgnoreCase(tp2.getDescription()))
-                .collect(Collectors.toList());
+                .sorted((tp1, tp2) -> tp1.getDescription().compareToIgnoreCase(tp2.getDescription())).toList();
 
         for (FileAnalysisTaskPipeline task : tasks)
             taskOptions.add(new Option<>(task.getId().toString(), task.getDescription()));
@@ -576,7 +574,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
         String usernameHref = baseHref + "runasusername";
         String assayProviderHref = baseHref + "assayprovider";
 
-        List<Field> fields = List.of(
+        List<Field<?>> fields = List.of(
                 new TextField("name", "Name", null, true, ""),
                 new TextareaField("description", "Description", null, false, ""),
                 new SelectField<>("type", "Type", null, true, typeDefaultValue, typeOptions),
@@ -906,10 +904,9 @@ public class PipelineJobServiceImpl implements PipelineJobService
         if (provider == null)
             throw new NotFoundException("No pipeline provider found for task pipeline: " + taskPipeline);
 
-        if (!(taskPipeline instanceof FileAnalysisTaskPipeline))
+        if (!(taskPipeline instanceof FileAnalysisTaskPipeline fatp))
             throw new NotFoundException("Task pipeline is not a FileAnalysisTaskPipeline: " + taskPipeline);
 
-        FileAnalysisTaskPipeline fatp = (FileAnalysisTaskPipeline)taskPipeline;
         //noinspection unchecked
         return provider.getProtocolFactory(fatp);
     }


### PR DESCRIPTION
#### Rationale
While we don't always want to always pay the perf overhead of capturing creation stack traces for ResultSets, knowing the thread responsible can sometimes be enough to track down code that fails to close it

#### Changes
* Capture and log the creating thread name after a leak
* Misc lint cleanup
