### PR TITLE
Issue 46830: Decouple SampleNameGenCounter from the ContextListener logger

### DIFF
--- a/api/src/org/labkey/api/admin/FolderImportContext.java
+++ b/api/src/org/labkey/api/admin/FolderImportContext.java
@@ -152,7 +152,7 @@ public class FolderImportContext extends AbstractFolderContext
     {
         if (_xarJobId == null)
         {
-            DbSequence newSequence = DbSequenceManager.getPreallocatingSequence(getContainer(), FOLDER_IMPORT_DB_SEQUENCE_PREFIX, 0, 1);
+            DbSequence newSequence = DbSequenceManager.get(getContainer(), FOLDER_IMPORT_DB_SEQUENCE_PREFIX);
             _xarJobId = "Xar-" + newSequence.next();
         }
 

--- a/api/src/org/labkey/api/data/DbSequence.java
+++ b/api/src/org/labkey/api/data/DbSequence.java
@@ -78,6 +78,11 @@ public class DbSequence
         return _c.toString() + ": " + _rowId;
     }
 
+    public void done()
+    {
+        // do nothing
+    }
+
 
     /** there are two ways we could write this
      * a) Support multiple DbSequence.Preallocate for the same sequence instance (e.g. rowid)
@@ -105,6 +110,8 @@ public class DbSequence
         // move to DbSequenceManager?
         public void done()
         {
+            shutdownPre();
+            shutdownStarted();
             ContextListener.removeShutdownListener(this);
         }
 

--- a/api/src/org/labkey/api/data/DbSequence.java
+++ b/api/src/org/labkey/api/data/DbSequence.java
@@ -151,9 +151,10 @@ public class DbSequence
             _lastReservedValue = null;
         }
 
+        @Override
         public synchronized void sync()
         {
-            if (null != _lastReservedValue && _currentValue != _lastReservedValue)
+            if (null != _lastReservedValue && !_lastReservedValue.equals(_currentValue))
             {
                 DbSequenceManager.setSequenceValue(this, _currentValue);
                 _lastReservedValue = _currentValue;

--- a/api/src/org/labkey/api/data/DbSequence.java
+++ b/api/src/org/labkey/api/data/DbSequence.java
@@ -15,9 +15,7 @@
  */
 package org.labkey.api.data;
 
-import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.Pair;
-import org.labkey.api.util.ShutdownListener;
 
 /**
  * User: adam
@@ -78,6 +76,11 @@ public class DbSequence
         return _c.toString() + ": " + _rowId;
     }
 
+    public void sync()
+    {
+        // pass
+    }
+
     public void done()
     {
         // do nothing
@@ -91,7 +94,7 @@ public class DbSequence
      *      just have to be thread safe is all, but how do we enforce the "exactly one per" rule?
      * NOTE: going with B
      */
-    protected static class Preallocate extends DbSequence implements ShutdownListener
+    protected static class Preallocate extends DbSequence
     {
         private final int _batchSize;
         private Long _currentValue = null;
@@ -104,16 +107,8 @@ public class DbSequence
         {
             super(c, name, rowId);
             _batchSize = batchSize;
-            ContextListener.addShutdownListener(this);
         }
 
-        // move to DbSequenceManager?
-        public void done()
-        {
-            shutdownPre();
-            shutdownStarted();
-            ContextListener.removeShutdownListener(this);
-        }
 
         @Override
         public synchronized long current()
@@ -156,18 +151,13 @@ public class DbSequence
             _lastReservedValue = null;
         }
 
-        @Override
-        public synchronized void shutdownPre()
+        public synchronized void sync()
         {
-        }
-
-        @Override
-        public synchronized void shutdownStarted()
-        {
-            if (null != _currentValue)
+            if (null != _lastReservedValue && _currentValue != _lastReservedValue)
+            {
                 DbSequenceManager.setSequenceValue(this, _currentValue);
-            _currentValue = null;
-            _lastReservedValue = null;
+                _lastReservedValue = _currentValue;
+            }
         }
     }
 }

--- a/api/src/org/labkey/api/data/DbSequence.java
+++ b/api/src/org/labkey/api/data/DbSequence.java
@@ -81,12 +81,6 @@ public class DbSequence
         // pass
     }
 
-    public void done()
-    {
-        // do nothing
-    }
-
-
     /** there are two ways we could write this
      * a) Support multiple DbSequence.Preallocate for the same sequence instance (e.g. rowid)
      *      potentially each would not have to be thread safe, but I think this would tend to generate lots of missing values

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -1349,16 +1349,12 @@ public class NameGenerator
         {
             _rowNumber = -1;
 
-            for (Map.Entry<String, Map<String, DbSequence>> prefixCounterSequence : _prefixCounterSequences.entrySet())
+            for (Map<String, DbSequence> counterSequences : _prefixCounterSequences.values())
             {
-                String counterSeqPrefix = prefixCounterSequence.getKey();
-                Map<String, DbSequence> counterSequences = prefixCounterSequence.getValue();
-                for (Map.Entry<String, DbSequence> counterSequence: counterSequences.entrySet())
+                for (DbSequence seq: counterSequences.values())
                 {
-                    DbSequence seq = counterSequence.getValue();
-                    seq.done();
-                    if (seq instanceof DbSequence.Preallocate)
-                        DbSequenceManager.invalidatePreallocatingSequence(_container, counterSeqPrefix + counterSequence.getKey(), 0);
+                    if (seq != null)
+                        seq.sync();
                 }
             }
         }

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -2192,7 +2192,8 @@ public class NameGenerator
                     if (existingCount > currentSeqMax || (_startIndex - 1) > currentSeqMax)
                         counterSeq.ensureMinimum(existingCount > (_startIndex - 1) ? existingCount : (_startIndex - 1));
 
-                    counterSequences.put(prefix, counterSeq);
+                    if (counterSequences != null)
+                        counterSequences.put(prefix, counterSeq);
                 }
                 else
                     counterSeq = counterSequences.get(prefix);

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -1356,13 +1356,9 @@ public class NameGenerator
                 for (Map.Entry<String, DbSequence> counterSequence: counterSequences.entrySet())
                 {
                     DbSequence seq = counterSequence.getValue();
+                    seq.done();
                     if (seq instanceof DbSequence.Preallocate)
-                    {
-                        ((DbSequence.Preallocate) seq).shutdownPre();
-                        ((DbSequence.Preallocate) seq).shutdownStarted();
-                        ((DbSequence.Preallocate) seq).done();
                         DbSequenceManager.invalidatePreallocatingSequence(_container, counterSeqPrefix + counterSequence.getKey(), 0);
-                    }
                 }
             }
         }


### PR DESCRIPTION
#### Rationale
DbSequence.Preallocate allow reserving a batch of ids from a sequence to avoid excess DB actions for certain tasks. Those Preallocated sequence gets added to ContextListener and will be cleaned up during server shut down. The withCounter naming syntax uses DBSequence to get the count of a unique string value. Preallocates are used and put in a local cache to allow efficient name generation that uses withCounter. For Preallocates used by withCounter, we should properly clean them up after the name generation task is done, instead of relying on ContextListener to clean them up.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* move counterSequence cache from CounterExpressionPart to State
* explicitly clean up counterSequences on State.close
* use a single shutdownlistener for all Preallocates
