### PR TITLE
Add userComment field in SampleTimelineAuditEvent and in the SampleTimelineEvent metadata

### DIFF
--- a/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
+++ b/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
@@ -88,6 +88,7 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
     private String _metadata;
     private String _inventoryUpdateType;
     private Long _transactionId;
+    private String _userComment;
 
     public SampleTimelineAuditEvent()
     {
@@ -189,6 +190,16 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
         _transactionId = transactionId;
     }
 
+    public String getUserComment()
+    {
+        return _userComment;
+    }
+
+    public void setUserComment(String userComment)
+    {
+        _userComment = userComment;
+    }
+
     @Override
     public Map<String, Object> getAuditLogMessageElements()
     {
@@ -202,6 +213,7 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
         elements.put("inventoryUpdateType", getInventoryUpdateType());
         elements.put("transactionId", getTransactionId());
         elements.put("metadata", getMetadata());
+        elements.put("userComment", getUserComment());
         elements.putAll(super.getAuditLogMessageElements());
         return elements;
     }

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -201,9 +201,9 @@ public interface SampleTypeService
 
     boolean parentAliasHasCorrectFormat(String parentAlias);
 
-    void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata);
+    void addAuditEvent(User user, Container container, String comment, String userComment, ExpMaterial sample, Map<String, Object> metadata);
 
-    void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, String updateType);
+    void addAuditEvent(User user, Container container, String comment, String userComment, ExpMaterial sample, Map<String, Object> metadata, String updateType);
 
     // find the max sequence number with '${sampleName}-' prefix
     long getMaxAliquotId(@NotNull String sampleName, @NotNull String sampleTypeLsid, Container container);

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -1452,7 +1452,7 @@ public class XarReader extends AbstractXarImporter
                 if (_auditBehaviorType == AuditBehaviorType.DETAILED)
                 {
                     SampleTypeServiceImpl service = SampleTypeServiceImpl.get();
-                    service.addAuditEvent(getUser(), getContainer(), service.getCommentDetailed(QueryService.AuditAction.INSERT, false), mi, null);
+                    service.addAuditEvent(getUser(), getContainer(), service.getCommentDetailed(QueryService.AuditAction.INSERT, false), null, mi, null);
                 }
                 if (xbMaterial.isSetAlias())
                 {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1082,14 +1082,14 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     public DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> existingRow)
     {
         // not doing anything with userComment at the moment
-        return createAuditRecord(c, getCommentDetailed(action, !existingRow.isEmpty()), action, row, existingRow);
+        return createAuditRecord(c, getCommentDetailed(action, !existingRow.isEmpty()), userComment, action, row, existingRow);
     }
 
     @Override
     protected AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row)
     {
         // not doing anything with userComment at the moment
-        return createAuditRecord(c, String.format(action.getCommentSummary(), rowCount), row);
+        return createAuditRecord(c, String.format(action.getCommentSummary(), rowCount), userComment, row);
     }
 
     @Override
@@ -1106,9 +1106,9 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         });
     }
 
-    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable Map<String, Object> row)
+    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, String userComment, @Nullable Map<String, Object> row)
     {
-        return createAuditRecord(c, comment, null, row, null);
+        return createAuditRecord(c, comment, userComment, null, row, null);
     }
 
     private boolean isInputFieldKey(String fieldKey)
@@ -1118,9 +1118,10 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 slash==ExpMaterial.MATERIAL_INPUT_PARENT.length() && StringUtils.startsWithIgnoreCase(fieldKey,ExpMaterial.MATERIAL_INPUT_PARENT);
     }
 
-    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, @Nullable QueryService.AuditAction action, @Nullable Map<String, Object> row, @Nullable Map<String, Object> existingRow)
+    private SampleTimelineAuditEvent createAuditRecord(Container c, String comment, String userComment, @Nullable QueryService.AuditAction action, @Nullable Map<String, Object> row, @Nullable Map<String, Object> existingRow)
     {
         SampleTimelineAuditEvent event = new SampleTimelineAuditEvent(c.getId(), comment);
+        event.setUserComment(userComment);
         var tx = getExpSchema().getScope().getCurrentTransaction();
         if (tx != null)
             event.setTransactionId(tx.getAuditId());
@@ -1192,13 +1193,13 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     }
 
     @Override
-    public void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata)
+    public void addAuditEvent(User user, Container container, String comment, String userComment, ExpMaterial sample, Map<String, Object> metadata)
     {
         AuditLogService.get().addEvent(user, createAuditRecord(container, comment, sample, metadata));
     }
 
     @Override
-    public void addAuditEvent(User user, Container container, String comment, ExpMaterial sample, Map<String, Object> metadata, String updateType)
+    public void addAuditEvent(User user, Container container, String comment, String userComment, ExpMaterial sample, Map<String, Object> metadata, String updateType)
     {
         SampleTimelineAuditEvent event = createAuditRecord(container, comment, sample, metadata);
         event.setInventoryUpdateType(updateType);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1081,14 +1081,12 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     @Override
     public DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> existingRow)
     {
-        // not doing anything with userComment at the moment
         return createAuditRecord(c, getCommentDetailed(action, !existingRow.isEmpty()), userComment, action, row, existingRow);
     }
 
     @Override
     protected AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row)
     {
-        // not doing anything with userComment at the moment
         return createAuditRecord(c, String.format(action.getCommentSummary(), rowCount), userComment, row);
     }
 

--- a/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
@@ -25,7 +25,7 @@ public class SampleTimelineAuditProvider extends AbstractAuditTypeProvider
     public static final String SAMPLE_TYPE_COLUMN_NAME = "SampleType";
     public static final String SAMPLE_TYPE_ID_COLUMN_NAME = "SampleTypeID";
     public static final String SAMPLE_NAME_COLUMN_NAME = "SampleName";
-    public static final String SAMPLE_LSID_COLUMN_NAME = "SampleLSID"; // ??? TODO remove once we have RowId always available
+    public static final String SAMPLE_LSID_COLUMN_NAME = "SampleLSID";
     public static final String SAMPLE_ID_COLUMN_NAME = "SampleID";
     public static final String METADATA_COLUMN_NAME = "Metadata";
     public static final String IS_LINEAGE_UPDATE_COLUMN_NAME = "IsLineageUpdate";
@@ -46,6 +46,7 @@ public class SampleTimelineAuditProvider extends AbstractAuditTypeProvider
         defaultVisibleColumns.add(FieldKey.fromParts(IS_LINEAGE_UPDATE_COLUMN_NAME));
         defaultVisibleColumns.add(FieldKey.fromParts(INVENTORY_UPDATE_TYPE_COLUMN_NAME));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_COMMENT));
+        defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_USER_COMMENT));
     }
 
     public SampleTimelineAuditProvider()
@@ -117,6 +118,10 @@ public class SampleTimelineAuditProvider extends AbstractAuditTypeProvider
                 {
                     col.setLabel("Transaction ID");
                 }
+                else if (COLUMN_NAME_USER_COMMENT.equalsIgnoreCase(col.getName()))
+                {
+                    col.setLabel("User Comment");
+                }
             }
         };
         table.setTitleColumn(SAMPLE_NAME_COLUMN_NAME);
@@ -155,6 +160,7 @@ public class SampleTimelineAuditProvider extends AbstractAuditTypeProvider
             fields.add(createPropertyDescriptor(IS_LINEAGE_UPDATE_COLUMN_NAME, PropertyType.BOOLEAN));
             fields.add(createPropertyDescriptor(INVENTORY_UPDATE_TYPE_COLUMN_NAME, PropertyType.STRING));
             fields.add(createPropertyDescriptor(METADATA_COLUMN_NAME, PropertyType.STRING, -1));        // varchar max
+            fields.add(createPropertyDescriptor(COLUMN_NAME_USER_COMMENT, PropertyType.STRING, -1));
             fields.add(createOldDataMapPropertyDescriptor());
             fields.add(createNewDataMapPropertyDescriptor());
             fields.add(createPropertyDescriptor(COLUMN_NAME_TRANSACTION_ID, PropertyType.BIGINT));        // varchar max


### PR DESCRIPTION
#### Rationale
We are adding the ability for users to provide comments when editing and deleting samples and need to capture these comments in the audit logs.  We already have the mechanism for getting these comments, just need to pass them through to the sample-specific operations.

#### Related Pull Requests
- https://github.com/LabKey/sampleManagement/pull/1518
- https://github.com/LabKey/inventory/pull/676

#### Changes
* Add UserComment field to SampleTimelineAuditEvent.
* pass user comment through to various methods that create audit logs
