### PR TITLE
Updates for import and export of bioloigcs registry and media data

### DIFF
--- a/api/src/org/labkey/api/action/ExtendedApiQueryResponse.java
+++ b/api/src/org/labkey/api/action/ExtendedApiQueryResponse.java
@@ -134,15 +134,13 @@ public class ExtendedApiQueryResponse extends ApiQueryResponse
             boolean includeFormattedValue,
             boolean doItWithStyle)
     {
-        if (dc instanceof NestedPropertyDisplayColumn)
+        if (dc instanceof NestedPropertyDisplayColumn npc)
         {
-            NestedPropertyDisplayColumn npc = (NestedPropertyDisplayColumn) dc;
             return getNestedPropertiesArray(ctx, npc, arrayMultiValueColumns, includeFormattedValue, doItWithStyle);
         }
-        else if (arrayMultiValueColumns && dc instanceof IMultiValuedDisplayColumn)
+        else if (arrayMultiValueColumns && dc instanceof IMultiValuedDisplayColumn mdc)
         {
             // render MultiValue columns as an array of 'value', 'displayValue', and 'url' objects
-            IMultiValuedDisplayColumn mdc = (IMultiValuedDisplayColumn)dc;
             return getMultiValuedColumnArray(ctx, includeFormattedValue, mdc);
         }
         else

--- a/api/src/org/labkey/api/data/TSVWriter.java
+++ b/api/src/org/labkey/api/data/TSVWriter.java
@@ -146,7 +146,7 @@ public abstract class TSVWriter extends TextWriter
     /**
      * Quote the value if necessary.  The quoting rules are:
      * <ul>
-     *   <li>Values containing leading or trailing whitespace, a newline, a carrage return, the row separator (usually newline), or the field separator will be quoted.
+     *   <li>Values containing leading or trailing whitespace, a newline, a carriage return, the row separator (usually newline), or the field separator will be quoted.
      *   <li>Values containing the quoting character will also be quoted with the quote character replaced by two quote characters.
      * </ul>
      * <p>

--- a/api/src/org/labkey/api/exp/api/ColumnExporter.java
+++ b/api/src/org/labkey/api/exp/api/ColumnExporter.java
@@ -1,0 +1,16 @@
+package org.labkey.api.exp.api;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.admin.FolderExportContext;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.TableInfo;
+
+import java.util.Collection;
+
+public interface ColumnExporter
+{
+    boolean shouldExportColumn(ColumnInfo col);
+
+    @Nullable Collection<ColumnInfo> getExportColumns(TableInfo tinfo, ColumnInfo col, FolderExportContext ctx);
+
+}

--- a/api/src/org/labkey/api/exp/api/ColumnExporter.java
+++ b/api/src/org/labkey/api/exp/api/ColumnExporter.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 
 public interface ColumnExporter
 {
-    boolean shouldExportColumn(ColumnInfo col);
+    boolean shouldExcludeColumn(TableInfo tableInfo, ColumnInfo col, FolderExportContext context);
 
     @Nullable Collection<ColumnInfo> getExportColumns(TableInfo tinfo, ColumnInfo col, FolderExportContext ctx);
 

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -727,8 +727,9 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     void registerObjectReferencer(ObjectReferencer referencer);
 
-    void registerColumnExporter(ColumnExporter exporer);
-    ColumnExporter getColumnExporter(TableInfo tInfo, ColumnInfo col, FolderExportContext ctx);
+    void registerColumnExporter(ColumnExporter exporter);
+
+    List<ColumnExporter> getColumnExporters();
 
     @NotNull
     List<ObjectReferencer> getObjectReferencers();

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -20,6 +20,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.admin.FolderExportContext;
+import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSchema;
@@ -724,6 +726,9 @@ public interface ExperimentService extends ExperimentRunTypeSource
     void registerProtocolInputCriteria(ExpProtocolInputCriteria.Factory factory);
 
     void registerObjectReferencer(ObjectReferencer referencer);
+
+    void registerColumnExporter(ColumnExporter exporer);
+    ColumnExporter getColumnExporter(TableInfo tInfo, ColumnInfo col, FolderExportContext ctx);
 
     @NotNull
     List<ObjectReferencer> getObjectReferencers();

--- a/experiment/src/org/labkey/experiment/LSIDRelativizer.java
+++ b/experiment/src/org/labkey/experiment/LSIDRelativizer.java
@@ -105,17 +105,22 @@ public enum LSIDRelativizer implements SafeToRenderEnum
                     id = suffix.substring(ind);
                 return lsids.uniquifyRelativizedLSID("urn:lsid:" + XarContext.LSID_AUTHORITY_SUBSTITUTION + ":" + prefix + ".Folder-" + containerSubstitution+ ".${XarJobId}" + id, lsid.getObjectId(), lsid.getVersion());
             }
-            else if (("Sample".equals(prefix) || "Material".equals(prefix) || ("Data".equals(prefix) && !lsid.getObjectId().contains("%2F"))))
+            else if ("Sample".equals(prefix) || "Material".equals(prefix))
             {
                 String xarJobId = ".${XarJobId}"; // XarJobId is more concise than XarFileId
                 return lsids.uniquifyRelativizedLSID("urn:lsid:" + XarContext.LSID_AUTHORITY_SUBSTITUTION + ":" + prefix + ".Folder-" + XarContext.CONTAINER_ID_SUBSTITUTION + xarJobId + lsids.getNextSampleId(), lsid.getObjectId(), lsid.getVersion());
             }
-            else if ("Data".equals(prefix))
-            {
-                // UNDONE: Now that "Data" prefix is used for DataClass, the AutoFileLSID is not a good default.
-                // UNDONE: Can we be more restrictive about which LSIDs this is applied to?  Maybe only if the objectId part of the LSID includes a "/" (%2F) or something?
-                // UNDONE: Maybe there is a better way to detect when we should use ${AutoFileLSID}?
-                return AutoFileLSIDReplacer.AUTO_FILE_LSID_SUBSTITUTION;
+            else if ("Data".equals(prefix))  {
+                if (lsid.getObjectId().contains("%2F"))
+                {
+                    // UNDONE: Maybe there is a better way to detect when we should use ${AutoFileLSID}?
+                    return AutoFileLSIDReplacer.AUTO_FILE_LSID_SUBSTITUTION;
+                }
+                else
+                {
+                    String xarJobId = ".${XarJobId}"; // XarJobId is more concise than XarFileId
+                    return lsids.uniquifyRelativizedLSID("urn:lsid:" + XarContext.LSID_AUTHORITY_SUBSTITUTION + ":" + prefix + ".Folder-" + XarContext.CONTAINER_ID_SUBSTITUTION + xarJobId + lsids.getNextDataId(), lsid.getObjectId(), lsid.getVersion());
+                }
             }
             else if (suffix != null && SUFFIX_PATTERN.matcher(suffix).matches())
             {

--- a/experiment/src/org/labkey/experiment/LSIDRelativizer.java
+++ b/experiment/src/org/labkey/experiment/LSIDRelativizer.java
@@ -56,9 +56,8 @@ public enum LSIDRelativizer implements SafeToRenderEnum
         @Override
         protected String relativize(ExpObject o, RelativizedLSIDs lsids)
         {
-            if (o instanceof ExpData)
+            if (o instanceof ExpData data)
             {
-                ExpData data = (ExpData)o;
                 // Most DataClass data don't have a dataFileUrl, but some do -- like NucSequence imported from a genbank file
                 if (data.getDataFileUrl() == null || data.getDataClass() != null)
                 {
@@ -111,16 +110,10 @@ public enum LSIDRelativizer implements SafeToRenderEnum
                 return lsids.uniquifyRelativizedLSID("urn:lsid:" + XarContext.LSID_AUTHORITY_SUBSTITUTION + ":" + prefix + ".Folder-" + XarContext.CONTAINER_ID_SUBSTITUTION + xarJobId + lsids.getNextSampleId(), lsid.getObjectId(), lsid.getVersion());
             }
             else if ("Data".equals(prefix))  {
-                if (lsid.getObjectId().contains("%2F"))
-                {
-                    // UNDONE: Maybe there is a better way to detect when we should use ${AutoFileLSID}?
-                    return AutoFileLSIDReplacer.AUTO_FILE_LSID_SUBSTITUTION;
-                }
-                else
-                {
-                    String xarJobId = ".${XarJobId}"; // XarJobId is more concise than XarFileId
-                    return lsids.uniquifyRelativizedLSID("urn:lsid:" + XarContext.LSID_AUTHORITY_SUBSTITUTION + ":" + prefix + ".Folder-" + XarContext.CONTAINER_ID_SUBSTITUTION + xarJobId + lsids.getNextDataId(), lsid.getObjectId(), lsid.getVersion());
-                }
+                // UNDONE: Now that "Data" prefix is used for DataClass, the AutoFileLSID is not a good default.
+                // UNDONE: Can we be more restrictive about which LSIDs this is applied to?  Maybe only if the objectId part of the LSID includes a "/" (%2F) or something?
+                // UNDONE: Maybe there is a better way to detect when we should use ${AutoFileLSID}?
+                return AutoFileLSIDReplacer.AUTO_FILE_LSID_SUBSTITUTION;
             }
             else if (suffix != null && SUFFIX_PATTERN.matcher(suffix).matches())
             {

--- a/experiment/src/org/labkey/experiment/LSIDRelativizer.java
+++ b/experiment/src/org/labkey/experiment/LSIDRelativizer.java
@@ -111,7 +111,7 @@ public enum LSIDRelativizer implements SafeToRenderEnum
                 // UNDONE: Maybe there is a better way to detect when we should use ${AutoFileLSID}?
                 return AutoFileLSIDReplacer.AUTO_FILE_LSID_SUBSTITUTION;
             }
-            else if (suffix != null && SUFFIX_PATTERN.matcher(suffix).matches())
+            else if (suffix != null && (SUFFIX_PATTERN.matcher(suffix).matches() || XAR_IMPORT_SUFFIX_PATTERN.matcher(suffix).matches()))
             {
                 String xarFileId = "";
                 if ("SampleSet".equals(prefix) || "DataClass".equals(prefix))
@@ -188,6 +188,7 @@ public enum LSIDRelativizer implements SafeToRenderEnum
     protected abstract String relativize(Lsid lsid, RelativizedLSIDs lsids);
 
     private static final Pattern SUFFIX_PATTERN = Pattern.compile("Folder-[0-9]+");
+    private static final Pattern XAR_IMPORT_SUFFIX_PATTERN = Pattern.compile("Folder-[0-9]+.Xar-[0-9]+");
 
     LSIDRelativizer(String description)
     {

--- a/experiment/src/org/labkey/experiment/LSIDRelativizer.java
+++ b/experiment/src/org/labkey/experiment/LSIDRelativizer.java
@@ -87,6 +87,11 @@ public enum LSIDRelativizer implements SafeToRenderEnum
             {
                 return lsids.uniquifyRelativizedLSID("${RunLSIDBase}", lsid.getObjectId(), lsid.getVersion());
             }
+            else if ("Recipe".equals(prefix))
+            {
+                String recipeName = suffix.substring(0, suffix.indexOf(":"));
+                return lsids.uniquifyRelativizedLSID("urn:lsid:" + XarContext.LSID_AUTHORITY_SUBSTITUTION + ":Recipe." + recipeName + ":Folder-" + XarContext.CONTAINER_ID_SUBSTITUTION, lsid.getObjectId(), lsid.getVersion());
+            }
             else if (MATERIAL_PREFIX_PLACEHOLDER_SUFFIX.equals(lsid.getObjectId()))
             {
                 /*
@@ -100,7 +105,7 @@ public enum LSIDRelativizer implements SafeToRenderEnum
                     id = suffix.substring(ind);
                 return lsids.uniquifyRelativizedLSID("urn:lsid:" + XarContext.LSID_AUTHORITY_SUBSTITUTION + ":" + prefix + ".Folder-" + containerSubstitution+ ".${XarJobId}" + id, lsid.getObjectId(), lsid.getVersion());
             }
-            else if (("Sample".equals(prefix) || "Material".equals(prefix)))
+            else if (("Sample".equals(prefix) || "Material".equals(prefix) || ("Data".equals(prefix) && !lsid.getObjectId().contains("%2F"))))
             {
                 String xarJobId = ".${XarJobId}"; // XarJobId is more concise than XarFileId
                 return lsids.uniquifyRelativizedLSID("urn:lsid:" + XarContext.LSID_AUTHORITY_SUBSTITUTION + ":" + prefix + ".Folder-" + XarContext.CONTAINER_ID_SUBSTITUTION + xarJobId + lsids.getNextSampleId(), lsid.getObjectId(), lsid.getVersion());
@@ -144,6 +149,11 @@ public enum LSIDRelativizer implements SafeToRenderEnum
             else if ("ProtocolApplication".equals(prefix))
             {
                 return lsids.uniquifyRelativizedLSID("${RunLSIDBase}", lsid.getObjectId(), lsid.getVersion());
+            }
+            else if ("Recipe".equals(prefix))
+            {
+                String recipeName = suffix.substring(0, suffix.indexOf(":"));
+                return lsids.uniquifyRelativizedLSID("urn:lsid:" + XarContext.LSID_AUTHORITY_SUBSTITUTION + ":Recipe." + recipeName + ":Folder-" + XarContext.CONTAINER_ID_SUBSTITUTION, lsid.getObjectId(), lsid.getVersion());
             }
             else if ("Sample".equals(prefix))
             {

--- a/experiment/src/org/labkey/experiment/LSIDRelativizer.java
+++ b/experiment/src/org/labkey/experiment/LSIDRelativizer.java
@@ -86,11 +86,6 @@ public enum LSIDRelativizer implements SafeToRenderEnum
             {
                 return lsids.uniquifyRelativizedLSID("${RunLSIDBase}", lsid.getObjectId(), lsid.getVersion());
             }
-            else if ("Recipe".equals(prefix))
-            {
-                String recipeName = suffix.substring(0, suffix.indexOf(":"));
-                return lsids.uniquifyRelativizedLSID("urn:lsid:" + XarContext.LSID_AUTHORITY_SUBSTITUTION + ":Recipe." + recipeName + ":Folder-" + XarContext.CONTAINER_ID_SUBSTITUTION, lsid.getObjectId(), lsid.getVersion());
-            }
             else if (MATERIAL_PREFIX_PLACEHOLDER_SUFFIX.equals(lsid.getObjectId()))
             {
                 /*
@@ -109,7 +104,8 @@ public enum LSIDRelativizer implements SafeToRenderEnum
                 String xarJobId = ".${XarJobId}"; // XarJobId is more concise than XarFileId
                 return lsids.uniquifyRelativizedLSID("urn:lsid:" + XarContext.LSID_AUTHORITY_SUBSTITUTION + ":" + prefix + ".Folder-" + XarContext.CONTAINER_ID_SUBSTITUTION + xarJobId + lsids.getNextSampleId(), lsid.getObjectId(), lsid.getVersion());
             }
-            else if ("Data".equals(prefix))  {
+            else if ("Data".equals(prefix))
+            {
                 // UNDONE: Now that "Data" prefix is used for DataClass, the AutoFileLSID is not a good default.
                 // UNDONE: Can we be more restrictive about which LSIDs this is applied to?  Maybe only if the objectId part of the LSID includes a "/" (%2F) or something?
                 // UNDONE: Maybe there is a better way to detect when we should use ${AutoFileLSID}?
@@ -147,11 +143,6 @@ public enum LSIDRelativizer implements SafeToRenderEnum
             else if ("ProtocolApplication".equals(prefix))
             {
                 return lsids.uniquifyRelativizedLSID("${RunLSIDBase}", lsid.getObjectId(), lsid.getVersion());
-            }
-            else if ("Recipe".equals(prefix))
-            {
-                String recipeName = suffix.substring(0, suffix.indexOf(":"));
-                return lsids.uniquifyRelativizedLSID("urn:lsid:" + XarContext.LSID_AUTHORITY_SUBSTITUTION + ":Recipe." + recipeName + ":Folder-" + XarContext.CONTAINER_ID_SUBSTITUTION, lsid.getObjectId(), lsid.getVersion());
             }
             else if ("Sample".equals(prefix))
             {

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -2993,8 +2993,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return emptyList();
     }
 
-    @Nullable @Override
-    public String getObjectReferenceDescription(Class referencedClass)
+    @Override
+    public @NotNull String getObjectReferenceDescription(Class referencedClass)
     {
         if (referencedClass != ExpRun.class)
             return "derived data or sample dependencies";
@@ -7286,28 +7286,13 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         _columnExporters.add(exporter);
     }
 
-    public boolean shouldExportColumn(ColumnInfo col)
+    @Override
+    public List<ColumnExporter> getColumnExporters()
     {
-        for (ColumnExporter exporter : _columnExporters)
-        {
-            if (!exporter.shouldExportColumn(col))
-                return false;
-        }
-        return true;
+        return _columnExporters;
     }
 
-    public ColumnExporter getColumnExporter(TableInfo tInfo, ColumnInfo col, FolderExportContext ctx)
-    {
-        // TODO need a way to establish precedence
-        for (ColumnExporter exporter : _columnExporters)
-        {
-            Collection<ColumnInfo> columns = exporter.getExportColumns(tInfo, col, ctx);
-            if (columns != null)
-                return exporter;
-        }
-        return null;
-    }
-
+    @Override
     @NotNull
     public List<ObjectReferencer> getObjectReferencers()
     {

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -151,8 +151,8 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                     typesReader.setStrictValidateExistingSampleType(xarCtx.isStrictValidateExistingSampleType());
                     typesReader.parseAndLoad(false, ctx.getAuditBehaviorType());
 
-                    // import data classes first because the media sample type (RawMaterials) has a lookup to the ingredient data class
-                    // registry files need to imported in a particular order because some files rely on data from other files
+                    // Import data classes first because the media sample type (RawMaterials) has a lookup to the ingredient data class.
+                    // Registry files need to imported in a particular order because some files rely on data from other files.
                     importTsvData(ctx, ExpSchema.SCHEMA_EXP_DATA.toString(), typesReader.getDataClasses().stream().map(Identifiable::getName).sorted(Comparator.comparing(REGISTRY_CLASS_ORDER::indexOf)).collect(Collectors.toList()),
                             dataClassDataFiles, xarDir, true, false);
 
@@ -180,7 +180,6 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                         XarReader runsReader = new FolderXarImporterFactory.FolderExportXarReader(runsXarSource, job);
                         runsReader.setStrictValidateExistingSampleType(xarCtx.isStrictValidateExistingSampleType());
                         runsReader.parseAndLoad(false, ctx.getAuditBehaviorType());
-                        // fix up the recipes
                     }
                 }
                 else

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -50,7 +50,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.DEFAULT_DIRECTORY;
-import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.EXCLUDED_TABLES;
+import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.EXCLUDED_TYPES;
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.XAR_RUNS_NAME;
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.XAR_RUNS_XML_NAME;
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.XAR_TYPES_NAME;
@@ -151,12 +151,13 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                     typesReader.setStrictValidateExistingSampleType(xarCtx.isStrictValidateExistingSampleType());
                     typesReader.parseAndLoad(false, ctx.getAuditBehaviorType());
 
-                    // process any sample type data files and data class files
-                    importTsvData(ctx, SamplesSchema.SCHEMA_NAME, typesReader.getSampleTypes().stream().map(Identifiable::getName).collect(Collectors.toList()),
-                            sampleTypeDataFiles, xarDir, true, false);
+                    // import data classes first because the media sample type (RawMaterials) has a lookup to the ingredient data class
                     // registry files need to imported in a particular order because some files rely on data from other files
                     importTsvData(ctx, ExpSchema.SCHEMA_EXP_DATA.toString(), typesReader.getDataClasses().stream().map(Identifiable::getName).sorted(Comparator.comparing(REGISTRY_CLASS_ORDER::indexOf)).collect(Collectors.toList()),
                             dataClassDataFiles, xarDir, true, false);
+
+                    importTsvData(ctx, SamplesSchema.SCHEMA_NAME, typesReader.getSampleTypes().stream().map(Identifiable::getName).collect(Collectors.toList()),
+                            sampleTypeDataFiles, xarDir, true, false);
 
                     // handle wiring up any derivation runs
                     if (runsXarFile != null)
@@ -325,7 +326,7 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                         log.error("Failed to find table '" + schemaName + "." + tableName + "' to import data file: " + dataFileName);
                     }
                 }
-                else if (fileRequired && !EXCLUDED_TABLES.contains(tableName))
+                else if (fileRequired && !EXCLUDED_TYPES.contains(tableName))
                 {
                     log.error("Unable to import TSV data for table " + tableName + ". File not found.");
                 }

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
@@ -612,26 +612,6 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter impleme
         }
     }
 
-    private static class ExportMultiValuedLookupColumn extends ExportDataColumn
-    {
-        private ExportMultiValuedLookupColumn(ColumnInfo col)
-        {
-            super(col);
-        }
-
-//        public ExportMultiValuedLookupColumn(DisplayColumn dc)
-//        {
-//            super(dc);
-//        }
-//
-        @Override
-        public Object getValue(RenderContext ctx)
-        {
-            return new JSONArray(new MultiValuedDisplayColumn(getBoundColumn().getRenderer(), true).getTsvFormattedValues(ctx));
-        }
-
-    }
-
     // similar to XarExporter.relativizeLSIDPropertyValue but for columns
     private static class ExportLsidDataColumn extends ExportDataColumn
     {

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
@@ -91,7 +91,7 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter impleme
     private PHI _exportPhiLevel = PHI.NotPHI;
     private XarExportContext _xarCtx;
     private LSIDRelativizer.RelativizedLSIDs _relativizedLSIDs;
-    public static final List<String> EXCLUDED_TABLES = List.of("MoleculeSet", "MolecularSpecies");
+    public static final List<String> EXCLUDED_TYPES = List.of("MoleculeSet", "MolecularSpecies", "MixtureBatches");
 
     private SampleTypeAndDataClassFolderWriter()
     {
@@ -106,7 +106,7 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter impleme
     @Override
     public boolean show(Container c)
     {
-        // need to always return true so it can be used in a folder template
+        // need to always return true, so it can be used in a folder template
         return true;
     }
 
@@ -136,10 +136,10 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter impleme
                 continue;
 
             // ignore sample types that are filtered out
-            if (_xarCtx != null && !_xarCtx.getIncludedSamples().containsKey(sampleType.getRowId()))
+            if ((_xarCtx != null && !_xarCtx.getIncludedSamples().containsKey(sampleType.getRowId())) || EXCLUDED_TYPES.contains(sampleType.getName()))
                 continue;
 
-            // filter out non sample type material sources
+            // filter out non-sample type material sources
             Lsid lsid = new Lsid(sampleType.getLSID());
 
             if (sampleTypeLsid.getNamespacePrefix().equals(lsid.getNamespacePrefix()))
@@ -157,7 +157,7 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter impleme
         for (ExpDataClass dataClass : ExperimentService.get().getDataClasses(c, ctx.getUser(), false))
         {
             // ignore data classes that are filtered out
-            if (_xarCtx != null && !_xarCtx.getIncludedDataClasses().containsKey(dataClass.getRowId()))
+            if ((_xarCtx != null && !_xarCtx.getIncludedDataClasses().containsKey(dataClass.getRowId())) || EXCLUDED_TYPES.contains(dataClass.getName()))
                 continue;
 
             Set<Integer> includedDatas = _xarCtx != null ? _xarCtx.getIncludedDataClasses().get(dataClass.getRowId()) : null;
@@ -259,9 +259,6 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter impleme
         {
             for (ExpDataClass dataClass : dataClasses)
             {
-                if (EXCLUDED_TABLES.contains(dataClass.getName()))
-                    continue;
-
                 TableInfo tinfo = userSchema.getTable(dataClass.getName());
                 if (tinfo != null)
                 {

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderWriter.java
@@ -1,6 +1,5 @@
 package org.labkey.experiment.samples;
 
-import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.labkey.api.admin.BaseFolderWriter;
 import org.labkey.api.admin.FolderArchiveDataTypes;
@@ -10,14 +9,12 @@ import org.labkey.api.admin.FolderWriterFactory;
 import org.labkey.api.attachments.AttachmentParent;
 import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
-import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnHeaderType;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
-import org.labkey.api.data.ForeignKey;
 import org.labkey.api.data.MultiValuedDisplayColumn;
 import org.labkey.api.data.MultiValuedForeignKey;
 import org.labkey.api.data.MutableColumnInfo;
@@ -43,8 +40,6 @@ import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.SampleTypeService;
-import org.labkey.api.exp.list.ListDefinition;
-import org.labkey.api.exp.list.ListService;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.query.ExpDataClassDataTable;
 import org.labkey.api.exp.query.ExpMaterialTable;
@@ -54,13 +49,11 @@ import org.labkey.api.query.AliasedColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
-import org.labkey.api.security.User;
 import org.labkey.api.study.SpecimenService;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.FileNameUniquifier;
 import org.labkey.api.util.FileUtil;
-import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.writer.VirtualFile;
 import org.labkey.experiment.LSIDRelativizer;
 import org.labkey.experiment.XarExporter;
@@ -98,6 +91,7 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter impleme
     private PHI _exportPhiLevel = PHI.NotPHI;
     private XarExportContext _xarCtx;
     private LSIDRelativizer.RelativizedLSIDs _relativizedLSIDs;
+    public static final List<String> EXCLUDED_TABLES = List.of("MoleculeSet", "MolecularSpecies");
 
     private SampleTypeAndDataClassFolderWriter()
     {
@@ -265,6 +259,9 @@ public class SampleTypeAndDataClassFolderWriter extends BaseFolderWriter impleme
         {
             for (ExpDataClass dataClass : dataClasses)
             {
+                if (EXCLUDED_TABLES.contains(dataClass.getName()))
+                    continue;
+
                 TableInfo tinfo = userSchema.getTable(dataClass.getName());
                 if (tinfo != null)
                 {

--- a/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
@@ -85,7 +85,8 @@ public class FolderXarWriterFactory implements FolderWriterFactory
             if (ctx != null)
                 xarCtx = ctx.getContext(XarExportContext.class);
 
-            // don't include the sample derivation runs, we now have a separate exporter explicitly for sample types
+            // Don't include the sample derivation runs; we now have a separate exporter explicitly for sample types.
+            // Also don't include recipe protocols; there's a separate folder writer and importer for the recipe module.
             // if an additional context has been furnished, filter out runs not included in this export
             final XarExportContext fxarCtx = xarCtx;
             List<ExpRun> allRuns = ExperimentService.get().getExpRuns(c, null, null).stream()
@@ -112,7 +113,8 @@ public class FolderXarWriterFactory implements FolderWriterFactory
 
         private List<Integer> getProtocols(Container c)
         {
-            // don't include the sample derivation runs, we now have a separate exporter explicitly for sample types
+            // Don't include the sample derivation runs; we now have a separate exporter explicitly for sample types.
+            // Also don't include recipe protocols; there's a separate folder writer and importer for the recipe module.
             List<ExpProtocol> protocols = ExperimentService.get().getExpProtocols(c)
                     .stream()
                     .filter(protocol ->

--- a/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
@@ -92,6 +92,8 @@ public class FolderXarWriterFactory implements FolderWriterFactory
                     .filter(
                         run -> !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID)
                                 && !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_LSID)
+                                && !"recipe".equalsIgnoreCase(run.getProtocol().getImplementationName())
+                                && !"recipe".equalsIgnoreCase(run.getProtocol().getLSIDNamespacePrefix())
                             && (fxarCtx == null || fxarCtx.getIncludedAssayRuns().contains(run.getRowId()))
                     )
                     .collect(Collectors.toList());
@@ -115,7 +117,10 @@ public class FolderXarWriterFactory implements FolderWriterFactory
                     .stream()
                     .filter(protocol ->
                             !protocol.getLSID().startsWith(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_NAME) &&
-                                    !protocol.getLSID().startsWith(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_NAME))
+                                    !protocol.getLSID().startsWith(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_NAME)
+                            && !"recipe".equalsIgnoreCase(protocol.getImplementationName())
+                            && !"recipe".equalsIgnoreCase(protocol.getLSIDNamespacePrefix())
+                    )
                     .collect(Collectors.toList());
             // the sm template tasks can make reference to assay designs, so we will put all the SM Job and Task Protocols at the end to assure
             // the assay definitions have already been processed and can be resolved properly.


### PR DESCRIPTION
#### Rationale
To enable easier updating of our demo data for LKB, we need to add some updates to the sample type and data class folder writer and importer. To keep some of the special logic within the Biologics module, we introduce a ColumnExporter interface and registry, but the actual import and export of the media and registry data classes stays here.  For media, we exclude these runs and protocols from the experiment XAR exports as they are handled by a new folder writer and importer in the recipe module.

#### Related Pull Requests
* https://github.com/LabKey/recipe/pull/71
* https://github.com/LabKey/biologics/pull/1580

#### Changes
* Introduce `ColumnExporter` interface and registry
* Updates to SampleTypeAndDataClassFolderWriter and Importer to account for special handling of media and registry
* exclude runs and protocols created for media from XAR exports