### PR TITLE
Convert PipelineJob.serializeJob from static to an instance method

### DIFF
--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -538,7 +538,7 @@ abstract public class PipelineJob extends Job implements Serializable
         File newFile = new File(file.getPath() + ".new");
         File origFile = new File(file.getPath() + ".orig");
 
-        String serializedJob = PipelineJob.serializeJob(this, true);
+        String serializedJob = serializeJob(true);
 
         try (FileOutputStream fOut = new FileOutputStream(newFile))
         {
@@ -704,7 +704,7 @@ abstract public class PipelineJob extends Job implements Serializable
         if (taskPipeline != null)
         {
             // Save the current job state marshalled to XML, in case of error.
-            String serializedJob = PipelineJob.serializeJob(this, true);
+            String serializedJob = serializeJob(true);
 
             // Note runStateMachine returns false, if the job cannot be run locally.
             // The job may still need to be put on a JMS queue for remote processing.
@@ -1885,14 +1885,9 @@ abstract public class PipelineJob extends Job implements Serializable
         return status.getNotificationType();
     }
 
-    public static String serializeJob(PipelineJob job)
+    public String serializeJob(boolean ensureDeserialize)
     {
-        return serializeJob(job, true);
-    }
-
-    public static String serializeJob(PipelineJob job, boolean ensureDeserialize)
-    {
-        return PipelineJobService.get().getJobStore().serializeToJSON(job, ensureDeserialize);
+        return PipelineJobService.get().getJobStore().serializeToJSON(this, ensureDeserialize);
     }
 
     public static String getClassNameFromJson(String serialized)

--- a/list/src/org/labkey/list/pipeline/ListReloadTask.java
+++ b/list/src/org/labkey/list/pipeline/ListReloadTask.java
@@ -84,7 +84,7 @@ public class ListReloadTask extends PipelineJob.Task<ListReloadTask.Factory>
 
                 context.setProps(params);
                 ListReloadJob reloadJob = new ListReloadJob(job.getInfo(), pr, dataFile, job.getLogFilePath(), context);
-                ListReloadJob unserializedJob = (ListReloadJob) PipelineJob.deserializeJob(PipelineJob.serializeJob(reloadJob, false));   // Force round trip to ensure serialization works
+                ListReloadJob unserializedJob = (ListReloadJob) PipelineJob.deserializeJob(reloadJob.serializeJob(false));   // Force round trip to ensure serialization works
                 unserializedJob.run();
 
                 if (reloadJob.getErrors() > 0)

--- a/pipeline/src/org/labkey/pipeline/analysis/ConvertTaskFactory.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/ConvertTaskFactory.java
@@ -211,7 +211,7 @@ public class ConvertTaskFactory extends AbstractTaskFactory<ConvertTaskFactorySe
         if (factory == null)
         {
             job.warn("Unexpected missing converter for job. The pipeline configuration may have changed to remove a previously configured converter.");
-            LOG.warn("Unexpected missing converter for job. The pipeline configuration may have changed to remove a previously configured converter. \n" + PipelineJob.serializeJob(job, false));
+            LOG.warn("Unexpected missing converter for job. The pipeline configuration may have changed to remove a previously configured converter. \n" + job.serializeJob(false));
             return true;
         }
 

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobStoreImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobStoreImpl.java
@@ -124,7 +124,7 @@ public class PipelineJobStoreImpl extends PipelineJobMarshaller
     @Override
     public void storeJob(PipelineJob job) throws NoSuchJobException
     {
-        PipelineStatusManager.storeJob(job.getJobGUID(), PipelineJob.serializeJob(job, true));
+        PipelineStatusManager.storeJob(job.getJobGUID(), job.serializeJob(true));
     }
 
     // Synchronize all splitting and joining to avoid SQL deadlocks.  Splitting

--- a/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
@@ -429,7 +429,7 @@ public class PipelineServiceImpl implements PipelineService
     public void queueJob(PipelineJob job, @Nullable String jobNotificationProvider) throws PipelineValidationException
     {
         // Test serialization by serializing and deserializating every job
-        PipelineJob deserializedJob = PipelineJob.deserializeJob(PipelineJob.serializeJob(job, false));
+        PipelineJob deserializedJob = PipelineJob.deserializeJob(job.serializeJob(false));
         getPipelineQueue().addJob(deserializedJob);
 
         PipelineJobNotificationProvider notificationProvider = PipelineService.get().getPipelineJobNotificationProvider(jobNotificationProvider, job);

--- a/pipeline/src/org/labkey/pipeline/api/PipelineStatusFileImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineStatusFileImpl.java
@@ -134,7 +134,7 @@ public class PipelineStatusFileImpl extends Entity implements Serializable, Pipe
             // The taskId is not really valid for the joined job at this point,
             // so avoid asking the TaskFactory about it.
             setActiveTaskId(job.getActiveTaskId().toString());
-            setJobStore(PipelineJob.serializeJob(job, true));
+            setJobStore(job.serializeJob(true));
         }
         // If there is an active task and this is waiting state, then checkpoint the
         // job to the database for retry.
@@ -144,7 +144,7 @@ public class PipelineStatusFileImpl extends Entity implements Serializable, Pipe
         {
             if (job.getActiveTaskFactory() != null)
                 setActiveTaskId(job.getActiveTaskFactory().getActiveId(job).toString());
-            setJobStore(PipelineJob.serializeJob(job, true));
+            setJobStore(job.serializeJob(true));
         }
     }
 

--- a/pipeline/src/org/labkey/pipeline/mule/transformers/PipelineJobToJMSMessage.java
+++ b/pipeline/src/org/labkey/pipeline/mule/transformers/PipelineJobToJMSMessage.java
@@ -52,7 +52,7 @@ public class PipelineJobToJMSMessage extends AbstractEventAwareTransformer
 
     protected Message transformJob(PipelineJob job) throws Exception
     {
-        String xml =  PipelineJob.serializeJob(job, true);
+        String xml =  job.serializeJob(true);
 
         if (logger.isDebugEnabled())
             logger.debug("Job xml for " + job.getClass() + ":\n" + xml);


### PR DESCRIPTION
#### Rationale
There's no reason for PipelineJob.serializeJob() to be static, and we'd like to provide a convenient mechanism for subclasses to be able to customize their behavior.

#### Changes
* Switch from static to instance method