### PR TITLE
Encode semicolon in expected href

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyMergeParticipantsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyMergeParticipantsTest.java
@@ -27,6 +27,8 @@ import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.Maps;
 
 import java.io.File;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @Category(Daily.class)
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
@@ -136,7 +138,8 @@ public class StudyMergeParticipantsTest extends StudyBaseTest
 
         log("Check url's to are correctly constructed");
         final String url = WebTestHelper.buildRelativeUrl("study", PROJECT_NAME + "/" + FOLDER_NAME, "dataset",
-                Maps.of("datasetId", 5018, "Dataset.ParticipantId~in", PTID_NO_ALIAS + ";" + PTID_NEW_2));
+                Maps.of("datasetId", 5018,
+                        "Dataset.ParticipantId~in", PTID_NO_ALIAS + URLEncoder.encode(";", StandardCharsets.UTF_8) + PTID_NEW_2));
         assertElementPresent(Locator.linkWithHref(url));
 
         log("Resolve conflicts and check for correct row retention");


### PR DESCRIPTION
#### Rationale
I updated this test to use `URLBuilder` but the resulting URL doesn't quite match. It needs to be encoded properly.

#### Related Pull Requests
* #3619 

#### Changes
* Encode semicolon
