### PR TITLE
Bump search schema to force reindex for Lucene 9.3.0 -> 9.4.1 upgrade

### DIFF
--- a/search/resources/schemas/dbscripts/postgresql/search-0.000-21.000.sql
+++ b/search/resources/schemas/dbscripts/postgresql/search-0.000-21.000.sql
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* search-0.00-10.10.sql */
-
 CREATE SCHEMA search;
 
 CREATE TABLE search.CrawlCollections
@@ -45,18 +43,3 @@ CREATE TABLE search.CrawlResources
     CONSTRAINT PK_Resources PRIMARY KEY (Parent,Name)
 );
 CLUSTER PK_Resources ON search.CrawlResources;
-
-CREATE TABLE search.ParticipantIndex
-(
-    Container ENTITYID NOT NULL,          -- see core.containers
-    ParticipantId VARCHAR(32) NOT NULL,   -- see study.participantvisit
-    LastIndexed TIMESTAMP NOT NULL,
-    CONSTRAINT PK_ParticipantIndex PRIMARY KEY (Container,ParticipantId)
-);
-
-/* search-12.30-13.10.sql */
-
--- We now use the search index (not a side table) to boost participant results.
-DROP TABLE search.ParticipantIndex;
-
-DROP SCHEMA IF EXISTS umls CASCADE;

--- a/search/resources/schemas/dbscripts/sqlserver/search-0.000-21.000.sql
+++ b/search/resources/schemas/dbscripts/sqlserver/search-0.000-21.000.sql
@@ -49,19 +49,3 @@ CREATE TABLE search.CrawlResources
     LastIndexed DATETIME NULL,  -- server time
     CONSTRAINT PK_Resources PRIMARY KEY (Parent,Name)
 );
-
-CREATE TABLE search.ParticipantIndex
-(
-    Container ENTITYID NOT NULL,          -- see core.containers
-    ParticipantId NVARCHAR(32) NOT NULL,   -- see study.participantvisit
-    LastIndexed DATETIME NOT NULL,
-    CONSTRAINT PK_ParticipantIndex PRIMARY KEY (Container,ParticipantId)
-);
-
-/* search-12.30-13.10.sql */
-
--- We now use the search index (not a side table) to boost participant results.
-DROP TABLE search.ParticipantIndex;
-
-EXEC core.fn_dropifexists '*', 'umls', 'SCHEMA'
-GO

--- a/search/src/org/labkey/search/SearchModule.java
+++ b/search/src/org/labkey/search/SearchModule.java
@@ -67,7 +67,7 @@ public class SearchModule extends DefaultModule
     @Override
     public Double getSchemaVersion()
     {
-        return 22.003;
+        return 22.004;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We upgraded Lucene to 9.4.1 in the related PR. We also need to force a reindex since the index format changed.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3826

#### Changes
* Bump schema version
* Remove pointless create/drop combos from bootstrap scripts
