### PR TITLE
More reliable approach for de-duplicating module names

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -533,7 +533,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
                 .collect(Collectors.toMap(ModuleContext::getName, ctx->ctx));
 
             // Names of managed modules with schemas where the installed version is less than "earliest upgrade version"
-            var tooOld = modules.stream()
+            var tooOld = _modules.stream()
                 .filter(Module::shouldManageVersion)
                 .map(m -> moduleContextMap.get(m.getName()))
                 .filter(Objects::nonNull)
@@ -1622,7 +1622,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
     }
 
 
-    void saveModuleContext(ModuleContext context)
+    public void saveModuleContext(ModuleContext context)
     {
         ModuleContext stored = getModuleContext(context.getName());
         if (null == stored)
@@ -1656,7 +1656,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
             scope.getSqlDialect().dropSchema(_core.getSchema(), schema);
         }
 
-        removeModuleContext(context);
+        Table.delete(getTableInfoModules(), context.getName());
 
         if (null != m && deleteFiles)
         {
@@ -1670,6 +1670,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
             removeMapValue(m, _moduleClassMap);
             removeMapValue(m, _moduleMap);
             removeMapValue(m, _controllerNameToModule);
+            _moduleContextMap.remove(context.getName());
             _modules.remove(m);
         }
 

--- a/core/resources/schemas/dbscripts/postgresql/core-23.000-23.001.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-23.000-23.001.sql
@@ -1,4 +1,4 @@
-SELECT core.executeJavaUpgradeCode('removeDuplicateModuleEntries');
+SELECT core.executeJavaUpgradeCode('deduplicateModuleEntries');
 
 -- Switch Name from PK to case-insensitive unique constraint
 ALTER TABLE core.Modules DROP CONSTRAINT PK_Modules;


### PR DESCRIPTION
#### Rationale
Previous approach didn't handle multiple unknown modules whose names differed by case only

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3999

#### Changes
* Deduplicate by updating module names with "_1", "_2", etc. suffixes
* Use the pruned module list when checking for modules that are too old for upgrades