### PR TITLE
46346: Perf issues rendering HTML wikis, continued

### DIFF
--- a/wiki/src/org/labkey/wiki/model/BaseWikiView.java
+++ b/wiki/src/org/labkey/wiki/model/BaseWikiView.java
@@ -22,6 +22,7 @@ import org.labkey.api.portal.ProjectUrls;
 import org.labkey.api.security.User;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
@@ -34,6 +35,7 @@ import org.labkey.wiki.WikiController;
 import org.labkey.wiki.WikiSelectManager;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * User: Mark Igra
@@ -116,8 +118,9 @@ public abstract class BaseWikiView extends JspView<Object>
             {
                 try
                 {
-                    html = wikiVersion.getHtml(c, wiki);
-                    addClientDependencies(wikiVersion.getClientDependencies(c, wiki));
+                    Pair<HtmlString, Set<ClientDependency>> rendered = wikiVersion.render(c, wiki);
+                    html = rendered.first;
+                    addClientDependencies(rendered.second);
                 }
                 catch (Exception e)
                 {

--- a/wiki/src/org/labkey/wiki/model/BaseWikiView.java
+++ b/wiki/src/org/labkey/wiki/model/BaseWikiView.java
@@ -118,6 +118,7 @@ public abstract class BaseWikiView extends JspView<Object>
             {
                 try
                 {
+                    // Issue 46346 - make a single call to get the HTML and dependency info to avoid double-rendering
                     Pair<HtmlString, Set<ClientDependency>> rendered = wikiVersion.render(c, wiki);
                     html = rendered.first;
                     addClientDependencies(rendered.second);

--- a/wiki/src/org/labkey/wiki/model/WikiVersion.java
+++ b/wiki/src/org/labkey/wiki/model/WikiVersion.java
@@ -22,7 +22,9 @@ import org.labkey.api.data.Container;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.MemTracker;
+import org.labkey.api.util.Pair;
 import org.labkey.api.view.template.ClientDependency;
+import org.labkey.api.wiki.FormattedHtml;
 import org.labkey.api.wiki.WikiRenderer;
 import org.labkey.api.wiki.WikiRendererType;
 import org.labkey.api.wiki.WikiRenderingService;
@@ -68,6 +70,7 @@ public class WikiVersion
 
     /**
      * Copy constructor used when creating a new version of a wiki
+     *
      * @param copy The current latest version
      */
     public WikiVersion(WikiVersion copy)
@@ -125,19 +128,17 @@ public class WikiVersion
     // TODO: WikiVersion should know its wiki & container
     public HtmlString getHtml(Container c, Wiki wiki)
     {
-        return HtmlStringBuilder.of(WikiRenderingService.WIKI_PREFIX)
-            .append(getHtmlForConvert(c, wiki))
-            .append(WikiRenderingService.WIKI_SUFFIX).getHtmlString();
+        return render(c, wiki).first;
     }
 
-    public HtmlString getHtmlForConvert(Container c, Wiki wiki)
+    public Pair<HtmlString, Set<ClientDependency>> render(Container c, Wiki wiki)
     {
-        return WikiContentCache.getHtml(c, wiki, this, _cache).getHtml();
-    }
-
-    public Set<ClientDependency> getClientDependencies(Container c, Wiki wiki)
-    {
-        return WikiContentCache.getHtml(c, wiki, this, _cache).getClientDependencies();
+        FormattedHtml rendered = WikiContentCache.getHtml(c, wiki, this, _cache);
+        return Pair.of(
+                HtmlStringBuilder.of(WikiRenderingService.WIKI_PREFIX)
+                    .append(rendered.getHtml())
+                    .append(WikiRenderingService.WIKI_SUFFIX).getHtmlString(),
+                rendered.getClientDependencies());
     }
 
     public String getTitle()


### PR DESCRIPTION
#### Rationale
We don't cache rendered wikis with dynamic content. Thus, we shouldn't make two calls to render when a single easily suffices

#### Changes
* Get both the HTML and ClientDependency info with a single call