### PR TITLE
fix for PIVOT query that does not involve protected columns

### DIFF
--- a/query/src/org/labkey/query/sql/QueryPivot.java
+++ b/query/src/org/labkey/query/sql/QueryPivot.java
@@ -307,6 +307,8 @@ public class QueryPivot extends QueryRelation
                 if (p instanceof QueryService.ParameterDecl)
                     throw new QueryService.NamedParameterNotProvided(((QueryService.ParameterDecl) p).getName());
 
+            // TODO handle the case where hasPhiColumns==true
+            // see https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=38886
             SqlSelector ss;
             if (!hasPhiColumns)
                 ss = new SqlSelector(getSchema().getDbSchema().getScope(), sqlPivotValues, QueryLogging.noValidationNeededQueryLogging());


### PR DESCRIPTION
#### Rationale
Issue 38886
PIVOT does not setup a logging environment for the query used to generate column names.  This fix correctly sets up the "no logging needed" environment when no PHI columns are involved.  The fix to also handle PHI columns will be addressed later.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=38886