### PR TITLE
Issue 46427: Slow queries for runs related to datas and materials

### DIFF
--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -1502,9 +1502,10 @@ public class ExperimentController extends SpringActionController
         }
     }
 
-    public static class AttachmentForm extends LsidForm
+    public static class AttachmentForm extends LsidForm implements BaseDownloadAction.InlineDownloader
     {
         private String _name;
+        private boolean _inline = true;
 
         public String getName()
         {
@@ -1514,6 +1515,17 @@ public class ExperimentController extends SpringActionController
         public void setName(String name)
         {
             _name = name;
+        }
+
+        @Override
+        public boolean isInline()
+        {
+            return _inline;
+        }
+
+        public void setInline(boolean inline)
+        {
+            _inline = inline;
         }
     }
 


### PR DESCRIPTION
#### Rationale
Datadog is showing some slow queries getting the runs related to data or material objects

#### Changes
* Revise query to help Postgres choose a more efficient execution plan