### PR TITLE
Label NameExpression column as "Naming Pattern"

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
@@ -75,14 +75,22 @@ public class ExpDataClassTableImpl extends ExpTableImpl<ExpDataClassTable.Column
         switch (column)
         {
             case Folder:
+            {
                 var columnInfo = wrapColumn(alias, _rootTable.getColumn("Container"));
                 columnInfo.setURL(new DetailsURL(new ActionURL(ExperimentController.ListDataClassAction.class, getContainer())));
                 return columnInfo;
+            }
 
             case Description:
-            case NameExpression:
             case RowId:
                 return wrapColumn(alias, _rootTable.getColumn(column.toString()));
+
+            case NameExpression:
+            {
+                var columnInfo = wrapColumn(alias, _rootTable.getColumn(column.toString()));
+                columnInfo.setLabel("Naming Pattern");
+                return columnInfo;
+            }
 
             case Name:
             {

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTableImpl.java
@@ -67,7 +67,6 @@ public class ExpSampleTypeTableImpl extends ExpTableImpl<ExpSampleTypeTable.Colu
             case LSID:
             case MaterialLSIDPrefix:
             case Name:
-            case AliquotNameExpression:
             case LabelColor:
             case MetricUnit:
             case AutoLinkTargetContainer:
@@ -86,6 +85,12 @@ public class ExpSampleTypeTableImpl extends ExpTableImpl<ExpSampleTypeTable.Colu
             {
                 var columnInfo =  wrapColumn(alias, _rootTable.getColumn(column.toString()));
                 columnInfo.setLabel("Naming Pattern");
+                return columnInfo;
+            }
+            case AliquotNameExpression:
+            {
+                var columnInfo =  wrapColumn(alias, _rootTable.getColumn(column.toString()));
+                columnInfo.setLabel("Aliquot Naming Pattern");
                 return columnInfo;
             }
             case SampleCount:

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTableImpl.java
@@ -58,14 +58,15 @@ public class ExpSampleTypeTableImpl extends ExpTableImpl<ExpSampleTypeTable.Colu
         switch (column)
         {
             case Folder:
+            {
                 var columnInfo = wrapColumn(alias, _rootTable.getColumn("Container"));
                 columnInfo.setURL(new DetailsURL(new ActionURL(ExperimentController.ShowSampleTypeAction.class, getContainer())));
                 return columnInfo;
+            }
             case Description:
             case LSID:
             case MaterialLSIDPrefix:
             case Name:
-            case NameExpression:
             case AliquotNameExpression:
             case LabelColor:
             case MetricUnit:
@@ -81,6 +82,12 @@ public class ExpSampleTypeTableImpl extends ExpTableImpl<ExpSampleTypeTable.Colu
                 return wrapColumn(alias, _rootTable.getColumn("Modified"));
             case ModifiedBy:
                 return createUserColumn(alias, _rootTable.getColumn("ModifiedBy"));
+            case NameExpression:
+            {
+                var columnInfo =  wrapColumn(alias, _rootTable.getColumn(column.toString()));
+                columnInfo.setLabel("Naming Pattern");
+                return columnInfo;
+            }
             case SampleCount:
             {
                 SQLFragment sql = new SQLFragment("(SELECT COUNT(*) FROM " +


### PR DESCRIPTION
#### Rationale
We've been using "Naming Pattern" in LKSM since the beginning and it seems to resonate better than "Name Expression", so this PR updates the label on this field to "Naming Pattern", obviating the need for an override in LKSM and providing one more bit of consistency.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/1326

#### Changes
* Update field label in Data Classes and Sample Types.
