### PR TITLE
Skip expensive work to improve PIVOT query metadata retrieval

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -27,8 +27,6 @@ List apache = [
         "org.apache.commons:commons-lang3:${commonsLang3Version}",
         "commons-pool:commons-pool:${commonsPoolVersion}",
         "commons-validator:commons-validator:${commonsValidatorVersion}",
-        "org.apache.httpcomponents:httpclient:${httpclientVersion}",
-        "org.apache.httpcomponents:httpcore:${httpcoreVersion}",
         "org.apache.httpcomponents.client5:httpclient5:${httpclient5Version}",
         "org.apache.httpcomponents.core5:httpcore5:${httpcore5Version}",
         "org.apache.poi:poi:${poiVersion}",

--- a/api/src/org/labkey/api/data/CrosstabTable.java
+++ b/api/src/org/labkey/api/data/CrosstabTable.java
@@ -306,33 +306,15 @@ public class CrosstabTable extends VirtualTable implements CrosstabTableInfo
         //finally group by the row dimensions
         sql.append("\nGROUP BY ");
         sep = "";
-        for(CrosstabDimension rowDim : getSettings().getRowAxis().getDimensions())
+        for (CrosstabDimension rowDim : getSettings().getRowAxis().getDimensions())
         {
-            sql.append(sep);
-            sql.append(PIVOT_ALIAS + "." + rowDim.getSourceColumn().getAlias());
+            sql.append(sep)
+                .append(PIVOT_ALIAS + ".")
+                .append(rowDim.getSourceColumn().getAlias());
             sep = ", ";
         }
 
     } //addCrosstabQuery()
-
-    public Map<String, String> getMeasureNameToColumnNameMap()
-    {
-        Map<String, String> measureNameToColumnName = new HashMap<>();
-        for (Map.Entry<String, ColumnInfo> entry : _columnMap.entrySet())
-        {
-            String colName = entry.getKey();
-            ColumnInfo col = entry.getValue();
-            String measureName;
-            if (col instanceof AggregateColumnInfo)
-                measureName = String.valueOf(((AggregateColumnInfo) col).getMember().getValue());
-            else if (col instanceof DimensionColumnInfo)
-                measureName = ((DimensionColumnInfo) col).getSourceFieldKey().toString();
-            else
-                measureName = col.getName();
-            measureNameToColumnName.put(measureName, colName);
-        }
-        return measureNameToColumnName;
-    }
 
     protected void addPivotQuery(SQLFragment sql)
     {
@@ -342,8 +324,9 @@ public class CrosstabTable extends VirtualTable implements CrosstabTableInfo
         String sep = "";
         for(CrosstabDimension rowDim : getSettings().getRowAxis().getDimensions())
         {
-            sql.append(sep);
-            sql.append(AGG_FILTERED_ALIAS + "." + rowDim.getSourceColumn().getAlias());
+            sql.append(sep)
+                .append(AGG_FILTERED_ALIAS + ".")
+                .append(rowDim.getSourceColumn().getAlias());
             sep = ", ";
         }
 
@@ -431,7 +414,7 @@ public class CrosstabTable extends VirtualTable implements CrosstabTableInfo
         CrosstabDimension colDimension = getSettings().getColumnAxis().getDimensions().get(0);
 
         sql.append("(CASE WHEN ");
-        sql.append(queryAlias + "." + colDimension.getSourceColumn().getAlias());
+        sql.append(queryAlias).append(".").append(colDimension.getSourceColumn().getAlias());
         sql.append("=");
         String value = getSQLValue(colDimension.getSourceColumn().getJdbcType(), member.getValue());
         sql.append(value);
@@ -530,19 +513,6 @@ public class CrosstabTable extends VirtualTable implements CrosstabTableInfo
         return sql;
     }
     
-
-    /**
-     * Returns a column map suitable for passing to SimpleFilter's getSQLFragment() method.
-     * The map contains the same columns that are added when the table info is constructed
-     * without any column members (e.g., for customize view).
-     *
-     * @return A column map
-     */
-    protected Map<String, ColumnInfo> getAggregateFilterColMap()
-    {
-        return new CrosstabTable(getSettings())._columnMap;
-    }
-
     protected Map<FieldKey, ColumnInfo> getAggregateFilterColMap(Collection<ColumnInfo> cols)
     {
         Map<FieldKey,ColumnInfo> map = new HashMap<>(cols.size());

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/api": "1.16.1",
+        "@labkey/api": "1.18.0",
         "@labkey/components": "2.242.8",
         "@labkey/themes": "1.3.0"
       },
@@ -2969,10 +2969,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.16.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.16.1.tgz",
-      "integrity": "sha512-OVHhObWPVu7w/6pDXHBo3uaRRfDztmAY31/X8omx2BV+AHPNplFwxORUjQFgIsBHj6u79T44ZpJLETdxuR2sSg==",
-      "license": "Apache-2.0"
+      "version": "1.18.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.0.tgz",
+      "integrity": "sha512-mBuV4oC85E/MgbwF1OYCkcpoAV+d948CLfBDoUYY0d6on9aqwwy4papbETaQxZUbStxKQz6ogC6MmLP0iVJx8w=="
     },
     "node_modules/@labkey/build": {
       "version": "6.3.2",
@@ -3057,6 +3056,11 @@
         "react-bootstrap": "^0.33.1",
         "react-dom": "^16.0"
       }
+    },
+    "node_modules/@labkey/components/node_modules/@labkey/api": {
+      "version": "1.16.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.16.1.tgz",
+      "integrity": "sha512-OVHhObWPVu7w/6pDXHBo3uaRRfDztmAY31/X8omx2BV+AHPNplFwxORUjQFgIsBHj6u79T44ZpJLETdxuR2sSg=="
     },
     "node_modules/@labkey/eslint-config-base": {
       "version": "0.0.12",
@@ -16947,9 +16951,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.16.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.16.1.tgz",
-      "integrity": "sha512-OVHhObWPVu7w/6pDXHBo3uaRRfDztmAY31/X8omx2BV+AHPNplFwxORUjQFgIsBHj6u79T44ZpJLETdxuR2sSg=="
+      "version": "1.18.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.0.tgz",
+      "integrity": "sha512-mBuV4oC85E/MgbwF1OYCkcpoAV+d948CLfBDoUYY0d6on9aqwwy4papbETaQxZUbStxKQz6ogC6MmLP0iVJx8w=="
     },
     "@labkey/build": {
       "version": "6.3.2",
@@ -17027,6 +17031,13 @@
         "redux-actions": "~2.3.2",
         "use-immer": "~0.6.0",
         "vis-network": "~6.5.2"
+      },
+      "dependencies": {
+        "@labkey/api": {
+          "version": "1.16.1",
+          "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.16.1.tgz",
+          "integrity": "sha512-OVHhObWPVu7w/6pDXHBo3uaRRfDztmAY31/X8omx2BV+AHPNplFwxORUjQFgIsBHj6u79T44ZpJLETdxuR2sSg=="
+        }
       }
     },
     "@labkey/eslint-config-base": {

--- a/core/package.json
+++ b/core/package.json
@@ -51,7 +51,7 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "1.16.1",
+    "@labkey/api": "1.18.0",
     "@labkey/components": "2.242.8",
     "@labkey/themes": "1.3.0"
   },

--- a/internal/webapp/sqv/Selector.js
+++ b/internal/webapp/sqv/Selector.js
@@ -533,14 +533,24 @@ Ext4.define('LABKEY.sqv.Model', {
             if (this.queryCombo.includeSystemQueries === false)
                 includeSystemQueries = false;
 
+            var includeTitle = true;
+            if (this.queryCombo.includeTitle === false)
+                includeTitle = false;
+
+            var includeViewDataUrl = true;
+            if (this.queryCombo.includeViewDataUrl === false)
+                includeViewDataUrl = false;
+
             this.queryCombo.setLoading(true);
             LABKEY.Query.getQueries({
                 containerPath: selectedContainerId,
-                schemaName : selectedSchema,
+                schemaName: selectedSchema,
                 includeUserQueries: includeUserQueries,
                 includeSystemQueries: includeSystemQueries,
+                includeTitle: includeTitle,
+                includeViewDataUrl: includeViewDataUrl,
                 includeColumns: false,
-                success : function (details) {
+                success: function (details) {
                     this.queryCombo.setLoading(false);
                     var newQueries = details.queries;
                     this.queryStore.loadData(newQueries);

--- a/query/src/org/labkey/query/QueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/QueryDefinitionImpl.java
@@ -565,7 +565,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
                     table = createTable(schema, errors, includeMetadata, null, skipSuggestedColumns);
                 }
 
-                if (null == table)
+                if (null == table || (null != errors && !errors.isEmpty()))
                     return null;
 
                 log.debug("Caching table " + schema.getName() + "." + table.getName());

--- a/query/src/org/labkey/query/sql/QueryPivot.java
+++ b/query/src/org/labkey/query/sql/QueryPivot.java
@@ -187,7 +187,7 @@ public class QueryPivot extends QueryRelation
 
                 // TODO check duplicate values as well as duplicate names
                 if (pivotValues.containsKey(name))
-                    parseError("Duplicate pivot column name: " + name + ".\nColumn names are case-insensitve, you may need to use lower() or upper() in your query to work around this.", node);
+                    parseError("Duplicate pivot column name: " + name + ".\nColumn names are case-insensitive, you may need to use lower() or upper() in your query to work around this.", node);
                 else
                     pivotValues.put(name, constant);
             }
@@ -233,14 +233,12 @@ public class QueryPivot extends QueryRelation
             parseError("Could not find pivot column in group by list, expression must match exactly: " + _pivotColumn.getAlias(), null);
     }
 
-
-
-    Map<String,IConstant> getPivotValues() throws SQLException
+    Map<String, IConstant> getPivotValues()
     {
         if (null != _pivotValues)
             return _pivotValues;
 
-        _pivotValues = new CaseInsensitiveMapWrapper<>(new LinkedHashMap<String,IConstant>());
+        _pivotValues = new CaseInsensitiveMapWrapper<>(new LinkedHashMap<>());
         SQLFragment sqlPivotValues = null;
         boolean hasPhiColumns = false;
 
@@ -345,6 +343,10 @@ public class QueryPivot extends QueryRelation
         {
             parseError("Pivot query unauthorized.", null);
         }
+        catch (SQLException | DataAccessException x)
+        {
+            parseError("Could not compute pivot column list", null);
+        }
 
         return _pivotValues;
     }
@@ -406,21 +408,6 @@ public class QueryPivot extends QueryRelation
         if (!getParseErrors().isEmpty())
             return null;
 
-        try
-        {
-            getPivotValues();
-        }
-        catch (QueryService.NamedParameterNotProvided x)
-        {
-            parseError("When used with parameterized query, PIVOT requires an explicit values list", null);
-            parseError(x.getMessage(), null);
-            return null;
-        }
-        catch (SQLException|DataAccessException x)
-        {
-            parseError("Could not compute pivot column list", null);
-            return null;
-        }
         return qti;
     }
 
@@ -512,22 +499,11 @@ public class QueryPivot extends QueryRelation
     {
         if (null == _columns)
         {
-            Map<String, IConstant> pivotValues;
-            try
-            {
-                // UNDONE: _from.getSql() has side-effect that seems to be important for declareFields()
-                _from.markAllSelected(this);
-                _from.getSql();
+            // UNDONE: _from.getSql() has side-effect that seems to be important for declareFields()
+            _from.markAllSelected(this);
+            _from.getSql();
 
-                pivotValues = getPivotValues();
-            }
-            catch (SQLException x)
-            {
-                assert(!getParseErrors().isEmpty());
-                if (getParseErrors().isEmpty())
-                    getParseErrors().add(new QueryException(getSqlDialect().sanitizeException(x), x));
-                pivotValues = Collections.EMPTY_MAP;
-            }
+            Map<String, IConstant> pivotValues = getPivotValues();
 
             _columns = new CaseInsensitiveMapWrapper<>(new LinkedHashMap<>(_select.size()*2));
             List<Map.Entry<String,RelationColumn>> aggs = new ArrayList<>(_aggregates.size());
@@ -601,21 +577,16 @@ public class QueryPivot extends QueryRelation
         if (!_aggregates.containsKey(agg.getFieldKey().getName()))
             return null;
 
-        Map<String, IConstant> pivotValues;
-        try
-        {
-            pivotValues = getPivotValues();
-        }
-        catch (SQLException x)
-        {
-            return null;
-        }
+        Map<String, IConstant> pivotValues = getPivotValues();
 
         if (null == pivotValues)
         {
             assert(!getParseErrors().isEmpty());
             return null;
         }
+
+        if (!getParseErrors().isEmpty())
+            return null;
 
         final IConstant c = pivotValues.get(name);
         final String alias = makePivotColumnAlias(agg.getAlias(), name);
@@ -784,24 +755,15 @@ public class QueryPivot extends QueryRelation
             }
 
             // getSql() does not return
-            Map<String,IConstant> pivotValues;
-            try
+            Map<String, IConstant> pivotValues = getPivotValues();
+
+            if (!getParseErrors().isEmpty())
             {
-                pivotValues = getPivotValues();
+                QueryException qe = getParseErrors().get(0);
+                _query.decorateException(qe);
+                throw qe;
             }
-            catch (QueryService.NamedParameterNotProvided x)
-            {
-                QueryParseException qpe = new QueryParseException("When used with parameterized query, PIVOT requires an explicit values list", null);
-                _query.decorateException(qpe);
-                throw qpe;
-            }
-            catch (SQLException x)
-            {
-                QueryParseException qpe = new QueryParseException("Could not compute pivot column list", null);
-                _query.decorateException(qpe);
-                throw qpe;
-            }
-            
+
             // add aggregate expressions
             for (Map.Entry<String,IConstant> pivotValue : pivotValues.entrySet())
             {
@@ -866,7 +828,11 @@ public class QueryPivot extends QueryRelation
         PivotTableInfo()
         {
             super(QueryPivot.this, "_pivot");
+        }
 
+        @Override
+        protected void initializeColumns()
+        {
             for (RelationColumn col : getAllColumns().values())
             {
                 var columnInfo = new RelationColumnInfo(this, col);
@@ -874,7 +840,7 @@ public class QueryPivot extends QueryRelation
             }
         }
 
-        SQLFragment _sqlPivot = null;
+        private SQLFragment _sqlPivot = null;
 
         @NotNull
         @Override
@@ -986,15 +952,10 @@ public class QueryPivot extends QueryRelation
         {
             if (_members == null)
             {
-                Map<String, IConstant> pivotValues;
-                try
+                Map<String, IConstant> pivotValues = getPivotValues();
+                if (!getParseErrors().isEmpty())
                 {
-                    pivotValues = getPivotValues();
-                }
-                catch (SQLException x)
-                {
-                    // UNDONE: need better error handling -- see other usages of getPivotValues()
-                    throw new RuntimeSQLException(x);
+                    throw getParseErrors().get(0);
                 }
 
                 _members = new ArrayList<>(pivotValues.size());
@@ -1126,20 +1087,20 @@ public class QueryPivot extends QueryRelation
                     return null;
                 }
             };
-            Map<String, IConstant> pivotValues;
-            try
-            {
-                pivotValues = getPivotValues();
-            }
-            catch (SQLException x)
-            {
-                return null;
-            }
+
+            Map<String, IConstant> pivotValues = getPivotValues();
+
             if (null == pivotValues)
             {
                 assert(!getParseErrors().isEmpty());
                 return null;
             }
+
+            if (!getParseErrors().isEmpty())
+            {
+                throw getParseErrors().get(0);
+            }
+
             for (String displayField : pivotValues.keySet())
             {
                 var c = new RelationColumnInfo(t, _agg);

--- a/query/src/org/labkey/query/view/linkedSchema.jsp
+++ b/query/src/org/labkey/query/view/linkedSchema.jsp
@@ -392,7 +392,9 @@
                     tablesValue = tables.join(",");
                 }
                 return tablesValue;
-            }
+            },
+            includeViewDataUrl: false,
+            includeTitle: false
         }));
         tablesCombo.on('change', updateTablesMessage);
         tablesCombo.on('dataloaded', updateTablesMessage);

--- a/study/src/org/labkey/study/query/ParticipantTable.java
+++ b/study/src/org/labkey/study/query/ParticipantTable.java
@@ -16,7 +16,6 @@
 
 package org.labkey.study.query;
 
-import org.jetbrains.annotations.NotNull;
 import org.labkey.api.collections.CaseInsensitiveTreeSet;
 import org.labkey.api.data.AbstractForeignKey;
 import org.labkey.api.data.BaseColumnInfo;
@@ -43,8 +42,6 @@ import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.TitleForeignKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
-import org.labkey.api.security.UserPrincipal;
-import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.model.ParticipantGroup;
@@ -166,6 +163,7 @@ public class ParticipantTable extends BaseStudyTable
         for (ParticipantCategoryImpl category : ParticipantGroupManager.getInstance().getParticipantCategories(getContainer(), _userSchema.getUser()))
         {
             var categoryColumn = new ParticipantCategoryColumn(category, this);
+            assert initialColumnsAreAdded(); // addColumn() calls above should have initialized the columns
             if (!_columnMap.containsKey(categoryColumn.getName()))
                 addColumn(categoryColumn);
         }


### PR DESCRIPTION
#### Rationale
Determining the column list of a PIVOT query can be very expensive, so avoid it, if possible. Back-ported from 23.1; see cherry-picked commits for more details.
