### PR TITLE
Reclassification Support

### DIFF
--- a/api/src/org/labkey/api/data/PropertyStorageSpec.java
+++ b/api/src/org/labkey/api/data/PropertyStorageSpec.java
@@ -170,10 +170,13 @@ public class PropertyStorageSpec
         setMvEnabled(propertyDescriptor.isMvEnabled());
         setDescription(propertyDescriptor.getDescription());
         setImportAliases(propertyDescriptor.getImportAliases());
+
+        if (null != propertyDescriptor.getDatabaseDefaultValue())
+            setDefaultValue(propertyDescriptor.getDatabaseDefaultValue());
     }
 
     /**
-     * bare mininum storage specification
+     * bare minimum storage specification
      */
     public PropertyStorageSpec(String name, JdbcType jdbcType)
     {

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -2511,6 +2511,8 @@ public class OntologyManager
             }
 
             PropertyDescriptor pexist = ensurePropertyDescriptor(pd);
+            pexist.setDatabaseDefaultValue(pd.getDatabaseDefaultValue());
+            pexist.setNullable(pd.isNullable());
             pexist.setRequired(pd.isRequired());
 
             ensurePropertyDomain(pexist, dexist, sortOrder);

--- a/api/src/org/labkey/api/exp/PropertyDescriptor.java
+++ b/api/src/org/labkey/api/exp/PropertyDescriptor.java
@@ -71,6 +71,7 @@ public class PropertyDescriptor extends ColumnRenderPropertiesImpl implements Pa
     private String _lookupQuery;
     private boolean _mvEnabled;
     private String _mvIndicatorStorageColumnName;        // only valid if mvEnabled
+    private Object _databaseDefaultValue;
 
     private static final Logger LOG = LogManager.getLogger(PropertyDescriptor.class);
 
@@ -218,7 +219,6 @@ public class PropertyDescriptor extends ColumnRenderPropertiesImpl implements Pa
         _storageColumnName = storageColumnName;
         if (_mvEnabled)
             _mvIndicatorStorageColumnName = makeMvIndicatorStorageColumnName();
-
     }
 
     public String getLegalSelectName(SqlDialect dialect)
@@ -291,11 +291,13 @@ public class PropertyDescriptor extends ColumnRenderPropertiesImpl implements Pa
         return _propertyURI + " name=" + _name + " project="+  (_project == null ? "null" : _project.getPath()) + " container="+  (_container ==null ? "null" : _container.getPath()) + " label=" + _label + " range=" + _rangeURI + " concept=" + _conceptURI;
     }
 
-    public Container getContainer() {
+    public Container getContainer()
+    {
         return _container;
     }
 
-    public void setContainer(Container container) {
+    public void setContainer(Container container)
+    {
         _container = container;
         if (null== _project)
             _project =container.getProject();
@@ -303,11 +305,13 @@ public class PropertyDescriptor extends ColumnRenderPropertiesImpl implements Pa
             _project =container;
     }
 
-    public Container getProject() {
+    public Container getProject()
+    {
         return _project;
     }
 
-    public void setProject(Container proj) {
+    public void setProject(Container proj)
+    {
         _project = proj;
     }
 
@@ -521,6 +525,16 @@ public class PropertyDescriptor extends ColumnRenderPropertiesImpl implements Pa
                     .anyMatch(d -> VOCABULARY_DOMAIN.equals(d.getKindName()));
         }
         return _vocabulary;
+    }
+
+    public @Nullable Object getDatabaseDefaultValue()
+    {
+        return _databaseDefaultValue;
+    }
+
+    public void setDatabaseDefaultValue(@Nullable Object databaseDefaultValue)
+    {
+        _databaseDefaultValue = databaseDefaultValue;
     }
 }
 

--- a/api/src/org/labkey/api/exp/api/ExpLineage.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineage.java
@@ -339,9 +339,6 @@ public class ExpLineage
         boolean findBothMaterialAndData
     )
     {
-        if (!_seeds.contains(seed))
-            throw new UnsupportedOperationException();
-
         assert cpasType != null || clazz == ExpMaterial.class || clazz == ExpData.class || findBothMaterialAndData;
 
         Map<String, Identifiable> nodes = processNodes();

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -1202,6 +1202,7 @@ public class DomainImpl implements Domain
     {
         PropertyDescriptor pd = new PropertyDescriptor();
         pd.setContainer(getContainer());
+        pd.setDatabaseDefaultValue(spec.getDefaultValue());
         pd.setName(spec.getName());
         pd.setJdbcType(spec.getJdbcType(), spec.getSize());
         pd.setNullable(spec.isNullable());


### PR DESCRIPTION
#### Rationale
This PR contains a variety of changes in support of LKB Registry reclassification. See https://github.com/LabKey/biologics/pull/1827 for more details.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/1827

#### Changes
* Support setting a database-level default value in a `PropertyDescriptor`. This allows for things like `setNullable()` on `PropertyStorageSpec` to be respected when adding columns to a domain.
* Add lineage utility algorithm `findNearestChildren`. Uses a refactored implementation of `findNearestParent` which existed previously.
