### PR TITLE
Issue 46094: RangeValidator to handle "~date" based filter types (i.e. ~dateeq, ~dategt, etc.)

### DIFF
--- a/experiment/src/org/labkey/experiment/api/property/RangeValidator.java
+++ b/experiment/src/org/labkey/experiment/api/property/RangeValidator.java
@@ -125,7 +125,12 @@ public class RangeValidator extends DefaultPropertyValidator implements Validato
             Date dateConstraint = new Date(DateUtil.parseDateTime(constraint.getValue()));
             int comparison = ((Date) value).compareTo(dateConstraint);
 
-            return comparisonValid(comparison, constraint.getKey());
+            // Issue 46094: handle "~date" based filter types (i.e. ~dateeq, ~dategt, etc.)
+            String type = constraint.getKey();
+            if (type != null && type.startsWith("~date"))
+                type = type.replace("~date", "~");
+
+            return comparisonValid(comparison, type);
         }
         return false;
     }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46094

#### Changes
* RangeValidator update to isValid() so that in the Date case it handles filter types like ~dateeq and ~eq
