### PR TITLE
Issue 46493: LKSM Sample Finder saved searches call gives NPE if study module not present

### DIFF
--- a/pipeline/src/org/labkey/pipeline/startPipelineImport.jsp
+++ b/pipeline/src/org/labkey/pipeline/startPipelineImport.jsp
@@ -42,19 +42,20 @@
     Container project = c.getProject();
     boolean isProjectAdmin = project != null && project.hasPermission(getUser(), AdminPermission.class);
     String importFormId = "pipelineImportForm";
+    StudyService studyService = StudyService.get();
 
     boolean canCreateSharedDatasets = false;
     if (!c.isProject() && null != project && project != c)
     {
         if (project.hasPermission(getViewContext().getUser(), AdminPermission.class))
         {
-            Study studyProject = StudyService.get().getStudy(project);
+            Study studyProject = studyService != null ? studyService.getStudy(project) : null;
             if (null != studyProject && studyProject.getShareDatasetDefinitions())
                 canCreateSharedDatasets = true;
         }
     }
 
-    Study study = StudyService.get().getStudy(getContainer());
+    Study study = studyService != null ? studyService.getStudy(getContainer()) : null;
     TimepointType timepointType = study != null ? study.getTimepointType() : null;
 %>
 

--- a/query/src/org/labkey/query/reports/ReportViewProvider.java
+++ b/query/src/org/labkey/query/reports/ReportViewProvider.java
@@ -219,8 +219,12 @@ public class ReportViewProvider implements DataViewProvider
                 ActionURL reportPermUrl = null;
                 if (c.hasPermission(user, AdminPermission.class))
                 {
-                    reportPermUrl = PageFlowUtil.urlProvider(StudyUrls.class).getManageReportPermissions(c).
-                        addParameter(ReportDescriptor.Prop.reportId, r.getDescriptor().getReportId().toString());
+                    StudyUrls urls = PageFlowUtil.urlProvider(StudyUrls.class);
+                    if (urls != null)
+                    {
+                        reportPermUrl = urls.getManageReportPermissions(c)
+                            .addParameter(ReportDescriptor.Prop.reportId, r.getDescriptor().getReportId().toString());
+                    }
 
                     URLHelper returnUrl = context.getActionURL().getReturnURL();
                     if (returnUrl != null)


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46493

Also, similar issue found with the start pipeline import page for the advanced import settings page. It was hitting an NPE when the study module isn't present because it was not null checking for the StudyService

#### Changes
* startPipelineImport.jsp null check for StudyService.get()
* ReportViewProvider null check for PageFlowUtil.urlProvider(StudyUrls.class)
