### PR TITLE
Issue 46598: Use a specified directory structure for uploaded temp files

### DIFF
--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -60,7 +60,10 @@ import org.labkey.api.view.template.PageConfig;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.multipart.MultipartResolver;
+import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;
@@ -71,6 +74,7 @@ import org.springframework.web.servlet.view.RedirectView;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
@@ -482,7 +486,9 @@ public abstract class SpringActionController implements Controller, HasViewConte
                 try
                 {
                     ViewBackgroundInfo info = new ViewBackgroundInfo(context.getContainer(), context.getUser(), context.getActionURL().clone());
-                    request = PremiumService.get().getMultipartResolver(info).resolveMultipart(request);
+                    CommonsMultipartResolver resolver = PremiumService.get().getMultipartResolver(info);
+                    resolver.setUploadTempDir(new FileSystemResource(getTempUploadDir()));
+                    request = resolver.resolveMultipart(request);
                     context.setRequest(request);
                     // ViewServlet doesn't check validChars for parameters in a multipart request, so check again
                     if (!ViewServlet.validChars(request))
@@ -541,6 +547,17 @@ public abstract class SpringActionController implements Controller, HasViewConte
         return null;
     }
 
+    private static File TEMP_UPLOAD_DIR;
+    /** Issue 46598 - use a directory of the primary temp dir for file uploads */
+    public static File getTempUploadDir()
+    {
+        if (TEMP_UPLOAD_DIR == null)
+        {
+            TEMP_UPLOAD_DIR = new File(new File(System.getProperty("java.io.tmpdir")), "httpUploads");
+            TEMP_UPLOAD_DIR.mkdirs();
+        }
+        return TEMP_UPLOAD_DIR;
+    }
 
     protected void handleException(Throwable x, ViewContext context, PageConfig pageConfig)
     {

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -430,6 +430,11 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
 
         ScriptEngineManagerImpl.registerEncryptionMigrationHandler();
 
+        deleteTempFiles();
+    }
+
+    private void deleteTempFiles()
+    {
         try
         {
             // Issue 46598 - clean up previously created temp files from file uploads
@@ -855,6 +860,24 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         }
         ContextListener.addShutdownListener(TempTableTracker.getShutdownListener());
         ContextListener.addShutdownListener(DavController.getShutdownListener());
+        ContextListener.addShutdownListener(new ShutdownListener()
+        {
+            @Override
+            public String getName()
+            {
+                return "Temp file cleanup";
+            }
+
+            @Override
+            public void shutdownPre()
+            {}
+
+            @Override
+            public void shutdownStarted()
+            {
+                deleteTempFiles();
+            }
+        });
 
         SimpleMetricsService.setInstance(new SimpleMetricsServiceImpl());
 

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.old.JSONObject;
+import org.labkey.api.action.SpringActionController;
 import org.labkey.api.admin.AdminConsoleService;
 import org.labkey.api.admin.FolderSerializationRegistry;
 import org.labkey.api.admin.HealthCheck;
@@ -134,6 +135,7 @@ import org.labkey.api.usageMetrics.UsageMetricsService;
 import org.labkey.api.util.CommandLineTokenizer;
 import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.ExceptionUtil;
+import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.MimeMap;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.ShutdownListener;
@@ -427,7 +429,17 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         ContextListener.addNewInstallCompleteListener(() -> sendSystemReadyEmail(UserManager.getAppAdmins()));
 
         ScriptEngineManagerImpl.registerEncryptionMigrationHandler();
-   }
+
+        try
+        {
+            // Issue 46598 - clean up previously created temp files from file uploads
+            FileUtil.deleteDirectoryContents(SpringActionController.getTempUploadDir().toPath());
+        }
+        catch (IOException e)
+        {
+            LOG.warn("Failed to clean up previously uploaded files from " + SpringActionController.getTempUploadDir(), e);
+        }
+    }
 
     private void registerHealthChecks()
     {


### PR DESCRIPTION
#### Rationale
We're leaking temp files. Some are from HTTP-based uploads and we can do a better job cleaning them up.

#### Changes
* Write HTTP uploads into a ./httpUploads subdirectory
* Clean out that subdirectory on server startup
* Delete files that failed virus scans