### PR TITLE
Handle NumberFormatException when parsing list IDs

### DIFF
--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -1098,8 +1098,15 @@ public class ListController extends SpringActionController
                 continue;
             }
 
-            int listId = Integer.parseInt(parts[0]);
-            pairs.add(Pair.of(listId, c));
+            try
+            {
+                int listId = Integer.parseInt(parts[0]);
+                pairs.add(Pair.of(listId, c));
+            }
+            catch (NumberFormatException badListId)
+            {
+                errors.add(String.format("Invalid listId: %s", s));
+            }
         }
 
         return pairs;


### PR DESCRIPTION
#### Rationale
Crawler triggered a 'NumberFormatException'.
```
java.lang.NumberFormatException: For input string: "-->">'>'"</script><img src="xss" onerror="alert('8(')">"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:67) ~[?:?]
	at java.lang.Integer.parseInt(Integer.java:668) ~[?:?]
	at java.lang.Integer.parseInt(Integer.java:786) ~[?:?]
	at org.labkey.list.controllers.ListController.getListIdContainerPairs(ListController.java:1101) ~[list-22.11-SNAPSHOT.jar:?]
	at org.labkey.list.controllers.ListController$DeleteListDefinitionAction.validateCommand(ListController.java:353) ~[list-22.11-SNAPSHOT.jar:?]
	at org.labkey.list.controllers.ListController$DeleteListDefinitionAction.validateCommand(ListController.java:299) ~[list-22.11-SNAPSHOT.jar:?]
	at org.labkey.api.action.ConfirmAction.validate(ConfirmAction.java:134) ~[api-22.11-SNAPSHOT.jar:?]
```

#### Related Pull Requests
* #3752 

#### Changes
* Handle NumberFormatException when parsing list IDs
