### PR TITLE
Remove obsolete 'Docker' report engines

### DIFF
--- a/api/src/org/labkey/api/reports/ExternalScriptEngineDefinition.java
+++ b/api/src/org/labkey/api/reports/ExternalScriptEngineDefinition.java
@@ -30,9 +30,6 @@ public interface ExternalScriptEngineDefinition
         Perl,
         External,
         Jupyter,
-
-        // Docker is no longer implemented/supported, but we don't want to blow up for existing saved configs
-        Docker
     }
 
     Integer getRowId();

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 22.005
+SchemaVersion: 22.006
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/core-22.005-22.006.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-22.005-22.006.sql
@@ -1,0 +1,1 @@
+DELETE FROM core.ReportEngines WHERE type = 'Docker';

--- a/core/resources/schemas/dbscripts/sqlserver/core-22.005-22.006.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-22.005-22.006.sql
@@ -1,0 +1,1 @@
+DELETE FROM core.ReportEngines WHERE type = 'Docker';

--- a/core/src/org/labkey/core/reports/ScriptEngineManagerImpl.java
+++ b/core/src/org/labkey/core/reports/ScriptEngineManagerImpl.java
@@ -290,12 +290,18 @@ public class ScriptEngineManagerImpl extends ScriptEngineManager implements LabK
                         return new RserveScriptEngineFactory(def).getScriptEngine();
                     else
                     {
-                        LOG.error(String.format("Remote R engine [%1$s] requested, but premium module not available/enabled.", def.getName()));
-                        throw new RemoteRNotEnabledException(def);
+                        RemoteRNotEnabledException ex = new RemoteRNotEnabledException(def);
+                        LOG.error(ex.getMessage());
+                        throw ex;
                     }
                 }
                 else
                     return new RScriptEngineFactory(def).getScriptEngine();
+            }
+            else if (def.getType().equals(ExternalScriptEngineDefinition.Type.Jupyter) && !PremiumService.get().isEnabled())
+            {
+                LOG.error(String.format("Jupyter Report engine [%1$s] requested, but premium module not available/enabled.", def.getName()));
+                throw new PremiumFeatureNotEnabledException("Jupyter Reports are not available. Please talk to your account representative for additional information.");
             }
             else
                 return new ExternalScriptEngineFactory(def).getScriptEngine();


### PR DESCRIPTION
#### Rationale
Old "Docker" script engines show up when calling `LabKeyScriptEngineManager.getEngineByExtension`, interfering with the operation of newly created "Jupyter" script engines.

#### Related Pull Requests
* #3750 

#### Changes
* Add upgrade script to remove "Docker" report engines
* Throw an exception if attempting to run a Jupyter report without premium
