### PR TITLE
46857: Missing Data When Updating DataClasses

### DIFF
--- a/api/src/org/labkey/api/dataiterator/DetailedAuditLogDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/DetailedAuditLogDataIterator.java
@@ -121,6 +121,12 @@ public class DetailedAuditLogDataIterator extends AbstractDataIterator
         _data.close();
     }
 
+    @Override
+    public boolean supportsGetExistingRecord()
+    {
+        return _data.supportsGetExistingRecord();
+    }
+
     public static DataIteratorBuilder getDataIteratorBuilder(TableInfo queryTable, @NotNull final DataIteratorBuilder builder, QueryService.AuditAction auditAction, final User user, final Container container)
     {
         return context ->

--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -172,7 +172,7 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
             if (null == di)
                 return null;           // Can happen if context has errors
 
-            assert !di.supportsGetExistingRecord();
+            //assert !di.supportsGetExistingRecord();
             if (di.supportsGetExistingRecord())
                 return di;
             QueryUpdateService.InsertOption option = context.getInsertOption();


### PR DESCRIPTION
#### Rationale
This is an initial pass at trying to address this [issue](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=46857).

A number of problems were discovered in LKB when trying import data into the registry data structures (data classes) using the `update` option. All of these are related to trigger scripts in the app and how they are setup. AFAIK, at least for this issue, the trigger scripts in LKB are fine, all of the issues are in the platform code especially in the utility class `TriggerDataBuilderHelper`.

The data loss in the ticket was caused by line 120 of `TriggerDataBuilderHelper`, the parameter to `outputAllColumns` in the `CoerceDataIterator` would null out the remaining columns not specified in the incoming data. The other primary issue is that the class was only implemented to handle the insert case so modifying it to handle at least merge should address this and other related issues. 

There were some changes made to the `ExistingRecordDataIterator` and how it is set up in the DI since in the update case we are using it to fetch the current row.

I haven't done this yet but one thing Matt and I discussed was adding some validation to prevent update triggers from modifying the PK of the table. While none of the LKB trigger scripts attempt to do this, we probably either need this or should introduce a new, different contract API into the `Trigger` class.