### PR TITLE
Refactor WarningProvider to pass in showAllWarnings flag

### DIFF
--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -1884,7 +1884,8 @@ public abstract class PostgreSql91Dialect extends SqlDialect
         if (null != _adminWarning)
             warnings.add(_adminWarning);
         else if (showAllWarnings) // PostgreSqlDialectFactory.getStandardWarningMessage() is not accessible from here, so hard-code a sample warning
-            warnings.add(HtmlString.of("LabKey Server has not been tested against version 22.7. PostgreSQL 15.x is the recommended version."));
+            warnings.add(HtmlString.of("LabKey Server has not been tested against this version. PostgreSQL 15.x is the recommended version."));
+
     }
 
     @Override

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -1883,6 +1883,8 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     {
         if (null != _adminWarning)
             warnings.add(_adminWarning);
+        else if (showAllWarnings) // PostgreSqlDialectFactory.getStandardWarningMessage() is not accessible from here, so hard-code a sample warning
+            warnings.add(HtmlString.of("LabKey Server has not been tested against version 22.7. PostgreSQL 15.x is the recommended version."));
     }
 
     @Override

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -1879,7 +1879,7 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     }
 
     @Override
-    public void addAdminWarningMessages(Warnings warnings)
+    public void addAdminWarningMessages(Warnings warnings, boolean showAllWarnings)
     {
         if (null != _adminWarning)
             warnings.add(_adminWarning);

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1429,7 +1429,7 @@ public abstract class SqlDialect
     // - Only on the LabKey DataSource's dialect instance (not external data sources)
     // - After the core module has been upgraded and the dialect has been prepared for the last time, meaning the dialect
     //   should reflect the final database configuration
-    public void addAdminWarningMessages(Warnings warnings)
+    public void addAdminWarningMessages(Warnings warnings, boolean showAllWarnings)
     {
     }
 

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -534,7 +534,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
             WarningService.get().register(new WarningProvider()
             {
                 @Override
-                public void addStaticWarnings(@NotNull Warnings warnings)
+                public void addStaticWarnings(@NotNull Warnings warnings, boolean showAllWarnings)
                 {
                     for (HtmlString error : _duplicateModuleErrors)
                     {
@@ -615,7 +615,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
             WarningService.get().register(new WarningProvider()
             {
                 @Override
-                public void addStaticWarnings(@NotNull Warnings warnings)
+                public void addStaticWarnings(@NotNull Warnings warnings, boolean showAllWarnings)
                 {
                     warnings.add(HtmlString.of(message));
                 }
@@ -1683,11 +1683,11 @@ public class ModuleLoader implements Filter, MemTrackerListener
         WarningService.get().register(new WarningProvider()
         {
             @Override
-            public void addDynamicWarnings(@NotNull Warnings warnings, @NotNull ViewContext context)
+            public void addDynamicWarnings(@NotNull Warnings warnings, @NotNull ViewContext context, boolean showAllWarnings)
             {
                 if (context.getUser().hasSiteAdminPermission())
                 {
-                    if (WarningService.get().showAllWarnings() || !_missingViews.isEmpty())
+                    if (showAllWarnings || !_missingViews.isEmpty())
                         warnings.add(HtmlStringBuilder.of("The following required database views are not present: " + _missingViews +
                             ". This is a serious problem that indicates the LabKey database schemas did not upgrade correctly and are in a bad state."));
                 }

--- a/api/src/org/labkey/api/security/Encryption.java
+++ b/api/src/org/labkey/api/security/Encryption.java
@@ -80,11 +80,11 @@ public class Encryption
 
         WarningService.get().register(new WarningProvider() {
             @Override
-            public void addDynamicWarnings(@NotNull Warnings warnings, @NotNull ViewContext context)
+            public void addDynamicWarnings(@NotNull Warnings warnings, @NotNull ViewContext context, boolean showAllWarnings)
             {
                 int count = DECRYPTION_EXCEPTIONS.get();
 
-                if (count > 0)
+                if (count > 0 || showAllWarnings)
                     warnings.add(HtmlString.of("On " + StringUtilsLabKey.pluralize(count, "attempt") + " the server failed to decrypt encrypted content using the " + ENCRYPTION_KEY_CHANGED +
                         " An administrator should change the encryption key back to the previous value or be prepared to re-enter and re-save all saved credentials."));
             }

--- a/api/src/org/labkey/api/view/template/WarningProvider.java
+++ b/api/src/org/labkey/api/view/template/WarningProvider.java
@@ -24,8 +24,9 @@ public interface WarningProvider
      * Add warnings for conditions that will never change while the server is running (e.g., size of JVM heap or Tomcat
      * version). These warnings are displayed to site administrators only.
      * @param warnings A @NotNull Warnings collector
+     * @param showAllWarnings A flag for testing that indicates the provider should unconditionally add all warnings
      */
-    default void addStaticWarnings(@NotNull Warnings warnings)
+    default void addStaticWarnings(@NotNull Warnings warnings, boolean showAllWarnings)
     {
     }
 
@@ -34,8 +35,9 @@ public interface WarningProvider
      * the context to limit who sees the warning(s); otherwise, ALL users (including guests) will see the warning(s).
      * @param warnings A @NotNull Warnings collector
      * @param context A @NotNull ViewContext that also guarantees a @NotNull getUser() and @NotNull getRequest()
+     * @param showAllWarnings A flag for testing that indicates the provider should unconditionally add all warnings
      */
-    default void addDynamicWarnings(@NotNull Warnings warnings, @NotNull ViewContext context)
+    default void addDynamicWarnings(@NotNull Warnings warnings, @NotNull ViewContext context, boolean showAllWarnings)
     {
     }
 }

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -38,7 +38,6 @@ import org.labkey.api.query.AliasManager;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.logging.LogHelper;
-import org.labkey.api.view.template.WarningService;
 import org.labkey.api.view.template.Warnings;
 import org.labkey.bigiron.mssql.synonym.SynonymTableResolver;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -1681,13 +1680,13 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     }
 
     @Override
-    public void addAdminWarningMessages(Warnings warnings)
+    public void addAdminWarningMessages(Warnings warnings, boolean showAllWarnings)
     {
         ClrAssemblyManager.addAdminWarningMessages(warnings);
 
         if (null != _adminWarning)
             warnings.add(_adminWarning);
-        else if (WarningService.get().showAllWarnings())
+        else if (showAllWarnings)
             warnings.add(HtmlString.of("LabKey Server no longer supports " + getProductName() + " " + _versionYear + "; please upgrade. " + MicrosoftSqlServerDialectFactory.RECOMMENDED));
     }
 

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -1687,7 +1687,7 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
         if (null != _adminWarning)
             warnings.add(_adminWarning);
         else if (showAllWarnings)
-            warnings.add(HtmlString.of("LabKey Server no longer supports " + getProductName() + " " + _versionYear + "; please upgrade. " + MicrosoftSqlServerDialectFactory.RECOMMENDED));
+            warnings.add(HtmlString.of(MicrosoftSqlServerDialectFactory.getStandardWarningMessage("no longer supports", _versionYear)));
     }
 
     @Override

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -95,7 +95,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
         PostgreSqlVersion psv = PostgreSqlVersion.get(versionNumber.getVersionInt());
 
         if (PostgreSqlVersion.POSTGRESQL_UNSUPPORTED == psv)
-            throw new DatabaseNotSupportedException(PRODUCT_NAME + " version " + databaseProductVersion + " is not supported. You must upgrade your database server installation; " + RECOMMENDED);
+            throw new DatabaseNotSupportedException(getStandardWarningMessage("does not support", databaseProductVersion));
 
         PostgreSql_10_Dialect dialect = psv.getDialect();
 
@@ -109,17 +109,22 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
         {
             if (!psv.isTested())
             {
-                _log.warn("LabKey Server has not been tested against " + PRODUCT_NAME + " version " + databaseProductVersion + ". " + RECOMMENDED);
+                _log.warn(getStandardWarningMessage("has not been tested against", databaseProductVersion));
             }
             else if (psv.isDeprecated())
             {
-                String deprecationWarning = "LabKey Server no longer supports " + PRODUCT_NAME + " version " + databaseProductVersion + ". " + RECOMMENDED;
+                String deprecationWarning = getStandardWarningMessage("no longer supports", databaseProductVersion);
                 _log.warn(deprecationWarning);
                 dialect.setAdminWarning(HtmlString.of(deprecationWarning));
             }
         }
 
         return dialect;
+    }
+
+    public static String getStandardWarningMessage(String warning, String databaseProductVersion)
+    {
+        return "LabKey Server " + warning + " " + PRODUCT_NAME + " version " + databaseProductVersion + ". " + RECOMMENDED;
     }
 
     @Override

--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -40,7 +40,6 @@ import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.template.WarningProvider;
-import org.labkey.api.view.template.WarningService;
 import org.labkey.api.view.template.Warnings;
 import org.labkey.core.admin.AdminController;
 import org.labkey.core.metrics.WebSocketConnectionManager;
@@ -64,8 +63,6 @@ import static org.labkey.api.view.template.WarningService.SESSION_WARNINGS_BANNE
 
 public class CoreWarningProvider implements WarningProvider
 {
-    private static final boolean SHOW_ALL_WARNINGS = WarningService.get().showAllWarnings();
-
     private final Map<String, List<SiteValidationResult>> _dbSchemaWarnings = new ConcurrentHashMap<>();
 
     public CoreWarningProvider()
@@ -91,40 +88,40 @@ public class CoreWarningProvider implements WarningProvider
     }
 
     @Override
-    public void addStaticWarnings(@NotNull Warnings warnings)
+    public void addStaticWarnings(@NotNull Warnings warnings, boolean showAllWarnings)
     {
         // Warn if running on a deprecated database version or some other non-fatal database configuration issue
         DbScope labkeyScope = DbScope.getLabKeyScope();
-        labkeyScope.getSqlDialect().addAdminWarningMessages(warnings);
+        labkeyScope.getSqlDialect().addAdminWarningMessages(warnings, showAllWarnings);
 
-        getHeapSizeWarnings(warnings);
+        getHeapSizeWarnings(warnings, showAllWarnings);
 
-        getConnectionPoolSizeWarnings(warnings, labkeyScope);
+        getConnectionPoolSizeWarnings(warnings, labkeyScope, showAllWarnings);
 
-        getJavaWarnings(warnings);
+        getJavaWarnings(warnings, showAllWarnings);
 
-        getTomcatWarnings(warnings);
+        getTomcatWarnings(warnings, showAllWarnings);
     }
 
     @Override
-    public void addDynamicWarnings(@NotNull Warnings warnings, @NotNull ViewContext context)
+    public void addDynamicWarnings(@NotNull Warnings warnings, @NotNull ViewContext context, boolean showAllWarnings)
     {
         if (context.getUser().hasSiteAdminPermission())
         {
-            getUserRequestedAdminOnlyModeWarnings(warnings);
+            getUserRequestedAdminOnlyModeWarnings(warnings, showAllWarnings);
 
-            getModuleErrorWarnings(warnings, context);
+            getModuleErrorWarnings(warnings, context, showAllWarnings);
 
-            getProbableLeakCountWarnings(warnings);
+            getProbableLeakCountWarnings(warnings, showAllWarnings);
 
-            getWebSocketConnectionWarnings(warnings);
+            getWebSocketConnectionWarnings(warnings, showAllWarnings);
 
-            getDbSchemaWarnings(warnings);
+            getDbSchemaWarnings(warnings, showAllWarnings);
 
             //upgrade message--show to admins
             HtmlString upgradeMessage = UsageReportingLevel.getUpgradeMessage();
 
-            if (null == upgradeMessage && SHOW_ALL_WARNINGS)
+            if (null == upgradeMessage && showAllWarnings)
             {
                 // Mock upgrade message for testing
                 upgradeMessage = HtmlStringBuilder.of("You really ought to upgrade this server! ").append(new LinkBuilder("Click here!").href(AppProps.getInstance().getHomePageActionURL()).clearClasses()).getHtmlString();
@@ -136,7 +133,7 @@ public class CoreWarningProvider implements WarningProvider
             }
         }
 
-        HtmlString warning = LimitActiveUsersSettings.getWarningMessage(context.getContainer(), context.getUser(), SHOW_ALL_WARNINGS);
+        HtmlString warning = LimitActiveUsersSettings.getWarningMessage(context.getContainer(), context.getUser(), showAllWarnings);
         if (null != warning)
             warnings.add(warning);
 
@@ -146,7 +143,7 @@ public class CoreWarningProvider implements WarningProvider
             message = ModuleHtmlView.replaceTokens(message, context);
             warnings.add(HtmlString.unsafe(message));  // We trust that the site admin has provided valid HTML
         }
-        else if (SHOW_ALL_WARNINGS)
+        else if (showAllWarnings)
         {
             warnings.add(HtmlString.of("Here is a sample ribbon message."));
         }
@@ -154,11 +151,11 @@ public class CoreWarningProvider implements WarningProvider
 
     private static final int MAX_SCHEMA_PROBLEMS_TO_SHOW = 3;
 
-    private void getDbSchemaWarnings(Warnings warnings)
+    private void getDbSchemaWarnings(Warnings warnings, boolean showAllWarnings)
     {
         Map<String, List<SiteValidationResult>> schemaProblems = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         schemaProblems.putAll(_dbSchemaWarnings);
-        if (SHOW_ALL_WARNINGS)
+        if (showAllWarnings)
         {
             schemaProblems.put("WorstSchemaEver", List.of(SiteValidationResult.Level.ERROR.create("Your schema is very, very bad")));
         }
@@ -185,14 +182,14 @@ public class CoreWarningProvider implements WarningProvider
         }
     }
 
-    private void getHeapSizeWarnings(Warnings warnings)
+    private void getHeapSizeWarnings(Warnings warnings, boolean showAllWarnings)
     {
         // Issue 9683 - show admins warning about inadequate heap size (< 2GB)
         MemoryMXBean membean = ManagementFactory.getMemoryMXBean();
         long maxMem = membean.getHeapMemoryUsage().getMax();
 
         // Issue 45171 - have a little slop since -Xmx2G ends up with slightly different sized heaps on different VMs
-        if (SHOW_ALL_WARNINGS || maxMem > 0 && maxMem < 2_000_000_000L)
+        if (showAllWarnings || maxMem > 0 && maxMem < 2_000_000_000L)
         {
             HtmlStringBuilder html = HtmlStringBuilder.of("The maximum amount of heap memory allocated to LabKey Server is too low (less than 2GB). LabKey recommends ");
             html.append(new HelpTopic("configWebappMemory").getSimpleLinkHtml("setting the maximum heap to at least 2 gigabytes (-Xmx2G) on test/evaluation servers and at least 4 gigabytes (-Xmx4G) on production servers"));
@@ -202,9 +199,9 @@ public class CoreWarningProvider implements WarningProvider
     }
 
     // Warn if running in production mode with an inadequate labkey db connection pool size
-    private void getConnectionPoolSizeWarnings(Warnings warnings, DbScope labkeyScope)
+    private void getConnectionPoolSizeWarnings(Warnings warnings, DbScope labkeyScope, boolean showAllWarnings)
     {
-        if (SHOW_ALL_WARNINGS || !AppProps.getInstance().isDevMode())
+        if (showAllWarnings || !AppProps.getInstance().isDevMode())
         {
             Integer maxTotal = labkeyScope.getDataSourceProperties().getMaxTotal();
 
@@ -212,16 +209,16 @@ public class CoreWarningProvider implements WarningProvider
             {
                 warnings.add(HtmlString.of("Could not determine the connection pool size for the labkeyDataSource; verify that the connection pool is properly configured in labkey.xml"));
             }
-            else if (SHOW_ALL_WARNINGS || maxTotal < 20)
+            else if (showAllWarnings || maxTotal < 20)
             {
                 addStandardWarning(warnings, "The configured labkeyDataSource connection pool size (" + maxTotal + ") is too small for a production server. Update the configuration and restart the server.", "troubleshootingAdmin#pool", "Connection Pool Size section of the Troubleshooting page");
             }
         }
     }
 
-    private void getJavaWarnings(Warnings warnings)
+    private void getJavaWarnings(Warnings warnings, boolean showAllWarnings)
     {
-        if (SHOW_ALL_WARNINGS || ModuleLoader.getInstance().getJavaVersion().isDeprecated())
+        if (showAllWarnings || ModuleLoader.getInstance().getJavaVersion().isDeprecated())
         {
             String javaInfo = JavaVersion.getJavaVersionDescription();
             addStandardWarning(warnings, "The deployed version of Java, " + javaInfo + ", is not supported. We recommend installing " + JavaVersion.getRecommendedJavaVersion() + ".", "supported", "Supported Technologies page");
@@ -253,9 +250,9 @@ public class CoreWarningProvider implements WarningProvider
         return result;
     }
 
-    private void getTomcatWarnings(Warnings warnings)
+    private void getTomcatWarnings(Warnings warnings, boolean showAllWarnings)
     {
-        if (SHOW_ALL_WARNINGS || ModuleLoader.getInstance().getTomcatVersion().isDeprecated())
+        if (showAllWarnings || ModuleLoader.getInstance().getTomcatVersion().isDeprecated())
         {
             String serverInfo = ModuleLoader.getServletContext().getServerInfo();
             addStandardWarning(warnings, "The deployed version of Tomcat, " + serverInfo + ", is not supported.", "supported", "Supported Technologies page");
@@ -272,7 +269,7 @@ public class CoreWarningProvider implements WarningProvider
                 StringUtils.startsWithIgnoreCase(webapp,"manager")
             );
 
-            if (SHOW_ALL_WARNINGS || (defaultTomcatWebappFound && !AppProps.getInstance().isDevMode()))
+            if (showAllWarnings || (defaultTomcatWebappFound && !AppProps.getInstance().isDevMode()))
                 addStandardWarning(warnings, "This server appears to be running with one or more default Tomcat web applications that should be removed. These may include 'docs', 'examples', 'host-manager', and 'manager'.", "configTomcat", "Tomcat Configuration");
         }
         catch (Exception x)
@@ -281,13 +278,13 @@ public class CoreWarningProvider implements WarningProvider
         }
     }
 
-    private void getModuleErrorWarnings(Warnings warnings, ViewContext context)
+    private void getModuleErrorWarnings(Warnings warnings, ViewContext context, boolean showAllWarnings)
     {
         //module failures during startup--show to admins
         Map<String, Throwable> moduleFailures = ModuleLoader.getInstance().getModuleFailures();
-        if (SHOW_ALL_WARNINGS || null != moduleFailures && moduleFailures.size() > 0)
+        if (showAllWarnings || null != moduleFailures && moduleFailures.size() > 0)
         {
-            if (SHOW_ALL_WARNINGS && moduleFailures.isEmpty())
+            if (showAllWarnings && moduleFailures.isEmpty())
             {
                 // Mock failures for testing purposes
                 moduleFailures = Map.of("core", new Throwable(), "flow",  new Throwable());
@@ -296,27 +293,27 @@ public class CoreWarningProvider implements WarningProvider
         }
     }
 
-    private void getWebSocketConnectionWarnings(Warnings warnings)
+    private void getWebSocketConnectionWarnings(Warnings warnings, boolean showAllWarnings)
     {
-        if (SHOW_ALL_WARNINGS || WebSocketConnectionManager.getInstance().showWarning())
+        if (showAllWarnings || WebSocketConnectionManager.getInstance().showWarning())
             addStandardWarning(warnings, "The WebSocket connection failed. LabKey Server uses WebSockets to send notifications and alert users when their session ends.", "configTomcat#websocket", "Tomcat Configuration");
     }
 
-    private void getUserRequestedAdminOnlyModeWarnings(Warnings warnings)
+    private void getUserRequestedAdminOnlyModeWarnings(Warnings warnings, boolean showAllWarnings)
     {
         //admin-only mode--show to admins
-        if (SHOW_ALL_WARNINGS || AppProps.getInstance().isUserRequestedAdminOnlyMode())
+        if (showAllWarnings || AppProps.getInstance().isUserRequestedAdminOnlyMode())
         {
             addStandardWarning(warnings, "This site is configured so that only administrators may sign in. To allow other users to sign in, turn off admin-only mode via the", "site settings page", PageFlowUtil.urlProvider(AdminUrls.class).getCustomizeSiteURL());
         }
     }
 
-    private void getProbableLeakCountWarnings(Warnings warnings)
+    private void getProbableLeakCountWarnings(Warnings warnings, boolean showAllWarnings)
     {
         if (AppProps.getInstance().isDevMode())
         {
             int leakCount = ConnectionWrapper.getProbableLeakCount();
-            if (SHOW_ALL_WARNINGS || leakCount > 0)
+            if (showAllWarnings || leakCount > 0)
             {
                 int count = ConnectionWrapper.getActiveConnectionCount();
                 HtmlStringBuilder html = HtmlStringBuilder.of(new LinkBuilder(count + " DB connection" + (count == 1 ? "" : "s") + " in use.").href(PageFlowUtil.urlProvider(AdminUrls.class).getMemTrackerURL()).clearClasses());

--- a/core/src/org/labkey/core/view/template/bootstrap/WarningServiceImpl.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/WarningServiceImpl.java
@@ -64,7 +64,7 @@ public class WarningServiceImpl implements WarningService
 
         List<HtmlString> messages = new LinkedList<>();
         Warnings warnings = Warnings.of(messages);
-        WarningService.get().forEachProvider(p -> p.addStaticWarnings(warnings));
+        WarningService.get().forEachProvider(p -> p.addStaticWarnings(warnings, WarningService.get().showAllWarnings()));
 
         messages = Collections.unmodifiableList(messages);
         if (ModuleLoader.getInstance().isStartupComplete())
@@ -112,7 +112,7 @@ public class WarningServiceImpl implements WarningService
             warningMessages.addAll(getStaticAdminWarnings());
 
         Warnings warnings = Warnings.of(warningMessages);
-        WarningService.get().forEachProvider(p->p.addDynamicWarnings(warnings, context));
+        WarningService.get().forEachProvider(p->p.addDynamicWarnings(warnings, context, showAllWarnings()));
 
         return warnings;
     }


### PR DESCRIPTION
#### Rationale
There's no need for every WarningProvider implementation to check the `showAllWarnings()` flag. Instead, we can pass it in as a parameter. This is more convenient and a good reminder.

Also, standardize dialect warning messages.
