### PR TITLE
Display errors in confirmDelete modal

### DIFF
--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -1136,12 +1136,15 @@ public class ExperimentController extends SpringActionController
                     ActionButton button = super.createDeleteButton();
                     if (button != null)
                     {
-                        String dependencyText = "derived data or sample dependencies";
-                        if (ModuleLoader.getInstance().hasModule("labbook"))
-                            dependencyText += " or references in one or more active notebooks";
+                        String dependencyText = ExperimentService.get()
+                                .getObjectReferencers()
+                                .stream()
+                                .map(referencer -> referencer.getObjectReferenceDescription(ExpData.class))
+                                .collect(Collectors.joining(" or "));
+
                         button.setScript("LABKEY.dataregion.confirmDelete(" +
                                 PageFlowUtil.jsString(getDataRegionName()) + ", " +
-                                PageFlowUtil.jsString(getSchema().getName())  + ", " +
+                                PageFlowUtil.jsString(ExpSchema.SCHEMA_EXP_DATA.toString())  + ", " +
                                 PageFlowUtil.jsString(getQueryDef().getName()) + ", " +
                                 "'experiment', 'getDataOperationConfirmationData.api', " +
                                 PageFlowUtil.jsString(getSelectionKey()) + ", " +

--- a/internal/webapp/dataregion/confirmDelete.js
+++ b/internal/webapp/dataregion/confirmDelete.js
@@ -107,27 +107,47 @@ LABKEY.dataregion.confirmDelete = function(
                                     apiVersion: 13.2
                                 },
                                 success: LABKEY.Utils.getCallbackWrapper(function(response)  {
-                                    // clear the selection only for the rows that were deleted
-                                    const ids = canDelete.map((row) => row.RowId);
-                                    const dr = LABKEY.DataRegions[dataRegionName];
-                                    if (dr) {
-                                        dr.setSelected({
-                                            ids,
-                                            checked: false
+                                    if (response.errors) {
+                                        var errorMsg = "There was a problem deleting your " + totalNoun + ". ";
+                                        if (typeof response.errors === 'string') {
+                                            errorMsg += response.errors;
+                                        } else if (response.errors.message) {
+                                            errorMsg += response.errors.message;
+                                        } else if (response.errors.msg) {
+                                            errorMsg += response.errors.msg;
+                                        } else if (response.errors.exception) {
+                                            errorMsg += response.errors.exception;
+                                        }
+                                        Ext4.Msg.hide();
+                                        Ext4.Msg.show({
+                                            title: "Delete " + totalNoun,
+                                            msg: errorMsg,
+                                            width: 450, // added to keep the text from being swallowed vertically
+                                            buttons: Ext4.Msg.OK
                                         });
                                     }
+                                    else {
+                                        // clear the selection only for the rows that were deleted
+                                        const ids = canDelete.map((row) => row.RowId);
+                                        const dr = LABKEY.DataRegions[dataRegionName];
+                                        if (dr) {
+                                            dr.setSelected({
+                                                ids,
+                                                checked: false
+                                            });
+                                        }
 
-                                    Ext4.Msg.hide();
-                                    var numDeleted = response.rowsAffected ? response.rowsAffected : ids.length;
-                                    var responseMsg = Ext4.Msg.show({
-                                        title: "Delete " + totalNoun,
-                                        msg:  numDeleted + " " + (numDeleted === 1 ? nounSingular : nounPlural) + " deleted."
-                                    });
-                                    Ext4.defer(function() {
-                                        responseMsg.hide();
-                                        window.location.reload();
-                                    }, 2500, responseMsg);
-
+                                        Ext4.Msg.hide();
+                                        var numDeleted = response.rowsAffected ? response.rowsAffected : ids.length;
+                                        var responseMsg = Ext4.Msg.show({
+                                            title: "Delete " + totalNoun,
+                                            msg: numDeleted + " " + (numDeleted === 1 ? nounSingular : nounPlural) + " deleted."
+                                        });
+                                        Ext4.defer(function () {
+                                            responseMsg.hide();
+                                            window.location.reload();
+                                        }, 2500, responseMsg);
+                                    }
                                 }),
                                 failure: LABKEY.Utils.getCallbackWrapper(function(response) {
                                     console.error("There was a problem deleting " + nounPlural, response);
@@ -135,6 +155,7 @@ LABKEY.dataregion.confirmDelete = function(
                                     Ext4.Msg.show({
                                         title: "Delete " + totalNoun,
                                         msg: "There was a problem deleting your " + totalNoun + ".",
+                                        width: 450, // added to keep the text from being swallowed vertically
                                         buttons: Ext4.Msg.OK
                                     });
                                 })


### PR DESCRIPTION
#### Rationale
Failure can come in many forms. When deleting rows, the request may return a successful response but that response may contain error messages that should be displayed instead of the success message.

#### Related Pull Requests
* #3589 

#### Changes
* Fix schema used for data class object deletion
* Display errors if present in response from deleteRows