### PR TITLE
Make Parameter dumb again

### DIFF
--- a/api/src/org/labkey/api/data/Parameter.java
+++ b/api/src/org/labkey/api/data/Parameter.java
@@ -17,16 +17,15 @@
 package org.labkey.api.data;
 
 import com.google.common.primitives.Ints;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONObject;
 import org.labkey.api.attachments.AttachmentFile;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.util.ResultSetUtil;
 import org.labkey.api.util.UnexpectedException;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,7 +55,7 @@ import java.util.concurrent.Callable;
 
 public class Parameter implements AutoCloseable
 {
-    static Logger LOG = LogManager.getLogger(Parameter.class);
+    static Logger LOG = LogHelper.getLogger(Parameter.class, "low-level jdbc parameter wrapper");
 
     public interface JdbcParameterValue
     {
@@ -115,8 +114,6 @@ public class Parameter implements AutoCloseable
     String _name;
     @Nullable String _uri = null;       // for migration of ontology based code
     final @Nullable JdbcType _type;
-    int _scale;
-    int _precision;
     boolean setFileAsName = false;
 
     // only allow setting once, do not clear
@@ -179,25 +176,10 @@ public class Parameter implements AutoCloseable
         _type = type;
     }
 
-    public Parameter(ColumnInfo c, int index)
+    public void setFileAsName(boolean b)
     {
-        this(c, new int[] { index });
+        setFileAsName = b;
     }
-
-    public Parameter(ColumnInfo c, int[] indexes)
-    {
-        // The jdbc resultset metadata replaces special characters in source column names.
-        // We need the parameter names to match so we can match to the column.
-        _name = c.getJdbcRsName();
-        _uri = c.getPropertyURI();
-        _type = c.getJdbcType();
-        _scale = c.getScale();
-        _precision = c.getPrecision();
-        _indexes = indexes;
-        // CONSIDER: this seems pretty low-level for this check (see also DefaultQueryUpdateService.convertTypes())
-        setFileAsName = (c.getInputType().equalsIgnoreCase("file") && _type == JdbcType.VARCHAR);
-    }
-
 
     public Parameter copy(PreparedStatement stmt)
     {
@@ -225,17 +207,6 @@ public class Parameter implements AutoCloseable
         return _type;
     }
 
-    public int getScale()
-    {
-        return _scale;
-    }
-
-    public int getPrecision()
-    {
-        return _precision;
-    }
-
-
     public void setValue(@Nullable Object in)
     {
         if (_constant)
@@ -261,12 +232,10 @@ public class Parameter implements AutoCloseable
                 return;
             }
 
-            if (value instanceof AttachmentFile)
+            if (value instanceof final AttachmentFile attachmentFile)
             {
                 if (_indexes.length > 1)
                     throw new IllegalArgumentException("AttachmentFile can only be bound to a single parameter");
-
-                final AttachmentFile attachmentFile = (AttachmentFile) value;
 
                 // Set up to close it
                 _autoCloseable = () -> {
@@ -298,16 +267,14 @@ public class Parameter implements AutoCloseable
                     }
                     catch (Exception x)
                     {
-                        SQLException sqlx = new SQLException();
-                        sqlx.initCause(x);
-                        throw sqlx;
+                        throw new SQLException(x);
                     }
                 }
             }
 
             if (value instanceof Collection)
             {
-                value = ((Collection)value).toArray();
+                value = ((Collection<?>)value).toArray();
             }
 
             if (value instanceof Object[])
@@ -345,7 +312,7 @@ public class Parameter implements AutoCloseable
             }
             catch (Exception e)
             {
-                throw new UnexpectedException(e);
+                throw UnexpectedException.wrap(e);
             }
         }
     }
@@ -380,7 +347,7 @@ public class Parameter implements AutoCloseable
         {
             try
             {
-                value = ((Callable)value).call();
+                value = ((Callable<?>)value).call();
             }
             catch (SQLException x)
             {
@@ -392,9 +359,8 @@ public class Parameter implements AutoCloseable
             }
         }
 
-        if (value instanceof QueryService.ParameterDecl)
+        if (value instanceof QueryService.ParameterDecl decl)
         {
-            QueryService.ParameterDecl decl = (QueryService.ParameterDecl)value;
             if (decl.isRequired())
                 throw new QueryService.NamedParameterNotProvided(decl.getName());
             value = decl.getDefault();
@@ -427,12 +393,12 @@ public class Parameter implements AutoCloseable
         else if (value.getClass() == java.lang.Character.class || value instanceof CharSequence)
             return value.toString();
         else if (value instanceof Enum && type != null && type.isNumeric())
-            return ((Enum)value).ordinal();
+            return ((Enum<?>)value).ordinal();
         else if (value instanceof Enum)
-            return ((Enum)value).name();
+            return ((Enum<?>)value).name();
         else if (value instanceof Class)
-            return (((Class) value).getName());
-        else if (value instanceof Lsid || value instanceof JSONObject || value instanceof File)
+            return (((Class<?>) value).getName());
+        else if (value instanceof Lsid || value instanceof org.json.JSONObject || value instanceof org.json.old.JSONObject || value instanceof File)
             return value.toString();
 
         return value;

--- a/api/src/org/labkey/api/data/StatementUtils.java
+++ b/api/src/org/labkey/api/data/StatementUtils.java
@@ -16,7 +16,6 @@
 package org.labkey.api.data;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -41,6 +40,7 @@ import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.TestContext;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -50,6 +50,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -64,7 +65,7 @@ import java.util.stream.Stream;
 // identify tests that exercise the code paths that will be changed.
 public class StatementUtils
 {
-    private static final Logger _log = LogManager.getLogger(StatementUtils.class);
+    private static final Logger _log = LogHelper.getLogger(StatementUtils.class, "SQL insert/update/delete generation");
 
     public enum Operation {insert, update, merge}
     public static String OWNEROBJECTID = "exp$object$ownerobjectid";
@@ -72,15 +73,14 @@ public class StatementUtils
     // configuration parameters
     private Operation _operation = Operation.insert;
     private SqlDialect _dialect;
-    private TableInfo _targetTable;
+    private final TableInfo _targetTable;
     private Set<String> _keyColumnNames = null;       // override the primary key of _table
     private Set<String> _skipColumnNames = null;
-    private Set<String> _dontUpdateColumnNames = new CaseInsensitiveHashSet();
+    private final Set<String> _dontUpdateColumnNames = new CaseInsensitiveHashSet();
     private boolean _updateBuiltInColumns = false;      // default to false, this should usually be handled by StandardDataIteratorBuilder
     private boolean _selectIds = false;
     private boolean _selectObjectUri = false;
     private boolean _allowUpdateAutoIncrement = false;
-    private boolean _allowInsertByLookupDisplayValue = false;
 
     // variable/parameter tracking helpers
     private boolean useVariables = false;
@@ -159,12 +159,6 @@ public class StatementUtils
     public StatementUtils allowSetAutoIncrement(boolean b)
     {
         _allowUpdateAutoIncrement = b;
-        return this;
-    }
-
-    public StatementUtils allowInsertByLookupDisplayValue(boolean b)
-    {
-        _allowInsertByLookupDisplayValue = b;
         return this;
     }
 
@@ -261,8 +255,33 @@ public class StatementUtils
 
     private static class ParameterHolder
     {
-        Parameter p;
-        int length = -1;
+        ParameterHolder(Parameter p)
+        {
+            this.p = p;
+            _columnInfo = null;
+        }
+
+        ParameterHolder(Parameter p, ColumnInfo c)
+        {
+            this.p = p;
+            _columnInfo = c;
+        }
+
+        int getScale()
+        {
+            var type = Objects.requireNonNull(p.getType());
+            if (type.isText() && type!= JdbcType.GUID && (null != _columnInfo && _columnInfo.getScale() > 0))
+                return _columnInfo.getScale();
+            return -1;
+        }
+
+        int getPrecision()
+        {
+            return null==_columnInfo ? -1 : _columnInfo.getPrecision();
+        }
+
+        final Parameter p;
+        final ColumnInfo _columnInfo;
         String variableName = null;
         Object constantValue = null;
         boolean isConstant = false;
@@ -284,15 +303,17 @@ public class StatementUtils
         ParameterHolder ph = parameters.get(c.getName());
         if (null == ph)
         {
-            ph = new ParameterHolder();
-            ph.p = new Parameter(c, null);
-            initParameterHolder(ph, c);
+            ph = new ParameterHolder(new Parameter(c.getName(), c.getJdbcType()), c);
+            // NOTE: earlier DataIterator should probably split file into two columns: attachment_name, attachment_body
+            if (c.getInputType().equalsIgnoreCase("file") && c.getJdbcType() == JdbcType.VARCHAR)
+                ph.p.setFileAsName(true);
+            initParameterHolder(ph);
             parameters.put(c.getName(), ph);
         }
         return ph;
     }
 
-    private void initParameterHolder(ParameterHolder ph, @Nullable ColumnInfo columnInfo)
+    private void initParameterHolder(ParameterHolder ph)
     {
         String name = ph.p.getName();
         JdbcType type = ph.p.getType();
@@ -307,8 +328,6 @@ public class StatementUtils
             }
         }
         ph.variableName = makeVariableName(name);
-        if (type.isText() && type!= JdbcType.GUID && (null != columnInfo && columnInfo.getScale() > 0))
-            ph.length = columnInfo.getScale();
     }
 
 
@@ -317,9 +336,8 @@ public class StatementUtils
         ParameterHolder ph = parameters.get(name);
         if (null == ph)
         {
-            ph = new ParameterHolder();
-            ph.p = new Parameter(name, type);
-            initParameterHolder(ph, null);
+            ph = new ParameterHolder(new Parameter(name, type));
+            initParameterHolder(ph);
             parameters.put(name, ph);
         }
         return ph;
@@ -331,9 +349,8 @@ public class StatementUtils
         ParameterHolder ph = parameters.get(name);
         if (null == ph)
         {
-            ph = new ParameterHolder();
-            ph.p = new Parameter(name, uri, null, type);
-            initParameterHolder(ph, null);
+            ph = new ParameterHolder(new Parameter(name, uri, null, type));
+            initParameterHolder(ph);
             parameters.put(name, ph);
         }
         return ph;
@@ -974,7 +991,7 @@ public class StatementUtils
                 fn.append(type);
                 // For PG (29687) we need the length for CHAR type
                 if (_dialect.isPostgreSQL() && JdbcType.CHAR.equals(ph.p.getType()))
-                    fn.append("(").append(ph.length).append(")");
+                    fn.append("(").append(ph.getScale()).append(")");
                 call.append(comma).append("?");
                 call.add(ph.p);
                 comma = ",";
@@ -1124,15 +1141,15 @@ public class StatementUtils
         // Workaround - SQLServer doesn't support TEXT, NTEXT, or IMAGE as local variables in statements, but is OK with NVARCHAR(MAX)
         if (jdbcType.isText())
         {
-            if ("NTEXT".equalsIgnoreCase(type) || "TEXT".equalsIgnoreCase(type) || ph.length>4000)
+            if ("NTEXT".equalsIgnoreCase(type) || "TEXT".equalsIgnoreCase(type) || ph.getScale()>4000)
                 type = "NVARCHAR(MAX)";
             else
                 type = "NVARCHAR(4000)";
         }
         // Add scale and precision for decimal values specifying scale
-        else if (jdbcType.isDecimal() && ph.p.getScale() > 0)
+        else if (jdbcType.isDecimal() && ph.getScale() > 0)
         {
-            type = type + "(" + ph.p.getPrecision() + "," + ph.p.getScale() + ")";
+            type = type + "(" + ph.getPrecision() + "," + ph.getScale() + ")";
         }
 
         sqlfDeclare.append(type);
@@ -1197,11 +1214,11 @@ public class StatementUtils
             try (Connection conn = principals.getSchema().getScope().getConnection())
             {
                 m = StatementUtils.insertStatement(conn, principals, null, container, user, null, true, true, false);
-                System.err.println(m.getDebugSql()+"\n\n");
+//                System.err.println(m.getDebugSql()+"\n\n");
                 m.close(); m = null;
 
                 m = StatementUtils.insertStatement(conn, test, null, container, user, null, true, true, false);
-                System.err.println(m.getDebugSql()+"\n\n");
+//                System.err.println(m.getDebugSql()+"\n\n");
                 m.close(); m = null;
             }
             finally
@@ -1220,11 +1237,11 @@ public class StatementUtils
             try (Connection conn = principals.getSchema().getScope().getConnection())
             {
                 m = StatementUtils.updateStatement(conn, principals, container, user, true, true);
-                System.err.println(m.getDebugSql()+"\n\n");
+//                System.err.println(m.getDebugSql()+"\n\n");
                 m.close(); m = null;
 
                 m = StatementUtils.updateStatement(conn, test, container, user, true, true);
-                System.err.println(m.getDebugSql()+"\n\n");
+//                System.err.println(m.getDebugSql()+"\n\n");
                 m.close(); m = null;
             }
             finally
@@ -1243,11 +1260,11 @@ public class StatementUtils
             try (Connection conn = principals.getSchema().getScope().getConnection())
             {
                 m = StatementUtils.mergeStatement(conn, principals, null, null, container, user, false, true);
-                System.err.println(m.getDebugSql()+"\n\n");
+//                System.err.println(m.getDebugSql()+"\n\n");
                 m.close(); m = null;
 
                 m = StatementUtils.mergeStatement(conn, test, null, null, container, user, false, true);
-                System.err.println(m.getDebugSql()+"\n\n");
+//                System.err.println(m.getDebugSql()+"\n\n");
                 m.close(); m = null;
             }
             finally

--- a/api/src/org/labkey/api/data/StatementUtils.java
+++ b/api/src/org/labkey/api/data/StatementUtils.java
@@ -75,7 +75,7 @@ public class StatementUtils
     private SqlDialect _dialect;
     private final TableInfo _targetTable;
     private Set<String> _keyColumnNames = null;       // override the primary key of _table
-    private Set<String> _skipColumnNames = null;
+    private Set<String> _skipColumnNames = Set.of();
     private final Set<String> _dontUpdateColumnNames = new CaseInsensitiveHashSet();
     private boolean _updateBuiltInColumns = false;      // default to false, this should usually be handled by StandardDataIteratorBuilder
     private boolean _selectIds = false;
@@ -127,7 +127,7 @@ public class StatementUtils
 
     public StatementUtils skip(Set<String> skip)
     {
-        _skipColumnNames = skip;
+        _skipColumnNames = null==skip ? Set.of() : skip;
         return this;
     }
 
@@ -303,7 +303,7 @@ public class StatementUtils
         ParameterHolder ph = parameters.get(c.getName());
         if (null == ph)
         {
-            ph = new ParameterHolder(new Parameter(c.getName(), c.getJdbcType()), c);
+            ph = new ParameterHolder(new Parameter(c.getName(), c.getPropertyURI(), null, c.getJdbcType()), c);
             // NOTE: earlier DataIterator should probably split file into two columns: attachment_name, attachment_body
             if (c.getInputType().equalsIgnoreCase("file") && c.getJdbcType() == JdbcType.VARCHAR)
                 ph.p.setFileAsName(true);
@@ -721,7 +721,7 @@ public class StatementUtils
         ColumnInfo autoIncrementColumn = null;
         CaseInsensitiveHashMap<String> remap = updatable.remapSchemaColumns();
         if (null == remap)
-            remap = new CaseInsensitiveHashMap<>();
+            remap = CaseInsensitiveHashMap.of();
 
         for (ColumnInfo column : table.getColumns())
         {
@@ -742,7 +742,6 @@ public class StatementUtils
             ColumnInfo updatableColumn = updatable.getColumn(column.getName());
             if (updatableColumn != null && updatableColumn.hasDbSequence())
                 _dontUpdateColumnNames.add(column.getName());
-
 
             SQLFragment valueSQL = new SQLFragment();
             if (column.getName().equalsIgnoreCase(objectIdColumnName))

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -354,6 +354,9 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
             context.putConfigParameter(Config.CheckForDuplicates, dupePolicy);
         }
 
+        // NOTE: This was done to help coalesce some old code paths.  However, this is a little weird, because
+        // the DI is over the DatasetSchemaTableInfo not the DatasetTableImpl you'd expect.  This all still works
+        // because of property URI matching in StatementDataIterator.
         return _dataset.getInsertDataIterator(user, data, context);
     }
 


### PR DESCRIPTION
#### Rationale
One Parameter constructor was substituting getJdbcRsName() instead of using the passed in column name. This breaks code since the caller expects to use the column name.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45368

The getJdbcRsName() code was a "fix" for https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=26694.  Hopefully we have regression tests for that.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* removed getJdbcRsName() code
* removed Parameter members that it didn't use itself (scale, parameter) and changed caller to keep track of these.
