### PR TITLE
Issue 47043: Increase property name length to account for long folder names as part of property name

### DIFF
--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 23.001
+SchemaVersion: 23.002
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/prop-23.001-23.002.sql
+++ b/core/resources/schemas/dbscripts/postgresql/prop-23.001-23.002.sql
@@ -1,0 +1,1 @@
+ALTER TABLE prop.properties ALTER COLUMN Name TYPE VARCHAR(400);

--- a/core/resources/schemas/dbscripts/sqlserver/prop-23.001-23.002.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/prop-23.001-23.002.sql
@@ -1,7 +1,7 @@
 ALTER TABLE prop.properties DROP CONSTRAINT PK_Properties;
 GO
 
-ALTER TABLE prop.properties ALTER COLUMN Name NVARCHAR(400);
-ALTER TABLE prop.properties ADD CONSTRAINT PK_Properties PRIMARY KEY CLUSTERED ("Set", Name)
+ALTER TABLE prop.properties ALTER COLUMN Name NVARCHAR(400) NOT NULL;
+ALTER TABLE prop.properties ADD CONSTRAINT PK_Properties PRIMARY KEY CLUSTERED ("Set", Name);
 
 GO

--- a/core/resources/schemas/dbscripts/sqlserver/prop-23.001-23.002.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/prop-23.001-23.002.sql
@@ -2,6 +2,6 @@ ALTER TABLE prop.properties DROP CONSTRAINT PK_Properties;
 GO
 
 ALTER TABLE prop.properties ALTER COLUMN Name NVARCHAR(400);
-ALTER TABLE prop.properties ADD CONSTRAINT PK_Properties PRIMARY KEY (Set, Name);
+ALTER TABLE prop.properties ADD CONSTRAINT PK_Properties PRIMARY KEY CLUSTERED ("Set", Name)
 
 GO

--- a/core/resources/schemas/dbscripts/sqlserver/prop-23.001-23.002.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/prop-23.001-23.002.sql
@@ -1,0 +1,1 @@
+ALTER TABLE prop.properties ALTER COLUMN Name NVARCHAR(400);

--- a/core/resources/schemas/dbscripts/sqlserver/prop-23.001-23.002.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/prop-23.001-23.002.sql
@@ -1,1 +1,7 @@
+ALTER TABLE prop.properties DROP CONSTRAINT PK_Properties;
+GO
+
 ALTER TABLE prop.properties ALTER COLUMN Name NVARCHAR(400);
+ALTER TABLE prop.properties ADD CONSTRAINT PK_Properties PRIMARY KEY (Set, Name);
+
+GO


### PR DESCRIPTION
#### Rationale
We currently allow folder names to have 255 characters. When a folder is deleted, we make an entry in the prop.properties table with the property name `<folder name>-TABDELETED-FOLDER-Biologics`, which then exceeds the 255 field length for prop.properties.name. In order to be able to delete these folders with really long names, we need more room for a property name derived from it


#### Changes
* Increate prop.properties.name length.
