### PR TITLE
Skip expensive work in getQueries.api if certain props aren't needed

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/api": "1.18.0-pivot-perf.0",
+        "@labkey/api": "1.18.0",
         "@labkey/components": "2.274.0",
         "@labkey/themes": "1.3.0"
       },
@@ -2986,9 +2986,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.18.0-pivot-perf.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.0-pivot-perf.0.tgz",
-      "integrity": "sha512-dCCWGwjLMLl3jtqckzyfgR5V0Rqk6RS0iND5qukhC2e02cotb/IbNypx+xqstuHmwVQZNyzQWW8V5YLqvHl87Q=="
+      "version": "1.18.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.0.tgz",
+      "integrity": "sha512-mBuV4oC85E/MgbwF1OYCkcpoAV+d948CLfBDoUYY0d6on9aqwwy4papbETaQxZUbStxKQz6ogC6MmLP0iVJx8w=="
     },
     "node_modules/@labkey/build": {
       "version": "6.8.0",
@@ -17148,9 +17148,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.18.0-pivot-perf.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.0-pivot-perf.0.tgz",
-      "integrity": "sha512-dCCWGwjLMLl3jtqckzyfgR5V0Rqk6RS0iND5qukhC2e02cotb/IbNypx+xqstuHmwVQZNyzQWW8V5YLqvHl87Q=="
+      "version": "1.18.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.0.tgz",
+      "integrity": "sha512-mBuV4oC85E/MgbwF1OYCkcpoAV+d948CLfBDoUYY0d6on9aqwwy4papbETaQxZUbStxKQz6ogC6MmLP0iVJx8w=="
     },
     "@labkey/build": {
       "version": "6.8.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/api": "1.17.1",
+        "@labkey/api": "1.18.0-pivot-perf.0",
         "@labkey/components": "2.274.0",
         "@labkey/themes": "1.3.0"
       },
@@ -2986,9 +2986,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.17.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.17.1.tgz",
-      "integrity": "sha512-WkHwxiLtaTw/G5puYpHHr+kNLUQLEa+d8rA46kMU6GGHv1yjDwLQdmzJHKWRLTsJdpTSZ+ODMQkJG4T/B/JInA=="
+      "version": "1.18.0-pivot-perf.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.0-pivot-perf.0.tgz",
+      "integrity": "sha512-dCCWGwjLMLl3jtqckzyfgR5V0Rqk6RS0iND5qukhC2e02cotb/IbNypx+xqstuHmwVQZNyzQWW8V5YLqvHl87Q=="
     },
     "node_modules/@labkey/build": {
       "version": "6.8.0",
@@ -3063,6 +3063,11 @@
         "react-bootstrap": "^0.33.1",
         "react-dom": "^16.0"
       }
+    },
+    "node_modules/@labkey/components/node_modules/@labkey/api": {
+      "version": "1.17.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.17.1.tgz",
+      "integrity": "sha512-WkHwxiLtaTw/G5puYpHHr+kNLUQLEa+d8rA46kMU6GGHv1yjDwLQdmzJHKWRLTsJdpTSZ+ODMQkJG4T/B/JInA=="
     },
     "node_modules/@labkey/eslint-config-base": {
       "version": "0.0.12",
@@ -17143,9 +17148,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.17.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.17.1.tgz",
-      "integrity": "sha512-WkHwxiLtaTw/G5puYpHHr+kNLUQLEa+d8rA46kMU6GGHv1yjDwLQdmzJHKWRLTsJdpTSZ+ODMQkJG4T/B/JInA=="
+      "version": "1.18.0-pivot-perf.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.0-pivot-perf.0.tgz",
+      "integrity": "sha512-dCCWGwjLMLl3jtqckzyfgR5V0Rqk6RS0iND5qukhC2e02cotb/IbNypx+xqstuHmwVQZNyzQWW8V5YLqvHl87Q=="
     },
     "@labkey/build": {
       "version": "6.8.0",
@@ -17213,6 +17218,13 @@
         "react-treebeard": "~3.2.4",
         "redux-actions": "~2.3.2",
         "vis-network": "~6.5.2"
+      },
+      "dependencies": {
+        "@labkey/api": {
+          "version": "1.17.1",
+          "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.17.1.tgz",
+          "integrity": "sha512-WkHwxiLtaTw/G5puYpHHr+kNLUQLEa+d8rA46kMU6GGHv1yjDwLQdmzJHKWRLTsJdpTSZ+ODMQkJG4T/B/JInA=="
+        }
       }
     },
     "@labkey/eslint-config-base": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "1.17.1",
+    "@labkey/api": "1.18.0-pivot-perf.0",
     "@labkey/components": "2.274.0",
     "@labkey/themes": "1.3.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "1.18.0-pivot-perf.0",
+    "@labkey/api": "1.18.0",
     "@labkey/components": "2.274.0",
     "@labkey/themes": "1.3.0"
   },

--- a/internal/webapp/sqv/Selector.js
+++ b/internal/webapp/sqv/Selector.js
@@ -533,14 +533,24 @@ Ext4.define('LABKEY.sqv.Model', {
             if (this.queryCombo.includeSystemQueries === false)
                 includeSystemQueries = false;
 
+            var includeTitle = true;
+            if (this.queryCombo.includeTitle === false)
+                includeTitle = false;
+
+            var includeViewDataUrl = true;
+            if (this.queryCombo.includeViewDataUrl === false)
+                includeViewDataUrl = false;
+
             this.queryCombo.setLoading(true);
             LABKEY.Query.getQueries({
                 containerPath: selectedContainerId,
-                schemaName : selectedSchema,
+                schemaName: selectedSchema,
                 includeUserQueries: includeUserQueries,
                 includeSystemQueries: includeSystemQueries,
+                includeTitle: includeTitle,
+                includeViewDataUrl: includeViewDataUrl,
                 includeColumns: false,
-                success : function (details) {
+                success: function (details) {
                     this.queryCombo.setLoading(false);
                     var newQueries = details.queries;
                     this.queryStore.loadData(newQueries);

--- a/query/src/org/labkey/query/controllers/GetSchemaQueryTreeAction.java
+++ b/query/src/org/labkey/query/controllers/GetSchemaQueryTreeAction.java
@@ -49,8 +49,7 @@ import java.util.TreeMap;
  * Date: Sep 3, 2009
  * Time: 1:09:00 PM
  *
- * This class is used by the schema browser and the linked schema admin page (because getQueries.api can be much more
- * expensive)
+ * This class is used by the schema explorer query tree only
  */
 
 @RequiresPermission(ReadPermission.class)

--- a/query/src/org/labkey/query/controllers/GetSchemaQueryTreeAction.java
+++ b/query/src/org/labkey/query/controllers/GetSchemaQueryTreeAction.java
@@ -49,7 +49,8 @@ import java.util.TreeMap;
  * Date: Sep 3, 2009
  * Time: 1:09:00 PM
  *
- * This class is used by the schema explorer query tree only
+ * This class is used by the schema browser and the linked schema admin page (because getQueries.api can be much more
+ * expensive)
  */
 
 @RequiresPermission(ReadPermission.class)

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -6221,6 +6221,8 @@ public class QueryController extends SpringActionController
         private boolean _includeUserQueries = true;
         private boolean _includeSystemQueries = true;
         private boolean _includeColumns = true;
+        private boolean _includeViewDataUrl = true;
+        private boolean _includeTitle = true;
         private boolean _queryDetailColumns = false;
 
         public String getSchemaName()
@@ -6272,6 +6274,26 @@ public class QueryController extends SpringActionController
         {
             _queryDetailColumns = queryDetailColumns;
         }
+
+        public boolean isIncludeViewDataUrl()
+        {
+            return _includeViewDataUrl;
+        }
+
+        public void setIncludeViewDataUrl(boolean includeViewDataUrl)
+        {
+            _includeViewDataUrl = includeViewDataUrl;
+        }
+
+        public boolean isIncludeTitle()
+        {
+            return _includeTitle;
+        }
+
+        public void setIncludeTitle(boolean includeTitle)
+        {
+            _includeTitle = includeTitle;
+        }
     }
 
 
@@ -6308,8 +6330,8 @@ public class QueryController extends SpringActionController
                 {
                     if (!qdef.isTemporary())
                     {
-                        ActionURL viewDataUrl = uschema.urlFor(QueryAction.executeQuery, qdef);
-                        qinfos.add(getQueryProps(qdef, viewDataUrl, true, uschema, form.isIncludeColumns(), form.isQueryDetailColumns()));
+                        ActionURL viewDataUrl = form.isIncludeViewDataUrl() ? uschema.urlFor(QueryAction.executeQuery, qdef) : null;
+                        qinfos.add(getQueryProps(qdef, viewDataUrl, true, uschema, form.isIncludeColumns(), form.isQueryDetailColumns(), form.isIncludeTitle()));
                     }
                 }
             }
@@ -6324,8 +6346,8 @@ public class QueryController extends SpringActionController
                     QueryDefinition qdef = uschema.getQueryDefForTable(qname);
                     if (qdef != null)
                     {
-                        ActionURL viewDataUrl = uschema.urlFor(QueryAction.executeQuery, qdef);
-                        qinfos.add(getQueryProps(qdef, viewDataUrl, false, uschema, form.isIncludeColumns(), form.isQueryDetailColumns()));
+                        ActionURL viewDataUrl = form.isIncludeViewDataUrl() ? uschema.urlFor(QueryAction.executeQuery, qdef) : null;
+                        qinfos.add(getQueryProps(qdef, viewDataUrl, false, uschema, form.isIncludeColumns(), form.isQueryDetailColumns(), form.isIncludeTitle()));
                     }
                 }
             }
@@ -6334,7 +6356,7 @@ public class QueryController extends SpringActionController
             return response;
         }
 
-        protected Map<String, Object> getQueryProps(QueryDefinition qdef, ActionURL viewDataUrl, boolean isUserDefined, UserSchema schema, boolean includeColumns, boolean useQueryDetailColumns)
+        protected Map<String, Object> getQueryProps(QueryDefinition qdef, ActionURL viewDataUrl, boolean isUserDefined, UserSchema schema, boolean includeColumns, boolean useQueryDetailColumns, boolean includeTitle)
         {
             Map<String, Object> qinfo = new HashMap<>();
             qinfo.put("hidden", qdef.isHidden());
@@ -6364,44 +6386,51 @@ public class QueryController extends SpringActionController
             String name = qdef.getName();
             try
             {
-                //get the table info if the user requested column info
-                TableInfo table = qdef.getTable(schema, null, true);
-
-                if (null != table)
+                // get the TableInfo if the user requested column info or title, otherwise skip (it can be expensive)
+                if (includeColumns || includeTitle)
                 {
-                    if (includeColumns)
-                    {
-                        Collection<Map<String, Object>> columns;
+                    TableInfo table = qdef.getTable(schema, null, true);
 
-                        if (useQueryDetailColumns)
+                    if (null != table)
+                    {
+                        if (includeColumns)
                         {
-                            columns = JsonWriter
+                            Collection<Map<String, Object>> columns;
+
+                            if (useQueryDetailColumns)
+                            {
+                                columns = JsonWriter
                                     .getNativeColProps(table, Collections.emptyList(), null, false, false)
                                     .values();
-                        }
-                        else
-                        {
-                            columns = new ArrayList<>();
-                            for (ColumnInfo col : table.getColumns())
-                            {
-                                Map<String, Object> cinfo = new HashMap<>();
-                                cinfo.put("name", col.getName());
-                                if (null != col.getLabel())
-                                    cinfo.put("caption", col.getLabel());
-                                if (null != col.getShortLabel())
-                                    cinfo.put("shortCaption", col.getShortLabel());
-                                if (null != col.getDescription())
-                                    cinfo.put("description", col.getDescription());
-
-                                columns.add(cinfo);
                             }
+                            else
+                            {
+                                columns = new ArrayList<>();
+                                for (ColumnInfo col : table.getColumns())
+                                {
+                                    Map<String, Object> cinfo = new HashMap<>();
+                                    cinfo.put("name", col.getName());
+                                    if (null != col.getLabel())
+                                        cinfo.put("caption", col.getLabel());
+                                    if (null != col.getShortLabel())
+                                        cinfo.put("shortCaption", col.getShortLabel());
+                                    if (null != col.getDescription())
+                                        cinfo.put("description", col.getDescription());
+
+                                    columns.add(cinfo);
+                                }
+                            }
+
+                            if (columns.size() > 0)
+                                qinfo.put("columns", columns);
                         }
 
-                        if (columns.size() > 0)
-                            qinfo.put("columns", columns);
+                        if (includeTitle)
+                        {
+                            name = table.getPublicName();
+                            title = table.getTitle();
+                        }
                     }
-                    name = table.getPublicName();
-                    title = table.getTitle();
                 }
             }
             catch(Exception e)

--- a/query/src/org/labkey/query/view/linkedSchema.jsp
+++ b/query/src/org/labkey/query/view/linkedSchema.jsp
@@ -392,7 +392,9 @@
                     tablesValue = tables.join(",");
                 }
                 return tablesValue;
-            }
+            },
+            includeViewDataUrl: false,
+            includeTitle: false
         }));
         tablesCombo.on('change', updateTablesMessage);
         tablesCombo.on('dataloaded', updateTablesMessage);


### PR DESCRIPTION
#### Rationale
As discussed in the related PR and ticket, generating the column list for PIVOT queries can be very expensive. Related PR avoided this work in some cases (e.g., schema browser tree). This PR adds flags and reworks `GetQueriesAction` to avoid querying for columns in other cases (e.g., linked schema table drop-down).

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47010

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3937

#### Changes
* Add new GetQueriesAction flags: `includeColumns` and `includeTitle`. If these two flags are `false` as well as the (existing) `includeColumns` flag, then avoid creating the TableInfo and invoking getPivotValues().
* Add the two flags to SQV selector and linked schema admin page.
