### PR TITLE
46695: No longer roundtripping "RowId" column through export/import

### DIFF
--- a/study/src/org/labkey/study/writer/DatasetDataWriter.java
+++ b/study/src/org/labkey/study/writer/DatasetDataWriter.java
@@ -310,15 +310,14 @@ public class DatasetDataWriter implements InternalStudyWriter
                 if ("ptid".equalsIgnoreCase(in.getName()) && !in.equals(ptidColumn))
                     continue;
 
-                if (def.isPublishedData())
+                if (def.isPublishedData() && !isKeyProperty)
                 {
                     // don't include some published data columns in the export
                     if (ExpMaterialTable.Column.Alias.name().equalsIgnoreCase(in.getName()) ||
                             ExpMaterialTable.Column.Flag.name().equalsIgnoreCase(in.getName()) ||
                             "run".equalsIgnoreCase(in.getName()) ||
                             "participantVisit/visit".equalsIgnoreCase(in.getName()) ||
-                            "ancestors".equalsIgnoreCase(in.getName()) ||
-                            "rowId".equalsIgnoreCase(in.getName()))
+                            "ancestors".equalsIgnoreCase(in.getName()))
                         continue;
                 }
 


### PR DESCRIPTION
#### Rationale
We filter some columns out at export time for either assay or sample `linked` data. This is because the source tables will no longer be present after folder import and some of those fields have no context without the linked source. However `rowId` is always needed as it becomes the default 3rd key at link to study time and without it we may run into uniqueness constraints.

#### Changes
Remove `rowId` from the filter list and also don't filter out these columns if they happen to be key fields.

[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46695)