### PR TITLE
Metric to track usage of AssayImporter GWT app

### DIFF
--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -117,6 +117,7 @@ import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.actions.TransformResultsAction;
 import org.labkey.api.study.publish.StudyPublishService;
+import org.labkey.api.usageMetrics.SimpleMetricsService;
 import org.labkey.api.util.ContainerTree;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.HtmlString;
@@ -1308,6 +1309,7 @@ public class AssayController extends SpringActionController
         @Override
         protected BaseRemoteService createService()
         {
+            SimpleMetricsService.get().increment(AssayModule.NAME, "AssayImportServiceAction", "GWTServiceCreation");
             return new AssayImportServiceImpl(getViewContext());
         }
     }

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -89,7 +89,7 @@ import static org.labkey.api.assay.DefaultDataTransformer.LEGACY_SESSION_ID_REPL
 
 public class AssayModule extends SpringModule
 {
-    private static final String NAME = "Assay";
+    public static final String NAME = "Assay";
 
     @Override
     public String getName()


### PR DESCRIPTION
#### Rationale
We'd like to get rid of DomainEditorServiceBase and other GWT code, but we don't know if anyone's using it

#### Changes
* New `AssayImportServiceAction.GWTServiceCreation` metric under the Assay module