### PR TITLE
Enabling product tier configuration with product groups and product features 

### DIFF
--- a/api/src/org/labkey/api/settings/AdminConsole.java
+++ b/api/src/org/labkey/api/settings/AdminConsole.java
@@ -218,7 +218,7 @@ public class AdminConsole
         return Collections.unmodifiableSet(_productGroups);
     }
 
-    public static Set<String> getProductFeatureList()
+    public static Set<String> getProductFeatureSet()
     {
         Set<String> productFeatures = new HashSet<>();
         AdminConsole.getProductGroups().forEach(group -> {
@@ -232,7 +232,7 @@ public class AdminConsole
 
     public static boolean isProductFeatureEnabled(ProductFeature feature)
     {
-        return getProductFeatureList().contains(feature.toString());
+        return getProductFeatureSet().contains(feature.toString());
     }
 
     public static abstract class ProductGroup implements Comparable<ProductGroup>

--- a/api/src/org/labkey/api/settings/AdminConsole.java
+++ b/api/src/org/labkey/api/settings/AdminConsole.java
@@ -230,6 +230,11 @@ public class AdminConsole
         return productFeatures;
     }
 
+    public static boolean isProductFeatureEnabled(ProductFeature feature)
+    {
+        return getProductFeatureList().contains(feature.toString());
+    }
+
     public static abstract class ProductGroup implements Comparable<ProductGroup>
     {
         public abstract String getName();

--- a/api/src/org/labkey/api/settings/ProductConfiguration.java
+++ b/api/src/org/labkey/api/settings/ProductConfiguration.java
@@ -3,9 +3,13 @@ package org.labkey.api.settings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.module.ModuleLoader;
+
+import java.util.Collection;
 
 public class ProductConfiguration extends AbstractWriteableSettingsGroup implements StartupProperty
 {
+    public static final String SCOPE_PRODUCT_CONFIGURATION = "ProductConfiguration";
     public static final String PROPERTY_NAME = "productKey";
 
     @Override
@@ -60,5 +64,16 @@ public class ProductConfiguration extends AbstractWriteableSettingsGroup impleme
     public String getDescription()
     {
         return "The key for the product tier that is enabled.";
+    }
+
+    public static void handleStartupProperties()
+    {
+        ModuleLoader.getInstance().handleStartupProperties(new LenientStartupPropertyHandler<>(SCOPE_PRODUCT_CONFIGURATION, new ProductConfiguration()) {
+            @Override
+            public void handle(Collection<StartupPropertyEntry> entries)
+            {
+                entries.forEach(entry -> ProductConfiguration.setProductKey(entry.getValue()));
+            }
+        });
     }
 }

--- a/api/src/org/labkey/api/settings/ProductConfiguration.java
+++ b/api/src/org/labkey/api/settings/ProductConfiguration.java
@@ -1,0 +1,64 @@
+package org.labkey.api.settings;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.ContainerManager;
+
+public class ProductConfiguration extends AbstractWriteableSettingsGroup implements StartupProperty
+{
+    public static final String PROPERTY_NAME = "productKey";
+
+    @Override
+    protected String getGroupName()
+    {
+        return "ProductConfiguration";
+    }
+
+    @Override
+    protected String getType()
+    {
+        return "Product Configuration";
+    }
+
+    public static void setProductKey(String productKey)
+    {
+        ProductConfiguration config = getWritableConfig();
+        config.storeStringValue(PROPERTY_NAME, productKey);
+        config.save();
+    }
+
+    private static ProductConfiguration getWritableConfig()
+    {
+        ProductConfiguration config = new ProductConfiguration();
+        config.makeWriteable(ContainerManager.getRoot());
+        return config;
+    }
+
+    @Nullable
+    public String getCurrentProduct()
+    {
+        return lookupStringValue(PROPERTY_NAME, null);
+    }
+
+    public boolean isProductEnabled(@NotNull String productKey, boolean defaultValue)
+    {
+        String currentProduct = getCurrentProduct();
+        if (currentProduct == null)
+            return defaultValue;
+        return productKey.equalsIgnoreCase(currentProduct);
+    }
+
+
+    @Nullable
+    @Override
+    public String getPropertyName()
+    {
+        return PROPERTY_NAME;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "The key for the product tier that is enabled.";
+    }
+}

--- a/api/src/org/labkey/api/settings/ProductFeature.java
+++ b/api/src/org/labkey/api/settings/ProductFeature.java
@@ -11,15 +11,15 @@ public enum ProductFeature
     SampleManagement("sampleManager"),
     Workflow("sampleManagement");
 
-    private final String _moduleProvider;
+    private final String _module;
 
-    ProductFeature(String moduleProvider)
+    ProductFeature(String module)
     {
-        _moduleProvider = moduleProvider;
+        _module = module;
     }
 
-    public String getModuleProvider()
+    public String getModule()
     {
-        return _moduleProvider;
+        return _module;
     }
 }

--- a/api/src/org/labkey/api/settings/ProductFeature.java
+++ b/api/src/org/labkey/api/settings/ProductFeature.java
@@ -1,0 +1,25 @@
+package org.labkey.api.settings;
+
+/**
+ * A listing of functionality that is available in the non-starter tiers of our applications
+ */
+public enum ProductFeature
+{
+    Assay("assay"),
+    ELN("labbook"),
+    FreezerManagement("inventory"),
+    SampleManagement("sampleManager"),
+    Workflow("sampleManagement");
+
+    private final String _moduleProvider;
+
+    ProductFeature(String moduleProvider)
+    {
+        _moduleProvider = moduleProvider;
+    }
+
+    public String getModuleProvider()
+    {
+        return _moduleProvider;
+    }
+}

--- a/api/src/org/labkey/api/settings/ProductFeature.java
+++ b/api/src/org/labkey/api/settings/ProductFeature.java
@@ -8,7 +8,7 @@ public enum ProductFeature
     Assay("assay"),
     ELN("labbook"),
     FreezerManagement("inventory"),
-    SampleManagement("sampleManager"),
+    SampleManagement("sampleManagement"),
     Workflow("sampleManagement");
 
     private final String _module;

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.json.JSONObject;
 import org.labkey.api.admin.AdminConsoleService;
 import org.labkey.api.admin.FolderSerializationRegistry;
 import org.labkey.api.admin.HealthCheck;
@@ -166,6 +167,7 @@ import org.labkey.api.webdav.WebdavResolverImpl;
 import org.labkey.api.webdav.WebdavResource;
 import org.labkey.api.webdav.WebdavService;
 import org.labkey.api.wiki.WikiRenderingService;
+import org.labkey.api.writer.ContainerUser;
 import org.labkey.core.admin.ActionsTsvWriter;
 import org.labkey.core.admin.AdminConsoleServiceImpl;
 import org.labkey.core.admin.AdminController;
@@ -1016,6 +1018,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                 .filter(AdminConsole.ExperimentalFeatureFlag::isEnabled)
                 .map(AdminConsole.ExperimentalFeatureFlag::getFlag)
                 .collect(Collectors.toList()));
+            results.put("productFeaturesEnabled", AdminConsole.getProductFeatureList());
             results.put("analyticsTrackingStatus", AnalyticsServiceImpl.get().getTrackingStatus().toString());
 
             // Report the total number of login entries in the audit log
@@ -1081,6 +1084,14 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         // ping, and then once every 24 hours.
         AppProps.getInstance().getUsageReportingLevel().scheduleUpgradeCheck();
         TempTableTracker.init();
+    }
+
+    @Override
+    public JSONObject getPageContextJson(ContainerUser context)
+    {
+        JSONObject json = new JSONObject(getDefaultPageContextJson(context.getContainer()));
+        json.put("productFeatures", AdminConsole.getProductFeatureList());
+        return json;
     }
 
     @Override

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -117,6 +117,7 @@ import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.settings.LookAndFeelPropertiesManager;
 import org.labkey.api.settings.LookAndFeelPropertiesManager.ResourceType;
 import org.labkey.api.settings.LookAndFeelPropertiesManager.SiteResourceHandler;
+import org.labkey.api.settings.ProductConfiguration;
 import org.labkey.api.settings.StandardStartupPropertyHandler;
 import org.labkey.api.settings.StartupProperty;
 import org.labkey.api.settings.StartupPropertyEntry;
@@ -811,6 +812,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         // Any containers in the cache have bogus folder types since they aren't registered until startup().  See #10310
         ContainerManager.clearCache();
 
+        ProductConfiguration.handleStartupProperties();
         // This listener deletes all properties; make sure it executes after most of the other listeners
         ContainerManager.addContainerListener(new CoreContainerListener(), ContainerManager.ContainerListener.Order.Last);
         ContainerManager.addContainerListener(new FolderSettingsCache.FolderSettingsCacheListener());
@@ -1315,6 +1317,8 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             }
         });
     }
+
+
 
     /**
      * This method handles the home project settings

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1021,7 +1021,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                 .filter(AdminConsole.ExperimentalFeatureFlag::isEnabled)
                 .map(AdminConsole.ExperimentalFeatureFlag::getFlag)
                 .collect(Collectors.toList()));
-            results.put("productFeaturesEnabled", AdminConsole.getProductFeatureList());
+            results.put("productFeaturesEnabled", AdminConsole.getProductFeatureSet());
             results.put("analyticsTrackingStatus", AnalyticsServiceImpl.get().getTrackingStatus().toString());
 
             // Report the total number of login entries in the audit log
@@ -1093,7 +1093,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
     public JSONObject getPageContextJson(ContainerUser context)
     {
         JSONObject json = new JSONObject(getDefaultPageContextJson(context.getContainer()));
-        json.put("productFeatures", AdminConsole.getProductFeatureList());
+        json.put("productFeatures", AdminConsole.getProductFeatureSet());
         return json;
     }
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -8790,39 +8790,20 @@ public class AdminController extends SpringActionController
 
     @AdminConsoleAction
     @RequiresPermission(AdminOperationsPermission.class)
-    public class ProductConfigurationAction extends FormViewAction<Object>
+    public class ProductConfigurationAction extends SimpleViewAction<Object>
     {
-
-        @Override
-        public void validateCommand(Object target, Errors errors)
-        {
-
-        }
-
-        @Override
-        public ModelAndView getView(Object o, boolean reshow, BindException errors) throws Exception
-        {
-            JspView<Object> view = new JspView<>("/org/labkey/core/admin/productConfiguration.jsp");
-            view.setFrame(WebPartView.FrameType.NONE);
-            return view;
-        }
-
-        @Override
-        public boolean handlePost(Object o, BindException errors) throws Exception
-        {
-            throw new UnsupportedOperationException("Nope");
-        }
-
-        @Override
-        public URLHelper getSuccessURL(Object o)
-        {
-            return getShowAdminURL();
-        }
-
         @Override
         public void addNavTrail(NavTree root)
         {
             addAdminNavTrail(root, "Product Configuration", getClass());
+        }
+
+        @Override
+        public ModelAndView getView(Object o, BindException errors) throws Exception
+        {
+            JspView<Object> view = new JspView<>("/org/labkey/core/admin/productConfiguration.jsp");
+            view.setFrame(WebPartView.FrameType.NONE);
+            return view;
         }
     }
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -141,6 +141,7 @@ import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.settings.LookAndFeelPropertiesManager.ResourceType;
 import org.labkey.api.settings.NetworkDriveProps;
+import org.labkey.api.settings.ProductConfiguration;
 import org.labkey.api.settings.WriteableAppProps;
 import org.labkey.api.settings.WriteableFolderLookAndFeelProperties;
 import org.labkey.api.settings.WriteableLookAndFeelProperties;
@@ -296,6 +297,8 @@ public class AdminController extends SpringActionController
         AdminConsole.addLink(Configuration, "authentication", urlProvider(LoginUrls.class).getConfigureURL());
         AdminConsole.addLink(Configuration, "email customization", new ActionURL(CustomizeEmailAction.class, root), AdminPermission.class);
         AdminConsole.addLink(Configuration, "experimental features", new ActionURL(ExperimentalFeaturesAction.class, root), AdminOperationsPermission.class);
+        if (!AdminConsole.getProductGroups().isEmpty())
+            AdminConsole.addLink(Configuration, "product configuration", new ActionURL(ProductConfigurationAction.class, root), AdminOperationsPermission.class);
         // TODO move to FileContentModule
         if (ModuleLoader.getInstance().hasModule("FileContent"))
             AdminConsole.addLink(Configuration, "files", new ActionURL(FilesSiteSettingsAction.class, root), AdminOperationsPermission.class);
@@ -8740,6 +8743,89 @@ public class AdminController extends SpringActionController
             addAdminNavTrail(root, "Experimental Features", getClass());
         }
     }
+
+    @RequiresPermission(AdminOperationsPermission.class)
+    public static class ProductFeatureAction extends BaseApiAction<ProductConfigForm>
+    {
+        @Override
+        protected ModelAndView handleGet() throws Exception
+        {
+            return handlePost(); // 'execute' ensures that only POSTs are mutating
+        }
+
+        @Override
+        public ApiResponse execute(ProductConfigForm form, BindException errors)
+        {
+            String productKey = StringUtils.trimToNull(form.getProductKey());
+            if (productKey == null)
+                throw new ApiUsageException("productKey is required");
+
+            Map<String, Object> ret = new HashMap<>();
+
+            if (isPost())
+            {
+               ProductConfiguration.setProductKey(form.getProductKey());
+            }
+
+            ret.put("productKey", new ProductConfiguration().getCurrentProduct());
+            return new ApiSimpleResponse(ret);
+        }
+    }
+
+    public static class ProductConfigForm
+    {
+        private String productKey;
+
+        public String getProductKey()
+        {
+            return productKey;
+        }
+
+        public void setProductKey(String productKey)
+        {
+            this.productKey = productKey;
+        }
+
+    }
+
+    @AdminConsoleAction
+    @RequiresPermission(AdminOperationsPermission.class)
+    public class ProductConfigurationAction extends FormViewAction<Object>
+    {
+
+        @Override
+        public void validateCommand(Object target, Errors errors)
+        {
+
+        }
+
+        @Override
+        public ModelAndView getView(Object o, boolean reshow, BindException errors) throws Exception
+        {
+            JspView<Object> view = new JspView<>("/org/labkey/core/admin/productConfiguration.jsp");
+            view.setFrame(WebPartView.FrameType.NONE);
+            return view;
+        }
+
+        @Override
+        public boolean handlePost(Object o, BindException errors) throws Exception
+        {
+            throw new UnsupportedOperationException("Nope");
+        }
+
+        @Override
+        public URLHelper getSuccessURL(Object o)
+        {
+            return getShowAdminURL();
+        }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        {
+            addAdminNavTrail(root, "Product Configuration", getClass());
+        }
+    }
+
 
     public static class FolderTypesBean
     {

--- a/core/src/org/labkey/core/admin/productConfiguration.jsp
+++ b/core/src/org/labkey/core/admin/productConfiguration.jsp
@@ -1,0 +1,82 @@
+<%
+/*
+ * Copyright (c) 2022 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+%>
+<%@ page import="org.labkey.api.settings.AdminConsole" %>
+<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
+<%@ page import="org.apache.commons.lang3.StringUtils" %>
+<%@ page import="org.labkey.core.admin.AdminController" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+<%!
+    @Override
+    public void addClientDependencies(ClientDependencies dependencies)
+    {
+        dependencies.add("internal/jQuery");
+    }
+%>
+<style>
+    .description-text {
+        font-style: italic;
+    }
+
+    .toggle-label-text {
+        font-size: 1.1em;
+        padding-top: 0.1em;
+        padding-bottom: 0.1em;
+    }
+</style>
+
+<div class="description-text">
+    The set of features associated with each product is dependent on the modules included in the current deployment.
+    If you don't see features you might expect associated with certain products,
+    check the <a href="<%=h(AdminController.getShowAdminURL() + "#modules")%>">Module Information</a> page for more insight.
+</div>
+
+<% for (AdminConsole.ProductGroup productGroup : AdminConsole.getProductGroups()) { %>
+<div class="list-group">
+    <h4><%=h(productGroup.getName())%></h4>
+    <% for (AdminConsole.Product product : productGroup.getProducts() ) { %>
+    <div class="product-group-item">
+        <label>
+            <input type="radio" id="<%=h(product.getKey())%>" name="<%=h(productGroup.getKey())%>" value="<%=h(product.getKey())%>" <%=checked(product.isEnabled())%>>
+            <span class="toggle-label-text"><%=h(product.getName())%> - Includes the following features: <%=h(StringUtils.join(product.getFeatureFlags(), ", "))%></span>
+        </label>
+    </div>
+    <% } %>
+<% } %>
+
+</div>
+<script type="application/javascript" nonce="<%=getScriptNonce()%>">
+    (function () {
+        let inputList = document.querySelectorAll('div.product-group-item input');
+        inputList.forEach(function (input) {
+            input.addEventListener('change', function (e) {
+                let productKey = input.id;
+                LABKEY.Ajax.request({
+                    url: LABKEY.ActionURL.buildURL('admin', 'productFeature.api'),
+                    method: 'POST',
+                    params: { productKey: productKey },
+                    // success: LABKEY.Utils.getCallbackWrapper(function(json) {
+                    //     console.log('Product set to ' + json.productKey + '.');
+                    // }),
+                    failure: LABKEY.Utils.getCallbackWrapper(null, null, true)
+                });
+            });
+        });
+    })();
+</script>
+

--- a/core/src/org/labkey/core/admin/productConfiguration.jsp
+++ b/core/src/org/labkey/core/admin/productConfiguration.jsp
@@ -40,6 +40,12 @@
     }
 </style>
 
+<% if (AdminConsole.getProductGroups().isEmpty()) { %>
+        <div class="description-text">
+            No products requiring configuration have been registered for this deployment.
+        </div>
+<% } else { %>
+
 <div class="description-text">
     The set of features associated with each product is dependent on the modules included in the current deployment.
     If you don't see features you might expect associated with certain products,
@@ -79,4 +85,4 @@
         });
     })();
 </script>
-
+<% } %>


### PR DESCRIPTION
#### Rationale
The LKSM Starter product does not include the Workflow and Assay functionality,  but there are also cases where we want to turn on one or the other of these products and, in general, want a mechanism for the server to communicate a set of features that are enabled so we can check for feature availability when deciding to present functionality in applications.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/936

#### Changes
* Add ProductConfiguration class and Admin console page for choosing a product from a group
* Add ProductFeature enum
* Add product groups registry in AdminConsole
