### PR TITLE
Simplify URLHelper/ActionURL JSON serialization

### DIFF
--- a/api/src/org/labkey/api/data/JsonTest.java
+++ b/api/src/org/labkey/api/data/JsonTest.java
@@ -138,7 +138,7 @@ public class JsonTest extends Assert
         // NOTE: In both cases, the date value is deserialized as a string because JSON sucks
         JSONObject jsonOrgRoundTrip =  new JSONObject(jacksonToString);
         JSONObject jacksonRoundTrip = mapper.readValue(jacksonToString, JSONObject.class);
-        assertTrue(jsonOrgRoundTrip.similar(jacksonRoundTrip)); // Note: JSONObject.equals() doesn't work as expected
+        assertTrue("Not equivalent: " + jsonOrgRoundTrip + " vs. " + jacksonRoundTrip, jsonOrgRoundTrip.similar(jacksonRoundTrip)); // Note: JSONObject.equals() doesn't work as expected
     }
 
     @Test

--- a/api/src/org/labkey/api/data/JsonTest.java
+++ b/api/src/org/labkey/api/data/JsonTest.java
@@ -18,19 +18,23 @@ package org.labkey.api.data;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.json.old.JSONArray;
-import org.json.old.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.labkey.api.util.JsonUtil;
+import org.labkey.api.view.ActionURL;
+import org.labkey.api.view.HttpView;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.Map;
 
 /**
  * User: adam
@@ -66,7 +70,6 @@ public class JsonTest extends Assert
         c2.setOrders(Arrays.asList(o3));
     }
 
-
     @Test
     public void jacksonTest()
     {
@@ -87,18 +90,44 @@ public class JsonTest extends Assert
     }
 
     @Test
-    public void jsonOrgViaJackson() throws IOException
+    public void oldJsonOrgViaJackson() throws IOException
     {
-        // Test serializing org.json JSON classes via Jackson
+        // Test serializing org.json.old JSON classes via Jackson
         ObjectMapper mapper = JsonUtil.DEFAULT_MAPPER;
 
-        final Date d = new GregorianCalendar(2011, 11, 3).getTime();
+        final Date d = new GregorianCalendar(2011, Calendar.DECEMBER, 3).getTime();
+
+        org.json.old.JSONObject obj = new org.json.old.JSONObject();
+        obj.put("str", "hello");
+        obj.put("arr", new org.json.old.JSONArray(Arrays.asList("one", null, 3, new org.json.old.JSONObject(Collections.singletonMap("four", 4)))));
+        obj.put("nul", (Object)null);
+        obj.put("d", d);
+
+        // Verify serializing org.json.old.JSONObject via Jackson is equivalent
+        String jacksonToString = mapper.writeValueAsString(obj);
+        String jsonOrgToString = obj.toString();
+        assertEquals(jsonOrgToString, jacksonToString);
+
+        // Verify deserializing org.json.old.JSONObject via Jackson is equivalent
+        // NOTE: In both cases, the date value is deserialized as a string because JSON sucks
+        org.json.old.JSONObject jsonOrgRoundTrip =  new org.json.old.JSONObject(jacksonToString);
+        org.json.old.JSONObject jacksonRoundTrip = mapper.readValue(jacksonToString, org.json.old.JSONObject.class);
+        assertEquals(jsonOrgRoundTrip, jacksonRoundTrip);
+    }
+
+    @Test
+    public void jsonOrgViaJackson() throws IOException
+    {
+        // Test serializing org.json.* classes via Jackson
+        ObjectMapper mapper = JsonUtil.DEFAULT_MAPPER;
+
+        final Date d = new GregorianCalendar(2011, Calendar.DECEMBER, 3).getTime();
 
         JSONObject obj = new JSONObject();
         obj.put("str", "hello");
         obj.put("arr", new JSONArray(Arrays.asList("one", null, 3, new JSONObject(Collections.singletonMap("four", 4)))));
         obj.put("nul", (Object)null);
-        obj.put("d", d);
+//        obj.put("d", d);  //TODO: new JSONObject serializes date-times as ISO
 
         // Verify serializing org.json.JSONObject via Jackson is equivalent
         String jacksonToString = mapper.writeValueAsString(obj);
@@ -109,7 +138,16 @@ public class JsonTest extends Assert
         // NOTE: In both cases, the date value is deserialized as a string because JSON sucks
         JSONObject jsonOrgRoundTrip =  new JSONObject(jacksonToString);
         JSONObject jacksonRoundTrip = mapper.readValue(jacksonToString, JSONObject.class);
-        assertEquals(jsonOrgRoundTrip, jacksonRoundTrip);
+        assertTrue(jsonOrgRoundTrip.similar(jacksonRoundTrip)); // Note: JSONObject.equals() doesn't work as expected
+    }
+
+    @Test
+    public void jsonOrgTest()
+    {
+        ActionURL url = HttpView.currentContext().getActionURL();
+        Map<String, Object> map = Map.of("url", url);
+        assertEquals(new org.json.old.JSONObject(map).toString(), new JSONObject(map).toString());
+        assertEquals("{\"url\":\"/labkey/home/junit-run.view?testCase=org.labkey.api.data.JsonTest\"}", new JSONObject(map).toString());
     }
 
     private static class Customer

--- a/api/src/org/labkey/api/data/JsonTest.java
+++ b/api/src/org/labkey/api/data/JsonTest.java
@@ -147,7 +147,7 @@ public class JsonTest extends Assert
         ActionURL url = HttpView.currentContext().getActionURL();
         Map<String, Object> map = Map.of("url", url);
         assertEquals(new org.json.old.JSONObject(map).toString(), new JSONObject(map).toString());
-        assertEquals("{\"url\":\"/labkey/home/junit-run.view?testCase=org.labkey.api.data.JsonTest\"}", new JSONObject(map).toString());
+        assertEquals("{\"url\":\"" + url + "\"}", new JSONObject(map).toString());
     }
 
     private static class Customer

--- a/api/src/org/labkey/api/util/URLHelper.java
+++ b/api/src/org/labkey/api/util/URLHelper.java
@@ -24,6 +24,8 @@ import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.json.JSONObject;
+import org.json.JSONString;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.action.ReturnUrlForm;
@@ -55,12 +57,11 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 /**
  * Represents a URL, typically within this instance of LabKey Server.
  */
-public class URLHelper implements Cloneable, Serializable
+public class URLHelper implements Cloneable, Serializable, JSONString
 {
     private static final Logger LOG = LogManager.getLogger(URLHelper.class);
 
@@ -733,6 +734,11 @@ public class URLHelper implements Cloneable, Serializable
         return getLocalURIString(true);
     }
 
+    @Override
+    public String toJSONString()
+    {
+        return JSONObject.quote(toString());
+    }
 
     @Override
     public URLHelper clone()
@@ -744,7 +750,7 @@ public class URLHelper implements Cloneable, Serializable
             n._readOnly = false;
             n._parameters = _parameters == null ? null : new ArrayList<>(_parameters.size());
             if (null != _parameters)
-                n._parameters.addAll(_parameters.stream().map(Pair::copy).collect(Collectors.toList()));
+                n._parameters.addAll(_parameters.stream().map(Pair::copy).toList());
             return n;
         }
         catch (Exception x)

--- a/search/src/org/labkey/search/model/DavCrawler.java
+++ b/search/src/org/labkey/search/model/DavCrawler.java
@@ -189,13 +189,13 @@ public class DavCrawler implements ShutdownListener
     public void shutdownStarted()
     {
         if (null != _crawlerThread)
-        try
-        {
-            _crawlerThread.join(1000);
-        }
-        catch (InterruptedException x)
-        {
-        }
+            try
+            {
+                _crawlerThread.join(1000);
+            }
+            catch (InterruptedException x)
+            {
+            }
     }
 
 


### PR DESCRIPTION
#### Rationale
`SignalDataRawTest` starting failing because the new `JSONObject` is more aggressive about serializing all fields of a Java object. The old JSONObject it would serialize `ActionURL` as a simple relative URL string (ActionURL.toString()) but the new JSONObject was throwing `org.json.JSONException: JavaBean object contains recursively defined member variable of key "originalPropertyValue"`. Implementing `JSONString` allows us to dictate the serialization; in this case, we simply quote toString().

Also, add a simple Junit test for ActionURL and expand the existing Jackson test to exercise Jackson + new JSONObject serialization.
