### PR TITLE
Proposed updates to the Announcements API

### DIFF
--- a/announcements/src/org/labkey/announcements/api/AnnouncementImpl.java
+++ b/announcements/src/org/labkey/announcements/api/AnnouncementImpl.java
@@ -23,6 +23,7 @@ import org.labkey.api.wiki.WikiRendererType;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 /**
  * User: Nick
@@ -148,6 +149,12 @@ public class AnnouncementImpl implements Announcement
     {
         _model.setRendererType(rendererType.getDisplayName());
     }
-    
+
+    @Override
+    public List<Integer> getMemberListIds()
+    {
+        return _model.getMemberListIds();
+    }
+
     // This needs to be filled out more completely
 }

--- a/announcements/src/org/labkey/announcements/api/AnnouncementImpl.java
+++ b/announcements/src/org/labkey/announcements/api/AnnouncementImpl.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.announcements.api;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.announcements.model.AnnouncementModel;
 import org.labkey.api.announcements.api.Announcement;
 import org.labkey.api.attachments.Attachment;
@@ -22,6 +23,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.wiki.WikiRendererType;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -151,9 +153,9 @@ public class AnnouncementImpl implements Announcement
     }
 
     @Override
-    public List<Integer> getMemberListIds()
+    public @NotNull List<Integer> getMemberListIds()
     {
-        return _model.getMemberListIds();
+        return _model.getMemberListIds() != null ? _model.getMemberListIds() : Collections.emptyList();
     }
 
     // This needs to be filled out more completely

--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -1289,7 +1289,7 @@ public class AnnouncementManager
                 this.messageSubject = typeProvider.getEmailSubject(c, UserManager.getUser(a.getCreatedBy()), a.getRowId(), a.getDiscussionSrcIdentifier(), a.getBody(), a.getTitle(), parentBody);
             }
             if (this.messageSubject == null)
-                this.messageSubject = StringUtils.trimToEmpty(isResponse ? "RE: " + parent.getTitle() : a.getTitle());
+                this.messageSubject = StringUtils.trimToEmpty(isResponse && parent.getTitle().equals(a.getTitle()) ? "RE: " + parent.getTitle() : a.getTitle());
 
             this.recipient = recipient;
             this.threadURL = AnnouncementsController.getThreadURL(c, recipient, a);

--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -1289,7 +1289,7 @@ public class AnnouncementManager
                 this.messageSubject = typeProvider.getEmailSubject(c, UserManager.getUser(a.getCreatedBy()), a.getRowId(), a.getDiscussionSrcIdentifier(), a.getBody(), a.getTitle(), parentBody);
             }
             if (this.messageSubject == null)
-                this.messageSubject = StringUtils.trimToEmpty(isResponse && parent.getTitle().equals(a.getTitle()) ? "RE: " + parent.getTitle() : a.getTitle());
+                this.messageSubject = StringUtils.trimToEmpty(isResponse ? "RE: " + (StringUtils.isNotBlank(a.getTitle()) ? a.getTitle() : parent.getTitle()) : a.getTitle());
 
             this.recipient = recipient;
             this.threadURL = AnnouncementsController.getThreadURL(c, recipient, a);

--- a/api/src/org/labkey/api/announcements/api/Announcement.java
+++ b/api/src/org/labkey/api/announcements/api/Announcement.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.announcements.api;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.attachments.Attachment;
 import org.labkey.api.data.Container;
 import org.labkey.api.wiki.WikiRendererType;
@@ -41,5 +42,5 @@ public interface Announcement
     Date getCreated();
     Date getModified();
     WikiRendererType getRendererType();
-    List<Integer> getMemberListIds();
+    @NotNull List<Integer> getMemberListIds();
 }

--- a/api/src/org/labkey/api/announcements/api/Announcement.java
+++ b/api/src/org/labkey/api/announcements/api/Announcement.java
@@ -21,6 +21,7 @@ import org.labkey.api.wiki.WikiRendererType;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 /**
  * User: Nick
@@ -40,4 +41,5 @@ public interface Announcement
     Date getCreated();
     Date getModified();
     WikiRendererType getRendererType();
+    List<Integer> getMemberListIds();
 }

--- a/api/src/org/labkey/api/announcements/api/AnnouncementService.java
+++ b/api/src/org/labkey/api/announcements/api/AnnouncementService.java
@@ -45,11 +45,22 @@ public interface AnnouncementService
     /** @param parentRowId optionally, the existing thread to add the post to. If null, start a new thread */
     Announcement insertAnnouncement(Container container, User u, String title, String body, boolean sendEmailNotification, @Nullable Integer parentRowId);
 
+    /**
+     * @param parentRowId optionally, the existing thread to add the post to. If null, start a new thread
+     * @param status status for the message thread. Ignored if it does not resolve to a DiscussionService.StatusOption
+     * @param memberList List of users that should be added to the notify list; Users that do not have permission to read the message are ignored.
+     */
+    Announcement insertAnnouncement(Container container, User u, String title, String body, boolean sendEmailNotification, @Nullable Integer parentRowId,
+                                    @Nullable String status, @Nullable List<User> memberList);
+
     // Get One
     Announcement getAnnouncement(Container container, User user, int RowId);
 
     // Get Many
     List<Announcement> getAnnouncements(Container... containers);
+
+    // Get the latest post
+    @Nullable Announcement getLatestPost(Container container, User user, int parentRowId);
 
     // Update
     Announcement updateAnnouncement(int RowId, Container c, User u, String title, String body);


### PR DESCRIPTION
#### Rationale
We would like to convert the Panorama Public requests message board to a secure message board so that we can communicate with the submitters over the message board while keeping each message private to the associated submitter.
Messages are posted automatically via the Panorama Public module when a new request is submitted / updated / deleted, and when the data is copied to Panorama Public.  If the submitter has any questions, or a Panorama Public admin needs to contact  the submitter, they should post a response to the message thread instead of sending emails. 

#### Changes
- Added a method to insert an announcement with status and member list
- Added a method to return the latest post for a message thread
- Use the title of the latest post as the email subject