### PR TITLE
Adjust file watcher jobs adding a timestamp to log file names.

### DIFF
--- a/api/src/org/labkey/api/pipeline/PipelineService.java
+++ b/api/src/org/labkey/api/pipeline/PipelineService.java
@@ -161,6 +161,10 @@ public interface PipelineService extends PipelineStatusFile.StatusReader, Pipeli
     @NotNull
     String startFileAnalysis(AnalyzeForm form, @Nullable Map<String, String> variableMap, ViewBackgroundInfo context) throws IOException, PipelineValidationException;
 
+    @NotNull
+    String startFileAnalysis(AnalyzeForm form, @Nullable Map<String, String> variableMap, ViewBackgroundInfo context, boolean timestampLog) throws IOException, PipelineValidationException;
+
+
     /** Configurations for the pipeline job webpart ButtonBar */
     enum PipelineButtonOption { Minimal, Assay, Standard }
 

--- a/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
+++ b/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
@@ -152,7 +152,7 @@ abstract public class AbstractFileAnalysisJob extends PipelineJob implements Fil
             _baseName = protocol.getBaseName(_filesInput.get(0));
         }
 
-        String logFile = protocol.isFromWatcher() ? FileUtil.makeFileNameWithTimestamp(_baseName) : _baseName;
+        String logFile = protocol.timestampLog() ? FileUtil.makeFileNameWithTimestamp(_baseName) : _baseName;
         setupLocalDirectoryAndJobLog(getPipeRoot(), "FileAnalysis", logFile);
     }
 

--- a/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisProtocol.java
+++ b/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisProtocol.java
@@ -65,7 +65,7 @@ public abstract class AbstractFileAnalysisProtocol<JOB extends AbstractFileAnaly
     protected String xml;
 
     protected String email;
-    protected boolean fromWatcher;
+    protected boolean timestampLog;
 
     public AbstractFileAnalysisProtocol(String name, String description, String xml)
     {
@@ -289,13 +289,13 @@ public abstract class AbstractFileAnalysisProtocol<JOB extends AbstractFileAnaly
         return createPipelineJob(info, root, filesInput.stream().map(Path::toFile).collect(Collectors.toList()), fileParameters.toFile(), variableMap);
     }
 
-    public boolean isFromWatcher()
+    public boolean timestampLog()
     {
-        return fromWatcher;
+        return timestampLog;
     }
 
-    public void setFromWatcher(boolean fromWatcher)
+    public void setTimestampLog(boolean timestampLog)
     {
-        this.fromWatcher = fromWatcher;
+        this.timestampLog = timestampLog;
     }
 }

--- a/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
@@ -850,7 +850,7 @@ public class PipelineServiceImpl implements PipelineService
 
     @Override
     @NotNull
-    public String startFileAnalysis(AnalyzeForm form, @Nullable Map<String, String> variableMap, ViewContext context) throws IOException, PipelineValidationException
+    public String startFileAnalysis(AnalyzeForm form, @Nullable Map<String, String> variableMap, @NotNull ViewContext context) throws IOException, PipelineValidationException
     {
         ViewBackgroundInfo info = new ViewBackgroundInfo(context.getContainer(), context.getUser(), context.getActionURL());
         return startFileAnalysis(form, variableMap, info);
@@ -859,6 +859,13 @@ public class PipelineServiceImpl implements PipelineService
     @Override
     @NotNull
     public String startFileAnalysis(AnalyzeForm form, @Nullable Map<String, String> variableMap, ViewBackgroundInfo context) throws IOException, PipelineValidationException
+    {
+        return startFileAnalysis(form, variableMap, context, false);
+    }
+
+    @Override
+    @NotNull
+    public String startFileAnalysis(AnalyzeForm form, @Nullable Map<String, String> variableMap, ViewBackgroundInfo context, boolean timestampLog) throws IOException, PipelineValidationException
     {
         if (form.getProtocolName() == null)
         {
@@ -979,7 +986,7 @@ public class PipelineServiceImpl implements PipelineService
             variableMap.put("pipelineDescription", pipelineDescription);
         }
 
-        protocol.setFromWatcher(true);
+        protocol.setTimestampLog(timestampLog);
         AbstractFileAnalysisJob job = protocol.createPipelineJob(context, root, filesInputList, fileParameters, variableMap);
         PipelineService.get().queueJob(job);
         return job.getJobGUID();


### PR DESCRIPTION
#### Rationale
Fix [ExpressionMatrixAssayTest.testReferenceFeatureAnnotationSetByName](https://teamcity.labkey.org/viewLog.html?buildId=2161601&buildTypeId=LabKey_2211Release_Community_DailySqlServer&fromSakuraUI=true#testNameId-7836921675753145052) and other tests where the log file is expected to not include a timestamp.

#### Related Pull Requests
* https://github.com/LabKey/premium/pull/355
* Previous change: https://github.com/LabKey/platform/pull/3899

#### Changes
* renamed flag to better reflect purpose
* Added new overload for startFileAnalysis to take new parameter
