### PR TITLE
Issue 46037: Don't surface samples without types in applications or search index

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -378,8 +378,9 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
 
     public void index(SearchService.IndexTask task)
     {
-        // Big hack to prevent study specimens from being indexed as
-        if (StudyService.SPECIMEN_NAMESPACE_PREFIX.equals(getLSIDNamespacePrefix()))
+        // Big hack to prevent study specimens and bogus samples created from some plate assays (Issue 46037)
+        // from being indexed as samples
+        if (StudyService.SPECIMEN_NAMESPACE_PREFIX.equals(getLSIDNamespacePrefix()) || "Material".equals(getCpasType()))
         {
             return;
         }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -765,9 +765,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
     public List<ExpMaterialImpl> getIndexableMaterials(Container container, @Nullable Date modifiedSince)
     {
-        // Big hack to prevent indexing study specimens. Also in ExpMaterialImpl.index()
+        // Big hack to prevent indexing study specimens and bogus samples created from some plate assays (Issue 46037). Also in ExpMaterialImpl.index()
         SQLFragment sql = new SQLFragment("SELECT * FROM " + getTinfoMaterial() + " _m_  WHERE Container = ? AND LSID NOT LIKE '%:"
-                + StudyService.SPECIMEN_NAMESPACE_PREFIX + "%'");
+                + StudyService.SPECIMEN_NAMESPACE_PREFIX + "%' AND cpastype != 'Material'");
         sql.add(container.getId());
         SQLFragment modifiedSQL = new SearchService.LastIndexedClause(getTinfoMaterial(), modifiedSince, "_m_").toSQLFragment(null, null);
         if (!modifiedSQL.isEmpty())


### PR DESCRIPTION
#### Rationale
Some of our plate-based assays (e.g., Nab) introduce samples when data are imported in order to store some metadata. These samples have a bogus sample type of "Material" stored as the cpastype in the exp.material table. These are not samples we want indexed for searching or able to be used within the application when adding samples to jobs or recording assay results, so we introduce a (hacky) filter to exclude these from our dropdowns and from the indexer.

#### Related Pull Requests

- https://github.com/LabKey/labkey-ui-components/pull/985
- https://github.com/LabKey/sampleManagement/pull/1299
- https://github.com/LabKey/biologics/pull/1662

#### Changes
* Add hack to filter out samples with bogus "Material" sample type from search indexing.
