### PR TITLE
Issue 46473: Don't retain a stale reference to Container object

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1727,7 +1727,8 @@ public class Container implements Serializable, Comparable<Container>, Securable
     }
 
     /** Convert a container into a reference that can be used to get the latest version of the container object. See issue 46473 */
-    public static Supplier<Container> supplierOf(Container c)
+    @NotNull
+    public static Supplier<Container> supplierOf(@Nullable Container c)
     {
         final GUID id = c == null ? null : c.getEntityId();
         return () -> id == null ? null : ContainerManager.getForId(id);

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -88,6 +88,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 
 
 /**
@@ -1723,5 +1724,12 @@ public class Container implements Serializable, Comparable<Container>, Securable
     public void setExpirationDate(LocalDate expirationDate)
     {
         _expirationDate = expirationDate;
+    }
+
+    /** Convert a container into a reference that can be used to get the latest version of the container object. See issue 46473 */
+    public static Supplier<Container> supplierOf(Container c)
+    {
+        final GUID id = c == null ? null : c.getEntityId();
+        return () -> id == null ? null : ContainerManager.getForId(id);
     }
 }

--- a/api/src/org/labkey/api/exp/IdentifiableBase.java
+++ b/api/src/org/labkey/api/exp/IdentifiableBase.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.exp;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 
 import java.io.Serializable;
@@ -34,7 +35,10 @@ public class IdentifiableBase implements Identifiable, Serializable
     private Integer objectId;
     // Issue 46473 - don't retain a reference to container itself from a potentially cached object,
     // just know how to easily resolve it so we can get the latest version
-    protected Supplier<Container> container;
+    private static final Supplier<Container> NULL_SUPPLIER = Container.supplierOf(null);
+
+    @NotNull
+    protected Supplier<Container> container = NULL_SUPPLIER;
 
     public IdentifiableBase()
     {

--- a/api/src/org/labkey/api/exp/IdentifiableBase.java
+++ b/api/src/org/labkey/api/exp/IdentifiableBase.java
@@ -19,6 +19,7 @@ import org.labkey.api.data.Container;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * Utility base class for implementations of {@link Identifiable}
@@ -31,7 +32,9 @@ public class IdentifiableBase implements Identifiable, Serializable
     private String _name;
     // some entities copy the exp.object.objectid value
     private Integer objectId;
-    protected Container container;
+    // Issue 46473 - don't retain a reference to container itself from a potentially cached object,
+    // just know how to easily resolve it so we can get the latest version
+    protected Supplier<Container> container;
 
     public IdentifiableBase()
     {
@@ -46,7 +49,7 @@ public class IdentifiableBase implements Identifiable, Serializable
     {
         _lsid = oo.getObjectURI();
         objectId = oo.getObjectId();
-        container = oo.getContainer();
+        container = Container.supplierOf(oo.getContainer());
     }
 
     @Override
@@ -97,13 +100,13 @@ public class IdentifiableBase implements Identifiable, Serializable
     @Override
     public Container getContainer()
     {
-        return container;
+        return container.get();
     }
 
     // for Table layer
     public void setContainer(Container container)
     {
-        this.container = container;
+        this.container = Container.supplierOf(container);
     }
 
 

--- a/experiment/src/org/labkey/experiment/api/IdentifiableEntity.java
+++ b/experiment/src/org/labkey/experiment/api/IdentifiableEntity.java
@@ -73,7 +73,7 @@ public class IdentifiableEntity extends IdentifiableBase implements Identifiable
     {
         if (null == entityId)
             entityId = GUID.makeGUID();
-        this.container = container;
+        this.container = Container.supplierOf(container);
         if (user != null)
             createdBy = user.getUserId();
         created = System.currentTimeMillis();


### PR DESCRIPTION
#### Rationale
When cached objects hold a reference to Containers, they may end up referencing a stale copy

#### Changes
* Switch from storing the Container itself to a Supplier<Container>