### PR TITLE
41377: Survey UI does not render entries that are not in the list default view

### DIFF
--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -1391,6 +1391,11 @@ public class DataRegion extends DisplayElement
             ignoreFilter = getSettings().getIgnoreUserFilter();
         dataRegionJSON.put("ignoreFilter", ignoreFilter);
 
+        boolean ignoreViewFilter = false;
+        if (getSettings() != null)
+            ignoreViewFilter = getSettings().getIgnoreViewFilter();
+        dataRegionJSON.put("ignoreViewFilter", ignoreViewFilter);
+
         VisualizationUrls visUrlProvider = PageFlowUtil.urlProvider(VisualizationUrls.class);
         if (visUrlProvider != null)
             dataRegionJSON.put("chartWizardURL", visUrlProvider.getGenericChartDesignerURL(ctx.getContainer(), user, getSettings(), null));

--- a/api/src/org/labkey/api/query/QuerySettings.java
+++ b/api/src/org/labkey/api/query/QuerySettings.java
@@ -75,6 +75,7 @@ public class QuerySettings
     private boolean _allowHeaderLock = true;
     private boolean _showReports = true;
     private boolean _ignoreUserFilter;
+    private boolean _ignoreViewFilter;
     private int _maxRows = 100;
     private boolean _maxRowsSet = false; // Explicitly track setting maxRows, allows for different defaults
     private long _offset = 0;
@@ -602,6 +603,16 @@ public class QuerySettings
     public void setIgnoreUserFilter(boolean b)
     {
         _ignoreUserFilter = b;
+    }
+
+    public boolean getIgnoreViewFilter()
+    {
+        return _ignoreViewFilter;
+    }
+
+    public void setIgnoreViewFilter(boolean ignoreViewFilter)
+    {
+        _ignoreViewFilter = ignoreViewFilter;
     }
 
     /** @return The maxRows parameter when {@link ShowRows#PAGINATED}, otherwise ALL_ROWS. */

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -323,6 +323,11 @@ public class QueryView extends WebPartView<Object>
                 (getSettings() != null && getSettings().getIgnoreUserFilter());
     }
 
+    // ignores filters on the custom view but not those added through query settings
+    protected boolean ignoreViewFilter()
+    {
+        return getSettings() != null && getSettings().getIgnoreViewFilter();
+    }
 
     protected void renderErrors(PrintWriter out, String message, List<? extends Throwable> errors)
     {
@@ -2227,7 +2232,7 @@ public class QueryView extends WebPartView<Object>
         }
 
         ActionURL customViewUrl = null;
-        if (_customView != null && _customView.hasFilterOrSort())
+        if (_customView != null && _customView.hasFilterOrSort() && !ignoreViewFilter())
         {
             customViewUrl = new ActionURL();
             _customView.applyFilterAndSortToURL(customViewUrl, getDataRegionName());

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -3656,7 +3656,7 @@ public class QueryController extends SpringActionController
 
             // Support for 'viewName'
             CustomView view = settings.getCustomView(getViewContext(), form.getQueryDef());
-            if (null != view && view.hasFilterOrSort())
+            if (null != view && view.hasFilterOrSort() && !settings.getIgnoreViewFilter())
             {
                 ActionURL url = new ActionURL(SelectDistinctAction.class, getContainer());
                 view.applyFilterAndSortToURL(url, dataRegionName);

--- a/survey/src/org/labkey/survey/SurveyController.java
+++ b/survey/src/org/labkey/survey/SurveyController.java
@@ -750,6 +750,8 @@ public class SurveyController extends SpringActionController implements SurveyUr
                         if (schema != null)
                         {
                             QuerySettings settings = schema.getSettings(getViewContext(), QueryView.DATAREGIONNAME_DEFAULT, surveyDesign.getQueryName());
+                            // issue 41377 : ignore any filters on the default view
+                            settings.setIgnoreViewFilter(true);
 
                             Object value = survey.getResponsesPk();
                             if (value == null)
@@ -783,7 +785,7 @@ public class SurveyController extends SpringActionController implements SurveyUr
                                             surveyDesign.getSchemaName(), surveyDesign.getQueryName(), settings.getOffset(), null,
                                             false, false, false);
 
-                                    // add some of the survey record information to the response
+                                    // add some survey record information to the response
                                     Map<String, Object> extraProps = new HashMap<>();
                                     extraProps.put("rowId", survey.getRowId());
                                     extraProps.put("label", survey.getLabel());


### PR DESCRIPTION
#### Rationale
When re-editing a saved survey, we try to fetch the current survey results using `SurveyController.GetSurveyResponseAction`. The action creates a `QueryView` to return an `ApiResponse` to the client code for processing. As detailed in the related issue, if the default view has a filter saved to it, the filter can cause the action to not return the corresponding record for the survey.

When the `DataView` is initialized we need to be able to ignore any filters on the custom view but respect any filters applied via the `QuerySettings` object, because this is how we select the existing row and why `QuerySettings.setIgnoreUserFilter` would not work. 

The way this is implemented is that `ignoreViewFilter` is a subset of `ignoreFilter` meaning you can't ignore the user filter but still have the custom view filter (only the other way around). I also did not end up exposing this setting via a `QueryParam` since folks aren't adding base filters through a `QuerySettings` object in these cases.

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=41377)