### PR TITLE
Study manage security fix for selenium test failure with ParticipantLevelPermissionsTest

### DIFF
--- a/study/src/org/labkey/study/security/study.jsp
+++ b/study/src/org/labkey/study/security/study.jsp
@@ -45,7 +45,7 @@ Any user with READ access to this folder may view some summary data. However, ac
     if (returnUrl != null)
         out.print(generateReturnUrlFormField(returnUrl));
 %>
-    <table class="table table-striped table-bordered labkey-data-region-header-lock" id="datasetSecurityFormTable">
+    <table class="table table-striped table-bordered labkey-data-region-header-lock" id="datasetSecurityGroupTable">
         <tr>
             <th>&nbsp;</th>
             <% if (includeEditOption)


### PR DESCRIPTION
#### Rationale
The related PR updated the tables on the manage study security page. It broke the "set all to" selection option in the per dataset group perm setting table because it introduced a duplicate DOM element id. This PR fixes that by using a distinct id for the group settings table.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3641

#### Changes
* Update DOM element id for table on study.jsp page
