### PR TITLE
46508: org.apache.xmlbeans.impl.values.XmlValueDisconnectedException when editing metadata

### DIFF
--- a/query/src/org/labkey/query/MetadataTableJSON.java
+++ b/query/src/org/labkey/query/MetadataTableJSON.java
@@ -479,6 +479,11 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
                 xmlColumn.unsetPrincipalConceptCode();
             }
 
+            if (metadataColumnJSON.isScannable() != rawColumnInfo.isScannable())
+            {
+                xmlColumn.setScannable(metadataColumnJSON.isScannable());
+            }
+
             if (xmlColumn.getWrappedColumnName() == null)
             {
                 NodeList childNodes = xmlColumn.getDomNode().getChildNodes();
@@ -489,11 +494,6 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
                     // Remove columns that no longer have any metadata set on them
                     removeColumn(xmlTable, xmlColumn);
                 }
-            }
-
-            if (metadataColumnJSON.isScannable() != rawColumnInfo.isScannable())
-            {
-                xmlColumn.setScannable(metadataColumnJSON.isScannable());
             }
         }
 


### PR DESCRIPTION
#### Rationale
Users were running into this error trying to save metadata when a field had its scannable property set. On closer inspection of the save code, we were trying to mutate the field after the element had been removed from the document.

```
ERROR ExceptionUtil 2022-10-03T14:07:10,863 http-nio-8080-exec-2 : Exception detected
org.apache.xmlbeans.impl.values.XmlValueDisconnectedException: null
    at org.apache.xmlbeans.impl.values.XmlObjectBase.check_orphaned(XmlObjectBase.java:1229) ~[xmlbeans-5.0.3.jar:?]
    at org.labkey.data.xml.impl.ColumnTypeImpl.setScannable(Unknown Source) ~[api-22.3.2.jar:?]
    at org.labkey.query.MetadataTableJSON.saveMetadata(MetadataTableJSON.java:486) ~[query-22.3.2.jar:?]
    at org.labkey.query.controllers.QueryController$SaveQueryMetadataAction.execute(QueryController.java:7106) ~[query-22.3.2.jar:?]
    at org.labkey.query.controllers.QueryController$SaveQueryMetadataAction.execute(QueryController.java:7074) ~[query-22.3.2.jar:?]
    at org.labkey.api.action.BaseApiAction.handlePost(BaseApiAction.java:214) [api-22.3.2.jar:?]
    at org.labkey.api.action.BaseApiAction.handleRequest(BaseApiAction.java:129) [api-22.3.2.jar:?]
    at org.labkey.api.action.BaseViewAction.handleRequest(BaseViewAction.java:178) [api-22.3.2.jar:?]
    at org.labkey.api.action.SpringActionController.handleRequest(SpringActionController.java:511) [api-22.3.2.jar:?]
    at org.labkey.api.module.DefaultModule.dispatch(DefaultModule.java:1111) [api-22.3.2.jar:?]
    at org.labkey.api.view.ViewServlet._service(ViewServlet.java:232) [api-22.3.2.jar:?]
    at org.labkey.api.view.ViewServlet.service(ViewServlet.java:156) [api-22.3.2.jar:?]
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:733) [servlet-api.jar:4.0.FR]
    at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231) [catalina.jar:9.0.37]
    at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) [catalina.jar:9.0.37]
```

[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46508)