### PR TITLE
46183: Lists : bulk import validation performed for text key field is case insensitive for case sensitive dialects

### DIFF
--- a/api/src/org/labkey/api/data/validator/DuplicateSingleKeyValidator.java
+++ b/api/src/org/labkey/api/data/validator/DuplicateSingleKeyValidator.java
@@ -27,16 +27,16 @@ import java.util.Set;
  */
 public class DuplicateSingleKeyValidator extends AbstractColumnValidator
 {
-    private final boolean _caseInsensitive;
+    private final boolean _caseSensitive;
     private final JdbcType _jdbcType;
 
     private Set _keys = null;
 
-    public DuplicateSingleKeyValidator(String columnName, JdbcType jdbcType, boolean caseInsensitive)
+    public DuplicateSingleKeyValidator(String columnName, JdbcType jdbcType, boolean caseSensitive)
     {
         super(columnName);
         _jdbcType = jdbcType;
-        _caseInsensitive = caseInsensitive;
+        _caseSensitive = caseSensitive;
     }
 
     @Override
@@ -44,7 +44,7 @@ public class DuplicateSingleKeyValidator extends AbstractColumnValidator
     {
         if (null == _keys)
         {
-            if (_caseInsensitive && _jdbcType.isText())
+            if (!_caseSensitive && _jdbcType.isText())
                 _keys = new CaseInsensitiveHashSet();
             else
                 _keys = new HashSet();


### PR DESCRIPTION
#### Rationale
If a list were configured with a text key field on Postgres and you tried to import data with row values that differed only in case, we would throw a duplicate keys validation error.

The `DuplicateSingleKeyValidator` was effectively inverting the `caseInsensitive` parameter. If you look at all callers of that class and up the chain, what is being passed down is the value of : `getSqlDialect().isCaseSensitive()`.


[Related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46183)