### PR TITLE
Add Datadog trace and span IDs for log messages

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -177,13 +177,39 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "com.datadoghq:dd-trace-api:0.108.1",
+            "com.datadoghq:dd-trace-api:${datadogVersion}",
             "Datadog Trace API client",
             "Datadog",
             "http://www.datadoghq.com/",
             ExternalDependency.APACHE_2_LICENSE_NAME,
             ExternalDependency.APACHE_2_LICENSE_URL,
             "Integrations to pass trace_ids and other info to Datadog",
+        )
+    )
+
+    BuildUtils.addExternalDependency(
+        project,
+        new ExternalDependency(
+            "io.opentracing:opentracing-api:${openTracingVersion}",
+            "OpenTracing Java API",
+            "OpenTracing",
+            "https://opentracing.io",
+            ExternalDependency.APACHE_2_LICENSE_NAME,
+            ExternalDependency.APACHE_2_LICENSE_URL,
+            "Standard telemetry/tracing APIs, used with Datadog",
+        )
+    )
+
+    BuildUtils.addExternalDependency(
+        project,
+        new ExternalDependency(
+            "io.opentracing:opentracing-util:${openTracingVersion}",
+            "OpenTracing Java Util",
+            "OpenTracing",
+            "https://opentracing.io",
+            ExternalDependency.APACHE_2_LICENSE_NAME,
+            ExternalDependency.APACHE_2_LICENSE_URL,
+            "Standard telemetry/tracing APIs, used with Datadog",
         )
     )
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -177,6 +177,19 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
+            "com.datadoghq:dd-trace-api:0.108.1",
+            "Datadog Trace API client",
+            "Datadog",
+            "http://www.datadoghq.com/",
+            ExternalDependency.APACHE_2_LICENSE_NAME,
+            ExternalDependency.APACHE_2_LICENSE_URL,
+            "Integrations to pass trace_ids and other info to Datadog",
+        )
+    )
+
+    BuildUtils.addExternalDependency(
+        project,
+        new ExternalDependency(
             "org.apache.xmlgraphics:batik-codec:${batikVersion}",
             "Apache Batik Codec",
             "Apache",

--- a/api/src/org/labkey/api/data/AsyncQueryRequest.java
+++ b/api/src/org/labkey/api/data/AsyncQueryRequest.java
@@ -17,6 +17,10 @@
 package org.labkey.api.data;
 
 import datadog.trace.api.CorrelationIdentifier;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import org.jetbrains.annotations.Nullable;
@@ -102,12 +106,18 @@ public class AsyncQueryRequest<T>
 
         String traceId = CorrelationIdentifier.getTraceId();
 
+        // Create the span, so we can connect the async query with its owning thread
+        final Tracer tracer = GlobalTracer.get();
+        final Span span = tracer.buildSpan("AsyncRequest").start();
+        String spanId = CorrelationIdentifier.getSpanId();
+
         Runnable runnable = () -> {
             if (current != null)
                  MemTracker.get().startProfiler("async query");
-            
-            ThreadContext.put("dd.trace_id", traceId);
-            ThreadContext.put("dd.span_id", CorrelationIdentifier.getSpanId());
+
+            // Connect log messages with the active trace and span
+            ThreadContext.put(CorrelationIdentifier.getTraceIdKey(), traceId);
+            ThreadContext.put(CorrelationIdentifier.getSpanIdKey(), spanId);
 
             qs.copyEnvironment(state);
             try
@@ -123,15 +133,19 @@ public class AsyncQueryRequest<T>
                 if (current != null)
                     MemTracker.get().merge(current);
                 qs.clearEnvironment();
-                ThreadContext.remove("dd.trace_id");
-                ThreadContext.remove("dd.span_id");
+
+                // Wrap up the span
+                span.finish();
+                ThreadContext.remove(CorrelationIdentifier.getTraceIdKey());
+                ThreadContext.remove(CorrelationIdentifier.getSpanId());
             }
         };
 
         Thread thread = new Thread(runnable, "AsyncQueryRequest: " + Thread.currentThread().getName());
         // We want the async thread to use the same database connection, in case we have a transaction open, and
         // so that when the original thread finishes processing the results it ends up closing the right connection
-        try (DbScope.ConnectionSharingCloseable ignored = DbScope.shareConnections(thread))
+        try (DbScope.ConnectionSharingCloseable ignored = DbScope.shareConnections(thread);
+             Scope ignore = tracer.activateSpan(span))
         {
             thread.start();
 

--- a/api/src/org/labkey/api/view/ViewServlet.java
+++ b/api/src/org/labkey/api/view/ViewServlet.java
@@ -185,8 +185,9 @@ public class ViewServlet extends HttpServlet
             _log.debug(">> " + description);
         }
 
-        ThreadContext.put("dd.trace_id", CorrelationIdentifier.getTraceId());
-        ThreadContext.put("dd.span_id", CorrelationIdentifier.getSpanId());
+        // Connect log messages with the active trace and span
+        ThreadContext.put(CorrelationIdentifier.getTraceIdKey(), CorrelationIdentifier.getTraceId());
+        ThreadContext.put(CorrelationIdentifier.getSpanId(), CorrelationIdentifier.getSpanId());
 
         MemoryUsageLogger.logMemoryUsage(_requestCount.incrementAndGet());
         try (RequestInfo r = MemTracker.get().startProfiler(request, request.getRequestURI()))
@@ -243,8 +244,8 @@ public class ViewServlet extends HttpServlet
         }
         finally
         {
-            ThreadContext.remove("dd.trace_id");
-            ThreadContext.remove("dd.span_id");
+            ThreadContext.remove(CorrelationIdentifier.getTraceIdKey());
+            ThreadContext.remove(CorrelationIdentifier.getSpanIdKey());
         }
 
     }

--- a/api/src/org/labkey/api/view/ViewServlet.java
+++ b/api/src/org/labkey/api/view/ViewServlet.java
@@ -15,8 +15,10 @@
  */
 package org.labkey.api.view;
 
+import datadog.trace.api.CorrelationIdentifier;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
@@ -183,6 +185,9 @@ public class ViewServlet extends HttpServlet
             _log.debug(">> " + description);
         }
 
+        ThreadContext.put("dd.trace_id", CorrelationIdentifier.getTraceId());
+        ThreadContext.put("dd.span_id", CorrelationIdentifier.getSpanId());
+
         MemoryUsageLogger.logMemoryUsage(_requestCount.incrementAndGet());
         try (RequestInfo r = MemTracker.get().startProfiler(request, request.getRequestURI()))
         {
@@ -236,6 +241,12 @@ public class ViewServlet extends HttpServlet
                 _log.debug("<< " + request.getMethod());
             }
         }
+        finally
+        {
+            ThreadContext.remove("dd.trace_id");
+            ThreadContext.remove("dd.span_id");
+        }
+
     }
 
 

--- a/study/src/org/labkey/study/visitmanager/PurgeParticipantsJob.java
+++ b/study/src/org/labkey/study/visitmanager/PurgeParticipantsJob.java
@@ -1,5 +1,6 @@
 package org.labkey.study.visitmanager;
 
+import datadog.trace.api.Trace;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.dialect.SqlDialect;
@@ -110,6 +111,7 @@ public class PurgeParticipantsJob extends PipelineJob
             _error = error;
         }
 
+        @Trace
         public void purgeParticipants()
         {
             // TODO: Seems like this code block should be moved into VisitManager and called by PurgeParticipantsMaintenanceTask as well (it has no exception handling and doesn't call updateParticipantVisitTable()


### PR DESCRIPTION
#### Rationale
As we continue to experiment with Datadog, we want to correlate log messages with APM and other data.

#### Changes
* Send trace and span IDs into Log4J's ThreadContext
* Instrument a few more entry points as traces