### PR TITLE
Check for existence of supportFolder before doing things with it.

### DIFF
--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1416,10 +1416,14 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             Group guests = SecurityManager.getGroup(Group.groupGuests);
             if (null != guests)
             {
-                MutableSecurityPolicy supportPolicy = new MutableSecurityPolicy(ContainerManager.getDefaultSupportContainer().getPolicy());
-                for (Role assignedRole : supportPolicy.getAssignedRoles(guests))
-                    supportPolicy.removeRoleAssignment(guests, assignedRole);
-                SecurityPolicyManager.savePolicy(supportPolicy);
+                Container supportFolder = ContainerManager.getDefaultSupportContainer();
+                if (supportFolder != null)
+                {
+                    MutableSecurityPolicy supportPolicy = new MutableSecurityPolicy(supportFolder.getPolicy());
+                    for (Role assignedRole : supportPolicy.getAssignedRoles(guests))
+                        supportPolicy.removeRoleAssignment(guests, assignedRole);
+                    SecurityPolicyManager.savePolicy(supportPolicy);
+                }
             }
         }
 

--- a/wiki/src/org/labkey/wiki/WikiModule.java
+++ b/wiki/src/org/labkey/wiki/WikiModule.java
@@ -124,7 +124,8 @@ public class WikiModule extends CodeOnlyModule implements SearchService.Document
         String defaultPageName = "default";
 
         loadWikiContent(homeContainer, moduleContext.getUpgradeUser(), defaultPageName, "Welcome to LabKey Server", "/org/labkey/wiki/welcomeWiki.txt");
-        loadWikiContent(supportContainer, moduleContext.getUpgradeUser(), defaultPageName, "Welcome to LabKey Support", "/org/labkey/wiki/supportWiki.txt");
+        if (supportContainer != null)
+            loadWikiContent(supportContainer, moduleContext.getUpgradeUser(), defaultPageName, "Welcome to LabKey Support", "/org/labkey/wiki/supportWiki.txt");
         loadWikiContent(sharedContainer, moduleContext.getUpgradeUser(), defaultPageName, "Shared Resources", "/org/labkey/wiki/sharedWiki.txt");
 
         addWebPart(supportContainer, defaultPageName);

--- a/wiki/src/org/labkey/wiki/WikiModule.java
+++ b/wiki/src/org/labkey/wiki/WikiModule.java
@@ -124,8 +124,7 @@ public class WikiModule extends CodeOnlyModule implements SearchService.Document
         String defaultPageName = "default";
 
         loadWikiContent(homeContainer, moduleContext.getUpgradeUser(), defaultPageName, "Welcome to LabKey Server", "/org/labkey/wiki/welcomeWiki.txt");
-        if (supportContainer != null)
-            loadWikiContent(supportContainer, moduleContext.getUpgradeUser(), defaultPageName, "Welcome to LabKey Support", "/org/labkey/wiki/supportWiki.txt");
+        loadWikiContent(supportContainer, moduleContext.getUpgradeUser(), defaultPageName, "Welcome to LabKey Support", "/org/labkey/wiki/supportWiki.txt");
         loadWikiContent(sharedContainer, moduleContext.getUpgradeUser(), defaultPageName, "Shared Resources", "/org/labkey/wiki/sharedWiki.txt");
 
         addWebPart(supportContainer, defaultPageName);


### PR DESCRIPTION
#### Rationale
In some cases (e.g., when configuring the home folder as a SM folder), we remove the /Home/support folder, so we want to make sure it exists before doing things with it.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/1442

#### Changes
* Check for existence of support container to avoid NPEs
