### PR TITLE
Make sure assay domain desginer functionality is enabled in community edition

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.15.0",
-        "@labkey/components": "2.212.3",
+        "@labkey/components": "2.213.2-communityAssay.0",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -2959,9 +2959,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.212.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.212.3.tgz",
-      "integrity": "sha512-dsJlQ5T4yToNri2Px2x5jpsAL1GcGU/FNGk5FZtgi/pQK2B8zUU8Vn66r8yu2nzl3p0Mk8uDfCmrUoAR1lpwGA==",
+      "version": "2.213.2-communityAssay.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.213.2-communityAssay.0.tgz",
+      "integrity": "sha512-E9JDjquaixCVa/+YvJ5gEVXQe+uxmAUmfx283qE11XeIzXaYxEVf+mJle4h+IqaU4lRn5Ml2RSdhyJcfekuxmw==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "~5.15.4",
@@ -16720,9 +16720,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.212.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.212.3.tgz",
-      "integrity": "sha512-dsJlQ5T4yToNri2Px2x5jpsAL1GcGU/FNGk5FZtgi/pQK2B8zUU8Vn66r8yu2nzl3p0Mk8uDfCmrUoAR1lpwGA==",
+      "version": "2.213.2-communityAssay.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.213.2-communityAssay.0.tgz",
+      "integrity": "sha512-E9JDjquaixCVa/+YvJ5gEVXQe+uxmAUmfx283qE11XeIzXaYxEVf+mJle4h+IqaU4lRn5Ml2RSdhyJcfekuxmw==",
       "requires": {
         "@fortawesome/fontawesome-free": "~5.15.4",
         "@fortawesome/fontawesome-svg-core": "~1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.15.0",
-        "@labkey/components": "2.213.2-communityAssay.0",
+        "@labkey/components": "2.213.2",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -2959,9 +2959,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.213.2-communityAssay.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.213.2-communityAssay.0.tgz",
-      "integrity": "sha512-E9JDjquaixCVa/+YvJ5gEVXQe+uxmAUmfx283qE11XeIzXaYxEVf+mJle4h+IqaU4lRn5Ml2RSdhyJcfekuxmw==",
+      "version": "2.213.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.213.2.tgz",
+      "integrity": "sha512-PE6qNNTXyr4deb5gaZ6LQDbVo528tXuEUHLFaHlU0h6o2FdNeVuC0dFi5p9NWRDq/WydrsHIsQvIVANuLFUp3w==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@fortawesome/fontawesome-free": "~5.15.4",
@@ -16720,9 +16720,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.213.2-communityAssay.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.213.2-communityAssay.0.tgz",
-      "integrity": "sha512-E9JDjquaixCVa/+YvJ5gEVXQe+uxmAUmfx283qE11XeIzXaYxEVf+mJle4h+IqaU4lRn5Ml2RSdhyJcfekuxmw==",
+      "version": "2.213.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.213.2.tgz",
+      "integrity": "sha512-PE6qNNTXyr4deb5gaZ6LQDbVo528tXuEUHLFaHlU0h6o2FdNeVuC0dFi5p9NWRDq/WydrsHIsQvIVANuLFUp3w==",
       "requires": {
         "@fortawesome/fontawesome-free": "~5.15.4",
         "@fortawesome/fontawesome-svg-core": "~1.2.36",

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.15.0",
-    "@labkey/components": "2.212.3",
+    "@labkey/components": "2.213.2-communityAssay.0",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.15.0",
-    "@labkey/components": "2.213.2-communityAssay.0",
+    "@labkey/components": "2.213.2",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Rationale
The changes to implement our product tiering didn't account for the use of the assay designer in our community edition. For the time being, at least, I've added a specific check for community edition in the isAssayEnabled method. It could be that we'll register a feature set for LKS and/or LKS Starter, but that's more of a change than I want for this fix (and it's not clear we'd get away from special logic here anyway since assay gets removed from LKSM Starter).

#### Related Pull Requests
https://github.com/LabKey/labkey-ui-components/pull/953
#3620 

#### Changes
* update package version
