### PR TITLE
Rework DialectStringHandler. Warn about substituteParameters().

### DIFF
--- a/api/src/org/labkey/api/data/Filter.java
+++ b/api/src/org/labkey/api/data/Filter.java
@@ -37,7 +37,7 @@ public interface Filter
 
     /**
      * @return the SQL fragment with the parameter values substituted in. Suitable for using as a key in a cache,
-     * or pasting into an external SQL tool.
+     * logging, debugging, or pasting into an external SQL tool. Not guaranteed to be valid or safe SQL!
      */
     String toSQLString(SqlDialect dialect);
 

--- a/api/src/org/labkey/api/data/InlineInClauseGenerator.java
+++ b/api/src/org/labkey/api/data/InlineInClauseGenerator.java
@@ -104,7 +104,7 @@ public class InlineInClauseGenerator implements InClauseGenerator
             _dialect = mockery.mock(SqlDialect.class);
             mockery.checking(new Expectations() {{
                 allowing(_dialect).getStringHandler();
-                will(returnValue(new StandardDialectStringHandler()));
+                will(returnValue(new StandardDialectStringHandler(_dialect)));
             }});
         }
 

--- a/api/src/org/labkey/api/data/InlineInClauseGenerator.java
+++ b/api/src/org/labkey/api/data/InlineInClauseGenerator.java
@@ -104,7 +104,7 @@ public class InlineInClauseGenerator implements InClauseGenerator
             _dialect = mockery.mock(SqlDialect.class);
             mockery.checking(new Expectations() {{
                 allowing(_dialect).getStringHandler();
-                will(returnValue(new StandardDialectStringHandler(_dialect)));
+                will(returnValue(new StandardDialectStringHandler()));
             }});
         }
 

--- a/api/src/org/labkey/api/data/SimpleFilter.java
+++ b/api/src/org/labkey/api/data/SimpleFilter.java
@@ -1651,7 +1651,7 @@ public class SimpleFilter implements Filter
     {
         protected void test(String expectedSQL, String description, FilterClause clause, SqlDialect dialect)
         {
-            assertEquals("Generated SQL did not match", expectedSQL, clause.toSQLFragment(Collections.emptyMap(), dialect).toDebugString());
+            assertEquals("Generated SQL did not match", expectedSQL, SQLFragment.filterDebugString(clause.toSQLFragment(Collections.emptyMap(), dialect).toDebugString()));
             StringBuilder sb = new StringBuilder();
             clause.appendFilterText(sb, new ColumnNameFormatter());
             assertEquals("Description did not match", description, sb.toString());

--- a/api/src/org/labkey/api/data/dialect/DialectStringHandler.java
+++ b/api/src/org/labkey/api/data/dialect/DialectStringHandler.java
@@ -29,6 +29,8 @@ public interface DialectStringHandler
 {
     String quoteStringLiteral(String str);
 
+    String booleanValue(Boolean value);
+
     /**
      * @return the SQL fragment with parameter values substituted in. Suitable for use as a key in a cache, logging,
      * debugging, or pasting into an external SQL tool. Not guaranteed to be valid or safe SQL!

--- a/api/src/org/labkey/api/data/dialect/DialectStringHandler.java
+++ b/api/src/org/labkey/api/data/dialect/DialectStringHandler.java
@@ -27,6 +27,11 @@ import org.labkey.api.data.SQLFragment;
 // Methods for escaping and parsing SQL identifiers and string literals, based on a particular database's rules.
 public interface DialectStringHandler
 {
-    public String quoteStringLiteral(String str);
-    public String substituteParameters(SQLFragment frag);
+    String quoteStringLiteral(String str);
+
+    /**
+     * @return the SQL fragment with parameter values substituted in. Suitable for use as a key in a cache, logging,
+     * debugging, or pasting into an external SQL tool. Not guaranteed to be valid or safe SQL!
+     */
+    String substituteParameters(SQLFragment frag);
 }

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -558,12 +558,6 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     }
 
     @Override
-    public String getBooleanLiteral(boolean b)
-    {
-        return Boolean.toString(b);
-    }
-
-    @Override
     public String getBinaryDataType()
     {
         return "BYTEA";

--- a/api/src/org/labkey/api/data/dialect/SimpleSqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SimpleSqlDialect.java
@@ -136,12 +136,6 @@ public abstract class SimpleSqlDialect extends SqlDialect
     }
 
     @Override
-    public String getBooleanLiteral(boolean b)
-    {
-        throw new UnsupportedOperationException(getClass().getSimpleName() + " does not implement");
-    }
-
-    @Override
     public String getSqlTypeName(PropertyStorageSpec prop)
     {
         if (prop.isAutoIncrement())

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -431,7 +431,7 @@ public abstract class SqlDialect
     // Called once when new scope is being prepared
     protected DialectStringHandler createStringHandler()
     {
-        return new StandardDialectStringHandler(this);
+        return new StandardDialectStringHandler();
     }
 
     public DialectStringHandler getStringHandler()
@@ -455,7 +455,7 @@ public abstract class SqlDialect
         return keywordSet;
     }
 
-    // Human readable product version number. Pass through by default; dialects should override this if they can provide
+    // Human-readable product version number. Pass through by default; dialects should override this if they can provide
     // more useful product version information than what's returned from DatabaseMetaData.getDatabaseProductVersion().
     public @Nullable String getProductVersion(String dbmdProductVersion)
     {
@@ -1040,7 +1040,10 @@ public abstract class SqlDialect
         return "CAST(0 AS " + getBooleanDataType() + ")";
     }
 
-    public abstract String getBooleanLiteral(boolean b);
+    public final String getBooleanLiteral(boolean b)
+    {
+        return getStringHandler().booleanValue(b);
+    }
 
     public abstract String getBinaryDataType();
 

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -431,7 +431,7 @@ public abstract class SqlDialect
     // Called once when new scope is being prepared
     protected DialectStringHandler createStringHandler()
     {
-        return new StandardDialectStringHandler();
+        return new StandardDialectStringHandler(this);
     }
 
     public DialectStringHandler getStringHandler()
@@ -1119,7 +1119,8 @@ public abstract class SqlDialect
     {
     }
 
-    // Substitute the parameter values into the SQL statement.
+    // Substitute parameter values into the SQL statement. Use for logging and debugging. Returned string is not
+    // guaranteed to be valid or safe SQL!
     public String substituteParameters(SQLFragment frag)
     {
         return _stringHandler.substituteParameters(frag);

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -98,8 +98,8 @@ public abstract class SqlDialect
         initializeJdbcTableTypeMap(_tableTypeMap);
         Set<String> types = _tableTypeMap.keySet();
         _tableTypes = types.toArray(new String[0]);
-
         _reservedWordSet = getReservedWords();
+        _stringHandler = createStringHandler();
 
         MemTracker.getInstance().put(this);
     }
@@ -417,16 +417,9 @@ public abstract class SqlDialect
     // during bootstrap or upgrade.
     public void prepare(DbScope scope)
     {
-        initialize();
     }
 
     public abstract void prepareConnection(Connection conn) throws SQLException;
-
-    // Post construction initialization that doesn't require a scope
-    void initialize()
-    {
-        _stringHandler = createStringHandler();
-    }
 
     // Called once when new scope is being prepared
     protected DialectStringHandler createStringHandler()
@@ -733,7 +726,7 @@ public abstract class SqlDialect
         return "";
     }
 
-    private Set<String> systemTableSet = Sets.newCaseInsensitiveHashSet(new CsvSet(getSystemTableNames()));
+    private final Set<String> systemTableSet = Sets.newCaseInsensitiveHashSet(new CsvSet(getSystemTableNames()));
 
     public boolean isSystemTable(String tableName)
     {

--- a/api/src/org/labkey/api/data/dialect/SqlDialectFactory.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialectFactory.java
@@ -39,13 +39,8 @@ public interface SqlDialectFactory
 
     // These tests must be safe to invoke when LabKey Server can't connect to any data sources matching the dialect and
     // even when the JDBC driver isn't present.
-    Collection<? extends Class> getJUnitTests();
+    Collection<? extends Class<?>> getJUnitTests();
 
     // Caller must invoke initialize() on the dialects.
     Collection<? extends SqlDialect> getDialectsToTest();
-
-    // Do not call; this is a complete no-op! Left in place to keep Synonym module building for now. TODO: Remove
-    default void setTableResolver(TableResolver tableResolver)
-    {
-    }
 }

--- a/api/src/org/labkey/api/data/dialect/SqlDialectManager.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialectManager.java
@@ -21,9 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /*
 * User: adam
@@ -75,31 +73,16 @@ public class SqlDialectManager
 
     public static Collection<? extends Class> getAllJUnitTests()
     {
-        Set<Class> classes = new HashSet<>();
-
-        for (SqlDialectFactory factory : FACTORIES)
-            classes.addAll(factory.getJUnitTests());
-
-        return classes;
+        return FACTORIES.stream()
+            .flatMap(sqlDialectFactory -> sqlDialectFactory.getJUnitTests().stream())
+            .toList();
     }
-
 
     // Returns instances of all dialect implementations for testing purposes
     public static Collection<? extends SqlDialect> getAllDialectsToTest()
     {
-        Set<SqlDialect> dialects = new HashSet<>();
-
-        for (SqlDialectFactory factory : FACTORIES)
-        {
-            for (SqlDialect dialect : factory.getDialectsToTest())
-            {
-                // Must initialize all dialects before using; most convenient to do it here instead of forcing each
-                // dialect to do this
-                dialect.initialize();
-                dialects.add(dialect);
-            }
-        }
-
-        return dialects;
+        return FACTORIES.stream()
+            .flatMap(sqlDialectFactory -> sqlDialectFactory.getDialectsToTest().stream())
+            .toList();
     }
 }

--- a/api/src/org/labkey/api/data/dialect/SqlDialectManager.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialectManager.java
@@ -71,7 +71,7 @@ public class SqlDialectManager
     }
 
 
-    public static Collection<? extends Class> getAllJUnitTests()
+    public static Collection<? extends Class<?>> getAllJUnitTests()
     {
         return FACTORIES.stream()
             .flatMap(sqlDialectFactory -> sqlDialectFactory.getJUnitTests().stream())

--- a/api/src/org/labkey/api/data/dialect/StandardDialectStringHandler.java
+++ b/api/src/org/labkey/api/data/dialect/StandardDialectStringHandler.java
@@ -19,7 +19,7 @@ package org.labkey.api.data.dialect;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
-import org.labkey.api.data.CoreSchema;
+import org.labkey.api.data.DbScope;
 import org.labkey.api.data.Parameter;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.util.DateUtil;
@@ -36,6 +36,13 @@ import java.util.List;
 */
 public class StandardDialectStringHandler implements DialectStringHandler
 {
+    private final SqlDialect _dialect;
+
+    public StandardDialectStringHandler(SqlDialect dialect)
+    {
+        _dialect = dialect;
+    }
+
     @Override
     public String quoteStringLiteral(String str)
     {
@@ -44,13 +51,12 @@ public class StandardDialectStringHandler implements DialectStringHandler
 
 
     @Override
-    // Substitute the parameters into the SQL string, following the rules for quoted identifiers, string literals, comments, etc.
-
-    // Previously, we used regular expressions to find (and ignore) string literals and quoted identifiers while doing
-    // parameter substitution, but the first attempt exploded with long string literals (#12866) and the second attempt
-    // occasionally failed to return. So, we wrote this dumb little parser instead.
     public String substituteParameters(SQLFragment frag)
     {
+        // Substitute the parameters into the SQL string, following the rules for quoted identifiers, string literals,
+        // comments, etc. Previously, we used regular expressions to find (and ignore) string literals and quoted
+        // identifiers while doing parameter substitution, but the first attempt exploded with long string literals
+        // (#12866) and the second attempt occasionally failed to return. So, we wrote this dumb little parser instead.
         String sql = frag.getSQL();
         StringBuilder ret = new StringBuilder();
         List<Object> params = new LinkedList<>(frag.getParams());
@@ -62,9 +68,10 @@ public class StandardDialectStringHandler implements DialectStringHandler
         {
             char c = sql.charAt(current);
 
-            switch(c)
+            switch (c)
             {
-                case('?'):
+                case ('?') ->
+                {
                     ret.append(sql.subSequence(begin, current));
                     if (params.isEmpty())
                         ret.append("NULL /*?missing?*/");
@@ -72,21 +79,12 @@ public class StandardDialectStringHandler implements DialectStringHandler
                         ret.append(formatParameter(params.remove(0)));
                     current++;
                     begin = current;
-                    break;
-                case('\''):
-                    current = findEndOfStringLiteral(sql, current + 1);
-                    break;
-                case('"'):
-                    current = findEndOfQuotedIdentifier(sql, current + 1);
-                    break;
-                case('/'):
-                    current = findEndOfBlockComment(sql, current + 1);
-                    break;
-                case('-'):
-                    current = findEndOfLineComment(sql, current + 1);
-                    break;
-                default:
-                    current++;
+                }
+                case ('\'') -> current = findEndOfStringLiteral(sql, current + 1);
+                case ('"') -> current = findEndOfQuotedIdentifier(sql, current + 1);
+                case ('/') -> current = findEndOfBlockComment(sql, current + 1);
+                case ('-') -> current = findEndOfLineComment(sql, current + 1);
+                default -> current++;
             }
         }
 
@@ -136,25 +134,27 @@ public class StandardDialectStringHandler implements DialectStringHandler
         {
             char c = sql.charAt(current++);
 
-            switch(prev)
+            switch (prev)
             {
-                case firstSlash:
+                case firstSlash ->
+                {
                     if (c == '*')
                         prev = Previous.somethingElse;
                     else
                         return --current;  // Not a comment after all, back it up so we don't lose this character
-                    break;
-                case star:
+                }
+                case star ->
+                {
                     if (c == '/')
                         return current;   // End of comment... we're done
-
                     prev = Previous.somethingElse;
                     current--;  // Not the end of comment, back it up so we don't lose this character
-                    break;
-                case somethingElse:
+                }
+                case somethingElse ->
+                {
                     if (c == '*')
                         prev = Previous.star;
-                    break;
+                }
             }
         }
 
@@ -224,10 +224,9 @@ public class StandardDialectStringHandler implements DialectStringHandler
     }
 
 
-    // TODO: This is wrong -- SQL could run against any database (not just core).  Need to pass in dialect.
     private String booleanValue(Boolean value)
     {
-        return CoreSchema.getInstance().getSqlDialect().getBooleanLiteral(value);
+        return _dialect.getBooleanLiteral(value);
     }
 
 
@@ -237,7 +236,7 @@ public class StandardDialectStringHandler implements DialectStringHandler
         @Test
         public void testSqlParserMethods()
         {
-            StandardDialectStringHandler handler = new StandardDialectStringHandler();
+            StandardDialectStringHandler handler = new StandardDialectStringHandler(DbScope.getLabKeyScope().getSqlDialect());
             assertEquals(14, handler.findEndOfStringLiteral("'foo bar blick", 1));      // Non-terminated should be end of string
             assertEquals(15, handler.findEndOfStringLiteral("'foo bar blick'", 1));     // Terminated at end of string should be end of string
             assertEquals(15, handler.findEndOfStringLiteral("'foo bar blick''", 1));    // Terminated should be at character after ending quote

--- a/api/src/org/labkey/api/data/dialect/StandardDialectStringHandler.java
+++ b/api/src/org/labkey/api/data/dialect/StandardDialectStringHandler.java
@@ -19,7 +19,6 @@ package org.labkey.api.data.dialect;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
-import org.labkey.api.data.DbScope;
 import org.labkey.api.data.Parameter;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.util.DateUtil;
@@ -36,13 +35,6 @@ import java.util.List;
 */
 public class StandardDialectStringHandler implements DialectStringHandler
 {
-    private final SqlDialect _dialect;
-
-    public StandardDialectStringHandler(SqlDialect dialect)
-    {
-        _dialect = dialect;
-    }
-
     @Override
     public String quoteStringLiteral(String str)
     {
@@ -223,12 +215,11 @@ public class StandardDialectStringHandler implements DialectStringHandler
         }
     }
 
-
-    private String booleanValue(Boolean value)
+    @Override
+    public String booleanValue(Boolean value)
     {
-        return _dialect.getBooleanLiteral(value);
+        return Boolean.toString(value); // Most dialects support true/false
     }
-
 
     // ParameterSubstitutionTest tests the full substitution process; this tests edge conditions in the parser.
     public static class TestCase extends Assert
@@ -236,7 +227,7 @@ public class StandardDialectStringHandler implements DialectStringHandler
         @Test
         public void testSqlParserMethods()
         {
-            StandardDialectStringHandler handler = new StandardDialectStringHandler(DbScope.getLabKeyScope().getSqlDialect());
+            StandardDialectStringHandler handler = new StandardDialectStringHandler();
             assertEquals(14, handler.findEndOfStringLiteral("'foo bar blick", 1));      // Non-terminated should be end of string
             assertEquals(15, handler.findEndOfStringLiteral("'foo bar blick'", 1));     // Terminated at end of string should be end of string
             assertEquals(15, handler.findEndOfStringLiteral("'foo bar blick''", 1));    // Terminated should be at character after ending quote

--- a/api/src/org/labkey/api/util/JdbcUtil.java
+++ b/api/src/org/labkey/api/util/JdbcUtil.java
@@ -17,6 +17,7 @@
 package org.labkey.api.util;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.dialect.DialectStringHandler;
 import org.labkey.api.data.dialect.SqlDialect;
@@ -38,11 +39,11 @@ public final class JdbcUtil
     }
 
 
-    // Not recommended -- without a dialect, we use SQL standard parsing of identifiers and string literals...
-    // which might not be correct for the incoming SQL.
+    // Not recommended -- this uses the LabKey scope to dictate parsing of identifiers and string literals... which
+    // might not be correct for the incoming SQL.
     public static String format(SQLFragment fragment)
     {
-        return format(fragment, new StandardDialectStringHandler());
+        return format(fragment, DbScope.getLabKeyScope().getSqlDialect().getStringHandler());
     }
 
 

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -28,6 +28,7 @@ import org.labkey.api.collections.Sets;
 import org.labkey.api.data.*;
 import org.labkey.api.data.bigiron.ClrAssemblyManager;
 import org.labkey.api.data.dialect.ColumnMetaDataReader;
+import org.labkey.api.data.dialect.DialectStringHandler;
 import org.labkey.api.data.dialect.JdbcHelper;
 import org.labkey.api.data.dialect.LimitRowsSqlGenerator;
 import org.labkey.api.data.dialect.PkMetaDataReader;
@@ -2415,5 +2416,11 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
         }
 
         return rds;
+    }
+
+    @Override
+    protected DialectStringHandler createStringHandler()
+    {
+        return new MicrosoftSqlServerStringHandler(this);
     }
 }

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -931,12 +931,6 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     }
 
     @Override
-    public String getBooleanLiteral(boolean b)
-    {
-        return b ? "1" : "0";
-    }
-
-    @Override
     public String getBinaryDataType()
     {
         return "IMAGE";
@@ -2421,6 +2415,6 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     @Override
     protected DialectStringHandler createStringHandler()
     {
-        return new MicrosoftSqlServerStringHandler(this);
+        return new MicrosoftSqlServerStringHandler();
     }
 }

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2019Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2019Dialect.java
@@ -22,6 +22,6 @@ public class MicrosoftSqlServer2019Dialect extends MicrosoftSqlServer2017Dialect
     @Override
     protected DialectStringHandler createStringHandler()
     {
-        return new MicrosoftSqlServerStringHandler();
+        return new MicrosoftSqlServerStringHandler(this);
     }
 }

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2019Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2019Dialect.java
@@ -15,13 +15,6 @@
  */
 package org.labkey.bigiron.mssql;
 
-import org.labkey.api.data.dialect.DialectStringHandler;
-
 public class MicrosoftSqlServer2019Dialect extends MicrosoftSqlServer2017Dialect
 {
-    @Override
-    protected DialectStringHandler createStringHandler()
-    {
-        return new MicrosoftSqlServerStringHandler(this);
-    }
 }

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerStringHandler.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerStringHandler.java
@@ -1,9 +1,15 @@
 package org.labkey.bigiron.mssql;
 
+import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.dialect.StandardDialectStringHandler;
 
 public class MicrosoftSqlServerStringHandler extends StandardDialectStringHandler
 {
+    public MicrosoftSqlServerStringHandler(SqlDialect dialect)
+    {
+        super(dialect);
+    }
+
     @Override
     public String quoteStringLiteral(String value)
     {

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerStringHandler.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerStringHandler.java
@@ -1,19 +1,19 @@
 package org.labkey.bigiron.mssql;
 
-import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.dialect.StandardDialectStringHandler;
 
 public class MicrosoftSqlServerStringHandler extends StandardDialectStringHandler
 {
-    public MicrosoftSqlServerStringHandler(SqlDialect dialect)
-    {
-        super(dialect);
-    }
-
     @Override
     public String quoteStringLiteral(String value)
     {
         // Prefix string literals with N to force Unicode
         return "N" + super.quoteStringLiteral(value);
+    }
+
+    @Override
+    public String booleanValue(Boolean value)
+    {
+        return value ? "1" : "0";
     }
 }

--- a/bigiron/src/org/labkey/bigiron/mysql/MySqlDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySqlDialectFactory.java
@@ -117,7 +117,7 @@ public class MySqlDialectFactory implements SqlDialectFactory
     }
 
     @Override
-    public Collection<? extends Class> getJUnitTests()
+    public Collection<? extends Class<?>> getJUnitTests()
     {
         return Collections.emptyList();
     }

--- a/bigiron/src/org/labkey/bigiron/oracle/OracleDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/oracle/OracleDialectFactory.java
@@ -118,7 +118,7 @@ public class OracleDialectFactory implements SqlDialectFactory
     }
 
     @Override
-    public Collection<? extends Class> getJUnitTests()
+    public Collection<? extends Class<?>> getJUnitTests()
     {
         return Arrays.asList(JdbcHelperTestCase.class, DialectRetrievalTestCase.class);
     }

--- a/bigiron/src/org/labkey/bigiron/sas/SasDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/sas/SasDialectFactory.java
@@ -65,7 +65,7 @@ public class SasDialectFactory implements SqlDialectFactory
     }
 
     @Override
-    public Collection<? extends Class> getJUnitTests()
+    public Collection<? extends Class<?>> getJUnitTests()
     {
         return Collections.emptyList();
     }

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -129,7 +129,6 @@ import org.labkey.api.security.WikiTermsOfUseProvider;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.QCAnalystPermission;
 import org.labkey.api.security.roles.CanSeeAuditLogRole;
-import org.labkey.api.security.roles.EditorRole;
 import org.labkey.api.security.roles.NoPermissionsRole;
 import org.labkey.api.security.roles.PlatformDeveloperRole;
 import org.labkey.api.security.roles.ReaderRole;

--- a/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
@@ -73,7 +73,7 @@ abstract class PostgreSql92Dialect extends PostgreSql91Dialect
         if (getStandardConformingStrings())
             return super.createStringHandler();
         else
-            return new PostgreSqlNonConformingStringHandler();
+            return new PostgreSqlNonConformingStringHandler(this);
     }
 
     @Override

--- a/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
@@ -92,7 +92,7 @@ abstract class PostgreSql92Dialect extends PostgreSql91Dialect
 
         List<String> warnings = new LinkedList<>();
 
-        // Split statements by semi-colon and CRLF
+        // Split statements by semicolon and CRLF
         for (String statement : noComments.split(";[\\n\\r]+"))
         {
             if (StringUtils.startsWithIgnoreCase(statement.trim(), "SET "))

--- a/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
@@ -73,7 +73,7 @@ abstract class PostgreSql92Dialect extends PostgreSql91Dialect
         if (getStandardConformingStrings())
             return super.createStringHandler();
         else
-            return new PostgreSqlNonConformingStringHandler(this);
+            return new PostgreSqlNonConformingStringHandler();
     }
 
     @Override

--- a/core/src/org/labkey/core/dialect/PostgreSqlNonConformingStringHandler.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlNonConformingStringHandler.java
@@ -17,6 +17,7 @@
 package org.labkey.core.dialect;
 
 import org.apache.commons.lang3.StringUtils;
+import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.dialect.StandardDialectStringHandler;
 
 /*
@@ -28,6 +29,11 @@ import org.labkey.api.data.dialect.StandardDialectStringHandler;
 // Adds support for backslash escaping in string literals
 public class PostgreSqlNonConformingStringHandler extends StandardDialectStringHandler
 {
+    public PostgreSqlNonConformingStringHandler(SqlDialect dialect)
+    {
+        super(dialect);
+    }
+
     // TODO: I don't think this is necessary... non-conforming strings and backslash_quote settings still allow '' for quote escaping;
     // they don't require \'
     @Override

--- a/core/src/org/labkey/core/dialect/PostgreSqlNonConformingStringHandler.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlNonConformingStringHandler.java
@@ -17,7 +17,6 @@
 package org.labkey.core.dialect;
 
 import org.apache.commons.lang3.StringUtils;
-import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.dialect.StandardDialectStringHandler;
 
 /*
@@ -29,11 +28,6 @@ import org.labkey.api.data.dialect.StandardDialectStringHandler;
 // Adds support for backslash escaping in string literals
 public class PostgreSqlNonConformingStringHandler extends StandardDialectStringHandler
 {
-    public PostgreSqlNonConformingStringHandler(SqlDialect dialect)
-    {
-        super(dialect);
-    }
-
     // TODO: I don't think this is necessary... non-conforming strings and backslash_quote settings still allow '' for quote escaping;
     // they don't require \'
     @Override


### PR DESCRIPTION
#### Rationale
Add `booleanLiteral()` to `DialectStringHandler` interface and implementations to give us dialect-correct substitution SQL. Make `SqlDialect` delegate to DialectStringHandler for boolean literals. Eliminate pointless `SqlDialect.initialize()`... just put this code in the constructor.

Move `MicrosoftSqlServerStringHandler` to `BaseMicrosoftSqlServerDialect.java` since it's appropriate for all supported versions of SQL Server. Fix up junit tests to tolerate SQL Server-specific substitution SQL.

`substituteParameters()` isn't appropriate for production SQL, so document as such.