### PR TITLE
Issue 46282: View vs download options for file and attachment fields

### DIFF
--- a/api/schemas/tableInfo.xsd
+++ b/api/schemas/tableInfo.xsd
@@ -726,6 +726,8 @@
                         is the string to display when false, and "null" is the string to display when null. For date and
                         datetime columns the values Date and DateTime can be used to display as
                         either date or date and time with the currently configured display formats for this folder.
+                        For file and attachment columns, use "inline" or "attachment" to request that the download
+                        action render within the browser or save as a file, respectively.
                         Supported for SQL metadata, dataset import/export and list import/export.
                     </xs:documentation>
 				</xs:annotation>

--- a/api/schemas/tableInfo.xsd
+++ b/api/schemas/tableInfo.xsd
@@ -726,8 +726,8 @@
                         is the string to display when false, and "null" is the string to display when null. For date and
                         datetime columns the values Date and DateTime can be used to display as
                         either date or date and time with the currently configured display formats for this folder.
-                        For file and attachment columns, use "inline" or "attachment" to request that the download
-                        action render within the browser or save as a file, respectively.
+                        For file and attachment columns, "attachment" to save files as a download, overriding the
+                        default behavior of displaying files like PDFs and images in the browser .
                         Supported for SQL metadata, dataset import/export and list import/export.
                     </xs:documentation>
 				</xs:annotation>

--- a/api/src/org/labkey/api/attachments/AttachmentForm.java
+++ b/api/src/org/labkey/api/attachments/AttachmentForm.java
@@ -21,10 +21,12 @@ package org.labkey.api.attachments;
  * Date: Jan 3, 2007
  * Time: 3:41:22 PM
  */
-public class AttachmentForm
+public class AttachmentForm implements BaseDownloadAction.InlineDownloader
 {
     private String _entityId = null;
     private String _name = null;
+
+    private boolean _inline = true;
 
     public String getEntityId()
     {
@@ -44,5 +46,16 @@ public class AttachmentForm
     public void setName(String name)
     {
         _name = name;
+    }
+
+    @Override
+    public boolean isInline()
+    {
+        return _inline;
+    }
+
+    public void setInline(boolean inline)
+    {
+        _inline = inline;
     }
 }

--- a/api/src/org/labkey/api/attachments/AttachmentService.java
+++ b/api/src/org/labkey/api/attachments/AttachmentService.java
@@ -62,7 +62,7 @@ public interface AttachmentService
         return ServiceRegistry.get().getService(AttachmentService.class);
     }
 
-    void download(HttpServletResponse response, AttachmentParent parent, String name) throws ServletException, IOException;
+    void download(HttpServletResponse response, AttachmentParent parent, String name, boolean inlineIfPossible) throws ServletException, IOException;
 
     HttpView getHistoryView(ViewContext context, AttachmentParent parent);
 

--- a/api/src/org/labkey/api/attachments/BaseBackgroundImageAction.java
+++ b/api/src/org/labkey/api/attachments/BaseBackgroundImageAction.java
@@ -26,7 +26,7 @@ import java.util.GregorianCalendar;
 // Abstract action that renders a portal image for a portal selection pages (e.g., GEL, Argos). Modules need an action
 // in their own controller that extends this class and handles security, creates the correct attachment parent, and
 // specifies the image filename.
-public abstract class BaseBackgroundImageAction<FORM> extends BaseDownloadAction<FORM>
+public abstract class BaseBackgroundImageAction<FORM extends BaseDownloadAction.InlineDownloader> extends BaseDownloadAction<FORM>
 {
     @Override
     public void export(FORM form, HttpServletResponse response, BindException errors) throws Exception

--- a/api/src/org/labkey/api/attachments/BaseDownloadAction.java
+++ b/api/src/org/labkey/api/attachments/BaseDownloadAction.java
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 
 // Abstract action that downloads an attachment associated with an AttachmentParent. Modules need an action in their own controller
 // that extends this class and handles security, creates the correct attachment parent, and specifies the attachment filename.
-public abstract class BaseDownloadAction<FORM> extends ExportAction<FORM>
+public abstract class BaseDownloadAction<FORM extends BaseDownloadAction.InlineDownloader> extends ExportAction<FORM>
 {
     @Override
     protected String getCommandClassMethodName()
@@ -43,8 +43,17 @@ public abstract class BaseDownloadAction<FORM> extends ExportAction<FORM>
         Pair<AttachmentParent, String> attachment = getAttachment(form);
 
         if (null != attachment)
-            AttachmentService.get().download(response, attachment.first, attachment.second);
+            AttachmentService.get().download(response, attachment.first, attachment.second, form.isInline());
     }
 
     public abstract @Nullable Pair<AttachmentParent, String> getAttachment(FORM form);
+
+    /**
+     * Optional URL parameter binding for forms. Use false to indicate that files should always be sent
+     * as a download instead of opening within the browser.
+     */
+    public interface InlineDownloader
+    {
+        default boolean isInline() { return true; }
+    }
 }

--- a/api/src/org/labkey/api/data/AbstractFileDisplayColumn.java
+++ b/api/src/org/labkey/api/data/AbstractFileDisplayColumn.java
@@ -35,14 +35,12 @@ import java.io.Writer;
  */
 public abstract class AbstractFileDisplayColumn extends DataColumn
 {
-    MimeMap _map;
     protected String _thumbnailWidth;
     protected String _popupWidth;
 
     public AbstractFileDisplayColumn(ColumnInfo col)
     {
         super(col);
-        _map = new MimeMap();
     }
 
     @Override
@@ -85,7 +83,14 @@ public abstract class AbstractFileDisplayColumn extends DataColumn
             {
                 if (null != url)
                 {
-                    out.write("<a title=\"Download attached file\" href=\"");
+                    out.write("<a title=\"Download attached file\"");
+                    if (getLinkTarget() != null && MimeMap.DEFAULT.canInlineFor(filename))
+                    {
+                        out.write(" target=\"");
+                        out.write(PageFlowUtil.filter(getLinkTarget()));
+                        out.write("\"");
+                    }
+                    out.write(" href=\"");
                     out.write(PageFlowUtil.filter(url));
                     out.write("\">");
                 }
@@ -107,7 +112,7 @@ public abstract class AbstractFileDisplayColumn extends DataColumn
             }
             else
             {
-                if (url != null && thumbnail && _map.isInlineImageFor(new File(filename)) )
+                if (url != null && thumbnail && MimeMap.DEFAULT.isInlineImageFor(new File(filename)) )
                 {
                     if (renderHelper.renderPopupImage())
                         out.write(PageFlowUtil.helpPopup(displayName, renderHelper.createPopupImage(), true, renderHelper.createThumbnailImage(), 310, renderHelper.createClickScript()));
@@ -206,7 +211,15 @@ public abstract class AbstractFileDisplayColumn extends DataColumn
         // render the click script when a user clicks on the grid cell
         public String createClickScript()
         {
-            return _url == null ? null : "window.location = '" + _url + "'";
+            if (_url == null)
+            {
+                return null;
+            }
+            if (getLinkTarget() != null)
+            {
+                return "window.open(" + PageFlowUtil.jsString(_url) + "," + PageFlowUtil.jsString(getLinkTarget()) + ", 'noopener,noreferrer')";
+            }
+            return "window.location = " + PageFlowUtil.jsString(_url);
         }
     }
 

--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -349,6 +349,7 @@ public class FileUtil
      * Returns the file name extension without the dot, null if there
      * isn't one.
      */
+    @Nullable
     public static String getExtension(String name)
     {
         if (name != null && name.lastIndexOf('.') != -1)

--- a/api/src/org/labkey/api/util/MimeMap.java
+++ b/api/src/org/labkey/api/util/MimeMap.java
@@ -165,7 +165,7 @@ public class MimeMap implements FileNameMap
     @Nullable
     public MimeType getMimeTypeFor(String fileName)
     {
-        String extn = getExtension(fileName);
+        String extn = FileUtil.getExtension(fileName);
         if (null == extn)
             return null;
         return getMimeType(extn);
@@ -178,41 +178,6 @@ public class MimeMap implements FileNameMap
         return type == null ? null : type.getContentType();
     }
 
-    /**
-     * Get extension of file name, stripping off any fragment id (after the #)
-     */
-    public static String getExtension(String fileName)
-    {
-        int i = fileName.lastIndexOf('.');
-        if (i != -1)
-        {
-            return fileName.substring(i + 1);
-        }
-        else
-        {
-            // no extension, no content type
-            return null;
-        }
-    }
-
-    /**
-     * Get extension of file
-     */
-    public static String getExtension(@NotNull File file)
-    {
-        int i = file.getName().lastIndexOf('.');
-        if (i != -1)
-        {
-            return file.getName().substring(i + 1);
-        }
-        else
-        {
-            // no extension, no content type
-            return null;
-        }
-    }
-
-
     public boolean isInlineImage(String extn)
     {
         MimeType type = getMimeType(extn);
@@ -222,7 +187,7 @@ public class MimeMap implements FileNameMap
 
     public boolean isInlineImageFor(String fileName)
     {
-        String extn = getExtension(fileName);
+        String extn = FileUtil.getExtension(fileName);
         if (extn != null)
         {
             return isInlineImage(extn);
@@ -235,7 +200,7 @@ public class MimeMap implements FileNameMap
 
     public boolean isInlineImageFor(@NotNull File file)
     {
-        String extn = getExtension(file);
+        String extn = FileUtil.getExtension(file);
         if (extn != null)
         {
             return isInlineImage(extn);
@@ -262,7 +227,7 @@ public class MimeMap implements FileNameMap
 
     public boolean isOfficeDocumentFor(String fileName)
     {
-        String extn = getExtension(fileName);
+        String extn = FileUtil.getExtension(fileName);
         if (extn != null)
         {
             return isOfficeDocument(extn);
@@ -277,7 +242,7 @@ public class MimeMap implements FileNameMap
     @Override
     public String getContentTypeFor(String fileName)
     {
-        String extn = getExtension(fileName);
+        String extn = FileUtil.getExtension(fileName);
         if (extn != null)
         {
             return getContentType(extn);

--- a/api/src/org/labkey/api/util/MimeMap.java
+++ b/api/src/org/labkey/api/util/MimeMap.java
@@ -158,6 +158,7 @@ public class MimeMap implements FileNameMap
     public boolean canInlineFor(String filename)
     {
         MimeType mime = getMimeTypeFor(filename);
+        // Don't allow inlining of HTML due to script injection concerns - see issue 38714
         return mime != null && mime.canInline() && mime != MimeMap.MimeType.HTML;
     }
 

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -490,9 +490,10 @@ public class CoreController extends SpringActionController
             {
                 // If the URL has requested that the content be sent inline or not (instead of as an attachment), respect that
                 // Otherwise, default to sending as attachment
-                MimeMap.MimeType mime = (new MimeMap()).getMimeTypeFor(file.getName());
-                boolean canInline = mime != null && mime.canInline() && mime != MimeMap.MimeType.HTML;
-                PageFlowUtil.streamFile(getViewContext().getResponse(), file.toPath(), !canInline || form.getInline() == null || !form.getInline().booleanValue());
+                boolean canInline = MimeMap.DEFAULT.canInlineFor(file.getName());
+                // Default to rendering inline when possible, but let caller force download as an attachment
+                boolean asAttachment = !canInline || (form.getInline() != null && !form.getInline().booleanValue());
+                PageFlowUtil.streamFile(getViewContext().getResponse(), file.toPath(), asAttachment);
             }
             return null;
         }

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -125,7 +125,6 @@ import java.util.TreeSet;
  */
 public class AttachmentServiceImpl implements AttachmentService, ContainerManager.ContainerListener
 {
-    private static final MimeMap _mimeMap = new MimeMap();
     private static final String UPLOAD_LOG = ".upload.log";
     private static final Map<String, AttachmentType> ATTACHMENT_TYPE_MAP = new HashMap<>();
 
@@ -136,15 +135,17 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
 
 
     @Override
-    public void download(HttpServletResponse response, AttachmentParent parent, String filename) throws ServletException, IOException
+    public void download(HttpServletResponse response, AttachmentParent parent, String filename, boolean inlineIfPossible) throws ServletException, IOException
     {
         if (null == filename || 0 == filename.length())
         {
             throw new NotFoundException();
         }
 
-        MimeMap.MimeType mime = _mimeMap.getMimeTypeFor(filename);
-        boolean asAttachment = null==mime || mime==MimeMap.MimeType.HTML || !mime.canInline();
+        boolean canInline = MimeMap.DEFAULT.canInlineFor(filename);
+
+        // Default to rendering inline when possible, but let caller force download as an attachment
+        boolean asAttachment = !canInline || !inlineIfPossible;
 
         response.reset();
         writeDocument(new ResponseWriter(response), parent, filename, asAttachment);

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -977,7 +977,7 @@ public class UserController extends SpringActionController
         }
     }
 
-    public static class AttachmentForm
+    public static class AttachmentForm implements BaseDownloadAction.InlineDownloader
     {
         private Integer _userId;
         private String _name;

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -1502,9 +1502,10 @@ public class ExperimentController extends SpringActionController
         }
     }
 
-    public static class AttachmentForm extends LsidForm
+    public static class AttachmentForm extends LsidForm implements BaseDownloadAction.InlineDownloader
     {
         private String _name;
+        private boolean _inline = true;
 
         public String getName()
         {
@@ -1514,6 +1515,17 @@ public class ExperimentController extends SpringActionController
         public void setName(String name)
         {
             _name = name;
+        }
+
+        @Override
+        public boolean isInline()
+        {
+            return _inline;
+        }
+
+        public void setInline(boolean inline)
+        {
+            _inline = inline;
         }
     }
 

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -1176,7 +1176,7 @@ public class IssuesController extends SpringActionController
     }
 
     // SAME as AttachmentForm, just to demonstrate GuidString
-    public static class _AttachmentForm
+    public static class _AttachmentForm implements BaseDownloadAction.InlineDownloader
     {
         private GUID _entityId = null;
         private String _name = null;

--- a/specimen/src/org/labkey/specimen/actions/SpecimenController.java
+++ b/specimen/src/org/labkey/specimen/actions/SpecimenController.java
@@ -1194,7 +1194,7 @@ public class SpecimenController extends SpringActionController
         }
     }
 
-    public static class SpecimenEventAttachmentForm
+    public static class SpecimenEventAttachmentForm implements BaseDownloadAction.InlineDownloader
     {
         private int _eventId;
         private String _name;


### PR DESCRIPTION
#### Rationale
We want consistent handling for viewing and downloading files across data types. We are standardizing on showing the file in the browser when supported (like PDFs and images) and opening in a new tab/window. Admins can also opt to always download on a per-field basis.

#### Changes
* Support an "attachment" format option for file and attachment fields, forcing the link to work as a download
* Make it easier for individual download actions to indicate they want to download vs view
* Make lists, datasets, sample types, data classes, and assay file/attachments behave consistently
* Remove unused code in MimeMap and use a singleton instance in more places