### PR TITLE
SQL Server: improve support for unicode characters

### DIFF
--- a/api/src/org/labkey/api/data/dialect/StandardDialectStringHandler.java
+++ b/api/src/org/labkey/api/data/dialect/StandardDialectStringHandler.java
@@ -21,12 +21,10 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.Parameter;
-import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.util.DateUtil;
 
 import java.sql.Array;
-import java.sql.SQLException;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -201,7 +199,7 @@ public class StandardDialectStringHandler implements DialectStringHandler
         }
         else if (value instanceof String strValue)
         {
-            return stringValue(strValue);
+            return quoteStringLiteral(strValue);
         }
         else if (value instanceof Date)
         {
@@ -230,12 +228,6 @@ public class StandardDialectStringHandler implements DialectStringHandler
     private String booleanValue(Boolean value)
     {
         return CoreSchema.getInstance().getSqlDialect().getBooleanLiteral(value);
-    }
-
-
-    protected String stringValue(String value)
-    {
-        return quoteStringLiteral(value);
     }
 
 

--- a/api/src/org/labkey/api/data/dialect/StandardDialectStringHandler.java
+++ b/api/src/org/labkey/api/data/dialect/StandardDialectStringHandler.java
@@ -199,9 +199,9 @@ public class StandardDialectStringHandler implements DialectStringHandler
         {
             return "NULL";
         }
-        else if (value instanceof String)
+        else if (value instanceof String strValue)
         {
-            return quoteStringLiteral((String)value);
+            return stringValue(strValue);
         }
         else if (value instanceof Date)
         {
@@ -230,6 +230,12 @@ public class StandardDialectStringHandler implements DialectStringHandler
     private String booleanValue(Boolean value)
     {
         return CoreSchema.getInstance().getSqlDialect().getBooleanLiteral(value);
+    }
+
+
+    protected String stringValue(String value)
+    {
+        return quoteStringLiteral(value);
     }
 
 

--- a/api/src/org/labkey/api/exp/api/ExpLineageOptions.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineageOptions.java
@@ -17,7 +17,6 @@ package org.labkey.api.exp.api;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.data.SQLFragment;
 
 /**
  * Captures options for doing a lineage search
@@ -170,17 +169,9 @@ public class ExpLineageOptions extends ResolveLsidsForm
         _runProtocolLsid = runProtocolLsid;
     }
 
-    public String getSourceKey()
+    public @Nullable String getSourceKey()
     {
-        return _sourceKey;
-    }
-
-    public @Nullable SQLFragment getSourceKeySQL()
-    {
-        String sourceKey = StringUtils.trimToNull(_sourceKey);
-        if (sourceKey == null)
-            return null;
-        return new SQLFragment("?", sourceKey);
+        return StringUtils.trimToNull(_sourceKey);
     }
 
     public void setSourceKey(String sourceKey)

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2019Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2019Dialect.java
@@ -15,6 +15,13 @@
  */
 package org.labkey.bigiron.mssql;
 
+import org.labkey.api.data.dialect.DialectStringHandler;
+
 public class MicrosoftSqlServer2019Dialect extends MicrosoftSqlServer2017Dialect
 {
+    @Override
+    protected DialectStringHandler createStringHandler()
+    {
+        return new MicrosoftSqlServerStringHandler();
+    }
 }

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerStringHandler.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerStringHandler.java
@@ -1,0 +1,13 @@
+package org.labkey.bigiron.mssql;
+
+import org.labkey.api.data.dialect.StandardDialectStringHandler;
+
+public class MicrosoftSqlServerStringHandler extends StandardDialectStringHandler
+{
+    @Override
+    protected String stringValue(String value)
+    {
+        // Prefix string literals with N to force Unicode
+        return "N" + quoteStringLiteral(value);
+    }
+}

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerStringHandler.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerStringHandler.java
@@ -5,9 +5,9 @@ import org.labkey.api.data.dialect.StandardDialectStringHandler;
 public class MicrosoftSqlServerStringHandler extends StandardDialectStringHandler
 {
     @Override
-    protected String stringValue(String value)
+    public String quoteStringLiteral(String value)
     {
         // Prefix string literals with N to force Unicode
-        return "N" + quoteStringLiteral(value);
+        return "N" + super.quoteStringLiteral(value);
     }
 }

--- a/experiment/src/org/labkey/experiment/api/ExperimentRunGraph2.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExperimentRunGraph2.jsp
@@ -64,7 +64,7 @@
       INNER JOIN $SELF$ _Graph ON _Edges.toObjectId = _Graph.fromObjectId
     WHERE 0 = {fn LOCATE('/' <%=CONCAT%> CAST(_Edges.fromObjectId as VARCHAR(20)) <%=CONCAT%> '/', _Graph.path)}
       AND _Graph.depth >= <%= (-1 * Math.abs(depth)) + 1 %>
-    <% if (bean.getSourceKeySQL() != null) { %>
+    <% if (bean.getSourceKey() != null) { %>
       AND _Edges.sourcekey = $SOURCEKEY$
     <% } %>
   ),
@@ -163,7 +163,7 @@
       INNER JOIN $SELF$ _Graph ON _Edges.fromObjectId = _Graph.toObjectId
     WHERE 0 = {fn LOCATE('/' <%=CONCAT%> CAST(_Edges.toObjectId AS VARCHAR(20)) <%=CONCAT%> '/', _Graph.path)}
       AND _Graph.depth <= <%= depth - 1 %>
-    <% if (bean.getSourceKeySQL() != null) { %>
+    <% if (bean.getSourceKey() != null) { %>
       AND _Edges.sourcekey = $SOURCEKEY$
     <% } %>
   ),

--- a/experiment/src/org/labkey/experiment/api/ExperimentRunGraphForLookup2.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExperimentRunGraphForLookup2.jsp
@@ -87,7 +87,7 @@
       INNER JOIN $SELF$ _Graph ON _Edges.toObjectId = _Graph.fromObjectId
     WHERE 0 = {fn LOCATE('/' <%=CONCAT%> CAST(_Edges.fromObjectId as VARCHAR(20)) <%=CONCAT%> '/', _Graph.path)}
       AND _Graph.depth >= <%= (-1 * Math.abs(depth)) + 1 %>
-    <% if (bean.getSourceKeySQL() != null) { %>
+    <% if (bean.getSourceKey() != null) { %>
       AND _Edges.sourcekey = $SOURCEKEY$
     <% } %>
   ),
@@ -182,7 +182,7 @@ if (bean.isOnlySelectObjectId()) {
       INNER JOIN $SELF$ _Graph ON _Edges.fromObjectId = _Graph.toObjectId
     WHERE 0 = {fn LOCATE('/' <%=CONCAT%> CAST(_Edges.toObjectId as VARCHAR(20)) <%=CONCAT%> '/', _Graph.path)}
       AND _Graph.depth <= <%= depth - 1 %>
-    <% if (bean.getSourceKeySQL() != null) { %>
+    <% if (bean.getSourceKey() != null) { %>
       AND _Edges.sourcekey = $SOURCEKEY$
     <% } %>
   ),

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -2546,6 +2546,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         }
 
         Map<String,String> map = new HashMap<>();
+        SqlDialect dialect = getExpSchema().getSqlDialect();
 
         String[] strs = StringUtils.splitByWholeSeparator(sourceSQL,"/* CTE */");
         for (int i=1 ; i<strs.length ; i++)
@@ -2564,14 +2565,14 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             {
                 select = select.replace("$LSIDS$", lsidsFrag.getRawSQL());
                 if (options.getSourceKeySQL() != null)
-                    select = select.replace("$SOURCEKEY$", "'" + options.getSourceKeySQL().getParams().get(0) + "'");
+                    select = select.replace("$SOURCEKEY$", dialect.getStringHandler().substituteParameters(options.getSourceKeySQL()));
             }
             map.put(name, select);
         }
 
         String edgesToken = null;
 
-        boolean recursive = getExpSchema().getSqlDialect().isPostgreSQL();
+        boolean recursive = dialect.isPostgreSQL();
 
         String parentsToken = null;
         if (options.isParents())

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -2564,8 +2564,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (name.equals("$PARENTS_INNER$") || name.equals("$CHILDREN_INNER$"))
             {
                 select = select.replace("$LSIDS$", lsidsFrag.getRawSQL());
-                if (options.getSourceKeySQL() != null)
-                    select = select.replace("$SOURCEKEY$", dialect.getStringHandler().substituteParameters(options.getSourceKeySQL()));
+                if (options.getSourceKey() != null)
+                    select = select.replace("$SOURCEKEY$", dialect.getStringHandler().quoteStringLiteral(options.getSourceKey()));
             }
             map.put(name, select);
         }

--- a/experiment/src/org/labkey/experiment/api/LineageTest.java
+++ b/experiment/src/org/labkey/experiment/api/LineageTest.java
@@ -702,7 +702,7 @@ public class LineageTest extends ExpProvisionedTableTestHelper
         // Attempt SQL injection #2
         {
             var lineageOptions = new ExpLineageOptions(true, false, 10);
-            lineageOptions.setSourceKey(sourceKey + " OR _Edges.sourcekey = \"SELECT(*\"");
+            lineageOptions.setSourceKey(sourceKey + " OR _Edges.sourcekey = 'SELECT(*'");
             var lineage = expSvc.getLineage(c, user, ee.identifiable, lineageOptions);
             assertEquals("Unexpected number of objects from SQL injection #2", 0, lineage.getObjects().size());
         }

--- a/visualization/src/org/labkey/visualization/sql/VisualizationCDSGenerator.java
+++ b/visualization/src/org/labkey/visualization/sql/VisualizationCDSGenerator.java
@@ -30,7 +30,6 @@ import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.Results;
 import org.labkey.api.data.ResultsImpl;
 import org.labkey.api.data.Sort;
-import org.labkey.api.data.dialect.DialectStringHandler;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorContext;
@@ -449,6 +448,9 @@ public class VisualizationCDSGenerator
             fullSQL.append(defaultString(sequenceColumnAlias, "CAST(NULL AS NUMERIC(15,4))")).append(" AS \"").append(selectAliasPrefix).append(sequenceNumColumnName).append("\"").append(", ");
 
             // dataset (or axis) name column
+            // CONSIDER: This should be aliased rather than the string quoted name. Example:
+            // Instead of: 'x' AS "http://cpas.labkey.com/Study#Dataset"
+            // Should be: vis_junit_flow_x AS "http://cpas.labkey.com/Study#Dataset"
             fullSQL.append(string_quote(datasetTables[i].getName())).append(" AS \"").append(selectAliasPrefix).append(datasetTableColumnName).append("\"");
 
             for (Map.Entry<String,JdbcType> entry : unionAliasList.entrySet())
@@ -503,13 +505,9 @@ public class VisualizationCDSGenerator
         return colAlias;
     }
 
-    DialectStringHandler sh = null;
-
     private String string_quote(String s)
     {
-        if (null == sh)
-            sh = getPrimarySchema().getDbSchema().getSqlDialect().getStringHandler();
-        return sh.quoteStringLiteral(s);
+        return "'" + StringUtils.replace(s, "'", "''") + "'";
     }
 
 


### PR DESCRIPTION
#### Rationale
This adds support for unicode characters for SQL Server by prefixing string literals `N'string'`.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3890

#### Changes
* Override `quoteStringLiteral()` with new implementation `MicrosoftSqlServerStringHandler` to prefix string literals.
* Utilize `dialect.getStringHandler().quoteStringLiteral()` to process "sourceKey" filter parameter in experiment lineage.
* Remove use of `SQLFragment` in "sourceKey" processing.
