### PR TITLE
Avoid infinite redirect when terms of use are needed when building menu

### DIFF
--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -58,6 +58,7 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.Portal;
+import org.labkey.api.view.RedirectException;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.ViewServlet;
@@ -430,6 +431,10 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
                         catch (UnauthorizedException e)
                         {
                             return null;
+                        }
+                        catch (RedirectException ignored)
+                        {
+                            // Likely a terms-of-use redirect, like for setting compliance activity
                         }
                     }
                     // Use the deprecated constructor, since passing in an action class like SimpleAction that is used


### PR DESCRIPTION
#### Rationale
My recent change to check permissions before offering links in the Go to Module menu broke compliance terms of use checks

https://github.com/LabKey/platform/pull/3997

https://teamcity.labkey.org/buildConfiguration/LabKey_2211Release_Premium_ModulesSuites_CompliancePostgres/2222742?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true

#### Changes
* Handle RedirectExceptions as well