### PR TITLE
Detect fatal error in ModuleLoader.init()

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -245,6 +245,12 @@ public class ModuleLoader implements Filter, MemTrackerListener
         }
         catch (Throwable t)
         {
+            if (null == _modules || _modules.isEmpty())
+            {
+                _log.fatal("Failure occurred during ModuleLoader init.", t);
+                System.err.println("The server cannot start.  Check the server error log.");
+                System.exit(1);
+            }
             setStartupFailure(t);
             _log.error("Failure occurred during ModuleLoader init.", t);
         }


### PR DESCRIPTION
#### Rationale
When module dependencies can't be resolved the server is left in an unusable state.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
