### PR TITLE
Lists: cross-folder support improvements

### DIFF
--- a/api/src/org/labkey/api/query/UserSchemaAction.java
+++ b/api/src/org/labkey/api/query/UserSchemaAction.java
@@ -24,6 +24,7 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.RuntimeSQLException;
@@ -68,7 +69,7 @@ public abstract class UserSchemaAction extends FormViewAction<QueryUpdateForm>
         {
             throw new NotFoundException("Schema not found");
         }
-        _table = _schema.getTable(_form.getQueryName(), null, true, true);
+        _table = _schema.getTable(_form.getQueryName(), getBindParametersContainerFilter(), true, true);
         if (null == _table)
         {
             throw new NotFoundException("Query not found");
@@ -79,6 +80,11 @@ public abstract class UserSchemaAction extends FormViewAction<QueryUpdateForm>
         BindException errors = new NullSafeBindException(new BeanUtilsPropertyBindingResult(command, "form"));
         command.validateBind(errors);
         return errors;
+    }
+
+    protected @Nullable ContainerFilter getBindParametersContainerFilter()
+    {
+        return QueryService.get().getContainerFilterForLookups(getContainer(), getUser());
     }
 
     protected QueryForm createQueryForm(ViewContext context)

--- a/api/src/org/labkey/api/query/UserSchemaAction.java
+++ b/api/src/org/labkey/api/query/UserSchemaAction.java
@@ -82,6 +82,9 @@ public abstract class UserSchemaAction extends FormViewAction<QueryUpdateForm>
         return errors;
     }
 
+    // This ContainerFilter is applied to the underlying table that backs this UserSchemaAction.
+    // As a result all lookup fields, that respect container filters, in these views will populate
+    // with this container filter applied.
     protected @Nullable ContainerFilter getBindParametersContainerFilter()
     {
         return QueryService.get().getContainerFilterForLookups(getContainer(), getUser());

--- a/experiment/resources/schemas/exp.xml
+++ b/experiment/resources/schemas/exp.xml
@@ -216,7 +216,7 @@
           </column>
           <column columnName="Container" />
           <column columnName="Name" >
-              <url>/list/grid.view?listId=${ListId}</url>
+              <url>/list/grid.view?name=${Name}</url>
           </column>
           <column columnName="DomainId" />
           <column columnName="KeyName" />

--- a/experiment/resources/schemas/exp.xml
+++ b/experiment/resources/schemas/exp.xml
@@ -216,6 +216,10 @@
           </column>
           <column columnName="Container" />
           <column columnName="Name" >
+              <!--
+                Resolve lists by "name" instead of "listId" as "name" will resolve cross-folder
+                where as "listId"s are only unique within a folder.
+              -->
               <url>/list/grid.view?name=${Name}</url>
           </column>
           <column columnName="DomainId" />

--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -302,9 +302,9 @@ public class ListController extends SpringActionController
         private final List<Integer> _listIDs = new ArrayList<>();
         private final List<Container> _containers = new ArrayList<>();
 
-        private boolean canDelete(int listId)
+        private boolean canDelete(Container listContainer, int listId)
         {
-            ListDef listDef = ListManager.get().getList(getContainer(), listId);
+            ListDef listDef = ListManager.get().getList(listContainer, listId);
             ListDefinitionImpl list = ListDefinitionImpl.of(listDef);
 
             if (list == null)
@@ -315,8 +315,8 @@ public class ListController extends SpringActionController
             {
                 boolean isOwnPicklist = listDef.getCreatedBy() == getUser().getUserId();
                 return isOwnPicklist || (listDef.getCategory() == ListDefinition.Category.PublicPicklist && list.getContainer().hasPermission(getUser(), AdminPermission.class));
-
             }
+
             return list.getContainer().hasPermission(getUser(), DesignListPermission.class);
         }
 
@@ -344,7 +344,7 @@ public class ListController extends SpringActionController
                     else
                     {
                         int listId = Integer.parseInt(parts[0]);
-                        if (canDelete(listId))
+                        if (canDelete(c, listId))
                         {
                             _listIDs.add(listId);
                             _containers.add(c);
@@ -359,7 +359,7 @@ public class ListController extends SpringActionController
             else
             {
                 //Accessed from the edit list page, where selection is not possible
-                if (canDelete(form.getListId()))
+                if (canDelete(getContainer(), form.getListId()))
                 {
                     _listIDs.add(form.getListId());
                     _containers.add(getContainer());

--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -586,7 +586,7 @@ public class ListController extends SpringActionController
 
             if (form.isShowHistory())
             {
-                WebPartView linkView = new HtmlView(PageFlowUtil.textLink("hide item history", getViewContext().cloneActionURL().deleteParameter("showHistory")));
+                WebPartView linkView = new HtmlView(PageFlowUtil.link("hide item history").href(getViewContext().cloneActionURL().deleteParameter("showHistory")).build());
                 linkView.setFrame(WebPartView.FrameType.NONE);
                 view.addView(linkView);
 
@@ -609,7 +609,7 @@ public class ListController extends SpringActionController
             }
             else
             {
-                view.addView(new HtmlView(PageFlowUtil.textLink("show item history", getViewContext().cloneActionURL().addParameter("showHistory", "1"))));
+                view.addView(new HtmlView(PageFlowUtil.link("show item history").href(getViewContext().cloneActionURL().addParameter("showHistory", "1")).build()));
             }
 
             if (_list.getDiscussionSetting().isLinked() && LookAndFeelProperties.getInstance(getContainer()).isDiscussionEnabled() && DiscussionService.get() != null)

--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -46,6 +46,7 @@ import org.labkey.api.audit.view.AuditChangesView;
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DataRegionSelection;
 import org.labkey.api.data.SQLFragment;
@@ -221,6 +222,9 @@ public class ListController extends SpringActionController
                     .append("' OR CreatedBy = ").append(getUser().getUserId());
             filter.addWhereClause(sql, FieldKey.fromParts("Category"), FieldKey.fromParts("CreatedBy"));
             settings.setBaseFilter(filter);
+
+            if (null == StringUtils.trimToNull(settings.getContainerFilterName()))
+                settings.setContainerFilterName(ContainerFilter.Type.CurrentPlusProjectAndShared.name());
 
             return schema.createView(getViewContext(), settings, errors);
         }

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -265,7 +265,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
         String type = getType(keyType, category);
         StringBuilder typeURI = getBaseURI(name, type, c);
 
-        // 13131: uniqueify the lsid for situations where a preexisting list was renamed
+        // Issue 13131: uniqueify the lsid for situations where a preexisting list was renamed
         int i = 1;
         String sTypeURI = typeURI.toString();
         String uniqueURI = sTypeURI;
@@ -362,13 +362,13 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
         String keyName = listProperties.getKeyName();
 
         if (StringUtils.isEmpty(name))
-            throw new ApiUsageException("List name must not be null");
+            throw new ApiUsageException("List name is required");
         if (name.length() > MAX_NAME_LENGTH)
             throw new ApiUsageException("List name cannot be longer than " + MAX_NAME_LENGTH + " characters");
-        if (ListService.get().getList(container, name, false) != null)
+        if (ListService.get().getList(container, name, true) != null)
             throw new ApiUsageException("The name '" + name + "' is already in use.");
         if (StringUtils.isEmpty(keyName))
-            throw new ApiUsageException("List keyName must not be null");
+            throw new ApiUsageException("List keyName is required");
 
         KeyType keyType = getDefaultKeyType();
 
@@ -382,7 +382,8 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
         }
 
         ListDefinition.Category category;
-        try {
+        try
+        {
             category = listProperties.getCategory() != null ? ListDefinition.Category.valueOf(listProperties.getCategory()) : null;
         }
         catch (IllegalArgumentException e)
@@ -700,7 +701,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
     @Override
     public boolean matchesTemplateXML(String templateName, DomainTemplateType template, List<GWTPropertyDescriptor> properties)
     {
-        if(!(template instanceof ListTemplateType))
+        if (!(template instanceof ListTemplateType))
             return false;
 
         ListOptionsType options = ((ListTemplateType) template).getOptions();
@@ -723,5 +724,4 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
     {
         var props = getBaseProperties(d);
     }
-
 }

--- a/list/src/org/labkey/list/model/ListImporter.java
+++ b/list/src/org/labkey/list/model/ListImporter.java
@@ -459,7 +459,7 @@ public class ListImporter
                 return true;
             }
         };
-        return ListManager.get().importListSchema(list, TYPE_NAME_COLUMN, importHelper, user, validatorImporters, errors);
+        return ListManager.get().importListSchema(list, importHelper, user, validatorImporters, errors);
     }
 
     private KeyType getKeyType(TableType listXml, String keyName) throws ImportException

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -1226,11 +1226,13 @@ public class ListManager implements SearchService.DocumentProvider
         return itemRecord;
     }
 
-    boolean importListSchema(ListDefinition unsavedList,
-                             ImportTypesHelper importHelper,
-                             User user,
-                             Collection<ValidatorImporter> validatorImporters,
-                             List<String> errors) throws Exception
+    boolean importListSchema(
+        ListDefinition unsavedList,
+        ImportTypesHelper importHelper,
+        User user,
+        Collection<ValidatorImporter> validatorImporters,
+        List<String> errors
+    ) throws Exception
     {
         if (!errors.isEmpty())
             return false;

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -207,10 +207,9 @@ public class ListManager implements SearchService.DocumentProvider
      */
     String getListTableName(TableInfo ti)
     {
-        if (ti instanceof ListTable)
-            return ((ListTable)ti).getRealTable().getSelectName();
-        else
-            return ti.getSelectName();  // if db is being upgraded from <= 13.1, lists are still SchemaTableInfo instances
+        if (ti instanceof ListTable lti)
+            return lti.getRealTable().getSelectName();
+        return ti.getSelectName();  // if db is being upgraded from <= 13.1, lists are still SchemaTableInfo instances
     }
 
     @Nullable
@@ -798,7 +797,7 @@ public class ListManager implements SearchService.DocumentProvider
         ListDefinition.IndexSetting setting = list.getEntireListIndexSetting();
         String documentId = getDocumentId(list);
 
-        // First check if meta data needs to be indexed: if the setting is enabled and the definition has changed
+        // First check if metadata needs to be indexed: if the setting is enabled and the definition has changed
         boolean needToIndex = (setting.indexMetaData() && hasDefinitionChangedSinceLastIndex(list));
 
         // If that didn't hold true then check for entire list data indexing: if the definition has changed or any item has been modified
@@ -856,7 +855,7 @@ public class ListManager implements SearchService.DocumentProvider
                     public void exec(Results results) throws StopIteratingException
                     {
                         body.append(template.eval(results.getFieldKeyRowMap())).append("\n");
-                        // Short circuit for very large list, #25366
+                        // Issue 25366: Short circuit for very large list
                         if (body.length() > fileSizeLimit)
                         {
                             body.setLength(fileSizeLimit); // indexer also checks size... make sure we're under the limit
@@ -959,7 +958,7 @@ public class ListManager implements SearchService.DocumentProvider
                 LOG.warn(getTemplateErrorMessage(list, "\"each item as a separate document\" title template", error));
         }
 
-        // If you're devious enough to put ${ in your list name then we'll just strip it out, #21794
+        // Issue 21794: If you're devious enough to put ${ in your list name then we'll just strip it out
         String name = list.getName().replaceAll("\\$\\{", "_{");
         template = createValidStringExpression("List " + name + " - ${" + PageFlowUtil.encode(listTable.getTitleColumn()) + "}", error);
 
@@ -994,7 +993,7 @@ public class ListManager implements SearchService.DocumentProvider
             {
                 sb.append(sep);
                 sb.append("${");
-                sb.append(column.getFieldKey().encode());  // Must encode, #21794
+                sb.append(column.getFieldKey().encode());  // Issue 21794: Must encode
                 sb.append("}");
                 sep = " ";
             }
@@ -1009,7 +1008,7 @@ public class ListManager implements SearchService.DocumentProvider
     }
 
 
-    // Perform some simple validation of custom indexing template, #21726.
+    // Issue 21726: Perform some simple validation of custom indexing template
     private @Nullable FieldKeyStringExpression createValidStringExpression(String template, StringBuilder error)
     {
         // Don't URL encode and use lenient substitution (replace nulls with blank)
@@ -1227,7 +1226,11 @@ public class ListManager implements SearchService.DocumentProvider
         return itemRecord;
     }
 
-    boolean importListSchema(ListDefinition unsavedList, String typeColumn, ImportTypesHelper importHelper, User user, Collection<ValidatorImporter> validatorImporters, List<String> errors) throws Exception
+    boolean importListSchema(ListDefinition unsavedList,
+                             ImportTypesHelper importHelper,
+                             User user,
+                             Collection<ValidatorImporter> validatorImporters,
+                             List<String> errors) throws Exception
     {
         if (!errors.isEmpty())
             return false;

--- a/list/src/org/labkey/list/model/ListManagerSchema.java
+++ b/list/src/org/labkey/list/model/ListManagerSchema.java
@@ -181,7 +181,7 @@ public class ListManagerSchema extends UserSchema
                     ActionURL urlExport;
                     ActionButton btnExport;
 
-                    if (s.getContainerFilterName() != null && s.getContainerFilterName().equals("CurrentAndSubfolders"))
+                    if (ContainerFilter.Type.CurrentAndSubfolders.name().equals(s.getContainerFilterName()))
                     {
                         btnExport = new ActionButton("Export List Archive", getReturnURL());
                         btnExport.setRequiresSelection(true, 1, 0, "You cannot export while viewing subFolders", "You cannot export while viewing subFolders", null);
@@ -203,7 +203,7 @@ public class ListManagerSchema extends UserSchema
                 {
                     if (getContainer().hasPermission(getUser(), DesignListPermission.class))
                     {
-                        SimpleDisplayColumn designColumn = new SimpleDisplayColumn()
+                        ret.add(new SimpleDisplayColumn()
                         {
                             @Override
                             public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
@@ -211,15 +211,14 @@ public class ListManagerSchema extends UserSchema
                                 Container c = ContainerManager.getForId(ctx.get(FieldKey.fromParts("container")).toString());
                                 ActionURL designUrl = new ActionURL(ListController.EditListDefinitionAction.class, c);
                                 designUrl.addParameter("listId", ctx.get(FieldKey.fromParts("listId")).toString());
-                                out.write(PageFlowUtil.textLink("Design", designUrl));
+                                out.write(PageFlowUtil.link("Design").href(designUrl).toString());
                             }
-                        };
-                        ret.add(designColumn);
+                        });
                     }
 
                     if (AuditLogService.get().isViewable())
                     {
-                        SimpleDisplayColumn historyColumn = new SimpleDisplayColumn()
+                        ret.add(new SimpleDisplayColumn()
                         {
                             @Override
                             public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
@@ -227,10 +226,9 @@ public class ListManagerSchema extends UserSchema
                                 Container c = ContainerManager.getForId(ctx.get(FieldKey.fromParts("container")).toString());
                                 ActionURL historyUrl = new ActionURL(ListController.HistoryAction.class, c);
                                 historyUrl.addParameter("listId", ctx.get(FieldKey.fromParts("listId")).toString());
-                                out.write(PageFlowUtil.textLink("View History", historyUrl));
+                                out.write(PageFlowUtil.link("View History").href(historyUrl).toString());
                             }
-                        };
-                        ret.add(historyColumn);
+                        });
                     }
                 }
             };
@@ -244,6 +242,7 @@ public class ListManagerSchema extends UserSchema
 
             return qv;
         }
+
         return super.createView(context, settings, errors);
     }
     @Override

--- a/list/src/org/labkey/list/model/ListManagerSchema.java
+++ b/list/src/org/labkey/list/model/ListManagerSchema.java
@@ -179,21 +179,9 @@ public class ListManagerSchema extends UserSchema
 
                 private ActionButton createExportArchiveButton()
                 {
-                    ActionURL urlExport;
-                    ActionButton btnExport;
-
-                    if (ContainerFilter.Type.CurrentAndSubfolders.name().equals(s.getContainerFilterName()))
-                    {
-                        btnExport = new ActionButton("Export List Archive", getReturnURL());
-                        btnExport.setRequiresSelection(true, 1, 0, "You cannot export while viewing subFolders", "You cannot export while viewing subFolders", null);
-                    }
-                    else
-                    {
-                        urlExport = new ActionURL(ListController.ExportListArchiveAction.class, getContainer());
-                        btnExport = new ActionButton(urlExport, "Export List Archive");
-                        btnExport.setRequiresSelection(true);
-                    }
-
+                    ActionURL urlExport = new ActionURL(ListController.ExportListArchiveAction.class, getContainer());
+                    ActionButton btnExport = new ActionButton(urlExport, "Export List Archive");
+                    btnExport.setRequiresSelection(true);
                     btnExport.setActionType(ActionButton.Action.POST);
                     btnExport.setDisplayPermission(DesignListPermission.class);
                     return btnExport;

--- a/list/src/org/labkey/list/model/ListManagerSchema.java
+++ b/list/src/org/labkey/list/model/ListManagerSchema.java
@@ -122,13 +122,14 @@ public class ListManagerSchema extends UserSchema
     }
 
     @Override
+    @NotNull
     public QueryView createView(ViewContext context, @NotNull QuerySettings settings, BindException errors)
     {
         if (LIST_MANAGER.equalsIgnoreCase(settings.getQueryName()))
         {
             QueryView qv = new QueryView(this, settings, errors)
             {
-                QuerySettings s = getSettings();
+                final QuerySettings s = getSettings();
 
                 @Override
                 protected void populateButtonBar(DataView view, ButtonBar bar)

--- a/list/src/org/labkey/list/model/ListManagerTable.java
+++ b/list/src/org/labkey/list/model/ListManagerTable.java
@@ -52,7 +52,10 @@ public class ListManagerTable extends FilteredTable<ListManagerSchema>
         addWrapColumn(_rootTable.getColumn(FieldKey.fromParts("Name")));
         addWrapColumn(_rootTable.getColumn(FieldKey.fromParts("Description")));
 
-        addWrapColumn(_rootTable.getColumn(FieldKey.fromParts("Container")));
+        {
+            var column = addWrapColumn(_rootTable.getColumn(FieldKey.fromParts("Container")));
+            column.setLabel("Folder");
+        }
         addWrapColumn(_rootTable.getColumn(FieldKey.fromParts("Created")));
         addWrapColumn(_rootTable.getColumn(FieldKey.fromParts("CreatedBy")));
         addWrapColumn(_rootTable.getColumn(FieldKey.fromParts("Modified")));

--- a/list/src/org/labkey/list/model/ListManagerTable.java
+++ b/list/src/org/labkey/list/model/ListManagerTable.java
@@ -29,6 +29,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.list.ListDefinition;
 import org.labkey.api.exp.list.ListService;
+import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.security.User;
@@ -49,7 +50,14 @@ public class ListManagerTable extends FilteredTable<ListManagerSchema>
         super(table, userSchema, cf);
 
         addWrapColumn(_rootTable.getColumn(FieldKey.fromParts("ListID")));
-        addWrapColumn(_rootTable.getColumn(FieldKey.fromParts("Name")));
+        {
+            var column = addWrapColumn(_rootTable.getColumn(FieldKey.fromParts("Name")));
+
+            // Lists can contain data that spans multiple folders.
+            // Override the container context for the details URL to always be the current folder.
+            if (column.getURL() instanceof DetailsURL detailsURL)
+                detailsURL.setContainerContext(getContainer());
+        }
         addWrapColumn(_rootTable.getColumn(FieldKey.fromParts("Description")));
 
         {
@@ -177,6 +185,6 @@ public class ListManagerTable extends FilteredTable<ListManagerSchema>
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return _userSchema.getContainer().hasPermission(this.getClass().getName() + " " + getName(), user, perm);
+        return getContainer().hasPermission(this.getClass().getName() + " " + getName(), user, perm);
     }
 }

--- a/list/src/org/labkey/list/model/ListManagerTable.java
+++ b/list/src/org/labkey/list/model/ListManagerTable.java
@@ -158,7 +158,11 @@ public class ListManagerTable extends FilteredTable<ListManagerSchema>
             }
         });
 
-        setDefaultVisibleColumns(Arrays.asList(FieldKey.fromParts("Name"), FieldKey.fromParts("Description"), FieldKey.fromParts("Container")));
+        setDefaultVisibleColumns(Arrays.asList(
+            FieldKey.fromParts("Name"),
+            FieldKey.fromParts("Description"),
+            FieldKey.fromParts("Container")
+        ));
     }
 
     @Override

--- a/list/src/org/labkey/list/model/ListManagerTable.java
+++ b/list/src/org/labkey/list/model/ListManagerTable.java
@@ -53,8 +53,9 @@ public class ListManagerTable extends FilteredTable<ListManagerSchema>
         {
             var column = addWrapColumn(_rootTable.getColumn(FieldKey.fromParts("Name")));
 
-            // Lists can contain data that spans multiple folders.
-            // Override the container context for the details URL to always be the current folder.
+            // This overrides the details URL for the "name" of the list column to always
+            // resolve to the current folder. This is done because lists can contain data that span multiple folders
+            // and we want to default to showing users data in the list for the folder their working in.
             if (column.getURL() instanceof DetailsURL detailsURL)
                 detailsURL.setContainerContext(getContainer());
         }

--- a/list/src/org/labkey/list/model/ListManagerTable.java
+++ b/list/src/org/labkey/list/model/ListManagerTable.java
@@ -59,8 +59,8 @@ public class ListManagerTable extends FilteredTable<ListManagerSchema>
         addWrapColumn(_rootTable.getColumn(FieldKey.fromParts("ModifiedBy")));
         addWrapColumn( _rootTable.getColumn(FieldKey.fromParts("Category")));
         MutableColumnInfo sharingCol = addWrapColumn("Sharing", _rootTable.getColumn(FieldKey.fromParts("Category")));
-        sharingCol.setDisplayColumnFactory(new DisplayColumnFactory() {
-
+        sharingCol.setDisplayColumnFactory(new DisplayColumnFactory()
+        {
             @Override
             public DisplayColumn createRenderer(ColumnInfo colInfo)
             {
@@ -99,8 +99,8 @@ public class ListManagerTable extends FilteredTable<ListManagerSchema>
 
         MutableColumnInfo countCol = addWrapColumn("ItemCount", _rootTable.getColumn(FieldKey.fromParts("ListID")));
         countCol.setHidden(true);
-        countCol.setDisplayColumnFactory(new DisplayColumnFactory() {
-
+        countCol.setDisplayColumnFactory(new DisplayColumnFactory()
+        {
             @Override
             public DisplayColumn createRenderer(ColumnInfo colInfo)
             {
@@ -158,7 +158,7 @@ public class ListManagerTable extends FilteredTable<ListManagerSchema>
             }
         });
 
-        setDefaultVisibleColumns(Arrays.asList(FieldKey.fromParts("Name"), FieldKey.fromParts("Description")));
+        setDefaultVisibleColumns(Arrays.asList(FieldKey.fromParts("Name"), FieldKey.fromParts("Description"), FieldKey.fromParts("Container")));
     }
 
     @Override

--- a/list/src/org/labkey/list/model/ListQuerySchema.java
+++ b/list/src/org/labkey/list/model/ListQuerySchema.java
@@ -124,6 +124,7 @@ public class ListQuerySchema extends UserSchema
     }
 
     @Override
+    @NotNull
     public QueryView createView(ViewContext context, @NotNull QuerySettings settings, BindException errors)
     {
         ListDefinition def = ListService.get().getList(getContainer(), settings.getQueryName(), true);

--- a/list/src/org/labkey/list/view/ListQueryView.java
+++ b/list/src/org/labkey/list/view/ListQueryView.java
@@ -18,6 +18,7 @@ package org.labkey.list.view;
 
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.exp.list.ListDefinition;
 import org.labkey.api.lists.permissions.DesignListPermission;
 import org.labkey.api.query.QuerySettings;
@@ -50,6 +51,12 @@ public class ListQueryView extends QueryView
     {
         setShowExportButtons(_list.getAllowExport());
         setShowUpdateColumn(true);
+        setAllowableContainerFilterTypes(
+            ContainerFilter.Type.Current,
+            ContainerFilter.Type.CurrentAndSubfoldersPlusShared,
+            ContainerFilter.Type.CurrentPlusProjectAndShared,
+            ContainerFilter.Type.AllFolders
+        );
     }
 
     @Override
@@ -73,7 +80,6 @@ public class ListQueryView extends QueryView
         }
         if (canDelete())
             bar.add(super.createDeleteAllRowsButton("list"));
-
     }
 
     public ListDefinition getList()

--- a/list/src/org/labkey/list/view/ListsWebPart.java
+++ b/list/src/org/labkey/list/view/ListsWebPart.java
@@ -99,6 +99,6 @@ public class ListsWebPart extends WebPartView<ViewContext>
         }
         out.write("</table>");
         if (model.getContainer().hasPermission(model.getUser(), DesignListPermission.class))
-            out.write(PageFlowUtil.textLink("manage lists", ListController.getBeginURL(model.getContainer())));
+            out.write(PageFlowUtil.link("manage lists").href(PageFlowUtil.urlProvider(ListUrls.class).getManageListsURL(model.getContainer())).toString());
     }
 }


### PR DESCRIPTION
#### Rationale
With #3001 (and all subsequent related PRs) we introduced support for cross-folder data in Lists. This was done out of necessity to support cross-folder data in LKB where Lists are utilized as the backing structure in a number of areas. As such, it works for query purposes (CRUD operations), but did not cover updates the LKS user experience to support cross-folder list data. This PR makes several notable updates to improve the experience.

#### Related Pull Requests
* #3001

#### Changes
* Prevent list name duplication within the scope of a list. Mimics behavior already in place for Sample Types (which also can have data which spans multiple folders).
* Default the `list-begin.view` to using the `CurrentPlusProjectAndShared` container filter.
* Relabel the `Container` column as `Folder` for the list management table.
* Add the `Folder` field to the default set of fields for the list management table.
* Resolve to the current folder for the details URL for the `Name` column on the list management table. Formerly, this resolved to the folder where the list was defined.
* Update the set of available container filters for lists to reflect those that best fit how data can be stored in lists.
* Support the product project container filter paradigm for lookups in query insert/update views. This means lookups (a.k.a. dropdowns) in those views will now include data from other folders. This behavior is consistent with what we do in our applications. Additionally, this is only enabled when the user is working from within a "Product Projects" enabled folder.
