### PR TITLE
Issue 46906: Schema mismatch for comm emailformats, emailoptions, and emailprefs tables

### DIFF
--- a/announcements/resources/schemas/dbscripts/postgresql/comm-22.003-22.004.sql
+++ b/announcements/resources/schemas/dbscripts/postgresql/comm-22.003-22.004.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS comm.EmailFormats;
+DROP TABLE IF EXISTS comm.EmailPrefs;
+DROP TABLE IF EXISTS comm.EmailOptions;

--- a/announcements/resources/schemas/dbscripts/sqlserver/comm-22.003-22.004.sql
+++ b/announcements/resources/schemas/dbscripts/sqlserver/comm-22.003-22.004.sql
@@ -1,3 +1,3 @@
-SELECT core.fn_dropifexists('EmailFormats', 'comm', 'TABLE', NULL);
-SELECT core.fn_dropifexists('EmailPrefs', 'comm', 'TABLE', NULL);
-SELECT core.fn_dropifexists('EmailOptions', 'comm', 'TABLE', NULL);
+EXEC core.fn_dropifexists 'EmailFormats', 'comm', 'TABLE', NULL;
+EXEC core.fn_dropifexists 'EmailPrefs', 'comm', 'TABLE', NULL;
+EXEC core.fn_dropifexists 'EmailOptions', 'comm', 'TABLE', NULL;

--- a/announcements/resources/schemas/dbscripts/sqlserver/comm-22.003-22.004.sql
+++ b/announcements/resources/schemas/dbscripts/sqlserver/comm-22.003-22.004.sql
@@ -1,0 +1,3 @@
+SELECT core.fn_dropifexists('EmailFormats', 'comm', 'TABLE', NULL);
+SELECT core.fn_dropifexists('EmailPrefs', 'comm', 'TABLE', NULL);
+SELECT core.fn_dropifexists('EmailOptions', 'comm', 'TABLE', NULL);

--- a/announcements/src/org/labkey/announcements/AnnouncementModule.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementModule.java
@@ -97,7 +97,7 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 22.003;
+        return 22.004;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Three tables in the comm schema should have been deleted but, at least on one deployment, the script didn't run as expected

#### Changes
* Conditionally drop the tables if they exist