### PR TITLE
Fix several problems with "view raw metadata" page

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10001,7 +10001,7 @@ public class AdminController extends SpringActionController
         public Object execute(Object o, BindException errors)
         {
             if (!getContainer().isRoot())
-                throw new NotFoundException();
+                throw new NotFoundException("Must be invoked in the root");
 
             // requires site-admin, unless there are no users
             if (!UserManager.hasNoRealUsers() && !getContainer().hasPermission(getUser(), AdminOperationsPermission.class))

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -705,7 +705,7 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
             SQLFragment allSql = new SQLFragment("SELECT Type, COUNT(*) AS Count FROM (\n");
             allSql.append(SQLFragment.join(selectStatements, "UNION\n"));
             allSql.append(") u\nGROUP BY Type\nORDER BY Type");
-            String link = currentUrl.clone().deleteParameters().addParameter("type", null).getLocalURIString();
+            ActionURL linkUrl = currentUrl.clone().deleteParameters().addParameter("type", null);
 
             // The second query shows all attachments that we can't associate with a type. We just need to assemble a big
             // WHERE NOT clause that ORs the conditions from every registered type.
@@ -773,7 +773,7 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
             }
             unknownView.setNavMenu(navMenu);
 
-            return new VBox(getResultSetView(allSql, "Attachment Types and Counts", link), unknownView);
+            return new VBox(getResultSetView(allSql, "Attachment Types and Counts", linkUrl), unknownView);
         }
         else
         {
@@ -859,12 +859,12 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
         selectStatements.add("    SELECT " + expression + " AS EntityId, '" + table.getSelectName() + "' AS TableName FROM " + table.getSelectName() + (null != where ? " WHERE " + where : "") + "\n");
     }
 
-    private WebPartView getResultSetView(SQLFragment sql, String title, @Nullable String link)
+    private WebPartView getResultSetView(SQLFragment sql, String title, @Nullable ActionURL linkUrl)
     {
         SqlSelector selector = new SqlSelector(DbScope.getLabKeyScope(), sql);
         ResultSet rs = selector.getResultSet();
 
-        return null != link ? new ResultSetView(rs, title, 1, link) : new ResultSetView(rs, title);
+        return null != linkUrl ? new ResultSetView(rs, title, "Type", linkUrl) : new ResultSetView(rs, title);
     }
 
     @Override

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -47,6 +47,7 @@ import org.labkey.api.audit.provider.ContainerAuditProvider;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.RowMapFactory;
+import org.labkey.api.collections.Sets;
 import org.labkey.api.data.*;
 import org.labkey.api.data.dialect.JdbcMetaDataLocator;
 import org.labkey.api.data.dialect.SqlDialect;
@@ -1495,20 +1496,20 @@ public class QueryController extends SpringActionController
             {
                 JdbcMetaDataSelector selector = new JdbcMetaDataSelector(locator,
                     (dbmd, locator1) -> dbmd.getTables(locator1.getCatalogName(), locator1.getSchemaNamePattern(), locator1.getTableNamePattern(), null));
+                Set<String> tableNames = Sets.newCaseInsensitiveHashSet(qs.getTableNames());
 
                 ActionURL url = new ActionURL(RawTableMetaDataAction.class, getContainer())
                     .addParameter("schemaName", _schemaName)
                     .addParameter("query.queryName", null);
-                String tableLink = url.getEncodedLocalURIString();
-                tablesView = new ResultSetView(CachedResultSets.create(selector.getResultSet(), true, Table.ALL_ROWS), "Tables", 3, tableLink)
+                tablesView = new ResultSetView(CachedResultSets.create(selector.getResultSet(), true, Table.ALL_ROWS), "Tables", "TABLE_NAME", url)
                 {
                     @Override
                     protected boolean shouldLink(ResultSet rs) throws SQLException
                     {
                         // Only link to tables and views (not indexes or sequences). And only if they're defined in the query schema.
-                        String name = rs.getString(3);
-                        String type = rs.getString(4);
-                        return ("TABLE".equalsIgnoreCase(type) || "VIEW".equalsIgnoreCase(type)) && qs.getTableNames().contains(name);
+                        String name = rs.getString("TABLE_NAME");
+                        String type = rs.getString("TABLE_TYPE");
+                        return ("TABLE".equalsIgnoreCase(type) || "VIEW".equalsIgnoreCase(type)) && tableNames.contains(name);
                     }
                 };
             }


### PR DESCRIPTION
#### Rationale
The "view raw metadata" action was messed up in several ways

#### Changes
* Stop double-encoding links
* Pass in column names since metadata columns (and therefore indexes) differ by database type
* Use case-insensitive check for column names present in query schema