### PR TITLE
correctly set schema in lineage lookup

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -214,8 +214,7 @@ public class ClosureQueryHelper
         ret.setLabel(target.getName());
         UserSchema schema = Objects.requireNonNull(parentTable.getUserSchema());
         var builder = new QueryForeignKey.Builder(schema, parentTable.getContainerFilter()).table(target.getName()).key("rowid");
-        if (sourceType != targetType)
-            builder.schema(targetType.schemaKey);
+        builder.schema(targetType.schemaKey);
         var qfk = new QueryForeignKey(builder) {
             @Override
             public ColumnInfo createLookupColumn(ColumnInfo foreignKey, String displayField)


### PR DESCRIPTION
#### Rationale
Fix broken lookup when source schema is not the "exp.material" or "samples"

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
