### PR TITLE
Backport NPE fix for ShowFileAction

### DIFF
--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -572,7 +572,7 @@ public class StatusController extends SpringActionController
 
                     // Ensure that the requested file is under the root for this container
                     PipeRoot root = PipelineService.get().findPipelineRoot(c);
-                    if (root != null && root.isUnderRoot(fileShow) && NetworkDrive.exists(fileShow))
+                    if (root != null && fileShow != null && root.isUnderRoot(fileShow) && NetworkDrive.exists(fileShow))
                     {
                         boolean visible = isVisibleFile(fileName, basename);
 


### PR DESCRIPTION
#### Rationale
The crawler is still hitting this in 22.7. Might as well fix it there to reduce noise.

#### Related Pull Requests
* #3616

#### Changes
* Backport `null` check in `ShowFileAction`
