### PR TITLE
Better guidance for JDBC driver and URL mismatches

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1547,8 +1547,7 @@ public class DbScope
             }
             catch (Exception e)
             {
-                LOG.error("ensureDataBase", e);
-                throw new ServletException("Internal error", e);
+                throw new ServletException("Connection to \"" + dsName + "\" at " + props.getUrl() + " failed", e);
             }
             finally
             {
@@ -1573,7 +1572,8 @@ public class DbScope
         return getRawConnection(props.getUrl(), props);
     }
 
-    // Establish a direct connection to the specified URL using the data source's driver and credentials. This bypasses the connection pool.
+    // Attempt to establish a direct connection to the specified URL using the data source's driver and credentials.
+    // This bypasses the connection pool.
     private static Connection getRawConnection(String url, DataSourceProperties props) throws ServletException, SQLException
     {
         Driver driver;
@@ -1597,6 +1597,9 @@ public class DbScope
         {
             throw new ServletException("Unable to retrieve data source properties", e);
         }
+
+        if (!driver.acceptsURL(url))
+            throw new ServletException("The specified driver (\"" + props.getDriverClassName() + "\") does not accept the specified URL (\"" + url + "\")");
 
         return driver.connect(url, info);
     }

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1141,8 +1141,8 @@ public abstract class SqlDialect
         {
             try
             {
-                Method getMethod = _ds.getClass().getMethod(methodName);
-                return (K)getMethod.invoke(_ds);
+                Method method = _ds.getClass().getMethod(methodName);
+                return (K)method.invoke(_ds);
             }
             catch (Exception e)
             {
@@ -1381,7 +1381,7 @@ public abstract class SqlDialect
 
 
     /**
-     * Encode wildcard characters in search string used by LIKE operator to force exact match of those charactors.
+     * Encode wildcard characters in search string used by LIKE operator to force exact match of those characters.
      * Currently only encodes single wildcard character '_' and '%' used by LIKE, while more complicated pattern such as [], {} are not encoded.
      * Example:
      *      String searchString = "search_string";
@@ -1390,7 +1390,7 @@ public abstract class SqlDialect
      *      sqlFragment.append(" LIKE ?");
      *      sqlFragment.add("_" + encodeLikeSearchString(searchString) + "%");
      *
-     *    ##encodeLikeSearchString(searchString) will ensure exact match of substring "search_string" and won't treate the the underscore as a wildcard.
+     *    ##encodeLikeSearchString(searchString) ensures an exact match of substring "search_string" and won't treat an underscore as a wildcard.
      * @param search
      * @return encoded search string
      */

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1141,8 +1141,8 @@ public abstract class SqlDialect
         {
             try
             {
-                Method getUrl = _ds.getClass().getMethod(methodName);
-                return (K)getUrl.invoke(_ds);
+                Method getMethod = _ds.getClass().getMethod(methodName);
+                return (K)getMethod.invoke(_ds);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
#### Rationale
`Driver.connect()` returns `null` if passed a URL whose prefix doesn't match what the driver expects. LabKey is not prepared for this and logs an NPE:

```
ERROR DbScopeLoader            2022-11-12T13:38:27,488       Catalina-utility-1 : Cannot connect to DataSource "ssDataSource" defined in labkey.xml. This DataSource will not be available during this server session.
java.lang.NullPointerException: Cannot invoke "java.sql.Connection.getMetaData()" because "conn" is null
	at org.labkey.api.data.DbScope.<init>(DbScope.java:319) ~[api-22.11-SNAPSHOT.jar:?]
	at org.labkey.api.data.DbScopeLoader.get(DbScopeLoader.java:66) ~[api-22.11-SNAPSHOT.jar:?]
	at org.labkey.api.data.DbScope.getDbScope(DbScope.java:1676) ~[api-22.11-SNAPSHOT.jar:?]
	at org.labkey.api.data.DbScope.initializeScopes(DbScope.java:1452) ~[api-22.11-SNAPSHOT.jar:?]
	at org.labkey.api.data.DbScope.initializeDataSources(DbScope.java:1294) ~[api-22.11-SNAPSHOT.jar:?]
```

The jTDS -> SQL Server transition makes it easier to end up with a mismatch; let's provide better guidance by detecting and reporting it:

```
ERROR DbScopeLoader            2022-11-12T13:43:11,228     http-nio-8080-exec-2 : Cannot connect to DataSource "ssDataSource" defined in labkey.xml. This DataSource will not be available during this server session.
javax.servlet.ServletException: The specified driver ("com.microsoft.sqlserver.jdbc.SQLServerDriver") does not accept the specified URL ("jdbc:jtds:sqlserver://localhost:1433/labkey22.11")
	at org.labkey.api.data.DbScope.getRawConnection(DbScope.java:1602) ~[api-22.11-SNAPSHOT.jar:?]
	at org.labkey.api.data.DbScope.getRawConnection(DbScope.java:1572) ~[api-22.11-SNAPSHOT.jar:?]
	at org.labkey.api.data.DbScope.<init>(DbScope.java:317) ~[api-22.11-SNAPSHOT.jar:?]
	at org.labkey.api.data.DbScopeLoader.get(DbScopeLoader.java:66) ~[api-22.11-SNAPSHOT.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
	at java.util.LinkedList$LLSpliterator.forEachRemaining(LinkedList.java:1242) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
	at org.labkey.api.data.DbScope.getDbScopes(DbScope.java:1696) ~[api-22.11-SNAPSHOT.jar:?]
```