### PR TITLE
Lists: reintegrate delete confirmation page

### DIFF
--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -299,9 +299,6 @@ public class ListController extends SpringActionController
     @RequiresAnyOf({DesignListPermission.class, ManagePicklistsPermission.class})
     public static class DeleteListDefinitionAction extends ConfirmAction<ListDeletionForm>
     {
-        private final List<Integer> _listIDs = new ArrayList<>();
-        private final List<Container> _containers = new ArrayList<>();
-
         private boolean canDelete(Container listContainer, int listId)
         {
             ListDef listDef = ListManager.get().getList(listContainer, listId);
@@ -321,9 +318,30 @@ public class ListController extends SpringActionController
         }
 
         @Override
+        public String getConfirmText()
+        {
+            return "Confirm Delete";
+        }
+
+        @Override
         public void validateCommand(ListDeletionForm form, Errors errors)
         {
-            if (form.getListId() == null)
+            if (form.getListId() != null)
+            {
+                if (canDelete(getContainer(), form.getListId()))
+                    form.getListContainerMap().add(Pair.of(form.getListId(), getContainer()));
+                else
+                    errors.reject(ERROR_MSG, String.format("You do not have permission to delete list %s in container %s", form.getListId(), getContainer().getName()));
+            }
+            else if (form.getName() != null)
+            {
+                var list = form.getList();
+                if (canDelete(list.getContainer(), list.getListId()))
+                    form.getListContainerMap().add(Pair.of(list.getListId(), getContainer()));
+                else
+                    errors.reject(ERROR_MSG, String.format("You do not have permission to delete list %s in container %s", list.getListId(), getContainer().getName()));
+            }
+            else
             {
                 List<String> errorMessages = new ArrayList<>();
                 Collection<String> listIDs;
@@ -338,10 +356,7 @@ public class ListController extends SpringActionController
                     var listContainer = pair.second;
 
                     if (canDelete(listContainer, listId))
-                    {
-                        _listIDs.add(listId);
-                        _containers.add(listContainer);
-                    }
+                        form.getListContainerMap().add(pair);
                     else
                         errorMessages.add(String.format("You do not have permission to delete list %s in container %s", listId, listContainer.getName()));
                 }
@@ -349,33 +364,25 @@ public class ListController extends SpringActionController
                 if (!errorMessages.isEmpty())
                     errors.reject(ERROR_MSG,  StringUtils.join(errorMessages, "\n"));
             }
-            else
-            {
-                //Accessed from the edit list page, where selection is not possible
-                if (canDelete(getContainer(), form.getListId()))
-                {
-                    _listIDs.add(form.getListId());
-                    _containers.add(getContainer());
-                }
-                else
-                    errors.reject(ERROR_MSG, String.format("You do not have permission to delete list %s in container %s", form.getListId(), getContainer().getName()));
-            }
+
+            if (form.getListContainerMap().isEmpty())
+                errors.reject(ERROR_MSG, "You must specify a list or lists to delete.");
         }
 
         @Override
         public ModelAndView getConfirmView(ListDeletionForm form, BindException errors)
         {
             if (getPageConfig().getTitle() == null)
-                setTitle("Delete List");
+                setTitle("Confirm Deletion");
             return new JspView<>("/org/labkey/list/view/deleteListDefinition.jsp", form, errors);
         }
 
         @Override
         public boolean handlePost(ListDeletionForm form, BindException errors)
         {
-            for(int i = 0; i < _listIDs.size(); i++)
+            for (Pair<Integer, Container> pair : form.getListContainerMap())
             {
-                ListDefinition listDefinition = ListService.get().getList(_containers.get(i), _listIDs.get(i));
+                ListDefinition listDefinition = ListService.get().getList(pair.second, pair.first);
                 if (null != listDefinition)
                 {
                     try
@@ -388,6 +395,7 @@ public class ListController extends SpringActionController
                     }
                 }
             }
+
             return !errors.hasErrors();
         }
 
@@ -401,6 +409,7 @@ public class ListController extends SpringActionController
     public static class ListDeletionForm extends ListDefinitionForm
     {
         private List<String> _listIds;
+        private final List<Pair<Integer, Container>> _listContainerMap = new ArrayList<>();
 
         public List<String> getListIds()
         {
@@ -410,6 +419,11 @@ public class ListController extends SpringActionController
         public void setListIds(List<String> listIds)
         {
             _listIds = listIds;
+        }
+
+        public List<Pair<Integer, Container>> getListContainerMap()
+        {
+            return _listContainerMap;
         }
     }
 

--- a/list/src/org/labkey/list/model/ListManagerSchema.java
+++ b/list/src/org/labkey/list/model/ListManagerSchema.java
@@ -170,10 +170,9 @@ public class ListManagerSchema extends UserSchema
                     urlDelete.addReturnURL(getReturnURL());
                     ActionButton btnDelete = new ActionButton(urlDelete, "Delete");
                     btnDelete.setIconCls("trash");
-                    btnDelete.setActionType(ActionButton.Action.POST);
-                    btnDelete.isLocked();
+                    btnDelete.setActionType(ActionButton.Action.GET);
                     btnDelete.setDisplayPermission(DesignListPermission.class);
-                    btnDelete.setRequiresSelection(true, "Are you sure you want to delete the selected row?", "Are you sure you want to delete the selected rows?");
+                    btnDelete.setRequiresSelection(true);
                     return btnDelete;
                 }
 

--- a/list/src/org/labkey/list/view/ListDefinitionForm.java
+++ b/list/src/org/labkey/list/view/ListDefinitionForm.java
@@ -16,6 +16,7 @@
 
 package org.labkey.list.view;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.action.ReturnUrlForm;
 import org.labkey.api.exp.list.ListDefinition;
 import org.labkey.api.exp.list.ListService;
@@ -32,6 +33,7 @@ public class ListDefinitionForm extends ViewForm
     private String _name = null;
     private QueryUpdateService.InsertOption _insertOption = QueryUpdateService.InsertOption.IMPORT;
 
+    @NotNull
     public ListDefinition getList()
     {
         if (null == _listDef)


### PR DESCRIPTION
#### Rationale
This reintegrates the list delete confirmation page. This page has been updated to support confirmation of deletion of multiple lists that can be defined across multiple folders.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3762
* https://github.com/LabKey/testAutomation/pull/1265

#### Changes
* Update confirmation view to accommodate reviewing lists to be deleted across multiple folders.
* Update `list-deleteListDefinition.view` to handle specify lists by name, listId, or listIds.
* Adjust list management "delete" button to route to confirmation.
