### PR TITLE
Bug fix for issue 46423, 45790, 46460, 46292 and 45405

### DIFF
--- a/api/src/org/labkey/api/action/ExtendedApiQueryResponse.java
+++ b/api/src/org/labkey/api/action/ExtendedApiQueryResponse.java
@@ -59,6 +59,7 @@ public class ExtendedApiQueryResponse extends ApiQueryResponse
         mvIndicator,
         mvRawValue,
         url,
+        urlTarget,
         style
     }
 
@@ -159,13 +160,16 @@ public class ExtendedApiQueryResponse extends ApiQueryResponse
         if (includeFormattedValue)
             formattedValue = dc.getFormattedText(ctx);
 
-        String url = null;
+        String url = null, urlTarget = null;
         if (null != value)
+        {
             url = dc.renderURL(ctx);
+            urlTarget = dc.getLinkTarget();
+        }
 
         //in the extended response format, each column will have a map of its own
         //that will contain entries for value, mvValue, mvIndicator, etc.
-        ColMap colMap = makeColMap(value, displayValue, formattedValue, url, includeFormattedValue);
+        ColMap colMap = makeColMap(value, displayValue, formattedValue, url, includeFormattedValue, urlTarget);
 
         //missing values
         if (dc instanceof MVDisplayColumn)
@@ -208,7 +212,7 @@ public class ExtendedApiQueryResponse extends ApiQueryResponse
             if (includeFormattedValue)
                 formattedValue = formatted.get(i);
             String url = urls.get(i);
-            ColMap nested = makeColMap(value, displayValue, formattedValue, url, includeFormattedValue);
+            ColMap nested = makeColMap(value, displayValue, formattedValue, url, includeFormattedValue, null);
 
             // TODO: missing value indicators ?
 
@@ -238,7 +242,7 @@ public class ExtendedApiQueryResponse extends ApiQueryResponse
 
     protected static ColMap makeColMap(
             @Nullable Object value, @Nullable Object displayValue, @Nullable String formattedValue, @Nullable String url,
-            boolean includeFormattedValue)
+            boolean includeFormattedValue, @Nullable String urlTarget)
     {
         ColMap colMap = new ColMap();
 
@@ -253,7 +257,11 @@ public class ExtendedApiQueryResponse extends ApiQueryResponse
             colMap.put(ColMapEntry.formattedValue, formattedValue);
 
         if (value != null && url != null)
+        {
             colMap.put(ColMapEntry.url, url);
+            if (!StringUtils.isEmpty(urlTarget))
+                colMap.put(ColMapEntry.urlTarget, urlTarget);
+        }
 
         return colMap;
     }

--- a/api/src/org/labkey/api/admin/notification/NotificationService.java
+++ b/api/src/org/labkey/api/admin/notification/NotificationService.java
@@ -18,6 +18,7 @@ package org.labkey.api.admin.notification;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
@@ -66,8 +67,12 @@ public interface NotificationService
     /*
      * Returns a list of notifications for a specific user. Sorted descending by created date.
      */
-    List<Notification> getNotificationsByUser(Container container, int notifyUserId, boolean unreadOnly);
+    default List<Notification> getNotificationsByUser(Container container, int notifyUserId, boolean unreadOnly)
+    {
+        return getNotificationsByUser(container, notifyUserId, unreadOnly, null);
+    }
 
+    List<Notification> getNotificationsByUser(Container container, int notifyUserId, boolean unreadOnly, @Nullable ContainerFilter containerFilter);
     /*
      * Returns just the count of notifications for a specific user. At any given instant, will match the length of the
      * list returned by getNotificationsByUser(), and is significantly more efficient to query.
@@ -82,8 +87,12 @@ public interface NotificationService
     /*
      * Returns a list of notifications for a specific user based on the specified type labels (e.g, 'Pipeline').
      */
-    List<Notification> getNotificationsByTypeLabels(Container container, @NotNull List<String> typeLabels, int notifyUserId, boolean unreadOnly);
+    default List<Notification> getNotificationsByTypeLabels(Container container, @NotNull List<String> typeLabels, int notifyUserId, boolean unreadOnly)
+    {
+        return getNotificationsByTypeLabels(container, typeLabels, notifyUserId, unreadOnly, null);
+    }
 
+    List<Notification> getNotificationsByTypeLabels(Container container, @NotNull List<String> typeLabels, int notifyUserId, boolean unreadOnly, @Nullable ContainerFilter containerFilter);
     /*
      * Returns a notification based on the notification's RowId.
      */

--- a/experiment/src/org/labkey/experiment/api/AncestorLookupDisplayColumn.java
+++ b/experiment/src/org/labkey/experiment/api/AncestorLookupDisplayColumn.java
@@ -52,6 +52,17 @@ public class AncestorLookupDisplayColumn extends DataColumn
     }
 
     @Override
+    @Nullable
+    public String getFormattedText(RenderContext ctx)
+    {
+        Integer lookupKey = getLookupId(ctx);
+        if (lookupKey != null && lookupKey < 0)
+            return  (-lookupKey) + " values";
+
+        return super.getFormattedText(ctx);
+    }
+
+    @Override
     public Object getValue(RenderContext ctx)
     {
         Integer lookupKey = getLookupId(ctx);

--- a/filecontent/webapp/File/panel/Browser.js
+++ b/filecontent/webapp/File/panel/Browser.js
@@ -2304,7 +2304,7 @@ Ext4.define('File.panel.Browser', {
 
             if (!selections.length && count > 0) {
                 emptySelection = true;
-                selections = store.getRange(0, count-1); // get all the available records
+                selections = store.data.getRange(0, count-1); // get all the loaded records without loading more into buffer
             }
 
             // Issue 25493: Intermittent JS error from FileBrowser.


### PR DESCRIPTION
#### Rationale
- 46423: [LKB: Sample Finder result tab throw bad sql error with multi numeric results found](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46423)
- 46292: [Sample Manager: Grid column URL doesn't respect urlTarget property configured in in query metadata](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46292)
- 45405: [SM: Async import status from other folders are registering in the current LKSM folder.](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45405)
- 45790: [After deleting a subset of files through the files web part, selection state is confused](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45790)

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/998

#### Changes
* update getQuery api to return urlTarget
* support byContainer and containerFilter parameter for notification actions
* Fix AncestorLookupDisplayColumn for multi values
