### PR TITLE
Include module name in module resource error messages

### DIFF
--- a/api/src/org/labkey/api/data/SchemaXmlCacheHandler.java
+++ b/api/src/org/labkey/api/data/SchemaXmlCacheHandler.java
@@ -89,7 +89,7 @@ public class SchemaXmlCacheHandler implements ModuleResourceCacheHandler<Map<Str
         }
         catch (IOException | XmlException e)
         {
-            Exception wrap = new Exception("Exception while attempting to load " + resource.getPath(), e);
+            Exception wrap = new Exception("Exception while attempting to load " + resource, e);
             ExceptionUtil.logExceptionToMothership(null, wrap);
         }
 

--- a/api/src/org/labkey/api/data/SqlScriptExecutor.java
+++ b/api/src/org/labkey/api/data/SqlScriptExecutor.java
@@ -303,7 +303,7 @@ public class SqlScriptExecutor
                 try (InputStream is = r.getInputStream())
                 {
                     if (null == is)
-                        throw new IllegalStateException("Could not open resource: " + r.getPath());
+                        throw new IllegalStateException("Could not open resource: " + r);
                     InputStream buffStream = new BufferedInputStream(is, 64 * 1024);
 
                     // DataLoader.get().createLoader() doesn't work, because the loader factories are not registered yet
@@ -321,7 +321,7 @@ public class SqlScriptExecutor
                         ((TabLoader)loader).setUnescapeBackslashes(false);
                     }
                     else
-                        throw new IllegalStateException("Unrecognized data file format for file: " + r.getPath());
+                        throw new IllegalStateException("Unrecognized data file format for file: " + r);
 
                     loader.setThrowOnErrors(true);
                     loader.setPreserveEmptyString(_preserveEmptyString);

--- a/api/src/org/labkey/api/module/ModuleHtmlViewDefinition.java
+++ b/api/src/org/labkey/api/module/ModuleHtmlViewDefinition.java
@@ -90,7 +90,7 @@ public class ModuleHtmlViewDefinition
         }
         catch (IOException e)
         {
-            throw new MinorConfigurationException("Error trying to read HTML content from " + r.getPath(), e);
+            throw new MinorConfigurationException("Error trying to read HTML content from " + r, e);
         }
 
         Resource parent = r.parent();
@@ -118,11 +118,11 @@ public class ModuleHtmlViewDefinition
                 {
                     try
                     {
-                        XmlBeansUtil.validateXmlDocument(viewDoc, r.getPath().toString());
+                        XmlBeansUtil.validateXmlDocument(viewDoc, r.toString());
                     }
                     catch (XmlValidationException e)
                     {
-                        _log.error("View XML file failed validation: " + r.getPath() + ". " + e.getDetails());
+                        _log.error("View XML file failed validation", e);
                     }
                 }
                 _viewDef = viewDoc.getView();
@@ -137,9 +137,9 @@ public class ModuleHtmlViewDefinition
             }
             catch(Exception e)
             {
-                _log.error("Error trying to read and parse the metadata XML content from " + r.getPath(), e);
+                _log.error("Error trying to read and parse the metadata XML content from " + r, e);
                 _html = HtmlString.unsafe("<p class='labkey-error'>The following exception occurred while attempting to load view metadata from "
-                         + PageFlowUtil.filter(r.getPath()) + ": "
+                         + PageFlowUtil.filter(r.toString()) + ": "
                          + e.getMessage() + "</p>");
             }
         }

--- a/api/src/org/labkey/api/module/ModuleXml.java
+++ b/api/src/org/labkey/api/module/ModuleXml.java
@@ -153,7 +153,7 @@ public class ModuleXml
         }
         catch(Exception e)
         {
-            LOG.error("Error trying to read and parse the metadata XML for module " + module.getName() + " from " + r.getPath(), e);
+            LOG.error("Error trying to read and parse the metadata XML for " + r, e);
         }
 
         _moduleProperties = Collections.unmodifiableMap(moduleProperties);

--- a/api/src/org/labkey/api/module/SimpleFolderType.java
+++ b/api/src/org/labkey/api/module/SimpleFolderType.java
@@ -173,12 +173,12 @@ public class SimpleFolderType extends MultiPortalFolderType
         {
             log.error(e);
             throw new RuntimeException("Unable to load custom folder type from file " +
-                    folderTypeFile.getPath() + ".", e);
+                    folderTypeFile + ".", e);
         }
         if(null == doc || null == doc.getFolderType())
         {
             IllegalStateException error = new IllegalStateException("Folder type definition file " +
-                    folderTypeFile.getPath() + " does not contain a root 'folderType' element!");
+                    folderTypeFile + " does not contain a root 'folderType' element!");
             log.error(error);
             throw error;
         }

--- a/api/src/org/labkey/api/reports/report/ModuleQueryReportResource.java
+++ b/api/src/org/labkey/api/reports/report/ModuleQueryReportResource.java
@@ -71,7 +71,7 @@ public class ModuleQueryReportResource extends ModuleReportResource
         }
         catch(IOException | XmlException e)
         {
-            LogManager.getLogger(ModuleQueryReportResource.class).warn("Unable to load query report metadata from file " + _sourceFile.getPath(), e);
+            LogManager.getLogger(ModuleQueryReportResource.class).warn("Unable to load query report metadata from file " + _sourceFile, e);
         }
 
         return d;

--- a/api/src/org/labkey/api/reports/report/ModuleRReportResource.java
+++ b/api/src/org/labkey/api/reports/report/ModuleRReportResource.java
@@ -96,7 +96,7 @@ public class ModuleRReportResource extends ModuleReportDependenciesResource
             catch (XmlException e)
             {
                 LogManager.getLogger(ModuleRReportResource.class).warn("Unable to load R report metadata from file "
-                        + _sourceFile.getPath(), e);
+                        + _sourceFile, e);
             }
         }
 

--- a/api/src/org/labkey/api/reports/report/ModuleReportDependenciesResource.java
+++ b/api/src/org/labkey/api/reports/report/ModuleReportDependenciesResource.java
@@ -68,7 +68,7 @@ public class ModuleReportDependenciesResource extends ModuleReportResource
             catch(XmlException e)
             {
                 LogManager.getLogger(ModuleReportDependenciesResource.class).warn("Unable to load report metadata from file "
-                        + _metaDataFile.getPath(), e);
+                        + _metaDataFile, e);
             }
         }
 

--- a/api/src/org/labkey/api/reports/report/ModuleReportResource.java
+++ b/api/src/org/labkey/api/reports/report/ModuleReportResource.java
@@ -60,7 +60,7 @@ public class ModuleReportResource
         }
         catch(IOException e)
         {
-            LogManager.getLogger(ModuleReportResource.class).warn("Unable to load report script from source file " + _sourceFile.getPath(), e);
+            LogManager.getLogger(ModuleReportResource.class).warn("Unable to load report script from source file " + _sourceFile, e);
         }
     }
 
@@ -85,17 +85,17 @@ public class ModuleReportResource
                     }
                     catch (ParseException e)
                     {
-                        LogManager.getLogger(ModuleReportResource.class).warn("Unable to parse moduleReportCreatedDate \"" + createdDateStr + "\" from file " + _sourceFile.getPath(), e);
+                        LogManager.getLogger(ModuleReportResource.class).warn("Unable to parse moduleReportCreatedDate \"" + createdDateStr + "\" from file " + _sourceFile, e);
                     }
                 }
             }
             catch(IOException e)
             {
-                LogManager.getLogger(ModuleReportResource.class).warn("Unable to load report metadata from file " + _metaDataFile.getPath(), e);
+                LogManager.getLogger(ModuleReportResource.class).warn("Unable to load report metadata from file " + _metaDataFile, e);
             }
             catch(XmlException e)
             {
-                LogManager.getLogger(ModuleReportResource.class).warn("Unable to load query report metadata from file " + _sourceFile.getPath(), e);
+                LogManager.getLogger(ModuleReportResource.class).warn("Unable to load query report metadata from file " + _sourceFile, e);
             }
         }
         return d;

--- a/api/src/org/labkey/api/resource/AbstractResource.java
+++ b/api/src/org/labkey/api/resource/AbstractResource.java
@@ -142,6 +142,6 @@ abstract public class AbstractResource implements Resource
     public String toString()
     {
         Resolver r = getResolver();
-        return (r == null ? "[]" : "[" + r.toString() + "] ") + getPath().toString();
+        return (r == null ? "[]" : "[" + r + "] ") + getPath();
     }
 }

--- a/pipeline/src/org/labkey/pipeline/analysis/FileAnalysisTaskPipelineImpl.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/FileAnalysisTaskPipelineImpl.java
@@ -384,7 +384,7 @@ public class FileAnalysisTaskPipelineImpl extends TaskPipelineImpl<FileAnalysisT
         {
             XmlOptions options = XmlBeansUtil.getDefaultParseOptions();
             doc = PipelineDocument.Factory.parse(pipelineConfig.getInputStream(), options);
-            XmlBeansUtil.validateXmlDocument(doc, "Task pipeline config '" + pipelineConfig.getPath() + "'");
+            XmlBeansUtil.validateXmlDocument(doc, "Task pipeline config '" + pipelineConfig + "'");
         }
         catch (XmlValidationException e)
         {
@@ -393,7 +393,7 @@ public class FileAnalysisTaskPipelineImpl extends TaskPipelineImpl<FileAnalysisT
         }
         catch (XmlException |IOException e)
         {
-            PipelineJobServiceImpl.LOG.error("Error loading task pipeline '" + pipelineConfig.getPath() + "':\n" + e.getMessage());
+            PipelineJobServiceImpl.LOG.error("Error loading task pipeline '" + pipelineConfig + "':\n", e);
             return null;
         }
 

--- a/query/src/org/labkey/query/ModuleQueryMetadataDef.java
+++ b/query/src/org/labkey/query/ModuleQueryMetadataDef.java
@@ -112,7 +112,7 @@ public class ModuleQueryMetadataDef
         }
         catch (IOException | TransformerException | ParserConfigurationException | SAXException e)
         {
-            LOG.warn("Unable to load meta-data from module query file " + resource.getPath(), e);
+            LOG.warn("Unable to load meta-data from module query file " + resource, e);
         }
     }
 


### PR DESCRIPTION
#### Rationale
When logging error messages related to module resource validation, etc., including the offending module's name would be very useful. `FileResource.toString()` includes the module name and the path, so log it instead of `getPath()`.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46860