### PR TITLE
Issue 46628: Panorama QC Plot set max number of points to render per series

### DIFF
--- a/internal/webapp/vis/src/geom.js
+++ b/internal/webapp/vis/src/geom.js
@@ -266,6 +266,11 @@ LABKEY.vis.Geom.Path.prototype.render = function(renderer, grid, scales, data, l
     this.pathColorAes = layerAes.pathColor ? layerAes.pathColor : parentAes.pathColor;
     this.sizeScale = scales.size;
 
+    this.hoverTextAes = layerAes.hoverText ? layerAes.hoverText : parentAes.hoverText;
+    this.mouseOverFnAes = layerAes.mouseOverFn ? layerAes.mouseOverFn : parentAes.mouseOverFn;
+    this.mouseOutFnAes = layerAes.mouseOutFn ? layerAes.mouseOutFn : parentAes.mouseOutFn;
+    this.mouseUpFnAes = layerAes.mouseUpFn ? layerAes.mouseUpFn : parentAes.mouseUpFn;
+
     this._dataspaceBoxPlot ? renderer.renderDataspaceBoxPlotPathGeom(data, this) : renderer.renderPathGeom(data, this);
 
     return true;

--- a/internal/webapp/vis/src/internal/D3Renderer.js
+++ b/internal/webapp/vis/src/internal/D3Renderer.js
@@ -2489,10 +2489,16 @@ LABKEY.vis.internal.D3Renderer = function(plot) {
                 .attr('stroke-opacity', geom.opacity)
                 .attr('fill', 'none');
 
+        if (geom.hoverTextAes) {
+            pathSel.append('title').text(geom.hoverTextAes.getValue);
+        }
+
         if (geom.dashed) {
             layer.selectAll('path').style("stroke-dasharray", ("3, 3"));
             layer.selectAll('path').style("stroke-dasharray", ("3, 3"));
         }
+
+        bindMouseEvents(pathSel, geom, layer);
     };
 
     var renderDataspaceBoxPlotPaths = function(layer, data, geom) {

--- a/internal/webapp/vis/src/plot.js
+++ b/internal/webapp/vis/src/plot.js
@@ -1651,6 +1651,12 @@ boxPlot.render();
  * @param {Function} [config.properties.legendMouseOutFn] (Optional) The function to call on legend item mouse out. The parameters to
  *                  that function will be the mouse event, and the legend data.
  * @param {Object} [config.properties.legendMouseOutFnScope] (Optional) The scope to use for the call to legendMouseOutFn.
+ * @param {Function} [config.properties.pathMouseOverFn] (Optional) The function to call on path/line mouse over. The parameters to
+ *                  that function will be the mouse event, path data, and the DOM element for the path itself.
+ * @param {Object} [config.properties.pathMouseOverFnScope] (Optional) The scope to use for the call to pathMouseOverFn.
+ * @param {Function} [config.properties.pathMouseOutFn] (Optional) The function to call on path/line item mouse out. The parameters to
+ *                  that function will be the mouse event, and the path data.
+ * @param {Object} [config.properties.pathMouseOutFnScope] (Optional) The scope to use for the call to pathMouseOutFn.
  */
 (function(){
     LABKEY.vis.TrendingLinePlotType = {
@@ -2260,6 +2266,24 @@ boxPlot.render();
                             return colorValue;
                         }
                     }
+                }
+
+                // add some mouse over effects to highlight selected point
+                pathLayerConfig.aes.mouseOverFn = function(event, pathData, layerSel, path) {
+                    if (config.properties.pathMouseOverFn) {
+                        config.properties.pathMouseOverFn.call(config.properties.pathMouseOverFnScope || this, event, pathData, layerSel, path, valueName, config);
+                    }
+                };
+
+                pathLayerConfig.aes.mouseOutFn = function(event, pathData, layerSel) {
+                    if (config.properties.pathMouseOutFn) {
+                        config.properties.pathMouseOutFn.call(config.properties.pathMouseOutFnScope || this, event, pathData, layerSel, valueName, config);
+                    }
+                };
+                if (config.properties.hoverTextFn) {
+                    pathLayerConfig.aes.hoverText = function() {
+                        return config.properties.hoverTextFn.call(this);
+                    };
                 }
 
                 return pathLayerConfig;


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46628

When the Panorama QC Trend plots render with a large number of data points per series, the points are too bunched together to really make sense of them or find the right one you are looking for to hover over. In this PR, we add the core plot.js and geom.js handling of binding the mouse over/hover events for the series paths.

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/638

#### Changes
- max points per series set to 300 and don't render point geom if over that max
- bind mouse events to path line to highlight (similar to point hover and legend hover)
- show hover static hover text when data points are not being rendered
