### PR TITLE
Check that supportFolder exists before updating its security policy

### DIFF
--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1418,10 +1418,14 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             Group guests = SecurityManager.getGroup(Group.groupGuests);
             if (null != guests)
             {
-                MutableSecurityPolicy supportPolicy = new MutableSecurityPolicy(ContainerManager.getDefaultSupportContainer().getPolicy());
-                for (Role assignedRole : supportPolicy.getAssignedRoles(guests))
-                    supportPolicy.removeRoleAssignment(guests, assignedRole);
-                SecurityPolicyManager.savePolicy(supportPolicy);
+                Container supportFolder = ContainerManager.getDefaultSupportContainer();
+                if (supportFolder != null)
+                {
+                    MutableSecurityPolicy supportPolicy = new MutableSecurityPolicy(supportFolder.getPolicy());
+                    for (Role assignedRole : supportPolicy.getAssignedRoles(guests))
+                        supportPolicy.removeRoleAssignment(guests, assignedRole);
+                    SecurityPolicyManager.savePolicy(supportPolicy);
+                }
             }
         }
 


### PR DESCRIPTION
#### Rationale
In some cases (e.g., when configuring the home folder as a SM folder), we remove the /Home/support folder, so we want to make sure it exists before doing things with it.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Check for existence of support container to avoid NPEs
