### PR TITLE
Issue 46857: Don't use ExistingRecordDataIterator for trigger helper for biologics eval data loading

### DIFF
--- a/api/src/org/labkey/api/admin/FolderImportContext.java
+++ b/api/src/org/labkey/api/admin/FolderImportContext.java
@@ -25,7 +25,6 @@ import org.labkey.api.module.FolderTypeManager;
 import org.labkey.api.reports.report.ReportDescriptor;
 import org.labkey.api.reports.report.view.ReportUtil;
 import org.labkey.api.security.User;
-import org.labkey.api.util.GUID;
 import org.labkey.api.util.XmlBeansUtil;
 import org.labkey.api.util.XmlValidationException;
 import org.labkey.api.writer.VirtualFile;
@@ -56,7 +55,9 @@ public class FolderImportContext extends AbstractFolderContext
 
     private static final String FOLDER_IMPORT_DB_SEQUENCE_PREFIX = "FolderImportJobCounter-";
 
-    private boolean _expDataNoMerge; // don't use merge for SampleTypeAndDataClassFolderImporter
+    private boolean _isNewFolderImport; // if we know the target folder is empty, can skip certain merge logic
+
+    public static final String IS_NEW_FOLDER_IMPORT_KEY = "isNewFolderImport";
 
     /** Required for xstream serialization on Java 7 */
     @SuppressWarnings({"UnusedDeclaration"})
@@ -184,14 +185,14 @@ public class FolderImportContext extends AbstractFolderContext
         return folderType == null ? null : folderType.getImportAuditBehavior();
     }
 
-    public boolean isExpDataNoMerge()
+    public boolean isNewFolderImport()
     {
-        return _expDataNoMerge;
+        return _isNewFolderImport;
     }
 
-    public void setExpDataNoMerge(boolean expDataNoMerge)
+    public void setNewFolderImport(boolean newFolderImport)
     {
-        _expDataNoMerge = expDataNoMerge;
+        _isNewFolderImport = newFolderImport;
     }
 
 }

--- a/api/src/org/labkey/api/admin/FolderImportContext.java
+++ b/api/src/org/labkey/api/admin/FolderImportContext.java
@@ -56,6 +56,8 @@ public class FolderImportContext extends AbstractFolderContext
 
     private static final String FOLDER_IMPORT_DB_SEQUENCE_PREFIX = "FolderImportJobCounter-";
 
+    private boolean _expDataNoMerge; // don't use merge for SampleTypeAndDataClassFolderImporter
+
     /** Required for xstream serialization on Java 7 */
     @SuppressWarnings({"UnusedDeclaration"})
     public FolderImportContext()
@@ -181,4 +183,15 @@ public class FolderImportContext extends AbstractFolderContext
             folderType = FolderTypeManager.get().getFolderType(xmlFolderType.getName());
         return folderType == null ? null : folderType.getImportAuditBehavior();
     }
+
+    public boolean isExpDataNoMerge()
+    {
+        return _expDataNoMerge;
+    }
+
+    public void setExpDataNoMerge(boolean expDataNoMerge)
+    {
+        _expDataNoMerge = expDataNoMerge;
+    }
+
 }

--- a/api/src/org/labkey/api/admin/ImportOptions.java
+++ b/api/src/org/labkey/api/admin/ImportOptions.java
@@ -45,6 +45,8 @@ public class ImportOptions
     private Path _analysisDir;
     private String _folderArchiveSourceName = null;
 
+    private boolean _expDataNoMerge; // don't use merge for SampleTypeAndDataClassFolderImporter
+
     public ImportOptions(String containerId, @Nullable Integer userId)
     {
         _containerId = containerId;
@@ -170,4 +172,15 @@ public class ImportOptions
     {
         _folderArchiveSourceName = folderArchiveSourceName;
     }
+
+    public boolean isExpDataNoMerge()
+    {
+        return _expDataNoMerge;
+    }
+
+    public void setExpDataNoMerge(boolean expDataNoMerge)
+    {
+        _expDataNoMerge = expDataNoMerge;
+    }
+
 }

--- a/api/src/org/labkey/api/admin/ImportOptions.java
+++ b/api/src/org/labkey/api/admin/ImportOptions.java
@@ -45,7 +45,7 @@ public class ImportOptions
     private Path _analysisDir;
     private String _folderArchiveSourceName = null;
 
-    private boolean _expDataNoMerge; // don't use merge for SampleTypeAndDataClassFolderImporter
+    private boolean _isNewFolderImport; // if we know the target folder is empty, can skip certain merge logic
 
     public ImportOptions(String containerId, @Nullable Integer userId)
     {
@@ -173,14 +173,14 @@ public class ImportOptions
         _folderArchiveSourceName = folderArchiveSourceName;
     }
 
-    public boolean isExpDataNoMerge()
+    public boolean isNewFolderImport()
     {
-        return _expDataNoMerge;
+        return _isNewFolderImport;
     }
 
-    public void setExpDataNoMerge(boolean expDataNoMerge)
+    public void setNewFolderImport(boolean newFolderImport)
     {
-        _expDataNoMerge = expDataNoMerge;
+        _isNewFolderImport = newFolderImport;
     }
 
 }

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -127,7 +127,7 @@ public class TriggerDataBuilderHelper
             boolean includeAllColumns = !context.getInsertOption().mergeRows || mergeKeys == null;
             DataIterator coerce = new CoerceDataIterator(pre, context, _target, includeAllColumns);
             coerce = LoggingDataIterator.wrap(coerce);
-            if (!includeAllColumns)
+            if (!includeAllColumns && _target.supportMerge())
                 coerce = ExistingRecordDataIterator.createBuilder(coerce, _target, mergeKeys, true).getDataIterator(context);
 
             return LoggingDataIterator.wrap(new BeforeIterator(new CachingDataIterator(coerce), context));

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -127,9 +127,13 @@ public class TriggerDataBuilderHelper
             boolean includeAllColumns = !context.getInsertOption().mergeRows || mergeKeys == null;
             DataIterator coerce = new CoerceDataIterator(pre, context, _target, includeAllColumns);
             coerce = LoggingDataIterator.wrap(coerce);
-            if (!includeAllColumns && _target.supportMerge())
-                coerce = ExistingRecordDataIterator.createBuilder(coerce, _target, mergeKeys, true).getDataIterator(context);
 
+            if (includeAllColumns)
+                LoggingDataIterator.wrap(new BeforeIterator(new CachingDataIterator(coerce), context));
+            else if (!_target.supportMerge())
+                return LoggingDataIterator.wrap(new BeforeIterator(coerce, context));
+
+            coerce = ExistingRecordDataIterator.createBuilder(coerce, _target, mergeKeys, true).getDataIterator(context);
             return LoggingDataIterator.wrap(new BeforeIterator(new CachingDataIterator(coerce), context));
         }
     }

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -28,6 +28,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
+import static org.labkey.api.admin.FolderImportContext.IS_NEW_FOLDER_IMPORT_KEY;
+
 /**
  * User: matthewb
  * Date: 2011-09-07
@@ -124,12 +126,18 @@ public class TriggerDataBuilderHelper
             if (_target instanceof ExpTable)
                 mergeKeys = ((ExpTable<?>)_target).getAltMergeKeys();
 
-            boolean includeAllColumns = !context.getInsertOption().mergeRows || mergeKeys == null;
+            boolean isNewFolderImport = false;
+            if (_extraContext != null && _extraContext.get(IS_NEW_FOLDER_IMPORT_KEY) != null)
+            {
+                isNewFolderImport = (boolean) _extraContext.get(IS_NEW_FOLDER_IMPORT_KEY);
+            }
+
+            boolean includeAllColumns = (!context.getInsertOption().mergeRows || mergeKeys == null) || isNewFolderImport;
             DataIterator coerce = new CoerceDataIterator(pre, context, _target, includeAllColumns);
             coerce = LoggingDataIterator.wrap(coerce);
 
             if (includeAllColumns)
-                LoggingDataIterator.wrap(new BeforeIterator(new CachingDataIterator(coerce), context));
+                return LoggingDataIterator.wrap(new BeforeIterator(new CachingDataIterator(coerce), context));
             else if (!_target.supportMerge())
                 return LoggingDataIterator.wrap(new BeforeIterator(coerce, context));
 

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -289,7 +289,7 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                                 if (qus != null)
                                 {
                                     DataIteratorContext context = new DataIteratorContext(errors);
-                                    context.setInsertOption(QueryUpdateService.InsertOption.MERGE);
+                                    context.setInsertOption(ctx.isExpDataNoMerge() ? QueryUpdateService.InsertOption.IMPORT : QueryUpdateService.InsertOption.MERGE);
                                     context.setAllowImportLookupByAlternateKey(true);
                                     ((AbstractQueryUpdateService)qus).setAttachmentDirectory(dir.getDir(tableName));
                                     Map<Enum, Object> options = new HashMap<>();

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.labkey.api.admin.FolderImportContext.IS_NEW_FOLDER_IMPORT_KEY;
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.DEFAULT_DIRECTORY;
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.EXCLUDED_TYPES;
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.XAR_RUNS_NAME;
@@ -289,7 +290,7 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                                 if (qus != null)
                                 {
                                     DataIteratorContext context = new DataIteratorContext(errors);
-                                    context.setInsertOption(ctx.isExpDataNoMerge() ? QueryUpdateService.InsertOption.IMPORT : QueryUpdateService.InsertOption.MERGE);
+                                    context.setInsertOption(ctx.isNewFolderImport() ? QueryUpdateService.InsertOption.IMPORT : QueryUpdateService.InsertOption.MERGE);
                                     context.setAllowImportLookupByAlternateKey(true);
                                     ((AbstractQueryUpdateService)qus).setAttachmentDirectory(dir.getDir(tableName));
                                     Map<Enum, Object> options = new HashMap<>();
@@ -307,7 +308,15 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
 
                                     context.setConfigParameters(options);
 
-                                    int count = qus.loadRows(ctx.getUser(), ctx.getContainer(), loader, context, null);
+                                    Map<String, Object> extraContext = null;
+                                    if (ctx.isNewFolderImport())
+                                    {
+                                        extraContext = new HashMap<>();
+                                        extraContext.put(IS_NEW_FOLDER_IMPORT_KEY, true);
+                                    }
+
+                                    new HashMap<>();
+                                    int count = qus.loadRows(ctx.getUser(), ctx.getContainer(), loader, context, extraContext);
                                     log.info("Imported a total of " + count + " rows into : " + tableName);
                                     if (context.getErrors().hasErrors())
                                     {

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -290,7 +290,7 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                                 if (qus != null)
                                 {
                                     DataIteratorContext context = new DataIteratorContext(errors);
-                                    context.setInsertOption(ctx.isNewFolderImport() ? QueryUpdateService.InsertOption.IMPORT : QueryUpdateService.InsertOption.MERGE);
+                                    context.setInsertOption(QueryUpdateService.InsertOption.MERGE);
                                     context.setAllowImportLookupByAlternateKey(true);
                                     ((AbstractQueryUpdateService)qus).setAttachmentDirectory(dir.getDir(tableName));
                                     Map<Enum, Object> options = new HashMap<>();

--- a/pipeline/src/org/labkey/pipeline/importer/FolderImportJob.java
+++ b/pipeline/src/org/labkey/pipeline/importer/FolderImportJob.java
@@ -82,7 +82,7 @@ public class FolderImportJob extends PipelineJob implements FolderJobSupport, Cl
         _ctx.setFailForUndefinedVisits(options.isFailForUndefinedVisits());
         _ctx.setIncludeSubfolders(options.isIncludeSubfolders());
         _ctx.setActivity(options.getActivity());
-        _ctx.setExpDataNoMerge(options.isExpDataNoMerge());
+        _ctx.setNewFolderImport(options.isNewFolderImport());
 
         LOG.info("Pipeline job initialized for importing folder archive to folder " + c.getPath());
     }

--- a/pipeline/src/org/labkey/pipeline/importer/FolderImportJob.java
+++ b/pipeline/src/org/labkey/pipeline/importer/FolderImportJob.java
@@ -82,6 +82,7 @@ public class FolderImportJob extends PipelineJob implements FolderJobSupport, Cl
         _ctx.setFailForUndefinedVisits(options.isFailForUndefinedVisits());
         _ctx.setIncludeSubfolders(options.isIncludeSubfolders());
         _ctx.setActivity(options.getActivity());
+        _ctx.setExpDataNoMerge(options.isExpDataNoMerge());
 
         LOG.info("Pipeline job initialized for importing folder archive to folder " + c.getPath());
     }


### PR DESCRIPTION
#### Rationale
The eval data loading uses Folder Import, which uses merge to load those sample and dataclass data. This is problematic in 2 ways: folder import is not officially supported for Biologics and merge is not supported for some registries. The changes made in TriggerDataBuilderHelper to use ExistingRecordDataIterator is not working for the eval data due to the state of data and is causing test failure: https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_LabkeyPremiumTrunk_GitModules_BiologicsPostgres95/2180057?buildTab=overview
I believe the eval data needs to be updated to add those missed columns. For now, we can treat eval data loading as a NEW load that writes into a clean folder, and allow the continued use of CoerceDataIterator.outputAllColumns for this type of import to avoid the test failure.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3940
* https://github.com/LabKey/biologics/pull/1803
* https://github.com/LabKey/trialServices/pull/35

* https://github.com/LabKey/platform/pull/3901

#### Changes
* added isNewFolderImport importOption to allow using CoerceDataIterator.outputAllColumns for TriggerDataBuilderHelper for eval data loading
* Skipping adding ExistingRecordIterators in TriggerDataBuilderHelper for registries that don't support merge
