### PR TITLE
Issue 45853: Switch controllerHits metrics to track cumulative totals

### DIFF
--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -43,6 +43,7 @@ import org.labkey.api.query.OlapSchemaInfo;
 import org.labkey.api.resource.Resource;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
+import org.labkey.api.usageMetrics.SimpleMetricsService;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.FileUtil;
@@ -1115,6 +1116,11 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         {
             _log.error("error", x);
             throw new ServletException(x);
+        }
+        finally
+        {
+            // Issue 45853 - Switch controllerHits metrics to cumulative totals instead of per-server-session tallies
+            SimpleMetricsService.get().increment(getName(), "controllerHits", url.getController());
         }
     }
 

--- a/api/src/org/labkey/api/util/UsageReportingLevel.java
+++ b/api/src/org/labkey/api/util/UsageReportingLevel.java
@@ -119,7 +119,6 @@ public enum UsageReportingLevel implements SafeToRenderEnum
             @SuppressWarnings("unchecked")
             Map<String, Map<String, Object>> modulesMap = (Map<String, Map<String, Object>>)metrics.computeIfAbsent("modules", s -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
 
-            putModuleControllerHits(modulesMap);
             putModulesMetrics(modulesMap);
             putModulesBuildInfo(modulesMap);
 
@@ -269,27 +268,6 @@ public enum UsageReportingLevel implements SafeToRenderEnum
 
             // Add to the module's info to be included in the submission
             moduleStats.put("buildInfo", moduleBuildInfo);
-        }
-    }
-
-    protected void putModuleControllerHits(Map<String, Map<String, Object>> allModulesStats)
-    {
-        try
-        {
-            ActionsHelper.getActionStatistics().forEach((module, controllersMap) -> {
-                Map<String, Object> moduleStats = allModulesStats.computeIfAbsent(module, k -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
-                Map<String, Long> controllerStats = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-                moduleStats.put("controllerHits", controllerStats);
-                controllersMap.forEach((controller, actionStatsMap) -> controllerStats.put(controller,
-                        actionStatsMap.values().stream().mapToLong(SpringActionController.ActionStats::getCount).sum()));
-            });
-        }
-        catch (InstantiationException | IllegalAccessException e)
-        {
-            // Unlikely to hit this, but just in case, still give module list
-            ModuleLoader.getInstance().getModules().forEach(module -> allModulesStats.computeIfAbsent(module.getName(), k -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));
-            // And put the error in the errors section of the metrics
-            allModulesStats.computeIfAbsent(UsageMetricsService.ERRORS, k -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)).put("controllerCounts", e.getMessage());
         }
     }
 


### PR DESCRIPTION
#### Rationale
Metrics are easier to interpret when they're more consistent. We now prefer tracking via cumulative totals instead of counts that reset whenever the server restarts.

#### Changes
* Leverage SimpleMetricsService to remember the values
* Fix problems logging metrics during shutdown