### PR TITLE
Limit serialized pipeline jobs to 100MB

### DIFF
--- a/api/src/org/labkey/api/pipeline/PipelineStatusFile.java
+++ b/api/src/org/labkey/api/pipeline/PipelineStatusFile.java
@@ -80,10 +80,9 @@ public interface PipelineStatusFile
 
         void join(PipelineJob job) throws IOException, NoSuchJobException;
 
-        String serializeToJSON(Object job);
-        String serializeToJSON(Object job, boolean ensureDeserialize);
+        String serializeToJSON(PipelineJob job, boolean ensureDeserialize);
 
-        Object deserializeFromJSON(String xml, Class<?> cls);
+        PipelineJob deserializeFromJSON(String xml, Class<? extends PipelineJob> cls);
     }
 
     Container lookupContainer();

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10918,11 +10918,23 @@ public class AdminController extends SpringActionController
 
     public static class SerializationTest extends PipelineJob.TestSerialization
     {
-        static class TestJob
+        static class TestJob extends PipelineJob
         {
             ImpersonationContext _impersonationContext;
             ImpersonationContext _impersonationContext1;
             ImpersonationContext _impersonationContext2;
+
+            @Override
+            public URLHelper getStatusHref()
+            {
+                return null;
+            }
+
+            @Override
+            public String getDescription()
+            {
+                return "Test Job";
+            }
         }
 
         @Test

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobStoreImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobStoreImpl.java
@@ -43,18 +43,12 @@ public class PipelineJobStoreImpl extends PipelineJobMarshaller
     private static Logger _log = LogManager.getLogger(PipelineJobStoreImpl.class);
 
     @Override
-    public Object deserializeFromJSON(String json, Class<?> cls)
+    public PipelineJob deserializeFromJSON(String json, Class<? extends PipelineJob> cls)
     {
-        Object obj = super.deserializeFromJSON(json, cls);
-        if (obj instanceof PipelineJob)
-        {
-            PipelineJob job = (PipelineJob)obj;
-            job.restoreQueue(PipelineService.get().getPipelineQueue());
-            job.restoreLocalDirectory();
-            return job;
-        }
-        _log.warn("Expected PipelineJob subclass: " + obj.getClass().getName());
-        return obj;
+        PipelineJob job = super.deserializeFromJSON(json, cls);
+        job.restoreQueue(PipelineService.get().getPipelineQueue());
+        job.restoreLocalDirectory();
+        return job;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
A recent support ticket reported OutOfMemoryErrors when processing pipeline jobs. It turned out that a custom pipeline job implementation was creating huge (>600MB) serialized JSON records that were being stored in pipeline.statusfiles in the DB. It was hard to clean up.

#### Changes
* Cap serialized pipeline jobs at 100MB, which is ridiculously large but should prevent hard-to-recover-from scenarios
* Clean up serialization API