### PR TITLE
Issue 46022: Make CustomViewSetKey case-insensitive

### DIFF
--- a/query/src/org/labkey/query/view/CustomViewSetKey.java
+++ b/query/src/org/labkey/query/view/CustomViewSetKey.java
@@ -57,14 +57,14 @@ public class CustomViewSetKey implements Serializable
             return false;
         CustomViewSetKey that = (CustomViewSetKey) other;
         return Objects.equals(_containerId, that._containerId) &&
-                Objects.equals(_queryName, that._queryName) &&
+                Objects.equals(_queryName.toLowerCase(), that._queryName.toLowerCase()) &&
                 Objects.equals(_schema, that._schema);
     }
 
     public int hashCode()
     {
         return Objects.hashCode(_containerId) ^
-                Objects.hashCode(_queryName) ^
+                Objects.hashCode(_queryName.toLowerCase()) ^
                 Objects.hashCode(_schema);
     }
 


### PR DESCRIPTION
#### Rationale
Case-sensitive keys cause heartache.  The Schema part of the key is already case-insensitive. 

#### Changes
* Make the CustomViewSetKey not case sensitive for the queryName.
