### PR TITLE
More reliable check for project vs. folder

### DIFF
--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -407,10 +407,8 @@ public abstract class SpringActionController implements Controller, HasViewConte
             }
             setActionForThread(controller);
 
-            if (!(controller instanceof PermissionCheckable))
+            if (!(controller instanceof PermissionCheckable checkable))
                 throw new IllegalStateException("All actions must implement PermissionCheckable. " + controller.getClass().getName() + " should extend PermissionCheckableAction or one of its subclasses.");
-
-            PermissionCheckable checkable = (PermissionCheckable)controller;
 
             ApiResponseWriter.Format responseFormat = ApiResponseWriter.Format.getFormatByName(request.getParameter(RESPONSE_FORMAT_PARAMETER_NAME), null);
             if (responseFormat == null)
@@ -426,7 +424,7 @@ public abstract class SpringActionController implements Controller, HasViewConte
 
             if (null != redirectURL)
             {
-                _log.debug("URL " + url.toString() + " was redirected to " + redirectURL + " instead");
+                _log.debug("URL " + url + " was redirected to " + redirectURL + " instead");
                 response.sendRedirect(redirectURL.toString());
                 return null;
             }
@@ -437,9 +435,9 @@ public abstract class SpringActionController implements Controller, HasViewConte
             Container c = context.getContainer();
             if (null == c)
             {
+                String containerPath = url.getExtraPath();
 
-                String containerPath = context.getActionURL().getExtraPath();
-                if (containerPath != null && containerPath.contains("/"))
+                if (!url.isProject())
                 {
                     throw new NotFoundException("No such folder or workbook: " + containerPath);
                 }

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -681,7 +681,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     }
 
     /**
-     * This method can be used to to replace the implementation of a column during construction.
+     * This method can be used to replace the implementation of a column during construction.
      * This is usually only done in TableInfo.afterConstruct() to modify the behavior of a column.
      * Because the ColumnInfo implementation can change in afterConstruct(), TableInfo implementations
      * should hold onto columnInfo references by FieldKey, and not by reference.

--- a/api/src/org/labkey/api/view/ActionURL.java
+++ b/api/src/org/labkey/api/view/ActionURL.java
@@ -573,8 +573,12 @@ public class ActionURL extends URLHelper implements Cloneable
     {
         return null == _action;
     }
-    
 
+    public boolean isProject()
+    {
+        return _path.size() == 1;
+    }
+    
     @Override
     public String getPath()
     {

--- a/api/src/org/labkey/api/view/ViewContext.java
+++ b/api/src/org/labkey/api/view/ViewContext.java
@@ -69,7 +69,8 @@ public class ViewContext implements MessageSource, ContainerContext, ContainerUs
     private ActionURL _url;                     // path and parameters on the URL (does not include posted values)
     private String _scopePrefix = "";
     private Container _c = null;
-    private Set<Role> _contextualRoles = new HashSet<>();
+
+    private final Set<Role> _contextualRoles = new HashSet<>();
 
     transient protected HashMap<String, Object> _map = new HashMap<>();
     PropertyValues _pvsBind = null;              // may be set by SpringActionController, representing values used to bind command object


### PR DESCRIPTION
#### Rationale
Recent `ClientAPITest.contentTypeResponseTest` failures pointed out that our unknown container check can't distinguish projects from folders when the path-first URLs setting is on. This PR introduces a more reliable check.

The `ActionURL.getExtraPath()` inconsistency remains; its return value includes a leading slash in the case of path-first URLs but no leading slash in the case of a non-path-first URL. This needs to be addressed, but can be a follow-on fix. See https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46969.