### PR TITLE
Issue 45368: Attachment fields containing field names with spaces doesn't show attachment

### DIFF
--- a/api/src/org/labkey/api/data/Parameter.java
+++ b/api/src/org/labkey/api/data/Parameter.java
@@ -186,16 +186,18 @@ public class Parameter implements AutoCloseable
 
     public Parameter(ColumnInfo c, int[] indexes)
     {
+        boolean isAttachmentField = (c.getInputType().equalsIgnoreCase("file") && c.getJdbcType() == JdbcType.VARCHAR);
+
         // The jdbc resultset metadata replaces special characters in source column names.
         // We need the parameter names to match so we can match to the column.
-        _name = c.getJdbcRsName();
+        _name = isAttachmentField ? c.getName() : c.getJdbcRsName(); // adding this check to fix Issue 45368: Attachment fields containing field names with spaces doesn't show attachment
         _uri = c.getPropertyURI();
         _type = c.getJdbcType();
         _scale = c.getScale();
         _precision = c.getPrecision();
         _indexes = indexes;
         // CONSIDER: this seems pretty low-level for this check (see also DefaultQueryUpdateService.convertTypes())
-        setFileAsName = (c.getInputType().equalsIgnoreCase("file") && _type == JdbcType.VARCHAR);
+        setFileAsName = isAttachmentField;
     }
 
 

--- a/api/src/org/labkey/api/dataiterator/StatementDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/StatementDataIterator.java
@@ -199,8 +199,6 @@ public class StatementDataIterator extends AbstractDataIterator
                     to = stmt.getParameter(col.getPropertyURI());
                 if (to == null)
                     to = stmt.getParameter(col.getName());
-                if (to == null)
-                    to = stmt.getParameter(col.getAlias());//Issue 45368: Attachment fields containing field names with spaces doesn't show attachment
                 if (null != to)
                 {
                     FieldKey mvName = col.getMvColumnName();

--- a/api/src/org/labkey/api/dataiterator/StatementDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/StatementDataIterator.java
@@ -199,6 +199,8 @@ public class StatementDataIterator extends AbstractDataIterator
                     to = stmt.getParameter(col.getPropertyURI());
                 if (to == null)
                     to = stmt.getParameter(col.getName());
+                if (to == null)
+                    to = stmt.getParameter(col.getAlias());
                 if (null != to)
                 {
                     FieldKey mvName = col.getMvColumnName();

--- a/api/src/org/labkey/api/dataiterator/StatementDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/StatementDataIterator.java
@@ -200,7 +200,7 @@ public class StatementDataIterator extends AbstractDataIterator
                 if (to == null)
                     to = stmt.getParameter(col.getName());
                 if (to == null)
-                    to = stmt.getParameter(col.getAlias());
+                    to = stmt.getParameter(col.getAlias());//Issue 45368: Attachment fields containing field names with spaces doesn't show attachment
                 if (null != to)
                 {
                     FieldKey mvName = col.getMvColumnName();


### PR DESCRIPTION
#### Rationale
Issue [45368](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45368): Attachment fields containing field names with spaces doesn't show attachment 

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/1240

#### Changes
* Get column alias when the name (for attachment column with spaces) is not present in the statement parameter
