### PR TITLE
Projects, Enhance UX to disallow cross-project actions earlier

### DIFF
--- a/api/src/org/labkey/api/dataiterator/CrossFolderRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/CrossFolderRecordDataIterator.java
@@ -1,0 +1,123 @@
+package org.labkey.api.dataiterator;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.QueryService;
+import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.ValidationException;
+import org.labkey.api.security.User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+// throws error if key values found in related folders
+public class CrossFolderRecordDataIterator extends WrapperDataIterator
+{
+    private final DataIteratorContext _context;
+    final QueryUpdateService qus;
+    final User user;
+    final Container c;
+
+    final CachingDataIterator _unwrapped;
+    final ArrayList<ColumnInfo> pkColumns = new ArrayList<>();
+    final ArrayList<Supplier<Object>> pkSuppliers = new ArrayList<>();
+
+    final Map<String,Object> _extraKeyValueMap;
+
+    int lastPrefetchRowNumber = -1;
+
+    protected CrossFolderRecordDataIterator(DataIterator in, DataIteratorContext context, TableInfo target, @Nullable Set<String> keys, @Nullable Map<String,Object> extraKeyValueMap)
+    {
+        super(in);
+        _context = context;
+        qus = target.getUpdateService();
+        user = target.getUserSchema().getUser();
+        c = target.getUserSchema().getContainer();
+        _extraKeyValueMap = extraKeyValueMap;
+
+        _unwrapped = (CachingDataIterator)in;
+
+        var map = DataIteratorUtil.createColumnNameMap(in);
+        Collection<String> keyNames = null==keys ? target.getPkColumnNames() : keys;
+        for (String name : keyNames)
+        {
+            Integer index = map.get(name);
+            ColumnInfo col = target.getColumn(name);
+            if (null == index || null == col)
+            {
+                pkSuppliers.clear();
+                pkColumns.clear();
+                throw new IllegalStateException("Key column not found: " + name);
+            }
+            pkSuppliers.add(in.getSupplier(index));
+            pkColumns.add(col);
+        }
+    }
+
+    @Override
+    public boolean next() throws BatchValidationException
+    {
+        _unwrapped.mark();  // unwrapped _delegate
+        boolean ret = super.next();
+        if (ret && !pkColumns.isEmpty())
+            prefetchExisting();
+        return ret;
+    }
+
+    protected void prefetchExisting() throws BatchValidationException
+    {
+        Integer rowNumber = (Integer)_delegate.get(0);
+        if (rowNumber <= lastPrefetchRowNumber)
+            return;
+
+        int rowsToFetch = 200;
+        Map<Integer, Map<String,Object>> keysMap = new LinkedHashMap<>();
+        do
+        {
+            lastPrefetchRowNumber = (Integer) _delegate.get(0);
+            Map<String,Object> keyMap = CaseInsensitiveHashMap.of();
+            for (int p=0 ; p<pkColumns.size() ; p++)
+                keyMap.put(pkColumns.get(p).getColumnName(), pkSuppliers.get(p).get());
+            if (_extraKeyValueMap != null)
+                keyMap.putAll(_extraKeyValueMap);
+            keysMap.put(lastPrefetchRowNumber, keyMap);
+        }
+        while (--rowsToFetch > 0 && _delegate.next());
+
+        if (qus.hasExistingRowsInOtherContainers(c, keysMap))
+            _context.getErrors().addRowError(new ValidationException("Cannot update data that don't belong to the current container."));
+
+        // backup to where we started so caller can iterate through them one at a time
+        _unwrapped.reset(); // unwrapped _delegate
+        _delegate.next();
+    }
+
+    public static DataIteratorBuilder createBuilder(DataIteratorBuilder dib, TableInfo target, @Nullable Set<String> keys, @Nullable Map<String,Object> extraKeyValueMap)
+    {
+        return context ->
+        {
+            DataIterator di = dib.getDataIterator(context);
+            if (null == di)
+                return null;
+
+            assert !di.supportsGetExistingRecord();
+            if (di.supportsGetExistingRecord())
+                return di;
+            QueryUpdateService.InsertOption option = context.getInsertOption();
+            if (option.mergeRows && QueryService.get().isProductProjectsEnabled(target.getUserSchema().getContainer()))
+            {
+                return new CrossFolderRecordDataIterator(new CachingDataIterator(di), context, target, keys, extraKeyValueMap);
+            }
+            return di;
+        };
+    }
+
+}

--- a/api/src/org/labkey/api/dataiterator/CrossFolderRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/CrossFolderRecordDataIterator.java
@@ -108,9 +108,6 @@ public class CrossFolderRecordDataIterator extends WrapperDataIterator
             if (null == di)
                 return null;
 
-            assert !di.supportsGetExistingRecord();
-            if (di.supportsGetExistingRecord())
-                return di;
             QueryUpdateService.InsertOption option = context.getInsertOption();
             if (option.mergeRows && QueryService.get().isProductProjectsEnabled(target.getUserSchema().getContainer()))
             {

--- a/api/src/org/labkey/api/dataiterator/EmbargoDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/EmbargoDataIterator.java
@@ -117,6 +117,8 @@ public class EmbargoDataIterator extends AbstractDataIterator
     @Override
     public Object get(int i)
     {
+        if (_currentRow == null)
+            return null;
         return _currentRow[i];
     }
 

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -18,7 +18,6 @@ package org.labkey.api.query;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -182,6 +181,12 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
                 result.put(key.getKey(), row);
         }
         return result;
+    }
+
+    @Override
+    public boolean hasExistingRowsInOtherContainers(Container container, Map<Integer, Map<String, Object>> keys)
+    {
+        return false;
     }
 
     public static TransactionAuditProvider.TransactionAuditEvent createTransactionAuditEvent(Container container, QueryService.AuditAction auditAction)

--- a/api/src/org/labkey/api/query/CacheClearingQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/CacheClearingQueryUpdateService.java
@@ -51,6 +51,14 @@ public abstract class CacheClearingQueryUpdateService implements QueryUpdateServ
     }
 
     @Override
+    public boolean hasExistingRowsInOtherContainers(Container container, Map<Integer, Map<String, Object>> keys)
+    {
+        var ret = _service.hasExistingRowsInOtherContainers(container, keys);
+        clearCache();
+        return ret;
+    }
+
+    @Override
     public Map<Integer, Map<String, Object>> getExistingRows(User user, Container container, Map<Integer, Map<String, Object>> keys)
             throws InvalidKeyException, QueryUpdateServiceException, SQLException
     {

--- a/api/src/org/labkey/api/query/QueryUpdateService.java
+++ b/api/src/org/labkey/api/query/QueryUpdateService.java
@@ -125,6 +125,8 @@ public interface QueryUpdateService extends HasPermission
     Map<Integer, Map<String, Object>> getExistingRows(User user, Container container, Map<Integer, Map<String, Object>> keys)
             throws InvalidKeyException, QueryUpdateServiceException, SQLException;
 
+    boolean hasExistingRowsInOtherContainers(Container container, Map<Integer, Map<String, Object>> keys);
+
     /**
      * Inserts or merges the given values into the source table of this query.
      * The operation to be performed and import behavior is configured by the <code>context</code> parameter.

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -1171,12 +1171,15 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             for (Map.Entry<Integer, Map<String, Object>> keyMap : keys.entrySet())
             {
                 Object oName = keyMap.getValue().get("Name");
-                Object oClassId = keyMap.getValue().get("ClassId");
 
-                if (oName != null && oClassId != null)
-                {
+                if (oName != null)
                     dataNames.add((String) oName);
-                    dataClassId = (Integer) (_converter.convert(Integer.class, oClassId));
+
+                if (dataClassId == null)
+                {
+                    Object oClassId = keyMap.getValue().get("ClassId");
+                    if (oClassId != null)
+                        dataClassId = (Integer) (_converter.convert(Integer.class, oClassId));
                 }
 
             }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -16,6 +16,7 @@
 package org.labkey.experiment.api;
 
 import org.apache.commons.beanutils.ConversionException;
+import org.apache.commons.beanutils.converters.IntegerConverter;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
@@ -29,24 +30,7 @@ import org.labkey.api.collections.ArrayListMap;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.Sets;
-import org.labkey.api.data.BaseColumnInfo;
-import org.labkey.api.data.ColumnHeaderType;
-import org.labkey.api.data.ColumnInfo;
-import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.DbScope;
-import org.labkey.api.data.JdbcType;
-import org.labkey.api.data.MutableColumnInfo;
-import org.labkey.api.data.PHI;
-import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.SimpleFilter;
-import org.labkey.api.data.Sort;
-import org.labkey.api.data.SqlSelector;
-import org.labkey.api.data.Table;
-import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.UnionContainerFilter;
-import org.labkey.api.data.UpdateableTableInfo;
+import org.labkey.api.data.*;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.dataiterator.AttachmentDataIterator;
 import org.labkey.api.dataiterator.CoerceDataIterator;
@@ -65,6 +49,7 @@ import org.labkey.api.exp.PropertyColumn;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExpData;
+import org.labkey.api.exp.api.ExpDataClass;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.NameExpressionOptionService;
 import org.labkey.api.exp.api.StorageProvisioner;
@@ -105,7 +90,6 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.StringExpressionFactory;
-import org.labkey.api.util.Tuple3;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
@@ -654,6 +638,11 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         return (!col.isHidden() && !col.isUnselectable() && !DEFAULT_HIDDEN_COLS.contains(col.getName()));
     }
 
+    public ExpDataClass getDataClass()
+    {
+        return _dataClass;
+    }
+
     @Override
     public List<Pair<String, String>> getImportTemplates(ViewContext ctx)
     {
@@ -868,6 +857,8 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
     class DataClassDataUpdateService extends DefaultQueryUpdateService
     {
+        IntegerConverter _converter = new IntegerConverter();
+
         public DataClassDataUpdateService(ExpDataClassDataTableImpl table)
         {
             super(table, table.getRealTable());
@@ -1170,6 +1161,31 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         protected AttachmentParentFactory getAttachmentParentFactory()
         {
             return (entityId, c) -> new ExpDataClassAttachmentParent(c, Lsid.parse(entityId));
+        }
+
+        @Override
+        public boolean hasExistingRowsInOtherContainers(Container container, Map<Integer, Map<String, Object>> keys)
+        {
+            Integer dataClassId = null;
+            Set<String> dataNames = new HashSet<>();
+            for (Map.Entry<Integer, Map<String, Object>> keyMap : keys.entrySet())
+            {
+                Object oName = keyMap.getValue().get("Name");
+                Object oClassId = keyMap.getValue().get("ClassId");
+
+                if (oName != null && oClassId != null)
+                {
+                    dataNames.add((String) oName);
+                    dataClassId = (Integer) (_converter.convert(Integer.class, oClassId));
+                }
+
+            }
+
+            SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("ClassId"), dataClassId);
+            filter.addCondition(FieldKey.fromParts("Name"), dataNames, CompareType.IN);
+            filter.addCondition(FieldKey.fromParts("Container"), container, CompareType.NEQ);
+
+            return new TableSelector(ExperimentService.get().getTinfoData(), filter, null).exists();
         }
     }
 }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -665,13 +665,12 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         for (Map.Entry<Integer, Map<String, Object>> keyMap : keys.entrySet())
         {
             String name = getMaterialName(keyMap.getValue());
-            Integer materialSourceId = getMaterialSourceId(keyMap.getValue());
 
-            if (name != null && materialSourceId != null)
-            {
-                sampleTypeId = materialSourceId;
+            if (name != null)
                 sampleNames.add(name);
-            }
+
+            if (sampleTypeId == null)
+                sampleTypeId = getMaterialSourceId(keyMap.getValue());
         }
 
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("MaterialSourceId"), sampleTypeId);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -658,6 +658,30 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
     }
 
     @Override
+    public boolean hasExistingRowsInOtherContainers(Container container, Map<Integer, Map<String, Object>> keys)
+    {
+        Integer sampleTypeId = null;
+        Set<String> sampleNames = new HashSet<>();
+        for (Map.Entry<Integer, Map<String, Object>> keyMap : keys.entrySet())
+        {
+            String name = getMaterialName(keyMap.getValue());
+            Integer materialSourceId = getMaterialSourceId(keyMap.getValue());
+
+            if (name != null && materialSourceId != null)
+            {
+                sampleTypeId = materialSourceId;
+                sampleNames.add(name);
+            }
+        }
+
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("MaterialSourceId"), sampleTypeId);
+        filter.addCondition(FieldKey.fromParts("Name"), sampleNames, CompareType.IN);
+        filter.addCondition(FieldKey.fromParts("Container"), container, CompareType.NEQ);
+
+        return new TableSelector(ExperimentService.get().getTinfoMaterial(), filter, null).exists();
+    }
+
+    @Override
     public Map<Integer, Map<String, Object>> getExistingRows(User user, Container container, Map<Integer, Map<String, Object>> keys)
             throws InvalidKeyException, QueryUpdateServiceException, SQLException
     {

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3454,7 +3454,7 @@ public class ExperimentController extends SpringActionController
     }
 
 
-    public static class DataOperationConfirmationForm extends OperationConfirmationForm
+    public static class DataOperationConfirmationForm extends DataViewSelectionForm
     {
         private ExpDataImpl.DataOperations _dataOperation;
 
@@ -3469,7 +3469,7 @@ public class ExperimentController extends SpringActionController
         }
     }
 
-    public static class OperationConfirmationForm extends ViewForm
+    public static class DataViewSelectionForm extends ViewForm
     {
         private String _dataRegionSelectionKey;
         private Set<Integer> _rowIds;
@@ -3539,7 +3539,7 @@ public class ExperimentController extends SpringActionController
         }
     }
 
-    public static class MaterialOperationConfirmationForm extends OperationConfirmationForm
+    public static class MaterialOperationConfirmationForm extends DataViewSelectionForm
     {
         private SampleTypeService.SampleOperations _sampleOperation;
 
@@ -7468,6 +7468,48 @@ public class ExperimentController extends SpringActionController
             _genId = genId;
         }
 
+    }
+
+    @Marshal(Marshaller.Jackson)
+    @RequiresPermission(ReadPermission.class)
+    public class GetCrossFolderDataSelectionAction extends ReadOnlyApiAction<CrossFolderSelectionForm>
+    {
+        @Override
+        public void validateForm(CrossFolderSelectionForm form, Errors errors)
+        {
+            if (form.getDataRegionSelectionKey() == null && form.getRowIds() == null)
+                errors.reject(ERROR_REQUIRED, "You must provide either a set of rowIds or a dataRegionSelectionKey.");
+            if (!"sample".equalsIgnoreCase(form.getDataType()) && "data".equalsIgnoreCase(form.getDataType()))
+                errors.reject(ERROR_REQUIRED, "Data type (sample or data) must be specified.");
+        }
+
+        @Override
+        public Object execute(CrossFolderSelectionForm form, BindException errors)
+        {
+            Pair<Integer, Integer> result = ExperimentServiceImpl.getCurrentAndCrossFolderDataCount(form.getIds(false), "sample".equalsIgnoreCase(form.getDataType()), getContainer());
+
+            ApiSimpleResponse resp = new ApiSimpleResponse();
+            resp.put("success", true);
+            resp.put("currentFolderSelectionCount", result.first);
+            resp.put("crossFolderSelectionCount", result.second);
+
+            return success(resp);
+        }
+    }
+
+    public static class CrossFolderSelectionForm extends DataViewSelectionForm
+    {
+        private String _dataType;
+
+        public String getDataType()
+        {
+            return _dataType;
+        }
+
+        public void setDataType(String dataType)
+        {
+            _dataType = dataType;
+        }
     }
 
 }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -7479,7 +7479,7 @@ public class ExperimentController extends SpringActionController
         {
             if (form.getDataRegionSelectionKey() == null && form.getRowIds() == null)
                 errors.reject(ERROR_REQUIRED, "You must provide either a set of rowIds or a dataRegionSelectionKey.");
-            if (!"sample".equalsIgnoreCase(form.getDataType()) && "data".equalsIgnoreCase(form.getDataType()))
+            if (!"sample".equalsIgnoreCase(form.getDataType()) && !"data".equalsIgnoreCase(form.getDataType()))
                 errors.reject(ERROR_REQUIRED, "Data type (sample or data) must be specified.");
         }
 


### PR DESCRIPTION
#### Rationale
The StatementUtil is not wired up to handle sample or data that exists in other folders. For performance concern, we will not allow cross folder merge. But instead, will throw error if a merge contains data from a different folder. This PR adds a step to the data iterator to check for cross folder data.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/957
* https://github.com/LabKey/platform/pull/3667
* https://github.com/LabKey/inventory/pull/540
* https://github.com/LabKey/sampleManagement/pull/1206
* https://github.com/LabKey/biologics/pull/1578

#### Changes
* added CrossFolderRecordDataIterator to check for cross folder data presence during import with merge
* added GetCrossFolderDataSelectionAction to check for cross folder selection for a data region
