### PR TITLE
Migrate ApiResponseWriter

### DIFF
--- a/api/src/org/labkey/api/action/ApiResponseWriter.java
+++ b/api/src/org/labkey/api/action/ApiResponseWriter.java
@@ -17,8 +17,8 @@ package org.labkey.api.action;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
-import org.json.old.JSONArray;
-import org.json.old.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.PropertyValidationError;
 import org.labkey.api.query.SimpleValidationError;
@@ -414,7 +414,7 @@ public abstract class ApiResponseWriter implements AutoCloseable
         return obj;
     }
 
-    public void toJSON(JSONArray parent, ValidationError error)
+    private void toJSON(JSONArray parent, ValidationError error)
     {
         String msg = error.getMessage();
         String key = null;

--- a/api/src/org/labkey/api/action/ExtFormResponseWriter.java
+++ b/api/src/org/labkey/api/action/ExtFormResponseWriter.java
@@ -15,7 +15,7 @@
  */
 package org.labkey.api.action;
 
-import org.json.old.JSONObject;
+import org.json.JSONObject;
 import org.labkey.api.query.PropertyValidationError;
 import org.labkey.api.query.ValidationError;
 import org.labkey.api.query.ValidationException;

--- a/api/src/org/labkey/api/util/JsonUtil.java
+++ b/api/src/org/labkey/api/util/JsonUtil.java
@@ -193,4 +193,14 @@ public class JsonUtil
             map.put(key, JSONObject.NULL == value ? null : value);
         });
     }
+
+    // New JSONObject discards all properties with null values. This returns a JSONObject containing all Map values,
+    // preserving null values using the JSONObject.NULL placeholder. This is a shallow copy; standard JSONObject
+    // handling will be performed on each top-level put.
+    public static JSONObject toJsonPreserveNulls(Map<String, Object> map)
+    {
+        JSONObject json = new JSONObject();
+        map.forEach((k, v) -> json.put(k, null == v ? JSONObject.NULL : v));
+        return json;
+    }
 }

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4308,7 +4308,6 @@ public class QueryController extends SpringActionController
             {
                 if (isSuccessOnValidationError())
                 {
-                    // Note: This old JSONObject gets converted into a new JSONObjects on put (because it's also a map)
                     response.put("errors", createResponseWriter().getJSON(e));
                 }
                 else

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -50,6 +50,7 @@ import org.labkey.api.audit.TransactionAuditProvider;
 import org.labkey.api.audit.provider.ContainerAuditProvider;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.collections.LabKeyCollectors;
 import org.labkey.api.collections.RowMapFactory;
 import org.labkey.api.collections.Sets;
 import org.labkey.api.data.*;
@@ -4258,7 +4259,9 @@ public class QueryController extends SpringActionController
                     auditEvent.setRowCount(responseRows.size());
 
                 if (commandType != CommandType.importRows)
-                    response.put("rows", responseRows);
+                    response.put("rows", responseRows.stream()
+                        .map(JsonUtil::toJsonPreserveNulls)
+                        .collect(LabKeyCollectors.toJSONArray()));
 
                 // if there is any provenance information, save it here
                 ProvenanceService svc = ProvenanceService.get();


### PR DESCRIPTION
#### Rationale
Switch the save rows response "errors" element (and, in fact, all of ApiResponseWriter) to use the new JSONObject. The previous old/new hybrid was causing issues with some code paths. For example, "TypeError: array.forEach is not a function" error in [WNPRC_EHRTest.testBilling](https://teamcity.labkey.org/viewLog.html?buildId=2200181&tab=buildResultsDiv&buildTypeId=LabKey_Trunk_Premium_Ehr_WnprcEhrPostgres&branch_LabKey_Trunk_Premium_Ehr=save_rows).

Restore save row's ability to return null values in the rows response. Example test failure: "java.lang.AssertionError: Save rows return is missing field: DEMasian" in [StudyTest.testSteps](https://teamcity.labkey.org/viewLog.html?buildId=2202400&tab=buildResultsDiv&buildTypeId=LabkeyTrunk_ModuleSuites_SpecimenSqlserver&branch_LabkeyTrunk_ModuleSuites=responsewriter).

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3967