### PR TITLE
Remove support for PostgreSQL 10.x

### DIFF
--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
-import org.labkey.api.collections.CsvSet;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.dialect.AbstractDialectRetrievalTestCase;
 import org.labkey.api.data.dialect.DatabaseNotSupportedException;
@@ -64,7 +63,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
     @Override
     public @Nullable SqlDialect createFromDriverClassName(String driverClassName)
     {
-        return "org.postgresql.Driver".equals(driverClassName) ? new PostgreSql_10_Dialect() : null;
+        return "org.postgresql.Driver".equals(driverClassName) ? new PostgreSql_11_Dialect() : null;
     }
 
     final static String PRODUCT_NAME = "PostgreSQL";
@@ -97,7 +96,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
         if (PostgreSqlVersion.POSTGRESQL_UNSUPPORTED == psv)
             throw new DatabaseNotSupportedException(getStandardWarningMessage("does not support", databaseProductVersion));
 
-        PostgreSql_10_Dialect dialect = psv.getDialect();
+        PostgreSql_11_Dialect dialect = psv.getDialect();
 
         Connection conn = md.getConnection();
         Map<String, String> parameterStatuses = (conn instanceof PgConnection ? ((PgConnection) conn).getParameterStatuses() : Collections.emptyMap());
@@ -136,10 +135,10 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
     @Override
     public Collection<? extends SqlDialect> getDialectsToTest()
     {
-        // PostgreSQL dialects are nearly identical, so just test 10.x
-        PostgreSql_10_Dialect conforming = new PostgreSql_10_Dialect();
+        // PostgreSQL dialects are nearly identical, so just test 11.x
+        PostgreSql_11_Dialect conforming = new PostgreSql_11_Dialect();
         conforming.setStandardConformingStrings(true);
-        PostgreSql_10_Dialect nonconforming = new PostgreSql_10_Dialect();
+        PostgreSql_11_Dialect nonconforming = new PostgreSql_11_Dialect();
         nonconforming.setStandardConformingStrings(false);
 
         return PageFlowUtil.set(
@@ -155,11 +154,10 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
         {
             final String connectionUrl = "jdbc:postgresql:";
 
-            // < 10.0 should result in bad version number exception
-            badVersion("PostgreSQL", 0.0, 10.0, null, connectionUrl);
+            // < 11.0 should result in bad version number exception
+            badVersion("PostgreSQL", 0.0, 11.0, null, connectionUrl);
 
             // Test good versions
-            good("PostgreSQL", 10.0, 11.0, "", connectionUrl, null, PostgreSql_10_Dialect.class);
             good("PostgreSQL", 11.0, 12.0, "", connectionUrl, null, PostgreSql_11_Dialect.class);
             good("PostgreSQL", 12.0, 13.0, "", connectionUrl, null, PostgreSql_12_Dialect.class);
             good("PostgreSQL", 13.0, 14.0, "", connectionUrl, null, PostgreSql_13_Dialect.class);
@@ -192,7 +190,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
                 "SELECT core.executeJaavUpgradeCode('upgradeCode');\n" +          // Misspell function name
                 "SELECT core.executeJavaUpgradeCode('upgradeCode')\n";            // No semicolon
 
-            SqlDialect dialect = new PostgreSql_10_Dialect();
+            SqlDialect dialect = new PostgreSql_11_Dialect();
             TestUpgradeCode good = new TestUpgradeCode();
             dialect.runSql(null, goodSql, good, null, null);
             assertEquals(5, good.getCounter());
@@ -213,24 +211,24 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
                 @Override
                 protected SqlDialect getDialect()
                 {
-                    return new PostgreSql_10_Dialect();
+                    return new PostgreSql_11_Dialect();
                 }
 
                 @NotNull
                 @Override
                 protected Set<String> getGoodUrls()
                 {
-                    return new CsvSet
+                    return Set.of
                     (
-                        "jdbc:postgresql:database," +
-                        "jdbc:postgresql://localhost/database," +
-                        "jdbc:postgresql://localhost:8300/database," +
-                        "jdbc:postgresql://www.host.com/database," +
-                        "jdbc:postgresql://www.host.com:8499/database," +
-                        "jdbc:postgresql:database?user=fred&password=secret&ssl=true," +
-                        "jdbc:postgresql://localhost/database?user=fred&password=secret&ssl=true," +
-                        "jdbc:postgresql://localhost:8672/database?user=fred&password=secret&ssl=true," +
-                        "jdbc:postgresql://www.host.com/database?user=fred&password=secret&ssl=true," +
+                        "jdbc:postgresql:database",
+                        "jdbc:postgresql://localhost/database",
+                        "jdbc:postgresql://localhost:8300/database",
+                        "jdbc:postgresql://www.host.com/database",
+                        "jdbc:postgresql://www.host.com:8499/database",
+                        "jdbc:postgresql:database?user=fred&password=secret&ssl=true",
+                        "jdbc:postgresql://localhost/database?user=fred&password=secret&ssl=true",
+                        "jdbc:postgresql://localhost:8672/database?user=fred&password=secret&ssl=true",
+                        "jdbc:postgresql://www.host.com/database?user=fred&password=secret&ssl=true",
                         "jdbc:postgresql://www.host.com:8992/database?user=fred&password=secret&ssl=true"
                     );
                 }
@@ -239,10 +237,10 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
                 @Override
                 protected Set<String> getBadUrls()
                 {
-                    return new CsvSet
+                    return Set.of
                     (
-                        "jddc:postgresql:database," +
-                        "jdbc:postgres://localhost/database," +
+                        "jddc:postgresql:database",
+                        "jdbc:postgres://localhost/database",
                         "jdbc:postgresql://www.host.comdatabase"
                     );
                 }

--- a/core/src/org/labkey/core/dialect/PostgreSqlInClauseTest.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlInClauseTest.java
@@ -17,19 +17,19 @@ import java.util.Arrays;
  */
 public class PostgreSqlInClauseTest extends Assert
 {
-    private PostgreSql_10_Dialect getDialect()
+    private PostgreSql_11_Dialect getDialect()
     {
         DbSchema core = CoreSchema.getInstance().getSchema();
         SqlDialect d = core.getSqlDialect();
-        if (d instanceof PostgreSql_10_Dialect)
-            return (PostgreSql_10_Dialect) d;
+        if (d instanceof PostgreSql_11_Dialect)
+            return (PostgreSql_11_Dialect) d;
         return null;
     }
 
     @Test
     public void testInClause()
     {
-        PostgreSql_10_Dialect d = getDialect();
+        PostgreSql_11_Dialect d = getDialect();
         if (null == d)
             return;
         DbSchema core = CoreSchema.getInstance().getSchema();

--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 public enum PostgreSqlVersion
 {
     POSTGRESQL_UNSUPPORTED(-1, true, false, null),
-    POSTGRESQL_10(100, true, true, PostgreSql_10_Dialect::new),
     POSTGRESQL_11(110, false, true, PostgreSql_11_Dialect::new),
     POSTGRESQL_12(120, false, true, PostgreSql_12_Dialect::new),
     POSTGRESQL_13(130, false, true, PostgreSql_13_Dialect::new),
@@ -27,9 +26,9 @@ public enum PostgreSqlVersion
     private final int _version;
     private final boolean _deprecated;
     private final boolean _tested;
-    private final Supplier<? extends PostgreSql_10_Dialect> _dialectFactory;
+    private final Supplier<? extends PostgreSql_11_Dialect> _dialectFactory;
 
-    PostgreSqlVersion(int version, boolean deprecated, boolean tested, Supplier<? extends PostgreSql_10_Dialect> dialectFactory)
+    PostgreSqlVersion(int version, boolean deprecated, boolean tested, Supplier<? extends PostgreSql_11_Dialect> dialectFactory)
     {
         _version = version;
         _deprecated = deprecated;
@@ -48,7 +47,7 @@ public enum PostgreSqlVersion
         return _tested;
     }
 
-    public PostgreSql_10_Dialect getDialect()
+    public PostgreSql_11_Dialect getDialect()
     {
         return _dialectFactory.get();
     }
@@ -83,7 +82,6 @@ public enum PostgreSqlVersion
         public void test()
         {
             // Good
-            test(100, POSTGRESQL_10);
             test(110, POSTGRESQL_11);
             test(120, POSTGRESQL_12);
             test(130, POSTGRESQL_13);
@@ -109,6 +107,7 @@ public enum PostgreSqlVersion
             test(97, POSTGRESQL_UNSUPPORTED);
             test(98, POSTGRESQL_UNSUPPORTED);
             test(99, POSTGRESQL_UNSUPPORTED);
+            test(100, POSTGRESQL_UNSUPPORTED);
         }
 
         private void test(int version, PostgreSqlVersion expectedVersion)

--- a/core/src/org/labkey/core/dialect/PostgreSql_10_Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql_10_Dialect.java
@@ -15,6 +15,6 @@
  */
 package org.labkey.core.dialect;
 
-public class PostgreSql_10_Dialect extends PostgreSql96Dialect
+public abstract class PostgreSql_10_Dialect extends PostgreSql96Dialect
 {
 }


### PR DESCRIPTION
#### Rationale
PostgreSQL 10.x reached end of life on November 10, 2022: https://www.postgresql.org/support/versioning/. Following our normal practice, we've announced that we'll remove support for 10.x in 22.12.