### PR TITLE
Issue 46412: When importing assay data, collect column names from results domain

### DIFF
--- a/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
+++ b/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
@@ -46,6 +46,7 @@ import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentJSONConverter;
+import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.PipeRoot;
@@ -71,6 +72,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.labkey.api.assay.AssayDataCollector.PRIMARY_FILE;
 import static org.labkey.api.assay.AssayFileWriter.createFile;
@@ -255,7 +257,9 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
                 File dir = AssayFileWriter.ensureUploadDirectory(getContainer());
                 // NOTE: We use a 'tmp' file extension so that DataLoaderService will sniff the file type by parsing the file's header.
                 file = createFile(protocol, dir, "tmp");
-                try (TSVMapWriter tsvWriter = new TSVMapWriter(rawData))
+                try (TSVMapWriter tsvWriter = new TSVMapWriter(
+                        provider.getResultsDomain(protocol).getProperties().stream().map(DomainProperty::getName).collect(Collectors.toList()),
+                        rawData))
                 {
                     tsvWriter.write(file);
                     factory.setRawData(null);


### PR DESCRIPTION
#### Rationale
[Issue 46412](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46412) Because we were inferring the set of columns using the first row of data provided from an import from the grid, this caused us to lose some data when the first row entered in a grid did not contain all of the fields for an assay run. This PR changes the initialization of the TSVWriter by passing in all results domain column names so we can pick up all fields from each record.


#### Changes
* Update TSVWriter initialization during assay result import
