### PR TITLE
Add metrics for study timepoint types

### DIFF
--- a/bigiron/src/org/labkey/bigiron/mysql/MySqlDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySqlDialectFactory.java
@@ -77,7 +77,7 @@ public class MySqlDialectFactory implements SqlDialectFactory
     @Override
     public @Nullable SqlDialect createFromDriverClassName(String driverClassName)
     {
-        return "com.mysql.jdbc.Driver".equals(driverClassName) ? new MySqlDialect() : null;
+        return "com.mysql.cj.jdbc.Driver".equals(driverClassName) || "com.mysql.jdbc.Driver".equals(driverClassName) ? new MySqlDialect() : null;
     }
 
     private final static String RECOMMENDED = getProductName() + " 8.0.x is the recommended version.";

--- a/core/src/org/labkey/core/webdav/WebdavServlet.java
+++ b/core/src/org/labkey/core/webdav/WebdavServlet.java
@@ -23,9 +23,9 @@ package org.labkey.core.webdav;
  */
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpStatus;
-import org.apache.logging.log4j.Logger;
+import org.apache.hc.core5.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.labkey.api.miniprofiler.RequestInfo;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.MemTracker;

--- a/query/src/org/labkey/query/reports/ReportServiceImpl.java
+++ b/query/src/org/labkey/query/reports/ReportServiceImpl.java
@@ -54,7 +54,6 @@ import org.labkey.api.reports.model.ViewCategoryManager;
 import org.labkey.api.reports.report.AbstractReportIdentifier;
 import org.labkey.api.reports.report.DbReportIdentifier;
 import org.labkey.api.reports.report.ModuleJavaScriptReportDescriptor;
-import org.labkey.api.reports.report.python.ModuleIpynbReportDescriptor;
 import org.labkey.api.reports.report.ModuleRReportDescriptor;
 import org.labkey.api.reports.report.ModuleReportDescriptor;
 import org.labkey.api.reports.report.ModuleReportIdentifier;
@@ -65,6 +64,7 @@ import org.labkey.api.reports.report.ReportIdentifier;
 import org.labkey.api.reports.report.ReportIdentifierConverter;
 import org.labkey.api.reports.report.ScriptEngineReport;
 import org.labkey.api.reports.report.ScriptReportDescriptor;
+import org.labkey.api.reports.report.python.ModuleIpynbReportDescriptor;
 import org.labkey.api.reports.report.view.ReportUtil;
 import org.labkey.api.security.MutableSecurityPolicy;
 import org.labkey.api.security.SecurityPolicyManager;
@@ -105,7 +105,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
-import static org.apache.http.util.TextUtils.isBlank;
 import static org.labkey.api.reports.report.ScriptReportDescriptor.REPORT_METADATA_EXTENSION;
 
 /**
@@ -572,7 +571,7 @@ public class ReportServiceImpl extends AbstractContainerListener implements Repo
     @Override
     public Report getReportByEntityId(Container c, String entityId)
     {
-        if (isBlank(entityId))
+        if (StringUtils.isBlank(entityId))
             return null;
         if (GUID.isGUID(entityId))
         {

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -17,7 +17,7 @@
 package org.labkey.search;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpStatus;
+import org.apache.hc.core5.http.HttpStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;

--- a/study/resources/schemas/dbscripts/postgresql/study-22.001-22.002.sql
+++ b/study/resources/schemas/dbscripts/postgresql/study-22.001-22.002.sql
@@ -1,0 +1,4 @@
+ALTER TABLE study.study DROP COLUMN AllowReload;
+ALTER TABLE study.study DROP COLUMN LastReload;
+ALTER TABLE study.study DROP COLUMN ReloadInterval;
+ALTER TABLE study.study DROP COLUMN ReloadUser;

--- a/study/resources/schemas/dbscripts/sqlserver/study-22.001-22.002.sql
+++ b/study/resources/schemas/dbscripts/sqlserver/study-22.001-22.002.sql
@@ -1,0 +1,5 @@
+EXEC core.fn_dropifexists 'Study', 'study', 'DEFAULT', 'AllowReload';
+ALTER TABLE study.study DROP COLUMN AllowReload;
+ALTER TABLE study.study DROP COLUMN LastReload;
+ALTER TABLE study.study DROP COLUMN ReloadInterval;
+ALTER TABLE study.study DROP COLUMN ReloadUser;

--- a/study/resources/schemas/study.xml
+++ b/study/resources/schemas/study.xml
@@ -71,18 +71,6 @@
       <column columnName="ShowPrivateDataByDefault">
         <description>Whether private data (as indicated by the data's quality control state) is visible by default.</description>
       </column>
-      <column columnName="AllowReload">
-        <description>Whether the study can be reloaded from disk-based files.</description>
-      </column>
-      <column columnName="ReloadInterval">
-        <description>How frequently automatic reloads of the study should take place.</description>
-      </column>
-      <column columnName="LastReload">
-        <description>The timestamp of the most recent study reload.</description>
-      </column>
-      <column columnName="ReloadUser">
-        <description>The user who initiated automatic reload.</description>
-      </column>
       <column columnName="AdvancedCohorts">
         <description>Whether advanced cohort assignment is enabled.  Advanced cohort support allows subjects to change cohorts over time.</description>
       </column>

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -440,8 +440,8 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
                         .collect(Collectors.groupingBy(Report::getType, Collectors.counting())))
                 );
 
-                metric.put("studyReloadCount", new SqlSelector(StudySchema.getInstance().getSchema(), "SELECT COUNT(*) FROM study.Study WHERE AllowReload = ? AND ReloadInterval > ?", true, 0).getObject(Long.class));
                 metric.put("securityType", new SqlSelector(StudySchema.getInstance().getSchema(), "SELECT SecurityType, COUNT(*) FROM study.Study GROUP BY SecurityType").getValueMap());
+                metric.put("timepointType", new SqlSelector(StudySchema.getInstance().getSchema(), "SELECT TimepointType, COUNT(*) FROM study.Study GROUP BY TimepointType").getValueMap());
 
                 metric.put("linkedSampleTypeDatasetCount", new SqlSelector(StudySchema.getInstance().getSchema(), "SELECT COUNT(PublishSourceType) FROM study.dataset WHERE PublishSourceType = 'SampleType'").getObject(Long.class));
                 metric.put("linkedAssayDatasetCount", new SqlSelector(StudySchema.getInstance().getSchema(), "SELECT COUNT(PublishSourceType) FROM study.dataset WHERE PublishSourceType = 'Assay'").getObject(Long.class));

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -235,7 +235,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
     @Override
     public Double getSchemaVersion()
     {
-        return 22.001;
+        return 22.002;
     }
 
     @Override
@@ -845,7 +845,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
             List<String> metricNames = List.of(
                 "studyCount",
                 "datasetCount",
-                "studyReloadCount",
+                "timepointType",
                 "reportCountsByType"
             );
             assertTrue("Mothership report missing expected metrics",

--- a/study/src/org/labkey/study/model/StudyImpl.java
+++ b/study/src/org/labkey/study/model/StudyImpl.java
@@ -122,7 +122,6 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
     private Integer _defaultDirectEntryQCState;
     private boolean _showPrivateDataByDefault = true;
     private boolean _blankQCStatePublic = false;
-    private Date _lastReload;
     private boolean _advancedCohorts;
     private Integer _participantCommentDatasetId;
     private String _participantCommentProperty;
@@ -573,16 +572,6 @@ public class StudyImpl extends ExtensibleStudyEntity<StudyImpl> implements Study
             return 0;
 
         return domain.getProperties().size();
-    }
-
-    public Date getLastReload()
-    {
-        return _lastReload;
-    }
-
-    public void setLastReload(Date lastReload)
-    {
-        _lastReload = lastReload;
     }
 
     @Override

--- a/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
@@ -17,7 +17,7 @@ package org.labkey.test.tests.study;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.http.HttpStatus;
+import org.apache.hc.core5.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;


### PR DESCRIPTION
#### Rationale
Study timepoint metrics could be useful: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46331

Reload columns are no longer used: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46316

Unrelated: fix the MySQL driver lookup name (not currently used, but might as well not be wrong) and remove a few HttpClient 4.x references.
