### PR TITLE
Issue 46229: Use time-based ordering to jitter points in Panorama QC plots

### DIFF
--- a/internal/webapp/vis/src/geom.js
+++ b/internal/webapp/vis/src/geom.js
@@ -151,6 +151,8 @@ LABKEY.vis.Geom.XY.prototype.getParentY = function(row){
  *      config.position is "jitter" and the x or y scale is discrete it will be moved just before or after the position
  *      on the grid by a random amount. "sequential" orders the x-axis points deterministically based on their ordering
  *      in the incoming data. Useful if there is overlapping data. Defaults to undefined.
+ * @param {String} [config.groupBy] (Optional) Data field being used to split into series, for use with "sequential"
+ *      positioning. Defaults to undefined.
  */
 LABKEY.vis.Geom.Point = function(config){
     this.type = "Point";
@@ -163,6 +165,7 @@ LABKEY.vis.Geom.Point = function(config){
     this.opacity = ('opacity' in config && config.opacity != null && config.opacity != undefined) ? config.opacity : 1;
     this.plotNullPoints = ('plotNullPoints' in config && config.plotNullPoints != null && config.plotNullPoints != undefined) ? config.plotNullPoints : false;
     this.position = ('position' in config && config.position != null && config.position != undefined) ? config.position : null;
+    this.groupBy = ('groupBy' in config && config.groupBy != null && config.groupBy != undefined) ? config.groupBy : null;
 
     return this;
 };

--- a/internal/webapp/vis/src/internal/D3Renderer.js
+++ b/internal/webapp/vis/src/internal/D3Renderer.js
@@ -1987,21 +1987,25 @@ LABKEY.vis.internal.D3Renderer = function(plot) {
                     jitterIndex[x] = true;
                 } else if (geom.position === position.sequential) {
 
-                    if (!jitterIndex[x]) {
+                    // We calculate based on both the x-axis position and (optionally) within the series as configured via groupBy
+                    const xGrouped = x + (geom.groupBy ? ('-' + row[geom.groupBy]) : '');
+
+                    if (!jitterIndex[xGrouped]) {
                         // Count how many points we have to distribute across the grouping, and reset the current
                         // indices for the groupings
                         jitters = {};
                         for (var i = 0; i < data.length; i++) {
-                            var x2 = geom.xAes.getValue(data[i]);
-                            var count = jitterIndex[x2] || 0;
-                            jitterIndex[x2] = count + 1;
+                            const x2 = geom.xAes.getValue(data[i]);
+                            const x2Grouped = x2 + (geom.groupBy ? ('-' + data[i][geom.groupBy]) : '');
+                            const count = jitterIndex[x2Grouped] || 0;
+                            jitterIndex[x2Grouped] = count + 1;
                         }
                     }
 
                     // Calculate the offset for the current point within the full count for the grouping
-                    var index = jitters[x] || 0;
-                    value = value - (xBinWidth / 2) + (xBinWidth / jitterIndex[x]) * (index + 0.5);
-                    jitters[x] = index + 1;
+                    var index = jitters[xGrouped] || 0;
+                    value = value - (xBinWidth / 2) + (xBinWidth / jitterIndex[xGrouped]) * (index + 0.5);
+                    jitters[xGrouped] = index + 1;
                 }
                 return value;
             };

--- a/internal/webapp/vis/src/plot.js
+++ b/internal/webapp/vis/src/plot.js
@@ -2312,6 +2312,7 @@ boxPlot.render();
             var pointLayerConfig = {
                 geom: new LABKEY.vis.Geom.Point({
                     position: config.properties.position,
+                    groupBy: config.properties.groupBy,
                     opacity: config.properties.pointOpacityFn,
                     size: config.properties.pointSize ? config.properties.pointSize : 3
                 }),


### PR DESCRIPTION
#### Rationale
In Panorama QC folder plots, you can group data based on acquisition date. However, this randomly jitters the points within the day.  Like we do in the reproducibility plots, it would be better to order them based on their acquisition time. This would make it clearer when a change happens mid-day. 

#### Changes
* When using "sequential" positioning, bucket based on the grouping (series) so that points are evenly distributed within a series