### PR TITLE
Issue 46985: Unable to update extensible table row that predates custom fields

### DIFF
--- a/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
@@ -255,9 +255,12 @@ public class DefaultQueryUpdateService extends AbstractQueryUpdateService
                     }
                 }
             }
-            else
+            // Issue 46985: Be tolerant of a row not having an LSID value (as the row may have been
+            // inserted before the table was made extensible), but make sure that we got an LSID field
+            // when fetching the row
+            else if (!row.containsKey(objectUriCol.getName()))
             {
-                throw new IllegalStateException("LSID value not found in table - " + table.getName());
+                throw new IllegalStateException("LSID value not returned when querying table - " + table.getName());
             }
         }
 


### PR DESCRIPTION
#### Rationale
In https://github.com/LabKey/platform/pull/3227 we got stricter about ensuring the extensible tables were set up correctly. We didn't account for rows that might have been inserted before the table had custom fields configured though, which may not have an LSID value yet.

#### Changes
* Be tolerant of rows that have a null LSID value but still make sure LSI was returned from DB query