### PR TITLE
Deprecate PostgreSQL 10 support

### DIFF
--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 public enum PostgreSqlVersion
 {
     POSTGRESQL_UNSUPPORTED(-1, true, false, null),
-    POSTGRESQL_10(100, false, true, PostgreSql_10_Dialect::new),
+    POSTGRESQL_10(100, true, true, PostgreSql_10_Dialect::new),
     POSTGRESQL_11(110, false, true, PostgreSql_11_Dialect::new),
     POSTGRESQL_12(120, false, true, PostgreSql_12_Dialect::new),
     POSTGRESQL_13(130, false, true, PostgreSql_13_Dialect::new),


### PR DESCRIPTION
#### Rationale
As of Nov 10, PostgreSQL 10 will no longer be maintained: https://www.postgresql.org/support/versioning/