### PR TITLE
Fix credit error checking in production mode

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -298,16 +298,6 @@ public class ApiModule extends CodeOnlyModule
     }
 
     @Override
-    public @NotNull Collection<String> getJarFilenames()
-    {
-        // Filter out "labkey-client-api-XX.X.jar" -- we don't need credits for our own jar. All of its dependencies will
-        // appear on the credits page, though.
-        return super.getJarFilenames().stream()
-            .filter(fn->!fn.startsWith("labkey-client-api-"))
-            .collect(Collectors.toList());
-    }
-
-    @Override
     public JSONObject getPageContextJson(ContainerUser context)
     {
         JSONObject json = new JSONObject(getDefaultPageContextJson(context.getContainer()));

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -1289,9 +1289,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
     @NotNull
     public Collection<String> getJarFilenames()
     {
-        if (!AppProps.getInstance().isDevMode())
-            return Collections.emptySet();
-
         return getDependenciesFromFile();
     }
 

--- a/core/resources/credits/tomcat_jars.txt
+++ b/core/resources/credits/tomcat_jars.txt
@@ -1,5 +1,5 @@
 {table}
 Filename|Component|Version|Source|License|LabKey Dev|Purpose
-javax.activation.jar|JavaBeans Activation Framework (JAF)|1.2.2|{link:Eclipse Project for JAF|https://projects.eclipse.org/projects/ee4j.jaf}|{link:Eclipse Public License 2.0|https://www.eclipse.org/legal/epl-2.0/}|adam|JavaMail and Workflow dependency
-mail.jar|Jakarta Mail|1.6.7|{link:Eclipse Project for Jakarta Mail|https://projects.eclipse.org/projects/ee4j.mail}|{link:Eclipse Public License 2.0|https://www.eclipse.org/legal/epl-2.0/}|adam|Send email from LabKey Server
+javax.activation.jar|Jakarta Activation™|1.2.2|{link:Eclipse|https://projects.eclipse.org/projects/ee4j.jaf}|{link:Eclipse Public License 2.0|https://www.eclipse.org/legal/epl-2.0/}|adam|Jakarta Mail and JAXB dependency
+mail.jar|Jakarta Mail™|1.6.7|{link:Eclipse|https://projects.eclipse.org/projects/ee4j.mail}|{link:Eclipse Public License 2.0|https://www.eclipse.org/legal/epl-2.0/}|adam|Send email from LabKey Server
 {table}

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1037,6 +1037,9 @@ public class AdminController extends SpringActionController
 
         private @NotNull String getErrors(@Nullable String wikiSource, String creditsFilename, Collection<String> foundFilenames, String fileType, String foundWhere, @Nullable String wikiSourceSearchPattern)
         {
+            if (foundFilenames.isEmpty() && null != wikiSource && "jars.txt".equals(creditsFilename))
+                return WIKI_LINE_SEP + "**WARNING: jars.txt file exists when no external jars are present in " + _component + "**";
+
             Set<String> documentedFilenames = new CaseInsensitiveTreeSet();
 
             if (null != wikiSource && null != wikiSourceSearchPattern)

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1037,38 +1037,38 @@ public class AdminController extends SpringActionController
 
         private @NotNull String getErrors(@Nullable String wikiSource, String creditsFilename, Collection<String> foundFilenames, String fileType, String foundWhere, @Nullable String wikiSourceSearchPattern)
         {
-            LOG.info("creditsFilename: " + creditsFilename);
-            LOG.info("foundFilenames: " + foundFilenames);
-            LOG.info("Dev mode: " + AppProps.getInstance().isDevMode());
-            LOG.info("wikiSource: " + wikiSource);
+            return "creditsFilename: " + creditsFilename + "\\\\" +
+                "foundFilenames: " + foundFilenames + "\\\\" +
+                "Dev mode: " + AppProps.getInstance().isDevMode() + "\\\\" +
+                "wikisource length: " + (null == wikiSource ? "null" : wikiSource.length()) + "\\\\";
 
-            if (foundFilenames.isEmpty() && null != wikiSource && "jars.txt".equals(creditsFilename))
-                return WIKI_LINE_SEP + "**WARNING: jars.txt file exists when no external jars are present in " + _component + "**";
-
-            Set<String> documentedFilenames = new CaseInsensitiveTreeSet();
-
-            if (null != wikiSource && null != wikiSourceSearchPattern)
-            {
-                Pattern p = Pattern.compile(wikiSourceSearchPattern, Pattern.MULTILINE);
-                Matcher m = p.matcher(wikiSource);
-
-                while(m.find())
-                {
-                    String found = m.group(1);
-                    documentedFilenames.add(found);
-                }
-            }
-
-            Set<String> documentedFilenamesCopy = new HashSet<>(documentedFilenames);
-            documentedFilenames.removeAll(foundFilenames);
-            foundFilenames.removeAll(documentedFilenamesCopy);
-            Collection<String> undocumented = new CaseInsensitiveTreeSet(foundFilenames);
-            undocumented.removeIf(name->name.startsWith("."));
-
-            String undocumentedErrors = foundFilenames.isEmpty() ? "" : WIKI_LINE_SEP + "**WARNING: The following " + fileType + " file" + (undocumented.size() > 1 ? "s were" : " was") + " found in your " + foundWhere + " but "+ (foundFilenames.size() > 1 ? "are" : "is") + " not documented in " + _component + " " + creditsFilename + ":**\\\\" + StringUtils.join(foundFilenames.iterator(), "\\\\");
-            String missingErrors = documentedFilenames.isEmpty() ? "" : WIKI_LINE_SEP + "**WARNING: The following " + fileType + " file" + (documentedFilenames.size() > 1 ? "s are" : " is") + " documented in " + _component + " " + creditsFilename + " but " + (documentedFilenames.size() > 1 ? "were" : "was") + " not found in your " + foundWhere + ":**\\\\" + StringUtils.join(documentedFilenames.iterator(), "\\\\");
-
-            return undocumentedErrors + missingErrors;
+//            if (foundFilenames.isEmpty() && null != wikiSource && "jars.txt".equals(creditsFilename))
+//                return WIKI_LINE_SEP + "**WARNING: jars.txt file exists when no external jars are present in " + _component + "**";
+//
+//            Set<String> documentedFilenames = new CaseInsensitiveTreeSet();
+//
+//            if (null != wikiSource && null != wikiSourceSearchPattern)
+//            {
+//                Pattern p = Pattern.compile(wikiSourceSearchPattern, Pattern.MULTILINE);
+//                Matcher m = p.matcher(wikiSource);
+//
+//                while(m.find())
+//                {
+//                    String found = m.group(1);
+//                    documentedFilenames.add(found);
+//                }
+//            }
+//
+//            Set<String> documentedFilenamesCopy = new HashSet<>(documentedFilenames);
+//            documentedFilenames.removeAll(foundFilenames);
+//            foundFilenames.removeAll(documentedFilenamesCopy);
+//            Collection<String> undocumented = new CaseInsensitiveTreeSet(foundFilenames);
+//            undocumented.removeIf(name->name.startsWith("."));
+//
+//            String undocumentedErrors = foundFilenames.isEmpty() ? "" : WIKI_LINE_SEP + "**WARNING: The following " + fileType + " file" + (undocumented.size() > 1 ? "s were" : " was") + " found in your " + foundWhere + " but "+ (foundFilenames.size() > 1 ? "are" : "is") + " not documented in " + _component + " " + creditsFilename + ":**\\\\" + StringUtils.join(foundFilenames.iterator(), "\\\\");
+//            String missingErrors = documentedFilenames.isEmpty() ? "" : WIKI_LINE_SEP + "**WARNING: The following " + fileType + " file" + (documentedFilenames.size() > 1 ? "s are" : " is") + " documented in " + _component + " " + creditsFilename + " but " + (documentedFilenames.size() > 1 ? "were" : "was") + " not found in your " + foundWhere + ":**\\\\" + StringUtils.join(documentedFilenames.iterator(), "\\\\");
+//
+//            return undocumentedErrors + missingErrors;
         }
 
         @Override

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1037,6 +1037,11 @@ public class AdminController extends SpringActionController
 
         private @NotNull String getErrors(@Nullable String wikiSource, String creditsFilename, Collection<String> foundFilenames, String fileType, String foundWhere, @Nullable String wikiSourceSearchPattern)
         {
+            LOG.info("creditsFilename: " + creditsFilename);
+            LOG.info("foundFilenames: " + foundFilenames);
+            LOG.info("Dev mode: " + AppProps.getInstance().isDevMode());
+            LOG.info("wikiSource: " + wikiSource);
+
             if (foundFilenames.isEmpty() && null != wikiSource && "jars.txt".equals(creditsFilename))
                 return WIKI_LINE_SEP + "**WARNING: jars.txt file exists when no external jars are present in " + _component + "**";
 


### PR DESCRIPTION
#### Rationale
A change I made yesterday broke special handling we had in place for `dependencies.txt` vs. `jars.txt` comparisons in production mode. Instead of restoring the special handling, I made production mode work the same as dev mode... removing additional special handling in `DefaultModule`. This special handling was likely needed before the introduction of `dependencies.txt`, but isn't now.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3634

#### Changes
* With the exception of Tomcat jars (which aren't worth looking for in production mode), handle `dependencies.txt` vs. `jars.txt` validation the same in production and dev modes.
* Update Tomcat jar names to the latest.
* Catch an additional error condition that was previously missed: a jars.txt file with no jars listed.