### PR TITLE
Let the warnings pass through when loading Query Definition

### DIFF
--- a/query/src/org/labkey/query/QueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/QueryDefinitionImpl.java
@@ -565,7 +565,8 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
                     table = createTable(schema, errors, includeMetadata, null, skipSuggestedColumns);
                 }
 
-                if (null == table || (null != errors && !errors.isEmpty() && errors.stream().anyMatch(error -> error instanceof QueryParseException && ((QueryParseException)error).isError())))
+                if (null == table || (null != errors && !errors.isEmpty() && !errors.stream().allMatch(error -> error instanceof QueryParseException && ((QueryParseException)error).isWarning())))
+
                     return null;
 
                 log.debug("Caching table " + schema.getName() + "." + table.getName());

--- a/query/src/org/labkey/query/QueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/QueryDefinitionImpl.java
@@ -565,7 +565,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
                     table = createTable(schema, errors, includeMetadata, null, skipSuggestedColumns);
                 }
 
-                if (null == table || (null != errors && !errors.isEmpty()))
+                if (null == table || (null != errors && !errors.isEmpty() && errors.stream().anyMatch(error -> error instanceof QueryParseException && ((QueryParseException)error).isError())))
                     return null;
 
                 log.debug("Caching table " + schema.getName() + "." + table.getName());


### PR DESCRIPTION
#### Rationale
Fix for WNPRC test failure "Error on line 4: Query or table not found: ehr_billing_public.aliases"
![image](https://user-images.githubusercontent.com/10765266/211497804-c2a9b36c-91b7-4517-af47-abf12b89d371.png)


These failures are unveiled as a result of recent change that added a check for presence of errors; however, in the above case, there are warnings generated while loading Query Definition for the linked table (ehr_billing_public.aliases) and are not actual errors.

#### Changes
* Add isError() check to ensure there are indeed any errors, and let the warnings pass through
