### PR TITLE
For Assay template downloads, use the protocol name as the prefix

### DIFF
--- a/assay/src/org/labkey/assay/actions/TemplateAction.java
+++ b/assay/src/org/labkey/assay/actions/TemplateAction.java
@@ -68,6 +68,7 @@ public class TemplateAction extends BaseAssayAction<ProtocolIdForm>
         ctx.setBaseFilter(filter);
 
         ExcelWriter xl = new ExcelWriter(()->dr.getResults(ctx), dr.getDisplayColumns(), ExcelWriter.ExcelDocumentType.xlsx);
+        xl.setFilenamePrefix(protocol.getName());
         xl.renderWorkbook(getViewContext().getResponse());
         return null;
     }


### PR DESCRIPTION
#### Rationale
Using a name other than the default "data" as the prefix to template download files makes it easier to distinguish the files from each other

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1002
- https://github.com/LabKey/testAutomation/pull/1291
- https://github.com/LabKey/biologics/pull/1691
- https://github.com/LabKey/inventory/pull/585
- https://github.com/LabKey/sampleManagement/pull/1337

#### Changes
* For Assay template download, use protocol name as filename prefix
