### PR TITLE
Issue 46962: Update size of containeralias path field 

### DIFF
--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 22.006
+SchemaVersion: 22.007
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/core-22.006-22.007.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-22.006-22.007.sql
@@ -1,0 +1,1 @@
+ALTER TABLE core.containeraliases ALTER COLUMN path TYPE VARCHAR(4000);

--- a/core/resources/schemas/dbscripts/sqlserver/core-22.006-22.007.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-22.006-22.007.sql
@@ -1,0 +1,1 @@
+ALTER TABLE core.containeraliases ALTER COLUMN path NVARCHAR(4000);


### PR DESCRIPTION
#### Rationale
The `containeralias.path` column has a length equal to the maximum length of a container name, but this field stores the path to the container, not just the single container name, so can have many long paths contained in it. Though theoretically we would need a limitless size here since to we don't currently limit the depth of folder nesting, practically speaking having a large upper limit seems like it shouldn't be problematic.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/140
- https://github.com/LabKey/labkey-ui-components/pull/1058
- https://github.com/LabKey/sampleManagement/pull/1474
- https://github.com/LabKey/biologics/pull/1800
- https://github.com/LabKey/inventory/pull/652

#### Changes
* Update the size of the containeralias.path column
