### PR TITLE
display additional information for query analysis failures

### DIFF
--- a/query/webapp/query/browser/view/Dependencies.js
+++ b/query/webapp/query/browser/view/Dependencies.js
@@ -14,8 +14,9 @@ Ext4.define('LABKEY.query.browser.view.Dependencies', {
         this.addEvents('dependencychanged');
 
         this.errorTpl = new Ext4.XTemplate(
-                '<span class="labkey-error" style="display: block; margin-top: 50px; margin-left: 50px;"><div>An Error Occurred Analyzing Queries : {exception}</div>',
+                '<span class="labkey-error" style="display: block; margin: 50px;"><div>An Error Occurred Analyzing Queries : {exception}</div>',
                 '<pre>',
+                '<div>{url}</div>',
                 '<div>{exceptionClass}</div>',
                 '<tpl for="stackTrace">',
                 '<div>{.}</div>',
@@ -140,12 +141,18 @@ Ext4.define('LABKEY.query.browser.view.Dependencies', {
         if (response && response.getResponseHeader && response.getResponseHeader('Content-Type')
                 && response.getResponseHeader('Content-Type').indexOf('application/json') >= 0){
             try {
-                return LABKEY.Utils.decode(response.responseText);
+                var error = LABKEY.Utils.decode(response.responseText);
+                error["url"] = response.responseURL;
+
+                return error;
             }
             catch (error){
                 //we still want to proceed even if we cannot decode the JSON
             }
         }
-        return {exception: LABKEY.Utils.getMsgFromError(response, opts)};
+        return {
+            exception: LABKEY.Utils.getMsgFromError(response, opts),
+            url: response.responseURL
+        };
     }
 });


### PR DESCRIPTION
#### Rationale
When there is a failure during the process of resolving query dependencies, we have added additional information to the error dialog to help with troubleshooting. This includes the `Exception` and `stacktrace` if one is available. This PR adds the `URL` from the failing request which will help determine which folder caused the failure.