### PR TITLE
Metric to track database size

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -143,6 +143,11 @@ public class DbScope
 
     private SqlDialect _dialect;
 
+    public long getDatabaseSize()
+    {
+        return new SqlSelector(this, getSqlDialect().getDatabaseSizeSql(getDatabaseName())).getObject(Long.class);
+    }
+
     public interface TransactionKind
     {
         /** A short description of what this transactions usage scenario is */

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -143,9 +143,15 @@ public class DbScope
 
     private SqlDialect _dialect;
 
+    /** @return the size of the database in bytes, or -1 if we don't know how to get it */
     public long getDatabaseSize()
     {
-        return new SqlSelector(this, getSqlDialect().getDatabaseSizeSql(getDatabaseName())).getObject(Long.class);
+        SQLFragment sql = getSqlDialect().getDatabaseSizeSql(getDatabaseName());
+        if (sql != null)
+        {
+            return new SqlSelector(this, sql).getObject(Long.class);
+        }
+        return -1;
     }
 
     public interface TransactionKind

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -137,6 +137,12 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     }
 
     @Override
+    public SQLFragment getDatabaseSizeSql(String databaseName)
+    {
+        return new SQLFragment("SELECT pg_database_size(?)", databaseName);
+    }
+
+    @Override
     public StatementWrapper getStatementWrapper(ConnectionWrapper conn, Statement stmt, String sql)
     {
         StatementWrapper statementWrapper = super.getStatementWrapper(conn, stmt, sql);

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -970,6 +970,11 @@ public abstract class SqlDialect
         return true;
     }
 
+    public SQLFragment getDatabaseSizeSql(String databaseName)
+    {
+        return new SQLFragment("SELECT -1");
+    }
+
     protected static class SQLSyntaxException extends SQLException
     {
         private final Collection<String> _errors;

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -970,9 +970,11 @@ public abstract class SqlDialect
         return true;
     }
 
+    /** @return null if dialect doesn't support this feature, otherwise the SQL to get the size of the specified DB in bytes */
+    @Nullable
     public SQLFragment getDatabaseSizeSql(String databaseName)
     {
-        return new SQLFragment("SELECT -1");
+        return null;
     }
 
     protected static class SQLSyntaxException extends SQLException

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2008R2Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2008R2Dialect.java
@@ -62,6 +62,12 @@ public class MicrosoftSqlServer2008R2Dialect extends BaseMicrosoftSqlServerDiale
     }
 
     @Override
+    public SQLFragment getDatabaseSizeSql(String databaseName)
+    {
+        return new SQLFragment("SELECT SUM(size) FROM sys.master_files WHERE database_id = DB_ID(?)", databaseName);
+    }
+
+    @Override
     public String getVarianceFunction()
     {
         return "var";

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1094,6 +1094,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             results.put("userLimits", new LimitActiveUsersSettings().getMetricsMap());
             results.put("systemUserCount", UserManager.getSystemUserCount());
             results.put("workbookCount", ContainerManager.getWorkbookCount());
+            results.put("databaseSize", CoreSchema.getInstance().getSchema().getScope().getDatabaseSize());
             Calendar cal = new GregorianCalendar();
             cal.set(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), 1, 0, 0, 0);
             results.put("uniqueUserCountThisMonth", UserManager.getUniqueUsersCount(cal.getTime()));


### PR DESCRIPTION
#### Rationale
We can make better decisions about provisioning resources if we know how much big databases are.

#### Changes
* Track the size of the primary LabKey database in bytes