### PR TITLE
Create new JSON helpers to replace org.json.old.* helpers. Migrate.

### DIFF
--- a/api/src/org/labkey/api/collections/LabKeyCollectors.java
+++ b/api/src/org/labkey/api/collections/LabKeyCollectors.java
@@ -3,7 +3,7 @@ package org.labkey.api.collections;
 import com.google.common.collect.Comparators;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
-import org.json.old.JSONArray;
+import org.json.JSONArray;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.util.HtmlString;
@@ -33,7 +33,7 @@ public class LabKeyCollectors
      * Returns a {@link Collector} that builds a {@link LinkedHashMap}, for cases where caller wants a map that preserves {@link Stream} order.
      * https://stackoverflow.com/questions/29090277/how-do-i-keep-the-iteration-order-of-a-list-when-using-collections-tomap-on-a
      */
-    public static <T, K, U> Collector<T, ?, Map<K,U>> toLinkedMap(
+    public static <T, K, U> Collector<T, ?, Map<K, U>> toLinkedMap(
         Function<? super T, ? extends K> keyMapper,
         Function<? super T, ? extends U> valueMapper)
     {
@@ -85,10 +85,10 @@ public class LabKeyCollectors
      * Returns a {@link Collector} that accumulates elements into a {@link MultiValuedMap} whose keys and values are the
      * result of applying the provided mapping functions to the input elements, an approach that mimics {@link Collectors#toMap(Function, Function)}.
      *
-     * @param <T> the type of the input elements
-     * @param <K> the output type of the key mapping function
-     * @param <V> the output type of the value mapping function
-     * @param keyMapper a mapping function to produce keys
+     * @param <T>         the type of the input elements
+     * @param <K>         the output type of the key mapping function
+     * @param <V>         the output type of the value mapping function
+     * @param keyMapper   a mapping function to produce keys
      * @param valueMapper a mapping function to produce values
      * @return a {@code Collector} that collects elements into a {@code MultiValuedMap} whose keys and values are the
      * result of applying mapping functions to the input elements
@@ -104,12 +104,12 @@ public class LabKeyCollectors
      * result of applying the provided mapping functions to the input elements, an approach that mimics {@link Collectors#toMap(Function, Function)}.
      * The {@link MultiValuedMap} is created by a provided supplier function.
      *
-     * @param <T> the type of the input elements
-     * @param <K> the output type of the key mapping function
-     * @param <V> the output type of the value mapping function
-     * @param keyMapper a mapping function to produce keys
+     * @param <T>         the type of the input elements
+     * @param <K>         the output type of the key mapping function
+     * @param <V>         the output type of the value mapping function
+     * @param keyMapper   a mapping function to produce keys
      * @param valueMapper a mapping function to produce values
-     * @param supplier a function that returns a new, empty {@code MultiValuedMap} into which the results will be inserted
+     * @param supplier    a function that returns a new, empty {@code MultiValuedMap} into which the results will be inserted
      * @return a {@code Collector} that collects elements into a {@code MultiValuedMap} whose keys and values are the
      * result of applying mapping functions to the input elements
      */
@@ -134,7 +134,11 @@ public class LabKeyCollectors
      */
     public static Collector<Object, JSONArray, JSONArray> toJSONArray()
     {
-        return JSONArray.collector();
+        return Collector.of(
+            JSONArray::new,
+            JSONArray::put,
+            JSONArray::putAll
+        );
     }
 
     /**

--- a/api/src/org/labkey/api/jsp/JspBase.java
+++ b/api/src/org/labkey/api/jsp/JspBase.java
@@ -19,8 +19,8 @@ package org.labkey.api.jsp;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONArray;
-import org.json.old.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.labkey.api.action.HasViewContext;
 import org.labkey.api.action.ReturnUrlForm;
 import org.labkey.api.action.SpringActionController;
@@ -223,20 +223,41 @@ public abstract class JspBase extends JspContext implements HasViewContext
         return HtmlString.of(url == null ? null : url.toString());
     }
 
-    // Note: If you have a stream, use JSONArray.collector()
+    // Note: If you have a stream, use LabKeyCollectors.toJsonArray()
     public JSONArray toJsonArray(Collection<?> c)
     {
         return new JSONArray(c);
     }
 
-    public JSONObject toJsonObject(Collection<Object> c)
+    public JSONObject toJsonObject(Map<?, ?> c)
     {
         return new JSONObject(c);
     }
 
-    public JSONObject toJsonObject(Map<?, ?> c)
+    /**
+     * Make a pretty-printed and SafeToRender JSON text of this JSONArray
+     * @param indentFactor Number of spaces to add to each level of indentation
+     * @return JavaScriptFragment holding the JSON representation
+     */
+    public JavaScriptFragment json(JSONArray array, int indentFactor)
     {
-        return new JSONObject(c);
+        return JavaScriptFragment.unsafe(array.toString(indentFactor));
+    }
+
+    /**
+     * Make a pretty-printed and SafeToRender JSON text of this JSONObject
+     * @param indentFactor Number of spaces to add to each level of indentation
+     * @return JavaScriptFragment holding the JSON representation
+     */
+    public JavaScriptFragment json(JSONObject jsonObject, int indentFactor)
+    {
+        return JavaScriptFragment.unsafe(jsonObject.toString(indentFactor));
+    }
+
+    @Deprecated // Just to help with migration. TODO: Eliminate usages and delete this
+    public JavaScriptFragment json(org.json.old.JSONObject jsonObject, int indentFactor)
+    {
+        return JavaScriptFragment.unsafe(jsonObject.toString(indentFactor));
     }
 
     /**

--- a/api/src/org/labkey/api/query/excelExportOptions.jsp
+++ b/api/src/org/labkey/api/query/excelExportOptions.jsp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.json.old.JSONObject" %>
+<%@ page import="org.json.JSONObject" %>
 <%@ page import="org.labkey.api.data.ColumnHeaderType" %>
 <%@ page import="org.labkey.api.query.QueryView" %>
 <%@ page import="org.labkey.api.util.GUID" %>
@@ -123,21 +123,21 @@
                 if (xlsxExportEl.is(':checked')) {
                     if (isSign) {
                         exportUrl = <%=q(model.getSignXlsxURL().getPath())%>;
-                        exportParams = <%=new JSONObject(model.getSignXlsxURL().getParameterMap()).getJavaScriptFragment(2)%>;
+                        exportParams = <%=json(new JSONObject(model.getSignXlsxURL().getParameterMap()), 2)%>;
                     }
                     else {
                         exportUrl = <%=q(model.getXlsxURL().getPath())%>;
-                        exportParams = <%=new JSONObject(model.getXlsxURL().getParameterMap()).getJavaScriptFragment(2)%>;
+                        exportParams = <%=json(new JSONObject(model.getXlsxURL().getParameterMap()), 2)%>;
                     }
                 }
                 else if (xlsExportEl.is(':checked')) {
                     if (isSign) {
                         exportUrl = <%=q(model.getSignXlsURL().getPath())%>;
-                        exportParams = <%=new JSONObject(model.getSignXlsURL().getParameterMap()).getJavaScriptFragment(2)%>;
+                        exportParams = <%=json(new JSONObject(model.getSignXlsURL().getParameterMap()), 2)%>;
                     }
                     else {
                         exportUrl = <%=q(model.getXlsURL().getPath())%>;
-                        exportParams = <%=new JSONObject(model.getXlsURL().getParameterMap()).getJavaScriptFragment(2)%>;
+                        exportParams = <%=json(new JSONObject(model.getXlsURL().getParameterMap()), 2)%>;
                     }
                 <% if (model.getIqyURL() != null) { %>
                 }

--- a/api/src/org/labkey/api/view/GWTView.jsp
+++ b/api/src/org/labkey/api/view/GWTView.jsp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.json.old.JSONObject" %>
+<%@ page import="org.json.JSONObject" %>
 <%@ page import="org.labkey.api.view.GWTView" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page extends="org.labkey.api.jsp.JspBase"%>
@@ -31,5 +31,5 @@ String jsPath = bean.getModuleName() + "/" + bean.getModuleName() + ".nocache.js
 <%=getScriptTag(jsPath)%>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
     <!-- Pass through name/value property map to GWT app so it can initialize itself appropriately -->
-<%=unsafe(GWTView.PROPERTIES_OBJECT_NAME)%> = <%=new JSONObject(bean.getProperties()).getJavaScriptFragment(3)%>;
+<%=unsafe(GWTView.PROPERTIES_OBJECT_NAME)%> = <%=json(new JSONObject(bean.getProperties()), 3)%>;
 </script>

--- a/assay/src/org/labkey/assay/view/batchDetails.jsp
+++ b/assay/src/org/labkey/assay/view/batchDetails.jsp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.json.old.JSONObject" %>
+<%@ page import="org.json.JSONObject" %>
 <%@ page import="org.labkey.api.exp.api.AssayJSONConverter" %>
 <%@ page import="org.labkey.api.exp.api.ExpExperiment" %>
 <%@ page import="org.labkey.api.exp.api.ExpProtocol" %>
@@ -34,12 +34,12 @@
     ExpExperiment batch = bean.expExperiment;
 
     Map<String, Object> assay = AssayController.serializeAssayDefinition(bean.expProtocol, bean.provider, getContainer(), getUser());
-    JSONObject batchJson = AssayJSONConverter.serializeBatch(batch, provider, protocol, getUser(), ExperimentJSONConverter.DEFAULT_SETTINGS);
+    org.json.old.JSONObject batchJson = AssayJSONConverter.serializeBatch(batch, provider, protocol, getUser(), ExperimentJSONConverter.DEFAULT_SETTINGS);
 %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
 LABKEY.page = LABKEY.page || {};
-LABKEY.page.assay = <%= new JSONObject(assay).getJavaScriptFragment(2) %>;
-LABKEY.page.batch = new LABKEY.Exp.RunGroup(<%=batchJson.getJavaScriptFragment(2)%>);
+LABKEY.page.assay = <%=json(new JSONObject(assay), 2) %>;
+LABKEY.page.batch = new LABKEY.Exp.RunGroup(<%=json(batchJson, 2)%>);
 LABKEY.page.batch.batchProtocolId = <%= protocol.getRowId() %>;
 LABKEY.page.batch.loaded = true;
 </script>

--- a/assay/src/org/labkey/assay/view/begin.jsp
+++ b/assay/src/org/labkey/assay/view/begin.jsp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.json.old.JSONObject" %>
+<%@ page import="org.json.JSONObject" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.assay.AssayController" %>
@@ -29,7 +29,7 @@
 %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
 LABKEY.page = LABKEY.page || {};
-LABKEY.page.assay = <%= new JSONObject(assay).getJavaScriptFragment(2) %>;
+LABKEY.page.assay = <%=json(new JSONObject(assay), 2) %>;
 </script>
 <p>
 <%

--- a/assay/src/org/labkey/assay/view/moduleAssayListView.jsp
+++ b/assay/src/org/labkey/assay/view/moduleAssayListView.jsp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.json.old.JSONObject" %>
+<%@ page import="org.json.JSONObject" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.assay.AssayController" %>
@@ -29,7 +29,7 @@
 %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
 LABKEY.page = LABKEY.page || {};
-LABKEY.page.assay = <%= new JSONObject(assay).getJavaScriptFragment(2) %>;
+LABKEY.page.assay = <%=json(new JSONObject(assay), 2) %>;
 </script>
 <p>
 <%

--- a/assay/src/org/labkey/assay/view/moduleAssayUpload.jsp
+++ b/assay/src/org/labkey/assay/view/moduleAssayUpload.jsp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.json.old.JSONObject"%>
+<%@ page import="org.json.JSONObject"%>
 <%@ page import="org.labkey.api.assay.AssayProvider" %>
 <%@ page import="org.labkey.api.assay.actions.AssayRunUploadForm" %>
 <%@ page import="org.labkey.api.exp.api.AssayJSONConverter" %>
@@ -65,13 +65,13 @@
 %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
 LABKEY.page = LABKEY.page || {};
-LABKEY.page.assay = <%= new JSONObject(assay).getJavaScriptFragment(2)%>;
+LABKEY.page.assay = <%=json(new JSONObject(assay), 2)%>;
 <%
  if (batchId > 0)
  {
     ExpExperiment batch = lookupBatch(batchId);
-    JSONObject batchJson = AssayJSONConverter.serializeBatch(batch, provider, protocol, getUser(), ExperimentJSONConverter.DEFAULT_SETTINGS);
-    %>LABKEY.page.batch = new LABKEY.Exp.RunGroup(<%=batchJson.getJavaScriptFragment(2)%>);<%
+    org.json.old.JSONObject batchJson = AssayJSONConverter.serializeBatch(batch, provider, protocol, getUser(), ExperimentJSONConverter.DEFAULT_SETTINGS);
+    %>LABKEY.page.batch = new LABKEY.Exp.RunGroup(<%=json(batchJson, 2)%>);<%
  }
  else
  {

--- a/assay/src/org/labkey/assay/view/resultDetails.jsp
+++ b/assay/src/org/labkey/assay/view/resultDetails.jsp
@@ -48,8 +48,8 @@
 %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
 LABKEY.page = LABKEY.page || {};
-LABKEY.page.assay = <%= new JSONObject(assay).getJavaScriptFragment(2) %>;
-LABKEY.page.result = <%= result.getJavaScriptFragment(2) %>;
+LABKEY.page.assay = <%=json(new org.json.JSONObject(assay), 2)%>;
+LABKEY.page.result = <%=json(result, 2)%>;
 </script>
 <p>
 <%

--- a/assay/src/org/labkey/assay/view/runDetails.jsp
+++ b/assay/src/org/labkey/assay/view/runDetails.jsp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.json.old.JSONObject" %>
+<%@ page import="org.json.JSONObject" %>
 <%@ page import="org.labkey.api.exp.api.AssayJSONConverter" %>
 <%@ page import="org.labkey.api.exp.api.ExpProtocol" %>
 <%@ page import="org.labkey.api.exp.api.ExpRun" %>
@@ -34,12 +34,12 @@
     ExpRun run = bean.expRun;
 
     Map<String, Object> assay = AssayController.serializeAssayDefinition(bean.expProtocol, bean.provider, getContainer(), getUser());
-    JSONObject runJson = AssayJSONConverter.serializeRun(run, provider, protocol, getUser(), ExperimentJSONConverter.DEFAULT_SETTINGS);
+    org.json.old.JSONObject runJson = AssayJSONConverter.serializeRun(run, provider, protocol, getUser(), ExperimentJSONConverter.DEFAULT_SETTINGS);
 %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
 LABKEY.page = LABKEY.page || {};
-LABKEY.page.assay = <%= new JSONObject(assay).getJavaScriptFragment(2) %>;
-LABKEY.page.run = new LABKEY.Exp.Run(<%= runJson.getJavaScriptFragment(2) %>);
+LABKEY.page.assay = <%=json(new JSONObject(assay), 2)%>;
+LABKEY.page.run = new LABKEY.Exp.Run(<%=json(runJson, 2)%>);
 </script>
 <p>
 <%

--- a/core/src/org/labkey/core/admin/customizeEmail.jsp
+++ b/core/src/org/labkey/core/admin/customizeEmail.jsp
@@ -16,9 +16,9 @@
  */
 %>
 <%@ page import="org.apache.commons.lang3.StringUtils" %>
-<%@ page import="org.json.old.JSONArray" %>
-<%@ page import="org.json.old.JSONObject" %>
+<%@ page import="org.json.JSONArray" %>
 <%@ page import="org.labkey.api.admin.AdminUrls" %>
+<%@ page import="org.labkey.api.collections.LabKeyCollectors" %>
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.data.ContainerManager" %>
 <%@ page import="org.labkey.api.security.permissions.AdminPermission" %>
@@ -50,14 +50,14 @@
     {
         return replacements.stream()
             .sorted()
-            .map(param -> new JSONObject(Map.of(
+            .map(param -> Map.of(
                 "paramName", param.getName(),
                 "format", param.getContentType().toString(),
                 "valueType", param.getValueType().getSimpleName(),
                 "paramDesc", param.getDescription(),
                 "paramValue", param.getFormattedValue(getContainer(), null, ContentType.HTML)
-            )))
-            .collect(JSONArray.collector());
+            ))
+            .collect(LabKeyCollectors.toJSONArray());
     }
 %>
 <%
@@ -157,7 +157,7 @@
     // create an array of email templates with their replacement parameters
     JSONArray array = emailTemplates.stream()
         // Some values could be null, so Map.of() is not an option for the top-level map
-        .map(et->new JSONObject(PageFlowUtil.map(
+        .map(et->PageFlowUtil.map(
             "name", et.getClass().getName(),
             "description", et.getDescription(),
             "sender", et.getSenderName(),
@@ -172,10 +172,10 @@
             "hasMultipleContentTypes", (et.getContentType() == ContentType.HTML),
             "standardReplacements", getReplacementJSON(et.getStandardReplacements()),
             "customReplacements", getReplacementJSON(et.getCustomReplacements())
-        )))
-        .collect(JSONArray.collector());
+        ))
+        .collect(LabKeyCollectors.toJSONArray());
 %>
-    var emailTemplates = <%=array.getJavaScriptFragment(4)%>
+    var emailTemplates = <%=json(array, 4)%>
 
     function changeEmailTemplate()
     {

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -20,7 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONArray;
+import org.json.JSONArray;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
 import org.labkey.api.action.FormHandlerAction;

--- a/core/src/org/labkey/core/workbook/MoveWorkbooksBean.java
+++ b/core/src/org/labkey/core/workbook/MoveWorkbooksBean.java
@@ -15,7 +15,8 @@
  */
 package org.labkey.core.workbook;
 
-import org.json.old.JSONArray;
+import org.json.JSONArray;
+import org.labkey.api.collections.LabKeyCollectors;
 import org.labkey.api.data.Container;
 
 import java.util.ArrayList;
@@ -44,6 +45,6 @@ public class MoveWorkbooksBean
     {
         return _workbooks.stream()
             .map(Container::getRowId)
-            .collect(JSONArray.collector());
+            .collect(LabKeyCollectors.toJSONArray());
     }
 }

--- a/experiment/src/org/labkey/experiment/ProtocolApplications.jsp
+++ b/experiment/src/org/labkey/experiment/ProtocolApplications.jsp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.json.old.JSONObject"%>
+<%@ page import="org.json.JSONObject"%>
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.exp.ExperimentDataHandler" %>
 <%@ page import="org.labkey.api.exp.Identifiable" %>
@@ -116,7 +116,7 @@
             <td valign="top">
                 <%
                     if (!props.isEmpty())
-                        out.print(new JSONObject(props).getJavaScriptFragment(2));
+                        out.print(json(new JSONObject(props), 2));
                 %>
             </td>
         </tr>
@@ -138,7 +138,7 @@
                         <td width="200px"><%= h(protocolInput != null ? protocolInput.getName() : null)%></td>
                         <td>
                             <% Map<String, Object> map = ((ExpMaterialRunInputImpl)materialRunInput).getProperties(); %>
-                            <% if (!map.isEmpty()) out.print(new JSONObject(map).getJavaScriptFragment(2)); %>
+                            <% if (!map.isEmpty()) out.print(json(new JSONObject(map), 2)); %>
                         </td>
                     </tr>
                     <% } %>
@@ -158,7 +158,7 @@
                         <td width="200px"><%= h(protocolInput != null ? protocolInput.getName() : null)%></td>
                         <td>
                             <% Map<String, Object> map = ((ExpDataRunInputImpl)dataRunInput).getProperties(); %>
-                            <% if (!map.isEmpty()) out.print(new JSONObject(map).getJavaScriptFragment(2)); %>
+                            <% if (!map.isEmpty()) out.print(json(new JSONObject(map), 2)); %>
                         </td>
                     </tr>
                     <% } %>
@@ -178,7 +178,7 @@
                         <td width="200px"><%= h(protocolInput != null ? protocolInput.getName() : null)%></td>
                         <td>
                             <% Map<String, Object> map = ((ExpMaterialRunInputImpl)materialRunInput).getProperties(); %>
-                            <% if (!map.isEmpty()) out.print(new JSONObject(map).getJavaScriptFragment(2)); %>
+                            <% if (!map.isEmpty()) out.print(json(new JSONObject(map), 2)); %>
                         </td>
                     </tr>
                     <% } %>
@@ -198,7 +198,7 @@
                         <td width="200px"><%= h(protocolInput != null ? protocolInput.getName() : null)%></td>
                         <td>
                             <% Map<String, Object> map = ((ExpDataRunInputImpl)dataRunInput).getProperties(); %>
-                            <% if (!map.isEmpty()) out.print(new JSONObject(map).getJavaScriptFragment(2)); %>
+                            <% if (!map.isEmpty()) out.print(json(new JSONObject(map), 2)); %>
                         </td>
                     </tr>
                     <% } %>

--- a/experiment/src/org/labkey/experiment/ProtocolSteps.jsp
+++ b/experiment/src/org/labkey/experiment/ProtocolSteps.jsp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.json.old.JSONObject"%>
+<%@ page import="org.json.JSONObject"%>
 <%@ page import="org.labkey.api.exp.ProtocolParameter" %>
 <%@ page import="org.labkey.api.exp.api.ExpDataClass" %>
 <%@ page import="org.labkey.api.exp.api.ExpDataProtocolInput" %>
@@ -122,7 +122,7 @@
             <%=h(predecessorNames)%>
         </td>
         <td valign="top">
-            <% if (!props.isEmpty()) out.print(new JSONObject(props).getJavaScriptFragment(2)); %>
+            <% if (!props.isEmpty()) out.print(json(new JSONObject(props), 2)); %>
         </td>
         <% } %>
     </tr>
@@ -172,7 +172,7 @@
                     <td width="20px"><%=mpi.getMaxOccurs()%></td>
                     <td>
                         <% Map<String, Object> map = ((ExpMaterialProtocolInputImpl)mpi).getProperties(); %>
-                        <% if (!map.isEmpty()) out.print(new JSONObject(map).getJavaScriptFragment(2)); %>
+                        <% if (!map.isEmpty()) out.print(json(new JSONObject(map), 2)); %>
                     </td>
                 </tr>
                 <% } %>
@@ -193,7 +193,7 @@
                     <td width="20px"><%=dpi.getMaxOccurs()%></td>
                     <td>
                         <% Map<String, Object> map = ((ExpDataProtocolInputImpl)dpi).getProperties(); %>
-                        <% if (!map.isEmpty()) out.print(new JSONObject(map).getJavaScriptFragment(2)); %>
+                        <% if (!map.isEmpty()) out.print(json(new JSONObject(map), 2)); %>
                     </td>
                 </tr>
                 <% } %>
@@ -219,7 +219,7 @@
                     <td width="20px"><%=h(mpo.getMaxOccurs())%></td>
                     <td>
                         <% Map<String, Object> map = ((ExpMaterialProtocolInputImpl)mpo).getProperties(); %>
-                        <% if (!map.isEmpty()) out.print(new JSONObject(map).getJavaScriptFragment(2)); %>
+                        <% if (!map.isEmpty()) out.print(json(new JSONObject(map), 2)); %>
                     </td>
                 </tr>
                 <% } %>
@@ -240,7 +240,7 @@
                     <td width="20px"><%=dpo.getMaxOccurs()%></td>
                     <td>
                         <% Map<String, Object> map = ((ExpDataProtocolInputImpl)dpo).getProperties(); %>
-                        <% if (!map.isEmpty()) out.print(new JSONObject(map).getJavaScriptFragment(2)); %>
+                        <% if (!map.isEmpty()) out.print(json(new JSONObject(map), 2)); %>
                     </td>
                 </tr>
                 <% } %>

--- a/query/src/org/labkey/query/view/editApp.jsp
+++ b/query/src/org/labkey/query/view/editApp.jsp
@@ -16,11 +16,11 @@
  */
 %>
 <%@ page import="org.json.old.JSONObject" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.query.controllers.OlapController" %>
 <%@ page import="java.util.Map" %>
-<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!

--- a/specimen/src/org/labkey/specimen/view/manageRequest.jsp
+++ b/specimen/src/org/labkey/specimen/view/manageRequest.jsp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.json.old.JSONArray"%>
+<%@ page import="org.labkey.api.collections.LabKeyCollectors"%>
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.data.ContainerManager"%>
 <%@ page import="org.labkey.api.security.User"%>
@@ -96,7 +96,7 @@
     var NONSITE_ACTORS = <%=Arrays.stream(actors)
         .filter(actor->!actor.isPerSite())
         .map(SpecimenRequestActor::getRowId)
-        .collect(JSONArray.collector())%>;
+        .collect(LabKeyCollectors.toJSONArray())%>;
 
     setCookieToRequestId(<%= bean.getSpecimenRequest().getRowId()%>);
 


### PR DESCRIPTION
#### Rationale
We hacked up the old `JSONObject` and `JSONArray` with various helper methods and used them. Adding replacement helpers for the new versions will ease the migration.

#### Changes
* New `toJSONArray()` collector
* New `JspBase.json()` for pretty printing from JSPs
* Migrate most helper usages to the new classes and helpers
