### PR TITLE
Fix NPE in ShowFileAction

### DIFF
--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -570,7 +570,7 @@ public class StatusController extends SpringActionController
 
                     // Ensure that the requested file is under the root for this container
                     PipeRoot root = PipelineService.get().findPipelineRoot(c);
-                    if (root != null && root.isUnderRoot(fileShow) && NetworkDrive.exists(fileShow))
+                    if (root != null && fileShow != null && root.isUnderRoot(fileShow) && NetworkDrive.exists(fileShow))
                     {
                         boolean visible = isVisibleFile(fileName, basename);
 


### PR DESCRIPTION
#### Rationale
Crawler hit an NPE from this action.
```
java.lang.NullPointerException: Cannot invoke "java.nio.file.Path.normalize()" because "file" is null
	at org.labkey.pipeline.api.PipeRootImpl.findRootPath(PipeRootImpl.java:317) ~[pipeline-22.8-SNAPSHOT.jar:?]
	at org.labkey.pipeline.api.PipeRootImpl.isUnderRoot(PipeRootImpl.java:510) ~[pipeline-22.8-SNAPSHOT.jar:?]
	at org.labkey.pipeline.status.StatusController$ShowFileAction.render(StatusController.java:573) ~[pipeline-22.8-SNAPSHOT.jar:?]
	at org.labkey.pipeline.status.StatusController$ShowFileAction.render(StatusController.java:538) ~[pipeline-22.8-SNAPSHOT.jar:?]
	at org.labkey.api.action.SimpleStreamAction.getView(SimpleStreamAction.java:84) ~[api-22.8-SNAPSHOT.jar:?]
	at org.labkey.api.action.SimpleViewAction.handleRequest(SimpleViewAction.java:75) ~[api-22.8-SNAPSHOT.jar:?]
```

#### Related Pull Requests
* #3452

#### Changes
* Fix NPE in ShowFileAction
