### PR TITLE
Lineage: support filtering edges by sourceKey

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExpLineageOptions.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineageOptions.java
@@ -15,7 +15,9 @@
  */
 package org.labkey.api.exp.api;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.SQLFragment;
 
 /**
  * Captures options for doing a lineage search
@@ -53,6 +55,7 @@ public class ExpLineageOptions extends ResolveLsidsForm
     private boolean _useObjectIds = false;
     private boolean _onlyReturnObjectId = false;
     private String _runProtocolLsid;
+    private String _sourceKey;
 
     public ExpLineageOptions()
     {
@@ -167,4 +170,21 @@ public class ExpLineageOptions extends ResolveLsidsForm
         _runProtocolLsid = runProtocolLsid;
     }
 
+    public String getSourceKey()
+    {
+        return _sourceKey;
+    }
+
+    public @Nullable SQLFragment getSourceKeySQL()
+    {
+        String sourceKey = StringUtils.trimToNull(_sourceKey);
+        if (sourceKey == null)
+            return null;
+        return new SQLFragment("?", sourceKey);
+    }
+
+    public void setSourceKey(String sourceKey)
+    {
+        _sourceKey = sourceKey;
+    }
 }

--- a/experiment/src/org/labkey/experiment/api/ExperimentRunGraph2.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExperimentRunGraph2.jsp
@@ -64,6 +64,9 @@
       INNER JOIN $SELF$ _Graph ON _Edges.toObjectId = _Graph.fromObjectId
     WHERE 0 = {fn LOCATE('/' <%=CONCAT%> CAST(_Edges.fromObjectId as VARCHAR(20)) <%=CONCAT%> '/', _Graph.path)}
       AND _Graph.depth >= <%= (-1 * Math.abs(depth)) + 1 %>
+    <% if (bean.getSourceKeySQL() != null) { %>
+      AND _Edges.sourcekey = $SOURCEKEY$
+    <% } %>
   ),
 
   /* CTE */
@@ -160,6 +163,9 @@
       INNER JOIN $SELF$ _Graph ON _Edges.fromObjectId = _Graph.toObjectId
     WHERE 0 = {fn LOCATE('/' <%=CONCAT%> CAST(_Edges.toObjectId AS VARCHAR(20)) <%=CONCAT%> '/', _Graph.path)}
       AND _Graph.depth <= <%= depth - 1 %>
+    <% if (bean.getSourceKeySQL() != null) { %>
+      AND _Edges.sourcekey = $SOURCEKEY$
+    <% } %>
   ),
 
   /* CTE */

--- a/experiment/src/org/labkey/experiment/api/ExperimentRunGraphForLookup2.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExperimentRunGraphForLookup2.jsp
@@ -87,6 +87,9 @@
       INNER JOIN $SELF$ _Graph ON _Edges.toObjectId = _Graph.fromObjectId
     WHERE 0 = {fn LOCATE('/' <%=CONCAT%> CAST(_Edges.fromObjectId as VARCHAR(20)) <%=CONCAT%> '/', _Graph.path)}
       AND _Graph.depth >= <%= (-1 * Math.abs(depth)) + 1 %>
+    <% if (bean.getSourceKeySQL() != null) { %>
+      AND _Edges.sourcekey = $SOURCEKEY$
+    <% } %>
   ),
 
   /* CTE */
@@ -179,6 +182,9 @@ if (bean.isOnlySelectObjectId()) {
       INNER JOIN $SELF$ _Graph ON _Edges.fromObjectId = _Graph.toObjectId
     WHERE 0 = {fn LOCATE('/' <%=CONCAT%> CAST(_Edges.toObjectId as VARCHAR(20)) <%=CONCAT%> '/', _Graph.path)}
       AND _Graph.depth <= <%= depth - 1 %>
+    <% if (bean.getSourceKeySQL() != null) { %>
+      AND _Edges.sourcekey = $SOURCEKEY$
+    <% } %>
   ),
 
   /* CTE */

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -2270,7 +2270,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return runsToInvestigate;
     }
 
-    // Get lisd of ExpRun LSIDs for the start Data or Material
+    // Get list of ExpRun LSIDs for the start Data or Material
     @Override
     public List<String> collectRunsToInvestigate(ExpRunItem start, ExpLineageOptions options)
     {
@@ -2283,7 +2283,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     // Get up and down maps of ExpRun LSID to Role
-    public Pair<Map<String, String>, Map<String, String>> collectRunsAndRolesToInvestigate(ExpRunItem start, ExpLineageOptions options)
+    private Pair<Map<String, String>, Map<String, String>> collectRunsAndRolesToInvestigate(ExpRunItem start, ExpLineageOptions options)
     {
         Map<String, String> runsUp = new HashMap<>();
         Map<String, String> runsDown = new HashMap<>();
@@ -2356,10 +2356,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
             // CONSIDER: add objectId to Identifiable?
             int objectId = -1;
-            if (seed instanceof ExpObject)
-                objectId = ((ExpObject)seed).getObjectId();
-            else if (seed instanceof IdentifiableBase)
-                objectId = ((IdentifiableBase)seed).getObjectId();
+            if (seed instanceof ExpObject expObjectSeed)
+                objectId = expObjectSeed.getObjectId();
+            else if (seed instanceof IdentifiableBase identifiableSeed)
+                objectId = identifiableSeed.getObjectId();
 
             if (objectId == -1)
                 throw new RuntimeException("Lineage not available for unknown object: " + seed.getLSID());
@@ -2561,7 +2561,11 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (select.startsWith("("))
                 select = select.substring(1).trim();
             if (name.equals("$PARENTS_INNER$") || name.equals("$CHILDREN_INNER$"))
+            {
                 select = select.replace("$LSIDS$", lsidsFrag.getRawSQL());
+                if (options.getSourceKeySQL() != null)
+                    select = select.replace("$SOURCEKEY$", "'" + options.getSourceKeySQL().getParams().get(0) + "'");
+            }
             map.put(name, select);
         }
 

--- a/experiment/src/org/labkey/experiment/api/data/LineageClause.java
+++ b/experiment/src/org/labkey/experiment/api/data/LineageClause.java
@@ -16,6 +16,7 @@
 package org.labkey.experiment.api.data;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.SQLFragment;
@@ -35,17 +36,19 @@ public class LineageClause extends CompareType.CompareClause
 {
     private String _lsid;
     private int _depth;
+    private String _sourceKey;
 
     public LineageClause(@NotNull FieldKey fieldKey, Object value)
     {
         super(fieldKey, CompareType.MEMBER_OF, value);
     }
 
-    public LineageClause(@NotNull FieldKey fieldKey, Object value, String lsid, int depth)
+    public LineageClause(@NotNull FieldKey fieldKey, Object value, String lsid, int depth, @Nullable String sourceKey)
     {
         this(fieldKey, value);
         _lsid = lsid;
         _depth = depth;
+        _sourceKey = sourceKey;
     }
 
     protected ExpRunItem getStart()
@@ -68,7 +71,15 @@ public class LineageClause extends CompareType.CompareClause
 
     protected ExpLineageOptions createOptions()
     {
-        return _depth < 0 ? LineageHelper.createParentOfOptions(_depth) : LineageHelper.createChildOfOptions(_depth);
+        ExpLineageOptions options;
+        if (_depth < 0)
+            options = LineageHelper.createParentOfOptions(_depth);
+        else
+            options = LineageHelper.createChildOfOptions(_depth);
+
+        if (_sourceKey != null)
+            options.setSourceKey(_sourceKey);
+        return options;
     }
 
     protected String getLsidColumn()
@@ -113,5 +124,4 @@ public class LineageClause extends CompareType.CompareClause
         else
             sb.append("Is ").append(filterTextType()).append(" '").append(start.getName()).append("'");
     }
-
 }

--- a/experiment/src/org/labkey/experiment/api/data/LineageCompareType.java
+++ b/experiment/src/org/labkey/experiment/api/data/LineageCompareType.java
@@ -12,8 +12,8 @@ import java.util.Set;
 
 /**
  * <code>
- * Filter.create('lsid', '{json:["urn:lsid:labkey.com:Data.Folder-123:1aec9396-3fa2-1038-86f4-495e1672e522",1]}', Filter.Types.EXP_LINEAGE_OF)
- * Filter.create('lsid', ["urn:lsid:labkey.com:Data.Folder-123:1aec9396-3fa2-1038-86f4-495e1672e522",1], Filter.Types.EXP_LINEAGE_OF)
+ * Filter.create('lsid', '{json:["urn:lsid:labkey.com:Data.Folder-123:1aec9396-3fa2-1038-86f4-495e1672e522",1,"sourceKey"]}', Filter.Types.EXP_LINEAGE_OF)
+ * Filter.create('lsid', ["urn:lsid:labkey.com:Data.Folder-123:1aec9396-3fa2-1038-86f4-495e1672e522",1,"sourceKey"], Filter.Types.EXP_LINEAGE_OF)
  * </code>
  */
 public class LineageCompareType extends CompareType
@@ -30,10 +30,10 @@ public class LineageCompareType extends CompareType
     {
         Object[] values;
         Object collection;
-        if (value instanceof Collection)
+        if (value instanceof Collection valueCollection)
         {
             collection = value;
-            values = ((Collection) value).toArray();
+            values = valueCollection.toArray();
         }
         else
         {
@@ -47,12 +47,21 @@ public class LineageCompareType extends CompareType
         if (values.length > 1)
         {
             Object depthObj = values[1];
-            if (depthObj instanceof String)
-                depth = Integer.parseInt((String) depthObj);
-            else if (depthObj instanceof Integer)
-                depth = (Integer) depthObj;
+            if (depthObj instanceof String depthObjStr)
+                depth = Integer.parseInt(depthObjStr);
+            else if (depthObj instanceof Integer depthObjInt)
+                depth = depthObjInt;
         }
-        return new LineageClause(fieldKey, collection, lsid, depth);
+
+        String sourceKey = null;
+        if (values.length > 2)
+        {
+            Object sourceKeyObj = values[2];
+            if (sourceKeyObj instanceof String sourceKeyStr)
+                sourceKey = sourceKeyStr;
+        }
+
+        return new LineageClause(fieldKey, collection, lsid, depth, sourceKey);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/data/LineageHelper.java
+++ b/experiment/src/org/labkey/experiment/api/data/LineageHelper.java
@@ -6,6 +6,7 @@ import org.labkey.api.exp.api.ExpLineageOptions;
 import org.labkey.api.exp.api.ExpRunItem;
 import org.labkey.experiment.api.ExperimentServiceImpl;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class LineageHelper
@@ -32,11 +33,12 @@ public class LineageHelper
             return null;
 
         ExperimentServiceImpl svc = ExperimentServiceImpl.get();
-        List<String> runsToInvestigate = svc.collectRunsToInvestigate(start, options);
-        if (runsToInvestigate.isEmpty())
-            return null;
 
-        return svc.generateExperimentTreeSQLLsidSeeds(runsToInvestigate, options);
+        List<String> lsidsToInvestigate = new ArrayList<>();
+        lsidsToInvestigate.add(start.getLSID());
+        lsidsToInvestigate.addAll(svc.collectRunsToInvestigate(start, options));
+
+        return svc.generateExperimentTreeSQLLsidSeeds(lsidsToInvestigate, options);
     }
 
     static ExpLineageOptions createChildOfOptions(int depth)


### PR DESCRIPTION
#### Rationale
In support of Registry reclassification this PR introduces a new capability to the lineage querying to filter the underlying edges by `sourceKey`. The notion of `sourceKey` was introduced with https://github.com/LabKey/platform/pull/3550 to allow for edges to have a "type" which is leveraged extensively by our Registry system.

Filtering by `sourceKey` is exposed via the `EXP_LINEAGE_OF` filter type. That filter type currently allows for specifying the seed LSID as well as a depth parameter. In JavaScript this looks like:

```js
const value = ['lsid:of:ps:123' /* LSID */, 10 /* depth */];
Filter.create('lsid', value, Filter.Types.EXP_LINEAGE_OF);
```

This work extends the filter type to accept a sourceKey value to filter edges upon.

```js
const value = ['lsid:of:ps:123' /* LSID */, 10 /* depth */, 'component' /* sourceKey */];
Filter.create('lsid', value, Filter.Types.EXP_LINEAGE_OF);
```

Note that these edges are filtered out prior to processing the results as a graph. As a result only directly connected relationships all having the same `sourceKey` will appear in the results.

#### Changes
* Adjust lineage SQL to filter edges by `sourceKey` when provided.
* Add support to `LineageCompareType` for a third `sourceKey` parameter.
* Add unit test coverage.
