### PR TITLE
Bugfixes to Ext4 form

### DIFF
--- a/internal/webapp/extWidgets/Ext4FormPanel.js
+++ b/internal/webapp/extWidgets/Ext4FormPanel.js
@@ -532,10 +532,14 @@ Ext4.define('LABKEY.ext4.DatabindPlugin', {
             var findMatchingField = function(f) {
                 if (f.isFormField) {
                     if (f.dataIndex) {
-                        this.addFieldListener(c);
+                        this.addFieldListener(f);
                     } else if (f.isComposite) {
                         f.items.each(findMatchingField, this);
                     }
+                }
+                // NOTE: this allows more complex nested containers
+                else if (f.isQueryable) {
+                    f.items.each(findMatchingField, this);
                 }
             };
             findMatchingField.call(this, c);
@@ -557,11 +561,11 @@ Ext4.define('LABKEY.ext4.DatabindPlugin', {
             // Can only contain one row of data.
             if (records.length == 0){
                 if(this.panel.bindConfig.createRecordOnLoad){
-                    var values = this.getForm.getFieldValues();
+                    var values = this.panel.getForm().getFieldValues();
                     var record = this.panel.store.model.create();
                     record.set(values); //otherwise record will not be dirty
                     record.phantom = true;
-                    this.store.add(record);
+                    this.panel.store.add(record);
                     this.bindRecord(record, true);
                 }
             }


### PR DESCRIPTION
@labkey-jeckels and @labkey-martyp: I cant create branches on the labkey side of this repo. Can you please create a 22.7_fb_ext4form branch, based on 22.7-snapshot, and merge this PR into it? This would kick off TeamCity (which this PR does not) and run tests. Note: I'm OK targeting 22.11 if that's easier to do at this point.

Note: this PR should not impact anything in EHR (which tests should confirm), but I found a couple small issues in Ext4Form. This would occur if you're trying to use an Ext4FormPanel with any layout that is more complex than a flat array of fields (such as a 2-column layout). The specific changes are:

1) Line 535 I think was always a bug, but never exercised. This f would equal c in all but fringe cases (like nested layouts). The code is expecting to add the listener to the field itself, not the owning container. There only existing case of nesting I know about is composite fields, like drug amount + units (two fields on the same row). The EHR test should verify I didnt break anything.

2) I'm pretty sure no code really exercises this, but lines 564 and 568 are also bugs. The properties they were querying dont exist. For example, "getForm.getFieldValues" would always have throw an exception.

