### PR TITLE
Issue 46226: Pipeline status page buttons go inactive when page refreshes

### DIFF
--- a/api/src/org/labkey/api/view/WebPartView.java
+++ b/api/src/org/labkey/api/view/WebPartView.java
@@ -136,17 +136,7 @@ public abstract class WebPartView<ModelBean> extends HttpView<ModelBean>
             try (var init = HttpView.initForRequest(nested, request, mr))
             {
                 WebPartView.this.render(request, mr);
-                var config = HttpView.currentPageConfig();
-                var sw = new StringWriter();
-                config.endOfBodyScript(sw);
-                var script = sw.toString();
-                if (!script.isBlank())
-                {
-                    var out = mr.getWriter();
-                    out.print("<script type=\"text/javascript\" nonce=\"" + config.getScriptNonce() + "\">");
-                    out.print(script);
-                    out.print("</script>");
-                }
+                renderEndOfBodyScript(HttpView.currentPageConfig(), mr);
             }
             catch (MockHttpResponseWithRealPassthrough.SizeLimitExceededException e)
             {
@@ -170,6 +160,20 @@ public abstract class WebPartView<ModelBean> extends HttpView<ModelBean>
                 writer.endResponse();
             }
         };
+    }
+
+    public static void renderEndOfBodyScript(PageConfig config, HttpServletResponse response) throws IOException
+    {
+        var sw = new StringWriter();
+        config.endOfBodyScript(sw);
+        var script = sw.toString();
+        if (!script.isBlank())
+        {
+            var out = response.getWriter();
+            out.print("<script type=\"text/javascript\" nonce=\"" + config.getScriptNonce() + "\">");
+            out.print(script);
+            out.print("</script>");
+        }
     }
 
     public WebPartView(FrameType ft)

--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -71,6 +71,7 @@ import org.labkey.api.view.RedirectException;
 import org.labkey.api.view.SpringErrorView;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.VBox;
+import org.labkey.api.view.WebPartView;
 import org.labkey.api.view.template.PageConfig;
 import org.labkey.pipeline.PipelineController;
 import org.labkey.pipeline.analysis.AnalysisController;
@@ -300,6 +301,7 @@ public class StatusController extends SpringActionController
             if (c.isRoot())
                 gridView.disableContainerFilterSelection();
             gridView.render(getViewContext().getRequest(), getViewContext().getResponse());
+            WebPartView.renderEndOfBodyScript(getPageConfig(), getViewContext().getResponse());
             return null;
         }
     }


### PR DESCRIPTION
#### Rationale
Changes to improve our resistance to XSS injection broken the JavaScript handlers after the pipeline job list refreshed

#### Changes
* Render the JavaScript that wires up the button handlers