### PR TITLE
Issue 46547: LKSM: Add Visit ID and Visit Date field types to data classes

### DIFF
--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -319,6 +319,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
         // Consider: it does not always make sense to preserve the "isKeyField" property.
         setKeyField(col.isKeyField());
         setColumnLogging(col.getColumnLogging());
+        setConceptURI(col.getConceptURI());     // Review TODO: Do we always want to do this?
     }
 
 

--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -224,13 +224,15 @@ public class ClosureQueryHelper
                 if (ret != null)
                 {
                     ret.setDisplayColumnFactory(colInfo -> new AncestorLookupDisplayColumn(foreignKey, colInfo));
-                    ret.setConceptURI(CONCEPT_URI);
                 }
                 return ret;
             }
         };
         ret.setFk(qfk);
-        ret.setConceptURI(CONCEPT_URI);
+
+        // Don't override an existing conceptUri
+        if(ret.getConceptURI() == null)
+            ret.setConceptURI(CONCEPT_URI);
         return ret;
     }
 

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -409,4 +409,10 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
         ExpDataClass dc = domain != null ? ExperimentService.get().getDataClass(domain.getDomainURI()) : null;
         return new DataClassDomainKindProperties(dc);
     }
+
+    @Override
+    public boolean allowTimepointProperties()
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
#### Rationale
[Issue 46547: LKSM: Add Visit ID and Visit Date field types to data classes](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46547)
Enable usage of lineage (Ancestor) lookups to pull study identifiers

#### Related Pull Requests
- [TestAutomation](https://github.com/LabKey/testAutomation/pull/1286)
- [Samplemanager](https://github.com/LabKey/sampleManagement/pull/1328)

#### Changes
* Added ConceptURI to set of properties copied for lookup columns
* Added override method to enable usage of time point Field types for data classes
