### PR TITLE
Fix url passing to query webpart ajax call

### DIFF
--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -3139,10 +3139,11 @@ if (!LABKEY.DataRegions) {
         if (LABKEY.Utils.isString(qString) && qString.length > 0) {
 
             var qmIdx = qString.indexOf('?');
+            var qStringWithoutPound;
             if (qmIdx > -1) {
                 qString = qString.substring(qmIdx + 1);
                 var poundIdx = qString.indexOf('#');
-                var qStringWithoutPound = poundIdx > -1 ? qString.substr(0, poundIdx) : qString;
+                qStringWithoutPound = poundIdx > -1 ? qString.substr(0, poundIdx) : qString;
             }
 
             if (qStringWithoutPound.length > 1) {

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -3141,10 +3141,12 @@ if (!LABKEY.DataRegions) {
             var qmIdx = qString.indexOf('?');
             if (qmIdx > -1) {
                 qString = qString.substring(qmIdx + 1);
+                var poundIdx = qString.indexOf('#');
+                var qStringWithoutPound = poundIdx > -1 ? qString.substr(0, poundIdx) : qString;
             }
 
-            if (qString.length > 1) {
-                var pairs = qString.split('&'), p, key,
+            if (qStringWithoutPound.length > 1) {
+                var pairs = qStringWithoutPound.split('&'), p, key,
                     LAST = '.lastFilter', lastIdx, skip = LABKEY.Utils.isArray(skipPrefixSet);
 
                 var exactMatches = EXACT_MATCH_PREFIXES.map(function(prefix) {
@@ -3152,9 +3154,7 @@ if (!LABKEY.DataRegions) {
                 });
 
                 $.each(pairs, function(i, pair) {
-                    var poundIdx = pair.indexOf('#');
-                    var pairWithoutPound = poundIdx > -1 ? pairWithoutPound = pair.substr(0, poundIdx) : pair;
-                    p = pairWithoutPound.split('=', 2);
+                    p = pair.split('=', 2);
                     key = p[0] = decodeURIComponent(p[0]);
                     lastIdx = key.indexOf(LAST);
 

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -3152,7 +3152,9 @@ if (!LABKEY.DataRegions) {
                 });
 
                 $.each(pairs, function(i, pair) {
-                    p = pair.split('=', 2);
+                    var poundIdx = pair.indexOf('#');
+                    var pairWithoutPound = poundIdx > -1 ? pairWithoutPound = pair.substr(0, poundIdx) : pair;
+                    p = pairWithoutPound.split('=', 2);
                     key = p[0] = decodeURIComponent(p[0]);
                     lastIdx = key.indexOf(LAST);
 

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -3146,7 +3146,7 @@ if (!LABKEY.DataRegions) {
                 qStringWithoutPound = poundIdx > -1 ? qString.substr(0, poundIdx) : qString;
             }
 
-            if (qStringWithoutPound.length > 1) {
+            if (qStringWithoutPound && qStringWithoutPound.length > 1) {
                 var pairs = qStringWithoutPound.split('&'), p, key,
                     LAST = '.lastFilter', lastIdx, skip = LABKEY.Utils.isArray(skipPrefixSet);
 


### PR DESCRIPTION
#### Rationale
Labkey Querywebpart api does not filter pound symbol which is often used in the urls and sends it as a parameter value back to the server when updating the grid on container filters.

#### Related Pull Requests
* https://github.com/LabKey/MacCossLabModules/pull/249

#### Changes
* strip off everything after a pound for a query parameter
