### PR TITLE
Issue 46354: Study import overwriting system properties

### DIFF
--- a/api/src/org/labkey/api/exp/property/DomainProperty.java
+++ b/api/src/org/labkey/api/exp/property/DomainProperty.java
@@ -74,6 +74,7 @@ public interface DomainProperty extends ImportAliasable, MutableColumnConceptPro
     void setFormat(String s);
     void setRequired(boolean b);
     void setHidden(boolean hidden);
+    void setSwap(boolean swap);
     void setShownInInsertView(boolean shown);
     void setShownInUpdateView(boolean shown);
     void setShownInDetailsView(boolean shown);

--- a/api/src/org/labkey/api/exp/property/DomainProperty.java
+++ b/api/src/org/labkey/api/exp/property/DomainProperty.java
@@ -74,7 +74,6 @@ public interface DomainProperty extends ImportAliasable, MutableColumnConceptPro
     void setFormat(String s);
     void setRequired(boolean b);
     void setHidden(boolean hidden);
-    void setSwap(boolean swap);
     void setShownInInsertView(boolean shown);
     void setShownInUpdateView(boolean shown);
     void setShownInDetailsView(boolean shown);

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -628,12 +628,17 @@ public class DomainImpl implements Domain
                             generateStorageColumnName(impl._pd);
                     }
 
-                    if (impl.isRecreateRequired())
+                    if (impl.isRecreateRequired() && !impl.isSwap())
                     {
                         impl.markAsNew();
                     }
 
-                    if (impl.isNew())
+                    if (impl.isSwap())
+                    {
+                        // Property descriptor was swapped for a different pd
+                        propChanged = true;
+                    }
+                    else if (impl.isNew())
                     {
                         if (impl._pd.isRequired())
                             checkRequiredStatus.add(impl);

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -628,12 +628,12 @@ public class DomainImpl implements Domain
                             generateStorageColumnName(impl._pd);
                     }
 
-                    if (impl.isRecreateRequired() && !impl.isSwap())
+                    if (impl.isRecreateRequired() && !impl.isSystemPropertySwap())
                     {
                         impl.markAsNew();
                     }
 
-                    if (impl.isSwap())
+                    if (impl.isSystemPropertySwap())
                     {
                         // Property descriptor was swapped for a different pd
                         propChanged = true;

--- a/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
@@ -724,6 +724,11 @@ public class DomainPropertyImpl implements DomainProperty
         return _pd.getPropertyId() == 0;
     }
 
+    public boolean isSwap()
+    {
+        return isNew() && _pdOld != null && !_pd.getPropertyURI().equals(_pdOld.getPropertyURI());
+    }
+
     public boolean isDirty()
     {
         if (_pdOld != null) return true;
@@ -749,7 +754,12 @@ public class DomainPropertyImpl implements DomainProperty
 
     public void save(User user, DomainDescriptor dd, int sortOrder) throws ChangePropertyDescriptorException
     {
-        if (isNew())
+        if (isSwap())
+        {
+            _pd = OntologyManager.insertOrUpdatePropertyDescriptor(_pd, dd, sortOrder);
+            OntologyManager.removePropertyDescriptorFromDomain(new DomainPropertyImpl((DomainImpl) getDomain(), _pdOld));
+        }
+        else if (isNew())
         {
             _pd = OntologyManager.insertOrUpdatePropertyDescriptor(_pd, dd, sortOrder);
         }

--- a/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
@@ -730,12 +730,13 @@ public class DomainPropertyImpl implements DomainProperty
         _swap = swap;
     }
 
+    // Scenario to swap property descriptors on study upload instead of updating the current property descriptor.
+    // Currently only used when changing to/from system property.
     public boolean isSwap()
     {
-        // Assert necessary values to swap property descriptors
-        assert isNew() && _pdOld != null && _pd.getPropertyURI() != null
+        // Ensure necessary values to swap property descriptors
+        return _swap && _pd.getPropertyId() == 0 && _pdOld != null && _pd.getPropertyURI() != null
                 && _pdOld.getPropertyURI() != null && !_pd.getPropertyURI().equals(_pdOld.getPropertyURI());
-        return _swap;
     }
 
     public boolean isDirty()

--- a/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
@@ -726,7 +726,8 @@ public class DomainPropertyImpl implements DomainProperty
 
     public boolean isSwap()
     {
-        return isNew() && _pdOld != null && !_pd.getPropertyURI().equals(_pdOld.getPropertyURI());
+        return isNew() && _pdOld != null && _pd.getPropertyURI() != null
+                && _pdOld.getPropertyURI() != null && !_pd.getPropertyURI().equals(_pdOld.getPropertyURI());
     }
 
     public boolean isDirty()

--- a/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
@@ -70,6 +70,7 @@ public class DomainPropertyImpl implements DomainProperty
     private List<PropertyValidatorImpl> _validators;
     private List<ConditionalFormat> _formats;
     private String _defaultValue;
+    private boolean _swap;
 
 
     public DomainPropertyImpl(DomainImpl type, PropertyDescriptor pd)
@@ -724,10 +725,17 @@ public class DomainPropertyImpl implements DomainProperty
         return _pd.getPropertyId() == 0;
     }
 
+    public void setSwap(boolean swap)
+    {
+        _swap = swap;
+    }
+
     public boolean isSwap()
     {
-        return isNew() && _pdOld != null && _pd.getPropertyURI() != null
+        // Assert necessary values to swap property descriptors
+        assert isNew() && _pdOld != null && _pd.getPropertyURI() != null
                 && _pdOld.getPropertyURI() != null && !_pd.getPropertyURI().equals(_pdOld.getPropertyURI());
+        return _swap;
     }
 
     public boolean isDirty()

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -3805,6 +3805,7 @@ public class StudyManager
                 if (propertyUriChange && (toSystemProp || fromSystemProp))
                 {
                     p.getPropertyDescriptor().setPropertyId(0);
+                    p.setSwap(true);
                 }
             }
             else

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -3805,7 +3805,6 @@ public class StudyManager
                     p.getPropertyDescriptor().setPropertyId(0);
                     p.getPropertyDescriptor().setContainer(ipd.pd.getContainer());
                     p.getPropertyDescriptor().setProject(ipd.pd.getProject());
-                    p.setSwap(true);
                 }
             }
             else

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -3796,15 +3796,15 @@ public class StudyManager
                     // by dropping/adding the property and its storage at domain save time
                     p.setSchemaImport(true);
                     OntologyManager.updateDomainPropertyFromDescriptor(p, ipd.pd);
-
-                    // Could be changing from a shared property descriptor
-                    p.getPropertyDescriptor().setContainer(ipd.pd.getContainer());
                 }
 
-                // Flag this as a property descriptor swap
+                // Flag this as a property descriptor swap. EnsurePropertyDescriptor will find correct property Id
+                // by propertyURI. Ensure correct container/projects set.
                 if (propertyUriChange && (toSystemProp || fromSystemProp))
                 {
                     p.getPropertyDescriptor().setPropertyId(0);
+                    p.getPropertyDescriptor().setContainer(ipd.pd.getContainer());
+                    p.getPropertyDescriptor().setProject(ipd.pd.getProject());
                     p.setSwap(true);
                 }
             }

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -3801,7 +3801,7 @@ public class StudyManager
                     p.getPropertyDescriptor().setContainer(ipd.pd.getContainer());
                 }
 
-                // Set property Id to zero if swapping to a different property descriptor
+                // Flag this as a property descriptor swap
                 if (propertyUriChange && (toSystemProp || fromSystemProp))
                 {
                     p.getPropertyDescriptor().setPropertyId(0);

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -3778,12 +3778,12 @@ public class StudyManager
 
             if (null != p)
             {
-                final String toPropertyUri = p.getPropertyDescriptor().getPropertyURI();
+                final String fromPropertyUri = p.getPropertyDescriptor().getPropertyURI();
                 boolean fromSystemProp = SystemProperty.getProperties().stream().anyMatch(sp ->
-                        sp.getPropertyURI().equals(toPropertyUri));
+                        sp.getPropertyURI().equals(fromPropertyUri));
                 boolean toSystemProp = SystemProperty.getProperties().stream().anyMatch(sp ->
                         sp.getPropertyURI().equals(ipd.pd.getPropertyURI()));
-                boolean propertyUriChange = !toPropertyUri.equals(ipd.pd.getPropertyURI());
+                boolean propertyUriChange = !fromPropertyUri.equals(ipd.pd.getPropertyURI());
 
                 // Don't copy values over a system prop, just setup swapping the property descriptor
                 if (propertyUriChange && toSystemProp)


### PR DESCRIPTION
#### Rationale
When swapping between system properties and non-system properties for dataset columns in a study import, the study properties get overwritten to local property descriptor values.

#### Changes
In study import check if changing to or from system property and handle that as a property descriptor swap between the system property and a local property descriptor (to or from).  Let OntologyManager handle finding the system property or creating the local property descriptor and any property descriptor cleanup after swap. 
