### PR TITLE
JSON and JSONB are not sortable (#3663)

### DIFF
--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -590,7 +590,7 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     @Override
     public boolean isSortableDataType(String sqlDataTypeName)
     {
-        return true;
+        return !"json".equals(sqlDataTypeName) && !"jsonb".equals(sqlDataTypeName);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Molly requested that this be back-ported (changed target from 22.11 to 22.7)

#### Related Pull Requests
https://github.com/LabKey/platform/pull/3663

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
