### PR TITLE
Stop leaking ThreadContext span/trace IDs

### DIFF
--- a/api/src/org/labkey/api/data/AsyncQueryRequest.java
+++ b/api/src/org/labkey/api/data/AsyncQueryRequest.java
@@ -115,6 +115,7 @@ public class AsyncQueryRequest<T>
             if (current != null)
                  MemTracker.get().startProfiler("async query");
 
+            assert ThreadContext.isEmpty();  // Prevent/detect leaks
             // Connect log messages with the active trace and span
             ThreadContext.put(CorrelationIdentifier.getTraceIdKey(), traceId);
             ThreadContext.put(CorrelationIdentifier.getSpanIdKey(), spanId);
@@ -137,7 +138,7 @@ public class AsyncQueryRequest<T>
                 // Wrap up the span
                 span.finish();
                 ThreadContext.remove(CorrelationIdentifier.getTraceIdKey());
-                ThreadContext.remove(CorrelationIdentifier.getSpanId());
+                ThreadContext.remove(CorrelationIdentifier.getSpanIdKey());
             }
         };
 

--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -1070,9 +1070,10 @@ abstract public class PipelineJob extends Job implements Serializable
     @Override @Trace
     public void run()
     {
+        assert ThreadContext.isEmpty();  // Prevent/detect leaks
         // Connect log messages with the active trace and span
         ThreadContext.put(CorrelationIdentifier.getTraceIdKey(), CorrelationIdentifier.getTraceId());
-        ThreadContext.put(CorrelationIdentifier.getSpanId(), CorrelationIdentifier.getSpanId());
+        ThreadContext.put(CorrelationIdentifier.getSpanIdKey(), CorrelationIdentifier.getSpanId());
 
         try
         {

--- a/api/src/org/labkey/api/view/ViewServlet.java
+++ b/api/src/org/labkey/api/view/ViewServlet.java
@@ -185,9 +185,10 @@ public class ViewServlet extends HttpServlet
             _log.debug(">> " + description);
         }
 
+        assert ThreadContext.isEmpty();  // Prevent/detect leaks
         // Connect log messages with the active trace and span
         ThreadContext.put(CorrelationIdentifier.getTraceIdKey(), CorrelationIdentifier.getTraceId());
-        ThreadContext.put(CorrelationIdentifier.getSpanId(), CorrelationIdentifier.getSpanId());
+        ThreadContext.put(CorrelationIdentifier.getSpanIdKey(), CorrelationIdentifier.getSpanId());
 
         MemoryUsageLogger.logMemoryUsage(_requestCount.incrementAndGet());
         try (RequestInfo r = MemTracker.get().startProfiler(request, request.getRequestURI()))


### PR DESCRIPTION
#### Rationale
There's a mismatch between the code that's poking Datadog IDs into the logging context, causing us to accumulate them and generate some very big JSON log entries.

#### Changes
* Fix the mismatch
* Assert that we're starting from an empty context to avoid leaking