### PR TITLE
Improve logging when setting site root fails

### DIFF
--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -627,9 +627,12 @@ public class FileContentServiceImpl implements FileContentService
     @Override
     public void setSiteDefaultRoot(File root, User user)
     {
-        if (root == null || !root.exists())
-            throw new IllegalArgumentException("Invalid site root: does not exist");
-        
+        if (root == null)
+            throw new IllegalArgumentException("Invalid site root: specified root is null");
+
+        if (!root.exists())
+            throw new IllegalArgumentException("Invalid site root: " + root.getAbsolutePath() + " does not exist");
+
         File prevRoot = getSiteDefaultRoot();
         WriteableAppProps props = AppProps.getWriteableInstance();
 


### PR DESCRIPTION
#### Rationale
Logging to help investigate problems when attempting to set the site root from startup properties. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=46307
