### PR TITLE
46952: Clear the Resolution field on Reopen

### DIFF
--- a/issues/src/org/labkey/issue/IssueServiceImpl.java
+++ b/issues/src/org/labkey/issue/IssueServiceImpl.java
@@ -81,7 +81,11 @@ public class IssueServiceImpl implements IssueService
                         }
                         issueObject.resolve(user);
                     }
-                    case reopen -> issueObject.open(container, user);
+                    case reopen -> {
+                        // issue 46952 ensure resolution is cleared on reopen
+                        issueObject.beforeReOpen(container, false);
+                        issueObject.open(container, user);
+                    }
                     case close -> issueObject.close(user);
                 }
 

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -2807,7 +2807,10 @@ public class StudyController extends BaseStudyController
                 {
                     Integer protocolId = form.getProtocolId();
                     Integer sampleTypeId = form.getSampleTypeId();
-                    assert protocolId != null || sampleTypeId != null : "Expected one protocolId or sampleTypeId parameters";
+
+                    if (protocolId == null && sampleTypeId == null)
+                        throw new IllegalArgumentException("Expected either a protocolId or sampleId parameter");
+
                     String sourceLsid = form.getSourceLsid(); // the assay protocol or sample type LSID
                     int recordCount = form.getRecordCount();
 


### PR DESCRIPTION
#### Rationale
A few minor fixes for the following issues:
- [46952: Clear the Resolution field on Reopen](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46952)
- [46931: NPE in PublishHistoryDetailsAction](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46931)