### PR TITLE
Issue 45131: JSON writer HTML encodes caption

### DIFF
--- a/api/src/org/labkey/api/data/JsonWriter.java
+++ b/api/src/org/labkey/api/data/JsonWriter.java
@@ -467,8 +467,9 @@ public class JsonWriter
             extGridColumn.put("align", dc.getTextAlign());
         if (dc.getDescription() != null)
             extGridColumn.put("tooltip", dc.getDescription());
-        if (dc.getCaption() != null)
-            extGridColumn.put("header", dc.getCaption());
+        String caption = dc.getCaption(null, false);
+        if (caption != null)
+            extGridColumn.put("header", caption);
         if (dc.getWidth() != null)
         {
             try


### PR DESCRIPTION
#### Rationale
We already migrated three of four uses of DisplayColumn.getCaption() in JSONWriter to not do HTML encoding. There's one remaining, and its single use case is safe to migrate too.

#### Changes
* Use the getCaption() variant that doesn't encode