### PR TITLE
Issue 46387: Sample type with trigger scripts do not allow insert: fail with error "Missing value for required field: Ancestors"

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -431,6 +431,7 @@ public class ClosureQueryHelper
         wrappedRowId.setReadOnly(true);
         wrappedRowId.setCalculated(true);
         wrappedRowId.setRequired(false);
+        wrappedRowId.setUserEditable(false);
         wrappedRowId.setFk(new AbstractForeignKey(parent.getUserSchema(),parent.getContainerFilter())
         {
             @Override

--- a/experiment/webapp/experiment/confirmDelete.js
+++ b/experiment/webapp/experiment/confirmDelete.js
@@ -118,13 +118,16 @@ LABKEY.experiment.confirmDelete = function(dataRegionName, schemaName, queryName
                                     Ext4.Msg.hide();
                                     var responseMsg = Ext4.Msg.show({
                                         title: "Delete " + totalNoun,
-                                        msg:  hasErrors ? response.errors.exception : response.rowsAffected + " " + (response.rowsAffected === 1 ? nounSingular : nounPlural) + " deleted."
+                                        msg:  hasErrors
+                                                ? response.errors.exception
+                                                : response.rowsAffected + " " + (response.rowsAffected === 1 ? nounSingular : nounPlural) + " deleted."
                                     });
-                                    Ext4.defer(function() {
-                                        responseMsg.hide();
-                                        if (!hasErrors) window.location.reload();
-                                    }, 2500, responseMsg);
-
+                                    if (!hasErrors) {
+                                        Ext4.defer(function () {
+                                            responseMsg.hide();
+                                            window.location.reload();
+                                        }, 2500, responseMsg);
+                                    }
                                 }),
                                 failure: LABKEY.Utils.getCallbackWrapper(function(response) {
                                     console.error("There was a problem deleting " + nounPlural, response);

--- a/experiment/webapp/experiment/confirmDelete.js
+++ b/experiment/webapp/experiment/confirmDelete.js
@@ -102,6 +102,8 @@ LABKEY.experiment.confirmDelete = function(dataRegionName, schemaName, queryName
                                     apiVersion: 13.2
                                 },
                                 success: LABKEY.Utils.getCallbackWrapper(function(response)  {
+                                    const hasErrors = response.errors !== undefined && response.errors.exception !== undefined;
+
                                     // clear the selection only for the rows that were deleted
                                     // TODO: support clearing selection in query-deleteRows.api using a selectionKey
                                     const ids = canDelete.map((row) => row.RowId);
@@ -116,11 +118,11 @@ LABKEY.experiment.confirmDelete = function(dataRegionName, schemaName, queryName
                                     Ext4.Msg.hide();
                                     var responseMsg = Ext4.Msg.show({
                                         title: "Delete " + totalNoun,
-                                        msg:  response.rowsAffected + " " + (response.rowsAffected === 1 ? nounSingular : nounPlural) + " deleted."
+                                        msg:  hasErrors ? response.errors.exception : response.rowsAffected + " " + (response.rowsAffected === 1 ? nounSingular : nounPlural) + " deleted."
                                     });
                                     Ext4.defer(function() {
                                         responseMsg.hide();
-                                        window.location.reload();
+                                        if (!hasErrors) window.location.reload();
                                     }, 2500, responseMsg);
 
                                 }),


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46387

When there is a trigger script attached to a sample type, the insert rows call fails because it things that the wrapped "Ancestors" column is required. This column is wrapping the RowId and should not be considered user editable.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1249

#### Changes
* set Ancestors wrapped column as not user editable
* update confirmDelete.js to show error message from trigger script
