### PR TITLE
Differentiate metrics from servers sharing a cloned DB

### DIFF
--- a/api/src/org/labkey/api/util/MothershipReport.java
+++ b/api/src/org/labkey/api/util/MothershipReport.java
@@ -413,7 +413,6 @@ public class MothershipReport implements Runnable
         ServletContext context = ModuleLoader.getServletContext();
         String servletContainer = context == null ? null : context.getServerInfo();
         addParam("servletContainer", servletContainer);
-        addParam("usedInstaller", usedInstaller());
         addParam("distribution", getDistributionStamp());
         addParam("usageReportingLevel", AppProps.getInstance().getUsageReportingLevel().toString());
         addParam("exceptionReportingLevel", AppProps.getInstance().getExceptionReportingLevel().toString());
@@ -422,14 +421,6 @@ public class MothershipReport implements Runnable
     public String getContent()
     {
         return _content;
-    }
-
-    public static boolean usedInstaller()
-    {
-        ServletContext context = ModuleLoader.getServletContext();
-        String usedInstaller = context == null ? null : context.getInitParameter("org.labkey.api.util.mothershipreport.usedInstaller");
-
-        return Boolean.parseBoolean(usedInstaller);
     }
 
     private static String getDistributionStamp()

--- a/mothership/resources/schemas/dbscripts/postgresql/mothership-22.002-22.003.sql
+++ b/mothership/resources/schemas/dbscripts/postgresql/mothership-22.002-22.003.sql
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- Migrate potentially mutable fields from install to session level
+ALTER TABLE mothership.ServerSession ADD COLUMN OrganizationName VARCHAR(200);
+UPDATE mothership.ServerSession SET OrganizationName = (SELECT OrganizationName FROM mothership.ServerInstallation si WHERE si.serverinstallationid = ServerSession.serverinstallationid);
+ALTER TABLE mothership.ServerInstallation DROP COLUMN OrganizationName;
+
+ALTER TABLE mothership.ServerSession ADD COLUMN SystemShortName VARCHAR(200);
+UPDATE mothership.ServerSession SET SystemShortName = (SELECT SystemShortName FROM mothership.ServerInstallation si WHERE si.serverinstallationid = ServerSession.serverinstallationid);
+ALTER TABLE mothership.ServerInstallation DROP COLUMN SystemShortName;
+
+ALTER TABLE mothership.ServerSession ADD COLUMN SystemDescription VARCHAR(200);
+UPDATE mothership.ServerSession SET SystemDescription = (SELECT SystemDescription FROM mothership.ServerInstallation si WHERE si.serverinstallationid = ServerSession.serverinstallationid);
+ALTER TABLE mothership.ServerInstallation DROP COLUMN SystemDescription;
+
+ALTER TABLE mothership.ServerSession ADD COLUMN LogoLink VARCHAR(200);
+UPDATE mothership.ServerSession SET LogoLink = (SELECT LogoLink FROM mothership.ServerInstallation si WHERE si.serverinstallationid = ServerSession.serverinstallationid);
+ALTER TABLE mothership.ServerInstallation DROP COLUMN LogoLink;
+
+-- We don't care about tracking this anymore
+ALTER TABLE mothership.ServerInstallation DROP COLUMN UsedInstaller;
+
+-- We only want to track this at the session level
+ALTER TABLE mothership.ServerInstallation DROP COLUMN ServerIp;
+
+-- Going forward, we identify servers based on the combination of GUID (from the DB) and their host name
+-- This helps differentiate staging from production and other cases where a copy of the same DB is used by multiple servers
+ALTER TABLE mothership.ServerInstallation DROP CONSTRAINT UQ_ServerInstallation_ServerInstallationGUID;
+ALTER TABLE mothership.ServerInstallation ADD CONSTRAINT UQ_ServerInstallation_ServerInstallationGUID_ServerHostName UNIQUE (ServerInstallationGUID, ServerHostName);
+
+-- Create new install records for every host name we've seen
+INSERT INTO mothership.ServerInstallation (ServerInstallationGUID,
+                                           Note,
+                                           Container,
+                                           ServerHostName,
+                                           IgnoreExceptions)
+SELECT DISTINCT ServerInstallationGUID,
+                Note,
+                si.Container,
+                ss.ServerHostName,
+                IgnoreExceptions
+FROM mothership.ServerInstallation si
+INNER JOIN mothership.ServerSession ss ON
+    si.ServerInstallationId = ss.ServerInstallationId AND
+    si.ServerHostName != ss.ServerHostName;
+
+-- Point the sessions to the appropriate install based on their host name
+UPDATE mothership.ServerSession ss SET ServerInstallationId =
+    (SELECT si2.ServerInstallationId FROM mothership.ServerInstallation si1
+                                     INNER JOIN mothership.serverinstallation si2 ON ss.serverhostname = si2.ServerHostName AND si1.serverinstallationguid = si2.serverinstallationguid
+                                     WHERE si1.serverinstallationid = ss.serverinstallationid);
+

--- a/mothership/resources/schemas/mothership.xml
+++ b/mothership/resources/schemas/mothership.xml
@@ -85,30 +85,10 @@
                 <inputRows>3</inputRows>
             </column>
             <column columnName="Container"/>
-            <column columnName="SystemDescription">
-                <isReadOnly>true</isReadOnly>
-                <inputLength>60</inputLength>
-            </column>
-            <column columnName="LogoLink">
-                <isReadOnly>true</isReadOnly>
-                <inputLength>60</inputLength>
-            </column>
-            <column columnName="OrganizationName">
-                <isReadOnly>true</isReadOnly>
-                <inputLength>60</inputLength>
-            </column>
-            <column columnName="SystemShortName">
-                <isReadOnly>true</isReadOnly>
-                <inputLength>60</inputLength>
-            </column>
-            <column columnName="ServerIP">
-                <isReadOnly>true</isReadOnly>
-            </column>
             <column columnName="ServerHostName">
                 <inputLength>60</inputLength>
                 <scale>255</scale>
             </column>
-            <column columnName="UsedInstaller"/>
             <column columnName="IgnoreExceptions"/>
         </columns>
         <pkColumnName>ServerInstallationId</pkColumnName>
@@ -164,6 +144,22 @@
                 <columnTitle>Max Heap Size (MB)</columnTitle>
             </column>
             <column columnName="AdministratorEmail"/>
+            <column columnName="SystemDescription">
+                <isReadOnly>true</isReadOnly>
+                <inputLength>60</inputLength>
+            </column>
+            <column columnName="LogoLink">
+                <isReadOnly>true</isReadOnly>
+                <inputLength>60</inputLength>
+            </column>
+            <column columnName="OrganizationName">
+                <isReadOnly>true</isReadOnly>
+                <inputLength>60</inputLength>
+            </column>
+            <column columnName="SystemShortName">
+                <isReadOnly>true</isReadOnly>
+                <inputLength>60</inputLength>
+            </column>
             <column columnName="ServletContainer"/>
             <column columnName="Distribution"/>
             <column columnName="JsonMetrics"/>

--- a/mothership/src/org/labkey/mothership/MothershipController.java
+++ b/mothership/src/org/labkey/mothership/MothershipController.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.InetAddressValidator;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
@@ -85,6 +84,8 @@ import org.springframework.web.servlet.ModelAndView;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -613,17 +614,19 @@ public class MothershipController extends SpringActionController
         @Override
         public Object execute(ExceptionForm form, BindException errors)
         {
+            String serverIP = getRemoteIP();
+
             try
             {
                 ServerInstallation installation = new ServerInstallation();
                 if (form.getServerGUID() == null)
                 {
-                    logger.warn("No serverGUID specified in exception report from " + installation.getServerIP() + ", making one up so we don't lose the exception");
+                    logger.warn("No serverGUID specified in exception report from " + serverIP + ", making one up so we don't lose the exception");
                     installation.setServerInstallationGUID(GUID.makeGUID());
                 }
                 else
                 {
-                    ServerInstallation existingInstallation = MothershipManager.get().getServerInstallation(form.getServerGUID(), getContainer());
+                    ServerInstallation existingInstallation = MothershipManager.get().getServerInstallation(form.getServerGUID(), form.getBestServerHostName(serverIP), getContainer());
                     if (null != existingInstallation && Boolean.TRUE.equals(existingInstallation.getIgnoreExceptions()))
                     {
                         // Mothership is set to ignore exceptions from this installation, so just return
@@ -632,7 +635,6 @@ public class MothershipController extends SpringActionController
                     installation.setServerInstallationGUID(form.getServerGUID());
                 }
 
-                installation.setServerIP(getRemoteAddr(installation.getServerInstallationGUID()));
                 ExceptionStackTrace stackTrace = new ExceptionStackTrace();
                 stackTrace.setStackTrace(form.getStackTrace());
                 stackTrace.setContainer(getContainer().getId());
@@ -641,8 +643,7 @@ public class MothershipController extends SpringActionController
                 ServerSession session = sessionAndRelease.first;
                 SoftwareRelease release = sessionAndRelease.second;
 
-                installation.setUsedInstaller(form.isUsedInstaller());
-                session = MothershipManager.get().updateServerSession(form.getServerHostName(), session, installation, getContainer());
+                session = MothershipManager.get().updateServerSession(form, serverIP, session, installation, getContainer());
                 // Skip reports when we don't even know what code it's running
                 if (release.getVcsUrl() != null && release.getVcsRevision() != null)
                 {
@@ -722,10 +723,10 @@ public class MothershipController extends SpringActionController
     @CSRF(CSRF.Method.NONE)
     @SuppressWarnings("UnusedDeclaration")
     @RequiresNoPermission
-    public class CheckForUpdatesAction extends MutatingApiAction<UpdateCheckForm>
+    public class CheckForUpdatesAction extends MutatingApiAction<ServerInfoForm>
     {
         @Override
-        public Object execute(UpdateCheckForm form, BindException errors) throws Exception
+        public Object execute(ServerInfoForm form, BindException errors) throws Exception
         {
             if (form.getServerGUID() != null)
             {
@@ -739,19 +740,13 @@ public class MothershipController extends SpringActionController
         }
     }
 
-    private Pair<ServerSession, SoftwareRelease> saveSessionInfo(UpdateCheckForm form)
+    private Pair<ServerSession, SoftwareRelease> saveSessionInfo(ServerInfoForm form)
     {
         Pair<ServerSession, SoftwareRelease> sessionAndRelease = form.toSession(getContainer());
         ServerInstallation installation = new ServerInstallation();
         installation.setServerInstallationGUID(form.getServerGUID());
-        installation.setLogoLink(form.getLogoLink());
-        installation.setOrganizationName(form.getOrganizationName());
-        installation.setServerIP(getRemoteAddr(form.getServerGUID()));
-        installation.setSystemDescription(form.getSystemDescription());
-        installation.setSystemShortName(form.getSystemShortName());
         installation.setContainer(getContainer().getId());
-        installation.setUsedInstaller(form.isUsedInstaller());
-        MothershipManager.get().updateServerSession(form.getServerHostName(), sessionAndRelease.first, installation, getContainer());
+        MothershipManager.get().updateServerSession(form, getRemoteIP(), sessionAndRelease.first, installation, getContainer());
         return sessionAndRelease;
     }
 
@@ -803,7 +798,7 @@ public class MothershipController extends SpringActionController
             {
                 JSONObject parsed = new JSONObject(manualImportForm.getJson());
 
-                UpdateCheckForm form = new UpdateCheckForm();
+                ServerInfoForm form = new ServerInfoForm();
 
                 if (!parsed.has("serverGUID"))
                 {
@@ -862,16 +857,13 @@ public class MothershipController extends SpringActionController
     /**
      * @return If this server is behind a load balancer, get the original request IP instead of the load balancer's address.
      */
-    private String getRemoteAddr(String serverGUID)
+    private String getRemoteIP()
     {
         String forwardedFor = getViewContext().getRequest().getHeader(MothershipReport.X_FORWARDED_FOR);
         if (null != forwardedFor)
         {
             if (InetAddressValidator.getInstance().isValid(forwardedFor))
                 return forwardedFor;
-            else
-                _log.warn("Invalid (spoofed?) IP address submitted in mothership report for server GUID: " + serverGUID + " . Bad IP: " + forwardedFor);
-
         }
         return getViewContext().getRequest().getRemoteAddr();
     }
@@ -893,7 +885,7 @@ public class MothershipController extends SpringActionController
         return "";
     }
 
-    public static abstract class ServerInfoForm
+    public static class ServerInfoForm
     {
         private String _svnRevision;
         private String _svnURL;
@@ -914,7 +906,6 @@ public class MothershipController extends SpringActionController
         private String _administratorEmail;
         private boolean _enterprisePipelineEnabled;
         private String _servletContainer;
-        private boolean _usedInstaller;
         private String _description;
         private String _distribution;
         private String _usageReportingLevel;
@@ -922,6 +913,52 @@ public class MothershipController extends SpringActionController
         private String _jsonMetrics;
         private String _serverHostName;
         private Date _buildTime;
+
+        private String _systemDescription;
+        private String _logoLink;
+        private String _organizationName;
+        private String _systemShortName;
+
+        public String getLogoLink()
+        {
+            return _logoLink;
+        }
+
+        public void setLogoLink(String logoLink)
+        {
+            _logoLink = logoLink;
+        }
+
+        public String getOrganizationName()
+        {
+            return _organizationName;
+        }
+
+        public void setOrganizationName(String organizationName)
+        {
+            _organizationName = organizationName;
+        }
+
+        public String getSystemShortName()
+        {
+            return _systemShortName;
+        }
+
+        public void setSystemShortName(String systemShortName)
+        {
+            _systemShortName = systemShortName;
+        }
+
+        public String getSystemDescription()
+        {
+            return _systemDescription;
+        }
+
+        public void setSystemDescription(String systemDescription)
+        {
+            _systemDescription = systemDescription;
+        }
+
 
         public String getSvnURL()
         {
@@ -1093,9 +1130,26 @@ public class MothershipController extends SpringActionController
             _heapSize = heapSize;
         }
 
+        @NotNull
         public String getServerHostName()
         {
             return _serverHostName;
+        }
+
+        public String getBestServerHostName(String serverIP)
+        {
+            if (null == _serverHostName || MothershipReport.BORING_HOSTNAMES.contains(_serverHostName))
+            {
+                try
+                {
+                    _serverHostName = InetAddress.getByName(serverIP).getCanonicalHostName();
+                }
+                catch (UnknownHostException e)
+                {
+                    _serverHostName = "UnknownHostName";
+                }
+            }
+            return StringUtils.left(_serverHostName, 256);
         }
 
         public void setServerHostName(String serverHostName)
@@ -1220,16 +1274,6 @@ public class MothershipController extends SpringActionController
             _servletContainer = servletContainer;
         }
 
-        public boolean isUsedInstaller()
-        {
-            return _usedInstaller;
-        }
-
-        public void setUsedInstaller(boolean usedInstaller)
-        {
-            _usedInstaller = usedInstaller;
-        }
-
         public String getDescription()
         {
             return _description;
@@ -1288,54 +1332,6 @@ public class MothershipController extends SpringActionController
         public void setBuildTime(Date buildTime)
         {
             _buildTime = buildTime;
-        }
-    }
-
-    public static class UpdateCheckForm extends ServerInfoForm
-    {
-        private String _systemDescription;
-        private String _logoLink;
-        private String _organizationName;
-        private String _systemShortName;
-
-        public String getLogoLink()
-        {
-            return _logoLink;
-        }
-
-        public void setLogoLink(String logoLink)
-        {
-            _logoLink = logoLink;
-        }
-
-        public String getOrganizationName()
-        {
-            return _organizationName;
-        }
-
-        public void setOrganizationName(String organizationName)
-        {
-            _organizationName = organizationName;
-        }
-
-        public String getSystemShortName()
-        {
-            return _systemShortName;
-        }
-
-        public void setSystemShortName(String systemShortName)
-        {
-            _systemShortName = systemShortName;
-        }
-
-        public String getSystemDescription()
-        {
-            return _systemDescription;
-        }
-
-        public void setSystemDescription(String systemDescription)
-        {
-            _systemDescription = systemDescription;
         }
     }
 
@@ -1706,29 +1702,16 @@ public class MothershipController extends SpringActionController
             requestedColumns.add(FieldKey.fromParts("ServerHostName"));
             requestedColumns.add(FieldKey.fromParts("Note"));
             requestedColumns.add(FieldKey.fromParts("MostRecentSession", "AdministratorEmail"));
-            requestedColumns.add(FieldKey.fromParts("ServerIP"));
-            requestedColumns.add(FieldKey.fromParts("OrganizationName"));
             requestedColumns.add(FieldKey.fromParts("ServerInstallationId"));
             requestedColumns.add(FieldKey.fromParts("ServerInstallationGUID"));
-            requestedColumns.add(FieldKey.fromParts("LogoLink"));
-            requestedColumns.add(FieldKey.fromParts("SystemDescription"));
-            requestedColumns.add(FieldKey.fromParts("SystemShortName"));
-
-            requestedColumns.add(FieldKey.fromParts("MostRecentSession", "UserCount"));
-            requestedColumns.add(FieldKey.fromParts("MostRecentSession", "ActiveUserCount"));
-            requestedColumns.add(FieldKey.fromParts("MostRecentSession", "ProjectCount"));
-            requestedColumns.add(FieldKey.fromParts("MostRecentSession", "ContainerCount"));
+            requestedColumns.add(FieldKey.fromParts("ClonedInstances"));
 
             requestedColumns.add(FieldKey.fromParts("ExceptionCount"));
             requestedColumns.add(FieldKey.fromParts("VersionCount"));
             requestedColumns.add(FieldKey.fromParts("DaysActive"));
             requestedColumns.add(FieldKey.fromParts("LastPing"));
             requestedColumns.add(FieldKey.fromParts("FirstPing"));
-            requestedColumns.add(FieldKey.fromParts("UsedInstaller"));
 
-            requestedColumns.add(FieldKey.fromParts("MostRecentSession", "Distribution"));
-            requestedColumns.add(FieldKey.fromParts("MostRecentSession", "UsageReportingLevel"));
-            requestedColumns.add(FieldKey.fromParts("MostRecentSession", "ExceptionReportingLevel"));
             requestedColumns.add(FieldKey.fromParts("IgnoreExceptions"));
 
             Map<FieldKey, ColumnInfo> columns = QueryService.get().getColumns(serverInstallationTable, requestedColumns);

--- a/mothership/src/org/labkey/mothership/MothershipController.java
+++ b/mothership/src/org/labkey/mothership/MothershipController.java
@@ -1609,7 +1609,7 @@ public class MothershipController extends SpringActionController
         {
             super(new DataRegion(), form);
             getDataRegion().setTable(MothershipManager.get().getTableInfoServerSession());
-            getDataRegion().addColumns(MothershipManager.get().getTableInfoServerSession(), "ServerSessionId,ServerSessionGUID,ServerInstallationId,EarliestKnownTime,LastKnownTime,DatabaseProductName,DatabaseProductVersion,DatabaseDriverName,DatabaseDriverVersion,RuntimeOS,JavaVersion,SoftwareReleaseId,UserCount,ActiveUserCount,ProjectCount,ContainerCount,AdministratorEmail,EnterprisePipelineEnabled,ServletContainer,BuildTime");
+            getDataRegion().addColumns(MothershipManager.get().getTableInfoServerSession(), "ServerSessionId,ServerSessionGUID,ServerInstallationId,EarliestKnownTime,LastKnownTime,DatabaseProductName,DatabaseProductVersion,DatabaseDriverName,DatabaseDriverVersion,RuntimeOS,JavaVersion,SoftwareReleaseId,UserCount,ActiveUserCount,ProjectCount,ContainerCount,AdministratorEmail,EnterprisePipelineEnabled,Distribution,ServerIP,ServerHostName,ServletContainer,BuildTime");
             final DisplayColumn defaultServerInstallationColumn = getDataRegion().getDisplayColumn("ServerInstallationId");
             defaultServerInstallationColumn.setVisible(false);
             DataColumn replacementServerInstallationColumn = new DataColumn(defaultServerInstallationColumn.getColumnInfo())
@@ -1619,8 +1619,6 @@ public class MothershipController extends SpringActionController
                 {
                     Map<String, Object> row = ctx.getRow();
 
-                    ColumnInfo displayColumn = defaultServerInstallationColumn.getColumnInfo().getDisplayField();
-
                     ServerInstallation si = MothershipManager.get().getServerInstallation(((Integer) row.get("ServerInstallationId")).intValue(), ctx.getContainer());
                     if (si != null && si.getNote() != null && si.getNote().trim().length() > 0)
                     {
@@ -1628,20 +1626,15 @@ public class MothershipController extends SpringActionController
                     }
                     else
                     {
-                        Object displayValue = displayColumn.getValue(ctx);
-                        if (displayValue == null || "".equals(displayValue))
+                        if (si != null && si.getServerHostName() != null && si.getServerHostName().trim().length() > 0)
                         {
-                            if (si != null && si.getServerHostName() != null && si.getServerHostName().trim().length() > 0)
-                            {
-                                return HtmlString.of(si.getServerHostName());
-                            }
-                            else
-                            {
-                                return HtmlString.of("[Unnamed]");
-                            }
+                            return HtmlString.of(si.getServerHostName());
+                        }
+                        else
+                        {
+                            return HtmlString.of("[Unnamed]");
                         }
                     }
-                    return super.getFormattedHtml(ctx);
                 }
             };
 

--- a/mothership/src/org/labkey/mothership/MothershipModule.java
+++ b/mothership/src/org/labkey/mothership/MothershipModule.java
@@ -74,7 +74,7 @@ public class MothershipModule extends DefaultModule
     @Override
     public Double getSchemaVersion()
     {
-        return 22.002;
+        return 22.003;
     }
 
     @Override

--- a/mothership/src/org/labkey/mothership/ServerInstallation.java
+++ b/mothership/src/org/labkey/mothership/ServerInstallation.java
@@ -26,54 +26,8 @@ public class ServerInstallation
     private String _serverInstallationGUID;
     private String _note;
     private String _container;
-    private String _systemDescription;
-    private String _logoLink;
-    private String _organizationName;
-    private String _systemShortName;
-    private String _serverIP;
     private String _serverHostName;
-    private Boolean _usedInstaller; // The Windows installer was used to install LabKey, Tomcat, Postgres.
     private Boolean _ignoreExceptions;
-
-    public String getSystemDescription()
-    {
-        return _systemDescription;
-    }
-
-    public void setSystemDescription(String systemDescription)
-    {
-        _systemDescription = systemDescription;
-    }
-
-    public String getLogoLink()
-    {
-        return _logoLink;
-    }
-
-    public void setLogoLink(String logoLink)
-    {
-        _logoLink = logoLink;
-    }
-
-    public String getOrganizationName()
-    {
-        return _organizationName;
-    }
-
-    public void setOrganizationName(String organizationName)
-    {
-        _organizationName = organizationName;
-    }
-
-    public String getSystemShortName()
-    {
-        return _systemShortName;
-    }
-
-    public void setSystemShortName(String systemShortName)
-    {
-        _systemShortName = systemShortName;
-    }
 
     public int getServerInstallationId()
     {
@@ -115,16 +69,6 @@ public class ServerInstallation
         _container = container;
     }
 
-    public String getServerIP()
-    {
-        return _serverIP;
-    }
-
-    public void setServerIP(String serverIP)
-    {
-        _serverIP = serverIP;
-    }
-
     public String getServerHostName()
     {
         return _serverHostName;
@@ -133,16 +77,6 @@ public class ServerInstallation
     public void setServerHostName(String serverHostName)
     {
         _serverHostName = serverHostName;
-    }
-
-    public Boolean getUsedInstaller()
-    {
-        return _usedInstaller;
-    }
-
-    public void setUsedInstaller(Boolean usedInstaller)
-    {
-        _usedInstaller = usedInstaller;
     }
 
     public Boolean getIgnoreExceptions()

--- a/mothership/src/org/labkey/mothership/ServerSession.java
+++ b/mothership/src/org/labkey/mothership/ServerSession.java
@@ -57,6 +57,10 @@ public class ServerSession
     private String _serverHostName;
     private String _serverIP;
     private Integer _originalServerSessionId;
+    private String _systemDescription;
+    private String _logoLink;
+    private String _organizationName;
+    private String _systemShortName;
 
     public String getDatabaseProductVersion()
     {
@@ -346,5 +350,45 @@ public class ServerSession
     public void setOriginalServerSessionId(Integer originalServerSessionId)
     {
         _originalServerSessionId = originalServerSessionId;
+    }
+
+    public String getSystemDescription()
+    {
+        return _systemDescription;
+    }
+
+    public void setSystemDescription(String systemDescription)
+    {
+        _systemDescription = systemDescription;
+    }
+
+    public String getLogoLink()
+    {
+        return _logoLink;
+    }
+
+    public void setLogoLink(String logoLink)
+    {
+        _logoLink = logoLink;
+    }
+
+    public String getOrganizationName()
+    {
+        return _organizationName;
+    }
+
+    public void setOrganizationName(String organizationName)
+    {
+        _organizationName = organizationName;
+    }
+
+    public String getSystemShortName()
+    {
+        return _systemShortName;
+    }
+
+    public void setSystemShortName(String systemShortName)
+    {
+        _systemShortName = systemShortName;
     }
 }

--- a/mothership/src/org/labkey/mothership/query/MothershipSchema.java
+++ b/mothership/src/org/labkey/mothership/query/MothershipSchema.java
@@ -230,7 +230,9 @@ public class MothershipSchema extends UserSchema
         defaultCols.add(FieldKey.fromString("RecentUserCount"));
         defaultCols.add(FieldKey.fromString("ContainerCount"));
         defaultCols.add(FieldKey.fromString("HeapSize"));
+        defaultCols.add(FieldKey.fromString("Distribution"));
         defaultCols.add(FieldKey.fromString("ServletContainer"));
+        defaultCols.add(FieldKey.fromString("ServerIP"));
         result.setDefaultVisibleColumns(defaultCols);
 
         ActionURL base = new ActionURL(MothershipController.ShowServerSessionDetailAction.class, getContainer());

--- a/mothership/test/src/org/labkey/test/pages/mothership/ShowInstallationDetailPage.java
+++ b/mothership/test/src/org/labkey/test/pages/mothership/ShowInstallationDetailPage.java
@@ -34,12 +34,7 @@ public class ShowInstallationDetailPage extends LabKeyPage<ShowInstallationDetai
 
     public static ShowInstallationDetailPage beginAt(WebDriverWrapper driver)
     {
-        return beginAt(driver, MothershipHelper.MOTHERSHIP_PROJECT);
-    }
-
-    public static ShowInstallationDetailPage beginAt(WebDriverWrapper driver, String containerPath)
-    {
-        driver.beginAt(WebTestHelper.buildURL("mothership", containerPath, "showInstallationDetail", Collections.singletonMap("serverInstallationId", "1")));
+        driver.beginAt(WebTestHelper.buildURL("mothership", MothershipHelper.MOTHERSHIP_PROJECT, "showInstallationDetail", Collections.singletonMap("serverInstallationId", "1")));
         return new ShowInstallationDetailPage(driver.getDriver());
     }
 

--- a/mothership/test/src/org/labkey/test/pages/mothership/ShowInstallationDetailPage.java
+++ b/mothership/test/src/org/labkey/test/pages/mothership/ShowInstallationDetailPage.java
@@ -48,11 +48,6 @@ public class ShowInstallationDetailPage extends LabKeyPage<ShowInstallationDetai
         return getInstallationValue("Distribution");
     }
 
-    public String getServerIP()
-    {
-        return getInstallationValue("Server IP");
-    }
-
     public String getServerHostName()
     {
         return Locator.input("serverHostName").findElement(getDriver()).getAttribute("value");

--- a/mothership/test/src/org/labkey/test/tests/mothership/MothershipReportTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/MothershipReportTest.java
@@ -80,14 +80,10 @@ public class MothershipReportTest extends BaseWebDriverTest implements PostgresO
     @Test
     public void testTopLevelItems()
     {
-        // TODO: Test others
-
         _mothershipHelper.createUsageReport(MothershipHelper.ReportLevel.ON, true, null);
         ShowInstallationDetailPage installDetail = ShowInstallationDetailPage.beginAt(this);
         String distributionName = isTestRunningOnTeamCity() ? "teamcity" : "localBuild";
-        assertEquals("Incorrect distribution name", distributionName, installDetail.getDistributionName());
-        assertNotNull("Usage reporting level is empty", StringUtils.trimToNull(installDetail.getInstallationValue("Usage Reporting Level")));
-        assertNotNull("Exception reporting level is empty", StringUtils.trimToNull(installDetail.getInstallationValue("Exception Reporting Level")));
+        assertTextPresent(distributionName);
     }
 
     @Test
@@ -110,6 +106,7 @@ public class MothershipReportTest extends BaseWebDriverTest implements PostgresO
         goToProjectHome("/_mothership");
         goToSchemaBrowser();
         var table = viewQueryData("mothership", "recentJsonMetricValues");
+        assertTrue("Should have at least one row, but was " + table.getDataRowCount(), table.getDataRowCount() > 0);
         table.setFilter("DisplayKey", "Equals", "modules.Core.simpleMetricCounts.controllerHits.admin");
         table = new DataRegionTable("query", this);
         assertTrue("Should have at least one row, but was " + table.getDataRowCount(), table.getDataRowCount() > 0);
@@ -139,24 +136,13 @@ public class MothershipReportTest extends BaseWebDriverTest implements PostgresO
         String forwardedFor = "172.217.5.68"; // The IP address for www.google.com, so unlikely to ever be the real test server IP address
         _mothershipHelper.createUsageReport(MothershipHelper.ReportLevel.ON, true, forwardedFor);
         ShowInstallationDetailPage installDetail = ShowInstallationDetailPage.beginAt(this);
-        assertEquals("Incorrect forwarded IP address", forwardedFor, installDetail.getServerIP());
-    }
-
-    @Test
-    public void testServerHostName() throws Exception
-    {
-        log("Send test server host name from base server url");
-        String hostName = "TEST_" + new URI(CustomizeSitePage.beginAt(this).getBaseServerUrl()).getHost();
-        _mothershipHelper.createUsageReport(MothershipHelper.ReportLevel.ON, true, null);
-        ShowInstallationDetailPage installDetail = ShowInstallationDetailPage.beginAt(this);
-        assertEquals("Incorrect server host name", hostName, installDetail.getServerHostName());
+        assertTextPresent(forwardedFor);
     }
 
     private int triggerNpeAndGetCount()
     {
         return _mothershipHelper.getReportCount(_mothershipHelper.triggerException(TestActions.ExceptionActions.npe));
     }
-    // TODO: Test output of each reporting level
 
     // TODO: test the View sample report buttons from Customize Site page?
 }

--- a/mothership/test/src/org/labkey/test/tests/mothership/MothershipReportTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/MothershipReportTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.labkey.test.TestProperties.isTestRunningOnTeamCity;
 import static org.labkey.test.util.mothership.MothershipHelper.MOTHERSHIP_PROJECT;
 
@@ -107,7 +108,8 @@ public class MothershipReportTest extends BaseWebDriverTest implements PostgresO
         goToSchemaBrowser();
         var table = viewQueryData("mothership", "recentJsonMetricValues");
         assertTrue("Should have at least one row, but was " + table.getDataRowCount(), table.getDataRowCount() > 0);
-        table.setFilter("DisplayKey", "Equals", "modules.Core.simpleMetricCounts.controllerHits.admin");
+        table.setFilter("DisplayKey", "Contains", "modules.Core.simpleMetricCounts.controllerHits.");
+        fail("testing");
         table = new DataRegionTable("query", this);
         assertTrue("Should have at least one row, but was " + table.getDataRowCount(), table.getDataRowCount() > 0);
         table.clearAllFilters();

--- a/mothership/test/src/org/labkey/test/tests/mothership/MothershipReportTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/MothershipReportTest.java
@@ -15,12 +15,15 @@
  */
 package org.labkey.test.tests.mothership;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.OrderWith;
+import org.junit.runner.manipulation.Alphanumeric;
 import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.core.admin.CustomizeSitePage;
 import org.labkey.test.pages.mothership.ShowInstallationDetailPage;
@@ -34,14 +37,13 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.labkey.test.TestProperties.isTestRunningOnTeamCity;
 import static org.labkey.test.util.mothership.MothershipHelper.MOTHERSHIP_PROJECT;
 
 @Category({Daily.class})
-@BaseWebDriverTest.ClassTimeout(minutes = 4)
+@BaseWebDriverTest.ClassTimeout(minutes = 4) @OrderWith(Alphanumeric.class)
 public class MothershipReportTest extends BaseWebDriverTest implements PostgresOnlyTest
 {
     private MothershipHelper _mothershipHelper;
@@ -109,7 +111,6 @@ public class MothershipReportTest extends BaseWebDriverTest implements PostgresO
         var table = viewQueryData("mothership", "recentJsonMetricValues");
         assertTrue("Should have at least one row, but was " + table.getDataRowCount(), table.getDataRowCount() > 0);
         table.setFilter("DisplayKey", "Contains", "modules.Core.simpleMetricCounts.controllerHits.");
-        fail("testing");
         table = new DataRegionTable("query", this);
         assertTrue("Should have at least one row, but was " + table.getDataRowCount(), table.getDataRowCount() > 0);
         table.clearAllFilters();
@@ -145,6 +146,21 @@ public class MothershipReportTest extends BaseWebDriverTest implements PostgresO
     {
         return _mothershipHelper.getReportCount(_mothershipHelper.triggerException(TestActions.ExceptionActions.npe));
     }
+
+    @Test
+    public void testServerHostName() throws Exception
+    {
+        log("Send test server host name from base server url");
+        _mothershipHelper.createUsageReport(MothershipHelper.ReportLevel.ON, true, null);
+
+        String hostName = new URI(CustomizeSitePage.beginAt(this).getBaseServerUrl()).getHost();
+        String hostName2 = "TEST_" + hostName;
+
+        beginAt(WebTestHelper.buildURL("mothership", MothershipHelper.MOTHERSHIP_PROJECT, "showInstallations"));
+        assertElementPresent(Locator.linkWithText(hostName));
+        assertElementPresent(Locator.linkWithText(hostName2));
+    }
+
 
     // TODO: test the View sample report buttons from Customize Site page?
 }

--- a/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
@@ -49,6 +49,7 @@ import java.util.regex.Pattern;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.labkey.test.pages.test.TestActions.ExceptionActions;
 import static org.labkey.test.util.mothership.MothershipHelper.MOTHERSHIP_PROJECT;
@@ -58,6 +59,7 @@ import static org.labkey.test.util.mothership.MothershipHelper.MOTHERSHIP_PROJEC
 public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTest
 {
     private static final String ASSIGNEE = "assignee@mothership.test";
+    private static final String ASSIGNEE2 = "assignee2@mothership.test";
     private static final String NON_ASSIGNEE = "non_assignee@mothership.test";
     private static final String MOTHERSHIP_GROUP = "Mothership Test Group";
     private static final String ISSUES_PROJECT = "MothershipTest Issues";
@@ -65,14 +67,14 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
     public static final String ISSUES_LIST = "mothershipissues";
 
     private static MothershipHelper _mothershipHelper; // Static to remember site settings between tests
-    private ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
+    private final ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
 
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
         _containerHelper.deleteProject(ISSUES_PROJECT, false);
         // Don't delete mothership project
-        _userHelper.deleteUsers(afterTest, ASSIGNEE, NON_ASSIGNEE);
+        _userHelper.deleteUsers(afterTest, ASSIGNEE, ASSIGNEE2, NON_ASSIGNEE);
         permissionsHelper.deleteGroup(MOTHERSHIP_GROUP, MOTHERSHIP_PROJECT, false);
     }
 
@@ -89,10 +91,12 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         _mothershipHelper = new MothershipHelper(this);
 
         _userHelper.createUser(ASSIGNEE);
+        _userHelper.createUser(ASSIGNEE2);
         _userHelper.createUser(NON_ASSIGNEE);
         permissionsHelper.createProjectGroup(MOTHERSHIP_GROUP, MOTHERSHIP_PROJECT);
         permissionsHelper.addMemberToRole(MOTHERSHIP_GROUP, "Editor", MemberType.group, MOTHERSHIP_PROJECT);
         permissionsHelper.addUserToProjGroup(ASSIGNEE, MOTHERSHIP_PROJECT, MOTHERSHIP_GROUP);
+        permissionsHelper.addUserToProjGroup(ASSIGNEE2, MOTHERSHIP_PROJECT, MOTHERSHIP_GROUP);
         permissionsHelper.addMemberToRole(NON_ASSIGNEE, "Project Admin", MemberType.user, MOTHERSHIP_PROJECT);
 
         EditUpgradeMessagePage configurePage = EditUpgradeMessagePage.beginAt(this);
@@ -129,7 +133,7 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
     {
         IssuesHelper issuesHelper = new IssuesHelper(this);
         Integer highestIssueId = issuesHelper.getHighestIssueId(ISSUES_PROJECT, ISSUES_LIST);
-        Integer stackTraceId = ensureUnassignedException();
+        int stackTraceId = ensureUnassignedException();
 
         ShowExceptionsPage showExceptionsPage = ShowExceptionsPage.beginAt(this);
         ExceptionSummaryDataRegion exceptionSummary = showExceptionsPage.exceptionSummary();
@@ -158,16 +162,16 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
     @Test
     public void testAssignException()
     {
-        final String assigneeDisplayName = _userHelper.getDisplayNameForEmail(ASSIGNEE);
-        Integer stackTraceId = ensureUnassignedException();
+        final String assigneeDisplayName = _userHelper.getDisplayNameForEmail(ASSIGNEE2);
+        int stackTraceId = ensureUnassignedException();
 
         ShowExceptionsPage showExceptionsPage = ShowExceptionsPage.beginAt(this);
         ExceptionSummaryDataRegion exceptionSummary = showExceptionsPage.exceptionSummary();
-        exceptionSummary.uncheckAll();
+        exceptionSummary.uncheckAllOnPage();
         exceptionSummary.checkCheckboxByPrimaryKey(stackTraceId);
         exceptionSummary.assignSelectedTo(assigneeDisplayName);
 
-        impersonate(ASSIGNEE);
+        impersonate(ASSIGNEE2);
         {
             showExceptionsPage = goToMothership().clickMyExceptions();
             exceptionSummary = showExceptionsPage.exceptionSummary();
@@ -182,11 +186,11 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
     @Test
     public void testIgnoreExceptionFromDataRegion()
     {
-        Integer stackTraceId = ensureUnassignedException();
+        int stackTraceId = ensureUnassignedException();
 
         ShowExceptionsPage showExceptionsPage = ShowExceptionsPage.beginAt(this);
         ExceptionSummaryDataRegion exceptionSummary = showExceptionsPage.exceptionSummary();
-        exceptionSummary.uncheckAll();
+        exceptionSummary.uncheckAllOnPage();
         exceptionSummary.checkCheckboxByPrimaryKey(stackTraceId);
         exceptionSummary.ignoreSelected();
 
@@ -197,11 +201,11 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
     @Test
     public void testCreateIssueForAssignedException()
     {
-        Integer stackTraceId = ensureUnassignedException();
+        int stackTraceId = ensureUnassignedException();
 
         ShowExceptionsPage showExceptionsPage = ShowExceptionsPage.beginAt(this);
         ExceptionSummaryDataRegion exceptionSummary = showExceptionsPage.exceptionSummary();
-        exceptionSummary.uncheckAll();
+        exceptionSummary.uncheckAllOnPage();
         exceptionSummary.checkCheckboxByPrimaryKey(stackTraceId);
         exceptionSummary.assignSelectedTo(_userHelper.getDisplayNameForEmail(ASSIGNEE));
 
@@ -268,7 +272,7 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         _mothershipHelper.disableExceptionReporting();
         checkErrors();
         ExceptionActions.illegalState.beginAt(this);
-        assertEquals("Shouldn't generate an error code when exception reporting is disabled", null, getErrorCode());
+        assertNull("Shouldn't generate an error code when exception reporting is disabled", getErrorCode());
         resetErrors();
     }
 
@@ -277,7 +281,7 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         if (!isElementPresent(Locator.tagWithClass("div", "labkey-error-instruction")))
             fail("Expected to be on an error page");
         String error = Locators.labkeyErrorInstruction.findElement(getDriver()).getText();
-        Pattern errorCodePattern = Pattern.compile(".*Your unique reference code is: ([^\\s]+)");
+        Pattern errorCodePattern = Pattern.compile(".*Your unique reference code is: (\\S+)");
         Matcher matcher = errorCodePattern.matcher(error);
         if(matcher.find())
             return matcher.group(1);

--- a/mothership/test/src/org/labkey/test/util/mothership/MothershipHelper.java
+++ b/mothership/test/src/org/labkey/test/util/mothership/MothershipHelper.java
@@ -228,7 +228,7 @@ public class MothershipHelper
         for (Pair<TestActions.ExceptionActions, String> action : actionsWithMessages)
         {
             action.getLeft().triggerException(action.getRight());
-            sleep(100); // Wait for mothership to pick up exception
+            sleep(500); // Wait for mothership to pick up exception
             exceptionIds.add(getLatestStackTraceId());
         }
         test.resetErrors();

--- a/mothership/test/src/org/labkey/test/util/mothership/MothershipHelper.java
+++ b/mothership/test/src/org/labkey/test/util/mothership/MothershipHelper.java
@@ -35,6 +35,8 @@ import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.Maps;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,7 +50,7 @@ public class MothershipHelper
 {
     public static final String ID_COLUMN = "ExceptionStackTraceId";
     public static final String SERVER_INSTALLATION_ID_COLUMN = "ServerInstallationId";
-    public static final String SERVER_INSTALLATION_QUERY = "ServerInstallations";
+    public static final String SERVER_INSTALLATION_QUERY = "ServerInstallation";
     public static final String MOTHERSHIP_PROJECT = "_mothership";
 
     private boolean selfReportingEnabled;
@@ -155,7 +157,7 @@ public class MothershipHelper
     }
 
     @LogMethod
-    public void setIgnoreExceptions(boolean ignore) throws IOException, CommandException
+    public void setIgnoreExceptions(boolean ignore) throws IOException, CommandException, URISyntaxException
     {
         // Find the current server GUID
         String serverGUID = test.goToAdminConsole().getServerGUID();
@@ -165,6 +167,8 @@ public class MothershipHelper
         SelectRowsCommand select = new SelectRowsCommand("mothership", SERVER_INSTALLATION_QUERY);
         select.setColumns(Collections.singletonList(SERVER_INSTALLATION_ID_COLUMN));
         select.addFilter("ServerInstallationGUID", serverGUID, Filter.Operator.EQUAL);
+        String hostName = new URI(CustomizeSitePage.beginAt(test).getBaseServerUrl()).getHost();
+        select.addFilter("ServerHostName", hostName, Filter.Operator.EQUAL);
         SelectRowsResponse response = select.execute(connection, MOTHERSHIP_PROJECT);
         if (!response.getRows().isEmpty())
         {


### PR DESCRIPTION
#### Rationale
Our metric tracking gets confused when we have multiple servers using DBs with the same ServerInstallationGUID. That's common for staging and production servers since they frequently take a DB backup and restore it. Less commonly, one production server forks from another.

Reviewing actual metric data, we reliably pull the server host name and can use it to distinguish these instances from each other.

#### Changes
* Identify servers based on GUID and host name
* Stop caring if an install used the Windows installer, which is long dead
* Track more per-instance properties, like organization name and server IP, solely the session level as they can change over time