### PR TITLE
Add "Media" Product Feature

### DIFF
--- a/api/src/org/labkey/api/settings/ProductFeature.java
+++ b/api/src/org/labkey/api/settings/ProductFeature.java
@@ -8,6 +8,7 @@ public enum ProductFeature
     Assay("assay"),
     ELN("labbook"),
     FreezerManagement("inventory"),
+    Media("recipe"),
     SampleManagement("sampleManagement"),
     Workflow("sampleManagement");
 


### PR DESCRIPTION
#### Rationale
Adds the "Media" product feature and relates it to the `recipe` module. This is used for product feature tiering.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3736
* https://github.com/LabKey/labkey-ui-components/pull/975
* https://github.com/LabKey/biologics/pull/1639

#### Changes
* Add `Media` as a new `ProductFeature` and relate it to the `recipe` module via the enum value.