### PR TITLE
Bump to components package to support tricky names

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.16.1",
-        "@labkey/components": "2.242.6",
+        "@labkey/components": "2.242.7-fb-trickyNames.0",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3010,9 +3010,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.242.6",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.242.6.tgz",
-      "integrity": "sha512-MTOk/7wy1ePcBw2Ku5KIdoHqcaPnI8ZcLoqiYrYiTxId2hsR6G+EgkXcF2qW+Ty4tiI8EjjO03Q6SWqsdz3ftw==",
+      "version": "2.242.7-fb-trickyNames.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.242.7-fb-trickyNames.0.tgz",
+      "integrity": "sha512-V9Sv0SL2Ct+C0fPrEuKUaNgSBgHyebmSe0eA2xpAZmQuom49bql2dbdkVKCR3+WjxbAAzRiqd95WaRs9H9rV/Q==",
       "dependencies": {
         "@fortawesome/fontawesome-free": "~5.15.4",
         "@fortawesome/fontawesome-svg-core": "~1.2.36",
@@ -16987,9 +16987,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.242.6",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.242.6.tgz",
-      "integrity": "sha512-MTOk/7wy1ePcBw2Ku5KIdoHqcaPnI8ZcLoqiYrYiTxId2hsR6G+EgkXcF2qW+Ty4tiI8EjjO03Q6SWqsdz3ftw==",
+      "version": "2.242.7-fb-trickyNames.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.242.7-fb-trickyNames.0.tgz",
+      "integrity": "sha512-V9Sv0SL2Ct+C0fPrEuKUaNgSBgHyebmSe0eA2xpAZmQuom49bql2dbdkVKCR3+WjxbAAzRiqd95WaRs9H9rV/Q==",
       "requires": {
         "@fortawesome/fontawesome-free": "~5.15.4",
         "@fortawesome/fontawesome-svg-core": "~1.2.36",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.16.1",
-        "@labkey/components": "2.242.7-fb-trickyNames.0",
+        "@labkey/components": "2.242.8",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3010,9 +3010,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.242.7-fb-trickyNames.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.242.7-fb-trickyNames.0.tgz",
-      "integrity": "sha512-V9Sv0SL2Ct+C0fPrEuKUaNgSBgHyebmSe0eA2xpAZmQuom49bql2dbdkVKCR3+WjxbAAzRiqd95WaRs9H9rV/Q==",
+      "version": "2.242.8",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.242.8.tgz",
+      "integrity": "sha512-1tRJI0lPFAC6YcFIOaqATGfTyRnfNSsupKW7geI0ElNm5lanBH8JRnLwtQBTQ3QP1TUOCbbxXoIoCHB3P/cQHA==",
       "dependencies": {
         "@fortawesome/fontawesome-free": "~5.15.4",
         "@fortawesome/fontawesome-svg-core": "~1.2.36",
@@ -16987,9 +16987,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.242.7-fb-trickyNames.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.242.7-fb-trickyNames.0.tgz",
-      "integrity": "sha512-V9Sv0SL2Ct+C0fPrEuKUaNgSBgHyebmSe0eA2xpAZmQuom49bql2dbdkVKCR3+WjxbAAzRiqd95WaRs9H9rV/Q==",
+      "version": "2.242.8",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.242.8.tgz",
+      "integrity": "sha512-1tRJI0lPFAC6YcFIOaqATGfTyRnfNSsupKW7geI0ElNm5lanBH8JRnLwtQBTQ3QP1TUOCbbxXoIoCHB3P/cQHA==",
       "requires": {
         "@fortawesome/fontawesome-free": "~5.15.4",
         "@fortawesome/fontawesome-svg-core": "~1.2.36",

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.16.1",
-    "@labkey/components": "2.242.6",
+    "@labkey/components": "2.242.7-fb-trickyNames.0",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.16.1",
-    "@labkey/components": "2.242.7-fb-trickyNames.0",
+    "@labkey/components": "2.242.8",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Rationale
[Sample Type tricky name test failure](https://teamcity.labkey.org/buildConfiguration/LabKey_2211Release_Premium_ProductSuites_SampleManager_SampleManagerDPostgres/2095527?buildTab=tests&name=SMSampleTypeDesignerTest.testCreateSampleTypeWithTrickyName)

#### Related Pull Requests
* [Components](https://github.com/LabKey/labkey-ui-components/pull/1014)

#### Changes
* Update components package version