### PR TITLE
Delete obsolete jars.txt

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1016,14 +1016,8 @@ public class AdminController extends SpringActionController
             super(title);
 
             _component = StringUtils.trimToEmpty(component);
-
-            // If both wikiSource and filenames are null there can't be a problem.
-            // trims/empty check allow for problem reporting if one is null but not the other.
-            if (!filenames.isEmpty())
-            {
-                _errors = getErrors(wikiSource, creditsFilename, filenames, fileType, foundWhere, wikiSourceSearchPattern);
-                wikiSource = StringUtils.trimToEmpty(wikiSource) + _errors;
-            }
+            _errors = getErrors(wikiSource, creditsFilename, filenames, fileType, foundWhere, wikiSourceSearchPattern);
+            wikiSource = StringUtils.trimToEmpty(wikiSource) + _errors;
 
             if (StringUtils.isNotEmpty(wikiSource))
             {
@@ -1038,11 +1032,11 @@ public class AdminController extends SpringActionController
             return _errors;
         }
 
-        private @NotNull String getErrors(String wikiSource, String creditsFilename, Collection<String> foundFilenames, String fileType, String foundWhere, String wikiSourceSearchPattern)
+        private @NotNull String getErrors(@Nullable String wikiSource, String creditsFilename, Collection<String> foundFilenames, String fileType, String foundWhere, @Nullable String wikiSourceSearchPattern)
         {
             Set<String> documentedFilenames = new CaseInsensitiveTreeSet();
 
-            if (null != wikiSource)
+            if (null != wikiSource && null != wikiSourceSearchPattern)
             {
                 Pattern p = Pattern.compile(wikiSourceSearchPattern, Pattern.MULTILINE);
                 Matcher m = p.matcher(wikiSource);

--- a/mothership/resources/credits/jars.txt
+++ b/mothership/resources/credits/jars.txt
@@ -1,4 +1,0 @@
-{table}
-Filename|Component|Version|Source|License|LabKey Dev|Purpose
-json-path-2.4.0.jar|Jayway JsonPath|2.4.0|{link:Github|https://github.com/json-path/JsonPath}|{link:Apache|http://www.apache.org/licenses/LICENSE-2.0.txt}|ankurj|Java port of Stefan Goessner JsonPath.
-{table}


### PR DESCRIPTION
#### Rationale
No need to document dependencies that don't exist. Also, we should display an error in the case where no jars exist but jars.txt documents jars.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1920