### PR TITLE
Fix various FlowTests broken by change to use Supplier<Container>

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1738,7 +1738,8 @@ public class Container implements Serializable, Comparable<Container>, Securable
     {
         private final GUID _entityId;
 
-        public ContainerSupplier(GUID entityId)
+        @JsonCreator
+        public ContainerSupplier(@JsonProperty("entityId") GUID entityId)
         {
             _entityId = entityId;
         }

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1731,6 +1731,22 @@ public class Container implements Serializable, Comparable<Container>, Securable
     public static Supplier<Container> supplierOf(@Nullable Container c)
     {
         final GUID id = c == null ? null : c.getEntityId();
-        return () -> id == null ? null : ContainerManager.getForId(id);
+        return new ContainerSupplier(id);
+    }
+
+    private static class ContainerSupplier implements Supplier<Container>, Serializable
+    {
+        private final GUID _entityId;
+
+        public ContainerSupplier(GUID entityId)
+        {
+            _entityId = entityId;
+        }
+
+        @Override
+        public Container get()
+        {
+            return _entityId == null ? null : ContainerManager.getForId(_entityId);
+        }
     }
 }

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1745,7 +1745,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
         }
 
         @Override
-        public Container get()
+        public @Nullable Container get()
         {
             return _entityId == null ? null : ContainerManager.getForId(_entityId);
         }


### PR DESCRIPTION
#### Rationale
My change to use a Supplier<Container> instead of holding a Container reference in IndentifiableBase broke Jackson serialization. Example test failures:

https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyCPostgres/2068558?hideProblemsFromDependencies=false&expandBuildTestsSection=true&hideTestsFromDependencies=false&expandBuildChangesSection=true

#### Changes
* Use a Jackson-annotated class instead of a lambda