### PR TITLE
Throwing unknown startup property exceptions is too aggressive

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -2195,7 +2195,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
                 .map(entry -> entry.getScope() + "." + entry.getName() + ": " + entry.getValue()).toList();
 
             if (!unknown.isEmpty())
-                throw new IllegalArgumentException("Unknown startup propert" + (unknown.size() == 1 ? "y: " : "ies: ") + unknown);
+                _log.info("Unknown startup propert" + (unknown.size() == 1 ? "y: " : "ies: ") + unknown);
 
             // Failing this check indicates a coding issue, so execute it only when assertions are on
             assert checkPropertyScopeMapping();

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -6349,7 +6349,7 @@ public class QueryController extends SpringActionController
             boolean canEdit = qdef.canEdit(getUser());
             qinfo.put("canEdit", canEdit);
             qinfo.put("canEditSharedViews", getContainer().hasPermission(getUser(), EditSharedViewPermission.class));
-            // CONSIDER: do we want to separate the 'canEditMetadata' property and 'isMetadataOverridable' properties to differentiate between cabability and the permission check?
+            // CONSIDER: do we want to separate the 'canEditMetadata' property and 'isMetadataOverridable' properties to differentiate between capability and the permission check?
             qinfo.put("isMetadataOverrideable", qdef.isMetadataEditable() && qdef.canEditMetadata(getUser()));
 
             if (isUserDefined)


### PR DESCRIPTION
#### Rationale
Be nicer.

In the related PR, we switched to throwing `IllegalArgumentException` if an unknown startup property was encountered. Unfortunately, the startup property files are not customized to each distribution. For example, distributions without the Search module will fail to start because the `SearchSettings` properties will be present.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3866

#### Changes
* Switch to INFO-level logging
* Unrelated spelling correction
