### PR TITLE
46857: Missing Data When Updating DataClasses

### DIFF
--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -172,7 +172,6 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
             if (null == di)
                 return null;           // Can happen if context has errors
 
-            assert !di.supportsGetExistingRecord();
             if (di.supportsGetExistingRecord())
                 return di;
             QueryUpdateService.InsertOption option = context.getInsertOption();

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -19,12 +19,16 @@ import org.labkey.api.data.AbstractTableInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.triggers.Trigger;
+import org.labkey.api.exp.query.ExpDataClassDataTable;
+import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * User: matthewb
@@ -117,9 +121,28 @@ public class TriggerDataBuilderHelper
             if (!_target.hasTriggers(_c))
                 return pre;
             pre = LoggingDataIterator.wrap(pre);
-            DataIterator coerce = new CoerceDataIterator(pre, context, _target);
+
+            boolean includeAllColumns = !(context.getInsertOption().mergeRows && (_target instanceof ExpMaterialTable || _target instanceof ExpDataClassDataTable));
+            DataIterator coerce = new CoerceDataIterator(pre, context, _target, includeAllColumns);
             coerce = LoggingDataIterator.wrap(coerce);
-            return LoggingDataIterator.wrap(new BeforeIterator(coerce, context));
+            if (!includeAllColumns)
+            {
+                Set<String> mergeKeys = new HashSet<>();
+                if (_target instanceof ExpMaterialTable)
+                {
+                    mergeKeys.add("materialSourceId");
+                    mergeKeys.add("name");
+                }
+                else
+                {
+                    mergeKeys.add("classid");
+                    mergeKeys.add("name");
+                }
+
+                coerce = ExistingRecordDataIterator.createBuilder(coerce, _target, mergeKeys, true).getDataIterator(context);
+            }
+
+            return LoggingDataIterator.wrap(new BeforeIterator(new CachingDataIterator(coerce), context));
         }
     }
 

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -19,14 +19,12 @@ import org.labkey.api.data.AbstractTableInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.triggers.Trigger;
-import org.labkey.api.exp.query.ExpDataClassDataTable;
-import org.labkey.api.exp.query.ExpMaterialTable;
+import org.labkey.api.exp.query.ExpTable;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -122,25 +120,15 @@ public class TriggerDataBuilderHelper
                 return pre;
             pre = LoggingDataIterator.wrap(pre);
 
-            boolean includeAllColumns = !(context.getInsertOption().mergeRows && (_target instanceof ExpMaterialTable || _target instanceof ExpDataClassDataTable));
+            Set<String> mergeKeys = null;
+            if (_target instanceof ExpTable)
+                mergeKeys = ((ExpTable<?>)_target).getAltMergeKeys();
+
+            boolean includeAllColumns = !context.getInsertOption().mergeRows || mergeKeys == null;
             DataIterator coerce = new CoerceDataIterator(pre, context, _target, includeAllColumns);
             coerce = LoggingDataIterator.wrap(coerce);
             if (!includeAllColumns)
-            {
-                Set<String> mergeKeys = new HashSet<>();
-                if (_target instanceof ExpMaterialTable)
-                {
-                    mergeKeys.add("materialSourceId");
-                    mergeKeys.add("name");
-                }
-                else
-                {
-                    mergeKeys.add("classid");
-                    mergeKeys.add("name");
-                }
-
                 coerce = ExistingRecordDataIterator.createBuilder(coerce, _target, mergeKeys, true).getDataIterator(context);
-            }
 
             return LoggingDataIterator.wrap(new BeforeIterator(new CachingDataIterator(coerce), context));
         }

--- a/api/src/org/labkey/api/exp/query/ExpDataClassDataTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpDataClassDataTable.java
@@ -30,6 +30,7 @@ public interface ExpDataClassDataTable extends ExpTable<ExpDataClassDataTable.Co
         Name,
         Description,
         DataClass,
+        ClassId,
         Created,
         CreatedBy,
         Modified,

--- a/api/src/org/labkey/api/exp/query/ExpTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpTable.java
@@ -30,6 +30,8 @@ import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.permissions.Permission;
 
+import java.util.Set;
+
 public interface ExpTable<C extends Enum> extends ContainerFilterable, TableInfo
 {
     Container getContainer();
@@ -123,6 +125,11 @@ public interface ExpTable<C extends Enum> extends ContainerFilterable, TableInfo
 
     /** returns a column that wraps objectid, this is only required to support the expObject() table method */
     default ColumnInfo getExpObjectColumn()
+    {
+        return null;
+    }
+
+    @Nullable default Set<String> getAltMergeKeys()
     {
         return null;
     }

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -1778,8 +1778,7 @@ public class ExpDataIterators
                     extraKeyValueMap = new CaseInsensitiveHashMap<>();
                     extraKeyValueMap.put("materialSourceId", ((ExpMaterialTableImpl) _expTable).getSampleType().getRowId());
 
-                    keyColumns.add("materialSourceId");
-                    keyColumns.add("name");
+                    keyColumns.addAll(((ExpMaterialTableImpl) _expTable).getAltMergeKeys());
                     propertyKeyColumns.add("name");
                 }
 
@@ -1792,8 +1791,7 @@ public class ExpDataIterators
                 extraKeyValueMap = new CaseInsensitiveHashMap<>();
                 extraKeyValueMap.put("classid", ((ExpDataClassDataTableImpl) _expTable).getDataClass().getRowId());
 
-                keyColumns.add("classid");
-                keyColumns.add("name");
+                keyColumns.addAll(((ExpDataClassDataTableImpl) _expTable).getAltMergeKeys());
             }
 
             // Check if record exist in related folder as cross folder merge is not supported

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -103,6 +103,7 @@ import org.labkey.experiment.controllers.exp.ExperimentController;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -125,6 +126,11 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 {
     private final @NotNull ExpDataClassImpl _dataClass;
     public static final String DATA_COUNTER_SEQ_PREFIX = "DataNameGenCounter-";
+
+    public static final Set<String> DATA_CLASS_ALT_KEYS;
+    static {
+        DATA_CLASS_ALT_KEYS = new HashSet<>(Arrays.asList(Column.ClassId.name(), Name.name()));
+    }
 
     private Map<String/*domain name*/, DataClassVocabularyProviderProperties> _vocabularyDomainProviders;
 
@@ -759,6 +765,12 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             return m;
         }
         return null;
+    }
+
+    @Override
+    public Set<String> getAltMergeKeys()
+    {
+        return DATA_CLASS_ALT_KEYS;
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -120,6 +120,11 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     ExpSampleTypeImpl _ss;
     Set<String> _uniqueIdFields;
 
+    public static final Set<String> MATERIAL_ALT_KEYS;
+    static {
+        MATERIAL_ALT_KEYS = new HashSet<>(Arrays.asList(Column.MaterialSourceId.name(), Column.Name.name()));
+    }
+
     public ExpMaterialTableImpl(String name, UserSchema schema, ContainerFilter cf)
     {
         super(name, ExperimentServiceImpl.get().getTinfoMaterial(), schema, cf);
@@ -1052,6 +1057,12 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         }
 
         return m;
+    }
+
+    @Override
+    public Set<String> getAltMergeKeys()
+    {
+        return MATERIAL_ALT_KEYS;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
DataClass data and samples uses ExpDataIterator to handle insert/merge into their materialized table as well as a provisioned table. The automatically generated LSID is the default key for those tables. When import with merge, TriggerDataBuilderHelper needs to outputAllColumns in the CoerceDataIterator, or else any columns not provided in the import file will get blanked out. For data types whose key are included in the import file (such as lists or dataset), the key can be used to query for existing data. For dataclass and samples, an alternative set of keys needs be to used since LSIDs are an auto generated during import and cannot be used to query existing data.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3897

#### Changes
* hard code TriggerDataBuilderHelper to use alternative keys for samples and dataclass during import with merge
