### PR TITLE
Dial back overly aggressive check on DatasetAutoJoinTable

### DIFF
--- a/study/src/org/labkey/study/query/DatasetAutoJoinTable.java
+++ b/study/src/org/labkey/study/query/DatasetAutoJoinTable.java
@@ -140,9 +140,6 @@ public class DatasetAutoJoinTable extends VirtualTable
             if (getColumn(name) != null)
                 continue;
 
-            if (_sequenceNumColumn == null && !dataset.isDemographicData())
-                continue;
-
             var datasetColumn = createDatasetColumn(name, dataset, cf);
             if (datasetColumn != null)
             {


### PR DESCRIPTION
#### Rationale
This recent [change](https://github.com/LabKey/platform/pull/3668) was causing test outages. The symptoms were that datasets listed in the `Datasets FK` were being limited to demographics only datasets.

The code was trying to prevent listing datasets that couldn't be joined to the FK parent table because it lacked a `SequenceNum` column. Unfortunately we don't have this information at the time of the construction of the table info and it isn't until we traverse into the dataset that this information is known. The prior code will detect the error and prevent the user from displaying or saving the view but it would have been nicer if we could know ahead of time whether the `SequenceNum` join would be possible. For know, removing the check will fix the existing tests.