### PR TITLE
SampleTypeDomainKind - add "Ancestors" as reserved name

### DIFF
--- a/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
+++ b/internal/src/org/labkey/experiment/api/SampleTypeDomainKind.java
@@ -113,6 +113,7 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
         RESERVED_NAMES.add("AliquotCount");
         RESERVED_NAMES.add("AliquotVolume");
         RESERVED_NAMES.add("AliquotUnit");
+        RESERVED_NAMES.add("Ancestors");
         RESERVED_NAMES.add("Container");
         RESERVED_NAMES.add(ExpMaterialTable.Column.SampleState.name());
         RESERVED_NAMES.addAll(InventoryService.INVENTORY_STATUS_COLUMN_NAMES);


### PR DESCRIPTION
#### Rationale
While helping to triage a support ticket related to Sample Type insertRows issues with the "Ancestors" column, I tried adding a column with that name to my sample type. I got an error...but it looks like the Ancestors column was actually added to the domain and the error was while the ExpMaterialTableImpl was trying to add the calculated column of the same name. This got my server into a bad state.

#### Changes
* SampleTypeDomainKind - add "Ancestors" as reserved name
