### PR TITLE
MicrosoftSqlServerVersion to capture supported versions and their properties

### DIFF
--- a/bigiron/src/org/labkey/bigiron/BigIronModule.java
+++ b/bigiron/src/org/labkey/bigiron/BigIronModule.java
@@ -25,6 +25,7 @@ import org.labkey.api.module.ModuleContext;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.bigiron.mssql.GroupConcatInstallationManager;
 import org.labkey.bigiron.mssql.MicrosoftSqlServerDialectFactory;
+import org.labkey.bigiron.mssql.MicrosoftSqlServerVersion;
 import org.labkey.bigiron.mssql.synonym.SynonymTestCase;
 import org.labkey.bigiron.mysql.MySqlDialectFactory;
 import org.labkey.bigiron.oracle.OracleDialectFactory;
@@ -85,6 +86,7 @@ public class BigIronModule extends CodeOnlyModule
     {
         return Set.of(
             GroupConcatInstallationManager.TestCase.class,
+            MicrosoftSqlServerVersion.TestCase.class,
             SynonymTestCase.class
         );
     }

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -89,6 +89,8 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     private volatile String _versionYear = null;
     private volatile Edition _edition = null;
 
+    private HtmlString _adminWarning = null;
+
     @SuppressWarnings("unused")
     enum Edition
     {
@@ -1687,12 +1689,19 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
         GroupConcatInstallationManager.get().ensureInstalled(context);
     }
 
+    public void setAdminWarning(HtmlString warning)
+    {
+        _adminWarning = warning;
+    }
+
     @Override
     public void addAdminWarningMessages(Warnings warnings)
     {
         ClrAssemblyManager.addAdminWarningMessages(warnings);
 
-        if (WarningService.get().showAllWarnings() || "2008R2".equals(_versionYear) || "2012".equals(_versionYear))
+        if (null != _adminWarning)
+            warnings.add(_adminWarning);
+        else if (WarningService.get().showAllWarnings())
             warnings.add(HtmlString.of("LabKey Server no longer supports " + getProductName() + " " + _versionYear + "; please upgrade. " + MicrosoftSqlServerDialectFactory.RECOMMENDED));
 
         if (WarningService.get().showAllWarnings() || CoreSchema.getInstance().getScope().getDriverName().contains("jTDS"))

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
@@ -107,7 +107,7 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
 
         if (logWarnings)
         {
-            // It's an old version being used as an external schema... we support this but still warn to encourage upgrades
+            // It's an old version being used as an external schema... we allow this but still warn to encourage upgrades
             if (!ssv.isAllowedAsPrimaryDataSource())
             {
                 LOG.warn("LabKey Server no longer supports " + getProductName() + " version " + databaseProductVersion + ". " + RECOMMENDED);
@@ -125,53 +125,7 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
             }
         }
 
-        BaseMicrosoftSqlServerDialect oldDialect = oldGetDialect(version, databaseProductVersion, logWarnings, primaryDataSource);
-        Assert.assertEquals(dialect.getClass().getSimpleName(), oldDialect.getClass().getSimpleName());
-
         return dialect;
-    }
-
-    private BaseMicrosoftSqlServerDialect oldGetDialect(int version, String databaseProductVersion, boolean logWarnings, boolean primaryDataSource)
-    {
-        // We support only 2014 and higher as the primary data source, or 2012/2008/2008R2 as an external data source
-        if (version >= 100)
-        {
-            if (version >= 170)
-            {
-                // Warn for > SQL Server 2022, for now.
-                if (logWarnings)
-                    LOG.warn("LabKey Server has not been tested against " + getProductName() + " version " + databaseProductVersion + ". " + RECOMMENDED);
-            }
-
-            if (version >= 160)
-                return new MicrosoftSqlServer2022Dialect();
-
-            if (version >= 150)
-                return new MicrosoftSqlServer2019Dialect();
-
-            if (version >= 140)
-                return new MicrosoftSqlServer2017Dialect();
-
-            if (version >= 130)
-                return new MicrosoftSqlServer2016Dialect();
-
-            if (version >= 120)
-                return new MicrosoftSqlServer2014Dialect();
-
-            // Accept 2008, 2008R2, or 2012 as an external/supplemental database, but not as the primary database
-            if (!primaryDataSource)
-            {
-                if (logWarnings)
-                    LOG.warn("LabKey Server no longer supports " + getProductName() + " version " + databaseProductVersion + ". " + RECOMMENDED);
-
-                if (version >= 110)
-                    return new MicrosoftSqlServer2012Dialect();
-
-                return new MicrosoftSqlServer2008R2Dialect();
-            }
-        }
-
-        return null;
     }
 
     @Override

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerVersion.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerVersion.java
@@ -1,0 +1,125 @@
+package org.labkey.bigiron.mssql;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Enum that specifies the versions of Microsoft SQL Server that LabKey supports plus their properties
+ */
+public enum MicrosoftSqlServerVersion
+{
+    /*
+        Good resources for past & current SQL Server version numbers:
+        - http://www.sqlteam.com/article/sql-server-versions
+        - http://sqlserverbuilds.blogspot.se/
+     */
+
+    // We support 2014 and higher as the primary data source, but allow 2012/2008/2008R2 as an external data source
+    SQL_SERVER_UNSUPPORTED(Integer.MIN_VALUE, true, false, false, null),
+    SQL_SERVER_2008(100, false, true, false, MicrosoftSqlServer2008R2Dialect::new),
+    SQL_SERVER_2012(110, false, true, false, MicrosoftSqlServer2012Dialect::new),
+    SQL_SERVER_2014(120, false, true, true, MicrosoftSqlServer2014Dialect::new),
+    SQL_SERVER_2016(130, false, true, true, MicrosoftSqlServer2016Dialect::new),
+    SQL_SERVER_2017(140, false, true, true, MicrosoftSqlServer2017Dialect::new),
+    SQL_SERVER_2019(150, false, true, true, MicrosoftSqlServer2019Dialect::new),
+    SQL_SERVER_2022(160, false, false, true, MicrosoftSqlServer2022Dialect::new),
+    SQL_SERVER_FUTURE(170, false, false, true, MicrosoftSqlServer2022Dialect::new);
+
+    private final int _version;
+    private final boolean _deprecated;
+    private final boolean _tested;
+    private final boolean _allowedAsPrimaryDataSource;
+    private final Supplier<? extends MicrosoftSqlServer2008R2Dialect> _dialectFactory;
+
+    MicrosoftSqlServerVersion(int version, boolean deprecated, boolean tested, boolean allowedAsPrimaryDataSource, Supplier<? extends MicrosoftSqlServer2008R2Dialect> dialectFactory)
+    {
+        _version = version;
+        _deprecated = deprecated;
+        _tested = tested;
+        _allowedAsPrimaryDataSource = allowedAsPrimaryDataSource;
+        _dialectFactory = dialectFactory;
+    }
+
+    // Should LabKey warn administrators that support for this SQL Server version will be removed soon?
+    public boolean isDeprecated()
+    {
+        return _deprecated;
+    }
+
+    public boolean isTested()
+    {
+        return _tested;
+    }
+
+    public boolean isAllowedAsPrimaryDataSource()
+    {
+        return _allowedAsPrimaryDataSource;
+    }
+
+    public MicrosoftSqlServer2008R2Dialect getDialect()
+    {
+        return _dialectFactory.get();
+    }
+
+    static @NotNull MicrosoftSqlServerVersion get(final int version, boolean primaryDataSource)
+    {
+        Optional<MicrosoftSqlServerVersion> optional = Arrays.stream(values())
+            .sorted(Comparator.reverseOrder())
+            .filter(v -> version >= v._version)
+            .findFirst();
+
+        MicrosoftSqlServerVersion ssv = optional.orElseThrow(); // At least SQL_SERVER_UNSUPPORTED should match
+
+        return primaryDataSource && !ssv.isAllowedAsPrimaryDataSource() ? SQL_SERVER_UNSUPPORTED : ssv;
+    }
+
+    public static class TestCase extends Assert
+    {
+        @Test
+        public void test()
+        {
+            // Good
+            test(100, false, SQL_SERVER_2008);
+            test(110, false, SQL_SERVER_2012);
+            test(120, true, SQL_SERVER_2014);
+            test(120, false, SQL_SERVER_2014);
+            test(130, true, SQL_SERVER_2016);
+            test(130, false, SQL_SERVER_2016);
+            test(140, true, SQL_SERVER_2017);
+            test(140, false, SQL_SERVER_2017);
+            test(150, true, SQL_SERVER_2019);
+            test(150, false, SQL_SERVER_2019);
+            test(160, true, SQL_SERVER_2022);
+            test(160, false, SQL_SERVER_2022);
+
+            // Future
+            test(170, true, SQL_SERVER_FUTURE);
+            test(170, false, SQL_SERVER_FUTURE);
+            test(180, true, SQL_SERVER_FUTURE);
+            test(180, false, SQL_SERVER_FUTURE);
+
+            // Bad
+            test(80, true, SQL_SERVER_UNSUPPORTED);
+            test(80, false, SQL_SERVER_UNSUPPORTED);
+            test(85, true, SQL_SERVER_UNSUPPORTED);
+            test(85, false, SQL_SERVER_UNSUPPORTED);
+            test(90, true, SQL_SERVER_UNSUPPORTED);
+            test(90, false, SQL_SERVER_UNSUPPORTED);
+            test(95, true, SQL_SERVER_UNSUPPORTED);
+            test(95, false, SQL_SERVER_UNSUPPORTED);
+            test(99, true, SQL_SERVER_UNSUPPORTED);
+            test(99, false, SQL_SERVER_UNSUPPORTED);
+        }
+
+        private void test(int version, boolean primary, MicrosoftSqlServerVersion expectedVersion)
+        {
+            Assert.assertEquals(get(version, primary), expectedVersion);
+        }
+    }
+}


### PR DESCRIPTION
#### Rationale
An `enum` that captures all supported versions of Microsoft SQL Server and their properties (reported version number, tested, deprecated, allowed as primary data source, dialect factory to use, etc.) eases maintenance and testing of the dialect selection rules. See `PostgreSqlVersion` as the model.

#### Changes
* Add `MicrosoftSqlServerVersion` enum to capture supported versions and properties
* Replace version-specific `if` statements with generic logic that delegates to the enum properties
* Add junit test to verify expected dialects are returned for every version int
* Add admin warning for deprecated SQL Server version, consistent with PostgreSQL behavior