### PR TITLE
Issue 44923: ConfigurationSummaryAction double-echos config properties

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -9994,7 +9994,7 @@ public class AdminController extends SpringActionController
         }
     }
 
-    @JsonIgnoreProperties(value = { "password", "changePassword" })
+    @JsonIgnoreProperties(value = { "password", "changePassword", "configuration" })
     private static class IgnorePasswordMixIn
     {
     }


### PR DESCRIPTION
#### Rationale
We're double-echoing configuration, both as individual properties and as a child JSON property

#### Changes
* Suppress the duplicate `configuration` property from serialization