### PR TITLE
Move NR Project Manager custom role into the NIHS module

### DIFF
--- a/query/src/org/labkey/query/EditQueriesPermission.java
+++ b/query/src/org/labkey/query/EditQueriesPermission.java
@@ -19,7 +19,7 @@ import org.labkey.api.security.permissions.AbstractPermission;
 
 public class EditQueriesPermission extends AbstractPermission
 {
-    protected EditQueriesPermission()
+    public EditQueriesPermission()
     {
         super("Edit Queries", "My create, edit, and delete queries");
     }


### PR DESCRIPTION
#### Rationale
The `EditQueriesPermission` has a protected constructor which made it difficult for custom security roles which needed to include this permission from being registered.

#### Related Pull Requests
- https://github.com/LabKey/nihs/pull/36