### PR TITLE
Add timestamp to pipeline analysis job log

### DIFF
--- a/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
+++ b/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
@@ -19,13 +19,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.collections.RowMapFactory;
-import org.labkey.api.data.TSVMapWriter;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.ExperimentUrls;
-import org.labkey.api.pipeline.LocalDirectory;
 import org.labkey.api.pipeline.ParamParser;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJob;
@@ -33,7 +30,6 @@ import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.pipeline.RecordedAction;
 import org.labkey.api.pipeline.TaskId;
 import org.labkey.api.pipeline.TaskPipeline;
-import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.NetworkDrive;
@@ -46,7 +42,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -106,7 +101,7 @@ abstract public class AbstractFileAnalysisJob extends PipelineJob implements Fil
         );
     }
 
-    public AbstractFileAnalysisJob(AbstractFileAnalysisProtocol protocol,
+    public AbstractFileAnalysisJob(@NotNull AbstractFileAnalysisProtocol protocol,
                                    String providerName,
                                    ViewBackgroundInfo info,
                                    PipeRoot root,
@@ -157,7 +152,8 @@ abstract public class AbstractFileAnalysisJob extends PipelineJob implements Fil
             _baseName = protocol.getBaseName(_filesInput.get(0));
         }
 
-        setupLocalDirectoryAndJobLog(getPipeRoot(), "FileAnalysis", FileUtil.makeFileNameWithTimestamp(_baseName));
+        String logFile = protocol.isFromWatcher() ? FileUtil.makeFileNameWithTimestamp(_baseName) : _baseName;
+        setupLocalDirectoryAndJobLog(getPipeRoot(), "FileAnalysis", logFile);
     }
 
     /**
@@ -195,23 +191,6 @@ abstract public class AbstractFileAnalysisJob extends PipelineJob implements Fil
         _baseName = (_inputTypes.isEmpty() ? filesInput.get(0).getName() : _inputTypes.get(0).getBaseName(filesInput.get(0)));
 
         setupLocalDirectoryAndJobLog(getPipeRoot(), "FileAnalysis", _baseName);
-
-        // CONSIDER: Remove writing out jobInfo file completely
-        // If parent job wrote a job info file, assume the child should too
-//        if (job._fileJobInfo != null)
-//        {
-//            try
-//            {
-//                String infoFileName = _baseName + "-jobInfo";
-//                _fileJobInfo = TabLoader.TSV_FILE_TYPE.newFile(_dirAnalysis, infoFileName);
-//                writeJobInfoTSV(_fileJobInfo);
-//                getParameters().put(PIPELINE_JOB_INFO_PARAM, _fileJobInfo.getAbsolutePath());
-//            }
-//            catch (IOException e)
-//            {
-//                throw new RuntimeException(e);
-//            }
-//        }
     }
 
     @Override

--- a/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
+++ b/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
@@ -157,7 +157,7 @@ abstract public class AbstractFileAnalysisJob extends PipelineJob implements Fil
             _baseName = protocol.getBaseName(_filesInput.get(0));
         }
 
-        setupLocalDirectoryAndJobLog(getPipeRoot(), "FileAnalysis", _baseName);
+        setupLocalDirectoryAndJobLog(getPipeRoot(), "FileAnalysis", FileUtil.makeFileNameWithTimestamp(_baseName));
     }
 
     /**

--- a/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisProtocol.java
+++ b/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisProtocol.java
@@ -65,6 +65,7 @@ public abstract class AbstractFileAnalysisProtocol<JOB extends AbstractFileAnaly
     protected String xml;
 
     protected String email;
+    protected boolean fromWatcher;
 
     public AbstractFileAnalysisProtocol(String name, String description, String xml)
     {
@@ -288,4 +289,13 @@ public abstract class AbstractFileAnalysisProtocol<JOB extends AbstractFileAnaly
         return createPipelineJob(info, root, filesInput.stream().map(Path::toFile).collect(Collectors.toList()), fileParameters.toFile(), variableMap);
     }
 
+    public boolean isFromWatcher()
+    {
+        return fromWatcher;
+    }
+
+    public void setFromWatcher(boolean fromWatcher)
+    {
+        this.fromWatcher = fromWatcher;
+    }
 }

--- a/pipeline/src/org/labkey/pipeline/analysis/FileAnalysisPipelineProvider.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/FileAnalysisPipelineProvider.java
@@ -16,7 +16,7 @@
 package org.labkey.pipeline.analysis;
 
 import org.apache.commons.beanutils.ConversionException;
-import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpRun;
@@ -35,6 +35,7 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.ReturnURLString;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
 
@@ -174,7 +175,7 @@ public class FileAnalysisPipelineProvider extends AbstractFileAnalysisProvider<F
             {
                 if (FileUtil.deleteDir(analysisDir))
                 {
-                    LogManager.getLogger(FileAnalysisPipelineProvider.class).info(String.format("Job '%s' analysis directory no longer referenced by any runs and was moved to .deleted: %s", sf.getInfo(), analysisDir));
+                    getLogger().info(String.format("Job '%s' analysis directory no longer referenced by any runs and was moved to .deleted: %s", sf.getInfo(), analysisDir));
 
                     // Delete any ExpData remains
                     for (ExpData data : children)
@@ -189,7 +190,7 @@ public class FileAnalysisPipelineProvider extends AbstractFileAnalysisProvider<F
                     {
                         if (FileUtil.deleteDir(parent))
                         {
-                            LogManager.getLogger(FileAnalysisPipelineProvider.class).info(String.format("Job '%s' parent analysis directory no longer referenced by any runs and was moved to .deleted: %s", sf.getInfo(), parent));
+                            getLogger().info(String.format("Job '%s' parent analysis directory no longer referenced by any runs and was moved to .deleted: %s", sf.getInfo(), parent));
                             parent = parent.getParentFile();
                             contents = parent.list();
                         }
@@ -197,9 +198,14 @@ public class FileAnalysisPipelineProvider extends AbstractFileAnalysisProvider<F
                 }
                 else
                 {
-                    LogManager.getLogger(FileAnalysisPipelineProvider.class).warn(String.format("Failed to move job '%s' analysis directory to .deleted: %s", sf.getDescription(), analysisDir));
+                    getLogger().warn(String.format("Failed to move job '%s' analysis directory to .deleted: %s", sf.getDescription(), analysisDir));
                 }
             }
         }
+    }
+
+    private Logger getLogger()
+    {
+        return LogHelper.getLogger(FileAnalysisPipelineProvider.class, "File analysis pipeline logger");
     }
 }

--- a/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
@@ -979,6 +979,7 @@ public class PipelineServiceImpl implements PipelineService
             variableMap.put("pipelineDescription", pipelineDescription);
         }
 
+        protocol.setFromWatcher(true);
         AbstractFileAnalysisJob job = protocol.createPipelineJob(context, root, filesInputList, fileParameters, variableMap);
         PipelineService.get().queueJob(job);
         return job.getJobGUID();


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46124
Job log gets reused if file name triggering watch is unchanged

#### Changes
* Added time stamp to log file name
