### PR TITLE
Add logging for creation and removal of support container

### DIFF
--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -2361,6 +2361,7 @@ public class ContainerManager
 
     public static Container createDefaultSupportContainer()
     {
+        LOG.info("Creating default support container: " + DEFAULT_SUPPORT_PROJECT_PATH);
         // create a "support" container. Admins can do anything,
         // Users can read/write, Guests can read.
         return bootstrapContainer(DEFAULT_SUPPORT_PROJECT_PATH,
@@ -2374,6 +2375,7 @@ public class ContainerManager
         Container support = getDefaultSupportContainer();
         if (support != null)
         {
+            LOG.info("Removing default support container: " + DEFAULT_SUPPORT_PROJECT_PATH);
             ContainerManager.delete(support, user);
         }
     }


### PR DESCRIPTION
#### Rationale
We should be deleting the support container as part of the sample manager trial configuration, but for some reason are not. Logs might help to know when the container is created and when it is deleted.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/1448

#### Changes
* Add log messages
