### PR TITLE
Issue 46857: Handle dataclass that doesn't support merge

### DIFF
--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -127,7 +127,7 @@ public class TriggerDataBuilderHelper
             boolean includeAllColumns = !context.getInsertOption().mergeRows || mergeKeys == null;
             DataIterator coerce = new CoerceDataIterator(pre, context, _target, includeAllColumns);
             coerce = LoggingDataIterator.wrap(coerce);
-            if (!includeAllColumns)
+            if (!includeAllColumns && _target.supportMerge())
                 coerce = ExistingRecordDataIterator.createBuilder(coerce, _target, mergeKeys, true).getDataIterator(context);
 
             return LoggingDataIterator.wrap(new BeforeIterator(new CachingDataIterator(coerce), context));


### PR DESCRIPTION
#### Rationale
There are some Biologics registry types that don't support merge, some due to the existence of preinsert triggers, some due to lack of api. The eval data loading in automated tests uses merge to load those data, which is not technically correct. Without changing the way the test loads data, this PR modifies the code that causes failures for those scenarios. 

https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_LabkeyPremiumTrunk_GitModules_BiologicsPostgres95/2180057?buildTab=overview 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3901

#### Changes
* Skipping adding ExistingRecordIterators in TriggerDataBuilderHelper for registries that don't support merge 
