### PR TITLE
Issue 46122: Pipeline actions don't return to the starting URL, instead redirect to folder homepage

### DIFF
--- a/api/src/org/labkey/api/pipeline/file/FileAnalysisTaskPipeline.java
+++ b/api/src/org/labkey/api/pipeline/file/FileAnalysisTaskPipeline.java
@@ -75,7 +75,7 @@ public interface FileAnalysisTaskPipeline extends TaskPipeline<FileAnalysisTaskP
     FilePathFilter getInitialFileTypeFilter();
 
     @NotNull
-    URLHelper getAnalyzeURL(Container c, String path, ReturnURLString parsedReturnUrl);
+    URLHelper getAnalyzeURL(Container c, String path, @Nullable ReturnURLString parsedReturnUrl);
 
     @NotNull
     Map<FileType, List<FileType>> getTypeHierarchy();

--- a/api/src/org/labkey/api/pipeline/file/FileAnalysisTaskPipeline.java
+++ b/api/src/org/labkey/api/pipeline/file/FileAnalysisTaskPipeline.java
@@ -22,6 +22,7 @@ import org.labkey.api.formSchema.FormSchema;
 import org.labkey.api.pipeline.PipelineActionConfig;
 import org.labkey.api.pipeline.TaskPipeline;
 import org.labkey.api.util.FileType;
+import org.labkey.api.util.ReturnURLString;
 import org.labkey.api.util.URLHelper;
 
 import java.io.File;
@@ -74,7 +75,7 @@ public interface FileAnalysisTaskPipeline extends TaskPipeline<FileAnalysisTaskP
     FilePathFilter getInitialFileTypeFilter();
 
     @NotNull
-    URLHelper getAnalyzeURL(Container c, String path);
+    URLHelper getAnalyzeURL(Container c, String path, ReturnURLString parsedReturnUrl);
 
     @NotNull
     Map<FileType, List<FileType>> getTypeHierarchy();

--- a/api/src/org/labkey/api/view/WebPartView.java
+++ b/api/src/org/labkey/api/view/WebPartView.java
@@ -136,17 +136,7 @@ public abstract class WebPartView<ModelBean> extends HttpView<ModelBean>
             try (var init = HttpView.initForRequest(nested, request, mr))
             {
                 WebPartView.this.render(request, mr);
-                var config = HttpView.currentPageConfig();
-                var sw = new StringWriter();
-                config.endOfBodyScript(sw);
-                var script = sw.toString();
-                if (!script.isBlank())
-                {
-                    var out = mr.getWriter();
-                    out.print("<script type=\"text/javascript\" nonce=\"" + config.getScriptNonce() + "\">");
-                    out.print(script);
-                    out.print("</script>");
-                }
+                renderEndOfBodyScript(HttpView.currentPageConfig(), mr);
             }
             catch (MockHttpResponseWithRealPassthrough.SizeLimitExceededException e)
             {
@@ -170,6 +160,20 @@ public abstract class WebPartView<ModelBean> extends HttpView<ModelBean>
                 writer.endResponse();
             }
         };
+    }
+
+    public static void renderEndOfBodyScript(PageConfig config, HttpServletResponse response) throws IOException
+    {
+        var sw = new StringWriter();
+        config.endOfBodyScript(sw);
+        var script = sw.toString();
+        if (!script.isBlank())
+        {
+            var out = response.getWriter();
+            out.print("<script type=\"text/javascript\" nonce=\"" + config.getScriptNonce() + "\">");
+            out.print(script);
+            out.print("</script>");
+        }
     }
 
     public WebPartView(FrameType ft)

--- a/filecontent/webapp/File/panel/Browser.js
+++ b/filecontent/webapp/File/panel/Browser.js
@@ -275,8 +275,13 @@ Ext4.define('File.panel.Browser', {
          * @private
          */
         _getActions : function(cb, containerPath, scope) {
+            var params = {path : scope.getFullFolderOffset() };
+            var returnUrl = LABKEY.ActionURL.getParameter('returnUrl');
+            if (returnUrl) {
+                params.returnUrl = returnUrl;
+            }
             Ext4.Ajax.request({
-                url: LABKEY.ActionURL.buildURL('pipeline', 'actions.api', containerPath, {path : scope.getFullFolderOffset() }),
+                url: LABKEY.ActionURL.buildURL('pipeline', 'actions.api', containerPath, params),
                 method: 'GET',
                 disableCaching: false,
                 success : Ext4.isFunction(cb) ? cb : undefined,
@@ -2229,6 +2234,7 @@ Ext4.define('File.panel.Browser', {
                         if (files[j] == selections[i].data.name)
                         {
                             var fileField = document.createElement("input");
+                            fileField.setAttribute("type", "hidden");
                             fileField.setAttribute("name", "file");
                             fileField.setAttribute("value", selections[i].data.name);
                             form.appendChild(fileField);
@@ -2243,6 +2249,7 @@ Ext4.define('File.panel.Browser', {
                     }
                 }
                 var hiddenField = document.createElement("input");
+                hiddenField.setAttribute("type", "hidden");
                 hiddenField.setAttribute("name", "X-LABKEY-CSRF");
                 hiddenField.setAttribute("value", LABKEY.CSRF);
                 form.appendChild(hiddenField);

--- a/filecontent/webapp/File/panel/Browser.js
+++ b/filecontent/webapp/File/panel/Browser.js
@@ -276,7 +276,7 @@ Ext4.define('File.panel.Browser', {
          */
         _getActions : function(cb, containerPath, scope) {
             var params = {path : scope.getFullFolderOffset() };
-            var returnUrl = LABKEY.ActionURL.getParameter('returnUrl');
+            var returnUrl = LABKEY.ActionURL.getReturnUrl();
             if (returnUrl) {
                 params.returnUrl = returnUrl;
             }

--- a/pipeline/src/org/labkey/pipeline/analysis/AnalysisController.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/AnalysisController.java
@@ -63,6 +63,7 @@ import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.ReturnURLString;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HtmlView;
@@ -107,11 +108,16 @@ public class AnalysisController extends SpringActionController
         setActionResolver(_resolver);
     }
 
-    public static ActionURL urlAnalyze(Container container, TaskId tid, String path)
+    public static ActionURL urlAnalyze(Container container, TaskId tid, String path, @Nullable ReturnURLString returnUrl)
     {
-        return new ActionURL(AnalyzeAction.class, container)
+        ActionURL result = new ActionURL(AnalyzeAction.class, container)
                 .addParameter(AnalyzeForm.Params.taskId, tid.toString())
                 .addParameter(AnalyzeForm.Params.path, path);
+        if (returnUrl != null)
+        {
+            result.addParameter(ActionURL.Param.returnUrl, returnUrl.toString());
+        }
+        return result;
     }
 
     @RequiresPermission(InsertPermission.class)

--- a/pipeline/src/org/labkey/pipeline/analysis/FileAnalysisTaskPipelineImpl.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/FileAnalysisTaskPipelineImpl.java
@@ -44,12 +44,14 @@ import org.labkey.api.pipeline.file.FileAnalysisTaskPipelineSettings;
 import org.labkey.api.resource.Resource;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.ReturnURLString;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.util.XmlBeansUtil;
 import org.labkey.api.util.XmlValidationException;
+import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
 import org.labkey.pipeline.api.PipelineJobServiceImpl;
@@ -273,7 +275,7 @@ public class FileAnalysisTaskPipelineImpl extends TaskPipelineImpl<FileAnalysisT
 
     @Override
     @NotNull
-    public URLHelper getAnalyzeURL(Container c, String path)
+    public URLHelper getAnalyzeURL(Container c, String path, ReturnURLString parsedReturnUrl)
     {
         if (_analyzeURL != null)
         {
@@ -292,6 +294,10 @@ public class FileAnalysisTaskPipelineImpl extends TaskPipelineImpl<FileAnalysisT
                 {
                     result.addParameter("taskId", getId().toString());
                 }
+                if (parsedReturnUrl != null)
+                {
+                    result.addParameter(ActionURL.Param.returnUrl.name(), parsedReturnUrl.toString());
+                }
                 return result;
             }
             catch (URISyntaxException e)
@@ -299,7 +305,7 @@ public class FileAnalysisTaskPipelineImpl extends TaskPipelineImpl<FileAnalysisT
                 throw new UnexpectedException(e);
             }
         }
-        return AnalysisController.urlAnalyze(c, getId(), path);
+        return AnalysisController.urlAnalyze(c, getId(), path, parsedReturnUrl);
     }
 
     @Override

--- a/pipeline/src/org/labkey/pipeline/analysis/FileAnalysisTaskPipelineImpl.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/FileAnalysisTaskPipelineImpl.java
@@ -20,6 +20,7 @@ import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlObject;
 import org.apache.xmlbeans.XmlOptions;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.HasViewContext;
 import org.labkey.api.data.Container;
 import org.labkey.api.formSchema.CheckboxField;
@@ -275,7 +276,7 @@ public class FileAnalysisTaskPipelineImpl extends TaskPipelineImpl<FileAnalysisT
 
     @Override
     @NotNull
-    public URLHelper getAnalyzeURL(Container c, String path, ReturnURLString parsedReturnUrl)
+    public URLHelper getAnalyzeURL(Container c, String path, @Nullable ReturnURLString parsedReturnUrl)
     {
         if (_analyzeURL != null)
         {

--- a/pipeline/src/org/labkey/pipeline/analysis/analyze.jsp
+++ b/pipeline/src/org/labkey/pipeline/analysis/analyze.jsp
@@ -57,7 +57,7 @@
             saveProtocol: analyzeFormCmp.getElementById("saveProtocolInput").checked,
             protocolName: protocolName,
             successCallback: function() {
-                var returnUrl = LABKEY.ActionURL.getParameter('returnUrl');
+                var returnUrl = LABKEY.ActionURL.getReturnUrl();
                 if (!returnUrl) {
                     returnUrl = LABKEY.ActionURL.buildURL("project", "start.view");
                 }

--- a/pipeline/src/org/labkey/pipeline/analysis/analyze.jsp
+++ b/pipeline/src/org/labkey/pipeline/analysis/analyze.jsp
@@ -56,7 +56,13 @@
             files: selectedFileNames,
             saveProtocol: analyzeFormCmp.getElementById("saveProtocolInput").checked,
             protocolName: protocolName,
-            successCallback: function() { window.location = LABKEY.ActionURL.buildURL("project", "start.view") }
+            successCallback: function() {
+                var returnUrl = LABKEY.ActionURL.getParameter('returnUrl');
+                if (!returnUrl) {
+                    returnUrl = LABKEY.ActionURL.buildURL("project", "start.view");
+                }
+                window.location = returnUrl;
+            }
         };
 
         if (analyzeFormCmp.getElementById("protocolSelect").selectedIndex == 0) {

--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -71,6 +71,7 @@ import org.labkey.api.view.RedirectException;
 import org.labkey.api.view.SpringErrorView;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.VBox;
+import org.labkey.api.view.WebPartView;
 import org.labkey.api.view.template.PageConfig;
 import org.labkey.pipeline.PipelineController;
 import org.labkey.pipeline.analysis.AnalysisController;
@@ -300,6 +301,7 @@ public class StatusController extends SpringActionController
             if (c.isRoot())
                 gridView.disableContainerFilterSelection();
             gridView.render(getViewContext().getRequest(), getViewContext().getResponse());
+            WebPartView.renderEndOfBodyScript(getPageConfig(), getViewContext().getResponse());
             return null;
         }
     }


### PR DESCRIPTION
#### Rationale
We used to get users back to the folder tab they started via .lastFilter. That not longer remembers the tab name, and users have requested that this particular workflow continue to work the same.

#### Changes
* Pull the returnUrl through the full sequence and send the user back there