### PR TITLE
Fix overzealous HTML encoding in database check

### DIFF
--- a/api/src/org/labkey/api/data/DbSchema.java
+++ b/api/src/org/labkey/api/data/DbSchema.java
@@ -33,6 +33,8 @@ import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.test.TestTimeout;
 import org.labkey.api.test.TestWhen;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringUtilsLabKey;
@@ -766,7 +768,7 @@ public class DbSchema
         return row;
     }
 
-    public static String checkAllContainerCols(User user, boolean bfix)
+    public static HtmlString checkAllContainerCols(User user, boolean bfix)
     {
         List<Module> modules = ModuleLoader.getInstance().getModules();
         Integer lastRowId = 0;
@@ -794,7 +796,7 @@ public class DbSchema
             
             """;
 
-        final StringBuilder sbOut = new StringBuilder();
+        final HtmlStringBuilder sbOut = HtmlStringBuilder.of();
 
         SQLFragment sbCheck = new SQLFragment();
 
@@ -832,43 +834,50 @@ public class DbSchema
 
                     //remove the ACLs that were there
                     SecurityPolicyManager.removeAll(recovered);
-                    sbOut.append("<br> Recovered objects from table ");
-                    sbOut.append(rs.getString(1));
-                    sbOut.append(" to project ");
-                    sbOut.append(recovered.getName());
+                    sbOut.append(HtmlString.BR)
+                        .append(" Recovered objects from table ")
+                        .append(rs.getString(1))
+                        .append(" to project ")
+                        .append(recovered.getName());
                 }
                 catch (Exception se)
                 {
-                    sbOut.append("<br> Failed attempt to recover some objects from table ");
-                    sbOut.append(rs.getString(1));
-                    sbOut.append(" due to error ").append(se.getMessage());
-                    sbOut.append(". Retrying recovery may work.  ");
+                    sbOut.append(HtmlString.BR)
+                        .append(" Failed attempt to recover some objects from table ")
+                        .append(rs.getString(1))
+                        .append(" due to error ")
+                        .append(se.getMessage())
+                        .append(". Retrying recovery may work.  ");
                 }
             });
 
             recovered.setActiveModules(modulesOfOrphans, user);
 
-            return sbOut.toString();
+            return sbOut.getHtmlString();
         }
         else
         {
             new SqlSelector(coreSchema, " SELECT * FROM " + tempTableName
                 + " WHERE OrphanedContainer IS NOT NULL ORDER BY 1,3 ;").forEach(rs -> {
-                    sbOut.append("<br/>&nbsp;&nbsp;&nbsp;ERROR:  ");
-                    sbOut.append(rs.getString(1));
-                    sbOut.append(" &nbsp;&nbsp;&nbsp;&nbsp; ");
-                    sbOut.append(rs.getString(2));
-                    sbOut.append("." ).append(rs.getString(3));
-                    sbOut.append(" = ");
-                    sbOut.append(rs.getString(4));
-                    sbOut.append("&nbsp;&nbsp;&nbsp;Module:  ");
-                    sbOut.append(rs.getString(5));
-                    sbOut.append("&nbsp;&nbsp;&nbsp;Container:  ");
-                    sbOut.append(rs.getString(6));
-                    sbOut.append("\n");
+                    sbOut.append(HtmlString.unsafe("<br/>&nbsp;&nbsp;&nbsp;"))
+                        .append("ERROR:  ")
+                        .append(rs.getString(1))
+                        .append(HtmlString.unsafe(" &nbsp;&nbsp;&nbsp;&nbsp; "))
+                        .append(rs.getString(2))
+                        .append("." )
+                        .append(rs.getString(3))
+                        .append(" = ")
+                        .append(rs.getString(4))
+                        .append(HtmlString.unsafe("&nbsp;&nbsp;&nbsp;"))
+                        .append("Module:  ")
+                        .append(rs.getString(5))
+                        .append(HtmlString.unsafe("&nbsp;&nbsp;&nbsp;"))
+                        .append("Container:  ")
+                        .append(rs.getString(6))
+                        .append("\n");
                 });
 
-            return sbOut.toString();
+            return sbOut.getHtmlString();
         }
     }
 }

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -55,6 +55,8 @@ import org.labkey.api.test.TestTimeout;
 import org.labkey.api.test.TestWhen;
 import org.labkey.api.util.CPUTimer;
 import org.labkey.api.util.GUID;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.ResultSetUtil;
 import org.labkey.api.util.TestContext;
@@ -3643,23 +3645,23 @@ public class OntologyManager
         return getExpSchema().getTable("ObjectPropertiesView");
     }
 
-    public static String doProjectColumnCheck(boolean bFix)
+    public static HtmlString doProjectColumnCheck(boolean bFix)
     {
-        StringBuilder msgBuffer = new StringBuilder();
+        HtmlStringBuilder builder = HtmlStringBuilder.of();
         String descriptorTable = getTinfoPropertyDescriptor().toString();
         String uriColumn = "PropertyURI";
         String idColumn = "PropertyID";
-        doProjectColumnCheck(descriptorTable, uriColumn, idColumn, msgBuffer, bFix);
+        doProjectColumnCheck(descriptorTable, uriColumn, idColumn, builder, bFix);
 
         descriptorTable = getTinfoDomainDescriptor().toString();
         uriColumn = "DomainURI";
         idColumn = "DomainID";
-        doProjectColumnCheck(descriptorTable, uriColumn, idColumn, msgBuffer, bFix);
+        doProjectColumnCheck(descriptorTable, uriColumn, idColumn, builder, bFix);
 
-        return msgBuffer.toString();
+        return builder.getHtmlString();
     }
 
-    private static void doProjectColumnCheck(final String descriptorTable, final String uriColumn, final String idColumn, final StringBuilder msgBuilder, final boolean bFix)
+    private static void doProjectColumnCheck(final String descriptorTable, final String uriColumn, final String idColumn, final HtmlStringBuilder msgBuilder, final boolean bFix)
     {
         // get all unique combos of Container, project
 
@@ -3678,14 +3680,16 @@ public class OntologyManager
                 {
                     fixProjectColumn(descriptorTable, uriColumn, idColumn, container, projectId, newProjectId);
                     msgBuilder
-                        .append("<br/>&nbsp;&nbsp;&nbsp;Fixed inconsistent project ids found for ")
+                        .append(HtmlString.unsafe("<br/>&nbsp;&nbsp;&nbsp;"))
+                        .append("Fixed inconsistent project ids found for ")
                         .append(descriptorTable).append(" in folder ")
                         .append(ContainerManager.getForId(containerId).getPath());
 
                 }
                 else
                     msgBuilder
-                        .append("<br/>&nbsp;&nbsp;&nbsp;ERROR: Inconsistent project ids found for ")
+                        .append(HtmlString.unsafe("<br/>&nbsp;&nbsp;&nbsp;"))
+                        .append("ERROR: Inconsistent project ids found for ")
                         .append(descriptorTable).append(" in folder ").append(container.getPath());
             }
         });


### PR DESCRIPTION
#### Rationale
Double encoding is better than no encoding, but it's still not ideal...

Related PR applied HTML filtering to some Strings that contain HTML. This is too easy to get wrong, so bite the bullet and convert `DoCheckAction` and its dependencies to use `HtmlStringBuilder`.

Targeting 22.12 since we put a link to this action in the admin warning if there are schema problems.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3884