### PR TITLE
Issue 46149: Permissions inaccessible due to NPE from S3 file config

### DIFF
--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -498,12 +498,14 @@ public class FileUtil
         }
     }
 
+    @NotNull
     public static String getFileName(Path fullPath)
     {
         // We want unencoded fileName
         if (hasCloudScheme(fullPath))
         {
-            return fullPath.getFileName().toUri().getPath();
+            Path path = fullPath.getFileName();
+            return path == null ? "" : path.toUri().getPath();
         }
         else
         {

--- a/pipeline/src/org/labkey/pipeline/api/PipeRootImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipeRootImpl.java
@@ -560,7 +560,8 @@ public class PipeRootImpl implements PipeRoot
     @NotNull
     public String getResourceName()
     {
-        return FileUtil.getFileName(getRootNioPath());
+        String fileName = FileUtil.getFileName(getRootNioPath());
+        return fileName.isEmpty() ? "Root for " + getContainer().getName() : fileName;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Configuring an S3 bucket that points directly at the root causes problems via SecurableResources

#### Changes
* Handle nulls from the root of the bucket