### PR TITLE
Issue 46465: Fix behavior of grid actions when using a filtered set of selections

### DIFF
--- a/api/src/org/labkey/api/data/DataRegionSelection.java
+++ b/api/src/org/labkey/api/data/DataRegionSelection.java
@@ -59,7 +59,7 @@ public class DataRegionSelection
 
     // set/updated using query-setSnapshotSelection
     // can be used to hold an arbitrary set of selections in session
-    // example usage: set an filtered set of selected values in session
+    // example usage: set a filtered set of selected values in session
     public static final String SNAPSHOT_SELECTED_VALUES = ".snapshotSelectValues";
 
     private static @NotNull String getSessionAttributeKey(@NotNull String path, @NotNull String key, boolean useSnapshot)

--- a/api/src/org/labkey/api/data/RenderContext.java
+++ b/api/src/org/labkey/api/data/RenderContext.java
@@ -479,7 +479,11 @@ public class RenderContext implements Map<String, Object>, Serializable
             container = _viewContext.getContainer();
         }
         if (_currentRegion != null && _showRows == ShowRows.SELECTED || _showRows == ShowRows.UNSELECTED)
+        {
             buildSelectedFilter(filter, tinfo, _showRows == ShowRows.UNSELECTED);
+            // Issue 46465: If you've selected items then filtered the grid, we want to respect the filter
+            filter.addUrlFilters(url, name, displayColumns, user, container);
+        }
         else
             filter.addUrlFilters(url, name, displayColumns, user, container);
 

--- a/api/src/org/labkey/api/data/RenderContext.java
+++ b/api/src/org/labkey/api/data/RenderContext.java
@@ -481,11 +481,9 @@ public class RenderContext implements Map<String, Object>, Serializable
         if (_currentRegion != null && _showRows == ShowRows.SELECTED || _showRows == ShowRows.UNSELECTED)
         {
             buildSelectedFilter(filter, tinfo, _showRows == ShowRows.UNSELECTED);
-            // Issue 46465: If you've selected items then filtered the grid, we want to respect the filter
-            filter.addUrlFilters(url, name, displayColumns, user, container);
         }
-        else
-            filter.addUrlFilters(url, name, displayColumns, user, container);
+        // Issue 46465: If you've selected items then filtered the grid, we want to respect the filter
+        filter.addUrlFilters(url, name, displayColumns, user, container);
 
         return filter;
     }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3471,6 +3471,7 @@ public class ExperimentController extends SpringActionController
     public static class DataOperationConfirmationForm extends DataViewSelectionForm
     {
         private ExpDataImpl.DataOperations _dataOperation;
+        private boolean _useSnapshotSelection;
 
         public ExpDataImpl.DataOperations getDataOperation()
         {
@@ -3480,6 +3481,16 @@ public class ExperimentController extends SpringActionController
         public void setDataOperation(ExpDataImpl.DataOperations dataOperation)
         {
             _dataOperation = dataOperation;
+        }
+
+        public boolean isUseSnapshotSelection()
+        {
+            return _useSnapshotSelection;
+        }
+
+        public void setUseSnapshotSelection(boolean useSnapshotSelection)
+        {
+            _useSnapshotSelection = useSnapshotSelection;
         }
     }
 
@@ -3556,6 +3567,7 @@ public class ExperimentController extends SpringActionController
     public static class MaterialOperationConfirmationForm extends DataViewSelectionForm
     {
         private SampleTypeService.SampleOperations _sampleOperation;
+        private boolean _useSnapshotSelection;
 
         public SampleTypeService.SampleOperations getSampleOperation()
         {
@@ -3565,6 +3577,26 @@ public class ExperimentController extends SpringActionController
         public void setSampleOperation(SampleTypeService.SampleOperations sampleOperation)
         {
             _sampleOperation = sampleOperation;
+        }
+
+        public boolean isUseSnapshotSelection()
+        {
+            return _useSnapshotSelection;
+        }
+
+        public void setUseSnapshotSelection(boolean useSnapshotSelection)
+        {
+            _useSnapshotSelection = useSnapshotSelection;
+        }
+
+        @Override
+        public Set<Integer> getIds(boolean clear)
+        {
+            if (_rowIds != null) return _rowIds;
+            if (_useSnapshotSelection)
+                return DataRegionSelection.getSnapshotSelectedIntegers(getViewContext(), getDataRegionSelectionKey());
+            else
+                return DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
         }
     }
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3517,7 +3517,7 @@ public class ExperimentController extends SpringActionController
 
     @Marshal(Marshaller.Jackson)
     @RequiresPermission(ReadPermission.class)
-    public class GetMaterialOperationConfirmationDataAction extends ReadOnlyApiAction<MaterialOperationConfirmationForm>
+    public static class GetMaterialOperationConfirmationDataAction extends ReadOnlyApiAction<MaterialOperationConfirmationForm>
     {
         @Override
         public void validateForm(MaterialOperationConfirmationForm form, Errors errors)
@@ -7515,6 +7515,7 @@ public class ExperimentController extends SpringActionController
     {
         private String _dataType;
         private String _picklistName;
+        private boolean _useSnapshotSelection;
 
         public String getDataType()
         {
@@ -7536,12 +7537,26 @@ public class ExperimentController extends SpringActionController
             _picklistName = picklistName;
         }
 
+        public boolean isUseSnapshotSelection()
+        {
+            return _useSnapshotSelection;
+        }
+
+        public void setUseSnapshotSelection(boolean useSnapshotSelection)
+        {
+            _useSnapshotSelection = useSnapshotSelection;
+        }
+
         @Override
         public Set<Integer> getIds(boolean clear)
         {
             if (_rowIds != null)
                 return _rowIds;
-            Set<Integer> selectedIds = DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
+            Set<Integer> selectedIds;
+            if (_useSnapshotSelection)
+                selectedIds = DataRegionSelection.getSnapshotSelectedIntegers(getViewContext(), getDataRegionSelectionKey());
+            else
+                selectedIds = DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
             if (_picklistName != null)
             {
                 User user = getViewContext().getUser();

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3468,10 +3468,9 @@ public class ExperimentController extends SpringActionController
     }
 
 
-    public static class DataOperationConfirmationForm extends DataViewSelectionForm
+    public static class DataOperationConfirmationForm extends DataViewSnapshotSelectionForm
     {
         private ExpDataImpl.DataOperations _dataOperation;
-        private boolean _useSnapshotSelection;
 
         public ExpDataImpl.DataOperations getDataOperation()
         {
@@ -3482,6 +3481,12 @@ public class ExperimentController extends SpringActionController
         {
             _dataOperation = dataOperation;
         }
+
+    }
+
+    public static class DataViewSnapshotSelectionForm extends DataViewSelectionForm
+    {
+        private boolean _useSnapshotSelection;
 
         public boolean isUseSnapshotSelection()
         {
@@ -3574,10 +3579,9 @@ public class ExperimentController extends SpringActionController
         }
     }
 
-    public static class MaterialOperationConfirmationForm extends DataViewSelectionForm
+    public static class MaterialOperationConfirmationForm extends DataViewSnapshotSelectionForm
     {
         private SampleTypeService.SampleOperations _sampleOperation;
-        private boolean _useSnapshotSelection;
 
         public SampleTypeService.SampleOperations getSampleOperation()
         {
@@ -3587,26 +3591,6 @@ public class ExperimentController extends SpringActionController
         public void setSampleOperation(SampleTypeService.SampleOperations sampleOperation)
         {
             _sampleOperation = sampleOperation;
-        }
-
-        public boolean isUseSnapshotSelection()
-        {
-            return _useSnapshotSelection;
-        }
-
-        public void setUseSnapshotSelection(boolean useSnapshotSelection)
-        {
-            _useSnapshotSelection = useSnapshotSelection;
-        }
-
-        @Override
-        public Set<Integer> getIds(boolean clear)
-        {
-            if (_rowIds != null) return _rowIds;
-            if (_useSnapshotSelection)
-                return new HashSet<>(DataRegionSelection.getSnapshotSelectedIntegers(getViewContext(), getDataRegionSelectionKey()));
-            else
-                return DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
         }
     }
 
@@ -7553,11 +7537,10 @@ public class ExperimentController extends SpringActionController
         }
     }
 
-    public static class CrossFolderSelectionForm extends DataViewSelectionForm
+    public static class CrossFolderSelectionForm extends DataViewSnapshotSelectionForm
     {
         private String _dataType;
         private String _picklistName;
-        private boolean _useSnapshotSelection;
 
         public String getDataType()
         {
@@ -7579,23 +7562,13 @@ public class ExperimentController extends SpringActionController
             _picklistName = picklistName;
         }
 
-        public boolean isUseSnapshotSelection()
-        {
-            return _useSnapshotSelection;
-        }
-
-        public void setUseSnapshotSelection(boolean useSnapshotSelection)
-        {
-            _useSnapshotSelection = useSnapshotSelection;
-        }
-
         @Override
         public Set<Integer> getIds(boolean clear)
         {
             if (_rowIds != null)
                 return _rowIds;
             Set<Integer> selectedIds;
-            if (_useSnapshotSelection)
+            if (isUseSnapshotSelection())
                 selectedIds = new HashSet<>(DataRegionSelection.getSnapshotSelectedIntegers(getViewContext(), getDataRegionSelectionKey()));
             else
                 selectedIds = DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3498,7 +3498,7 @@ public class ExperimentController extends SpringActionController
         {
             if (_rowIds != null) return _rowIds;
             if (_useSnapshotSelection)
-                return DataRegionSelection.getSnapshotSelectedIntegers(getViewContext(), getDataRegionSelectionKey());
+                return new HashSet<>(DataRegionSelection.getSnapshotSelectedIntegers(getViewContext(), getDataRegionSelectionKey()));
             else
                 return DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
         }
@@ -3604,7 +3604,7 @@ public class ExperimentController extends SpringActionController
         {
             if (_rowIds != null) return _rowIds;
             if (_useSnapshotSelection)
-                return DataRegionSelection.getSnapshotSelectedIntegers(getViewContext(), getDataRegionSelectionKey());
+                return new HashSet<>(DataRegionSelection.getSnapshotSelectedIntegers(getViewContext(), getDataRegionSelectionKey()));
             else
                 return DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
         }
@@ -7596,7 +7596,7 @@ public class ExperimentController extends SpringActionController
                 return _rowIds;
             Set<Integer> selectedIds;
             if (_useSnapshotSelection)
-                selectedIds = DataRegionSelection.getSnapshotSelectedIntegers(getViewContext(), getDataRegionSelectionKey());
+                selectedIds = new HashSet<>(DataRegionSelection.getSnapshotSelectedIntegers(getViewContext(), getDataRegionSelectionKey()));
             else
                 selectedIds = DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
             if (_picklistName != null)

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3492,6 +3492,16 @@ public class ExperimentController extends SpringActionController
         {
             _useSnapshotSelection = useSnapshotSelection;
         }
+
+        @Override
+        public Set<Integer> getIds(boolean clear)
+        {
+            if (_rowIds != null) return _rowIds;
+            if (_useSnapshotSelection)
+                return DataRegionSelection.getSnapshotSelectedIntegers(getViewContext(), getDataRegionSelectionKey());
+            else
+                return DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
+        }
     }
 
     public static class DataViewSelectionForm extends ViewForm


### PR DESCRIPTION
#### Rationale
When a user selects items on a grid and then filters the grid so only a subset of the items is shown, the expectation is that any actions performed will use the selections shown in the filtered grid. For many actions, however, we pick up the original set of selections for performing actions. This PR modifies the behavior in these cases to use a snapshot selection in order to get at the filtered items.

#### Related Pull Requests
- https://github.com/LabKey/sampleManagement/pull/1444
- https://github.com/LabKey/biologics/pull/1778
- https://github.com/LabKey/labkey-ui-components/pull/1046
- https://github.com/LabKey/inventory/pull/637

#### Changes
* When exporting, we want to obey filters as well as selection key if present
* Allow for use of snapshot selections when getting operation confirmation data
