### PR TITLE
Allow saveRows to use an array of commands where each can supply containerPath

### DIFF
--- a/core/resources/scripts/labkey/Query.js
+++ b/core/resources/scripts/labkey/Query.js
@@ -725,6 +725,8 @@ LABKEY.Query = new function()
         * @param {Object} config An object which contains the following configuration properties.
         * @param {Array} config.commands An array of all of the update/insert/delete operations to be performed.
         * Each command has the following structure:
+         @param {String} config.commands[].containerPath Optional. The container path in which the schema and query name are defined for this command.
+         If not supplied, the top-level containerPath property will be used. Supplying containerPath per-command allows commands to operate against different containers.
         * @param {String} config.commands[].schemaName Name of a schema defined within the current container. See also: <a class="link"
 					href="https://www.labkey.org/Documentation/wiki-page.view?name=findNames">
 					How To Find schemaName, queryName &amp; viewName</a>.

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -340,6 +340,7 @@ public class QueryModule extends DefaultModule
             ModuleReportCache.TestCase.class,
             OlapController.TestCase.class,
             QueryController.TestCase.class,
+            QueryController.SaveRowsTestCase.class,
             QueryServiceImpl.TestCase.class,
             RolapReader.RolapTest.class,
             RolapTestCase.class,

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4119,7 +4119,7 @@ public class QueryController extends SpringActionController
         protected Container getContainerForCommand(JSONObject json)
         {
             Container container;
-            String containerPath = json.optString(PROP_CONTAINER_PATH);
+            String containerPath = StringUtils.trimToNull(json.optString(PROP_CONTAINER_PATH));
             if (containerPath == null)
             {
                 container = getContainer();

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4116,7 +4116,7 @@ public class QueryController extends SpringActionController
             String containerPath = json.optString(PROP_CONTAINER_PATH);
             if (containerPath == null)
             {
-                return getContainer();
+                container = getContainer();
             }
             else
             {
@@ -4127,6 +4127,7 @@ public class QueryController extends SpringActionController
                 }
             }
 
+            // Issue 21850: Verify that the user has at least some sort of basic access to the container. We'll check for more downstream
             if (!container.hasPermission(getUser(), ReadPermission.class) &&
                     !container.hasPermission(getUser(), DeletePermission.class) &&
                     !container.hasPermission(getUser(), InsertPermission.class) &&

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -77,12 +77,17 @@ import org.labkey.api.security.ActionNames;
 import org.labkey.api.security.AdminConsoleAction;
 import org.labkey.api.security.CSRF;
 import org.labkey.api.security.IgnoresTermsOfUse;
+import org.labkey.api.security.MutableSecurityPolicy;
 import org.labkey.api.security.RequiresAllOf;
 import org.labkey.api.security.RequiresAnyOf;
 import org.labkey.api.security.RequiresLogin;
 import org.labkey.api.security.RequiresNoPermission;
 import org.labkey.api.security.RequiresPermission;
+import org.labkey.api.security.SecurityManager;
+import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
+import org.labkey.api.security.UserManager;
+import org.labkey.api.security.ValidEmail;
 import org.labkey.api.security.permissions.AbstractActionPermissionTest;
 import org.labkey.api.security.permissions.AdminOperationsPermission;
 import org.labkey.api.security.permissions.AdminPermission;
@@ -93,6 +98,7 @@ import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.PlatformDeveloperPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.security.roles.EditorRole;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.LookAndFeelProperties;
@@ -7649,6 +7655,8 @@ public class QueryController extends SpringActionController
         private static final String PROJECT_NAME1 = "SaveRowsTestProject1";
         private static final String PROJECT_NAME2 = "SaveRowsTestProject2";
 
+        private static final String USER_EMAIL = "saveRows@action.test";
+
         private static final String LIST1 = "List1";
         private static final String LIST2 = "List2";
 
@@ -7676,7 +7684,7 @@ public class QueryController extends SpringActionController
         }
 
         @After
-        public void doCleanup()
+        public void doCleanup() throws Exception
         {
             Container project = ContainerManager.getForPath(PROJECT_NAME1);
             if (project != null)
@@ -7689,6 +7697,43 @@ public class QueryController extends SpringActionController
             {
                 ContainerManager.deleteAll(project2, TestContext.get().getUser());
             }
+
+            User u = UserManager.getUser(new ValidEmail(USER_EMAIL));
+            if (u != null)
+            {
+                UserManager.deleteUser(u.getUserId());
+            }
+        }
+
+        private JSONObject getCommand(String val1, String val2)
+        {
+            JSONObject command1 = new JSONObject();
+            command1.put("containerPath", ContainerManager.getForPath(PROJECT_NAME1).getPath());
+            command1.put("command", "insert");
+            command1.put("schemaName", "lists");
+            command1.put("queryName", LIST1);
+            command1.put("rows", getTestRows(val1));
+
+            JSONObject command2 = new JSONObject();
+            command2.put("containerPath", ContainerManager.getForPath(PROJECT_NAME2).getPath());
+            command2.put("command", "insert");
+            command2.put("schemaName", "lists");
+            command2.put("queryName", LIST2);
+            command2.put("rows", getTestRows(val2));
+
+            JSONObject json = new JSONObject();
+            json.put("commands", Arrays.asList(command1, command2));
+
+            return json;
+        }
+
+        private MockHttpServletResponse makeRequest(JSONObject json, User user) throws Exception
+        {
+            Map<String, Object> headers = new HashMap<>();
+            headers.put("Content-Type", "application/json");
+
+            HttpServletRequest request = ViewServlet.mockRequest(RequestMethod.POST.name(), DetailsURL.fromString("/query/saveRows.view").copy(ContainerManager.getForPath(PROJECT_NAME1)).getActionURL(), user, headers, json.toString());
+            return ViewServlet.mockDispatch(request, null);
         }
 
         @Test
@@ -7697,37 +7742,16 @@ public class QueryController extends SpringActionController
             User user = TestContext.get().getUser();
             assertTrue(user.hasSiteAdminPermission());
 
-            Container project1 = ContainerManager.getForPath(PROJECT_NAME1);
-            Container project2 = ContainerManager.getForPath(PROJECT_NAME2);
-
-            Map<String, Object> headers = new HashMap<>();
-            headers.put("Content-Type", "application/json");
-
-            JSONObject command1 = new JSONObject();
-            command1.put("containerPath", project1.getPath());
-            command1.put("command", "insert");
-            command1.put("schemaName", "lists");
-            command1.put("queryName", LIST1);
-            command1.put("rows", getTestRows(PROJECT_NAME1));
-
-            JSONObject command2 = new JSONObject();
-            command2.put("containerPath", project2.getPath());
-            command2.put("command", "insert");
-            command2.put("schemaName", "lists");
-            command2.put("queryName", LIST2);
-            command2.put("rows", getTestRows(PROJECT_NAME2));
-
-            JSONObject json = new JSONObject();
-            json.put("commands", Arrays.asList(command1, command2));
-
-            HttpServletRequest request = ViewServlet.mockRequest(RequestMethod.POST.name(), DetailsURL.fromString("/query/saveRows.view").copy(ContainerManager.getForPath(PROJECT_NAME1)).getActionURL(), TestContext.get().getUser(), headers, json.toString());
-
-            MockHttpServletResponse response = ViewServlet.mockDispatch(request, null);
+            JSONObject json = getCommand(PROJECT_NAME1, PROJECT_NAME2);
+            MockHttpServletResponse response = makeRequest(json, TestContext.get().getUser());
             if (response.getStatus() != HttpServletResponse.SC_OK)
             {
                 JSONObject responseJson = new JSONObject(response.getContentAsString());
                 throw new RuntimeException("Problem saving rows across folders: " + responseJson.getString("exception"));
             }
+
+            Container project1 = ContainerManager.getForPath(PROJECT_NAME1);
+            Container project2 = ContainerManager.getForPath(PROJECT_NAME2);
 
             TableInfo list1 = ListService.get().getList(project1, LIST1).getTable(TestContext.get().getUser());
             TableInfo list2 = ListService.get().getList(project2, LIST2).getTable(TestContext.get().getUser());
@@ -7736,7 +7760,46 @@ public class QueryController extends SpringActionController
             assertEquals("Incorrect row count, list2", 1L, new TableSelector(list2).getRowCount());
 
             assertEquals("Incorrect value", PROJECT_NAME1, new TableSelector(list1, PageFlowUtil.set("TextField")).getObject(PROJECT_NAME1, String.class));
-            assertEquals("Incorrect value", PROJECT_NAME2, new TableSelector(list1, PageFlowUtil.set("TextField")).getObject(PROJECT_NAME2, String.class));
+            assertEquals("Incorrect value", PROJECT_NAME2, new TableSelector(list2, PageFlowUtil.set("TextField")).getObject(PROJECT_NAME2, String.class));
+
+            list1.getUpdateService().truncateRows(TestContext.get().getUser(), project1, null, null);
+            list2.getUpdateService().truncateRows(TestContext.get().getUser(), project2, null, null);
+        }
+
+        @Test
+        public void testWithoutPermissions() throws Exception
+        {
+            // Now test failure without appropriate permissions:
+            User withoutPermissions = SecurityManager.addUser(new ValidEmail(USER_EMAIL), TestContext.get().getUser()).getUser();
+
+            User user = TestContext.get().getUser();
+            assertTrue(user.hasSiteAdminPermission());
+
+            Container project1 = ContainerManager.getForPath(PROJECT_NAME1);
+            Container project2 = ContainerManager.getForPath(PROJECT_NAME2);
+
+            MutableSecurityPolicy securityPolicy = new MutableSecurityPolicy(SecurityPolicyManager.getPolicy(project1));
+            securityPolicy.addRoleAssignment(withoutPermissions, EditorRole.class);
+            SecurityPolicyManager.savePolicy(securityPolicy);
+
+            assertTrue("Should have insert permission", project1.hasPermission(withoutPermissions, InsertPermission.class));
+            assertFalse("Should not have insert permission", project2.hasPermission(withoutPermissions, InsertPermission.class));
+
+            // repeat insert:
+            JSONObject json = getCommand("ShouldFail1", "ShouldFail2");
+            MockHttpServletResponse response = makeRequest(json, withoutPermissions);
+            if (response.getStatus() != HttpServletResponse.SC_FORBIDDEN)
+            {
+                JSONObject responseJson = new JSONObject(response.getContentAsString());
+                throw new RuntimeException("Problem saving rows across folders: " + responseJson.getString("exception"));
+            }
+
+            TableInfo list1 = ListService.get().getList(project1, LIST1).getTable(TestContext.get().getUser());
+            TableInfo list2 = ListService.get().getList(project2, LIST2).getTable(TestContext.get().getUser());
+
+            // The insert should have failed
+            assertEquals("Incorrect row count, list1", 0L, new TableSelector(list1).getRowCount());
+            assertEquals("Incorrect row count, list2", 0L, new TableSelector(list2).getRowCount());
         }
 
         private JSONArray getTestRows(String val)


### PR DESCRIPTION
@labkey-jeckels Would it be possible to make a clone of this branch on the LK repo if you're willing to entertain this?

The rationale is that saveRows is a client API that lets the user submit an array of commands as a transaction. This PR augments each command object so it can supply containerPath, which would override the top-level containerPath. I added an integration test to test the basic usage. The broad use-case is to let the client submit a transacted list of commands that span containers.