### PR TITLE
JSON and JSONB are not sortable

### DIFF
--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -590,7 +590,7 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     @Override
     public boolean isSortableDataType(String sqlDataTypeName)
     {
-        return true;
+        return !"json".equals(sqlDataTypeName) && !"jsonb".equals(sqlDataTypeName);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Sorting on JSON or JSONB columns generates an error in postgres
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46273

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3666

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
