### PR TITLE
Less cryptic error message for unresolved sample Ids during assay import

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -989,7 +989,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                         Object remapped = cache.remap(lookupTable, (String)o, true);
                         if (remapped == null)
                         {
-                            if (pd.getConceptURI().equals(SAMPLE_CONCEPT_URI))
+                            if (pd.getConceptURI() != null && SAMPLE_CONCEPT_URI.equals(pd.getConceptURI()))
                                 errors.add(new PropertyValidationError(  o + " not found in the current context.", pd.getName()));
                             else
                                 errors.add(new PropertyValidationError("Failed to convert '" + pd.getName() + "': Could not translate value: " + o, pd.getName()));

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -93,6 +93,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toList;
+import static org.labkey.api.gwt.client.ui.PropertyType.SAMPLE_CONCEPT_URI;
 
 /**
  * User: jeckels
@@ -988,7 +989,10 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                         Object remapped = cache.remap(lookupTable, (String)o, true);
                         if (remapped == null)
                         {
-                            errors.add(new PropertyValidationError("Failed to convert '" + pd.getName() + "': Could not translate value: " + o, pd.getName()));
+                            if (pd.getConceptURI().equals(SAMPLE_CONCEPT_URI))
+                                errors.add(new PropertyValidationError(  o + " not found in the current context.", pd.getName()));
+                            else
+                                errors.add(new PropertyValidationError("Failed to convert '" + pd.getName() + "': Could not translate value: " + o, pd.getName()));
                         }
                         else if (o != remapped)
                         {

--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -480,7 +480,7 @@ public abstract class AssayProtocolSchema extends AssaySchema implements UserSch
         }
     }
 
-    private void addPropertyColumn(ExpTable table, Domain domain, String columnName, ContainerFilter containerFilter)
+    private void addPropertyColumn(ExpTable table, Domain domain, String columnName, @Nullable ContainerFilter containerFilter)
     {
         var propsCol = table.addColumns(domain, columnName, containerFilter);
         if (propsCol != null)

--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -367,7 +367,7 @@ public abstract class AssayProtocolSchema extends AssaySchema implements UserSch
         Domain batchDomain = provider.getBatchDomain(protocol);
         if (batchDomain != null)
         {
-            addPropertyColumn(result, batchDomain, BATCH_PROPERTIES_COLUMN_NAME);
+            addPropertyColumn(result, batchDomain, BATCH_PROPERTIES_COLUMN_NAME, containerFilter);
             result.setDomain(batchDomain);
         }
 
@@ -417,7 +417,7 @@ public abstract class AssayProtocolSchema extends AssaySchema implements UserSch
         Domain runDomain = getProvider().getRunDomain(getProtocol());
         if (runDomain != null)
         {
-            addPropertyColumn(runTable, runDomain, RUN_PROPERTIES_COLUMN_NAME);
+            addPropertyColumn(runTable, runDomain, RUN_PROPERTIES_COLUMN_NAME, cf);
             runTable.setDomain(runDomain);
         }
 
@@ -480,9 +480,9 @@ public abstract class AssayProtocolSchema extends AssaySchema implements UserSch
         }
     }
 
-    private void addPropertyColumn(ExpTable table, Domain domain, String columnName)
+    private void addPropertyColumn(ExpTable table, Domain domain, String columnName, ContainerFilter containerFilter)
     {
-        var propsCol = table.addColumns(domain, columnName);
+        var propsCol = table.addColumns(domain, columnName, containerFilter);
         if (propsCol != null)
         {
             // Will be null if the domain doesn't have any properties

--- a/api/src/org/labkey/api/exp/PropertyColumn.java
+++ b/api/src/org/labkey/api/exp/PropertyColumn.java
@@ -63,9 +63,10 @@ public class PropertyColumn extends LookupColumn
     /**
      * @param container container in which the query is going to be executed. Used optionally as a join condition, and
      * to construct the appropriate TableInfo for lookups.
-     * @param joinOnContainer when creating the join as a LookupColumn, whether or not to also match based on container
+     * @param joinOnContainer when creating the join as a LookupColumn, whether to also match based on container
+     * @param containerFilter container filter to use for property column data
      */
-    public PropertyColumn(@NotNull final PropertyDescriptor pd, @NotNull final ColumnInfo lsidColumn, final Container container, User user, boolean joinOnContainer, ContainerFilter containerFilter)
+    public PropertyColumn(@NotNull final PropertyDescriptor pd, @NotNull final ColumnInfo lsidColumn, final Container container, User user, boolean joinOnContainer, @Nullable ContainerFilter containerFilter)
     {
         super(lsidColumn, OntologyManager.getTinfoObject().getColumn("ObjectURI"), OntologyManager.getTinfoObjectProperty().getColumn(getPropertyCol(pd)));
         _joinOnContainer = joinOnContainer;
@@ -95,7 +96,7 @@ public class PropertyColumn extends LookupColumn
         copyAttributes(user, to, dp, container, lsidColumnFieldKey, null);
     }
 
-    public static void copyAttributes(User user, MutableColumnInfo to, PropertyDescriptor pd, Container container, FieldKey lsidColumnFieldKey, ContainerFilter containerFilter)
+    public static void copyAttributes(User user, MutableColumnInfo to, PropertyDescriptor pd, Container container, FieldKey lsidColumnFieldKey, @Nullable ContainerFilter containerFilter)
     {
         copyAttributes(user, to, pd, container, null, null, null, lsidColumnFieldKey, containerFilter);
     }

--- a/api/src/org/labkey/api/exp/PropertyColumn.java
+++ b/api/src/org/labkey/api/exp/PropertyColumn.java
@@ -63,9 +63,9 @@ public class PropertyColumn extends LookupColumn
     /**
      * @param container container in which the query is going to be executed. Used optionally as a join condition, and
      * to construct the appropriate TableInfo for lookups.
-     * @param joinOnContainer when creating the join as a LookupColumn, whether or not to also match based on container 
+     * @param joinOnContainer when creating the join as a LookupColumn, whether or not to also match based on container
      */
-    public PropertyColumn(@NotNull final PropertyDescriptor pd, @NotNull final ColumnInfo lsidColumn, final Container container, User user, boolean joinOnContainer)
+    public PropertyColumn(@NotNull final PropertyDescriptor pd, @NotNull final ColumnInfo lsidColumn, final Container container, User user, boolean joinOnContainer, ContainerFilter containerFilter)
     {
         super(lsidColumn, OntologyManager.getTinfoObject().getColumn("ObjectURI"), OntologyManager.getTinfoObjectProperty().getColumn(getPropertyCol(pd)));
         _joinOnContainer = joinOnContainer;
@@ -74,8 +74,18 @@ public class PropertyColumn extends LookupColumn
 
         _pd = pd;
         _container = container;
-        
-        copyAttributes(user, this, pd, _container, lsidColumn.getFieldKey());
+
+        copyAttributes(user, this, pd, _container, lsidColumn.getFieldKey(), containerFilter);
+    }
+
+    /**
+     * @param container container in which the query is going to be executed. Used optionally as a join condition, and
+     * to construct the appropriate TableInfo for lookups.
+     * @param joinOnContainer when creating the join as a LookupColumn, whether to also match based on container
+     */
+    public PropertyColumn(@NotNull final PropertyDescriptor pd, @NotNull final ColumnInfo lsidColumn, final Container container, User user, boolean joinOnContainer)
+    {
+        this(pd, lsidColumn, container, user, joinOnContainer, null);
     }
 
     // We must have a DomainProperty in order to retrieve the default values. TODO: Transition more callers to pass in DomainProperty
@@ -83,6 +93,11 @@ public class PropertyColumn extends LookupColumn
     public static void copyAttributes(User user, MutableColumnInfo to, DomainProperty dp, Container container, @Nullable FieldKey lsidColumnFieldKey)
     {
         copyAttributes(user, to, dp, container, lsidColumnFieldKey, null);
+    }
+
+    public static void copyAttributes(User user, MutableColumnInfo to, PropertyDescriptor pd, Container container, FieldKey lsidColumnFieldKey, ContainerFilter containerFilter)
+    {
+        copyAttributes(user, to, pd, container, null, null, null, lsidColumnFieldKey, containerFilter);
     }
 
     public static void copyAttributes(

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -296,6 +296,9 @@ public interface ExperimentService extends ExperimentRunTypeSource
     @Nullable
     ExpMaterial getExpMaterial(int rowid);
 
+    @Nullable
+    ExpMaterial getExpMaterial(int rowid, ContainerFilter containerFilter);
+
     /**
      * Get material by rowId in this, project, or shared container and within the provided sample type.
      *

--- a/api/src/org/labkey/api/exp/query/ExpTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpTable.java
@@ -87,7 +87,7 @@ public interface ExpTable<C extends Enum> extends ContainerFilterable, TableInfo
         return addColumns(domain, legacyName, null);
     }
 
-    MutableColumnInfo addColumns(Domain domain, @Nullable String legacyName, ContainerFilter cf);
+    MutableColumnInfo addColumns(Domain domain, @Nullable String legacyName,@Nullable ContainerFilter cf);
 
 
     void setTitle(String title);

--- a/api/src/org/labkey/api/exp/query/ExpTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpTable.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerFilterable;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.SQLFragment;
@@ -81,7 +82,13 @@ public interface ExpTable<C extends Enum> extends ContainerFilterable, TableInfo
      * @param legacyName if non-null, the name of a hidden node to be added as a FK for backwards compatibility
      * @return if a legacyName is specified, the ColumnInfo for the hidden node. Otherwise, null
      */
-    MutableColumnInfo addColumns(Domain domain, @Nullable String legacyName);
+    default MutableColumnInfo addColumns(Domain domain, @Nullable String legacyName)
+    {
+        return addColumns(domain, legacyName, null);
+    }
+
+    MutableColumnInfo addColumns(Domain domain, @Nullable String legacyName, ContainerFilter cf);
+
 
     void setTitle(String title);
 

--- a/api/src/org/labkey/api/module/SimpleAction.java
+++ b/api/src/org/labkey/api/module/SimpleAction.java
@@ -99,7 +99,7 @@ public class SimpleAction extends BaseViewAction implements NavTrailAction
         getPageConfig().setIncludePostParameters(true);
 
         //override page template if view requests
-        if (null != _view.getPageTemplate())
+        if (_view != null && null != _view.getPageTemplate())
             getPageConfig().setTemplate(_view.getPageTemplate());
 
         return _view;

--- a/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
@@ -291,11 +291,12 @@ abstract public class ExpTableImpl<C extends Enum>
 
     /**
      * Add columns directly to the table itself, and optionally also as a single column that is a FK to the full set of properties
-     * @param domain the domain from which to add all of the properties
+     * @param domain the domain from which to add all the properties
      * @param legacyName if non-null, the name of a hidden node to be added as a FK for backwards compatibility
+     * @param containerFilter Container filter to be applied to property fields
      */
     @Override
-    public MutableColumnInfo addColumns(Domain domain, @Nullable String legacyName)
+    public MutableColumnInfo addColumns(Domain domain, @Nullable String legacyName, @Nullable ContainerFilter containerFilter)
     {
         MutableColumnInfo colProperty = null;
         if (legacyName != null && !domain.getProperties().isEmpty())
@@ -309,7 +310,7 @@ abstract public class ExpTableImpl<C extends Enum>
         for (DomainProperty dp : domain.getProperties())
         {
             PropertyDescriptor pd = dp.getPropertyDescriptor();
-            PropertyColumn propColumn = new PropertyColumn(pd, getColumn("LSID"), getContainer(), _userSchema.getUser(), false);
+            PropertyColumn propColumn = new PropertyColumn(pd, getColumn("LSID"), getContainer(), _userSchema.getUser(), false, containerFilter);
             if (getColumn(propColumn.getName()) == null)
             {
                 addColumn(propColumn);

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -657,6 +657,16 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
     @Override
     @Nullable
+    public ExpMaterialImpl getExpMaterial(int rowid, ContainerFilter containerFilter)
+    {
+        SimpleFilter filter = new SimpleFilter();
+        filter.addClause(containerFilter.createFilterClause(getExpSchema(), FieldKey.fromParts("Container")));
+        Material material = new TableSelector(getTinfoMaterial(), filter, null).getObject(rowid, Material.class);
+        return material == null ? null : new ExpMaterialImpl(material);
+    }
+
+    @Override
+    @Nullable
     public ExpMaterialImpl getExpMaterial(Container c, User u, int rowId, @Nullable ExpSampleType sampleType)
     {
         List<ExpMaterialImpl> materials = getExpMaterials(c, u, List.of(rowId), sampleType);

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -659,8 +659,12 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Nullable
     public ExpMaterialImpl getExpMaterial(int rowid, ContainerFilter containerFilter)
     {
-        SimpleFilter filter = new SimpleFilter();
-        filter.addClause(containerFilter.createFilterClause(getExpSchema(), FieldKey.fromParts("Container")));
+        SimpleFilter filter = null;
+        if (containerFilter != null)
+        {
+            filter = new SimpleFilter();
+            filter.addClause(containerFilter.createFilterClause(getExpSchema(), FieldKey.fromParts("Container")));
+        }
         Material material = new TableSelector(getTinfoMaterial(), filter, null).getObject(rowid, Material.class);
         return material == null ? null : new ExpMaterialImpl(material);
     }


### PR DESCRIPTION
#### Rationale
When we do not find a sample ID during assay import, the error message can be a little less tech-like than the generic "Failed to convert" message. We could possibly use the less tech-y version of the message for other data as well, but being uncertain about the range of "failures to convert", I was aiming to keep this change small

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/1304
* https://github.com/LabKey/labkey-ui-components/pull/988
* https://github.com/LabKey/biologics/pull/1667

#### Changes
* Update the error messaging when failed to find sample ID.