### PR TITLE
Fix CreateContainer & SaveModuleProperties APIs

### DIFF
--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -729,7 +729,7 @@ public class CoreController extends SpringActionController
             boolean isWorkbook = false;
             if (typeName == null)
             {
-                isWorkbook = json.has("isWorkbook") && !json.isNull("isWorkbook") ? json.getBoolean("isWorkbook") : false;
+                isWorkbook = json.optBoolean("isWorkbook");
                 typeName = isWorkbook ? WorkbookContainerType.NAME : NormalContainerType.NAME;
             }
             ContainerType type = ContainerTypeRegistry.get().getType(typeName);
@@ -750,11 +750,7 @@ public class CoreController extends SpringActionController
 
             try
             {
-                String folderTypeName = json.optString("folderType");
-                if (folderTypeName == null && isWorkbook)
-                {
-                    folderTypeName = WorkbookFolderType.NAME;
-                }
+                String folderTypeName = json.optString("folderType", isWorkbook ? WorkbookFolderType.NAME : null);
 
                 FolderType folderType = null;
                 if (folderTypeName != null)
@@ -1659,13 +1655,14 @@ public class CoreController extends SpringActionController
                     if (mp == null)
                         throw new IllegalArgumentException("Invalid module property: " + name);
 
-                    Container ct = ContainerManager.getForId(row.getString("container"));
-                    if (ct == null && (Boolean.TRUE == row.getBoolean("currentContainer")))
+                    String containerId = row.optString("container", null);
+                    Container ct = null != containerId ? ContainerManager.getForId(containerId) : null;
+                    if (ct == null && row.getBoolean("currentContainer"))
                         ct = getContainer();
                     if (ct == null)
                         throw new IllegalArgumentException("Invalid container: " + row.getString("container"));
 
-                    mp.saveValue(ctx.getUser(), ct, row.optString("value"));
+                    mp.saveValue(ctx.getUser(), ct, row.optString("value", null));
                 }
                 transaction.commit();
             }

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -841,7 +841,7 @@ public class CoreController extends SpringActionController
         public void validateForm(SimpleApiJsonForm form, Errors errors)
         {
             JSONObject object = form.getNewJsonObject();
-            String targetIdentifier = object.getString("container");
+            String targetIdentifier = object.optString("container", null);
 
             if (null == targetIdentifier)
             {
@@ -849,7 +849,7 @@ public class CoreController extends SpringActionController
                 return;
             }
 
-            String parentIdentifier = object.getString("parent");
+            String parentIdentifier = object.optString("parent", null);
 
             if (null == parentIdentifier)
             {
@@ -897,7 +897,7 @@ public class CoreController extends SpringActionController
                 List<Container> children = parent.getChildren();
                 for (Container child : children)
                 {
-                    if (child.getName().toLowerCase().equals(target.getName().toLowerCase()))
+                    if (child.getName().equalsIgnoreCase(target.getName()))
                     {
                         errors.reject(ERROR_MSG, "Subfolder of '" + parent.getPath() + "' with name '" +
                                 target.getName() + "' already exists.");
@@ -927,9 +927,8 @@ public class CoreController extends SpringActionController
             // Prepare aliases
             JSONObject object = form.getNewJsonObject();
             Boolean addAlias = (Boolean) object.get("addAlias");
-            
-            List<String> aliasList = new ArrayList<>();
-            aliasList.addAll(ContainerManager.getAliasesForContainer(target));
+
+            List<String> aliasList = new ArrayList<>(ContainerManager.getAliasesForContainer(target));
             aliasList.add(target.getPath());
             
             // Perform move


### PR DESCRIPTION
#### Rationale
`JSONObject` upgrade introduced a couple behavior changes that were pointed out by test failures

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3710

#### Changes
* Return the correct folder type on workflow creation . `optString("folderType")` returns empty string (!?) if the field doesn't exist; we usually want to default to `null`, so `optString("folderType", null)` should be our best practice for an optional String. In this case, be even more clever about the default. This should fix the LabModulesTest.
* Replace tortured code `isWorkbook = json.has("isWorkbook") && !json.isNull("isWorkbook") ? json.getBoolean("isWorkbook") : false` with `isWorkbook = json.optBoolean("isWorkbook")`
* Apparently the "container" field is optional when saving module properties, so use `optString("container", null)`. This should fix the SimpleModuleTest.