### PR TITLE
Issue 46939: Naming Patterns for Mixture Batches Not Working in SubProjects

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -866,7 +866,15 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 //              TODO check if this covers all the functionality, in particular how is alternateKeyCandidates used?
                 di = LoggingDataIterator.wrap(new CoerceDataIterator(di, context, ExpDataClassDataTableImpl.this, false));
 
-                di = LoggingDataIterator.wrap(new NameExpressionDataIterator(di, context, ExpDataClassDataTableImpl.this, getContainer(), _dataClass.getMaxDataCounterFunction(), DATA_COUNTER_SEQ_PREFIX + _dataClass.getRowId() + "-")
+                TableInfo dataClassTInfo = ExpDataClassDataTableImpl.this;
+                if (c.hasProductProjects() && !c.isProject())
+                {
+                    User user = getUserSchema().getUser();
+                    ContainerFilter cf = new ContainerFilter.CurrentPlusProjectAndShared(c, user); // use lookup CF
+                    dataClassTInfo = QueryService.get().getUserSchema(user, c, "exp.data").getTable(getName(), cf);
+                }
+
+                di = LoggingDataIterator.wrap(new NameExpressionDataIterator(di, context, dataClassTInfo, getContainer(), _dataClass.getMaxDataCounterFunction(), DATA_COUNTER_SEQ_PREFIX + _dataClass.getRowId() + "-")
                         .setAllowUserSpecifiedNames(NameExpressionOptionService.get().allowUserSpecifiedNames(getContainer()))
                         .addExtraPropsFn(() -> {
                             if (c != null)

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -416,7 +416,7 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
 
         if (dataContainer != null && dataContainer.hasProductProjects())
         {
-            // get samples table using CF relative to sampleTypeContainer
+            // get samples table using CF relative to sampleTypeContainer since sampleTypeContainer is used to get UserSchema
             if (sampleTypeContainer.isProject())
                 cf = new ContainerFilter.CurrentAndSubfoldersPlusShared(sampleTypeContainer, user);
             else if (!sampleTypeContainer.isProject() && sampleTypeContainer.getProject() != null)

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -559,7 +559,7 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
                     map.put(NameExpressionOptionService.FOLDER_PREFIX_TOKEN, StringUtils.trimToEmpty(NameExpressionOptionService.get().getExpressionPrefix(container)));
                 return map;
             };
-            return nameGen.generateName(state, rowMap, parentDatas, parentSamples, List.of(extraPropsFn)); // how to get here?
+            return nameGen.generateName(state, rowMap, parentDatas, parentSamples, List.of(extraPropsFn));
         }
         catch (NameGenerator.NameGenerationException e)
         {

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -396,7 +396,7 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
     }
 
     @NotNull
-    private NameGenerator createNameGenerator(@NotNull String expr, Container dataContainer)
+    private NameGenerator createNameGenerator(@NotNull String expr, @Nullable Container dataContainer)
     {
         Map<String, String> importAliasMap = null;
         try
@@ -415,15 +415,9 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
         ContainerFilter cf = null;
 
         if (dataContainer != null && dataContainer.hasProductProjects())
-        {
-            // get samples table using CF relative to sampleTypeContainer since sampleTypeContainer is used to get UserSchema
-            if (sampleTypeContainer.isProject())
-                cf = new ContainerFilter.CurrentAndSubfoldersPlusShared(sampleTypeContainer, user);
-            else if (!sampleTypeContainer.isProject() && sampleTypeContainer.getProject() != null)
-                cf = new ContainerFilter.CurrentPlusProjectAndShared(sampleTypeContainer, user);
-        }
+            cf = new ContainerFilter.CurrentPlusProjectAndShared(dataContainer, user); // use lookup CF
 
-        TableInfo parentTable = QueryService.get().getUserSchema(user, sampleTypeContainer, SamplesSchema.SCHEMA_NAME).getTable(getName(), cf);
+        TableInfo parentTable = QueryService.get().getUserSchema(user, nameGenContainer, SamplesSchema.SCHEMA_NAME).getTable(getName(), cf);
 
         return new NameGenerator(expr, parentTable, true, importAliasMap, nameGenContainer, getMaxSampleCounterFunction(), SAMPLE_COUNTER_SEQ_PREFIX + getRowId() + "-");
     }


### PR DESCRIPTION
#### Rationale
NameGenerator uses parentTable tableInfo for getting lookup column's LookupTableInfo. In a multi projects setup, we allow looking up to self + home.  This PR would allow name generator to also use lookup values from self + home.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* use CF for the samples and dataclass TableInfo that's used by NameGenerator
