### PR TITLE
EHR Sample Manager: All sample types metadata overlay

### DIFF
--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -56,6 +56,7 @@ import java.util.Set;
 public class SamplesSchema extends AbstractExpSchema
 {
     public static final String SCHEMA_NAME = "samples";
+    // AllSampleTypes.query.xml metadata file is applied to all Sample Types in a container
     public static final String SCHEMA_METADATA_NAME = "AllSampleTypes";
     public static final SchemaKey SCHEMA_SAMPLES = SchemaKey.fromParts(SamplesSchema.SCHEMA_NAME);
     public static final String SCHEMA_DESCR = "Contains data about the samples used in experiment runs.";

--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -56,6 +56,7 @@ import java.util.Set;
 public class SamplesSchema extends AbstractExpSchema
 {
     public static final String SCHEMA_NAME = "samples";
+    public static final String SCHEMA_METADATA_NAME = "AllSampleTypes";
     public static final SchemaKey SCHEMA_SAMPLES = SchemaKey.fromParts(SamplesSchema.SCHEMA_NAME);
     public static final String SCHEMA_DESCR = "Contains data about the samples used in experiment runs.";
     static final Logger log = LogManager.getLogger(SamplesSchema.class);


### PR DESCRIPTION
#### Rationale
Similar to studyData.query.xml, add the ability to apply metadata to all sample types in a container. For EHR Sample Manager module, this is applying a java customizer to all sample types.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/422

#### Changes
* Add AllSampleTypes metadata overlay for sample types
