### PR TITLE
Issue 46371: LKS grid column header menus don't work when scrolled down so they 'lock'

### DIFF
--- a/api/webapp/clientapi/dom/Utils.js
+++ b/api/webapp/clientapi/dom/Utils.js
@@ -866,10 +866,11 @@ LABKEY.Utils = new function(impl, $) {
             return;
         const fn = function()
         {
-            if (typeof el === "string")
-                el = document.getElementById(el);
-            if (el)
-                el['on' + eventName] = handler;
+            if (typeof el === "string") {
+                const list = document.querySelectorAll('#' + el);
+                for (let i in list)
+                    list[i]['on' + eventName] = handler;
+            }
         };
         (immediate || document.readyState!=="loading") ? fn() : document.addEventListener('load', fn);
     };

--- a/api/webapp/clientapi/dom/Utils.js
+++ b/api/webapp/clientapi/dom/Utils.js
@@ -860,9 +860,12 @@ LABKEY.Utils = new function(impl, $) {
     };
 
     impl.isValidQuerySelector = function(selector) {
-        try { document.createDocumentFragment().querySelector(selector) }
-        catch { return false }
-        return true
+        try {
+            document.createDocumentFragment().querySelector(selector);
+        } catch(ignore) {
+            return false;
+        }
+        return true;
     }
 
     // attach handlers to element events e.g. onclick=fn() etc.

--- a/api/webapp/clientapi/dom/Utils.js
+++ b/api/webapp/clientapi/dom/Utils.js
@@ -145,6 +145,15 @@ LABKEY.Utils = new function(impl, $) {
         return nextRow;
     };
 
+    var isValidQuerySelector = function(selector) {
+        try {
+            document.createDocumentFragment().querySelector(selector);
+        } catch(ignore) {
+            return false;
+        }
+        return true;
+    };
+
     /**
      * Shows an error dialog box to the user in response to an error from an AJAX request, including
      * any error messages from the server.
@@ -859,15 +868,6 @@ LABKEY.Utils = new function(impl, $) {
         (immediate || document.readyState!=="loading") ? fn() : document.addEventListener('load', fn);
     };
 
-    impl.isValidQuerySelector = function(selector) {
-        try {
-            document.createDocumentFragment().querySelector(selector);
-        } catch(ignore) {
-            return false;
-        }
-        return true;
-    }
-
     // attach handlers to element events e.g. onclick=fn() etc.
     impl.attachEventHandler = function(el, eventName, handler, immediate)
     {
@@ -878,7 +878,7 @@ LABKEY.Utils = new function(impl, $) {
             if (typeof el === "string") {
                 // Issue 46371: LKS grid column header locking clones the header row which results in multiple
                 //      DOM elements with the same id attr, but only the first was getting the event handler attached
-                if (impl.isValidQuerySelector(el)) {
+                if (isValidQuerySelector(el)) {
                     const list = document.querySelectorAll('#' + el);
                     for (let i in list) {
                         list[i]['on' + eventName] = handler;


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46371

DataRegion.js code for header locking is making a clone of the header row. This results in two DOM elements for each header cell menu item with the same ID. In the attachEventHandler Util.js function, we are using document.getElementById() to find the DOM element for the event handling. This is then only finding the first element and not attaching to the cloned / floating header row elements.

Ideally we'd switch away from this "header row cloning" behavior and use the CSS `position: sticky`. I mocked this up locally and it worked well. We'd have to figure out a few things like what to do with the floating pagination component, styling for the floating header bottom border, etc. 

#### Changes
* update attachEventHandler to switch to document.querySelectorAll() instead of document.getElementById()
