### PR TITLE
Restore mock ViewContext to fix background triggers needing user and URL

### DIFF
--- a/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
+++ b/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
@@ -235,6 +235,13 @@ public class ScriptTrigger implements Trigger
 
     private <T> T _try(Container c, User user, Map<String, Object> extraContext, ScriptFn<T> fn)
     {
+        ViewContext.StackResetter viewContextResetter = null;
+        if (!HttpView.hasCurrentView())
+        {
+            // Push a view context if we don't already have one available. It may be pulled to get the user
+            // in ext4Bridge.js
+            viewContextResetter = ViewContext.pushMockViewContext(user, c, new ActionURL("dummy", "dummy", c));
+        }
         try
         {
             if (!_script.evaluated())
@@ -270,6 +277,13 @@ public class ScriptTrigger implements Trigger
         catch (NoSuchMethodException | ScriptException e)
         {
             throw UnexpectedException.wrap(e);
+        }
+        finally
+        {
+            if (viewContextResetter != null)
+            {
+                viewContextResetter.close();
+            }
         }
     }
 

--- a/api/src/org/labkey/api/view/HttpView.java
+++ b/api/src/org/labkey/api/view/HttpView.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.HasViewContext;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerManager;
 import org.labkey.api.miniprofiler.MiniProfiler;
 import org.labkey.api.util.Debug;
 import org.labkey.api.util.ExceptionUtil;
@@ -634,10 +633,6 @@ public abstract class HttpView<ModelBean> extends DefaultModelAndView<ModelBean>
     public static URLHelper getContextURLHelper()
     {
         ViewContext context = getRootContext();
-        // If we're invoked from a background thread that lacks a ViewContext, just return a dummy
-        // value. This lets trigger scripts import ActionURL.js without error.
-        if (context == null)
-            return new ActionURL("dummy", "dummy", ContainerManager.getRoot());
         HttpServletRequest request = context.getRequest();
         URLHelper url = (URLHelper)request.getAttribute(ViewServlet.ORIGINAL_URL_URLHELPER);
 

--- a/api/src/org/labkey/api/view/HttpView.java
+++ b/api/src/org/labkey/api/view/HttpView.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.HasViewContext;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.miniprofiler.MiniProfiler;
 import org.labkey.api.util.Debug;
 import org.labkey.api.util.ExceptionUtil;
@@ -633,6 +634,10 @@ public abstract class HttpView<ModelBean> extends DefaultModelAndView<ModelBean>
     public static URLHelper getContextURLHelper()
     {
         ViewContext context = getRootContext();
+        // If we're invoked from a background thread that lacks a ViewContext, just return a dummy
+        // value. This lets trigger scripts import ActionURL.js without error.
+        if (context == null)
+            return new ActionURL("dummy", "dummy", ContainerManager.getRoot());
         HttpServletRequest request = context.getRequest();
         URLHelper url = (URLHelper)request.getAttribute(ViewServlet.ORIGINAL_URL_URLHELPER);
 


### PR DESCRIPTION
#### Rationale
Additional tests last night turned up a problem with the PR I merged that correctly tracks the container for a given TableInfo trigger event even if it's a different container from the originating ViewContext. Ideally we'd not rely on the ViewContext at all and may be able to revisit, but need to get these scenarios working in the meantime. They only rely on the User and URL, so they aren't varying from operation to operation at this time.

https://teamcity.labkey.org/buildConfiguration/LabKey_2211Release_Premium_Ehr_DailyEhrPostgres/2185329?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&expandBuildChangesSection=true

https://github.com/LabKey/platform/pull/3942

#### Changes
* Push a mock view context when we don't have one already