### PR TITLE
47093: NAb: 'Created By' rendered as userID in run details view

### DIFF
--- a/assay/api-src/org/labkey/api/assay/nab/RenderAssayBean.java
+++ b/assay/api-src/org/labkey/api/assay/nab/RenderAssayBean.java
@@ -125,7 +125,7 @@ public class RenderAssayBean extends RenderAssayForm
                         Object value = entry.getValue();
                         if (value != null)
                         {
-                            _displayProperties.put(property.getNonBlankCaption(), formatValue(property, value));
+                            _displayProperties.put(property.getNonBlankCaption(), formatValue(property, value, _context.getUser()));
                         }
                     }
                 }
@@ -147,9 +147,14 @@ public class RenderAssayBean extends RenderAssayForm
         return _displayProperties;
     }
 
-    public Object formatValue(PropertyDescriptor pd, Object value)
+    public Object formatValue(PropertyDescriptor pd, Object value, User user)
     {
-        if (pd.getFormat() != null)
+        // issue 47093 - special handling for created by field
+        if ("CreatedBy".equalsIgnoreCase(pd.getName()) && value instanceof Integer userId)
+        {
+            value = UserManager.getDisplayName(userId, user);
+        }
+        else if (pd.getFormat() != null)
         {
             if (pd.getPropertyType() == PropertyType.DOUBLE)
             {

--- a/assay/src/org/labkey/api/assay/nab/view/sampleProperties.jsp
+++ b/assay/src/org/labkey/api/assay/nab/view/sampleProperties.jsp
@@ -120,7 +120,7 @@
                             if (!pdsWithData.contains(pd.getName()))
                                 continue;
 
-                            Object value = bean.formatValue(pd, entry.getValue());
+                            Object value = bean.formatValue(pd, entry.getValue(), getUser());
                     %>
                             <td><%= h(value) %></td>
                     <%


### PR DESCRIPTION
#### Rationale
In the run summary section at the top of the NAb details report we include the `CreatedBy` field. However it renders as the `userid` instead of a display name. Fixing by handling this as a special case during formatting of run properties.

![image](https://user-images.githubusercontent.com/5741543/212779610-3570e66c-72db-4b50-a7a3-09d8b098d0db.png)
