### PR TITLE
Add new org.json JSON library plus a few usages

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -52,9 +52,7 @@ List runtime = [
 
 configurations {
     // Exclude the bundled org.json library from com.fasterxml.jackson.datatype:jackson-datatype-json-org dependency
-    // and the org.json module as well because they get in the way of our own JSON object implementations from server/api
     all*.exclude group: "org.apache.geronimo.bundles", module: "json"
-    all*.exclude group: "org.json", module: "json"
 
     creditable {
         canBeConsumed = false
@@ -126,45 +124,6 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "com.datadoghq:dd-trace-api:${datadogVersion}",
-            "Datadog Trace API client",
-            "Datadog",
-            "http://www.datadoghq.com/",
-            ExternalDependency.APACHE_2_LICENSE_NAME,
-            ExternalDependency.APACHE_2_LICENSE_URL,
-            "Integrations to pass trace_ids and other info to Datadog",
-        )
-    )
-
-    BuildUtils.addExternalDependency(
-        project,
-        new ExternalDependency(
-            "io.opentracing:opentracing-api:${openTracingVersion}",
-            "OpenTracing Java API",
-            "OpenTracing",
-            "https://opentracing.io",
-            ExternalDependency.APACHE_2_LICENSE_NAME,
-            ExternalDependency.APACHE_2_LICENSE_URL,
-            "Standard telemetry/tracing APIs, used with Datadog",
-        )
-    )
-
-    BuildUtils.addExternalDependency(
-        project,
-        new ExternalDependency(
-            "io.opentracing:opentracing-util:${openTracingVersion}",
-            "OpenTracing Java Util",
-            "OpenTracing",
-            "https://opentracing.io",
-            ExternalDependency.APACHE_2_LICENSE_NAME,
-            ExternalDependency.APACHE_2_LICENSE_URL,
-            "Standard telemetry/tracing APIs, used with Datadog",
-        )
-    )
-
-    BuildUtils.addExternalDependency(
-        project,
-        new ExternalDependency(
             "org.apache.xmlgraphics:batik-codec:${batikVersion}",
             "Apache Batik Codec",
             "Apache",
@@ -200,6 +159,7 @@ dependencies {
             "Used by Spring Framework and jMock",
         )
     )
+
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
@@ -327,6 +287,19 @@ dependencies {
             ExternalDependency.LGPL_LICENSE_NAME,
             ExternalDependency.LGPL_LICENSE_URL,
             "XHTML/CSS rendering library",
+        )
+    )
+
+    BuildUtils.addExternalDependency(
+        project,
+        new ExternalDependency(
+            "com.datadoghq:dd-trace-api:${datadogVersion}",
+            "Datadog Trace API client",
+            "Datadog",
+            "http://www.datadoghq.com/",
+            ExternalDependency.APACHE_2_LICENSE_NAME,
+            ExternalDependency.APACHE_2_LICENSE_URL,
+            "Integrations to pass trace_ids and other info to Datadog",
         )
     )
 
@@ -573,6 +546,19 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
+            "org.json:json:${orgJsonVersion}",
+            "JSON in Java",
+            "JSON-java",
+            "https://github.com/stleary/JSON-java",
+            "Public Domain",
+            "https://github.com/stleary/JSON-java/blob/master/LICENSE",
+            "JSON library",
+        )
+    )
+
+    BuildUtils.addExternalDependency(
+        project,
+        new ExternalDependency(
             "net.sf.jtidy:jtidy:${jtidyVersion}",
             "Java Tidy",
             "SourceForge",
@@ -650,6 +636,32 @@ dependencies {
             ExternalDependency.APACHE_2_LICENSE_NAME,
             ExternalDependency.APACHE_2_LICENSE_URL,
             "Logging",
+        )
+    )
+
+    BuildUtils.addExternalDependency(
+        project,
+        new ExternalDependency(
+            "io.opentracing:opentracing-api:${openTracingVersion}",
+            "OpenTracing Java API",
+            "OpenTracing",
+            "https://opentracing.io",
+            ExternalDependency.APACHE_2_LICENSE_NAME,
+            ExternalDependency.APACHE_2_LICENSE_URL,
+            "Standard telemetry/tracing APIs, used with Datadog",
+        )
+    )
+
+    BuildUtils.addExternalDependency(
+        project,
+        new ExternalDependency(
+            "io.opentracing:opentracing-util:${openTracingVersion}",
+            "OpenTracing Java Util",
+            "OpenTracing",
+            "https://opentracing.io",
+            ExternalDependency.APACHE_2_LICENSE_NAME,
+            ExternalDependency.APACHE_2_LICENSE_URL,
+            "Standard telemetry/tracing APIs, used with Datadog",
         )
     )
 

--- a/api/src/org/labkey/api/action/ApiSimpleResponse.java
+++ b/api/src/org/labkey/api/action/ApiSimpleResponse.java
@@ -50,6 +50,11 @@ public class ApiSimpleResponse implements ApiResponse, Map<String,Object>
         _json = json;
     }
 
+    public ApiSimpleResponse(org.json.JSONObject json)
+    {
+        this(json.toMap());
+    }
+
     public ApiSimpleResponse(Map<String, ?> values)
     {
         _json = new JSONObject(values);

--- a/api/src/org/labkey/api/action/SimpleApiJsonForm.java
+++ b/api/src/org/labkey/api/action/SimpleApiJsonForm.java
@@ -29,16 +29,22 @@ public class SimpleApiJsonForm implements CustomApiForm
     protected JSONObject json;
 
     @Override
-    public void bindProperties(Map<String,Object> properties)
+    public void bindProperties(Map<String, Object> properties)
     {
-        if (properties instanceof JSONObject)
-            json = (JSONObject)properties;
+        if (properties instanceof JSONObject jsonObject)
+            json = jsonObject;
         else
             json = new JSONObject(properties);
     }
 
+    @Deprecated
     public JSONObject getJsonObject()
     {
         return json;
+    }
+
+    public org.json.JSONObject getNewJsonObject()
+    {
+        return new org.json.JSONObject(json);
     }
 }

--- a/api/src/org/labkey/api/action/SimpleApiJsonForm.java
+++ b/api/src/org/labkey/api/action/SimpleApiJsonForm.java
@@ -45,6 +45,6 @@ public class SimpleApiJsonForm implements CustomApiForm
 
     public org.json.JSONObject getNewJsonObject()
     {
-        return new org.json.JSONObject(json);
+        return new org.json.JSONObject(json.toString());
     }
 }

--- a/api/src/org/labkey/api/admin/notification/Notification.java
+++ b/api/src/org/labkey/api/admin/notification/Notification.java
@@ -207,7 +207,7 @@ public class Notification
         props.put("UserId", getUserId());
         props.put("ObjectId", getObjectId());
         props.put("Type", getType());
-        props.put("ContainerId", getContainer());
+        props.put("ContainerId", getContainer().toString());
         props.put("HtmlContent", getHtmlContent().toString());
         props.put("Content", getContent());
         props.put("ContentType", getContentType());

--- a/api/src/org/labkey/api/data/ActivityService.java
+++ b/api/src/org/labkey/api/data/ActivityService.java
@@ -16,7 +16,7 @@
 package org.labkey.api.data;
 
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONObject;
+import org.json.JSONObject;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.view.ViewContext;
 

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -23,8 +23,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONArray;
-import org.json.old.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.labkey.api.Constants;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.admin.FolderExportContext;
@@ -1378,7 +1378,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
 
         if (this.hasPermission(user, ReadPermission.class))
         {
-            containerProps.put("startUrl", getStartURL(user));
+            containerProps.put("startUrl", getStartURL(user).toString());
             containerProps.put("iconHref", getIconHref());
             containerProps.put("id", getId());
             containerProps.put("sortOrder", getSortOrder());

--- a/api/src/org/labkey/api/jsp/LabKeyJspWriter.java
+++ b/api/src/org/labkey/api/jsp/LabKeyJspWriter.java
@@ -46,7 +46,7 @@ public class LabKeyJspWriter extends JspWriterWrapper
     public void print(Object obj) throws IOException
     {
         // These are the only objects we consider safe-to-render
-        if (null == obj || obj instanceof SafeToRender || obj instanceof Number || obj instanceof Boolean | obj instanceof JSONObject || obj instanceof JSONArray)
+        if (null == obj || obj instanceof SafeToRender || obj instanceof Number || obj instanceof Boolean || obj instanceof JSONObject || obj instanceof JSONArray)
         {
             super.print(obj);
         }

--- a/api/src/org/labkey/api/jsp/LabKeyJspWriter.java
+++ b/api/src/org/labkey/api/jsp/LabKeyJspWriter.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.api.jsp;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.SafeToRender;
 
@@ -44,7 +46,7 @@ public class LabKeyJspWriter extends JspWriterWrapper
     public void print(Object obj) throws IOException
     {
         // These are the only objects we consider safe-to-render
-        if (null == obj || obj instanceof SafeToRender || obj instanceof Number || obj instanceof Boolean)
+        if (null == obj || obj instanceof SafeToRender || obj instanceof Number || obj instanceof Boolean | obj instanceof JSONObject || obj instanceof JSONArray)
         {
             super.print(obj);
         }

--- a/api/src/org/labkey/api/module/ModuleProperty.java
+++ b/api/src/org/labkey/api/module/ModuleProperty.java
@@ -18,7 +18,7 @@ package org.labkey.api.module;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONObject;
+import org.json.JSONObject;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.PropertyManager;
@@ -49,8 +49,9 @@ public class ModuleProperty
     Note that module properties can be defined in module.xml files, so if adding property options here, they should also
     be added to propertyType in module.xsd and wired through in DefaultModule.loadXmlFile()
      */
-    private Module _module;
-    private String _name;
+    private final Module _module;
+    private final String _name;
+
     private String _label;
     private boolean _canSetPerContainer = false;
     private boolean _excludeFromClientContext = false;

--- a/api/src/org/labkey/api/security/AuthenticationProvider.java
+++ b/api/src/org/labkey/api/security/AuthenticationProvider.java
@@ -18,7 +18,7 @@ package org.labkey.api.security;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONArray;
+import org.json.JSONArray;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ObjectFactory;
 import org.labkey.api.module.ModuleLoader;

--- a/api/src/org/labkey/api/security/FixedHtmlField.java
+++ b/api/src/org/labkey/api/security/FixedHtmlField.java
@@ -18,7 +18,7 @@ public class FixedHtmlField extends SettingsField
         FixedHtmlField field = new FixedHtmlField();
         field.put("type", FieldType.fixedHtml);
         field.put("caption", caption);
-        field.put("html", html);
+        field.put("html", html.toString()); // JSONObject doesn't know how to serialize HtmlString
 
         return field;
     }

--- a/api/src/org/labkey/api/util/JSONArrayDeserializer.java
+++ b/api/src/org/labkey/api/util/JSONArrayDeserializer.java
@@ -11,6 +11,7 @@ import org.json.old.JSONObject;
 
 import java.io.IOException;
 
+@Deprecated
 public class JSONArrayDeserializer extends StdDeserializer<JSONArray>
 {
     private static final long serialVersionUID = 1L;

--- a/api/src/org/labkey/api/util/JSONArraySerializer.java
+++ b/api/src/org/labkey/api/util/JSONArraySerializer.java
@@ -1,16 +1,19 @@
 package org.labkey.api.util;
 
-import java.io.IOException;
-import java.lang.reflect.Type;
-
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.WritableTypeId;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import org.json.old.JSONArray;
 import org.json.old.JSONObject;
 
-import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.core.type.WritableTypeId;
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import java.io.IOException;
+import java.lang.reflect.Type;
 
+@Deprecated
 public class JSONArraySerializer extends JSONBaseSerializer<JSONArray>
 {
     private static final long serialVersionUID = 1L;

--- a/api/src/org/labkey/api/util/JSONBaseSerializer.java
+++ b/api/src/org/labkey/api/util/JSONBaseSerializer.java
@@ -2,6 +2,7 @@ package org.labkey.api.util;
 
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
+@Deprecated
 abstract class JSONBaseSerializer<T> extends StdSerializer<T>
 {
     private static final long serialVersionUID = 1L;

--- a/api/src/org/labkey/api/util/JSONObjectDeserializer.java
+++ b/api/src/org/labkey/api/util/JSONObjectDeserializer.java
@@ -10,6 +10,7 @@ import org.json.old.JSONObject;
 
 import java.io.IOException;
 
+@Deprecated
 public class JSONObjectDeserializer extends StdDeserializer<JSONObject>
 {
     private static final long serialVersionUID = 1L;

--- a/api/src/org/labkey/api/util/JSONObjectSerializer.java
+++ b/api/src/org/labkey/api/util/JSONObjectSerializer.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.Iterator;
 
+@Deprecated
 public class JSONObjectSerializer extends JSONBaseSerializer<JSONObject>
 {
     private static final long serialVersionUID = 1L;

--- a/api/src/org/labkey/api/util/JsonOrgOldModule.java
+++ b/api/src/org/labkey/api/util/JsonOrgOldModule.java
@@ -1,13 +1,13 @@
 package org.labkey.api.util;
 
 import com.fasterxml.jackson.databind.module.SimpleModule;
-
 import com.fasterxml.jackson.datatype.jsonorg.PackageVersion;
 import org.json.old.JSONArray;
 import org.json.old.JSONObject;
 
 // A temporary module to support serialization/deserialization of our deprecated JSONObject and JSONArray classes
 // TODO: Remove this once migration is complete
+@Deprecated
 public class JsonOrgOldModule extends SimpleModule
 {
     private static final long serialVersionUID = 1;
@@ -25,5 +25,13 @@ public class JsonOrgOldModule extends SimpleModule
         addDeserializer(JSONObject.class, JSONObjectDeserializer.instance);
         addSerializer(JSONArraySerializer.instance);
         addSerializer(JSONObjectSerializer.instance);
+
+        // For now, we add serializers & deserializers for the new org.json.* classes here. (Attempting to register both
+        // JsonOrgOldModule and JsonOrgModule caused strange problems with serialization... perhaps because these modules
+        // aren't given explicit names?) Once migration is complete, go back to registering JsonOrgModule.
+        addDeserializer(org.json.JSONArray.class, com.fasterxml.jackson.datatype.jsonorg.JSONArrayDeserializer.instance);
+        addDeserializer(org.json.JSONObject.class, com.fasterxml.jackson.datatype.jsonorg.JSONObjectDeserializer.instance);
+        addSerializer(com.fasterxml.jackson.datatype.jsonorg.JSONArraySerializer.instance);
+        addSerializer(com.fasterxml.jackson.datatype.jsonorg.JSONObjectSerializer.instance);
     }
 }

--- a/api/src/org/labkey/api/util/JsonUtil.java
+++ b/api/src/org/labkey/api/util/JsonUtil.java
@@ -47,7 +47,7 @@ public class JsonUtil
     {
         DEFAULT_MAPPER = new ObjectMapper();
         // Allow org.json classes to be serialized by Jackson
-//        DEFAULT_MAPPER.registerModule(new JsonOrgModule());
+        DEFAULT_MAPPER.registerModule(new JsonOrgModule());
         // Allow org.json.old classes to be serialized by Jackson (TODO: Remove this after migrating from org.json.old.* -> org.json.*)
         DEFAULT_MAPPER.registerModule(new JsonOrgOldModule());
         // We must register JavaTimeModule in order to serialize LocalDate, etc.

--- a/api/src/org/labkey/api/util/JsonUtil.java
+++ b/api/src/org/labkey/api/util/JsonUtil.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsonorg.JsonOrgModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.json.old.JSONArray;
 import org.json.old.JSONObject;
@@ -47,7 +46,7 @@ public class JsonUtil
     {
         DEFAULT_MAPPER = new ObjectMapper();
         // Allow org.json classes to be serialized by Jackson
-        DEFAULT_MAPPER.registerModule(new JsonOrgModule());
+//        DEFAULT_MAPPER.registerModule(new JsonOrgModule()); // TODO: Uncomment this once we remove JsonOrgOldModule
         // Allow org.json.old classes to be serialized by Jackson (TODO: Remove this after migrating from org.json.old.* -> org.json.*)
         DEFAULT_MAPPER.registerModule(new JsonOrgOldModule());
         // We must register JavaTimeModule in order to serialize LocalDate, etc.

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -723,9 +723,9 @@ public class CoreController extends SpringActionController
                 throw new NotFoundException("No JSON posted");
             }
             String name = StringUtils.trimToNull(json.getString("name"));
-            String title = StringUtils.trimToNull(json.getString("title"));
-            String description = StringUtils.trimToNull(json.getString("description"));
-            String typeName = StringUtils.trimToNull(json.getString("type"));
+            String title = StringUtils.trimToNull(json.optString("title"));
+            String description = StringUtils.trimToNull(json.optString("description"));
+            String typeName = StringUtils.trimToNull(json.optString("type"));
             boolean isWorkbook = false;
             if (typeName == null)
             {
@@ -750,7 +750,7 @@ public class CoreController extends SpringActionController
 
             try
             {
-                String folderTypeName = json.getString("folderType");
+                String folderTypeName = json.optString("folderType");
                 if (folderTypeName == null && isWorkbook)
                 {
                     folderTypeName = WorkbookFolderType.NAME;

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -24,8 +24,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.xmlbeans.XmlObject;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONArray;
-import org.json.old.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.Test;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
@@ -189,7 +189,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -200,7 +199,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static org.labkey.api.view.template.WarningService.SESSION_WARNINGS_BANNER_KEY;
 
@@ -718,7 +717,7 @@ public class CoreController extends SpringActionController
         @Override
         public ApiResponse execute(SimpleApiJsonForm form, BindException errors)
         {
-            JSONObject json = form.getJsonObject();
+            JSONObject json = form.getNewJsonObject();
             if (json == null)
             {
                 throw new NotFoundException("No JSON posted");
@@ -771,8 +770,8 @@ public class CoreController extends SpringActionController
                 Set<Module> ensureModules = new HashSet<>();
                 if (json.has("ensureModules") && !json.isNull("ensureModules"))
                 {
-                    List<String> requestedModules = Arrays.stream(json.getJSONArray("ensureModules")
-                            .toArray()).map(Object::toString).collect(Collectors.toList());
+                    List<String> requestedModules = StreamSupport.stream(json.getJSONArray("ensureModules").spliterator(), false)
+                        .map(Object::toString).toList();
                     for (String moduleName : requestedModules)
                     {
                         Module module = ModuleLoader.getInstance().getModule(moduleName);
@@ -845,7 +844,7 @@ public class CoreController extends SpringActionController
         @Override
         public void validateForm(SimpleApiJsonForm form, Errors errors)
         {
-            JSONObject object = form.getJsonObject();
+            JSONObject object = form.getNewJsonObject();
             String targetIdentifier = object.getString("container");
 
             if (null == targetIdentifier)
@@ -930,7 +929,7 @@ public class CoreController extends SpringActionController
             }
 
             // Prepare aliases
-            JSONObject object = form.getJsonObject();
+            JSONObject object = form.getNewJsonObject();
             Boolean addAlias = (Boolean) object.get("addAlias");
             
             List<String> aliasList = new ArrayList<>();
@@ -1499,7 +1498,7 @@ public class CoreController extends SpringActionController
         {
             JSONObject ret = new JSONObject();
 
-            if(form.getModuleName() == null)
+            if (form.getModuleName() == null)
             {
                 errors.reject(ERROR_MSG, "Must provide the name of the module");
                 return null;
@@ -1638,7 +1637,7 @@ public class CoreController extends SpringActionController
         public ApiResponse execute(SaveModulePropertiesForm form, BindException errors)
         {
             ViewContext ctx = getViewContext();
-            JSONObject formData = form.getJsonObject();
+            JSONObject formData = form.getNewJsonObject();
             JSONArray a = formData.getJSONArray("properties");
             try (DbScope.Transaction transaction = ExperimentService.get().ensureTransaction())
             {

--- a/core/src/org/labkey/core/notification/NotificationController.java
+++ b/core/src/org/labkey/core/notification/NotificationController.java
@@ -15,7 +15,7 @@
  */
 package org.labkey.core.notification;
 
-import org.json.old.JSONObject;
+import org.json.JSONObject;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
 import org.labkey.api.action.FormHandlerAction;

--- a/core/src/org/labkey/core/project/projects.jsp
+++ b/core/src/org/labkey/core/project/projects.jsp
@@ -16,7 +16,7 @@
  */
 %>
 <%@ page import="org.apache.commons.lang3.StringUtils" %>
-<%@ page import="org.json.old.JSONObject" %>
+<%@ page import="org.json.JSONObject" %>
 <%@ page import="org.labkey.api.admin.AdminUrls" %>
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.data.ContainerFilter" %>
@@ -194,7 +194,7 @@
         LABKEY.requiresScript(["Ext4","Ext4ClientApi","core/customizeProjectWebPart.js"], function()
         {
             Ext4.onReady(function() {
-                const config = <%=new JSONObject(properties)%>;
+                const config = <%=unsafe(new JSONObject(properties).toString())%>;
                 _customizeProjectWebpart(Ext4, <%=webPart.getRowId()%>, <%=q(webPart.getPageId())%>, <%=webPart.getIndex()%>, config);
             });
         });

--- a/core/src/org/labkey/core/project/projects.jsp
+++ b/core/src/org/labkey/core/project/projects.jsp
@@ -194,7 +194,7 @@
         LABKEY.requiresScript(["Ext4","Ext4ClientApi","core/customizeProjectWebPart.js"], function()
         {
             Ext4.onReady(function() {
-                const config = <%=unsafe(new JSONObject(properties).toString())%>;
+                const config = <%=new JSONObject(properties)%>;
                 _customizeProjectWebpart(Ext4, <%=webPart.getRowId()%>, <%=q(webPart.getPageId())%>, <%=webPart.getIndex()%>, config);
             });
         });

--- a/core/src/org/labkey/core/wiki/MarkdownServiceImpl.java
+++ b/core/src/org/labkey/core/wiki/MarkdownServiceImpl.java
@@ -18,7 +18,7 @@ package org.labkey.core.wiki;
 import org.apache.commons.pool.KeyedPoolableObjectFactory;
 import org.apache.commons.pool.impl.StackKeyedObjectPool;
 import org.apache.logging.log4j.Logger;
-import org.json.old.JSONObject;
+import org.json.JSONObject;
 import org.labkey.api.markdown.MarkdownService;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;

--- a/devtools/src/org/labkey/devtools/authentication/TestSsoProvider.java
+++ b/devtools/src/org/labkey/devtools/authentication/TestSsoProvider.java
@@ -16,7 +16,7 @@
 package org.labkey.devtools.authentication;
 
 import org.jetbrains.annotations.NotNull;
-import org.json.old.JSONArray;
+import org.json.JSONArray;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.AuthenticationProvider.SSOAuthenticationProvider;
 import org.labkey.api.security.ConfigurationSettings;


### PR DESCRIPTION
#### Rationale
We're migrating to a new version of `org.json.JSONObject` / `org.json.JSONArray`. See https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46305.

#### Changes
* Add dependency for current org.json.JSONObject and org.json.JSONArray library
* Fix `ApiJsonWriter`, `ApiSimpleResponse`, `SimplaeApiJsonForm`, `AuthenticationProvider`, and other classes to support new JSON library
* Register Jackson seriailzers / deserializers for new JSON library
* Indicate that new JSONObject and JSONArray are safe-to-render in JSPs