### PR TITLE
Issue 46092 - Stop relying on DB peptide startIndex and endIndex fields when rendering sequence coverage

### DIFF
--- a/api/src/org/labkey/api/protein/PeptideCharacteristic.java
+++ b/api/src/org/labkey/api/protein/PeptideCharacteristic.java
@@ -20,6 +20,4 @@ public class PeptideCharacteristic
     private String confidenceColor;
     private String color;
     private String foregroundColor;
-    private int startIndex;
-    private int endIndex;
 }


### PR DESCRIPTION
#### Rationale
Remove not needed (now calculated) instance variables from PeptideCharacteristic

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/514


