### PR TITLE
Issue 46326: Support specifying DbSequence batch size per column

### DIFF
--- a/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
@@ -753,6 +753,12 @@ public abstract class AbstractWrappedColumnInfo implements ColumnInfo
     }
 
     @Override
+    public @Nullable Integer getDbSequenceBatchSize()
+    {
+        return delegate.getDbSequenceBatchSize();
+    }
+
+    @Override
     public boolean hasDbSequence()
     {
         return delegate.hasDbSequence();

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -112,6 +112,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     private boolean _shouldLog = true;
     private boolean _lockName = false;
     private SimpleTranslator.RemapMissingBehavior _remapMissingBehavior = null;
+    private Integer _dbSequenceBatchSize = null;
 
     /**
      * True if this column isn't really part of the database. It might be a calculated value, or an alternate
@@ -934,6 +935,18 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     {
         checkLocked();
         _isAutoIncrement = autoIncrement;
+    }
+
+    @Override
+    public @Nullable Integer getDbSequenceBatchSize()
+    {
+        return _dbSequenceBatchSize;
+    }
+
+    @Override
+    public void setDbSequenceBatchSize(@Nullable Integer dbSequenceBatchSize)
+    {
+        _dbSequenceBatchSize = dbSequenceBatchSize;
     }
 
     @Override

--- a/api/src/org/labkey/api/data/ColumnInfo.java
+++ b/api/src/org/labkey/api/data/ColumnInfo.java
@@ -313,6 +313,11 @@ public interface ColumnInfo extends ColumnRenderProperties
 
     boolean isRootDbSequence();
 
+    @Nullable default Integer getDbSequenceBatchSize()
+    {
+        return null;
+    }
+
     default Container getDbSequenceContainer(Container container)
     {
         return isRootDbSequence() ? ContainerManager.getRoot() : container;

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -236,7 +236,6 @@ public class ContainerManager
         Map<String, Object> properties = new HashMap<>();
         properties.put("type", type);
         return createContainer(parent, name, title, description, user, properties);
-
     }
 
     public static Container createContainer(Container parent, String name, @Nullable String title, @Nullable String description, User user, Map<String, Object> properties)

--- a/api/src/org/labkey/api/data/MutableColumnInfo.java
+++ b/api/src/org/labkey/api/data/MutableColumnInfo.java
@@ -107,6 +107,8 @@ public interface MutableColumnInfo extends MutableColumnRenderProperties, Column
 
     void setColumnLogging(ColumnLogging columnLogging);
 
+    void setDbSequenceBatchSize(@Nullable Integer batchSize);
+
     void setHasDbSequence(boolean b);
 
     void setIsRootDbSequence(boolean b);

--- a/api/src/org/labkey/api/data/WrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/WrappedColumnInfo.java
@@ -921,15 +921,21 @@ public class WrappedColumnInfo
         }
 
         @Override
+        public void setDbSequenceBatchSize(@Nullable Integer batchSize)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public void setHasDbSequence(boolean b)
         {
-            throw new java.lang.UnsupportedOperationException();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public void setIsRootDbSequence(boolean b)
         {
-            throw new java.lang.UnsupportedOperationException();
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -1438,7 +1438,12 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             .stream()
             .filter(columnInfo -> columnInfo.hasDbSequence() && !columnInfo.isUniqueIdField())
             .forEach(columnInfo -> {
-                addSequenceColumn(columnInfo, columnInfo.getDbSequenceContainer(c), target.getDbSequenceName(columnInfo.getName()), null, 100, null);
+                // Issue 46326: Allow specific columns to specify preallocated batch size to avoid gaps
+                Integer dbSequenceBatchSize = columnInfo.getDbSequenceBatchSize();
+                if (dbSequenceBatchSize == null)
+                    dbSequenceBatchSize = 100;
+
+                addSequenceColumn(columnInfo, columnInfo.getDbSequenceContainer(c), target.getDbSequenceName(columnInfo.getName()), null, dbSequenceBatchSize, null);
                 added.add(columnInfo.getName());
             });
         return added;


### PR DESCRIPTION
#### Rationale
This adds support to `ColumnInfo` to allow for specifying the `DbSequence` batch size when preallocating a sequence for sequence columns.

#### Related Pull Requests
* https://github.com/LabKey/labbook/pull/283

#### Changes
* Add `getDbSequenceBatchSize()` to `ColumnInfo` and expose setter on `MutableColumnInfo`.
* Respect batch size setting when constructing a `SequenceColumn`.
