### PR TITLE
Updates for handling of product projects

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -447,7 +447,7 @@ public abstract class AssayProtocolSchema extends AssaySchema implements UserSch
             visibleColumns.add(FieldKey.fromParts(AssayQCFlagColumn.NAME));
         }
 
-        boolean hasProductProjects = getContainer().getProductProjectsCount() > 0;
+        boolean hasProductProjects = getContainer().hasProductProjects();
         if (hasProductProjects)
         {
             var folderColumn = runTable.getMutableColumn(ExpRunTable.Column.Folder);

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1653,17 +1653,18 @@ public class Container implements Serializable, Comparable<Container>, Securable
     /**
      * Returns the subfolder count of the project container, if product projects feature is enabled in project
      */
-    public int getProductProjectsCount()
+    public boolean hasProductProjects()
     {
         if (!isProductProjectsEnabled())
-            return 0;
+            return false;
 
         Container project = getProject();
 
         if (project == null)
-            return 0;
+            return false;
 
-        return project.getChildren().size();
+        // need to exclude the notebook folders in particular here
+        return project.getChildren().stream().anyMatch(c -> c.getContainerType().isInFolderNav());
     }
 
     public boolean isDataspace()

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -2389,6 +2389,15 @@ public class ContainerManager
                 null);
     }
 
+    public static void removeDefaultSupportContainer(User user)
+    {
+        Container support = getDefaultSupportContainer();
+        if (support != null)
+        {
+            ContainerManager.delete(support, user);
+        }
+    }
+
     public static Container getDefaultSupportContainer()
     {
         return getForPath(DEFAULT_SUPPORT_PROJECT_PATH);

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -588,7 +588,7 @@ public class ContainerManager
             if (!c.getFolderType().getName().equals(folderType.getName()))
                 continue;
 
-            int childCount = c.getChildren().size();
+            int childCount = c.getChildren().stream().filter(Container::isInFolderNav).toList().size();
             counts.add(childCount);
         }
 

--- a/api/src/org/labkey/api/module/FolderType.java
+++ b/api/src/org/labkey/api/module/FolderType.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.security.User;
+import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.ProductFeature;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.FolderTab;
@@ -204,7 +205,9 @@ public interface FolderType
 
     default boolean isProductFeatureEnabled(ProductFeature feature)
     {
-        return false;
+        return isProduct() && AdminConsole.isProductFeatureEnabled(feature);
     }
+
+    default boolean isProduct() { return false; }
 }
 

--- a/api/src/org/labkey/api/settings/AdminConsole.java
+++ b/api/src/org/labkey/api/settings/AdminConsole.java
@@ -252,6 +252,7 @@ public class AdminConsole
         return isProductFeatureEnabled(feature, null);
     }
 
+    // TODO This is currently (22.12) not in use, but could become useful. We will leave it for the time being.
     public static boolean isProductFeatureEnabled(ProductFeature feature, @Nullable String groupKey)
     {
         return getProductFeatureSet(groupKey).contains(feature.toString());

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -40,7 +40,33 @@ import org.labkey.api.audit.provider.ContainerAuditProvider;
 import org.labkey.api.audit.provider.FileSystemAuditProvider;
 import org.labkey.api.audit.provider.GroupAuditProvider;
 import org.labkey.api.cache.CacheManager;
-import org.labkey.api.data.*;
+import org.labkey.api.data.CompareType;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.ContainerService;
+import org.labkey.api.data.ContainerServiceImpl;
+import org.labkey.api.data.ContainerTypeRegistry;
+import org.labkey.api.data.CoreSchema;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DataRegion;
+import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbScope;
+import org.labkey.api.data.MvUtil;
+import org.labkey.api.data.NormalContainerType;
+import org.labkey.api.data.OutOfRangeDisplayColumn;
+import org.labkey.api.data.PropertySchema;
+import org.labkey.api.data.SchemaTableInfoFactory;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.SqlExecutor;
+import org.labkey.api.data.TSVWriter;
+import org.labkey.api.data.TabContainerType;
+import org.labkey.api.data.Table;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.data.TempTableTracker;
+import org.labkey.api.data.TestSchema;
+import org.labkey.api.data.WorkbookContainerType;
 import org.labkey.api.data.dialect.SqlDialectManager;
 import org.labkey.api.data.dialect.SqlDialectRegistry;
 import org.labkey.api.data.statistics.StatsService;
@@ -103,6 +129,7 @@ import org.labkey.api.security.WikiTermsOfUseProvider;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.QCAnalystPermission;
 import org.labkey.api.security.roles.CanSeeAuditLogRole;
+import org.labkey.api.security.roles.EditorRole;
 import org.labkey.api.security.roles.NoPermissionsRole;
 import org.labkey.api.security.roles.PlatformDeveloperRole;
 import org.labkey.api.security.roles.ReaderRole;
@@ -748,7 +775,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             scope.getSqlDialect().prepare(scope);
 
         // Now that we know the standard containers have been created, add a listener that warms the just-cleared caches with
-        // core.Containers meta data and a few common containers. This may prevent some deadlocks during upgrade, #33550.
+        // core.Containers metadata and a few common containers. This may prevent some deadlocks during upgrade, #33550.
         CacheManager.addListener(() -> {
             ContainerManager.getRoot();
             ContainerManager.getHomeContainer();

--- a/core/src/org/labkey/core/admin/productConfiguration.jsp
+++ b/core/src/org/labkey/core/admin/productConfiguration.jsp
@@ -58,7 +58,7 @@
     <% for (AdminConsole.Product product : productGroup.getProducts() ) { %>
     <div class="product-group-item">
         <label>
-            <input type="radio" id="<%=h(product.getKey())%>" name="<%=h(productGroup.getKey())%>" value="<%=h(product.getKey())%>" <%=checked(product.isEnabled())%>>
+            <input type="radio" id="<%=h(product.getKey())%>" name="productKey" value="<%=h(product.getKey())%>" <%=checked(product.isEnabled())%>>
             <span class="toggle-label-text"><%=h(product.getName())%> - Includes the following features: <%=h(StringUtils.join(product.getFeatureFlags(), ", "))%></span>
         </label>
     </div>

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -332,7 +332,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         defaultVisible.add(FieldKey.fromParts(Column.Name));
 
         var folderCol = addContainerColumn(Column.Folder, null);
-        if (getContainer().getProductProjectsCount() > 0)
+        if (getContainer().hasProductProjects())
         {
             folderCol.setLabel("Project");
             defaultVisible.add(FieldKey.fromParts(Column.Folder));

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -611,7 +611,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         typeColumnInfo.setShownInInsertView(false);
 
         var folderCol = addContainerColumn(ExpMaterialTable.Column.Folder, null);
-        boolean hasProductProjects = getContainer().getProductProjectsCount() > 0;
+        boolean hasProductProjects = getContainer().hasProductProjects();
         if (hasProductProjects)
             folderCol.setLabel("Project");
 

--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -97,6 +97,7 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
     {
         defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "Name"));
         defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "LabelColor"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "SampleSet_Folder"));
         defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "SampleSet"));
         defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "SampleState"));
         defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "StoredAmount"));

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -398,7 +398,7 @@ public class QueryModule extends DefaultModule
         Container container = context.getContainer();
         boolean isProductProjectsEnabled = container != null && container.isProductProjectsEnabled();  // TODO: should these be moved to CoreModule?
         json.put(QueryService.PRODUCT_PROJECTS_ENABLED, container != null && container.isProductProjectsEnabled());
-        json.put(QueryService.PRODUCT_PROJECTS_EXIST, isProductProjectsEnabled && container.getProductProjectsCount() > 0);
+        json.put(QueryService.PRODUCT_PROJECTS_EXIST, isProductProjectsEnabled && container.hasProductProjects());
 
         return json;
     }


### PR DESCRIPTION
#### Rationale
During testing of the incorporation of products into LKSM, a few bugs were founds and adjustments requested.  Here we implement part of the request to show the Project field by default in grids and detail views when there are product projects available.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/619
* https://github.com/LabKey/labkey-ui-components/pull/1033
* https://github.com/LabKey/sampleManagement/pull/1411
* https://github.com/LabKey/biologics/pull/1747

#### Changes
* `getProductProjectsCount `-> `hasProductProjects` and adjust to not count notebook as product projects
* Update product configuration page to use a single radio group for less confusion
* Include the container column in picklist default views
