### PR TITLE
Issue 46250: .lastFilter URL stored in session can get mangled

### DIFF
--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -2886,12 +2886,15 @@ public class PageFlowUtil
         {
             if (paramName.endsWith("." + QueryParam.offset))
                 clone.deleteParameter(paramName);
-            // CONSIDER: Should we whitelist params that don't contain a "."?  They are not usually dataregion related.
-            // We know pageId should not be persisted (Issue 45617)
-            clone.deleteParameter("pageId");
         }
 
+        // CONSIDER: Should we pass through only selected params that don't contain "."?  They are not usually dataregion related.
+        // We know pageId should not be persisted (Issue 45617)
+        clone.deleteParameter("pageId");
         clone.deleteParameter(scope + DataRegion.LAST_FILTER_PARAM);
+
+        clone.setReadOnly();
+
         HttpSession session = context.getRequest().getSession(false);
         // We should already have a session at this point, but check anyway - see bug #7761
         if (session != null)

--- a/api/src/org/labkey/api/view/ViewServlet.java
+++ b/api/src/org/labkey/api/view/ViewServlet.java
@@ -410,6 +410,7 @@ public class ViewServlet extends HttpServlet
                 ActionURL expand = (ActionURL) request.getSession(true).getAttribute(url.getPath() + "#" + paramName);
                 if (null != expand)
                 {
+                    expand = expand.clone();
                     // any parameters on the URL override those stored in the last filter:
                     for (Pair<String, String> parameter : url.getParameters())
                     {


### PR DESCRIPTION
#### Rationale
Hitting the server with a sequence of .lastFilter-related URLs can end up storing an invalid URL in the session, making .lastFilter=true requests redirect to it. This causes intermittent test failures in the crawler.

#### Changes
* Don't mutate the session-stored lastFilter URL