### PR TITLE
Fix NPE in ShowFileAction (backport from develop)

### DIFF
--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -572,7 +572,7 @@ public class StatusController extends SpringActionController
 
                     // Ensure that the requested file is under the root for this container
                     PipeRoot root = PipelineService.get().findPipelineRoot(c);
-                    if (root != null && root.isUnderRoot(fileShow) && NetworkDrive.exists(fileShow))
+                    if (root != null && fileShow != null && root.isUnderRoot(fileShow) && NetworkDrive.exists(fileShow))
                     {
                         boolean visible = isVisibleFile(fileName, basename);
 


### PR DESCRIPTION
#### Rationale
We're getting intermittent failures in 22.7 on a NPE that's been addressed in develop.

Example failure:

https://teamcity.labkey.org/buildConfiguration/LabKey_227Release_Community_DailySuites_DailyESqlserver/2020863?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true

#### Changes
* Check for null!