### PR TITLE
Remove support for deprecated startup properties

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -2197,7 +2197,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
                 .map(entry -> entry.getScope() + "." + entry.getName() + ": " + entry.getValue()).toList();
 
             if (!unknown.isEmpty())
-                throw new NotFoundException("Unknown startup propert" + (unknown.size() == 1 ? "y: " : "ies: ") + unknown);
+                throw new IllegalArgumentException("Unknown startup propert" + (unknown.size() == 1 ? "y: " : "ies: ") + unknown);
 
             // Failing this check indicates a coding issue, so execute it only when assertions are on
             assert checkPropertyScopeMapping();

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -81,7 +81,6 @@ import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.util.logging.ErrorLogRotator;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.HttpView;
-import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.ViewServlet;
 import org.labkey.api.view.template.WarningProvider;
@@ -134,7 +133,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.apache.commons.lang3.StringUtils.join;
 
 /**
  * Drives the process of initializing all the modules at startup time and otherwise managing their life cycle.

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -18,7 +18,6 @@ package org.labkey.api.module;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -82,6 +81,7 @@ import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.util.logging.ErrorLogRotator;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.HttpView;
+import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.ViewServlet;
 import org.labkey.api.view.template.WarningProvider;
@@ -134,6 +134,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.join;
 
 /**
  * Drives the process of initializing all the modules at startup time and otherwise managing their life cycle.
@@ -2190,14 +2191,13 @@ public class ModuleLoader implements Filter, MemTrackerListener
         public void moduleStartupComplete(ServletContext servletContext)
         {
             // Log error for any unknown startup properties (admin error)
-            ModuleLoader.getInstance().getStartupPropertyEntries(null)
+            List<String> unknown = ModuleLoader.getInstance().getStartupPropertyEntries(null)
                 .stream()
                 .filter(entry -> null == entry.getStartupProperty())
-                .forEach(entry -> {
-                    // Suppress ERROR logging on this special snowflake. TODO: Remove this hack once Server Provisioner, Accounterer, etc. are updated. See Issue 45867 and Issue 45842
-                    Level logLevel = "SiteSettings".equals(entry.getScope()) && "experimentalFeature.disableGuestAccount".equals(entry.getName()) ? Level.WARN : Level.ERROR;
-                    _log.log(logLevel, "Unknown startup property: " + entry.getScope() + "." + entry.getName() + ": " + entry.getValue());
-                });
+                .map(entry -> entry.getScope() + "." + entry.getName() + ": " + entry.getValue()).toList();
+
+            if (!unknown.isEmpty())
+                throw new NotFoundException("Unknown startup propert" + (unknown.size() == 1 ? "y: " : "ies: ") + unknown);
 
             // Failing this check indicates a coding issue, so execute it only when assertions are on
             assert checkPropertyScopeMapping();

--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -604,24 +604,7 @@ class AppPropsImpl extends AbstractWriteableSettingsGroup implements AppProps
         // for a list of recognized site setting properties see the "Available Site Settings" action
 
         ModuleLoader.getInstance().handleStartupProperties(new SiteSettingsPropertyHandler());
-
-        ModuleLoader.getInstance().handleStartupProperties(new StandardStartupPropertyHandler<>(SCOPE_SITE_SETTINGS, RandomStartupProperties.class)
-        {
-            @Override
-            public void handle(Map<RandomStartupProperties, StartupPropertyEntry> properties)
-            {
-                if (!properties.isEmpty())
-                {
-                    WriteableAppProps writeable = AppProps.getWriteableInstance();
-                    properties.forEach((rsp, cp) -> {
-                        LOG.info("Setting additional site-level startup property '" + rsp.name() + "' to '" + cp.getValue() + "'");
-                        rsp.setValue(writeable, cp.getValue());
-                    });
-                    writeable.save(null);
-                }
-            }
-        });
-
+        ModuleLoader.getInstance().handleStartupProperties(new RandomSiteSettingsPropertyHandler());
         ModuleLoader.getInstance().handleStartupProperties(new StandardStartupPropertyHandler<>(SCOPE_SITE_SETTINGS, StashedStartupProperties.class)
         {
             @Override

--- a/api/src/org/labkey/api/settings/RandomSiteSettingsPropertyHandler.java
+++ b/api/src/org/labkey/api/settings/RandomSiteSettingsPropertyHandler.java
@@ -1,0 +1,30 @@
+package org.labkey.api.settings;
+
+import org.apache.logging.log4j.Logger;
+import org.labkey.api.util.logging.LogHelper;
+
+import java.util.Map;
+
+public class RandomSiteSettingsPropertyHandler extends StandardStartupPropertyHandler<RandomStartupProperties>
+{
+    private static final Logger LOG = LogHelper.getLogger(AppPropsImpl.class, "Additional site settings startup properties");
+
+    public RandomSiteSettingsPropertyHandler()
+    {
+        super(AppProps.SCOPE_SITE_SETTINGS, RandomStartupProperties.class);
+    }
+
+    @Override
+    public void handle(Map<RandomStartupProperties, StartupPropertyEntry> properties)
+    {
+        if (!properties.isEmpty())
+        {
+            WriteableAppProps writeable = AppProps.getWriteableInstance();
+            properties.forEach((rsp, cp) -> {
+                LOG.info("Setting additional site-level startup property '" + rsp.name() + "' to '" + cp.getValue() + "'");
+                rsp.setValue(writeable, cp.getValue());
+            });
+            writeable.save(null);
+        }
+    }
+}

--- a/api/src/org/labkey/api/settings/RandomStartupProperties.java
+++ b/api/src/org/labkey/api/settings/RandomStartupProperties.java
@@ -44,7 +44,6 @@ public enum RandomStartupProperties implements StartupProperty, SafeToRenderEnum
             writeable.setMailRecorderEnabled(Boolean.parseBoolean(value));
         }
     },
-    // TODO: Remove SiteRootStartupProperties.siteRootFile in favor of this property
     siteFileRoot("Site-level file root")
     {
         @Override

--- a/api/src/org/labkey/api/settings/SiteSettingsProperties.java
+++ b/api/src/org/labkey/api/settings/SiteSettingsProperties.java
@@ -14,15 +14,6 @@ import java.util.Arrays;
 // Site settings constants are defined here in the same order as on the site settings page
 public enum SiteSettingsProperties implements StartupProperty, SafeToRenderEnum
 {
-    defaultDomain("Default email domain for authentication purposes. DO NOT USE... use Authentication.DefaultDomain instead.")
-    {
-        @Override
-        public void setValue(WriteableAppProps writeable, String value)
-        {
-            AuthenticationManager.setDefaultDomain(UserManager.getGuestUser(), value);
-            LOG.warn("Support for the \"SiteSettings.defaultDomain\" startup property will be removed shortly; use \"Authentication.DefaultDomain\" instead.");
-        }
-    },
     administratorContactEmail("Primary site administrator")
     {
         @Override

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -121,7 +121,6 @@ import org.labkey.api.settings.LookAndFeelPropertiesManager.ResourceType;
 import org.labkey.api.settings.LookAndFeelPropertiesManager.SiteResourceHandler;
 import org.labkey.api.settings.ProductConfiguration;
 import org.labkey.api.settings.StandardStartupPropertyHandler;
-import org.labkey.api.settings.StartupProperty;
 import org.labkey.api.settings.StartupPropertyEntry;
 import org.labkey.api.settings.StashedStartupProperties;
 import org.labkey.api.settings.WriteableAppProps;
@@ -1361,8 +1360,6 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         });
     }
 
-
-
     /**
      * This method handles the home project settings
      */
@@ -1398,25 +1395,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             }
         }
 
-        // TODO: Delete this (and inline replaceHomeProjectWebparts()) after transitioning to SiteSettings.homeProjectWebparts
-        ModuleLoader.getInstance().handleStartupProperties(new StandardStartupPropertyHandler<>(WriteableLookAndFeelProperties.SCOPE_LOOK_AND_FEEL_SETTINGS, DeprecatedProperties.class)
-        {
-            @Override
-            public void handle(Map<DeprecatedProperties, StartupPropertyEntry> properties)
-            {
-                if (!properties.isEmpty())
-                {
-                    LOG.warn("Support for the \"LookAndFeelSettings.homeProjectInitWebparts\" startup property will be removed shortly; use \"SiteSettings.homeProjectWebparts\" instead.");
-                    replaceHomeProjectWebparts(properties.get(DeprecatedProperties.homeProjectInitWebparts));
-                }
-            }
-        });
-
-        replaceHomeProjectWebparts(props.get(homeProjectWebparts));
-    }
-
-    private void replaceHomeProjectWebparts(StartupPropertyEntry webparts)
-    {
+        StartupPropertyEntry webparts = props.get(homeProjectWebparts);
         if (null != webparts)
         {
             // Clear existing webparts added by core and wiki modules
@@ -1428,18 +1407,6 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                 WebPartFactory webPartFactory = Portal.getPortalPart(webpartName);
                 if (webPartFactory != null)
                     addWebPart(webPartFactory.getName(), homeContainer, HttpView.BODY);
-            }
-        }
-    }
-
-    private enum DeprecatedProperties implements StartupProperty
-    {
-        homeProjectInitWebparts
-        {
-            @Override
-            public String getDescription()
-            {
-                return "Semicolon-separated list of webpart names to add to the home project. DO NOT USE... use SiteSettings.homeProjectWebparts instead.";
             }
         }
     }

--- a/filecontent/src/org/labkey/filecontent/FileContentModule.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentModule.java
@@ -171,9 +171,6 @@ public class FileContentModule extends DefaultModule
         {
             fsr.addFactories(new FileWriter.Factory(), new FileImporter.Factory());
         }
-
-        // populate File Site Root Settings with values read from startup properties as appropriate for not bootstrap
-        FileContentServiceImpl.populateSiteRootFileWithStartupProps();
     }
 
     @Override

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -126,12 +126,6 @@ public class FileContentServiceImpl implements FileContentService
 
     private volatile boolean _fileRootSetViaStartupProperty = false;
 
-    enum Props
-    {
-        root,
-        rootDisabled,
-    }
-
     enum FileAction
     {
         UPLOAD,
@@ -1780,7 +1774,7 @@ public class FileContentServiceImpl implements FileContentService
          * Test that the Site Settings can be configured from startup properties
          */
         @Test
-        public void testStartupPropertiesForSiteRootSettings() throws Exception
+        public void testStartupPropertiesForSiteRootSettings()
         {
             // save the original Site Root File settings so that we can restore them when this test is done
             File originalSiteRootFile = FileContentService.get().getSiteDefaultRoot();
@@ -1788,7 +1782,6 @@ public class FileContentServiceImpl implements FileContentService
             // create the new site root file to test with as a child of the current site root file so that we know it is in a dir that exist
             String originalSiteRootFilePath = originalSiteRootFile.getAbsolutePath();
             File testSiteRootFile = new File(originalSiteRootFilePath, "testSiteRootFile");
-            Assert.assertFalse(testSiteRootFile.createNewFile());
 
             ModuleLoader.getInstance().handleStartupProperties(new RandomSiteSettingsPropertyHandler(){
                 @Override

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -69,8 +69,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
-import org.labkey.api.settings.StandardStartupPropertyHandler;
-import org.labkey.api.settings.StartupProperty;
+import org.labkey.api.settings.RandomSiteSettingsPropertyHandler;
 import org.labkey.api.settings.StartupPropertyEntry;
 import org.labkey.api.settings.WriteableAppProps;
 import org.labkey.api.test.TestWhen;
@@ -108,6 +107,8 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Pattern;
 
+import static org.labkey.api.settings.AppProps.SCOPE_SITE_SETTINGS;
+
 /**
  * User: klum
  * Date: Dec 9, 2009
@@ -116,7 +117,6 @@ public class FileContentServiceImpl implements FileContentService
 {
     private static final Logger _log = LogManager.getLogger(FileContentServiceImpl.class);
     private static final String UPLOAD_LOG = ".upload.log";
-    private static final String SCOPE_SITE_ROOT_SETTINGS = "SiteRootSettings";
     private static final FileContentServiceImpl INSTANCE = new FileContentServiceImpl();
 
     private final ContainerListener _containerListener = new FileContentServiceContainerListener();
@@ -1222,42 +1222,6 @@ public class FileContentServiceImpl implements FileContentService
         return frag;
     }
 
-    // TODO: Delete this in favor of SiteSettings.siteFileRoot
-    @Deprecated
-    public enum SiteRootStartupProperties implements StartupProperty
-    {
-        siteRootFile
-        {
-            @Override
-            public String getDescription()
-            {
-                return "Site-level file root. DO NOT USE... use SiteSettings.siteFileRoot instead.";
-            }
-        }
-    }
-
-    // TODO: Delete this in favor of SiteSettingsProperties.webRoot
-    public static class SiteRootStartupPropertyHandler extends StandardStartupPropertyHandler<SiteRootStartupProperties>
-    {
-        public SiteRootStartupPropertyHandler()
-        {
-            super(SCOPE_SITE_ROOT_SETTINGS, SiteRootStartupProperties.class);
-        }
-
-        @Override
-        public void handle(Map<SiteRootStartupProperties, StartupPropertyEntry> map)
-        {
-            StartupPropertyEntry entry = map.get(SiteRootStartupProperties.siteRootFile);
-            if (null != entry)
-            {
-                _log.warn("Support for SiteRootSettings.siteRootFile will be removed soon; use SiteSettings.siteFileRoot instead.");
-                File fileRoot = new File(entry.getValue());
-                FileContentService.get().setSiteDefaultRoot(fileRoot, null);
-                FileContentService.get().setFileRootSetViaStartupProperty(true);
-            }
-        }
-    }
-
     public void setFileRootSetViaStartupProperty(boolean fileRootSetViaStartupProperty)
     {
         _fileRootSetViaStartupProperty = fileRootSetViaStartupProperty;
@@ -1267,14 +1231,6 @@ public class FileContentServiceImpl implements FileContentService
     public boolean isFileRootSetViaStartupProperty()
     {
         return _fileRootSetViaStartupProperty;
-    }
-
-    public static void populateSiteRootFileWithStartupProps()
-    {
-        // populate the site root file settings with values read from startup properties
-        // expects startup properties formatted like: FileSiteRootSettings.fileRoot;bootstrap=/labkey/labkey/files
-        // if more than one FileSiteRootSettings.siteRootFile specified in the startup properties file then the last one overrides the previous ones
-        ModuleLoader.getInstance().handleStartupProperties(new SiteRootStartupPropertyHandler());
     }
 
     public ContainerListener getContainerListener()
@@ -1832,13 +1788,13 @@ public class FileContentServiceImpl implements FileContentService
             // create the new site root file to test with as a child of the current site root file so that we know it is in a dir that exist
             String originalSiteRootFilePath = originalSiteRootFile.getAbsolutePath();
             File testSiteRootFile = new File(originalSiteRootFilePath, "testSiteRootFile");
-            testSiteRootFile.createNewFile();
+            Assert.assertFalse(testSiteRootFile.createNewFile());
 
-            ModuleLoader.getInstance().handleStartupProperties(new SiteRootStartupPropertyHandler(){
+            ModuleLoader.getInstance().handleStartupProperties(new RandomSiteSettingsPropertyHandler(){
                 @Override
                 public @NotNull Collection<StartupPropertyEntry> getStartupPropertyEntries()
                 {
-                    return List.of(new StartupPropertyEntry("siteRootFile", testSiteRootFile.getAbsolutePath(), "startup", SCOPE_SITE_ROOT_SETTINGS));
+                    return List.of(new StartupPropertyEntry("siteFileRoot", testSiteRootFile.getAbsolutePath(), "startup", SCOPE_SITE_SETTINGS));
                 }
 
                 @Override

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -1774,7 +1774,7 @@ public class FileContentServiceImpl implements FileContentService
          * Test that the Site Settings can be configured from startup properties
          */
         @Test
-        public void testStartupPropertiesForSiteRootSettings()
+        public void testStartupPropertiesForSiteRootSettings() throws IOException
         {
             // save the original Site Root File settings so that we can restore them when this test is done
             File originalSiteRootFile = FileContentService.get().getSiteDefaultRoot();
@@ -1782,6 +1782,7 @@ public class FileContentServiceImpl implements FileContentService
             // create the new site root file to test with as a child of the current site root file so that we know it is in a dir that exist
             String originalSiteRootFilePath = originalSiteRootFile.getAbsolutePath();
             File testSiteRootFile = new File(originalSiteRootFilePath, "testSiteRootFile");
+            testSiteRootFile.createNewFile();
 
             ModuleLoader.getInstance().handleStartupProperties(new RandomSiteSettingsPropertyHandler(){
                 @Override


### PR DESCRIPTION
#### Rationale
We deprecated the following startup properties (in favor of their alternatives) back in June, 2022:

- SiteRootSettings.siteRootFile -> SiteSettings.siteFileRoot
- LookAndFeelSettings.homeProjectInitWebparts -> SiteSettings.homeProjectWebparts
- SiteSettings.defaultDomain -> Authentication.DefaultDomain
- SiteSettings.experimentalFeature.disableGuestAccount -> ExperimentalFeature.disableGuestAccount

It's now time to stop accepting the deprecated properties. We'll also now throw a startup exception if unrecognized startup properties are provided.

We will wait to merge until the cloud deployment team has scrubbed all uses of the deprecated properties from deployment scripts, etc.
