### PR TITLE
Issue 47060: NAb calculation of sample group PercentNeutralizationInitialDilution incorrect when plate layout uses ReverseDilutionDirection

### DIFF
--- a/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
+++ b/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
@@ -123,7 +123,7 @@ public class NAbSpecimenTable extends FilteredTable<AssayProtocolSchema>
         return new SQLFragment("(SELECT PercentNeutralization FROM ")
             .append(DilutionManager.getTableInfoDilutionData(), "dd")
             .append(" WHERE dd.RunDataId = ").append(ExprColumn.STR_TABLE_ALIAS + ".RowId")
-            .append(" AND dd.DilutionOrder = 1)");
+            .append(" AND dd.Dilution = dd.MinDilution)");
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47060

#### Changes
- use the PercentNeutralization value for the DilutionData row where the Dilution matches the MinDilution instead of just DilutionOrder = 1
