### PR TITLE
participantid, sequencenum, lsid should be NOT NULL

### DIFF
--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -118,8 +118,8 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
             new PropertyStorageSpec(DSROWID, JdbcType.BIGINT, 0, PropertyStorageSpec.Special.PrimaryKeyNonClustered, false, true, null),
             new PropertyStorageSpec(CONTAINER, JdbcType.GUID).setNullable(false),
             new PropertyStorageSpec(PARTICIPANTID, JdbcType.VARCHAR, 32).setNullable(false),
-            new PropertyStorageSpec(LSID, JdbcType.VARCHAR, 200),
-            new PropertyStorageSpec(SEQUENCENUM, JdbcType.DECIMAL),
+            new PropertyStorageSpec(LSID, JdbcType.VARCHAR, 200).setNullable(false),
+            new PropertyStorageSpec(SEQUENCENUM, JdbcType.DECIMAL).setNullable(false),
             new PropertyStorageSpec(SOURCELSID, JdbcType.VARCHAR, 200),
             new PropertyStorageSpec(_KEY, JdbcType.VARCHAR, 200),
             new PropertyStorageSpec(QCSTATE, JdbcType.INTEGER),
@@ -135,9 +135,9 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
 
         BASE_PROPERTIES = new HashSet<>(Arrays.asList(
             new PropertyStorageSpec(DSROWID, JdbcType.BIGINT, 0, PropertyStorageSpec.Special.PrimaryKeyNonClustered, false, true, null),
-            new PropertyStorageSpec(PARTICIPANTID, JdbcType.VARCHAR, 32),
-            new PropertyStorageSpec(LSID, JdbcType.VARCHAR, 200),
-            new PropertyStorageSpec(SEQUENCENUM, JdbcType.DECIMAL),
+            new PropertyStorageSpec(PARTICIPANTID, JdbcType.VARCHAR, 32).setNullable(false),
+            new PropertyStorageSpec(LSID, JdbcType.VARCHAR, 200).setNullable(false),
+            new PropertyStorageSpec(SEQUENCENUM, JdbcType.DECIMAL).setNullable(false),
             new PropertyStorageSpec(SOURCELSID, JdbcType.VARCHAR, 200),
             new PropertyStorageSpec(_KEY, JdbcType.VARCHAR, 200),
             new PropertyStorageSpec(QCSTATE, JdbcType.INTEGER),


### PR DESCRIPTION
#### Rationale
These were all NOT NULL as designed in the original study.data table.  This constraint seems to have been lost over time.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
