### PR TITLE
Issue 46238: Custom Menu webpart should not pull through the reportId param on the current page URL

### DIFF
--- a/core/src/org/labkey/core/admin/MenuViewFactory.java
+++ b/core/src/org/labkey/core/admin/MenuViewFactory.java
@@ -79,6 +79,7 @@ public class MenuViewFactory
             //current URL and query string
             settings.setAllowChooseView(false);
             settings.setAllowCustomizeView(false);
+            settings.setReportId(null); // Issue 46238
 
             settings.setShowRows(ShowRows.PAGINATED);
             settings.setMaxRows(100);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46238

#### Changes
* MenuViewFactory.createMenuQueryView() to null out settings reportId
