### PR TITLE
Don't attempt to include modules that would be excluded

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoaderStartupProperties.java
+++ b/api/src/org/labkey/api/module/ModuleLoaderStartupProperties.java
@@ -33,7 +33,7 @@ public enum ModuleLoaderStartupProperties implements StartupProperty
 
     LinkedList<String> getList()
     {
-        return _list;
+        return new LinkedList<>(_list);
     }
 
     static void populate()
@@ -45,7 +45,7 @@ public enum ModuleLoaderStartupProperties implements StartupProperty
                 map.forEach((sp, cp)-> Arrays.stream(StringUtils.split(cp.getValue(), ","))
                     .map(StringUtils::trimToNull)
                     .filter(Objects::nonNull)
-                    .forEach(sp.getList()::add));
+                    .forEach(sp._list::add));
             }
         });
     }


### PR DESCRIPTION
#### Rationale
We are starting to use startup properties on TeamCity to run test servers with different module sets; generating a list of modules from a specified distribution. Some distributions include modules that aren't tested on TeamCity but we might want to test on that distribution otherwise (e.g. `AssayPortal` in the `panoramaweb` distribution). This change allows us to ignore these missing modules if they are explicitly excluded via the `ModuleLoader.exclude` startup property (otherwise we get an NPE when `ModuleLoader` tries to get the name of the non-existent module).
```
java.lang.NullPointerException: Cannot invoke "org.labkey.api.module.Module.getName()" because "m" is null
	at org.labkey.api.module.ModuleLoader.loadModules(ModuleLoader.java:951) ~[api-23.1-SNAPSHOT.jar:?]
	at org.labkey.api.module.ModuleLoader.doInitWithSourceModule(ModuleLoader.java:291) ~[api-23.1-SNAPSHOT.jar:?]
	at org.labkey.api.module.ModuleLoader.doInit(ModuleLoader.java:483) ~[api-23.1-SNAPSHOT.jar:?]
	at org.labkey.api.module.ModuleLoader.init(ModuleLoader.java:244) ~[api-23.1-SNAPSHOT.jar:?]
```

This change also makes `ModuleLoader.loadModules` log an error/warning in this scenario, instead of throwing the NPE.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/159

#### Changes
* Don't attempt to include modules that would be excluded
* Log a warning/error if 'ModuleLoader.include' references missing modules
* Make `ModuleLoaderStartupProperties.getList()` return a copy of the module list
