### PR TITLE
Fix dependencies report

### DIFF
--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -19,7 +19,7 @@ package org.labkey.api.query;
 import org.apache.commons.collections4.SetValuedMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONObject;
+import org.json.JSONObject;
 import org.labkey.api.audit.AuditHandler;
 import org.labkey.api.audit.DetailedAuditTypeEvent;
 import org.labkey.api.query.column.ColumnInfoTransformer;


### PR DESCRIPTION
#### Rationale
Dependency report broke with the latest `JSONObject` change. Something about the mix of old and new JSONObjects in the AnalyzeDependencyAction response.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3955
