### PR TITLE
Avoid reindexing participants that haven't changed

### DIFF
--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -796,7 +796,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
     @Override
     public void enumerateDocuments(@NotNull SearchService.IndexTask task, @NotNull Container c, Date modifiedSince)
     {
-        StudyManager._enumerateDocuments(task, c);
+        StudyManager._enumerateDocuments(task, c, modifiedSince);
     }
     
     @Override

--- a/study/src/org/labkey/study/visitmanager/VisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/VisitManager.java
@@ -488,7 +488,7 @@ public abstract class VisitManager
             if (null != potentiallyInsertedParticipants)
             {
                 final ArrayList<String> ptids = new ArrayList<>(potentiallyInsertedParticipants);
-                Runnable r = () -> StudyManager.indexParticipants(ss.defaultTask(), c, ptids);
+                Runnable r = () -> StudyManager.indexParticipants(ss.defaultTask(), c, ptids, null);
                 ss.defaultTask().addRunnable(r, SearchService.PRIORITY.group);
             }
             else
@@ -498,7 +498,7 @@ public abstract class VisitManager
                     SimpleFilter filter = SimpleFilter.createContainerFilter(c);
                     filter.addCondition(FieldKey.fromParts("LastIndexed"), null, CompareType.ISBLANK);
                     List<String> ptids = new TableSelector(StudySchema.getInstance().getTableInfoParticipant(), Collections.singleton("ParticipantId"), filter, null).getArrayList(String.class);
-                    StudyManager.indexParticipants(ss.defaultTask(), c, ptids);
+                    StudyManager.indexParticipants(ss.defaultTask(), c, ptids, null);
                 };
                 ss.defaultTask().addRunnable(r, SearchService.PRIORITY.group);
             }


### PR DESCRIPTION
#### Rationale
We've seen cases where servers spend a lot of effort reindexing participants in studies that haven't changed. It's because the crawler isn't filtering on `modifiedSince`.

#### Changes
* Pull the modifiedSince value through a few method calls and use it to filter