### PR TITLE
Stop double-encoding reset password error page

### DIFF
--- a/api/src/org/labkey/api/view/HtmlView.java
+++ b/api/src/org/labkey/api/view/HtmlView.java
@@ -58,7 +58,7 @@ public class HtmlView extends WebPartView
         this(HtmlString.unsafe(html));
     }
 
-    /** Use the HtmlString or or Renderable constructor instead */
+    /** Use the HtmlString or Renderable constructor instead */
     @Deprecated
     public HtmlView(String title, String html)
     {

--- a/core/resources/scripts/labkey/Message.js
+++ b/core/resources/scripts/labkey/Message.js
@@ -16,7 +16,7 @@ LABKEY.Utils = require("./Utils").Utils;/**
  *            <p>Additional documentation on SMTP setup for LabKey Server:
  *              <ul>
  *                  <li><a href="https://www.labkey.org/Documentation/wiki-page.view?name=configWindows">Install LabKey via the Installer</a></li>
- *                  <li><a href="https://www.labkey.org/Documentation/wiki-page.view?name=cpasxml">Modify the Configuration File -- Includes SMTP Settings</a></li>
+ *                  <li><a href="https://www.labkey.org/Documentation/wiki-page.view?name=labkeyxml">Modify the Configuration File -- Includes SMTP Settings</a></li>
  *              </ul>
  *           </p>
  */

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -1737,7 +1737,7 @@ public class SecurityController extends SpringActionController
         {
             HtmlStringBuilder builder = HtmlStringBuilder.of()
                 .append(HtmlString.unsafe("<p>"))
-                .append(form.getEmail() + ": Password " + (_loginExists ? "reset" : "created"))
+                .append(form.getEmail() + ": Password " + (_loginExists ? "reset" : "created") + ".")
                 .append(HtmlString.unsafe("</p><p>"))
                 .append(getErrorMessage(errors))
                 .append(HtmlString.unsafe("</p>"))

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -96,6 +96,7 @@ import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
+import org.labkey.api.util.Link;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.TestContext;
@@ -1734,50 +1735,53 @@ public class SecurityController extends SpringActionController
         @Override
         public ModelAndView getFailView(EmailForm form, BindException errors)
         {
-            String errorMessage = PageFlowUtil.filter(getErrorMessage(errors));
-
-            String page = String.format(
-                "<p>%1$s: Password %2$s.</p><p>%3$s</p>%4$s",
-                PageFlowUtil.filter(form.getEmail()),
-                _loginExists ? "reset" : "created",
-                errorMessage,
-                PageFlowUtil.button("Done").href(form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL()))
-            );
+            HtmlStringBuilder builder = HtmlStringBuilder.of()
+                .append(HtmlString.unsafe("<p>"))
+                .append(form.getEmail() + ": Password " + (_loginExists ? "reset" : "created"))
+                .append(HtmlString.unsafe("</p><p>"))
+                .append(getErrorMessage(errors))
+                .append(HtmlString.unsafe("</p>"))
+                .append(PageFlowUtil.button("Done").href(form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL())));
 
             getPageConfig().setTemplate(PageConfig.Template.Dialog);
             setTitle("Password Reset Failed");
-            return new HtmlView(page);
+            return new HtmlView(builder);
         }
 
-        private String getErrorMessage(BindException errors)
+        private HtmlString getErrorMessage(BindException errors)
         {
-            StringBuilder sb = new StringBuilder();
+            HtmlStringBuilder builder = HtmlStringBuilder.of();
+
             for(ObjectError e : errors.getAllErrors())
             {
-                sb.append(e.getDefaultMessage()).append('\n');
+                if (e instanceof LabKeyError le)
+                    builder.append(le.renderToHTML(getViewContext()));
+                else
+                    builder.append(e.getDefaultMessage()).append('\n');
             }
 
-            return sb.toString();
+            return builder.getHtmlString();
         }
 
-        private String getMailHelpText(String emailAddress)
+        private HtmlString getMailHelpText(String emailAddress)
         {
             ActionURL mailHref = new ActionURL(ShowResetEmailAction.class, getContainer()).addParameter("email", emailAddress);
 
-            StringBuilder sb = new StringBuilder();
-            sb.append("<p>You can attempt to resend this mail later by going to the Site Users link, clicking on the appropriate user from the list, and resetting their password.");
+            HtmlStringBuilder builder = HtmlStringBuilder.of()
+                .append(HtmlString.unsafe("<p>"))
+                .append("You can attempt to resend this mail later by going to the Site Users link, clicking on the appropriate user from the list, and resetting their password.");
             if (mailHref != null)
             {
-                sb.append(" Alternatively, you can copy the <a href=\"");
-                sb.append(mailHref);
-                sb.append("\" target=\"_blank\">contents of the message</a> into an email client and send it to the user manually.");
+                builder.append(" Alternatively, you can copy the ")
+                    .append(new Link.LinkBuilder("contents of the message").href(mailHref).target("_blank").clearClasses())
+                    .append(" into an email client and send it to the user manually.");
             }
-            sb.append("</p>");
-            sb.append("<p>For help on fixing your mail server settings, please consult the SMTP section of the ");
-            sb.append(new HelpTopic("cpasxml").getSimpleLinkHtml("LabKey Server documentation on modifying your configuration file"));
-            sb.append(".</p>");
+            builder.append(HtmlString.unsafe("</p>\n<p>"))
+                .append("For help on fixing your mail server settings, please consult the SMTP section of the ")
+                .append(new HelpTopic("labkeyxml").getSimpleLinkHtml("LabKey Server documentation on modifying your configuration file"))
+                .append(HtmlString.unsafe(".</p>"));
 
-            return sb.toString();
+            return builder.getHtmlString();
         }
     }
 


### PR DESCRIPTION
#### Rationale
All the HTML content on the reset password error page (shown when the server fails to send the verification email) is double encoded.

Before:

![image](https://user-images.githubusercontent.com/5107383/203427883-da387cc1-0282-4941-9a3e-959e8f1715b0.png)

After:

![image](https://user-images.githubusercontent.com/5107383/203447890-d0fba729-5b00-4a49-afbb-7dca8781840e.png)

Discovered while investigating https://www.labkey.org/Genomics%20England/Support%20Tickets/issues-details.view?issueId=46750

#### Changes
* Switch content generation to `HtmlString` / `HtmlStringBuilder` and helpers
* Use `LabKeyErrorWithHtml` and teach `getErrorMessage()` how to render a `LabKeyError`
* Render simple links for reset email content
* Switch to modern help topic: `cpasxml` -> `labkeyxml`
