### PR TITLE
Container: compose toJSON result using collections

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -23,8 +23,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.labkey.api.Constants;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.admin.FolderExportContext;
@@ -1392,11 +1390,11 @@ public class Container implements Serializable, Comparable<Container>, Securable
             containerProps.put("isWorkbook", isWorkbook());
             containerProps.put("isContainerTab", isContainerTab());
             containerProps.put("type", getContainerNoun());
-            JSONArray activeModuleNames = new JSONArray();
+            List<String> activeModuleNames = new ArrayList<>();
             Set<Module> activeModules = getActiveModules(user);
             for (Module module : activeModules)
             {
-                activeModuleNames.put(module.getName());
+                activeModuleNames.add(module.getName());
             }
             containerProps.put("activeModules", activeModuleNames);
             containerProps.put("folderType", getFolderType().getName());
@@ -1412,7 +1410,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
         }
 
         LookAndFeelProperties props = LookAndFeelProperties.getInstance(this);
-        JSONObject formats = new JSONObject();
+        Map<String, Object> formats = new HashMap<>();
         formats.put("dateFormat", DateUtil.getDateFormatString(this));
         formats.put("dateTimeFormat", props.getDefaultDateTimeFormat());
         formats.put("numberFormat", props.getDefaultNumberFormat());


### PR DESCRIPTION
#### Rationale
This addresses runtime errors caused by changes to the serialization of JSON properties on `Container`. Namely, the `activeModules` and `formats` properties were being serialized as strings when they are intended to be an array and object respectively. This was due to the serializer not recognizing the use of `JSONArray` and `JSONObject` within a collection (in this case a `Map<String, Object>`) and defaulting to serializing them as strings.

**Note:** This is not necessarily the most optimal fix. It is likely that this is intended to be fixed by making the underlying serialization mechanism recognize this use case and serialize these properties to JSON. @labkey-adam can speak to that.

Before:
![image](https://user-images.githubusercontent.com/3926239/192390878-f6c27f97-9c15-4a32-b72d-f2fb95cdb49f.png)

After:
![image](https://user-images.githubusercontent.com/3926239/192390900-6f1e98e5-9173-45d0-881f-74147c4cc25b.png)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3710

#### Changes
* Replace usages of `JSONArray` and `JSONObject` in the JSON serialization of a `Container` with `List` and `Map` respectively.
