### PR TITLE
Handle update and clarify merge - app UI

### DIFF
--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -158,6 +158,8 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     protected AuditBehaviorType _xmlAuditBehaviorType = null;
     private FieldKey _auditRowPk;
 
+    private boolean _supportMerge;
+
     private final Map<String, CounterDefinition> _counterDefinitionMap = new CaseInsensitiveHashMap<>();    // Really only 1 for now, but could be more in future
 
     @NotNull
@@ -1929,6 +1931,17 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     public boolean hasDeleteURLOverride()
     {
         return _hasDeleteURLOverride;
+    }
+
+    public void setSupportMerge(boolean supportMerge)
+    {
+        _supportMerge = supportMerge;
+    }
+
+    @Override
+    public boolean supportMerge()
+    {
+        return _supportMerge;
     }
 
     public static class TestCase extends Assert{

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -757,4 +757,9 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
     {
         return List.of();
     }
+
+    default boolean supportMerge()
+    {
+        return false;
+    }
 }

--- a/api/src/org/labkey/api/query/QueryUpdateService.java
+++ b/api/src/org/labkey/api/query/QueryUpdateService.java
@@ -47,21 +47,26 @@ public interface QueryUpdateService extends HasPermission
     enum InsertOption
     {
         // interactive/api
-        INSERT(false, false, false, false, false),
-        UPSERT(false, true, false, false, false),  // like merge, but with reselectids
+        INSERT(false, false, false, false, false, false),
+        UPSERT(false, true, false, false, false, false),  // like merge, but with reselectids
 
         // bulk
-        IMPORT(true, false, true, false, false),
+        IMPORT(true, false, true, false, false, false),
         /**
          * Insert or updates a subset of columns.
          * NOTE: Not supported for all tables -- tables with auto-increment primary keys in particular.
          */
-        MERGE(true, true, true, false, false),
+        MERGE(true, true, true, false, false, false),
         /**
          * Like MERGE, but will insert or "re-insert" (NULLs values that are not in the import column set.)
          */
-        REPLACE(true, true, true, true, false),
-        IMPORT_IDENTITY(true, false, true, false, true);
+        REPLACE(true, true, true, true, false, false),
+        IMPORT_IDENTITY(true, false, true, false, true, false),
+
+        /**
+         * Will only update existing rows
+         */
+        UPDATE(true, false, true, false, false, true);
 
         final public boolean batch;
         final public boolean mergeRows;
@@ -69,8 +74,9 @@ public interface QueryUpdateService extends HasPermission
         final public boolean reselectIds;
         final public boolean replace;
         final public boolean identity_insert;
+        final public boolean updateOnly;
 
-        InsertOption(boolean batch, boolean merge, boolean aliases, boolean replace, boolean identity_insert)
+        InsertOption(boolean batch, boolean merge, boolean aliases, boolean replace, boolean identity_insert, boolean updateOnly)
         {
             this.batch = batch;
             mergeRows = merge;
@@ -80,6 +86,7 @@ public interface QueryUpdateService extends HasPermission
             this.replace = replace;
             assert !identity_insert || (batch && !merge);   // identity_insert is only supported for bulk_insert
             this.identity_insert = identity_insert;
+            this.updateOnly = updateOnly;
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -140,6 +140,8 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
         // Filter exp.data to only those rows that are members of the DataClass
         addCondition(new SimpleFilter(FieldKey.fromParts("classId"), _dataClass.getRowId()));
+
+        setSupportMerge(true);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -128,6 +128,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         setPublicSchemaName(ExpSchema.SCHEMA_NAME);
         addAllowablePermission(InsertPermission.class);
         addAllowablePermission(UpdatePermission.class);
+        setSupportMerge(true);
     }
 
     public Set<String> getUniqueIdFields()

--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -325,6 +325,8 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
         }
 
         _defaultVisibleColumns = Collections.unmodifiableList(QueryService.get().getDefaultVisibleColumns(defaultColumnsCandidates));
+
+        setSupportMerge(_list.getKeyType() != ListDefinition.KeyType.AutoIncrementInteger);
     }
 
     @Override

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -72,6 +72,7 @@ import org.labkey.api.security.roles.PlatformDeveloperRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.settings.AdminConsole;
+import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.stats.AnalyticsProviderRegistry;
 import org.labkey.api.stats.SummaryStatisticRegistry;
 import org.labkey.api.util.JspTestCase;
@@ -134,6 +135,8 @@ import java.util.Set;
 
 public class QueryModule extends DefaultModule
 {
+    public static final String ALLOW_IMPORT_WITH_UPDATE = "allowImportUsingUpdateOnly";
+
     public QueryModule()
     {
         QueryService.setInstance(new QueryServiceImpl());
@@ -226,6 +229,9 @@ public class QueryModule extends DefaultModule
         AdminConsole.addExperimentalFeatureFlag(QueryServiceImpl.EXPERIMENTAL_LAST_MODIFIED, "Include Last-Modified header on query metadata requests",
                 "For schema, query, and view metadata requests include a Last-Modified header such that the browser can cache the response. " +
                 "The metadata is invalidated when performing actions such as creating a new List or modifying the columns on a custom view", false);
+        AdminConsole.addExperimentalFeatureFlag(ALLOW_IMPORT_WITH_UPDATE, "Allow importing data using updating only option",
+                "In addition to 'import' or 'merge', allow 'update' option to import and update existing data only.", false);
+
     }
 
 
@@ -400,6 +406,7 @@ public class QueryModule extends DefaultModule
         boolean isProductProjectsEnabled = container != null && container.isProductProjectsEnabled();  // TODO: should these be moved to CoreModule?
         json.put(QueryService.PRODUCT_PROJECTS_ENABLED, container != null && container.isProductProjectsEnabled());
         json.put(QueryService.PRODUCT_PROJECTS_EXIST, isProductProjectsEnabled && container.hasProductProjects());
+        json.put(ALLOW_IMPORT_WITH_UPDATE, ExperimentalFeatureService.get().isFeatureEnabled(ALLOW_IMPORT_WITH_UPDATE));
 
         return json;
     }

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -160,6 +160,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
             throw new NotFoundException("Could not find the specified query in the schema '" + form.getSchemaName() + "'");
 
         resp.put("supportGroupConcatSubSelect", tinfo.getSqlDialect().supportsGroupConcatSubSelect());
+        resp.put("supportMerge", tinfo.supportMerge());
 
         // check if this query is shadowing a local table
         if (isUserDefined)

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -2482,7 +2482,7 @@ public class StudyController extends BaseStudyController
             if (null == PipelineService.get().findPipelineRoot(getContainer()))
                 return new RequirePipelineView(_study, true, errors);
 
-            setShowImportOptions(true);
+            setShowImportOptions(_def.getKeyManagementType() == Dataset.KeyManagementType.None);
             setSuccessMessageSuffix("imported");  //Works for when the merge option is selected (may include updates) vs default "inserted"
             return getDefaultImportView(form, errors);
         }

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -468,6 +468,8 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
         addColumn(datasetId);
 
         addFolderColumn();
+
+        setSupportMerge(true);
     }
 
 

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -469,7 +469,7 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
 
         addFolderColumn();
 
-        setSupportMerge(true);
+        setSupportMerge(getDataset().getKeyManagementType() == Dataset.KeyManagementType.None);
     }
 
 


### PR DESCRIPTION
#### Rationale
Merge has been misrepresented as Update in the product UI for ease of understanding, which causes confusion when users are expecting an update action. This PR modifies the app UI to allow user to Update data from file under an experimental flag. The server side work to support Update from file will be done in a follow up story. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1053
* https://github.com/LabKey/platform/pull/3915
* https://github.com/LabKey/inventory/pull/642
* https://github.com/LabKey/sampleManagement/pull/1457
* https://github.com/LabKey/biologics/pull/1791

#### Changes
* added InsertOption.UPDATE
* added new experimental flag ALLOW_IMPORT_WITH_UPDATE
* added supportMerge to TableInfo to allow showing merge toggle on UI