### PR TITLE
Improve automated metrics submission

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -172,7 +172,6 @@ public class ModuleLoader implements Filter, MemTrackerListener
             (__) |_(_||_)|\\(/_\\/  _)(/_| \\/(/_| \s
                               /                 \s""".indent(2);
 
-    private boolean _deferUsageReport = false;
     private File _webappDir;
     private UpgradeState _upgradeState;
 
@@ -1346,24 +1345,9 @@ public class ModuleLoader implements Filter, MemTrackerListener
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException
     {
-        if (isUpgradeRequired())
-        {
-            setDeferUsageReport(true);
-        }
-
         filterChain.doFilter(servletRequest, servletResponse);
 
         ConnectionWrapper.dumpLeaksForThread(Thread.currentThread());
-    }
-
-    public boolean isDeferUsageReport()
-    {
-        return _deferUsageReport;
-    }
-
-    public void setDeferUsageReport(boolean defer)
-    {
-        _deferUsageReport = defer;
     }
 
     // Run scripts using the default upgrade script runner

--- a/api/src/org/labkey/api/util/UsageReportingLevel.java
+++ b/api/src/org/labkey/api/util/UsageReportingLevel.java
@@ -151,14 +151,11 @@ public enum UsageReportingLevel implements SafeToRenderEnum
     public void scheduleUpgradeCheck()
     {
         cancelUpgradeCheck();
-        if (!ModuleLoader.getInstance().isDeferUsageReport())
+        TimerTask task = createTimerTask();
+        if (task != null)
         {
-            TimerTask task = createTimerTask();
-            if (task != null)
-            {
-                _timer = new Timer("UpgradeCheck", true);
-                _timer.scheduleAtFixedRate(task, 0, DateUtils.MILLIS_PER_DAY);
-            }
+            _timer = new Timer("UpgradeCheck", true);
+            _timer.scheduleAtFixedRate(task, 0, DateUtils.MILLIS_PER_DAY);
         }
     }
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1163,7 +1163,6 @@ public class AdminController extends SpringActionController
         @Override
         public boolean handlePost(SiteSettingsForm form, BindException errors) throws Exception
         {
-            ModuleLoader.getInstance().setDeferUsageReport(false);
             HttpServletRequest request = getViewContext().getRequest();
 
             // We only need to check that SSL is running if the user isn't already using SSL
@@ -1215,9 +1214,7 @@ public class AdminController extends SpringActionController
                 level = UsageReportingLevel.valueOf(form.getUsageReportingLevel());
                 props.setUsageReportingLevel(level);
             }
-            catch (IllegalArgumentException e)
-            {
-            }
+            catch (IllegalArgumentException ignored) {}
 
             props.setAdministratorContactEmail(form.getAdministratorContactEmail() == null ? null : form.getAdministratorContactEmail().trim());
 
@@ -3773,7 +3770,6 @@ public class AdminController extends SpringActionController
                 lafProps.save();
 
                 // Send an immediate report now that they've set up their account and defaults, and then every 24 hours after.
-                ModuleLoader.getInstance().setDeferUsageReport(false);
                 AppProps.getInstance().getUsageReportingLevel().scheduleUpgradeCheck();
 
                 return true;


### PR DESCRIPTION
#### Rationale
We've been holding off on starting metric submission and upgrade checks if there's a module upgrade to be performed. Somewhere along the way, we lost the code that reenables the background process.

#### Changes
* The submission/check fires after all modules are upgraded, so there's no longer any need to delay it