### PR TITLE
Issue 46646: Add metrics for report invocations

### DIFF
--- a/api/src/org/labkey/api/reports/report/InternalScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/InternalScriptEngineReport.java
@@ -15,10 +15,13 @@
  */
 package org.labkey.api.reports.report;
 
+import org.labkey.api.ApiModule;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.reports.ExternalScriptEngine;
 import org.labkey.api.reports.report.r.ParamReplacement;
 import org.labkey.api.reports.report.r.ParamReplacementSvc;
 import org.labkey.api.reports.report.r.view.ConsoleOutput;
+import org.labkey.api.usageMetrics.SimpleMetricsService;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.HttpView;
@@ -114,6 +117,9 @@ public class InternalScriptEngineReport extends ScriptEngineReport
                 bindings.put("consoleOut", consolePw);
 
                 bindings.put(ExternalScriptEngine.WORKING_DIRECTORY, getReportDir(context.getContainer().getId()).getAbsolutePath());
+
+                SimpleMetricsService.get().increment(ModuleLoader.getInstance().getModule(ApiModule.class).getName(), METRIC_FEATURE_AREA, "Internal-" + engine.getFactory().getEngineName());
+
                 Object output = engine.eval(createScript(engine, context, outputSubst, inputDataTsv, inputParameters));
                 consolePw.flush();
                 String consoleString = consoleOut.toString();

--- a/api/src/org/labkey/api/reports/report/ScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/ScriptEngineReport.java
@@ -106,6 +106,8 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
     public static final String SUBSTITUTION_MAP = "substitutionMap.txt";
     public static final String CONSOLE_OUTPUT = "console.txt";
 
+    public static final String METRIC_FEATURE_AREA = "ReportInvocation";
+
     private static final Logger LOG = LogManager.getLogger(ScriptEngineReport.class);
 
     static

--- a/api/src/org/labkey/api/reports/report/python/IpynbReport.java
+++ b/api/src/org/labkey/api/reports/report/python/IpynbReport.java
@@ -18,8 +18,10 @@ import org.apache.xmlbeans.impl.common.IOUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
+import org.labkey.api.ApiModule;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.premium.PremiumService;
 import org.labkey.api.reports.ExternalScriptEngine;
 import org.labkey.api.reports.ExternalScriptEngineDefinition;
@@ -30,6 +32,7 @@ import org.labkey.api.reports.report.ScriptReportDescriptor;
 import org.labkey.api.reports.report.r.view.ConsoleOutput;
 import org.labkey.api.reports.report.r.view.IpynbOutput;
 import org.labkey.api.security.SessionApiKeyManager;
+import org.labkey.api.usageMetrics.SimpleMetricsService;
 import org.labkey.api.util.CSRFUtil;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.FileUtil;
@@ -367,6 +370,8 @@ public class IpynbReport extends DockerScriptReport
                 return 0;
 
             tryPing(service);
+
+            SimpleMetricsService.get().increment(ModuleLoader.getInstance().getModule(ApiModule.class).getName(), ScriptEngineReport.METRIC_FEATURE_AREA, getClass().getSimpleName());
 
             try (CloseableHttpClient client = HttpClients.createDefault())
             {


### PR DESCRIPTION
#### Rationale
To help us understand usage patterns and size our SaaS infrastructure appropriately, we need to track the number of times that reports are invoked. We have a few categories - internal (executed in-process via a Java script engine), external (R, in various permutations), and Docker-based (Jupyter).

#### Changes
* Instrument report execution and track via SimpleMetricsService