### PR TITLE
Avoid calling getPivotValues() to improve PIVOT query performance

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -27,8 +27,6 @@ List apache = [
         "org.apache.commons:commons-lang3:${commonsLang3Version}",
         "commons-pool:commons-pool:${commonsPoolVersion}",
         "commons-validator:commons-validator:${commonsValidatorVersion}",
-        "org.apache.httpcomponents:httpclient:${httpclientVersion}",
-        "org.apache.httpcomponents:httpcore:${httpcoreVersion}",
         "org.apache.httpcomponents.client5:httpclient5:${httpclient5Version}",
         "org.apache.httpcomponents.core5:httpcore5:${httpcore5Version}",
         "org.apache.poi:poi:${poiVersion}",

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -129,7 +129,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     private int _cacheSize = CacheManager.DEFAULT_CACHE_SIZE;
 
     protected final Map<String, ColumnInfo> _columnMap;
-    /** Columns that aren't part of this table any more, but can still be resolved for backwards compatibility */
+    /** Columns that aren't part of this table anymore, but can still be resolved for backwards compatibility */
     protected final Map<String, ColumnInfo> _resolvedColumns = new CaseInsensitiveHashMap<>();
     private Map<String, MethodInfo> _methodMap;
     private Set<FieldKey> _methodFieldKeys;
@@ -161,6 +161,31 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     private boolean _supportMerge;
 
     private final Map<String, CounterDefinition> _counterDefinitionMap = new CaseInsensitiveHashMap<>();    // Really only 1 for now, but could be more in future
+
+    private boolean _initialColumnsAreAdded = false;
+
+    protected boolean initialColumnsAreAdded()
+    {
+        return _initialColumnsAreAdded;
+    }
+
+    // Every method that interacts directly with _columnMap should call this first
+    private void ensureInitialColumnsAreAdded()
+    {
+        if (!_initialColumnsAreAdded)
+        {
+            _initialColumnsAreAdded = true;
+            initializeColumns();
+        }
+    }
+
+    // Initializing the column list can be expensive for certain TableInfos (e.g., PivotTableInfo). Adding all columns
+    // in an override of this method (instead of the constructor) allows the TableInfo to avoid that expensive operation
+    // in cases where the column list isn't needed (e.g., schema browser tree, query dependencies, linked schema
+    // drop-down list, etc.).
+    protected void initializeColumns()
+    {
+    }
 
     @NotNull
     @Override
@@ -217,7 +242,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     public AbstractTableInfo(DbSchema schema, String name)
     {
         _schema = schema;
-        _columnMap = constructColumnMap();
+        _columnMap = constructColumnMap(); // This is just an empty map, not populating any columns yet
         setName(name);
         addTriggerFactory(new ScriptTriggerFactory());
         MemTracker.getInstance().put(this);
@@ -499,6 +524,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     @Nullable
     public ColumnInfo getColumn(@NotNull String name, boolean resolveIfNeeded)
     {
+        ensureInitialColumnsAreAdded();
         ColumnInfo ret = _columnMap.get(name);
         if (ret != null)
             return ret;
@@ -603,6 +629,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     @Override
     public List<ColumnInfo> getColumns()
     {
+        ensureInitialColumnsAreAdded();
         return List.copyOf(_columnMap.values());
     }
 
@@ -610,6 +637,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     public List<MutableColumnInfo> getMutableColumns()
     {
         checkLocked();
+        ensureInitialColumnsAreAdded();
         return _columnMap.values().stream()
             .map(c -> (MutableColumnInfo)c)
             .peek(MutableColumnInfo::checkLocked)
@@ -619,6 +647,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     @Override
     public Set<String> getColumnNameSet()
     {
+        ensureInitialColumnsAreAdded();
         // Make the set case-insensitive
         return Collections.unmodifiableSet(new CaseInsensitiveTreeSet(_columnMap.keySet()));
     }
@@ -656,6 +685,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     public boolean removeColumn(ColumnInfo column)
     {
         checkLocked();
+        ensureInitialColumnsAreAdded();
         // Clear the cached resolved columns so we regenerate it if the shape of the table changes
         _resolvedColumns.clear();
         return _columnMap.remove(column.getName()) != null;
@@ -664,6 +694,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     public MutableColumnInfo addColumn(MutableColumnInfo column)
     {
         checkLocked();
+        ensureInitialColumnsAreAdded();
         // Not true if this is a VirtualTableInfo
         // assert column.getParentTable() == this;
         if (_columnMap.containsKey(column.getName()))
@@ -694,6 +725,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     public ColumnInfo replaceColumn(ColumnInfo updated, ColumnInfo existing)
     {
         checkLocked();
+        ensureInitialColumnsAreAdded();
         if (updated == existing)
             return updated;
 
@@ -1320,6 +1352,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
             {
                 // Reorder based on the sequence of columns in XML
                 Map<String, ColumnInfo> originalColumns = constructColumnMap();
+                assert initialColumnsAreAdded(); // getColumnNameSet() call above should have initialized the columns
                 originalColumns.putAll(_columnMap);
                 for (ColumnInfo columnInfo : originalColumns.values())
                 {
@@ -1337,7 +1370,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                 }
                 for (ColumnInfo column : originalColumns.values())
                 {
-                    // Readd the rest of the columns that weren't in the XML. It's backed by a LinkedHashMap, so they'll
+                    // Read the rest of the columns that weren't in the XML. It's backed by a LinkedHashMap, so they'll
                     // be in the same order they were in originally
                     addColumn((BaseColumnInfo) column);
                 }

--- a/api/src/org/labkey/api/data/CrosstabTable.java
+++ b/api/src/org/labkey/api/data/CrosstabTable.java
@@ -306,33 +306,15 @@ public class CrosstabTable extends VirtualTable implements CrosstabTableInfo
         //finally group by the row dimensions
         sql.append("\nGROUP BY ");
         sep = "";
-        for(CrosstabDimension rowDim : getSettings().getRowAxis().getDimensions())
+        for (CrosstabDimension rowDim : getSettings().getRowAxis().getDimensions())
         {
-            sql.append(sep);
-            sql.append(PIVOT_ALIAS + "." + rowDim.getSourceColumn().getAlias());
+            sql.append(sep)
+                .append(PIVOT_ALIAS + ".")
+                .append(rowDim.getSourceColumn().getAlias());
             sep = ", ";
         }
 
     } //addCrosstabQuery()
-
-    public Map<String, String> getMeasureNameToColumnNameMap()
-    {
-        Map<String, String> measureNameToColumnName = new HashMap<>();
-        for (Map.Entry<String, ColumnInfo> entry : _columnMap.entrySet())
-        {
-            String colName = entry.getKey();
-            ColumnInfo col = entry.getValue();
-            String measureName;
-            if (col instanceof AggregateColumnInfo)
-                measureName = String.valueOf(((AggregateColumnInfo) col).getMember().getValue());
-            else if (col instanceof DimensionColumnInfo)
-                measureName = ((DimensionColumnInfo) col).getSourceFieldKey().toString();
-            else
-                measureName = col.getName();
-            measureNameToColumnName.put(measureName, colName);
-        }
-        return measureNameToColumnName;
-    }
 
     protected void addPivotQuery(SQLFragment sql)
     {
@@ -342,8 +324,9 @@ public class CrosstabTable extends VirtualTable implements CrosstabTableInfo
         String sep = "";
         for(CrosstabDimension rowDim : getSettings().getRowAxis().getDimensions())
         {
-            sql.append(sep);
-            sql.append(AGG_FILTERED_ALIAS + "." + rowDim.getSourceColumn().getAlias());
+            sql.append(sep)
+                .append(AGG_FILTERED_ALIAS + ".")
+                .append(rowDim.getSourceColumn().getAlias());
             sep = ", ";
         }
 
@@ -431,7 +414,7 @@ public class CrosstabTable extends VirtualTable implements CrosstabTableInfo
         CrosstabDimension colDimension = getSettings().getColumnAxis().getDimensions().get(0);
 
         sql.append("(CASE WHEN ");
-        sql.append(queryAlias + "." + colDimension.getSourceColumn().getAlias());
+        sql.append(queryAlias).append(".").append(colDimension.getSourceColumn().getAlias());
         sql.append("=");
         String value = getSQLValue(colDimension.getSourceColumn().getJdbcType(), member.getValue());
         sql.append(value);
@@ -530,19 +513,6 @@ public class CrosstabTable extends VirtualTable implements CrosstabTableInfo
         return sql;
     }
     
-
-    /**
-     * Returns a column map suitable for passing to SimpleFilter's getSQLFragment() method.
-     * The map contains the same columns that are added when the table info is constructed
-     * without any column members (e.g., for customize view).
-     *
-     * @return A column map
-     */
-    protected Map<String, ColumnInfo> getAggregateFilterColMap()
-    {
-        return new CrosstabTable(getSettings())._columnMap;
-    }
-
     protected Map<FieldKey, ColumnInfo> getAggregateFilterColMap(Collection<ColumnInfo> cols)
     {
         Map<FieldKey,ColumnInfo> map = new HashMap<>(cols.size());

--- a/query/src/org/labkey/query/QueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/QueryDefinitionImpl.java
@@ -565,7 +565,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
                     table = createTable(schema, errors, includeMetadata, null, skipSuggestedColumns);
                 }
 
-                if (null == table || !errors.isEmpty())
+                if (null == table || (null != errors && !errors.isEmpty()))
                     return null;
 
                 log.debug("Caching table " + schema.getName() + "." + table.getName());

--- a/query/src/org/labkey/query/QueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/QueryDefinitionImpl.java
@@ -565,7 +565,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
                     table = createTable(schema, errors, includeMetadata, null, skipSuggestedColumns);
                 }
 
-                if (null == table)
+                if (null == table || !errors.isEmpty())
                     return null;
 
                 log.debug("Caching table " + schema.getName() + "." + table.getName());

--- a/query/src/org/labkey/query/sql/QueryPivot.java
+++ b/query/src/org/labkey/query/sql/QueryPivot.java
@@ -17,7 +17,6 @@ package org.labkey.query.sql;
 
 import org.apache.commons.beanutils.ConvertUtils;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.collections.NamedObjectList;
 import org.labkey.api.data.*;
@@ -831,74 +830,15 @@ public class QueryPivot extends QueryRelation
             super(QueryPivot.this, "_pivot");
         }
 
-        private boolean _initialColumnsAreAdded = false;
-
-        private void ensureInitialColumnsAreAdded()
+        @Override
+        protected void initializeColumns()
         {
-            if (!_initialColumnsAreAdded)
+            for (RelationColumn col : getAllColumns().values())
             {
-                _initialColumnsAreAdded = true;
-
-                for (RelationColumn col : getAllColumns().values())
-                {
-                    var columnInfo = new RelationColumnInfo(this, col);
-                    addColumn(columnInfo);
-                }
+                var columnInfo = new RelationColumnInfo(this, col);
+                addColumn(columnInfo);
             }
         }
-
-        // Override all methods that directly interact with AbstractTableInfo._columnMap to add calls to ensureInitialColumnsAreAdded()
-
-        @Override
-        public List<ColumnInfo> getColumns(String colNames)
-        {
-            ensureInitialColumnsAreAdded();
-            return super.getColumns(colNames);
-        }
-
-        @Override
-        public Set<String> getColumnNameSet()
-        {
-            ensureInitialColumnsAreAdded();
-            return super.getColumnNameSet();
-        }
-
-        @Override
-        public @Nullable ColumnInfo getColumn(@NotNull String name, boolean resolveIfNeeded)
-        {
-            ensureInitialColumnsAreAdded();
-            return super.getColumn(name, resolveIfNeeded);
-        }
-
-        @Override
-        public @NotNull List<MutableColumnInfo> getMutableColumns()
-        {
-            ensureInitialColumnsAreAdded();
-            return super.getMutableColumns();
-        }
-
-        @Override
-        public boolean removeColumn(ColumnInfo column)
-        {
-            ensureInitialColumnsAreAdded();
-            return super.removeColumn(column);
-        }
-
-        @Override
-        public MutableColumnInfo addColumn(MutableColumnInfo column)
-        {
-            ensureInitialColumnsAreAdded();
-            return super.addColumn(column);
-        }
-
-        @Override
-        public ColumnInfo replaceColumn(ColumnInfo updated, ColumnInfo existing)
-        {
-            ensureInitialColumnsAreAdded();
-            return super.replaceColumn(updated, existing);
-        }
-
-        // End of ensureInitialColumnsAreAdded() overrides
 
         private SQLFragment _sqlPivot = null;
 

--- a/study/src/org/labkey/study/query/ParticipantTable.java
+++ b/study/src/org/labkey/study/query/ParticipantTable.java
@@ -16,7 +16,6 @@
 
 package org.labkey.study.query;
 
-import org.jetbrains.annotations.NotNull;
 import org.labkey.api.collections.CaseInsensitiveTreeSet;
 import org.labkey.api.data.AbstractForeignKey;
 import org.labkey.api.data.BaseColumnInfo;
@@ -43,8 +42,6 @@ import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.TitleForeignKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
-import org.labkey.api.security.UserPrincipal;
-import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.model.ParticipantGroup;
@@ -166,6 +163,7 @@ public class ParticipantTable extends BaseStudyTable
         for (ParticipantCategoryImpl category : ParticipantGroupManager.getInstance().getParticipantCategories(getContainer(), _userSchema.getUser()))
         {
             var categoryColumn = new ParticipantCategoryColumn(category, this);
+            assert initialColumnsAreAdded(); // addColumn() calls above should have initialized the columns
             if (!_columnMap.containsKey(categoryColumn.getName()))
                 addColumn(categoryColumn);
         }


### PR DESCRIPTION
#### Rationale
In the absence of an explicit `PIVOT ... IN` clause, LabKey must execute portions of PIVOT queries to determine the resulting column list. Depending on the query, this can be very expensive; see https://www.labkey.org/OHSU/Support%20Tickets/issues-details.view?issueId=46881. This PR attempts to avoid calling `getPivotValues()` (the column-list query) unless it's absolutely required. This can improve performance significantly for cases that don't need the query results, e.g., rendering the schema browser tree and populating the linked schema table drop-down list. Approach:

- `AbstractTableInfo`: introduce `initializeColumns()`, called immediately before columns are accessed for the first time. Adding columns in this method (instead of the constructor) avoids the potentially expensive operation in cases where the columns aren't used. Call `ensureInitialColumnsAreAdded()` from all methods that interact directly with `_columnMap`.
- `PivotTableInfo`: populate the initial columns in `initializeColumns()` and defer validation (missing parameter values, etc.) to `getAllColumns()`. Rework the exception handling in getPivotValues() and its callers to ensure reasonably friendly error messages.

Schema browser tree now avoids executing PIVOT queries. `GetQueriesAction` (used in linked schema admin page) still indirectly invokes getPivotValues() (e.g., for URL handling). We should either parameterize GetQueriesAction further (`includeUrls` parameter, maybe `false` by default?) or switch linked schema admin page to call `getSchemaTree.api` instead of `getQueries.api`, to avoid the expensive query. Will address this in a follow-on PR.