### PR TITLE
Issue 44923: ConfigurationSummaryAction echos more config properties

### DIFF
--- a/api/src/org/labkey/api/util/JsonUtil.java
+++ b/api/src/org/labkey/api/util/JsonUtil.java
@@ -41,16 +41,17 @@ public class JsonUtil
     // The ObjectMapper is thread-safe and can be shared across requests
     // but shouldn't be mutated. If you need to reconfigure the ObjectMapper,
     // create a new instance by calling <code>ObjectMapper.copy()</code>.
-    public static final ObjectMapper DEFAULT_MAPPER;
+    public static final ObjectMapper DEFAULT_MAPPER = createDefaultMapper();
 
-    static
+    public static ObjectMapper createDefaultMapper()
     {
-        DEFAULT_MAPPER = new ObjectMapper();
+        ObjectMapper result = new ObjectMapper();
         // Allow org.json classes to be serialized by Jackson
-        DEFAULT_MAPPER.registerModule(new JsonOrgModule());
+        result.registerModule(new JsonOrgModule());
         // We must register JavaTimeModule in order to serialize LocalDate, etc.
-        DEFAULT_MAPPER.registerModule(new JavaTimeModule());
-        DEFAULT_MAPPER.setDateFormat(new SimpleDateFormat(DateUtil.getJsonDateTimeFormatString()));
+        result.registerModule(new JavaTimeModule());
+        result.setDateFormat(new SimpleDateFormat(DateUtil.getJsonDateTimeFormatString()));
+        return result;
     }
 
     public static JsonLocation expectObjectStart(JsonParser p) throws IOException

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.core.admin;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.apache.commons.beanutils.ConversionException;
@@ -188,6 +190,7 @@ import org.labkey.core.admin.sql.SqlScriptController;
 import org.labkey.core.portal.CollaborationFolderType;
 import org.labkey.core.portal.ProjectController;
 import org.labkey.core.query.CoreQuerySchema;
+import org.labkey.core.reports.ExternalScriptEngineDefinitionImpl;
 import org.labkey.core.security.SecurityController;
 import org.labkey.data.xml.TablesDocument;
 import org.labkey.security.xml.GroupEnumType;
@@ -9981,6 +9984,19 @@ public class AdminController extends SpringActionController
             json = getConfigurationJson();
             return json;
         }
+
+        @Override
+        protected ObjectMapper createResponseObjectMapper()
+        {
+            ObjectMapper result = JsonUtil.createDefaultMapper();
+            result.addMixIn(ExternalScriptEngineDefinitionImpl.class, IgnorePasswordMixIn.class);
+            return result;
+        }
+    }
+
+    @JsonIgnoreProperties(value = { "password", "changePassword" })
+    private static class IgnorePasswordMixIn
+    {
     }
 
     @AdminConsoleAction()

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10228,7 +10228,7 @@ public class AdminController extends SpringActionController
         final Map<String,Map<String,Object>> sets = new TreeMap<>();
         new SqlSelector(CoreSchema.getInstance().getScope(),
             new SQLFragment("SELECT category, name, value FROM prop.propertysets PS inner join prop.properties P on PS.\"set\" = P.\"set\"\n" +
-            "WHERE objectid = ? AND category IN ('SiteConfig') AND encryption='None'", ContainerManager.getRoot())).forEachMap(m ->
+            "WHERE objectid = ? AND category IN ('SiteConfig') AND encryption='None' AND LOWER(name) NOT LIKE '%password%'", ContainerManager.getRoot())).forEachMap(m ->
             {
                 String category = (String)m.get("category");
                 String name = (String)m.get("name");


### PR DESCRIPTION
#### Rationale
Share as much as needed, but no more, to help validate configuration

#### Changes
* Customize JSON serialization to omit some properties
* Refactor to make it easy to piggyback on the standard ObjectMapper without mutating it