### PR TITLE
Add samples to storage in the order they are in grid

### DIFF
--- a/api/src/org/labkey/api/data/DataRegionSelection.java
+++ b/api/src/org/labkey/api/data/DataRegionSelection.java
@@ -212,17 +212,17 @@ public class DataRegionSelection
         return asInts(getSelected(context, key, clearSession));
     }
 
-    public static @NotNull Set<String> getSnapshotSelected(ViewContext context, @Nullable String key)
+    public static @NotNull ArrayList<String> getSnapshotSelected(ViewContext context, @Nullable String key)
     {
-        return getSet(context, key, false, true);
+        return new ArrayList<>(getSet(context, key, false, true));
     }
 
-    public static @NotNull Set<Integer> getSnapshotSelectedIntegers(ViewContext context, @Nullable String key)
+    public static @NotNull ArrayList<Integer> getSnapshotSelectedIntegers(ViewContext context, @Nullable String key)
     {
-        return asInts(getSnapshotSelected(context, key));
+        return new ArrayList<>(asInts(getSnapshotSelected(context, key)));
     }
 
-    private static @NotNull Set<Integer> asInts(Set<String> ids)
+    private static @NotNull Set<Integer> asInts(Collection<String> ids)
     {
         Set<Integer> result = new LinkedHashSet<>();
         for (String s : ids)

--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -97,7 +97,7 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
     {
         defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "Name"));
         defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "LabelColor"));
-        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "SampleSet_Folder"));
+        defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "Folder"));
         defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "SampleSet"));
         defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "SampleState"));
         defaultPicklistVisibleColumns.add(FieldKey.fromParts(PICKLIST_SAMPLE_ID, "StoredAmount"));

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -6062,7 +6062,7 @@ public class QueryController extends SpringActionController
         @Override
         public ApiResponse execute(final SelectForm form, BindException errors) throws Exception
         {
-            Set<String> selected = DataRegionSelection.getSnapshotSelected(getViewContext(), form.getKey());
+            List<String> selected = DataRegionSelection.getSnapshotSelected(getViewContext(), form.getKey());
             return new ApiSimpleResponse("selected", selected);
         }
     }


### PR DESCRIPTION
#### Rationale
When adding samples to storage, user had to manually adjust each sample's assigned location in freezer location, because the ordering of the selected samples are not carried through. This PR modifies snapshot selection to be ordered lists instead of sets so sample orders can be remembered in session for use in storage.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1041
* https://github.com/LabKey/platform/pull/3892
* https://github.com/LabKey/inventory/pull/632
* https://github.com/LabKey/sampleManagement/pull/1430
* https://github.com/LabKey/biologics/pull/1767

#### Changes
* use List instead of Set for snapshot selections
* use sample/folder instead of sampleset/folder for picklist Project column