### PR TITLE
App logout page redirect back to app when container is an app project subfolder

### DIFF
--- a/core/resources/views/success.html
+++ b/core/resources/views/success.html
@@ -16,6 +16,12 @@
     }
 
     document.getElementById('success-header').innerHTML = header;
+
+    // if logged out of a product and container is not the project, redirect back to app instead of project-start
+    if (product && LABKEY.container.parentPath !== '/') {
+        startHref = LABKEY.ActionURL.buildURL(product.replaceAll(' ', '').toLowerCase(), 'app');
+    }
+
     document.getElementById('success-content').innerHTML = content
         + (LABKEY.user.isGuest ? '<a class="labkey-button primary" href="' + startHref + '">Return to Application</a>' : '');
 </script>


### PR DESCRIPTION
#### Rationale
Since Project subfolders are of folder type Collaboration the project-start redirect doesn't work as it does with the main app folder. This PR fixes that by adding a special case check for this in the success.html to create the URL directly to the app instead of via project-start.

#### Changes
* add check in success.html for app Project subfolder for "Return to Application" button href
