### PR TITLE
Issue 46279: LKSM: Sample Timeline error

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1373,13 +1373,11 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
     public ExpDataClassImpl getDataClassByObjectId(Container c, Integer objectId)
     {
-        SimpleFilter filter = SimpleFilter.createContainerFilter(c);
-        filter.addCondition(FieldKey.fromParts("ObjectId"), objectId);
-
-        DataClass dataClass = new TableSelector(getTinfoDataClass(), filter, null).getObject(DataClass.class);
-        if (dataClass == null)
+        OntologyObject obj = OntologyManager.getOntologyObject(objectId);
+        if (obj == null)
             return null;
-        return new ExpDataClassImpl(dataClass);
+
+        return getDataClass(obj.getObjectURI());
     }
 
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -53,6 +53,8 @@ import org.labkey.api.data.TableSelector;
 import org.labkey.api.defaults.DefaultValueService;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
+import org.labkey.api.exp.OntologyManager;
+import org.labkey.api.exp.OntologyObject;
 import org.labkey.api.exp.TemplateInfo;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpMaterial;
@@ -337,13 +339,11 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
     public ExpSampleTypeImpl getSampleTypeByObjectId(Container c, Integer objectId)
     {
-        SimpleFilter filter = SimpleFilter.createContainerFilter(c);
-        filter.addCondition(FieldKey.fromParts("ObjectId"), objectId);
-
-        MaterialSource materialSource = new TableSelector(getTinfoMaterialSource(), filter, null).getObject(MaterialSource.class);
-        if (materialSource == null)
+        OntologyObject obj = OntologyManager.getOntologyObject(objectId);
+        if (obj == null)
             return null;
-        return new ExpSampleTypeImpl(materialSource);
+
+        return getSampleType(obj.getObjectURI());
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
The util to get dataclass and sampletype by objectId was not doing the right thing. It's filtering on objectid field, which doesn't exist on the type table. It should query for lsid from exp.object using objectId, then query for dataclass or sampletype from the lsid. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3677
* https://github.com/LabKey/sampleManagement/pull/1214

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
