### PR TITLE
Restrict remote rserve usages

### DIFF
--- a/api/src/org/labkey/api/assay/DefaultDataTransformer.java
+++ b/api/src/org/labkey/api/assay/DefaultDataTransformer.java
@@ -38,7 +38,6 @@ import org.labkey.api.util.CSRFUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
-import org.labkey.api.view.ViewServlet;
 
 import javax.script.Bindings;
 import javax.script.ScriptContext;
@@ -114,6 +113,13 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
                         .getEngineByExtension(context.getContainer(), FileUtil.getExtension(scriptFile), LabKeyScriptEngineManager.EngineContext.pipeline);
                 if (engine != null)
                 {
+                    // issue : 46838 remote scripting engines don't support transform scripts yet
+                    if (engine instanceof ExternalScriptEngine externalScriptEngine)
+                    {
+                        if (!externalScriptEngine.supportsContext(LabKeyScriptEngineManager.EngineContext.pipeline))
+                            throw new ValidationException("The script engine : " + externalScriptEngine.getEngineDefinition().getName() + " does not support running in a transform script." );
+                    }
+
                     File scriptDir = getScriptDir(context.getProtocol(), scriptFile, isDefault);
                     // issue 13643: ensure script dir is initially empty
                     FileUtil.deleteDirectoryContents(scriptDir);

--- a/api/src/org/labkey/api/reports/ExternalScriptEngine.java
+++ b/api/src/org/labkey/api/reports/ExternalScriptEngine.java
@@ -554,4 +554,12 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
     {
         return false;
     }
+
+    // Returns whether this engine can be run in to specified context. Some remote engines
+    // don't support all contexts because input or output files aren't copied into the location
+    // that the script is run.
+    public boolean supportsContext(LabKeyScriptEngineManager.EngineContext context)
+    {
+        return true;
+    }
 }

--- a/api/src/org/labkey/api/reports/report/r/RserveScriptEngine.java
+++ b/api/src/org/labkey/api/reports/report/r/RserveScriptEngine.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.xmlbeans.impl.common.IOUtil;
 import org.labkey.api.pipeline.file.PathMapper;
 import org.labkey.api.reports.ExternalScriptEngineDefinition;
+import org.labkey.api.reports.LabKeyScriptEngineManager;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.UnexpectedException;
@@ -686,4 +687,15 @@ public class RserveScriptEngine extends RScriptEngine
         //
         return true;
     }
- }
+
+    @Override
+    public boolean supportsContext(LabKeyScriptEngineManager.EngineContext context)
+    {
+        if (context.equals(LabKeyScriptEngineManager.EngineContext.pipeline))
+        {
+            ModusOperandi mo = getModusOperandi(getEngineDefinition());
+            return !mo.requiresCopyFiles();
+        }
+        return true;
+    }
+}

--- a/pipeline/src/org/labkey/pipeline/api/ScriptTaskImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/ScriptTaskImpl.java
@@ -101,6 +101,13 @@ public class ScriptTaskImpl extends CommandTaskImpl
         if (_engine == null)
             throw new PipelineJobException("Script engine not found: " + extension);
 
+        // issue 46884 : don't allow script pipeline jobs for remote script engines
+        if (_engine instanceof ExternalScriptEngine externalScriptEngine)
+        {
+            if (!externalScriptEngine.supportsContext(LabKeyScriptEngineManager.EngineContext.pipeline))
+                throw new PipelineJobException("The script engine : " + externalScriptEngine.getEngineDefinition().getName() + " does not support running in a pipeline job." );
+        }
+
         try
         {
             @Nullable File scriptFile = null;


### PR DESCRIPTION
#### Rationale
Some contexts that an Rserve engine is invoked in don't work well when the engine is remote and doesn't share a file system with the server. This is because not all of the inputs or outputs that might be required by the script are copied to and from the Rserve file system. These include transform scripts and script pipeline jobs.

While we can eventually make these work, the approach for now is to restrict those contexts to only cases where there is a shared file system.

#### Related Issues
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46838
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46844