### PR TITLE
45753: Warning about double-closing SpringAttachmentFile when drag/dropping into file listing

### DIFF
--- a/api/src/org/labkey/api/attachments/ByteArrayAttachmentFile.java
+++ b/api/src/org/labkey/api/attachments/ByteArrayAttachmentFile.java
@@ -82,7 +82,7 @@ public class ByteArrayAttachmentFile implements AttachmentFile
             _inputStream = null;
         }
         else
-            LOG.warn("No input stream is active for this ByteArrayAttachmentFile");
+            LOG.debug("No input stream is active for this ByteArrayAttachmentFile");
     }
 
     @Override

--- a/api/src/org/labkey/api/attachments/FileAttachmentFile.java
+++ b/api/src/org/labkey/api/attachments/FileAttachmentFile.java
@@ -90,7 +90,7 @@ public class FileAttachmentFile implements AttachmentFile
             _in = null;
         }
         else
-            LOG.warn("No input stream is active for this FileAttachmentFile");
+            LOG.debug("No input stream is active for this FileAttachmentFile");
     }
 
     @Override

--- a/api/src/org/labkey/api/attachments/SpringAttachmentFile.java
+++ b/api/src/org/labkey/api/attachments/SpringAttachmentFile.java
@@ -109,7 +109,7 @@ public class SpringAttachmentFile implements AttachmentFile
             _in = null;
         }
         else
-            LOG.warn("No input stream is active for this SpringAttachmentFile");
+            LOG.debug("No input stream is active for this SpringAttachmentFile");
     }
 
     public static List<AttachmentFile> createList(Map<String, MultipartFile> fileMap)

--- a/core/src/org/labkey/core/attachment/DatabaseAttachmentFile.java
+++ b/core/src/org/labkey/core/attachment/DatabaseAttachmentFile.java
@@ -129,6 +129,6 @@ public class DatabaseAttachmentFile implements AttachmentFile
             _rs = ResultSetUtil.close(_rs);
         }
         else
-            LOG.warn("No input stream is active for this DatabaseAttachmentFile");
+            LOG.debug("No input stream is active for this DatabaseAttachmentFile");
     }
 }


### PR DESCRIPTION
#### Rationale
Reduce the warnings to debug log messages. We can alway raise to an error level if we wanted to make a push to reduce these messages. Probably not urgent given that we haven't been overly concerned with closing the stream multiple times.

[Related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45753)
