### PR TITLE
When writing out Xar files, add back all Sample workflow protocols in the reordered list

### DIFF
--- a/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
@@ -131,7 +131,7 @@ public class FolderXarWriterFactory implements FolderWriterFactory
                     )
                     .collect(Collectors.toList());
             protocols.stream()
-                    .filter(protocol -> ExpProtocol.isSampleWorkflowTaskProtocol(protocol.getLSID()))
+                    .filter(protocol -> ExpProtocol.isSampleWorkflowProtocol(protocol.getLSID()))
                     .forEach(reorderedProtocols::add);
             return reorderedProtocols.stream()
                     .map(ExpObject::getRowId)


### PR DESCRIPTION
#### Rationale
Job templates that have no jobs associated with them are not being exported because we filter them out to put them at the end of the list of protocols, but then don't add all of them back.

#### Related Pull Requests
* 

#### Changes
* Change filter when adding protocols back to reordered list.
