### PR TITLE
Issue 46710: ClassCastException in BaseViewAction.handleSpecialProperties()

### DIFF
--- a/api/src/org/labkey/api/action/BaseViewAction.java
+++ b/api/src/org/labkey/api/action/BaseViewAction.java
@@ -167,7 +167,6 @@ public abstract class BaseViewAction<FORM> extends PermissionCheckableAction imp
         return pv == null ? null : pv.getValue();
     }
 
-
     public PropertyValues getPropertyValues()
     {
         return _pvs;
@@ -206,18 +205,41 @@ public abstract class BaseViewAction<FORM> extends PermissionCheckableAction imp
 
         // Special flag puts actions in "debug" mode, during which they should log extra information that would be
         // helpful for testing or debugging problems
-        if (!_robot && null != StringUtils.trimToNull((String) getProperty("_debug")))
+        if (!_robot && hasStringValue("_debug"))
         {
             _debug = true;
         }
 
-        if (null != StringUtils.trimToNull((String) getProperty("_print")) ||
-            null != StringUtils.trimToNull((String) getProperty("_print.x")))
+        if (hasStringValue("_print") ||
+            hasStringValue("_print.x"))
         {
             _print = true;
         }
     }
 
+    private boolean hasStringValue(String propertyName)
+    {
+        Object o = getProperty(propertyName);
+        if (o == null)
+        {
+            return false;
+        }
+        if (o instanceof String s)
+        {
+            return null != StringUtils.trimToNull(s);
+        }
+        if (o instanceof String[] strings)
+        {
+            for (String s : strings)
+            {
+                if (null != StringUtils.trimToNull(s))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 
     public abstract ModelAndView handleRequest() throws Exception;
 


### PR DESCRIPTION
#### Rationale
We shouldn't throw on exception when there are duplicate _debug, _print, or _print.x HTTP parameters

#### Changes
* Handle string arrays as well