### PR TITLE
Improve site settings help links. Disentangle network drive functiona…

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1019,7 +1019,7 @@ public class AdminController extends SpringActionController
         return null == is ? null : PageFlowUtil.getStreamContentsAsString(is);
     }
 
-    private void validateNetworkDrive(SiteSettingsForm form, Errors errors)
+    private void validateNetworkDrive(NetworkDriveForm form, Errors errors)
     {
         if (isBlank(form.getNetworkDriveUser()) || isBlank(form.getNetworkDrivePath()) ||
             isBlank(form.getNetworkDrivePassword()) || isBlank(form.getNetworkDriveLetter()))
@@ -1139,9 +1139,8 @@ public class AdminController extends SpringActionController
             if (form.isUpgradeInProgress())
                 getPageConfig().setTemplate(Template.Dialog);
 
-            SiteSettingsBean bean = new SiteSettingsBean(form.isUpgradeInProgress(), form.isTestInPage());
+            SiteSettingsBean bean = new SiteSettingsBean(form.isUpgradeInProgress());
             setHelpTopic("configAdmin");
-            getPageConfig().setFocusId("defaultDomain");
             return new JspView<>("/org/labkey/core/admin/customizeSite.jsp", bean, errors);
         }
 
@@ -1270,30 +1269,72 @@ public class AdminController extends SpringActionController
         }
     }
 
+    public static class NetworkDriveForm
+    {
+        private String _networkDriveLetter;
+        private String _networkDrivePath;
+        private String _networkDriveUser;
+        private String _networkDrivePassword;
+
+        public String getNetworkDriveLetter()
+        {
+            return _networkDriveLetter;
+        }
+
+        public void setNetworkDriveLetter(String networkDriveLetter)
+        {
+            _networkDriveLetter = networkDriveLetter;
+        }
+
+        public String getNetworkDrivePassword()
+        {
+            return _networkDrivePassword;
+        }
+
+        public void setNetworkDrivePassword(String networkDrivePassword)
+        {
+            _networkDrivePassword = networkDrivePassword;
+        }
+
+        public String getNetworkDrivePath()
+        {
+            return _networkDrivePath;
+        }
+
+        public void setNetworkDrivePath(String networkDrivePath)
+        {
+            _networkDrivePath = networkDrivePath;
+        }
+
+        public String getNetworkDriveUser()
+        {
+            return _networkDriveUser;
+        }
+
+        public void setNetworkDriveUser(String networkDriveUser)
+        {
+            _networkDriveUser = networkDriveUser;
+        }
+    }
+
     @RequiresPermission(AdminOperationsPermission.class)
     @AdminConsoleAction
-    public class MapNetworkDriveAction extends FormViewAction<SiteSettingsForm>
+    public class MapNetworkDriveAction extends FormViewAction<NetworkDriveForm>
     {
         @Override
-        public void validateCommand(SiteSettingsForm form, Errors errors)
+        public void validateCommand(NetworkDriveForm form, Errors errors)
         {
             validateNetworkDrive(form, errors);
         }
 
         @Override
-        public ModelAndView getView(SiteSettingsForm form, boolean reshow, BindException errors)
+        public ModelAndView getView(NetworkDriveForm form, boolean reshow, BindException errors)
         {
-            SiteSettingsBean bean = new SiteSettingsBean(
-                    form.isUpgradeInProgress(),
-                    form.isTestInPage(),
-                    new HelpTopic("setRoots#map").getSimpleLinkHtml("more info...")
-            );
-
-            return new JspView<>("/org/labkey/core/admin/mapNetworkDrive.jsp", bean, errors);
+            return new JspView<>("/org/labkey/core/admin/mapNetworkDrive.jsp", null, errors);
         }
 
         @Override
-        public boolean handlePost(SiteSettingsForm form, BindException errors) throws Exception
+        public boolean handlePost(NetworkDriveForm form, BindException errors) throws Exception
         {
             NetworkDriveProps.setNetworkDriveLetter(form.getNetworkDriveLetter().trim());
             NetworkDriveProps.setNetworkDrivePath(form.getNetworkDrivePath().trim());
@@ -1304,7 +1345,7 @@ public class AdminController extends SpringActionController
         }
 
         @Override
-        public URLHelper getSuccessURL(SiteSettingsForm siteSettingsForm)
+        public URLHelper getSuccessURL(NetworkDriveForm siteSettingsForm)
         {
             return new ActionURL(FilesSiteSettingsAction.class, getContainer());
         }
@@ -1319,25 +1360,18 @@ public class AdminController extends SpringActionController
 
     public static class SiteSettingsBean
     {
-        public final HtmlString helpLink;
-        public final boolean upgradeInProgress;
-        public final boolean testInPage;
-        public final boolean showSelfReportExceptions;
+        public final boolean _upgradeInProgress;
+        public final boolean _showSelfReportExceptions;
 
-        private SiteSettingsBean(boolean upgradeInProgress, boolean testInPage)
+        private SiteSettingsBean(boolean upgradeInProgress)
         {
-            this.upgradeInProgress = upgradeInProgress;
-            this.testInPage = testInPage;
-            this.showSelfReportExceptions = MothershipReport.isShowSelfReportExceptions();
-            helpLink = new HelpTopic("configAdmin").getSimpleLinkHtml("more info...");
+            _upgradeInProgress = upgradeInProgress;
+            _showSelfReportExceptions = MothershipReport.isShowSelfReportExceptions();
         }
 
-        private SiteSettingsBean(boolean upgradeInProgress, boolean testInPage, HtmlString helpLink)
+        public HtmlString getSiteSettingsHelpLink(String fragment)
         {
-            this.upgradeInProgress = upgradeInProgress;
-            this.testInPage = testInPage;
-            this.showSelfReportExceptions = MothershipReport.isShowSelfReportExceptions();
-            this.helpLink = helpLink;
+            return new HelpTopic("configAdmin", fragment).getSimpleLinkHtml("more info...");
         }
     }
 
@@ -1876,7 +1910,6 @@ public class AdminController extends SpringActionController
     public static class SiteSettingsForm
     {
         private boolean _upgradeInProgress = false;
-        private boolean _testInPage = false;
 
         private String _pipelineToolsDirectory;
         private boolean _sslRequired;
@@ -1894,10 +1927,6 @@ public class AdminController extends SpringActionController
         private String _usageReportingLevel;
         private String _administratorContactEmail;
 
-        private String _networkDriveLetter;
-        private String _networkDrivePath;
-        private String _networkDriveUser;
-        private String _networkDrivePassword;
         private String _baseServerURL;
         private String _callbackPassword;
         private boolean _useContainerRelativeURL;
@@ -2058,46 +2087,6 @@ public class AdminController extends SpringActionController
             _maxBLOBSize = maxBLOBSize;
         }
 
-        public String getNetworkDriveLetter()
-        {
-            return _networkDriveLetter;
-        }
-
-        public void setNetworkDriveLetter(String networkDriveLetter)
-        {
-            _networkDriveLetter = networkDriveLetter;
-        }
-
-        public String getNetworkDrivePassword()
-        {
-            return _networkDrivePassword;
-        }
-
-        public void setNetworkDrivePassword(String networkDrivePassword)
-        {
-            _networkDrivePassword = networkDrivePassword;
-        }
-
-        public String getNetworkDrivePath()
-        {
-            return _networkDrivePath;
-        }
-
-        public void setNetworkDrivePath(String networkDrivePath)
-        {
-            _networkDrivePath = networkDrivePath;
-        }
-
-        public String getNetworkDriveUser()
-        {
-            return _networkDriveUser;
-        }
-
-        public void setNetworkDriveUser(String networkDriveUser)
-        {
-            _networkDriveUser = networkDriveUser;
-        }
-
         public String getBaseServerURL()
         {
             return _baseServerURL;
@@ -2106,16 +2095,6 @@ public class AdminController extends SpringActionController
         public void setBaseServerURL(String baseServerURL)
         {
             _baseServerURL = baseServerURL;
-        }
-
-        public boolean isTestInPage()
-        {
-            return _testInPage;
-        }
-
-        public void setTestInPage(boolean testInPage)
-        {
-            _testInPage = testInPage;
         }
 
         public String getCallbackPassword()
@@ -2261,16 +2240,16 @@ public class AdminController extends SpringActionController
 
 
     @RequiresPermission(AdminOperationsPermission.class)
-    public class ShowNetworkDriveTestAction extends SimpleViewAction<SiteSettingsForm>
+    public class ShowNetworkDriveTestAction extends SimpleViewAction<NetworkDriveForm>
     {
         @Override
-        public void validate(SiteSettingsForm form, BindException errors)
+        public void validate(NetworkDriveForm form, BindException errors)
         {
             validateNetworkDrive(form, errors);
         }
 
         @Override
-        public ModelAndView getView(SiteSettingsForm form, BindException errors)
+        public ModelAndView getView(NetworkDriveForm form, BindException errors)
         {
             NetworkDrive testDrive = new NetworkDrive();
             testDrive.setPassword(form.getNetworkDrivePassword());

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -93,11 +93,11 @@ var testMothershipReport = function (type, level, download) {
 </script>
 
 <labkey:form name="preferences" enctype="multipart/form-data" method="post">
-<input type="hidden" name="upgradeInProgress" value="<%=bean.upgradeInProgress ? 1 : 0%>" />
+<input type="hidden" name="upgradeInProgress" value="<%=bean._upgradeInProgress ? 1 : 0%>" />
 
 <table>
 <%
-if (bean.upgradeInProgress)
+if (bean._upgradeInProgress)
 {%>
 <tr>
     <td><p>You can use this page to customize your LabKey Server installation. If you prefer to customize it later, you can reach this page again by clicking <strong>Admin->Site->Admin Console->Site Settings</strong>.</p>
@@ -128,7 +128,7 @@ Click the Save button at any time to accept the current settings and continue.</
 </tr>
 
 <tr>
-    <td colspan=2>Set site administrators (<%=bean.helpLink%>)</td>
+    <td colspan=2>Set site administrators (<%=bean.getSiteSettingsHelpLink("siteadmins")%>)</td>
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
@@ -148,7 +148,7 @@ Click the Save button at any time to accept the current settings and continue.</
 </tr>
 
 <tr>
-    <td colspan=2>URL settings (<%=bean.helpLink%>)</td>
+    <td colspan=2>URL settings (<%=bean.getSiteSettingsHelpLink("url")%>)</td>
 
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
@@ -167,7 +167,7 @@ Click the Save button at any time to accept the current settings and continue.</
 
 <tr>
     <td colspan=2>Automatically check for updates to LabKey Server and
-        report usage statistics to LabKey. (<%=bean.helpLink%>)</td>
+        report usage statistics to LabKey. (<%=bean.getSiteSettingsHelpLink("usage")%>)</td>
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
@@ -207,7 +207,7 @@ Click the Save button at any time to accept the current settings and continue.</
     <td>&nbsp;</td>
 </tr>
 <tr>
-    <td colspan=2>Automatically report exceptions (<%=bean.helpLink%>)</td>
+    <td colspan=2>Automatically report exceptions (<%=bean.getSiteSettingsHelpLink("exception")%>)</td>
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
@@ -256,7 +256,7 @@ Click the Save button at any time to accept the current settings and continue.</
     </td>
 </tr>
 <%-- Only show this option if the mothership module has enabled it --%>
-<% if (bean.showSelfReportExceptions) { %>
+<% if (bean._showSelfReportExceptions) { %>
 <tr>
     <td class="labkey-form-label" valign="top">Report exceptions to the local server</td>
     <td>
@@ -271,7 +271,7 @@ Click the Save button at any time to accept the current settings and continue.</
 </tr>
 
 <tr>
-    <td colspan=2>Customize LabKey system properties (<%=bean.helpLink%>)</td>
+    <td colspan=2>Customize LabKey system properties (<%=bean.getSiteSettingsHelpLink("props")%>)</td>
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
@@ -295,7 +295,7 @@ Click the Save button at any time to accept the current settings and continue.</
 </tr>
 
 <tr>
-    <td colspan=2>Configure Security (<%=bean.helpLink%>)</td>
+    <td colspan=2>Configure Security (<%=bean.getSiteSettingsHelpLink("security")%>)</td>
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
@@ -311,7 +311,7 @@ Click the Save button at any time to accept the current settings and continue.</
     <td>&nbsp;</td>
 </tr>
 <tr>
-    <td colspan=2>Configure API Keys (<%=helpLink("configAdmin#apiKey", "more info...")%>)</td>
+    <td colspan=2>Configure API Keys (<%=bean.getSiteSettingsHelpLink("apiKey")%>)</td>
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
@@ -345,7 +345,7 @@ Click the Save button at any time to accept the current settings and continue.</
     <td>&nbsp;</td>
 </tr>
 <tr>
-    <td colspan=2>Configure pipeline settings (<%=bean.helpLink%>)</td>
+    <td colspan=2>Configure pipeline settings (<%=bean.getSiteSettingsHelpLink("pipeline")%>)</td>
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
@@ -357,7 +357,7 @@ Click the Save button at any time to accept the current settings and continue.</
 </tr>
 
 <tr>
-    <td colspan=2>Ribbon Bar Message (<%=bean.helpLink%>)</td>
+    <td colspan=2>Ribbon Bar Message (<%=bean.getSiteSettingsHelpLink("ribbon")%>)</td>
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
@@ -373,7 +373,7 @@ Click the Save button at any time to accept the current settings and continue.</
     <td>&nbsp;</td>
 </tr>
 <tr>
-    <td colspan=2>Put web site in administrative mode (<%=bean.helpLink%>)</td>
+    <td colspan=2>Put web site in administrative mode (<%=bean.getSiteSettingsHelpLink("adminonly")%>)</td>
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
@@ -389,7 +389,7 @@ Click the Save button at any time to accept the current settings and continue.</
     <td>&nbsp;</td>
 </tr>
 <tr>
-    <td colspan=2>HTTP security settings</td>
+    <td colspan=2>HTTP security settings (<%=bean.getSiteSettingsHelpLink("http")%>)</td>
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
@@ -404,7 +404,7 @@ Click the Save button at any time to accept the current settings and continue.</
     <td>&nbsp;</td>
 </tr>
 <tr>
-    <td colspan=2>Customize navigation options</td>
+    <td colspan=2>Customize navigation options (<%=bean.getSiteSettingsHelpLink("nav")%>)</td>
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>

--- a/core/src/org/labkey/core/admin/mapNetworkDrive.jsp
+++ b/core/src/org/labkey/core/admin/mapNetworkDrive.jsp
@@ -18,16 +18,12 @@
 <%@ page import="org.labkey.api.security.permissions.AdminOperationsPermission" %>
 <%@ page import="org.labkey.api.settings.NetworkDriveProps" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
-<%@ page import="org.labkey.api.view.HttpView" %>
-<%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.core.admin.AdminController.ShowNetworkDriveTestAction" %>
-<%@ page import="org.labkey.core.admin.AdminController.SiteSettingsBean" %>
 <%@ page import="org.labkey.core.admin.FilesSiteSettingsAction" %>
 <%@ page extends="org.labkey.api.jsp.FormPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 
 <%
-    SiteSettingsBean bean = ((JspView<SiteSettingsBean>) HttpView.currentView()).getModelBean();
     boolean hasAdminOpsPerms = getContainer().hasPermission(getUser(), AdminOperationsPermission.class);
 %>
 
@@ -76,7 +72,7 @@
     The user account that represents the service may not automatically have permissions to access a network share that the
     logged-in user does have access to. If you are running on Windows and using LabKey Server to access files on a remote server,
     for example via the LabKey Server pipeline, you'll need to configure the server to map the network drive for the service's user account.<br>
-    (<%=bean.helpLink%>)
+    (<%=helpLink("setRoots#map", "more info...")%>)
 </p>
 
 <labkey:errors/>


### PR DESCRIPTION
…lity from site settings.

#### Rationale
Point the ("more info...") links to their corresponding help topic anchor tags. Extract "map network drive" from from SiteSettingsForm. Eliminate unused "testInPage" parameter.
