### PR TITLE
46087: File Fields in a Dataset are not showing a valid link to the file

### DIFF
--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -35,7 +35,6 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.property.Domain;
-import org.labkey.api.query.ValidationException;
 import org.labkey.api.reports.model.ViewCategory;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
@@ -362,18 +361,6 @@ public interface Dataset extends StudyEntity, StudyCachable<Dataset>
     void delete(User user);
 
     void deleteAllRows(User user);
-
-    /**
-     * Update a single dataset row
-     * @return the new lsid for the updated row
-     * @param u user performing the update
-     * @param lsid the lsid of the dataset row
-     * @param data the data to be updated
-     *
-     * Don't use this method unless you are DatasetUpdateService
-     */
-    @Deprecated
-    String updateDatasetRow_forDatasetUpdateService(User u, String lsid, Map<String,Object> data) throws ValidationException;
 
     /**
      * Fetches a single row from a dataset given an LSID


### PR DESCRIPTION
#### Rationale
Dataset fields configured as `File` types didn't work completely. While they do work in the insert case, the update case would result in the rendered field value displaying a string similar to : `org.springframework.web.multipart.commons.CommonsMultipartFile@12b2ff6c (unavailable)` and not rendering either a thumbnail or being downloadable.
 
[Related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46087)

#### Changes
The existing code path was quite complex for the update case with the call chain like : `QueryUpdateService.updateRow` -> `Dataset.updateDatasetRow_forDatasetUpdateService` -> `StudyManager.importDatasetData` -> `QueryUpdateService.loadRows`.

The primary problem was the `DataLoader` that gets used to create the `DataIterator` doesn't know about files and the object gets eventually converted to a string. The proposed fix was to refactor the existing code to eliminate the code paths through the `deprecated` methods and consolidate most of the code into the update service.

- Move the code previously in `Dataset.updateDatasetRow_forDatasetUpdateService` into `DatasetUpdateService`
- In the moved code, use `insertRows` to re-add the row instead of the deprecated method : `StudyManager.importDatasetData` the dataset update row case is strange given that we do a delete and then add.

