### PR TITLE
Issue 46969: ActionURL.getExtraPath() inconsistency

### DIFF
--- a/announcements/src/org/labkey/announcements/model/DiscussionServiceImpl.java
+++ b/announcements/src/org/labkey/announcements/model/DiscussionServiceImpl.java
@@ -78,7 +78,7 @@ public class DiscussionServiceImpl implements DiscussionService
 
     public static String toSaved(ActionURL url)
     {
-        Container c = ContainerManager.getForPath(url.getExtraPath());
+        Container c = ContainerManager.getForURL(url);
         ActionURL saveURL = url.clone();
         if (null != c)
             saveURL.setContainer(c);

--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -435,15 +435,13 @@ public abstract class SpringActionController implements Controller, HasViewConte
             Container c = context.getContainer();
             if (null == c)
             {
-                String containerPath = url.getExtraPath();
-
                 if (!url.isProject())
                 {
-                    throw new NotFoundException("No such folder or workbook: " + containerPath);
+                    throw new NotFoundException("No such folder or workbook: " +  url.getExtraPath());
                 }
                 else
                 {
-                    throw new NotFoundException("No such project: " + containerPath);
+                    throw new NotFoundException("No such project: " +  url.getExtraPath());
                 }
             }
 

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1064,6 +1064,16 @@ public class ContainerManager
         return map.get(name);
     }
 
+
+    public static Container getForURL(@NotNull ActionURL url)
+    {
+        Container ret = getForPath(url.getExtraPath());
+        if (ret == null)
+            ret = getForId(StringUtils.strip(url.getExtraPath(), "/"));
+        return ret;
+    }
+
+
     public static Container getForPath(@NotNull String path)
     {
         Path p = Path.parse(path);

--- a/api/src/org/labkey/api/query/DetailsURL.java
+++ b/api/src/org/labkey/api/query/DetailsURL.java
@@ -301,7 +301,7 @@ public final class DetailsURL extends StringExpressionFactory.FieldKeyStringExpr
                     throw new IllegalArgumentException("Failed to parse url '" + _urlSource + "'." + SUPPORTED_URL_FORMATS);
                 }
 
-                if (!_parsedUrl.getExtraPath().isEmpty())
+                if (!_parsedUrl.getParsedExtraPath().isEmpty())
                     throw new IllegalArgumentException("Url '" + _urlSource + "' included a container path." + SUPPORTED_URL_FORMATS);
             }
         }

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -2430,7 +2430,7 @@ public class PageFlowUtil
             try
             {
                 URLHelper urlHelper = new URLHelper(returnURL);
-                Container redirectContainer = ContainerManager.getForPath(new ActionURL(urlHelper.getLocalURIString()).getExtraPath());
+                Container redirectContainer = ContainerManager.getForURL(new ActionURL(urlHelper.getLocalURIString()));
                 if (null != redirectContainer)
                     termsContainer = redirectContainer.getProject();
             }

--- a/api/src/org/labkey/api/util/Path.java
+++ b/api/src/org/labkey/api/util/Path.java
@@ -233,6 +233,12 @@ public class Path implements Serializable, Comparable, Iterable<String>
     }
 
 
+    public boolean isEmpty()
+    {
+        return 0 == _length;
+    }
+
+
     public String get(int i)
     {
         return _path[i];

--- a/api/src/org/labkey/api/util/StringExpressionFactory.java
+++ b/api/src/org/labkey/api/util/StringExpressionFactory.java
@@ -163,7 +163,7 @@ public class StringExpressionFactory
             try
             {
                 ActionURL url = new ActionURL(str);
-                if (StringUtils.isEmpty(url.getExtraPath()))
+                if (url.getParsedExtraPath().isEmpty())
                     expr = new DetailsURL(url, null, nullValueBehavior);
             }
             catch (IllegalArgumentException x)

--- a/api/src/org/labkey/api/util/URLHelper.java
+++ b/api/src/org/labkey/api/util/URLHelper.java
@@ -314,12 +314,14 @@ public class URLHelper implements Cloneable, Serializable, JSONString
      */
     public URLHelper setPath(String path)
     {
-        return setParsedPath(_parsePath(path, false));
+        if (StringUtils.isEmpty(path))
+            setParsedPath(Path.rootPath);
+        else
+            setParsedPath(_parsePath(path, false));
+        return this;
     }
 
-    /**
-     * The path argument is not URL encoded.
-     */
+
     public URLHelper setPath(Path path)
     {
         return setParsedPath(path);

--- a/api/src/org/labkey/api/view/ActionURL.java
+++ b/api/src/org/labkey/api/view/ActionURL.java
@@ -475,21 +475,37 @@ public class ActionURL extends URLHelper implements Cloneable
     }
 
 
+    /*
+    * This is the portion path that is not used to resolve the controller-action.
+    * THis is usually the container path or container id.
+     */
     public ActionURL setExtraPath(String extraPath)
     {
-        if (null == extraPath) extraPath = "";
-        setParsedPath(Path.parse(extraPath));
+        if (StringUtils.isEmpty(extraPath))
+            return setExtraPath(Path.rootPath);
+        else
+            return setExtraPath(Path.parse(extraPath));
+    }
+
+
+    public ActionURL setExtraPath(@NotNull Path extraPath)
+    {
+        setParsedPath(extraPath);
         return this;
     }
 
 
     public String getExtraPath()
     {
-        String path = _path.toString();
-        if (path.endsWith("/"))
-            path = path.substring(0,path.length()-1);
-        return path;
+        return _path.toString("/", "");
     }
+
+
+    public Path getParsedExtraPath()
+    {
+        return _path;
+    }
+
 
     /**
      * The path argument is not URL encoded.
@@ -586,8 +602,8 @@ public class ActionURL extends URLHelper implements Cloneable
     }
 
 
-    // CONSIDER: should this override getParsedPath()
-    public Path getFullParsedPath()
+    /** This subclass reuses the base class member _path, so we need to override getParsedPath() as well as getPath() */
+    public Path getParsedPath()
     {
         return _contextPath.append(_controller).append(_path).append(_action + ".view");
     }

--- a/api/src/org/labkey/api/view/ActionURL.java
+++ b/api/src/org/labkey/api/view/ActionURL.java
@@ -477,7 +477,7 @@ public class ActionURL extends URLHelper implements Cloneable
 
     /*
     * This is the portion path that is not used to resolve the controller-action.
-    * THis is usually the container path or container id.
+    * This is usually the container path or container id.
      */
     public ActionURL setExtraPath(String extraPath)
     {

--- a/api/src/org/labkey/api/view/ViewContext.java
+++ b/api/src/org/labkey/api/view/ViewContext.java
@@ -337,21 +337,15 @@ public class ViewContext implements MessageSource, ContainerContext, ContainerUs
         return container;
     }
 
+
     @Override
     public Container getContainer()
     {
         if (null == _c)
         {
-            Container c = null;
             ActionURL url = getActionURL();
             if (null != url)
-            {
-                String path = url.getExtraPath();
-                c = ContainerManager.getForPath(path);
-                if (c == null)
-                    c = ContainerManager.getForId(StringUtils.strip(path, "/"));
-            }
-            _c = c;
+                _c = ContainerManager.getForURL(url);
         }
         return _c;
     }

--- a/api/src/org/labkey/api/view/ViewServlet.java
+++ b/api/src/org/labkey/api/view/ViewServlet.java
@@ -443,7 +443,7 @@ public class ViewServlet extends HttpServlet
 
     private Container canonicalizeContainer(HttpServletRequest request, ActionURL url)
     {
-        Path path = url.getParsedPath();
+        Path path = url.getParsedExtraPath();
         request.setAttribute(ORIGINAL_URL_CONTAINER_PATH, path);
 
         Container c = ContainerManager.getForPath(path);
@@ -609,10 +609,7 @@ public class ViewServlet extends HttpServlet
         else
             url = new ActionURL(request.getRequestURI());
 
-        String path = url.getExtraPath();
-        Container c = ContainerManager.getForPath(path);
-        if (null == c)
-            c = ContainerManager.getForId(StringUtils.strip(path,"/"));
+        Container c = ContainerManager.getForURL(url);
         if (null != c)
             url.setExtraPath(c.getPath());
         url.setReadOnly();

--- a/api/src/org/labkey/api/webdav/SimpleDocumentResource.java
+++ b/api/src/org/labkey/api/webdav/SimpleDocumentResource.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.webdav;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
@@ -68,15 +69,18 @@ public class SimpleDocumentResource extends AbstractDocumentResource
         _modifiedBy = modifiedBy;
         _modified = toTime("modified", modified, properties);
         // Make sure the "execute URL" container is supplied as a GUID, not a path, since paths are not stable. Also,
-        // the GUID should match either the container ID or the resource ID (if present).
-        assert !(_executeUrl instanceof ActionURL) || ((ActionURL)_executeUrl).getExtraPath().equals(_containerId) || (null != properties && ((ActionURL)_executeUrl).getExtraPath().equals(properties.get(SearchService.PROPERTY.securableResourceId.toString())));
+        if (_executeUrl instanceof ActionURL actionURL)
+        {
+            String extraPath = StringUtils.strip(actionURL.getExtraPath(),"/");
+            assert extraPath.equals(_containerId) || (null != properties && extraPath.equals(properties.get(SearchService.PROPERTY.securableResourceId.toString())));
+        }
         if (null != properties)
             _properties = new HashMap<>(properties);
     }
 
     public SimpleDocumentResource(Path path, String documentId, String contentType, @Nullable String body, ActionURL executeUrl, @Nullable Map<String, Object> properties)
     {
-        this(path, documentId, executeUrl.getExtraPath(), contentType, body, executeUrl, properties);
+        this(path, documentId, executeUrl.getParsedExtraPath().toString("",""), contentType, body, executeUrl, properties);
     }
 
     private static long toTime(String fieldName, @Nullable Date d, @Nullable Map<String, Object> properties)

--- a/api/src/org/labkey/api/webdav/SimpleDocumentResource.java
+++ b/api/src/org/labkey/api/webdav/SimpleDocumentResource.java
@@ -68,7 +68,7 @@ public class SimpleDocumentResource extends AbstractDocumentResource
         _created = toTime("created", created, properties);
         _modifiedBy = modifiedBy;
         _modified = toTime("modified", modified, properties);
-        // Make sure the "execute URL" container is supplied as a GUID, not a path, since paths are not stable. Also,
+        // Make sure the "execute URL" container is supplied as a GUID, not a path, since paths are not stable.
         if (_executeUrl instanceof ActionURL actionURL)
         {
             String extraPath = StringUtils.strip(actionURL.getExtraPath(),"/");

--- a/core/src/org/labkey/core/view/template/bootstrap/PageTemplate.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/PageTemplate.java
@@ -28,6 +28,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.settings.BannerProperties;
 import org.labkey.api.settings.FooterProperties;
 import org.labkey.api.settings.TemplateProperties;
+import org.labkey.api.util.Path;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpStatusException;
 import org.labkey.api.view.HttpView;
@@ -349,9 +350,9 @@ public class PageTemplate extends JspView<PageConfig>
     {
         if (page.shouldAppendPathToTitle())
         {
-            String extraPath = getRootContext().getActionURL().getExtraPath();
-            if (extraPath.length() > 0)
-                page.setTitle(page.getTitle() + (page.getTitle() != null && !page.getTitle().isEmpty() ? ": " : "") + extraPath);
+            Path extraPath = getRootContext().getActionURL().getParsedExtraPath();
+            if (!extraPath.isEmpty())
+                page.setTitle(page.getTitle() + (page.getTitle() != null && !page.getTitle().isEmpty() ? ": " : "") + extraPath.toString("",""));
         }
     }
 }

--- a/core/src/org/labkey/core/view/template/bootstrap/PrintTemplate.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/PrintTemplate.java
@@ -17,6 +17,7 @@ package org.labkey.core.view.template.bootstrap;
 
 import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.settings.LookAndFeelProperties;
+import org.labkey.api.util.Path;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.template.PageConfig;
@@ -60,15 +61,9 @@ public class PrintTemplate extends PageTemplate
                 title = title.substring(0, dotIndex);
         }
 
-        String extraPath = helper.getExtraPath();
-        if (null != extraPath && !"".equals(extraPath))
-        {
-            int slashIndex = extraPath.lastIndexOf('/');
-            if (-1 != slashIndex)
-                extraPath = extraPath.substring(slashIndex + 1);
-
-            title = title + ": " + extraPath;
-        }
+        Path extraPath = helper.getParsedPath();
+        if (!extraPath.isEmpty())
+            title = title + ": " + extraPath.getName();
 
         return title;
     }

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -569,8 +569,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         if (!(x instanceof ActionURL) && x.getPath().endsWith(".view"))
             x = new ActionURL(x.toString());
 
-        Path path = x instanceof ActionURL ? ((ActionURL)x).getFullParsedPath() : x.getParsedPath();
-        return normalize(path);
+        return normalize(x.getParsedPath());
     }
 
     /** query parameters will be modified */


### PR DESCRIPTION
#### Rationale
Force consistent behavior for getExtraPath() also while we're here:

new method getParsedExtraPath()
fix ActionURL.getParsedPath() to match getPath()

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
