### PR TITLE
Lookup Views

### DIFF
--- a/api/schemas/expTypes.xsd
+++ b/api/schemas/expTypes.xsd
@@ -508,6 +508,7 @@
             <xs:element name="ShownInInsertView" type="boolean" minOccurs="0" maxOccurs="1"/>
             <xs:element name="ShownInUpdateView" type="boolean" minOccurs="0" maxOccurs="1"/>
             <xs:element name="ShownInDetailsView" type="boolean" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="ShownInLookupView" type="boolean" minOccurs="0" maxOccurs="1"/>
             <xs:element name="RangeURI" type="string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="ConceptURI" type="string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="Label" type="string" minOccurs="0" maxOccurs="1"/>

--- a/api/schemas/tableInfo.xsd
+++ b/api/schemas/tableInfo.xsd
@@ -519,6 +519,13 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="shownInLookupView" type="xs:boolean" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defaults to false. Set to true if the column should not be shown in lookup views.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="measure" type="xs:boolean" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>

--- a/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
@@ -547,6 +547,12 @@ public abstract class AbstractWrappedColumnInfo implements ColumnInfo
     }
 
     @Override
+    public boolean isShownInLookupView()
+    {
+        return delegate.isShownInLookupView();
+    }
+
+    @Override
     public StringExpression getURL()
     {
         return delegate.getURL();

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -382,6 +382,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
         setShownInDetailsView(col.isShownInDetailsView());
         setShownInInsertView(col.isShownInInsertView());
         setShownInUpdateView(col.isShownInUpdateView());
+        setShownInLookupView(col.isShownInLookupView());
         setConditionalFormats(col.getConditionalFormats());
         setValidators(col.getValidators());
 
@@ -1187,6 +1188,8 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
             _shownInUpdateView = xmlCol.getShownInUpdateView();
         if (xmlCol.isSetShownInDetailsView())
             _shownInDetailsView = xmlCol.getShownInDetailsView();
+        if (xmlCol.isSetShownInLookupView())
+            _shownInLookupView = xmlCol.getShownInLookupView();
         if (xmlCol.isSetDimension())
             _dimension = xmlCol.getDimension();
         if (xmlCol.isSetMeasure())

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -465,6 +465,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
         setShownInDetailsView(col.isShownInDetailsView());
         setShownInInsertView(col.isShownInInsertView());
         setShownInUpdateView(col.isShownInUpdateView());
+        setShownInLookupView(col.isShownInLookupView());
         setConditionalFormats(col.getConditionalFormats());
         setValidators(col.getValidators());
 

--- a/api/src/org/labkey/api/data/ColumnRenderProperties.java
+++ b/api/src/org/labkey/api/data/ColumnRenderProperties.java
@@ -70,6 +70,8 @@ public interface ColumnRenderProperties extends ImportAliasable
 
     boolean isShownInUpdateView();
 
+    boolean isShownInLookupView();
+
     StringExpression getURL();
 
     String getURLTargetWindow();

--- a/api/src/org/labkey/api/data/ColumnRenderPropertiesImpl.java
+++ b/api/src/org/labkey/api/data/ColumnRenderPropertiesImpl.java
@@ -85,6 +85,7 @@ public abstract class ColumnRenderPropertiesImpl implements MutableColumnRenderP
     protected boolean _shownInInsertView = true;
     protected boolean _shownInUpdateView = true;
     protected boolean _shownInDetailsView = true;
+    protected boolean _shownInLookupView = false;
     protected StringExpression _url;
     protected String _urlTargetWindow;
     protected String _urlCls;
@@ -394,6 +395,18 @@ public abstract class ColumnRenderPropertiesImpl implements MutableColumnRenderP
     {
         assert _checkLocked();
         _shownInUpdateView = shownInUpdateView;
+    }
+
+    @Override
+    public boolean isShownInLookupView()
+    {
+        return _shownInLookupView;
+    }
+
+    @Override
+    public void setShownInLookupView(boolean shownInLookupView)
+    {
+        _shownInLookupView = shownInLookupView;
     }
 
     @Override

--- a/api/src/org/labkey/api/data/JsonWriter.java
+++ b/api/src/org/labkey/api/data/JsonWriter.java
@@ -157,6 +157,7 @@ public class JsonWriter
         props.put("shownInInsertView", cinfo != null && cinfo.isShownInInsertView());
         props.put("shownInUpdateView", cinfo != null && cinfo.isShownInUpdateView());
         props.put("shownInDetailsView", cinfo == null || cinfo.isShownInDetailsView());
+        props.put("shownInLookupView", cinfo != null && cinfo.isShownInLookupView());
         props.put("dimension", cinfo != null && cinfo.isDimension());
         props.put("measure", cinfo != null && cinfo.isMeasure());
         props.put("recommendedVariable", cinfo != null && cinfo.isRecommendedVariable());

--- a/api/src/org/labkey/api/data/MutableColumnRenderProperties.java
+++ b/api/src/org/labkey/api/data/MutableColumnRenderProperties.java
@@ -42,6 +42,8 @@ public interface MutableColumnRenderProperties extends ColumnRenderProperties, M
 
     void setShownInUpdateView(boolean shownInUpdateView);
 
+    void setShownInLookupView(boolean shownInLookupView);
+
     void setURL(StringExpression url);
 
     void setURLTargetWindow(String urlTargetWindow);

--- a/api/src/org/labkey/api/data/ReportingWriter.java
+++ b/api/src/org/labkey/api/data/ReportingWriter.java
@@ -139,6 +139,7 @@ public class ReportingWriter
         props.put("shownInInsertView", cinfo != null && cinfo.isShownInInsertView());
         props.put("shownInUpdateView", cinfo != null && cinfo.isShownInUpdateView());
         props.put("shownInDetailsView", cinfo == null || cinfo.isShownInDetailsView());
+        props.put("shownInLookupView", cinfo != null && cinfo.isShownInLookupView());
         props.put("dimension", cinfo != null && cinfo.isDimension());
         props.put("measure", cinfo != null && cinfo.isMeasure());
         props.put("recommendedVariable", cinfo != null && cinfo.isRecommendedVariable());

--- a/api/src/org/labkey/api/data/TableInfoWriter.java
+++ b/api/src/org/labkey/api/data/TableInfoWriter.java
@@ -119,12 +119,18 @@ public class TableInfoWriter
 
         if (column.isHidden())
             columnXml.setIsHidden(true);
+
         if (!column.isShownInInsertView())
             columnXml.setShownInInsertView(false);
+
         if (!column.isShownInUpdateView())
             columnXml.setShownInUpdateView(false);
+
         if (!column.isShownInDetailsView())
             columnXml.setShownInDetailsView(false);
+
+        if (column.isShownInLookupView())
+            columnXml.setShownInLookupView(true);
 
         if (column.isDimension() != ColumnRenderPropertiesImpl.inferIsDimension(column))
             columnXml.setDimension(column.isDimension());

--- a/api/src/org/labkey/api/data/WrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/WrappedColumnInfo.java
@@ -347,6 +347,22 @@ public class WrappedColumnInfo
         }
 
         @Override
+        public void setShownInLookupView(boolean shownInLookupView)
+        {
+            checkLocked();
+            if (shownInLookupView == delegate.isShownInLookupView())
+                return;
+            delegate = new AbstractWrappedColumnInfo(delegate)
+            {
+                @Override
+                public boolean isShownInLookupView()
+                {
+                    return shownInLookupView;
+                }
+            };
+        }
+
+        @Override
         public void setURL(StringExpression url)
         {
             checkLocked();

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -2894,6 +2894,7 @@ public class OntologyManager
         p.setShownInInsertView(pd.isShownInInsertView());
         p.setShownInUpdateView(pd.isShownInUpdateView());
         p.setShownInDetailsView(pd.isShownInDetailsView());
+        p.setShownInLookupView(pd.isShownInLookupView());
         p.setDimension(pd.isDimension());
         p.setMeasure(pd.isMeasure());
         p.setRecommendedVariable(pd.isRecommendedVariable());

--- a/api/src/org/labkey/api/exp/PropertyDescriptor.java
+++ b/api/src/org/labkey/api/exp/PropertyDescriptor.java
@@ -149,6 +149,7 @@ public class PropertyDescriptor extends ColumnRenderPropertiesImpl implements Pa
         setShownInDetailsView(col.isShownInDetailsView());
         setShownInInsertView(col.isShownInInsertView());
         setShownInUpdateView(col.isShownInUpdateView());
+        setShownInLookupView(col.isShownInLookupView());
         setDimension(col.isDimension());
         setMeasure(col.isMeasure());
         setLabel(col.getLabel());

--- a/api/src/org/labkey/api/exp/property/DomainProperty.java
+++ b/api/src/org/labkey/api/exp/property/DomainProperty.java
@@ -51,6 +51,7 @@ public interface DomainProperty extends ImportAliasable, MutableColumnConceptPro
     boolean isShownInInsertView();
     boolean isShownInUpdateView();
     boolean isShownInDetailsView();
+    boolean isShownInLookupView();
     boolean isMeasure();
     boolean isDimension();
     boolean isRecommendedVariable();
@@ -77,6 +78,7 @@ public interface DomainProperty extends ImportAliasable, MutableColumnConceptPro
     void setShownInInsertView(boolean shown);
     void setShownInUpdateView(boolean shown);
     void setShownInDetailsView(boolean shown);
+    void setShownInLookupView(boolean shown);
     void setMvEnabled(boolean mv);
     void setMeasure(boolean isMeasure);
     void setDimension(boolean isDimension);

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.18.0",
-        "@labkey/components": "2.280.0-fb-lookup-views.2",
+        "@labkey/components": "2.280.0",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3057,9 +3057,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.280.0-fb-lookup-views.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.280.0-fb-lookup-views.2.tgz",
-      "integrity": "sha512-o7YXZPpk45PaiJcl5u662xuE418oItLsqNNi7yXY5HqzzWu7wehmGkmXj34vSIkofaz7e867HHdq+tiKVYW6Lg==",
+      "version": "2.280.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.280.0.tgz",
+      "integrity": "sha512-BtG3zfXkOaGuAEXUm3/9cfNDp5QMLr065jK6liBKXunOXv07odbmAy1FGgFN84ZfK9gUkigYbhgOHxsht98kxw==",
       "dependencies": {
         "@labkey/api": "1.18.1",
         "bootstrap": "~3.4.1",
@@ -17250,9 +17250,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.280.0-fb-lookup-views.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.280.0-fb-lookup-views.2.tgz",
-      "integrity": "sha512-o7YXZPpk45PaiJcl5u662xuE418oItLsqNNi7yXY5HqzzWu7wehmGkmXj34vSIkofaz7e867HHdq+tiKVYW6Lg==",
+      "version": "2.280.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.280.0.tgz",
+      "integrity": "sha512-BtG3zfXkOaGuAEXUm3/9cfNDp5QMLr065jK6liBKXunOXv07odbmAy1FGgFN84ZfK9gUkigYbhgOHxsht98kxw==",
       "requires": {
         "@labkey/api": "1.18.1",
         "bootstrap": "~3.4.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.18.0",
-        "@labkey/components": "2.280.0-fb-lookup-views.1",
+        "@labkey/components": "2.280.0-fb-lookup-views.2",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3057,11 +3057,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.280.0-fb-lookup-views.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.280.0-fb-lookup-views.1.tgz",
-      "integrity": "sha512-fbvuRNuaaQmHzpIqIpcH7gtG098BwpFJSZxdod1+Ur/LKeOyZluPG0yETVktWmrKYRB0bTzpyzbucV5rKTI9TQ==",
+      "version": "2.280.0-fb-lookup-views.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.280.0-fb-lookup-views.2.tgz",
+      "integrity": "sha512-o7YXZPpk45PaiJcl5u662xuE418oItLsqNNi7yXY5HqzzWu7wehmGkmXj34vSIkofaz7e867HHdq+tiKVYW6Lg==",
       "dependencies": {
-        "@labkey/api": "1.18.0",
+        "@labkey/api": "1.18.1",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",
@@ -3095,6 +3095,11 @@
         "react-bootstrap": "^0.33.1",
         "react-dom": "^16.0"
       }
+    },
+    "node_modules/@labkey/components/node_modules/@labkey/api": {
+      "version": "1.18.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.1.tgz",
+      "integrity": "sha512-KaRMFTGoOinZRsPuqrLOskLPNFdK9MX0feO4S5tRGlcZmBpld29UeKQoNJkNCwx8dCdbpkVTZMaWlvDQrA1s+Q=="
     },
     "node_modules/@labkey/eslint-config-base": {
       "version": "0.0.12",
@@ -17245,11 +17250,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.280.0-fb-lookup-views.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.280.0-fb-lookup-views.1.tgz",
-      "integrity": "sha512-fbvuRNuaaQmHzpIqIpcH7gtG098BwpFJSZxdod1+Ur/LKeOyZluPG0yETVktWmrKYRB0bTzpyzbucV5rKTI9TQ==",
+      "version": "2.280.0-fb-lookup-views.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.280.0-fb-lookup-views.2.tgz",
+      "integrity": "sha512-o7YXZPpk45PaiJcl5u662xuE418oItLsqNNi7yXY5HqzzWu7wehmGkmXj34vSIkofaz7e867HHdq+tiKVYW6Lg==",
       "requires": {
-        "@labkey/api": "1.18.0",
+        "@labkey/api": "1.18.1",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",
@@ -17276,6 +17281,13 @@
         "react-treebeard": "~3.2.4",
         "redux-actions": "~2.3.2",
         "vis-network": "~6.5.2"
+      },
+      "dependencies": {
+        "@labkey/api": {
+          "version": "1.18.1",
+          "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.1.tgz",
+          "integrity": "sha512-KaRMFTGoOinZRsPuqrLOskLPNFdK9MX0feO4S5tRGlcZmBpld29UeKQoNJkNCwx8dCdbpkVTZMaWlvDQrA1s+Q=="
+        }
       }
     },
     "@labkey/eslint-config-base": {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.18.0",
-        "@labkey/components": "2.278.0",
+        "@labkey/components": "2.280.0-fb-lookup-views.1",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3057,9 +3057,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.278.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.278.0.tgz",
-      "integrity": "sha512-Nr8t7wKUiHZSe2w+7sFAhlRLZzEhugMv1aWb2JOjsHEhSbgFz4wuIn9y0eaZ6eoVAJli4OtKuVhvM6/QlwuW6Q==",
+      "version": "2.280.0-fb-lookup-views.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.280.0-fb-lookup-views.1.tgz",
+      "integrity": "sha512-fbvuRNuaaQmHzpIqIpcH7gtG098BwpFJSZxdod1+Ur/LKeOyZluPG0yETVktWmrKYRB0bTzpyzbucV5rKTI9TQ==",
       "dependencies": {
         "@labkey/api": "1.18.0",
         "bootstrap": "~3.4.1",
@@ -17245,9 +17245,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.278.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.278.0.tgz",
-      "integrity": "sha512-Nr8t7wKUiHZSe2w+7sFAhlRLZzEhugMv1aWb2JOjsHEhSbgFz4wuIn9y0eaZ6eoVAJli4OtKuVhvM6/QlwuW6Q==",
+      "version": "2.280.0-fb-lookup-views.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.280.0-fb-lookup-views.1.tgz",
+      "integrity": "sha512-fbvuRNuaaQmHzpIqIpcH7gtG098BwpFJSZxdod1+Ur/LKeOyZluPG0yETVktWmrKYRB0bTzpyzbucV5rKTI9TQ==",
       "requires": {
         "@labkey/api": "1.18.0",
         "bootstrap": "~3.4.1",

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.18.0",
-    "@labkey/components": "2.278.0",
+    "@labkey/components": "2.280.0-fb-lookup-views.1",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.18.0",
-    "@labkey/components": "2.280.0-fb-lookup-views.1",
+    "@labkey/components": "2.280.0-fb-lookup-views.2",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.18.0",
-    "@labkey/components": "2.280.0-fb-lookup-views.2",
+    "@labkey/components": "2.280.0",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/experiment/src/org/labkey/experiment/XarExporter.java
+++ b/experiment/src/org/labkey/experiment/XarExporter.java
@@ -845,6 +845,7 @@ public class XarExporter
         xProp.setShownInDetailsView(domainProp.isShownInDetailsView());
         xProp.setShownInInsertView(domainProp.isShownInInsertView());
         xProp.setShownInUpdateView(domainProp.isShownInUpdateView());
+        xProp.setShownInLookupView(domainProp.isShownInLookupView());
         xProp.setMvEnabled(domainProp.isMvEnabled());
 
         for (IPropertyValidator validator : domainProp.getValidators())

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -1048,6 +1048,8 @@ public class DomainImpl implements Domain
                 str.append("ShownInDetails: ").append(renderOldVsNew(renderBool(pdOld.isShownInDetailsView()), renderBool(prop.isShownInDetailsView()))).append("; ");
             if (pdOld.isShownInUpdateView() != prop.isShownInUpdateView())
                 str.append("ShownInUpdate: ").append(renderOldVsNew(renderBool(pdOld.isShownInUpdateView()), renderBool(prop.isShownInUpdateView()))).append("; ");
+            if (pdOld.isShownInLookupView() != prop.isShownInLookupView())
+                str.append("ShownInLookupView: ").append(renderOldVsNew(renderBool(pdOld.isShownInLookupView()), renderBool(prop.isShownInLookupView()))).append("; ");
             if (pdOld.isRecommendedVariable() != prop.isRecommendedVariable())
                 str.append("RecommendedVariable: ").append(renderOldVsNew(renderBool(pdOld.isRecommendedVariable()), renderBool(prop.isRecommendedVariable()))).append("; ");
             if (pdOld.isExcludeFromShifting() != prop.isExcludeFromShifting())

--- a/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
@@ -181,6 +181,12 @@ public class DomainPropertyImpl implements DomainProperty
     }
 
     @Override
+    public boolean isShownInLookupView()
+    {
+        return _pd.isShownInLookupView();
+    }
+
+    @Override
     public boolean isMeasure()
     {
         return _pd.isMeasure();
@@ -352,6 +358,14 @@ public class DomainPropertyImpl implements DomainProperty
         if (shown == isShownInUpdateView())
             return;
         edit().setShownInUpdateView(shown);
+    }
+
+    @Override
+    public void setShownInLookupView(boolean shown)
+    {
+        if (shown == isShownInLookupView())
+            return;
+        edit().setShownInLookupView(shown);
     }
 
     @Override
@@ -991,6 +1005,7 @@ public class DomainPropertyImpl implements DomainProperty
         setShownInDetailsView(propSrc.isShownInDetailsView());
         setShownInInsertView(propSrc.isShownInInsertView());
         setShownInUpdateView(propSrc.isShownInUpdateView());
+        setShownInLookupView(propSrc.isShownInLookupView());
         setMvEnabled(propSrc.isMvEnabled());
         setDefaultValueTypeEnum(propSrc.getDefaultValueTypeEnum());
         setScale(propSrc.getScale());

--- a/experiment/src/org/labkey/experiment/api/property/PropertyServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/PropertyServiceImpl.java
@@ -502,12 +502,18 @@ public class PropertyServiceImpl implements PropertyService, UsageMetricsProvide
 
         if (xProp.isSetHidden())
             prop.getPropertyDescriptor().setHidden(xProp.getHidden());
+
         if (xProp.isSetShownInDetailsView())
             prop.getPropertyDescriptor().setShownInDetailsView(xProp.getShownInDetailsView());
+
         if (xProp.isSetShownInInsertView())
             prop.getPropertyDescriptor().setShownInInsertView(xProp.getShownInInsertView());
+
         if (xProp.isSetShownInUpdateView())
             prop.getPropertyDescriptor().setShownInUpdateView(xProp.getShownInUpdateView());
+
+        if (xProp.isSetShownInLookupView())
+            prop.getPropertyDescriptor().setShownInLookupView(xProp.getShownInLookupView());
 
         if (xProp.isSetScale())
             prop.getPropertyDescriptor().setScale(xProp.getScale());

--- a/visualization/src/org/labkey/visualization/VisualizationServiceImpl.java
+++ b/visualization/src/org/labkey/visualization/VisualizationServiceImpl.java
@@ -309,6 +309,7 @@ public class VisualizationServiceImpl implements VisualizationService
         props.put("shownInDetailsView", col.isShownInDetailsView());
         props.put("shownInInsertView", col.isShownInInsertView());
         props.put("shownInUpdateView", col.isShownInUpdateView());
+        props.put("shownInLookupView", col.isShownInLookupView());
 
         return props;
     }


### PR DESCRIPTION
#### Rationale
This PR adds a new property, "shownInLookupView", to ColumnRenderProperties. This property will be used by the client to determine what fields should be rendered when rendering a lookup (typically these are the fields you see rendered in our drop downs).

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1081
* https://github.com/LabKey/labkey-ui-premium/pull/18
* https://github.com/LabKey/platform/pull/3998
* https://github.com/LabKey/biologics/pull/1853
* https://github.com/LabKey/sampleManagement/pull/1533
* https://github.com/LabKey/inventory/pull/686
* https://github.com/LabKey/labbook/pull/377

#### Changes
* Add shownInLookupView to ColumnRenderProperties and related classes
* Add shownInLookupView to tableinfo.xsd
* Add shownInLookupView to expTypes.xsd
* Bump ui-components dependency