### PR TITLE
Issue 46346: Perf issues rendering HTML wikis

### DIFF
--- a/api/src/org/labkey/api/wiki/FormattedHtml.java
+++ b/api/src/org/labkey/api/wiki/FormattedHtml.java
@@ -64,9 +64,9 @@ public class FormattedHtml
     {
         _html = null==html ? HtmlString.EMPTY_STRING : html;
         _volatile = isVolatile;
-        _wikiDependencies = wikiDependencies;
-        _anchors = anchors;
-        _clientDependencies = clientDependencies;
+        _wikiDependencies = Collections.unmodifiableSet(wikiDependencies);
+        _anchors = Collections.unmodifiableSet(anchors);
+        _clientDependencies = Collections.unmodifiableSet(clientDependencies);
     }
 
     @NotNull

--- a/core/src/org/labkey/core/wiki/HtmlRenderer.java
+++ b/core/src/org/labkey/core/wiki/HtmlRenderer.java
@@ -109,7 +109,9 @@ public class HtmlRenderer implements WikiRenderer
         // process A and IMG
         NodeList nl = doc.getElementsByTagName("a");
         Map<Element, String> linkExceptions = new HashMap<>();
-        for (int i=0 ; i<nl.getLength() ; i++)
+        // Some implementations calculate the length on all calls to getLength(), which can be expensive
+        int length = nl.getLength();
+        for (int i=0 ; i < length ; i++)
         {
             Element a = (Element)nl.item(i);
             try

--- a/core/src/org/labkey/core/wiki/HtmlRenderer.java
+++ b/core/src/org/labkey/core/wiki/HtmlRenderer.java
@@ -110,8 +110,7 @@ public class HtmlRenderer implements WikiRenderer
         NodeList nl = doc.getElementsByTagName("a");
         Map<Element, String> linkExceptions = new HashMap<>();
         // Some implementations calculate the length on all calls to getLength(), which can be expensive
-        int length = nl.getLength();
-        for (int i=0 ; i < length ; i++)
+        for (int i = 0, length = nl.getLength(); i < length ; i++)
         {
             Element a = (Element)nl.item(i);
             try
@@ -155,7 +154,7 @@ public class HtmlRenderer implements WikiRenderer
         }
 
         nl = doc.getElementsByTagName("img");
-        for (int i=0 ; i<nl.getLength() ; i++)
+        for (int i = 0, length = nl.getLength(); i < length; i++)
         {
             Element img = (Element)nl.item(i);
             String src = img.getAttribute("src");
@@ -177,7 +176,7 @@ public class HtmlRenderer implements WikiRenderer
 
             //look for style elements, as tidy moves them to the head section
             NodeList styleNodes = doc.getElementsByTagName("style");
-            for (int idx = 0; idx < styleNodes.getLength(); ++idx)
+            for (int idx = 0, length = styleNodes.getLength(); idx < length; ++idx)
             {
                 innerHtml.append(PageFlowUtil.convertNodeToHtml(styleNodes.item(idx)));
                 innerHtml.append('\n');

--- a/core/src/org/labkey/core/wiki/HtmlRenderer.java
+++ b/core/src/org/labkey/core/wiki/HtmlRenderer.java
@@ -109,7 +109,7 @@ public class HtmlRenderer implements WikiRenderer
         // process A and IMG
         NodeList nl = doc.getElementsByTagName("a");
         Map<Element, String> linkExceptions = new HashMap<>();
-        // Some implementations calculate the length on all calls to getLength(), which can be expensive
+        // Tidy recalculates the length on all calls to getLength(), which is expensive, so remember the value
         for (int i = 0, length = nl.getLength(); i < length ; i++)
         {
             Element a = (Element)nl.item(i);

--- a/wiki/src/org/labkey/wiki/WikiContentCache.java
+++ b/wiki/src/org/labkey/wiki/WikiContentCache.java
@@ -30,22 +30,21 @@ import org.labkey.wiki.model.WikiVersion;
  */
 public class WikiContentCache
 {
-    private static final Cache<String, HtmlString> CONTENT_CACHE = CacheManager.getStringKeyCache(50000, CacheManager.DAY, "Wiki Content");
+    private static final Cache<String, FormattedHtml> CONTENT_CACHE = CacheManager.getStringKeyCache(5000, CacheManager.DAY, "Wiki Content");
 
-    public static HtmlString getHtml(Container c, Wiki wiki, WikiVersion version, boolean cache)
+    public static FormattedHtml getHtml(Container c, Wiki wiki, WikiVersion version, boolean cache)
     {
         if (!cache)
-            return WikiManager.get().formatWiki(c, wiki, version).getHtml();
+            return WikiManager.get().formatWiki(c, wiki, version);
 
         String key = c.getId() + "/" + wiki.getName() + "/" + version.getVersion();
-        HtmlString html = CONTENT_CACHE.get(key);
+        FormattedHtml html = CONTENT_CACHE.get(key);
 
         if (null == html)
         {
-            FormattedHtml formattedHtml = WikiManager.get().formatWiki(c, wiki, version);
-            html = formattedHtml.getHtml();
+            html = WikiManager.get().formatWiki(c, wiki, version);
 
-            if (!formattedHtml.isVolatile())
+            if (!html.isVolatile())
                 CONTENT_CACHE.put(key, html);
         }
 

--- a/wiki/src/org/labkey/wiki/model/WikiVersion.java
+++ b/wiki/src/org/labkey/wiki/model/WikiVersion.java
@@ -132,12 +132,12 @@ public class WikiVersion
 
     public HtmlString getHtmlForConvert(Container c, Wiki wiki)
     {
-        return WikiContentCache.getHtml(c, wiki, this, _cache);
+        return WikiContentCache.getHtml(c, wiki, this, _cache).getHtml();
     }
 
     public Set<ClientDependency> getClientDependencies(Container c, Wiki wiki)
     {
-        return WikiManager.get().formatWiki(c, wiki, this).getClientDependencies();
+        return WikiContentCache.getHtml(c, wiki, this, _cache).getClientDependencies();
     }
 
     public String getTitle()


### PR DESCRIPTION
#### Rationale
We've seen servers get bogged down with wiki rendering.

#### Changes
* Don't double-render the page, once for HTML and once for ClientDependencies. Do it once for both and use our caching mechanism.
* Reduce usage of wildly inefficient DOM NodeList implementation method
* Don't cache as many wikis - they're potentially huge