### PR TITLE
Don't use `FieldDefinition.setType`

### DIFF
--- a/study/test/src/org/labkey/test/tests/experiment/ExpSchemaPropagateFilterTest.java
+++ b/study/test/src/org/labkey/test/tests/experiment/ExpSchemaPropagateFilterTest.java
@@ -188,8 +188,7 @@ public class ExpSchemaPropagateFilterTest extends BaseWebDriverTest
     protected TestDataGenerator createEmptySampleSet(String dataClassName, String path)
     {
         List<FieldDefinition> fields = new ArrayList<>();
-        fields.add(new FieldDefinition("name")
-                .setType(FieldDefinition.ColumnType.String));
+        fields.add(new FieldDefinition("name"));
         return createEmptyDomain("exp.materials", "SampleSet", dataClassName, path, fields);
     }
 

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
@@ -102,8 +102,8 @@ public class StudyDatasetFileFieldTest extends BaseWebDriverTest
 
         DomainFormPanel panel = definitionPage.getFieldsPanel();
         panel.manuallyDefineFields("textField");
-        panel.addField(new FieldDefinition("intField").setType(FieldDefinition.ColumnType.Integer));
-        panel.addField(new FieldDefinition("fileField").setType(FieldDefinition.ColumnType.File));
+        panel.addField(new FieldDefinition("intField", FieldDefinition.ColumnType.Integer));
+        panel.addField(new FieldDefinition("fileField", FieldDefinition.ColumnType.File));
         definitionPage.clickSave();
     }
 }

--- a/study/test/src/org/labkey/test/tests/study/StudyDateAndContinuousTimepointTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDateAndContinuousTimepointTest.java
@@ -72,7 +72,7 @@ public class StudyDateAndContinuousTimepointTest extends BaseWebDriverTest
                 .setName(datasetName);
 
         DomainFormPanel fieldsEditor = editDatasetPage.getFieldsPanel();
-        fieldsEditor.manuallyDefineFields(new FieldDefinition("TestDate").setLabel("TestDate").setType(FieldDefinition.ColumnType.DateAndTime));
+        fieldsEditor.manuallyDefineFields(new FieldDefinition("TestDate", FieldDefinition.ColumnType.DateAndTime).setLabel("TestDate"));
         editDatasetPage.clickSave();
 
         log("Inserting rows in the dataset");

--- a/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
@@ -139,15 +139,15 @@ public class StudySimpleExportTest extends StudyBaseTest
                 .setName(TEST_DATASET_NAME);
 
         DomainFormPanel fieldsEditor = editDatasetPage.getFieldsPanel();
-        fieldsEditor.manuallyDefineFields(new FieldDefinition("TestInt").setLabel("TestInt").setType(FieldDefinition.ColumnType.Integer)
+        fieldsEditor.manuallyDefineFields(new FieldDefinition("TestInt", FieldDefinition.ColumnType.Integer).setLabel("TestInt")
                 .setValidators(List.of(new FieldDefinition.RangeValidator("numberValidator", "numberValidator",
                         "TestInt must equals '999'.", FieldDefinition.RangeType.Equals, "999"))).setRequired(false));
-        fieldsEditor.addField(new FieldDefinition("TestString").setLabel("TestRequiredString").setType(FieldDefinition.ColumnType.String)
+        fieldsEditor.addField(new FieldDefinition("TestString", FieldDefinition.ColumnType.String).setLabel("TestRequiredString")
                 .setRequired(true));
         // Format "TestDate" as "Date"
-        fieldsEditor.addField(new FieldDefinition("TestDate").setLabel("TestDate").setType(FieldDefinition.ColumnType.DateAndTime));
+        fieldsEditor.addField(new FieldDefinition("TestDate", FieldDefinition.ColumnType.DateAndTime).setLabel("TestDate"));
         // "TestDateTime" format will default to date-time
-        fieldsEditor.addField(new FieldDefinition("TestDateTime").setLabel("TestDateTime").setType(FieldDefinition.ColumnType.DateAndTime));
+        fieldsEditor.addField(new FieldDefinition("TestDateTime", FieldDefinition.ColumnType.DateAndTime).setLabel("TestDateTime"));
         editDatasetPage
             .clickSave()
             .clickViewData()

--- a/study/test/src/org/labkey/test/tests/study/StudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyTest.java
@@ -803,7 +803,7 @@ public class StudyTest extends StudyBaseTest
             clickButton("Manage");
             DatasetDesignerPage editDatasetPage = new DatasetPropertiesPage(getDriver()).clickEditDefinition();
             editDatasetPage.getFieldsPanel()
-                    .addField(new FieldDefinition("Bad Name").setLabel("Bad Name").setType(FieldDefinition.ColumnType.String));
+                    .addField(new FieldDefinition("Bad Name", FieldDefinition.ColumnType.String).setLabel("Bad Name"));
             editDatasetPage.clickSave();
             new DatasetPropertiesPage(getDriver())
                 .clickViewData();
@@ -1287,7 +1287,7 @@ public class StudyTest extends StudyBaseTest
                 .clickEditDefinition();
         editDatasetPage
                 .getFieldsPanel()
-                .addField(new FieldDefinition("VisitDay").setLabel("VisitDay").setType(FieldDefinition.ColumnType.Integer));
+                .addField(new FieldDefinition("VisitDay", FieldDefinition.ColumnType.Integer).setLabel("VisitDay"));
         editDatasetPage.openAdvancedDatasetSettings()
                 .selectVisitDateColumn("DEMdt")
                 .clickApply()


### PR DESCRIPTION
#### Rationale
Column type should be provided at `FieldDefinition` construction time. `setType` already makes the type effectively final; this change is a step toward making it actually final.

#### Changes
* Remove usages of `FieldDefinition.setType`
