### PR TITLE
Backport 'Let the warnings pass through when loading Query Definition (#4003)'

### DIFF
--- a/query/src/org/labkey/query/QueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/QueryDefinitionImpl.java
@@ -565,7 +565,8 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
                     table = createTable(schema, errors, includeMetadata, null, skipSuggestedColumns);
                 }
 
-                if (null == table || (null != errors && !errors.isEmpty()))
+                if (null == table || (null != errors && !errors.isEmpty() && !errors.stream().allMatch(error -> error instanceof QueryParseException && ((QueryParseException)error).isWarning())))
+
                     return null;
 
                 log.debug("Caching table " + schema.getName() + "." + table.getName());


### PR DESCRIPTION
#### Rationale
Backport 'Let the warnings pass through when loading Query Definition (#4003)'
