### PR TITLE
Copy additonal column properties through to their lookup counterparts

### DIFF
--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -319,7 +319,10 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
         // Consider: it does not always make sense to preserve the "isKeyField" property.
         setKeyField(col.isKeyField());
         setColumnLogging(col.getColumnLogging());
-        setConceptURI(col.getConceptURI());     // Review TODO: Do we always want to do this?
+
+        // These properties need to be copied over so that the fields are properly displayed in the Apps.
+        setConceptURI(col.getConceptURI());
+        setUserEditable(col.isUserEditable());  //This can impact UniqueId fields if not set
     }
 
 


### PR DESCRIPTION
#### Rationale
SMSampleCreateTest looks for Unique Id properties in the Sample details view, since copying over the ConceptURI property these properties are not showing--and the test is failing.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3787

#### Changes
* Add isUserEditable to copied properties
