### PR TITLE
Fix up some save rows issues

### DIFF
--- a/api/src/org/labkey/api/util/JsonUtil.java
+++ b/api/src/org/labkey/api/util/JsonUtil.java
@@ -182,4 +182,15 @@ public class JsonUtil
 
         return result;
     }
+
+    // The new JSONObject.toMap() translates all JSONObjects into Maps and JSONArrays in Lists. In many cases, this is
+    // fine, but some existing code paths want to maintain the contained JSONObjects and JSONArrays. This method does
+    // that, acting more like the old JSONObject.toMap().
+    public static void fillMapShallow(JSONObject json, Map<String, Object> map)
+    {
+        json.keySet().forEach(key -> {
+            Object value = json.get(key);
+            map.put(key, JSONObject.NULL == value ? null : value);
+        });
+    }
 }

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -3971,10 +3971,10 @@ public class QueryController extends SpringActionController
                 for (Map<String, Object> row : rows)
                 {
                     //issue 13719: use CaseInsensitiveHashMaps.  Also allow either values or oldKeys to be null
-                    CaseInsensitiveHashMap newMap = row.get(SaveRowsAction.PROP_VALUES) != null ? new CaseInsensitiveHashMap((Map<String, Object>)row.get(SaveRowsAction.PROP_VALUES)) : new CaseInsensitiveHashMap();
+                    CaseInsensitiveHashMap<Object> newMap = row.get(SaveRowsAction.PROP_VALUES) != null ? new CaseInsensitiveHashMap<>(((JSONObject)row.get(SaveRowsAction.PROP_VALUES)).toMap()) : new CaseInsensitiveHashMap<>();
                     newRows.add(newMap);
 
-                    CaseInsensitiveHashMap oldMap = row.get(SaveRowsAction.PROP_OLD_KEYS) != null ? new CaseInsensitiveHashMap((Map<String, Object>)row.get(SaveRowsAction.PROP_OLD_KEYS)) : new CaseInsensitiveHashMap();
+                    CaseInsensitiveHashMap<Object> oldMap = row.get(SaveRowsAction.PROP_OLD_KEYS) != null ? new CaseInsensitiveHashMap<>(((JSONObject)row.get(SaveRowsAction.PROP_OLD_KEYS)).toMap()) : new CaseInsensitiveHashMap<>();
                     oldKeys.add(oldMap);
                 }
                 BatchValidationException errors = new BatchValidationException();
@@ -4034,10 +4034,10 @@ public class QueryController extends SpringActionController
                 {
                     // issue 13719: use CaseInsensitiveHashMaps.  Also allow either values or oldKeys to be null.
                     // this should never happen on an update, but we will let it fail later with a better error message instead of the NPE here
-                    CaseInsensitiveHashMap newMap = row.get(SaveRowsAction.PROP_VALUES) != null ? new CaseInsensitiveHashMap((Map<String, Object>)row.get(SaveRowsAction.PROP_VALUES)) : new CaseInsensitiveHashMap();
+                    CaseInsensitiveHashMap<Object> newMap = row.get(SaveRowsAction.PROP_VALUES) != null ? new CaseInsensitiveHashMap<>(((JSONObject)row.get(SaveRowsAction.PROP_VALUES)).toMap()) : new CaseInsensitiveHashMap<>();
                     newRows.add(newMap);
 
-                    CaseInsensitiveHashMap oldMap = row.get(SaveRowsAction.PROP_OLD_KEYS) != null ? new CaseInsensitiveHashMap((Map<String, Object>)row.get(SaveRowsAction.PROP_OLD_KEYS)) : new CaseInsensitiveHashMap();
+                    CaseInsensitiveHashMap<Object> oldMap = row.get(SaveRowsAction.PROP_OLD_KEYS) != null ? new CaseInsensitiveHashMap<>(((JSONObject)row.get(SaveRowsAction.PROP_OLD_KEYS)).toMap()) : new CaseInsensitiveHashMap<>();
                     oldKeys.add(oldMap);
                 }
                 List<Map<String, Object>> updatedRows = qus.updateRows(user, container, newRows, oldKeys, configParameters, extraContext);
@@ -4230,7 +4230,7 @@ public class QueryController extends SpringActionController
                     configParameters.put(DetailedAuditLogDataIterator.AuditConfigs.AuditUserComment, auditComment);
             }
 
-            //setup the response, providing the schema name, query name, and operation
+            //set up the response, providing the schema name, query name, and operation
             //so that the client can sort out which request this response belongs to
             //(clients often submit these async)
             response.put(PROP_SCHEMA_NAME, schemaName);

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1889,7 +1889,7 @@ public class QueryController extends SpringActionController
 
 
     /**
-     * Can be used to generate an Excel template for import into a table.  Supported URL params include:
+     * Can be used to generate an Excel template for import into a table. Supported URL params include:
      * <dl>
      *     <dt>filenamePrefix</dt>
      *     <dd>the prefix of the excel file that is generated, defaults to '_data'</dd>
@@ -1915,7 +1915,7 @@ public class QueryController extends SpringActionController
      *     </dd>
      *
      *     <dt>captionType</dt>
-     *     <dd>determines which column property is used in the header.  either Label or Name</dd>
+     *     <dd>determines which column property is used in the header, either Label or Name</dd>
      * </dl>
      */
     @RequiresPermission(ReadPermission.class)
@@ -2221,8 +2221,8 @@ public class QueryController extends SpringActionController
         if (canEdit)
         {
             // Issue 13594: Disallow setting of the customview inherit bit for query views
-            // that have no available container filter types.  Unfortunately, the only way
-            // to get the container filters is from the QueryView.  Ideally, the query def
+            // that have no available container filter types. Unfortunately, the only way
+            // to get the container filters is from the QueryView. Ideally, the query def
             // would know if it was container filterable or not instead of using the QueryView.
             if (inherit && canSaveForAllUsers && !session)
             {
@@ -3970,7 +3970,7 @@ public class QueryController extends SpringActionController
                 List<Map<String, Object>> oldKeys = new ArrayList<>();
                 for (Map<String, Object> row : rows)
                 {
-                    //issue 13719: use CaseInsensitiveHashMaps.  Also allow either values or oldKeys to be null
+                    //issue 13719: use CaseInsensitiveHashMaps. Also allow either values or oldKeys to be null
                     CaseInsensitiveHashMap<Object> newMap = row.get(SaveRowsAction.PROP_VALUES) != null ? new CaseInsensitiveHashMap<>(((JSONObject)row.get(SaveRowsAction.PROP_VALUES)).toMap()) : new CaseInsensitiveHashMap<>();
                     newRows.add(newMap);
 
@@ -4032,7 +4032,7 @@ public class QueryController extends SpringActionController
                 List<Map<String, Object>> oldKeys = new ArrayList<>();
                 for (Map<String, Object> row : rows)
                 {
-                    // issue 13719: use CaseInsensitiveHashMaps.  Also allow either values or oldKeys to be null.
+                    // issue 13719: use CaseInsensitiveHashMaps. Also allow either values or oldKeys to be null.
                     // this should never happen on an update, but we will let it fail later with a better error message instead of the NPE here
                     CaseInsensitiveHashMap<Object> newMap = row.get(SaveRowsAction.PROP_VALUES) != null ? new CaseInsensitiveHashMap<>(((JSONObject)row.get(SaveRowsAction.PROP_VALUES)).toMap()) : new CaseInsensitiveHashMap<>();
                     newRows.add(newMap);
@@ -4206,7 +4206,7 @@ public class QueryController extends SpringActionController
                 {
                     Map<String, Object> rowMap = null == f ? new CaseInsensitiveHashMap<>() : f.getRowMap();
                     // Use shallow copy since jsonObj.toMap() will translate contained JSONObjects into Maps, which we don't want
-                    jsonObj.keySet().forEach(key -> rowMap.put(key, jsonObj.get(key)));
+                    JsonUtil.fillMapShallow(jsonObj, rowMap);
                     if (allowRowAttachments())
                         addRowAttachments(rowMap, idx);
 
@@ -5588,7 +5588,7 @@ public class QueryController extends SpringActionController
             DbScope scope = QueryManager.get().getDbSchema().getScope();
             try (DbScope.Transaction tx = scope.ensureTransaction())
             {
-                // Delete the session view.  The view will be restored if an exception is thrown.
+                // Delete the session view. The view will be restored if an exception is thrown.
                 view.delete(getUser(), getViewContext().getRequest());
 
                 // Get any previously existing non-session view.
@@ -5629,11 +5629,11 @@ public class QueryController extends SpringActionController
                 }
                 else if (!existingView.isEditable())
                 {
-                    throw new IllegalArgumentException("Existing view '" + form.getNewName() + "' is not editable.  You may save this view with a different name.");
+                    throw new IllegalArgumentException("Existing view '" + form.getNewName() + "' is not editable. You may save this view with a different name.");
                 }
                 else
                 {
-                    // UNDONE: changing shared property of an existing view is unimplemented.  Not sure if it makes sense from a usability point of view.
+                    // UNDONE: changing shared property of an existing view is unimplemented. Not sure if it makes sense from a usability point of view.
                     existingView.setColumns(view.getColumns());
                     existingView.setFilterAndSort(view.getFilterAndSort());
                     existingView.setColumnProperties(view.getColumnProperties());

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4308,6 +4308,7 @@ public class QueryController extends SpringActionController
             {
                 if (isSuccessOnValidationError())
                 {
+                    // Note: This old JSONObject gets converted into a new JSONObjects on put (because it's also a map)
                     response.put("errors", createResponseWriter().getJSON(e));
                 }
                 else
@@ -4552,16 +4553,7 @@ public class QueryController extends SpringActionController
                     //this would be populated in executeJson when a BatchValidationException is thrown
                     if (commandResponse.has("errors"))
                     {
-                        // I don't see how commandResponse.get("errors") would ever return an org.json.JSONObject,
-                        // but WNPRC test failures are adamant that it's an org.json.JSONObject. Allow either for now.
-                        // TODO: Track this down.
-                        Object jsonErrors = commandResponse.get("errors");
-                        if (jsonErrors instanceof org.json.old.JSONObject older)
-                            errorCount += older.getInt("errorCount");
-                        else if (jsonErrors instanceof JSONObject newer)
-                            errorCount += newer.getInt("errorCount");
-                        else
-                            throw new IllegalStateException("jsonErrors was of unexpected class: " + jsonErrors.getClass());
+                        errorCount += commandResponse.getJSONObject("errors").getInt("errorCount");
                     }
 
                     // If we encountered errors with this particular command and the client requested that don't treat


### PR DESCRIPTION
#### Rationale
Related PR switched `executeJson()` to return `Map<String, Object>` instead of old `JSONObject`, because the new JSONObject doesn't support null values. That change caused other problems, so this is an attempt to switch to the new JSONObject and workaround the null issue.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3955
