### PR TITLE
Issue 46603: LKSM: Support naming patterns referencing things with a space

### DIFF
--- a/api/src/org/labkey/api/util/StringExpressionFactory.java
+++ b/api/src/org/labkey/api/util/StringExpressionFactory.java
@@ -1018,9 +1018,11 @@ public class StringExpressionFactory
 
             if (!map.containsKey(lookupKey))
             {
+                // check the encoded (PageFlowUtil.encode) key
                 lookupKey = _key.getParent() == null ? _key.getName() : _key.encode();
-                if (map.containsKey(lookupKey))
-                    LOG.debug("No string substitution found for FieldKey '" + _key.encode() + "', but found String '" + lookupKey + "'.");
+                // next, check key.toString(), which calls QueryKey.encodePart
+                if (!map.containsKey(lookupKey))
+                    lookupKey = _key.toString();
             }
 
             String result = applyFormats(map.get(lookupKey));


### PR DESCRIPTION
#### Rationale
When evaluating a name expression against a map of context values, each parsed field part is checked against the key sets in the value map. If not found, then the pageflow.encoded key is checked. This PR additionally checks for QueryKey.encoded parts. 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* check the presence of QueryKey.encodePart encoded substitute part
