### PR TITLE
Add startup properties for full-text search settings

### DIFF
--- a/api/src/org/labkey/api/action/ReturnUrlForm.java
+++ b/api/src/org/labkey/api/action/ReturnUrlForm.java
@@ -18,8 +18,8 @@ package org.labkey.api.action;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.HtmlString;
@@ -88,19 +88,10 @@ public class ReturnUrlForm
         return _urlhash;
     }
 
-    // TODO: Remove this. There is only one override in List
-    @Deprecated
-    protected URLHelper getDefaultReturnURLHelper()
-    {
-        return null;
-    }
-
     @Nullable
     public URLHelper getReturnURLHelper()
     {
-        return firstOf(
-                _returnUrl != null ? _returnUrl.getURLHelper() : null,
-                getDefaultReturnURLHelper());
+        return _returnUrl != null ? _returnUrl.getURLHelper() : null;
     }
 
     @Nullable

--- a/api/src/org/labkey/api/admin/AdminBean.java
+++ b/api/src/org/labkey/api/admin/AdminBean.java
@@ -20,12 +20,15 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.LabKeyCollectors;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.settings.AppProps;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
 
@@ -154,5 +157,33 @@ public class AdminBean
     public static Map<String, String> getPropertyMap()
     {
         return PROPERTY_MAP;
+    }
+
+    public static HtmlString getPropertyGridHtml(Map<String, String> propertyMap)
+    {
+        HtmlStringBuilder builder = HtmlStringBuilder.of()
+            .append(HtmlString.unsafe("<table class=\"labkey-data-region-legacy labkey-show-borders\">"))
+            .append(HtmlString.unsafe("<tr class=\"labkey-frame\"><th>Property</th><th>Current Value</th></tr>"))
+            .append
+            (
+                propertyMap.entrySet().stream()
+                    .map(e -> HtmlStringBuilder.of(HtmlString.unsafe("<tr valign=top class=\"labkey-row\"><td>"))
+                        .append(e.getKey())
+                        .append(HtmlString.unsafe("</td><td>"))
+                        .append(formatValue(e.getKey(), e.getValue()))
+                        .append(HtmlString.unsafe("</td></tr>\n"))
+                        .getHtmlString())
+                    .collect(LabKeyCollectors.joining(HtmlString.unsafe("\n")))
+            )
+           .append(HtmlString.unsafe("</table>\n"));
+
+        return builder.getHtmlString();
+    }
+
+    private static HtmlString formatValue(String key, String value)
+    {
+        // Format GUID properties with monospace font
+        return key.endsWith("Guid") ? HtmlStringBuilder.of(HtmlString.unsafe("<span style=\"font-family:monospace\">"))
+            .append(value).append(HtmlString.unsafe("</span>")).getHtmlString() : HtmlString.of(value);
     }
 }

--- a/api/src/org/labkey/api/admin/AdminBean.java
+++ b/api/src/org/labkey/api/admin/AdminBean.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -76,10 +77,12 @@ public class AdminBean
     @JsonIgnore
     public static final DbScope scope = CoreSchema.getInstance().getSchema().getScope();
 
-    private final static Map<String, String> propertyMap = new TreeMap<>();
+    private final static Map<String, String> PROPERTY_MAP;
 
     static
     {
+        Map<String, String> propertyMap = new TreeMap<>();
+
         Arrays.stream(AdminBean.class.getDeclaredFields())
             .filter(f -> Modifier.isStatic(f.getModifiers()))
             .filter(f -> f.getType().equals(String.class))
@@ -92,6 +95,8 @@ public class AdminBean
                 String key = StringUtils.uncapitalize(m.getName().substring(3));
                 propertyMap.put(key, getValue(m));
             });
+
+        PROPERTY_MAP = Collections.unmodifiableMap(propertyMap);
 
         //noinspection ConstantConditions,AssertWithSideEffects
         assert null != (asserts = "enabled");
@@ -148,6 +153,6 @@ public class AdminBean
 
     public static Map<String, String> getPropertyMap()
     {
-        return propertyMap;
+        return PROPERTY_MAP;
     }
 }

--- a/api/src/org/labkey/api/util/StringExpressionFactory.java
+++ b/api/src/org/labkey/api/util/StringExpressionFactory.java
@@ -964,7 +964,7 @@ public class StringExpressionFactory
 
     public static class SimpleStringExpression extends AbstractStringExpression
     {
-        boolean _urlEncodeSubstitutions = true;
+        private final boolean _urlEncodeSubstitutions;
 
         SimpleStringExpression(String source, boolean urlEncodeSubstitutions)
         {

--- a/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
+++ b/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
@@ -29,12 +29,12 @@
 <%@ page import="org.labkey.api.util.FolderDisplayMode" %>
 <%@ page import="org.labkey.api.util.Formats" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
+<%@ page import="org.labkey.api.util.HtmlStringBuilder" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.core.admin.AdminController" %>
 <%@ page import="org.labkey.core.admin.AdminController.AdminUrlsImpl" %>
 <%@ page import="java.util.Arrays" %>
-<%@ page import="java.util.stream.Collectors" %>
 <%@ page import="static org.labkey.api.settings.LookAndFeelProperties.Properties.*" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
@@ -80,17 +80,14 @@
     // If this is a folder then skip everything except default date & number formats
     if (!folder)
     {
-        String shortNameHelp = "The header short name supports string substitution of specific server properties. For example, " +
-            "the value:<br><br><code>&nbsp;&nbsp;LabKey ${releaseVersion}</code><br><br>will currently result in this header text:<br><br><code>&nbsp;&nbsp;LabKey " + AdminBean.releaseVersion + "</code><br><br>" +
-            "The supported properties and their current values are listed in the table below.<br><br>" +
-            "<table class=\"labkey-data-region-legacy labkey-show-borders\">" +
-            "<tr class=\"labkey-frame\"><th>Property</th><th>Current Value</th></tr>" +
-
-            AdminBean.getPropertyMap().entrySet().stream()
-                .map(e -> "<tr valign=top class=\"labkey-row\"><td>" + h(e.getKey()) + "</td><td>" + h(e.getValue()) + "</td></tr>\n")
-                .collect(Collectors.joining()) +
-
-            "</table>";
+        HtmlString shortNameHelp = HtmlStringBuilder.of("The header short name supports string substitution of specific server properties. For example, the value:")
+            .append(HtmlString.unsafe("<br><br><code>&nbsp;&nbsp;LabKey ${releaseVersion}</code><br><br>"))
+            .append("will currently result in this header text:")
+            .append(HtmlString.unsafe("<br><br><code>&nbsp;&nbsp;LabKey " + AdminBean.releaseVersion + "</code><br><br>"))
+            .append("The supported properties and their current values are listed in the table below.")
+            .append(HtmlString.unsafe("<br><br>"))
+            .append(AdminBean.getPropertyGridHtml(AdminBean.getPropertyMap()))
+            .getHtmlString();
 %>
 <tr>
     <td colspan=2>Customize the look and feel of <%=h(c.isRoot() ? "your LabKey Server installation" : "the '" + c.getProject().getName() + "' project")%> (<%=bean.helpLink%>)</td>
@@ -100,7 +97,7 @@
     <td><input type="text" name="<%=systemDescription%>" size="50" value="<%= h(laf.getDescription()) %>"></td>
 </tr>
 <tr>
-    <td class="labkey-form-label">Header short name (appears in every page header and in emails)<%=helpPopup("Header short name", shortNameHelp, true, 350)%></td>
+    <td class="labkey-form-label">Header short name (appears in every page header and in emails)<%=helpPopup("Header short name", shortNameHelp, 350)%></td>
     <td><input type="text" name="<%=systemShortName%>" size="50" value="<%= h(laf.getUnsubstitutedShortName()) %>"></td>
 </tr>
 <tr>

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -51,6 +51,7 @@ import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.ExceptionUtil;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.ResponseHelper;
@@ -98,6 +99,7 @@ public class SearchController extends SpringActionController
     }
 
 
+    @SuppressWarnings("unused")
     public static class SearchUrlsImpl implements SearchUrls
     {
         @Override
@@ -286,7 +288,7 @@ public class SearchController extends SpringActionController
 
             if (null != t)
             {
-                HtmlStringBuilder builder = HtmlStringBuilder.of("<span class=\"labkey-error\">Your search index is misconfigured. Search is disabled and documents are not being indexed, pending resolution of this issue. See below for details about the cause of the problem.</span></br></br>");
+                HtmlStringBuilder builder = HtmlStringBuilder.of(HtmlString.unsafe("<span class=\"labkey-error\">Your search index is misconfigured. Search is disabled and documents are not being indexed, pending resolution of this issue. See below for details about the cause of the problem.</span></br></br>"));
                 builder.append(ExceptionUtil.renderException(t));
                 WebPartView configErrorView = new HtmlView(builder);
                 configErrorView.setTitle("Search Configuration Error");

--- a/search/src/org/labkey/search/SearchModule.java
+++ b/search/src/org/labkey/search/SearchModule.java
@@ -26,6 +26,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.LimitedUser;
@@ -33,6 +34,8 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.roles.CanSeeAuditLogRole;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.settings.AdminConsole;
+import org.labkey.api.settings.StandardStartupPropertyHandler;
+import org.labkey.api.settings.StartupPropertyEntry;
 import org.labkey.api.usageMetrics.UsageMetricsService;
 import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.PageFlowUtil;
@@ -47,12 +50,14 @@ import org.labkey.search.audit.SearchAuditProvider;
 import org.labkey.search.model.AbstractSearchService;
 import org.labkey.search.model.DavCrawler;
 import org.labkey.search.model.LuceneSearchServiceImpl;
+import org.labkey.search.model.SearchStartupProperties;
 import org.labkey.search.view.SearchWebPartFactory;
 
 import javax.servlet.ServletContext;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 
@@ -127,6 +132,17 @@ public class SearchModule extends DefaultModule
     @Override
     public void doStartup(ModuleContext moduleContext)
     {
+        ModuleLoader.getInstance().handleStartupProperties(
+            new StandardStartupPropertyHandler<>("SearchSettings", SearchStartupProperties.class)
+            {
+                @Override
+                public void handle(Map<SearchStartupProperties, StartupPropertyEntry> properties)
+                {
+                    System.out.println(properties);
+                }
+            }
+        );
+
         final SearchService ss = SearchService.get();
 
         if (null != ss)
@@ -148,7 +164,6 @@ public class SearchModule extends DefaultModule
 
         UsageMetricsService.get().registerUsageMetrics(getName(), () ->
         {
-
             // Report the total number of search entries in the audit log
             User user = new LimitedUser(User.getSearchUser(), new int[0], Set.of(RoleManager.getRole(CanSeeAuditLogRole.class)), true);
             UserSchema auditSchema = AuditLogService.get().createSchema(user, ContainerManager.getRoot());

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -68,6 +68,7 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.admin.AdminBean;
+import org.labkey.api.collections.LabKeyCollectors;
 import org.labkey.api.collections.Sets;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -142,7 +143,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -270,12 +270,17 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
     public static File getIndexDirectory()
     {
         String adminSpecifiedDirectory = SearchPropertyManager.getUnsubstitutedIndexDirectory();
-        // Create Map of system properties with file-system escaped values
-        Map<String, String> escapedMap = AdminBean.getPropertyMap().entrySet().stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, e->FileUtil.makeLegalName(e.getValue())));
+        Map<String, String> escapedMap = getEscapedSystemPropertyMap();
         String encodedPath = StringExpressionFactory.create(adminSpecifiedDirectory).eval(escapedMap);
         File substitutedDirectory = new File(encodedPath);
         return AppProps.getInstance().isDevMode() ? new File(substitutedDirectory, "Lucene" + Version.LATEST.major) : substitutedDirectory;
+    }
+
+    // Create a Map of system properties with file-system escaped values
+    public static Map<String, String> getEscapedSystemPropertyMap()
+    {
+        return AdminBean.getPropertyMap().entrySet().stream()
+            .collect(LabKeyCollectors.toLinkedMap(Map.Entry::getKey, e->FileUtil.makeLegalName(e.getValue())));
     }
 
     @Override

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -67,6 +67,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.admin.AdminBean;
 import org.labkey.api.collections.Sets;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -98,6 +99,7 @@ import org.labkey.api.util.MultiPhaseCPUTimer.InvocationTimer;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.util.URLHelper;
@@ -266,8 +268,10 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
     // This prevents full index rebuilds when switching between branches with different major Lucene versions.
     public static File getIndexDirectory()
     {
-        File adminSpecifiedDirectory = SearchPropertyManager.getIndexDirectory();
-        return AppProps.getInstance().isDevMode() ? new File(adminSpecifiedDirectory, "Lucene" + Version.LATEST.major) : adminSpecifiedDirectory;
+        String adminSpecifiedDirectory = SearchPropertyManager.getUnsubstitutedIndexDirectory();
+        // TODO: Still need to encode
+        File substitutedDirectory = new File(StringExpressionFactory.create(adminSpecifiedDirectory).eval(AdminBean.getPropertyMap()));
+        return AppProps.getInstance().isDevMode() ? new File(substitutedDirectory, "Lucene" + Version.LATEST.major) : substitutedDirectory;
     }
 
     @Override

--- a/search/src/org/labkey/search/model/NoopWritableIndex.java
+++ b/search/src/org/labkey/search/model/NoopWritableIndex.java
@@ -108,6 +108,12 @@ public class NoopWritableIndex implements WritableIndexManager
         return false;
     }
 
+    @Override
+    public boolean isClosed()
+    {
+        return false;
+    }
+
     private void log(String action)
     {
         if (0 == (_errors.get() % 10000))

--- a/search/src/org/labkey/search/model/SearchPropertyManager.java
+++ b/search/src/org/labkey/search/model/SearchPropertyManager.java
@@ -54,12 +54,12 @@ public class SearchPropertyManager
         setProperty(CRAWLER_RUNNING_STATE, String.valueOf(running));
     }
 
-    public static File getIndexDirectory()
+    public static String getUnsubstitutedIndexDirectory()
     {
         String path = getProperty(INDEX_PATH);
 
         // Use path if set, otherwise fall back to temp directory.
-        return (null != path ? new File(path) : new File(FileUtil.getTempDirectory(), "labkey_full_text_index"));
+        return null != path ? path : new File(FileUtil.getTempDirectory(), "labkey_full_text_index").getPath();
     }
 
     public static void setIndexPath(String path)

--- a/search/src/org/labkey/search/model/SearchStartupProperties.java
+++ b/search/src/org/labkey/search/model/SearchStartupProperties.java
@@ -1,0 +1,28 @@
+package org.labkey.search.model;
+
+import org.labkey.api.settings.StartupProperty;
+import org.labkey.api.util.SafeToRenderEnum;
+
+import java.util.Arrays;
+
+public enum SearchStartupProperties implements StartupProperty, SafeToRenderEnum
+{
+    indexFilePath("Path to full-text search index"),
+    directoryType("Directory type. Valid values: " + Arrays.toString(LuceneDirectoryType.values())),
+    indexedFileSizeLimit("Maximum file size limit"),
+    pauseCrawler("Pause crawler. Value vales: [true, false]"),
+    deleteIndex("Delete the index entirely");
+
+    private final String _description;
+
+    SearchStartupProperties(String description)
+    {
+        _description = description;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return _description;
+    }
+}

--- a/search/src/org/labkey/search/model/WritableIndexManager.java
+++ b/search/src/org/labkey/search/model/WritableIndexManager.java
@@ -58,5 +58,7 @@ public interface WritableIndexManager
      */
     boolean isReal();
 
+    boolean isClosed();
+
     void refreshNow() throws IOException;
 }

--- a/search/src/org/labkey/search/model/WritableIndexManagerImpl.java
+++ b/search/src/org/labkey/search/model/WritableIndexManagerImpl.java
@@ -337,6 +337,12 @@ class WritableIndexManagerImpl extends IndexManager implements WritableIndexMana
         return true;
     }
 
+    @Override
+    public boolean isClosed()
+    {
+        return _closed;
+    }
+
     private void maybeRefresh()
     {
         _maybeRefreshRequests.incrementAndGet();
@@ -395,6 +401,7 @@ class WritableIndexManagerImpl extends IndexManager implements WritableIndexMana
         }
     }
 
+    @Override
     public void refreshNow() throws IOException
     {
         _manager.maybeRefresh();

--- a/search/src/org/labkey/search/view/indexerAdmin.jsp
+++ b/search/src/org/labkey/search/view/indexerAdmin.jsp
@@ -27,6 +27,8 @@
 <%@ page import="org.labkey.search.model.SearchPropertyManager" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="org.labkey.search.model.LuceneSearchServiceImpl" %>
+<%@ page import="org.labkey.api.admin.AdminBean" %>
+<%@ page import="org.labkey.api.util.HtmlStringBuilder" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
@@ -46,11 +48,20 @@ if (null == ss)
 }
 else
 {
+    HtmlString indexPathHelp = HtmlStringBuilder.of("The index path setting supports string substitution of specific server properties. For example, the value:")
+        .append(HtmlString.unsafe("<br><br><code>&nbsp;&nbsp;.\\temp\\${serverGuid}\\labkey_full_text_index</code><br><br>"))
+        .append("will currently result in this path:")
+        .append(HtmlString.unsafe("<br><br><code>&nbsp;&nbsp;.\\temp\\" + AdminBean.serverGuid + "\\labkey_full_text_index</code><br><br>"))
+        .append("The supported properties and their current values are listed in the table below. Note that illegal file system characters are replaced with underscores in all the values.")
+        .append(HtmlString.unsafe("<br><br>"))
+        .append(AdminBean.getPropertyGridHtml(LuceneSearchServiceImpl.getEscapedSystemPropertyMap()))
+        .getHtmlString();
+
     %><p><labkey:form method="POST" action="<%=urlFor(AdminAction.class)%>">
         <table>
             <%=getTroubleshooterWarning(hasAdminOpsPerms, HtmlString.unsafe("<br>"))%>
             <tr>
-                <td>Path to full-text search index:&nbsp;</td>
+                <td>Path to full-text search index<%=helpPopup("Path to full-text search index", indexPathHelp, 350)%>:&nbsp;</td>
                 <td><input name="indexPath" size="80" value="<%=h(SearchPropertyManager.getUnsubstitutedIndexDirectory())%>"></td>
             </tr>
             <tr>

--- a/search/src/org/labkey/search/view/indexerAdmin.jsp
+++ b/search/src/org/labkey/search/view/indexerAdmin.jsp
@@ -26,6 +26,7 @@
 <%@ page import="org.labkey.search.SearchController.AdminForm" %>
 <%@ page import="org.labkey.search.model.SearchPropertyManager" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="org.labkey.search.model.LuceneSearchServiceImpl" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
@@ -50,7 +51,13 @@ else
             <%=getTroubleshooterWarning(hasAdminOpsPerms, HtmlString.unsafe("<br>"))%>
             <tr>
                 <td>Path to full-text search index:&nbsp;</td>
-                <td><input name="indexPath" size="80" value="<%=h(SearchPropertyManager.getIndexDirectory().getPath())%>"></td>
+                <td><input name="indexPath" size="80" value="<%=h(SearchPropertyManager.getUnsubstitutedIndexDirectory())%>"></td>
+            </tr>
+            <tr>
+                <td>Current path resolves to:</td><td><%=h(LuceneSearchServiceImpl.getIndexDirectory().getPath())%></td>
+            </tr>
+            <tr>
+                <td colspan="2">&nbsp;</td>
             </tr><%
         if (hasAdminOpsPerms)
         {


### PR DESCRIPTION
#### Rationale
Startup properties for full-text search settings are needed to ensure accurate search results after upgrades and to help clean up <tomcat>/temp. See:

* https://docs.google.com/document/d/1btU0_n16ZCxC1Y2F3SW3Jx1LasY4NY6mSPATKdtx32E/edit
* https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=45271
* https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=46598

#### Changes
* Simplify some `SimpleRedirectAction`s to take a form
