### PR TITLE
Upgrade to Spring Framework 5.3.22

### DIFF
--- a/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
+++ b/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
@@ -393,11 +393,17 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
         {
             view.getDataRegion().addHiddenFormField("batchId", form.getBatchId().toString());
         }
+        // Strip parameters from the URL since they're being added as hidden POST values
+        ActionURL action = getViewContext().getActionURL().clone();
+        action.deleteParameter("uploadStep");
+        action.deleteParameter("rowId");
+        view.getDataRegion().setFormActionUrl(action);
+
         view.getDataRegion().addHiddenFormField("uploadStep", uploadStepName);
+        view.getDataRegion().addHiddenFormField("rowId", Integer.toString(_protocol.getRowId()));
         view.getDataRegion().addHiddenFormField("multiRunUpload", "false");
         view.getDataRegion().addHiddenFormField("severityLevel",((form.getTransformResult().getWarnings() != null)?"ERROR":"WARN"));
         view.getDataRegion().addHiddenFormField("resetDefaultValues", "false");
-        view.getDataRegion().addHiddenFormField("rowId", Integer.toString(_protocol.getRowId()));
         view.getDataRegion().addHiddenFormField("uploadAttemptID", form.getUploadAttemptID());
         if (form.isAllowCrossRunFileInputs())
             view.getDataRegion().addHiddenFormField("allowCrossRunFileInputs", "true");
@@ -493,7 +499,7 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
         addCancelButton(bbar, returnURL);
         insertView.getDataRegion().setButtonBar(bbar, DataRegion.MODE_INSERT);
 
-        JspView<AssayRunUploadForm> assayPropsView = new JspView<>("/org/labkey/assay/view/newUploadAssayProperties.jsp", runForm);
+        JspView<AssayRunUploadForm<?>> assayPropsView = new JspView<>("/org/labkey/assay/view/newUploadAssayProperties.jsp", runForm);
         assayPropsView.setTitle("Assay Properties");
 
         _stepDescription = "Batch Properties";

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -103,6 +103,7 @@ import org.labkey.api.security.roles.OwnerRole;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.util.Button;
 import org.labkey.api.util.CSRFUtil;
+import org.labkey.api.util.DOM;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
@@ -166,6 +167,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.labkey.api.util.DOM.at;
 
 public class IssuesController extends SpringActionController
 {
@@ -669,7 +672,7 @@ public class IssuesController extends SpringActionController
     /**
      * Generates a standard message if no issue list is available in the current folder (plus a link to create a list)
      */
-    public static String getUndefinedIssueListMessage(ContainerUser context, String issueDefName)
+    public static DOM.Renderable getUndefinedIssueListMessage(ContainerUser context, String issueDefName)
     {
         String warningMessage =
                 issueDefName == null ?
@@ -677,16 +680,14 @@ public class IssuesController extends SpringActionController
                         "There are no issues lists defined for this folder." :
                         String.format("'%s' not specified.", IssuesListView.ISSUE_LIST_DEF_NAME)) :
                 String.format("There is no issues list '%s' defined in this folder.", issueDefName);
-        StringBuilder sb = new StringBuilder().append("<span class='labkey-error'>").append(PageFlowUtil.filter(warningMessage)).append("</span><p>");
         boolean userHasAdmin = context.getContainer().hasPermission(context.getUser(), AdminPermission.class);
         Button button = PageFlowUtil.button(userHasAdmin ? "Manage Issue List Definitions" : "Show Available Issue Lists").href(QueryService.get().urlFor(context.getUser(),
                 context.getContainer(),
                 QueryAction.executeQuery,
                 "issues",
                 IssuesQuerySchema.TableType.IssueListDef.name())).build();
-        sb.append(button.toString());
 
-        return sb.toString();
+        return DOM.SPAN(at(DOM.cl("labkey-error")), warningMessage, DOM.P(), button);
     }
 
     public static class IssuesApiForm extends SimpleApiJsonForm

--- a/issues/src/org/labkey/issue/view/IssuesSummaryWebPartFactory.java
+++ b/issues/src/org/labkey/issue/view/IssuesSummaryWebPartFactory.java
@@ -43,14 +43,14 @@ public class IssuesSummaryWebPartFactory extends BaseWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext context, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext context, @NotNull Portal.WebPart webPart)
     {
         Map<String, String> propertyMap = webPart.getPropertyMap();
         String issueDefName = propertyMap.get(IssuesListView.ISSUE_LIST_DEF_NAME);
         if (issueDefName == null)
             issueDefName = IssueManager.getDefaultIssueListDefName(context.getContainer());
 
-        WebPartView view;
+        WebPartView<?> view;
         IssueListDef issueListDef = IssueManager.getIssueListDef(context.getContainer(), issueDefName);
         if (issueListDef != null)
             view = new SummaryWebPart(issueDefName, propertyMap);
@@ -65,7 +65,7 @@ public class IssuesSummaryWebPartFactory extends BaseWebPartFactory
     }
 
     @Override
-    public HttpView getEditView(Portal.WebPart webPart, ViewContext context)
+    public HttpView<?> getEditView(Portal.WebPart webPart, ViewContext context)
     {
         if (!IssueManager.getIssueListDefs(context.getContainer()).isEmpty())
             return new IssuesListView.IssuesListConfig(webPart);

--- a/issues/src/org/labkey/issue/view/updateView.jsp
+++ b/issues/src/org/labkey/issue/view/updateView.jsp
@@ -450,8 +450,6 @@
     }%>
     <input type="hidden" name=".oldValues" value="<%=PageFlowUtil.encodeObject(bean.getPrevIssue())%>">
     <input type="hidden" name="action" value="<%=h(bean.getAction().name())%>">
-    <input type="hidden" name="issueId" value="<%=issue.getIssueId()%>">
-    <input type="hidden" name="issueDefName" value="<%=h(StringUtils.trimToEmpty(issue.getIssueDefName()))%>">
     <input type="hidden" name="dirty" value="false">
 </labkey:form>
 <script type="text/javascript" for="window" event="onload">try {document.getElementById(<%=q(focusId)%>).focus();} catch (x) {}</script>

--- a/query/src/org/labkey/query/olap/OlapTestCase.jsp
+++ b/query/src/org/labkey/query/olap/OlapTestCase.jsp
@@ -15,12 +15,12 @@
 
 JSONObject executeJsonApi(ActionURL url, User user, String json) throws Exception
 {
-    Map<String,Object> headers = Map.of("Content-Type", (Object)"application/json");
+    Map<String,Object> headers = Map.of("Content-Type", "application/json");
     var req = ViewServlet.mockRequest("POST", url, user, headers, json);
     var res = ViewServlet.mockDispatch(req, null);
     // Oddly, BaseApiAction returns SC_BAD_REQUEST by default when an handled error is returned, even though the it is not a bad request.
     assertTrue(HttpServletResponse.SC_BAD_REQUEST == res.getStatus() || HttpServletResponse.SC_OK == res.getStatus());
-    assertEquals("application/json", res.getContentType());
+    assertEquals("application/json;charset=UTF-8", res.getContentType());
     return new JSONObject(res.getContentAsString());
 }
 

--- a/specimen/src/org/labkey/specimen/view/manageRequirement.jsp
+++ b/specimen/src/org/labkey/specimen/view/manageRequirement.jsp
@@ -44,9 +44,7 @@
     Location location = requirement.getLocation();
     String locationLabel = location != null ? location.getDisplayName() : "N/A";
 
-    ActionURL deleteURL = urlFor(DeleteRequirementAction.class)
-        .addParameter("id", requirement.getRequestId())
-        .addParameter("requirementId", requirement.getRowId());
+    ActionURL deleteURL = urlFor(DeleteRequirementAction.class);
 %>
 <labkey:errors />
 <table class="labkey-manage-display">


### PR DESCRIPTION
#### Rationale
We want to be on the latest, maintained version of Spring Framework.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/309

#### Changes
* Stop duplicating GET and POST parameters, which Spring now interprets as multiple values
* Fallback to UncategorizedSQLException on our own as the Spring translator now returns null when it doesn't recognize the SQLException variant
* Expect the character set appended to the content type
* Misc cleanup