### PR TITLE
Update JSP for assay run deletion confirmation with message about referenced runs

### DIFF
--- a/api/src/org/labkey/api/exp/ExperimentRunListView.java
+++ b/api/src/org/labkey/api/exp/ExperimentRunListView.java
@@ -85,10 +85,6 @@ public class ExperimentRunListView extends QueryView
         AssayService svc = AssayService.get();
         if (svc != null)
             addClientDependencies(svc.getClientDependenciesForImportButtons());
-        addClientDependencies(Set.of(
-                ClientDependency.fromPath("Ext4"),
-                ClientDependency.fromPath("dataregion/confirmDelete.js")
-        ));
     }
 
     public static QuerySettings getRunListQuerySettings(UserSchema schema, ViewContext model, String tableName, boolean allowCustomizations)

--- a/api/src/org/labkey/api/exp/ExperimentRunListView.java
+++ b/api/src/org/labkey/api/exp/ExperimentRunListView.java
@@ -49,7 +49,6 @@ import org.labkey.api.view.DataView;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
-import org.labkey.api.view.template.ClientDependencies;
 import org.labkey.api.view.template.ClientDependency;
 
 import javax.servlet.http.HttpServletRequest;
@@ -176,19 +175,12 @@ public class ExperimentRunListView extends QueryView
 
         if (showDeleteButton())
         {
-            ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getDeleteRunsURL(context.getContainer());
+            ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getDeleteSelectedExpRunsURL(context.getContainer(), getReturnURL());
             ActionButton deleteButton = new ActionButton(url, "Delete");
             deleteButton.setIconCls("trash");
             deleteButton.setActionType(ActionButton.Action.POST);
             deleteButton.setRequiresSelection(true);
             deleteButton.setDisplayPermission(DeletePermission.class);
-            deleteButton.setScript("LABKEY.dataregion.confirmDelete(" +
-                    PageFlowUtil.jsString(getDataRegionName()) + ", " +
-                    PageFlowUtil.jsString("assay." + getSchema().getName())  + ", " +
-                    PageFlowUtil.jsString(getQueryDef().getName()) + ", " +
-                    "'assay', 'getAssayRunDeletionConfirmationData.api', " +
-                    PageFlowUtil.jsString(getSelectionKey()) + ", " +
-                    "'assay run', 'assay runs', 'references in one or more active notebooks', {}, " + PageFlowUtil.jsString(url) + ", 'rowIds')");
             bar.add(deleteButton);
         }
 

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -728,6 +728,9 @@ public interface ExperimentService extends ExperimentRunTypeSource
     @NotNull
     List<ObjectReferencer> getObjectReferencers();
 
+    @NotNull
+    String getObjectReferenceDescription(Class referencedClass);
+
     @Nullable ProtocolImplementation getProtocolImplementation(String name);
 
     @Nullable ExpProtocolApplication getExpProtocolApplication(int rowId);

--- a/api/src/org/labkey/api/exp/api/ExperimentUrls.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentUrls.java
@@ -66,8 +66,6 @@ public interface ExperimentUrls extends UrlProvider
 
     default ActionURL getDeleteSelectedExpRunsURL(Container container, URLHelper returnURL) { return null; }
 
-    default ActionURL getDeleteRunsURL(Container container) { return null; }
-
     default ActionURL getCreateRunGroupURL(Container container, URLHelper returnURL, boolean addSelectedRuns) { return null; }
 
     default ActionURL getShowRunsURL(Container c, ExperimentRunType type) { return null; }

--- a/api/src/org/labkey/api/exp/api/ObjectReferencer.java
+++ b/api/src/org/labkey/api/exp/api/ObjectReferencer.java
@@ -14,4 +14,7 @@ public interface ObjectReferencer
 
     @NotNull
     Collection<Integer> getItemsWithReferences(Collection<Integer> referencedRowIds, @NotNull String referencedSchemaName, @Nullable String referencedQueryName);
+
+    @Nullable
+    String getObjectReferenceDescription(Class referencedClass);
 }

--- a/experiment/src/org/labkey/experiment/ConfirmDelete.jsp
+++ b/experiment/src/org/labkey/experiment/ConfirmDelete.jsp
@@ -84,9 +84,31 @@ else
         </ul>
     <% } %>
 
+<% if (bean.getReferencedItems().size() > 0) { %>
+    <span class="labkey-error">
+        <%= h(bean.getReferencedItems().size() > 1 ? Integer.toString(bean.getReferencedItems().size()) : "One") %> <%= h(bean.getObjectType())%><%= h(bean.getReferencedItems().size() > 1 ? "s" : "") %> cannot be deleted because there are <%= h(bean.getReferencesDescription())%>:
+    </span>
+    <ul>
+        <%  int count = 0;
+        for (ExpObject item: bean.getReferencedItems()) {
+            if (count >= 50)
+            {
+                %>(<%= bean.getReferencedItems().size() - count %> others omitted from list)<%
+                break;
+            }
+            count++;
+        %>
+            <li>
+                <a href="<%= h(item.detailsURL()) %>"><%= h(item.getName()) %></a>
+            </li>
+        <% } %>
+    </ul>
+<% } %>
+
 <% if (bean.getNoPermissionExtras().size() > 0) { %>
     <span class="labkey-error">
-        <%= h(bean.getNoPermissionExtras().size() > 1 ? Integer.toString(bean.getNoPermissionExtras().size()) : "One") %> <%= h(bean.getExtraNoun())%><%= h(bean.getDeleteableExtras().size() > 1 ? "s" : "") %> reference the <%= h(bean.getObjectType()) %>, but you do not have permission to delete them:</span>
+        <%= h(bean.getNoPermissionExtras().size() > 1 ? Integer.toString(bean.getNoPermissionExtras().size()) : "One") %> <%= h(bean.getExtraNoun())%><%= h(bean.getDeleteableExtras().size() > 1 ? "s" : "") %> reference the <%= h(bean.getObjectType()) %>, but you do not have permission to delete them:
+    </span>
 
     <ul>
     <%  int count = 0;

--- a/experiment/src/org/labkey/experiment/ConfirmDelete.jsp
+++ b/experiment/src/org/labkey/experiment/ConfirmDelete.jsp
@@ -45,9 +45,30 @@
         cancelUrl = successUrl;
 %>
 
+<% if (bean.getReferencedItems().size() > 0) { %>
+    <span class="labkey-error">
+        <%= h(bean.getReferencedItems().size() > 1 ? Integer.toString(bean.getReferencedItems().size()) : "One") %> <%= h(bean.getObjectType())%><%= h(bean.getReferencedItems().size() > 1 ? "s" : "") %> cannot be deleted because there are <%= h(bean.getReferencesDescription())%>:
+    </span>
+    <ul>
+        <%  int count = 0;
+            for (ExpObject item: bean.getReferencedItems()) {
+                if (count >= 50)
+                {
+        %>(<%= bean.getReferencedItems().size() - count %> others omitted from list)<%
+            break;
+        }
+        count++;
+    %>
+        <li>
+            <a href="<%= h(item.detailsURL()) %>"><%= h(item.getName()) %></a>
+        </li>
+        <% } %>
+    </ul>
+<% } %>
+
 <% if (bean.getObjects().isEmpty())
 {
-    %><p>There are no selected objects to delete.</p>
+    %><p>There are no <%= h(bean.getReferencedItems().size() > 0 ? " additional " : "")%>selected objects to delete.</p>
     <%= text(button("OK").href(successUrl).toString())%><%
 }
 else
@@ -84,26 +105,7 @@ else
         </ul>
     <% } %>
 
-<% if (bean.getReferencedItems().size() > 0) { %>
-    <span class="labkey-error">
-        <%= h(bean.getReferencedItems().size() > 1 ? Integer.toString(bean.getReferencedItems().size()) : "One") %> <%= h(bean.getObjectType())%><%= h(bean.getReferencedItems().size() > 1 ? "s" : "") %> cannot be deleted because there are <%= h(bean.getReferencesDescription())%>:
-    </span>
-    <ul>
-        <%  int count = 0;
-        for (ExpObject item: bean.getReferencedItems()) {
-            if (count >= 50)
-            {
-                %>(<%= bean.getReferencedItems().size() - count %> others omitted from list)<%
-                break;
-            }
-            count++;
-        %>
-            <li>
-                <a href="<%= h(item.detailsURL()) %>"><%= h(item.getName()) %></a>
-            </li>
-        <% } %>
-    </ul>
-<% } %>
+
 
 <% if (bean.getNoPermissionExtras().size() > 0) { %>
     <span class="labkey-error">

--- a/experiment/src/org/labkey/experiment/ConfirmDelete.jsp
+++ b/experiment/src/org/labkey/experiment/ConfirmDelete.jsp
@@ -43,18 +43,22 @@
     ActionURL cancelUrl = bean.getCancelUrl();
     if (cancelUrl == null)
         cancelUrl = successUrl;
+    int numReferencedItems = bean.getReferencedItems().size();
+    int numObjects = bean.getObjects().size();
+    int numNoPermissionExtras = bean.getNoPermissionExtras().size();
+    int numWithPermission = bean.getRunsWithPermission().size();
 %>
 
-<% if (bean.getReferencedItems().size() > 0) { %>
+<% if (numReferencedItems > 0) { %>
     <span class="labkey-error">
-        <%= h(bean.getReferencedItems().size() > 1 ? Integer.toString(bean.getReferencedItems().size()) : "One") %> <%= h(bean.getObjectType())%><%= h(bean.getReferencedItems().size() > 1 ? "s" : "") %> cannot be deleted because there are <%= h(bean.getReferencesDescription())%>:
+        <%= h(numReferencedItems > 1 ? Integer.toString(numReferencedItems) : "One") %> <%= h(bean.getObjectType())%><%= h(numReferencedItems > 1 ? "s" : "") %> cannot be deleted because there are <%= h(bean.getReferencesDescription())%>:
     </span>
     <ul>
         <%  int count = 0;
             for (ExpObject item: bean.getReferencedItems()) {
                 if (count >= 50)
                 {
-        %>(<%= bean.getReferencedItems().size() - count %> others omitted from list)<%
+        %>(<%= numReferencedItems - count %> others omitted from list)<%
             break;
         }
         count++;
@@ -68,12 +72,12 @@
 
 <% if (bean.getObjects().isEmpty())
 {
-    %><p>There are no <%= h(bean.getReferencedItems().size() > 0 ? " additional " : "")%>selected objects to delete.</p>
+    %><p>There are no <%= h(numReferencedItems > 0 ? " additional " : "")%>selected objects to delete.</p>
     <%= text(button("OK").href(successUrl).toString())%><%
 }
 else
 { %>
-    <p>Are you sure you want to delete the following <%= h(bean.getObjectType()) %><%= h(bean.getObjects().size() > 1 ? (bean.getObjectType().endsWith("h") ? "es" : "s") : "") %>?</p>
+    <p>Are you sure you want to delete the following <%= h(bean.getObjectType()) %><%= h(numObjects > 1 ? (bean.getObjectType().endsWith("h") ? "es" : "s") : "") %>?</p>
 
     <ul>
     <% for (ExpObject object : bean.getObjects()) { %>
@@ -89,7 +93,7 @@ else
             for (Pair<SecurableResource, ActionURL> entry : bean.getDeleteableExtras()) {
             if (count >= 50)
             {
-                %>(<%= bean.getRunsWithPermission().size() - count %> <%= h(bean.getExtraNoun()) %>s omitted from list)<%
+                %>(<%= numWithPermission - count %> <%= h(bean.getExtraNoun()) %>s omitted from list)<%
                 break;
             }
             count++;
@@ -107,9 +111,9 @@ else
 
 
 
-<% if (bean.getNoPermissionExtras().size() > 0) { %>
+<% if (numNoPermissionExtras > 0) { %>
     <span class="labkey-error">
-        <%= h(bean.getNoPermissionExtras().size() > 1 ? Integer.toString(bean.getNoPermissionExtras().size()) : "One") %> <%= h(bean.getExtraNoun())%><%= h(bean.getDeleteableExtras().size() > 1 ? "s" : "") %> reference the <%= h(bean.getObjectType()) %>, but you do not have permission to delete them:
+        <%= h(numNoPermissionExtras > 1 ? Integer.toString(numNoPermissionExtras) : "One") %> <%= h(bean.getExtraNoun())%><%= h(bean.getDeleteableExtras().size() > 1 ? "s" : "") %> reference the <%= h(bean.getObjectType()) %>, but you do not have permission to delete them:
     </span>
 
     <ul>
@@ -117,7 +121,7 @@ else
     for (Pair<SecurableResource, ActionURL> entry : bean.getNoPermissionExtras()) {
         if (count >= 50)
         {
-            %>(<%= bean.getNoPermissionExtras().size() - count %> others omitted from list)<%
+            %>(<%= numNoPermissionExtras - count %> others omitted from list)<%
             break;
         }
         count++;
@@ -133,8 +137,8 @@ else
     </ul>
 <% } %>
 
-    <% if (bean.getRunsWithPermission().size() > 0) { %>
-        <%= h(bean.getRunsWithPermission().size() > 1 ? Integer.toString(bean.getRunsWithPermission().size()) : "One") %> run<%= h(bean.getRunsWithPermission().size() > 1 ? "s" : "") %> will also be deleted:
+    <% if (numWithPermission > 0) { %>
+        <%= h(numWithPermission > 1 ? Integer.toString(numWithPermission) : "One") %> run<%= h(numWithPermission > 1 ? "s" : "") %> will also be deleted:
 
         <ul>
         <%  int count = 0;
@@ -143,7 +147,7 @@ else
             Container runContainer = runEntry.getValue();
             if (count >= 50)
             {
-                %>(<%= bean.getRunsWithPermission().size() - count %> runs omitted from list)<%
+                %>(<%= numWithPermission - count %> runs omitted from list)<%
                 break;
             }
             count++;
@@ -161,7 +165,7 @@ else
     <% } %>
 
     <% if (bean.getRunsWithoutPermission().size() > 0) { %>
-        <span class="labkey-error">The <%= h(bean.getObjectType()) %><%= h(bean.getObjects().size() > 1 ? "s" : "") %> are also referenced by the following
+        <span class="labkey-error">The <%= h(bean.getObjectType()) %><%= h(numObjects > 1 ? "s" : "") %> are also referenced by the following
             run<%= h(bean.getRunsWithoutPermission().size() > 1 ? "s" : "") %>, which you do not have permission to delete:</span>
 
         <ul>

--- a/experiment/src/org/labkey/experiment/ConfirmDeleteView.java
+++ b/experiment/src/org/labkey/experiment/ConfirmDeleteView.java
@@ -16,6 +16,8 @@
 
 package org.labkey.experiment;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpRun;
@@ -55,7 +57,7 @@ public class ConfirmDeleteView extends JspView<ConfirmDeleteView.ConfirmDeleteBe
         private final List<? extends ExpObject> _referencedItems;
         private final String _referencesDescription;
 
-        public ConfirmDeleteBean(Map<ExpRun, Container> runsWithPermission, Map<ExpRun, Container> runsWithoutPermission, List<? extends ExpObject> objects, String objectType, Class<? extends Controller> detailAction, Integer singleObjectRowId, String extraNoun, List<Pair<SecurableResource, ActionURL>> deleteableExtras, List<Pair<SecurableResource, ActionURL>> noPermissionExtras, List<? extends ExpObject> referencedItems, String referencesDescription)
+        public ConfirmDeleteBean(Map<ExpRun, Container> runsWithPermission, Map<ExpRun, Container> runsWithoutPermission, List<? extends ExpObject> objects, String objectType, Class<? extends Controller> detailAction, Integer singleObjectRowId, String extraNoun, List<Pair<SecurableResource, ActionURL>> deleteableExtras, List<Pair<SecurableResource, ActionURL>> noPermissionExtras, @NotNull List<? extends ExpObject> referencedItems, @Nullable String referencesDescription)
         {
             _runsWithPermission = runsWithPermission;
             _runsWithoutPermission = runsWithoutPermission;
@@ -161,7 +163,7 @@ public class ConfirmDeleteView extends JspView<ConfirmDeleteView.ConfirmDeleteBe
         this(objectType, detailAction, objects, form, runs, null, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), null);
     }
 
-    public ConfirmDeleteView(String objectType, Class<? extends Controller> detailAction, List<? extends ExpObject> objects, DeleteForm form, List<? extends ExpRun> runs, String extraNoun, List<Pair<SecurableResource, ActionURL>> deleteableExtras, List<Pair<SecurableResource, ActionURL>> noPermissionExtras, List<? extends ExpObject> referencedItems, String referenceDescription)
+    public ConfirmDeleteView(String objectType, Class<? extends Controller> detailAction, List<? extends ExpObject> objects, DeleteForm form, List<? extends ExpRun> runs, String extraNoun, List<Pair<SecurableResource, ActionURL>> deleteableExtras, List<Pair<SecurableResource, ActionURL>> noPermissionExtras, @NotNull List<? extends ExpObject> referencedItems, @Nullable String referenceDescription)
     {
         super("/org/labkey/experiment/ConfirmDelete.jsp");
 

--- a/experiment/src/org/labkey/experiment/ConfirmDeleteView.java
+++ b/experiment/src/org/labkey/experiment/ConfirmDeleteView.java
@@ -48,12 +48,14 @@ public class ConfirmDeleteView extends JspView<ConfirmDeleteView.ConfirmDeleteBe
         private ActionURL _cancelUrl;
         private ActionURL _successUrl;
         private String _dataRegionSelectionKey;
-        private Integer _singleObjectRowId;
+        private final Integer _singleObjectRowId;
         private final String _extraNoun;
         private final List<Pair<SecurableResource, ActionURL>> _deleteableExtras;
         private final List<Pair<SecurableResource, ActionURL>> _noPermissionExtras;
+        private final List<? extends ExpObject> _referencedItems;
+        private final String _referencesDescription;
 
-        public ConfirmDeleteBean(Map<ExpRun, Container> runsWithPermission, Map<ExpRun, Container> runsWithoutPermission, List<? extends ExpObject> objects, String objectType, Class<? extends Controller> detailAction, Integer singleObjectRowId, String extraNoun, List<Pair<SecurableResource, ActionURL>> deleteableExtras, List<Pair<SecurableResource, ActionURL>> noPermissionExtras)
+        public ConfirmDeleteBean(Map<ExpRun, Container> runsWithPermission, Map<ExpRun, Container> runsWithoutPermission, List<? extends ExpObject> objects, String objectType, Class<? extends Controller> detailAction, Integer singleObjectRowId, String extraNoun, List<Pair<SecurableResource, ActionURL>> deleteableExtras, List<Pair<SecurableResource, ActionURL>> noPermissionExtras, List<? extends ExpObject> referencedItems, String referencesDescription)
         {
             _runsWithPermission = runsWithPermission;
             _runsWithoutPermission = runsWithoutPermission;
@@ -64,6 +66,8 @@ public class ConfirmDeleteView extends JspView<ConfirmDeleteView.ConfirmDeleteBe
             _extraNoun = extraNoun;
             _deleteableExtras = deleteableExtras;
             _noPermissionExtras = noPermissionExtras;
+            _referencedItems = referencedItems;
+            _referencesDescription = referencesDescription;
         }
 
         public Map<ExpRun, Container> getRunsWithPermission()
@@ -140,14 +144,24 @@ public class ConfirmDeleteView extends JspView<ConfirmDeleteView.ConfirmDeleteBe
         {
             return _singleObjectRowId;
         }
+
+        public List<? extends ExpObject> getReferencedItems()
+        {
+            return _referencedItems;
+        }
+
+        public String getReferencesDescription()
+        {
+            return _referencesDescription;
+        }
     }
 
     public ConfirmDeleteView(String objectType, Class<? extends Controller> detailAction, List<? extends ExpObject> objects, DeleteForm form, List<? extends ExpRun> runs)
     {
-        this(objectType, detailAction, objects, form, runs, null, Collections.emptyList(), Collections.emptyList());
+        this(objectType, detailAction, objects, form, runs, null, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), null);
     }
 
-    public ConfirmDeleteView(String objectType, Class<? extends Controller> detailAction, List<? extends ExpObject> objects, DeleteForm form, List<? extends ExpRun> runs, String extraNoun, List<Pair<SecurableResource, ActionURL>> deleteableExtras, List<Pair<SecurableResource, ActionURL>> noPermissionExtras)
+    public ConfirmDeleteView(String objectType, Class<? extends Controller> detailAction, List<? extends ExpObject> objects, DeleteForm form, List<? extends ExpRun> runs, String extraNoun, List<Pair<SecurableResource, ActionURL>> deleteableExtras, List<Pair<SecurableResource, ActionURL>> noPermissionExtras, List<? extends ExpObject> referencedItems, String referenceDescription)
     {
         super("/org/labkey/experiment/ConfirmDelete.jsp");
 
@@ -166,7 +180,7 @@ public class ConfirmDeleteView extends JspView<ConfirmDeleteView.ConfirmDeleteBe
             }
         }
 
-        ConfirmDeleteBean bean = new ConfirmDeleteBean(runsWithPermission, runsWithoutPermission, objects, objectType, detailAction, form.getSingleObjectRowId(), extraNoun, deleteableExtras, noPermissionExtras);
+        ConfirmDeleteBean bean = new ConfirmDeleteBean(runsWithPermission, runsWithoutPermission, objects, objectType, detailAction, form.getSingleObjectRowId(), extraNoun, deleteableExtras, noPermissionExtras, referencedItems, referenceDescription);
         bean.setSuccessUrl(form.getSuccessActionURL());
         bean.setCancelUrl(form.getCancelActionURL());
         bean.setDataRegionSelectionKey(form.getDataRegionSelectionKey());

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -2991,6 +2991,14 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return emptyList();
     }
 
+    @Nullable @Override
+    public String getObjectReferenceDescription(Class referencedClass)
+    {
+        if (referencedClass != ExpRun.class)
+            return "derived data or sample dependencies";
+        return null;
+    }
+
     private class SyncRunEdgesTask implements Runnable
     {
         protected final int _runId;

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -6529,12 +6529,6 @@ public class ExperimentController extends SpringActionController
             return new ActionURL(DeleteSelectedExpRunsAction.class, container).addReturnURL(returnURL);
         }
 
-        @Override
-        public ActionURL getDeleteRunsURL(Container container)
-        {
-            return new ActionURL(DeleteRunsAction.class, container);
-        }
-
         public ActionURL getShowUpdateURL(ExpExperiment experiment)
         {
             return new ActionURL(ShowUpdateAction.class, experiment.getContainer()).addParameter("rowId", experiment.getRowId());

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -48,6 +48,8 @@ import org.labkey.api.action.SimpleResponse;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.assay.AssayFileWriter;
+import org.labkey.api.assay.AssayProtocolSchema;
+import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.actions.UploadWizardAction;
 import org.labkey.api.assay.security.DesignAssayPermission;
@@ -3081,6 +3083,8 @@ public class ExperimentController extends SpringActionController
         public ModelAndView getView(DeleteForm deleteForm, boolean reshow, BindException errors)
         {
             List<ExpRun> runs = new ArrayList<>();
+
+            Map<Integer, ExpRun> idToRunMap = new HashMap<>();
             for (int runId : deleteForm.getIds(false))
             {
                 ExpRun run = ExperimentService.get().getExpRun(runId);
@@ -3092,7 +3096,36 @@ public class ExperimentController extends SpringActionController
                                 + " in " + run.getContainer());
 
                     runs.add(run);
+                    idToRunMap.put(run.getRowId(), run);
                 }
+            }
+
+            Map<Integer, ExpRun> referencedItems = new HashMap<>();
+            List<String> referenceDescriptions = new ArrayList<>();
+            AssayService assayService = AssayService.get();
+            if (!idToRunMap.isEmpty() && assayService != null )
+            {
+                // using the first run as a representative, since all interactions here are (I believe) using the same protocol.
+                ExpProtocol protocol = runs.get(0).getProtocol();
+                AssayProvider provider = assayService.getProvider(protocol);
+                if (provider != null)
+                {
+                    SchemaKey key = AssayProtocolSchema.schemaName(provider, protocol);
+                    ExperimentService.get().getObjectReferencers()
+                            .forEach(referencer -> {
+                                        Collection<Integer> referenced = referencer.getItemsWithReferences(
+                                                idToRunMap.keySet(),
+                                                key.toString(),
+                                                "Runs"
+                                        );
+                                        referenced.forEach(id -> {
+                                            referencedItems.put(id, idToRunMap.get(id));
+                                        });
+                                        referenceDescriptions.add(referencer.getObjectReferenceDescription(ExpRun.class));
+                                    }
+                            );
+                }
+
             }
 
             List<Pair<SecurableResource, ActionURL>> permissionDatasetRows = new ArrayList<>();
@@ -3114,7 +3147,17 @@ public class ExperimentController extends SpringActionController
                 }
             }
 
-            return new ConfirmDeleteView("run", ShowRunGraphAction.class, runs, deleteForm, Collections.emptyList(), "dataset(s) have one or more rows which", permissionDatasetRows, noPermissionDatasetRows);
+            return new ConfirmDeleteView(
+                    "run",
+                    ShowRunGraphAction.class,
+                    runs.stream().filter(run -> !referencedItems.containsKey(run.getRowId())).toList(),
+                    deleteForm,
+                    Collections.emptyList(),
+                    "dataset(s) have one or more rows which",
+                    permissionDatasetRows,
+                    noPermissionDatasetRows,
+                    referencedItems.values().stream().toList(),
+                    referenceDescriptions.stream().filter(Objects::nonNull).collect(Collectors.joining(", ")));
         }
 
         @Override
@@ -3366,7 +3409,7 @@ public class ExperimentController extends SpringActionController
                 }
             }
 
-            return new ConfirmDeleteView(noun, ProtocolDetailsAction.class, protocols, form, runs, "Dataset", deleteableDatasets, noPermissionDatasets);
+            return new ConfirmDeleteView(noun, ProtocolDetailsAction.class, protocols, form, runs, "Dataset", deleteableDatasets, noPermissionDatasets, null, null);
         }
 
         @Override
@@ -3735,7 +3778,7 @@ public class ExperimentController extends SpringActionController
                     }
                 }
             }
-            return new ConfirmDeleteView("Sample Type", ShowSampleTypeAction.class, sampleTypes, deleteForm, getRuns(sampleTypes), "Dataset", deleteableDatasets, noPermissionDatasets);
+            return new ConfirmDeleteView("Sample Type", ShowSampleTypeAction.class, sampleTypes, deleteForm, getRuns(sampleTypes), "Dataset", deleteableDatasets, noPermissionDatasets, null, null);
         }
 
         private List<ExpSampleType> getSampleTypes(DeleteForm deleteForm)

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3157,7 +3157,7 @@ public class ExperimentController extends SpringActionController
                     permissionDatasetRows,
                     noPermissionDatasetRows,
                     referencedItems.values().stream().toList(),
-                    referenceDescriptions.stream().filter(Objects::nonNull).collect(Collectors.joining(", ")));
+                    referenceDescriptions.stream().filter(Objects::nonNull).collect(Collectors.joining(", or ")));
         }
 
         @Override
@@ -3409,7 +3409,7 @@ public class ExperimentController extends SpringActionController
                 }
             }
 
-            return new ConfirmDeleteView(noun, ProtocolDetailsAction.class, protocols, form, runs, "Dataset", deleteableDatasets, noPermissionDatasets, null, null);
+            return new ConfirmDeleteView(noun, ProtocolDetailsAction.class, protocols, form, runs, "Dataset", deleteableDatasets, noPermissionDatasets, Collections.emptyList(), null);
         }
 
         @Override
@@ -3778,7 +3778,7 @@ public class ExperimentController extends SpringActionController
                     }
                 }
             }
-            return new ConfirmDeleteView("Sample Type", ShowSampleTypeAction.class, sampleTypes, deleteForm, getRuns(sampleTypes), "Dataset", deleteableDatasets, noPermissionDatasets, null, null);
+            return new ConfirmDeleteView("Sample Type", ShowSampleTypeAction.class, sampleTypes, deleteForm, getRuns(sampleTypes), "Dataset", deleteableDatasets, noPermissionDatasets, Collections.emptyList(), null);
         }
 
         private List<ExpSampleType> getSampleTypes(DeleteForm deleteForm)


### PR DESCRIPTION
#### Rationale
The Previous PR incorporate a javascript confirmation alert for deletion. of assay runs, in keeping with the behavior we have for samples and data class objects, but this alert then missed notifying users about runs linked to studies and possible permission restrictions there.  Here, we revert the change to use the javascript alert and pass through data to the JSP page to communicate to users when assay runs cannot be deleted because of object references. 

#### Related Pull Requests
#3589

#### Changes
* Revert change to delete button action in ExperimentRunListView
* Update object referencer interface with a method for providing a description of the references
