### PR TITLE
Remove support for jTDS SQL Server JDBC driver

### DIFF
--- a/api/src/org/labkey/api/data/dialect/JdbcHelper.java
+++ b/api/src/org/labkey/api/data/dialect/JdbcHelper.java
@@ -20,5 +20,5 @@ import javax.servlet.ServletException;
 
 public interface JdbcHelper
 {
-    public String getDatabase(String url) throws ServletException;
+    String getDatabase(String url) throws ServletException;
 }

--- a/bigiron/build.gradle
+++ b/bigiron/build.gradle
@@ -9,19 +9,6 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "net.sourceforge.jtds:jtds:${jtdsVersion}", // JTDS SQLServer JDBC Driver
-            "jTDS JDBC Driver",
-            "SourceForge",
-            "http://jtds.sourceforge.net",
-            ExternalDependency.LGPL_LICENSE_NAME,
-            "http://jtds.sourceforge.net/license.html",
-            "Connect with Microsoft SQL Server database servers"
-        )
-    )
-
-    BuildUtils.addExternalDependency(
-        project,
-        new ExternalDependency(
             "com.microsoft.sqlserver:mssql-jdbc:${mssqlJdbcVersion}", // MS SQLServer JDBC Driver
             "Microsoft JDBC Driver for SQL Server",
             "Microsoft",

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -992,13 +992,19 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
         SQL Server example connection URLs we need to parse:
 
         jdbc:sqlserver://;databaseName=foo
+        jdbc:sqlserver://;database=foo
         jdbc:sqlserver://host;databaseName=foo
+        jdbc:sqlserver://host;database=foo
         jdbc:sqlserver://host:1433;databaseName=foo
+        jdbc:sqlserver://host:1433;database=foo
         jdbc:sqlserver://host:1433;databaseName=foo;SelectMethod=cursor
+        jdbc:sqlserver://host:1433;database=foo;SelectMethod=cursor
         jdbc:sqlserver://host:1433;SelectMethod=cursor;databaseName=database
+        jdbc:sqlserver://host:1433;SelectMethod=cursor;database=database
 
         Note: SQL Server JDBC driver accepts connection URLs that lack a "databaseName" parameter (in which case the
-        server uses the "default" database). But LabKey requires this parameter, especially for creating a new database.
+        server uses the "default" database). But LabKey requires this parameter, especially when creating a new database.
+        Although not documented, the driver will accept "database" as a synonym for "databaseName", so we allow it.
     */
 
     private static class SqlServerJdbcHelper implements JdbcHelper
@@ -1008,7 +1014,9 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
         {
             if (url.startsWith("jdbc:sqlserver://"))
             {
-                int dbDelimiter = url.indexOf(";databaseName=");
+                int dbDelimiter = url.indexOf(";database=");
+                if (-1 == dbDelimiter)
+                    dbDelimiter = url.indexOf(";databaseName=");
                 if (-1 == dbDelimiter)
                     throw new ServletException("Invalid sql server connection url; \"databaseName\" property is required: " + url);
                 dbDelimiter = url.indexOf("=", dbDelimiter)+1;

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2016Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2016Dialect.java
@@ -33,22 +33,12 @@ public class MicrosoftSqlServer2016Dialect extends MicrosoftSqlServer2014Dialect
     @Override
     public StatementWrapper getStatementWrapper(ConnectionWrapper conn, Statement stmt)
     {
-        if (isJTDS(conn.getScope()))
-        {
-            return super.getStatementWrapper(conn, stmt);
-        }
-
         return new TimestampStatementWrapper(conn, stmt);
     }
 
     @Override
     public StatementWrapper getStatementWrapper(ConnectionWrapper conn, Statement stmt, String sql)
     {
-        if (isJTDS(conn.getScope()))
-        {
-            return super.getStatementWrapper(conn, stmt, sql);
-        }
-
         return new TimestampStatementWrapper(conn, stmt, sql);
     }
 

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
-import org.labkey.api.collections.CsvSet;
 import org.labkey.api.data.dialect.AbstractDialectRetrievalTestCase;
 import org.labkey.api.data.dialect.DatabaseNotSupportedException;
 import org.labkey.api.data.dialect.JdbcHelperTest;
@@ -249,34 +248,34 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
                 @Override
                 protected Set<String> getGoodUrls()
                 {
-                    return new CsvSet
+                    return Set.of
                     (
-                        "jdbc:sqlserver://;databaseName=database," +
-                        "jdbc:sqlserver://;servername=localhost;databaseName=database," +
-                        "jdbc:sqlserver://localhost;databaseName=database," +
-                        "jdbc:sqlserver://localhost:1433;databaseName=database," +
-                        "jdbc:sqlserver://localhost\\instancename;databaseName=database," +
-                        "jdbc:sqlserver://localhost\\instancename:1433;databaseName=database," +
-                        "jdbc:sqlserver://www.host.com\\instancename;databaseName=database," +
-                        "jdbc:sqlserver://www.host.com\\instancename:1433;databaseName=database," +
-                        "jdbc:sqlserver://www.host.com:1433;databaseName=database," +
-                        "jdbc:sqlserver://www.host.com:1433\\instanceName;databaseName=database;," +
-                        "jdbc:sqlserver://www.host.com:1433;SelectMethod=cursor;databaseName=database," +
-                        "jdbc:sqlserver://www.host.com:1433;SelectMethod=cursor;databaseName=database;" +
-                        "jdbc:sqlserver://;servername=www.host.com;databaseName=database," +
-                        "jdbc:sqlserver://;database=database," +
-                        "jdbc:sqlserver://;servername=localhost;database=database," +
-                        "jdbc:sqlserver://localhost;database=database," +
-                        "jdbc:sqlserver://localhost:1433;database=database," +
-                        "jdbc:sqlserver://localhost\\instancename;database=database," +
-                        "jdbc:sqlserver://localhost\\instancename:1433;database=database," +
-                        "jdbc:sqlserver://www.host.com\\instancename;database=database," +
-                        "jdbc:sqlserver://www.host.com\\instancename:1433;database=database," +
-                        "jdbc:sqlserver://www.host.com:1433;database=database," +
-                        "jdbc:sqlserver://www.host.com:1433\\instanceName;database=database;," +
-                        "jdbc:sqlserver://www.host.com:1433;SelectMethod=cursor;database=database," +
-                        "jdbc:sqlserver://www.host.com:1433;SelectMethod=cursor;database=database;" +
-                        "jdbc:sqlserver://;servername=www.host.com;database=database,"
+                        "jdbc:sqlserver://;databaseName=database",
+                        "jdbc:sqlserver://;servername=localhost;databaseName=database",
+                        "jdbc:sqlserver://localhost;databaseName=database",
+                        "jdbc:sqlserver://localhost:1433;databaseName=database",
+                        "jdbc:sqlserver://localhost\\instancename;databaseName=database",
+                        "jdbc:sqlserver://localhost\\instancename:1433;databaseName=database",
+                        "jdbc:sqlserver://www.host.com\\instancename;databaseName=database",
+                        "jdbc:sqlserver://www.host.com\\instancename:1433;databaseName=database",
+                        "jdbc:sqlserver://www.host.com:1433;databaseName=database",
+                        "jdbc:sqlserver://www.host.com:1433\\instanceName;databaseName=database;",
+                        "jdbc:sqlserver://www.host.com:1433;SelectMethod=cursor;databaseName=database",
+                        "jdbc:sqlserver://www.host.com:1433;SelectMethod=cursor;databaseName=database;",
+                        "jdbc:sqlserver://;servername=www.host.com;databaseName=database",
+                        "jdbc:sqlserver://;database=database",
+                        "jdbc:sqlserver://;servername=localhost;database=database",
+                        "jdbc:sqlserver://localhost;database=database",
+                        "jdbc:sqlserver://localhost:1433;database=database",
+                        "jdbc:sqlserver://localhost\\instancename;database=database",
+                        "jdbc:sqlserver://localhost\\instancename:1433;database=database",
+                        "jdbc:sqlserver://www.host.com\\instancename;database=database",
+                        "jdbc:sqlserver://www.host.com\\instancename:1433;database=database",
+                        "jdbc:sqlserver://www.host.com:1433;database=database",
+                        "jdbc:sqlserver://www.host.com:1433\\instanceName;database=database;",
+                        "jdbc:sqlserver://www.host.com:1433;SelectMethod=cursor;database=database",
+                        "jdbc:sqlserver://www.host.com:1433;SelectMethod=cursor;database=database;",
+                        "jdbc:sqlserver://;servername=www.host.com;database=database"
                     );
                 }
 
@@ -284,22 +283,22 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
                 @Override
                 protected Set<String> getBadUrls()
                 {
-                    return new CsvSet
+                    return Set.of
                     (
-                        "jdbc:sqlserver://," +
-                        "jdbc:sqlserver://;servername=localhost," +
-                        "jdbc:sqlserver://localhost," +
-                        "jdbc:sqlserver://localhost:1433," +
-                        "jdbc:jtds:sqlserver://localhost/database," +
-                        "jdbc:jtds:sqlserver://localhost:1433/database," +
-                        "jdb:sqlserver://localhost/database," +
-                        "jdbc:sqlerver://localhost/database," +
-                        "jdbc:sqlserver://localhostdatabase," +
-                        "jdbc:sqlserver:database" +
-                        "jdbc:sqlserver://localhost\\instancename," +
-                        "jdbc:sqlserver://localhost\\instancename:1433," +
-                        "jdbc:sqlserver://www.host.com\\instancename," +
-                        "jdbc:sqlserver://www.host.com\\instancename:1433,"
+                        "jdbc:sqlserver://",
+                        "jdbc:sqlserver://;servername=localhost",
+                        "jdbc:sqlserver://localhost",
+                        "jdbc:sqlserver://localhost:1433",
+                        "jdbc:jtds:sqlserver://localhost/database",
+                        "jdbc:jtds:sqlserver://localhost:1433/database",
+                        "jdb:sqlserver://localhost/database",
+                        "jdbc:sqlerver://localhost/database",
+                        "jdbc:sqlserver://localhostdatabase",
+                        "jdbc:sqlserver:database",
+                        "jdbc:sqlserver://localhost\\instancename",
+                        "jdbc:sqlserver://localhost\\instancename:1433",
+                        "jdbc:sqlserver://www.host.com\\instancename",
+                        "jdbc:sqlserver://www.host.com\\instancename:1433"
                     );
                 }
             };

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
@@ -191,35 +191,35 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
         public void testJavaUpgradeCode()
         {
             String goodSql =
-                    "EXEC core.executeJavaUpgradeCode 'upgradeCode'\n" +                       // Normal
-                    "EXECUTE core.executeJavaUpgradeCode 'upgradeCode'\n" +                    // EXECUTE
-                    "execute core.executeJavaUpgradeCode'upgradeCode'\n" +                     // execute
+                "EXEC core.executeJavaUpgradeCode 'upgradeCode'\n" +                       // Normal
+                "EXECUTE core.executeJavaUpgradeCode 'upgradeCode'\n" +                    // EXECUTE
+                "execute core.executeJavaUpgradeCode'upgradeCode'\n" +                     // execute
 
-                    "EXEC core.executeJavaInitializationCode 'upgradeCode'\n" +                // executeJavaInitializationCode works as a synonym
-                    "EXECUTE core.executeJavaInitializationCode 'upgradeCode'\n" +             // EXECUTE
-                    "execute core.executeJavaInitializationCode'upgradeCode'\n" +              // execute
+                "EXEC core.executeJavaInitializationCode 'upgradeCode'\n" +                // executeJavaInitializationCode works as a synonym
+                "EXECUTE core.executeJavaInitializationCode 'upgradeCode'\n" +             // EXECUTE
+                "execute core.executeJavaInitializationCode'upgradeCode'\n" +              // execute
 
-                    "    EXEC     core.executeJavaUpgradeCode    'upgradeCode'         \n" +   // Lots of whitespace
-                    "exec CORE.EXECUTEJAVAUPGRADECODE 'upgradeCode'\n" +                       // Case insensitive
-                    "execute core.executeJavaUpgradeCode'upgradeCode';\n" +                    // execute (with ;)
-                    "    EXEC     core.executeJavaUpgradeCode    'upgradeCode'    ;     \n" +  // Lots of whitespace with ; in the middle
-                    "exec CORE.EXECUTEJAVAUPGRADECODE 'upgradeCode';     \n" +                 // Case insensitive (with ;)
-                    "EXEC core.executeJavaUpgradeCode 'upgradeCode'     ;\n" +                 // Lots of whitespace with ; at end
-                    "EXEC core.executeJavaUpgradeCode 'upgradeCode'";                          // No line ending
+                "    EXEC     core.executeJavaUpgradeCode    'upgradeCode'         \n" +   // Lots of whitespace
+                "exec CORE.EXECUTEJAVAUPGRADECODE 'upgradeCode'\n" +                       // Case insensitive
+                "execute core.executeJavaUpgradeCode'upgradeCode';\n" +                    // execute (with ;)
+                "    EXEC     core.executeJavaUpgradeCode    'upgradeCode'    ;     \n" +  // Lots of whitespace with ; in the middle
+                "exec CORE.EXECUTEJAVAUPGRADECODE 'upgradeCode';     \n" +                 // Case insensitive (with ;)
+                "EXEC core.executeJavaUpgradeCode 'upgradeCode'     ;\n" +                 // Lots of whitespace with ; at end
+                "EXEC core.executeJavaUpgradeCode 'upgradeCode'";                          // No line ending
 
 
             String badSql =
-                    "/* EXEC core.executeJavaUpgradeCode 'upgradeCode'\n" +           // Inside block comment
-                    "   more comment\n" +
-                    "*/" +
-                    "    -- EXEC core.executeJavaUpgradeCode 'upgradeCode'\n" +       // Inside single-line comment
-                    "EXECcore.executeJavaUpgradeCode 'upgradeCode'\n" +               // Bad syntax: EXECcore
-                    "EXEC core. executeJavaUpgradeCode 'upgradeCode'\n" +             // Bad syntax: core. execute...
-                    "EXECUT core.executeJavaUpgradeCode 'upgradeCode'\n" +            // Misspell EXECUTE
-                    "EXECUTEUTE core.executeJavaUpgradeCode 'upgradeCode'\n" +        // Misspell EXECUTE -- previous regex allowed this
-                    "EXEC core.executeJaavUpgradeCode 'upgradeCode'\n" +              // Misspell executeJavaUpgradeCode
-                    "EXEC core.executeJavaUpgradeCode 'upgradeCode';;\n" +            // Bad syntax: two semicolons
-                    "EXEC core.executeJavaUpgradeCode('upgradeCode')\n";              // Bad syntax: parentheses
+                "/* EXEC core.executeJavaUpgradeCode 'upgradeCode'\n" +           // Inside block comment
+                "   more comment\n" +
+                "*/" +
+                "    -- EXEC core.executeJavaUpgradeCode 'upgradeCode'\n" +       // Inside single-line comment
+                "EXECcore.executeJavaUpgradeCode 'upgradeCode'\n" +               // Bad syntax: EXECcore
+                "EXEC core. executeJavaUpgradeCode 'upgradeCode'\n" +             // Bad syntax: core. execute...
+                "EXECUT core.executeJavaUpgradeCode 'upgradeCode'\n" +            // Misspell EXECUTE
+                "EXECUTEUTE core.executeJavaUpgradeCode 'upgradeCode'\n" +        // Misspell EXECUTE -- previous regex allowed this
+                "EXEC core.executeJaavUpgradeCode 'upgradeCode'\n" +              // Misspell executeJavaUpgradeCode
+                "EXEC core.executeJavaUpgradeCode 'upgradeCode';;\n" +            // Bad syntax: two semicolons
+                "EXEC core.executeJavaUpgradeCode('upgradeCode')\n";              // Bad syntax: parentheses
 
             SqlDialect dialect = getEarliestSqlDialect();
             TestUpgradeCode good = new TestUpgradeCode();
@@ -263,7 +263,20 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
                         "jdbc:sqlserver://www.host.com:1433\\instanceName;databaseName=database;," +
                         "jdbc:sqlserver://www.host.com:1433;SelectMethod=cursor;databaseName=database," +
                         "jdbc:sqlserver://www.host.com:1433;SelectMethod=cursor;databaseName=database;" +
-                        "jdbc:sqlserver://;servername=www.host.com;databaseName=database,"
+                        "jdbc:sqlserver://;servername=www.host.com;databaseName=database," +
+                        "jdbc:sqlserver://;database=database," +
+                        "jdbc:sqlserver://;servername=localhost;database=database," +
+                        "jdbc:sqlserver://localhost;database=database," +
+                        "jdbc:sqlserver://localhost:1433;database=database," +
+                        "jdbc:sqlserver://localhost\\instancename;database=database," +
+                        "jdbc:sqlserver://localhost\\instancename:1433;database=database," +
+                        "jdbc:sqlserver://www.host.com\\instancename;database=database," +
+                        "jdbc:sqlserver://www.host.com\\instancename:1433;database=database," +
+                        "jdbc:sqlserver://www.host.com:1433;database=database," +
+                        "jdbc:sqlserver://www.host.com:1433\\instanceName;database=database;," +
+                        "jdbc:sqlserver://www.host.com:1433;SelectMethod=cursor;database=database," +
+                        "jdbc:sqlserver://www.host.com:1433;SelectMethod=cursor;database=database;" +
+                        "jdbc:sqlserver://;servername=www.host.com;database=database,"
                     );
                 }
 
@@ -277,8 +290,6 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
                         "jdbc:sqlserver://;servername=localhost," +
                         "jdbc:sqlserver://localhost," +
                         "jdbc:sqlserver://localhost:1433," +
-                        "jdbc:sqlserver://localhost;database=database," +
-                        "jdbc:sqlserver://localhost:1433;database=database," +
                         "jdbc:jtds:sqlserver://localhost/database," +
                         "jdbc:jtds:sqlserver://localhost:1433/database," +
                         "jdb:sqlserver://localhost/database," +


### PR DESCRIPTION
#### Rationale
We deprecated the use of the jTDS JDBC driver in 22.7 and 22.11, in favor of the maintained Microsoft SQL Server JDBC driver. We're now removing all support for jTDS, starting with 22.12.

#### Changes
* Remove jTDS dependency
* Remove jTDS warnings and special handling
* Rewrite SQL Server JdbcHelper to match connection URL requirements