### PR TITLE
DiscussionService.getDiscussions()

### DIFF
--- a/announcements/src/org/labkey/announcements/api/AnnouncementImpl.java
+++ b/announcements/src/org/labkey/announcements/api/AnnouncementImpl.java
@@ -23,7 +23,6 @@ import org.labkey.api.data.Container;
 import org.labkey.api.wiki.WikiRendererType;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -73,6 +72,12 @@ public class AnnouncementImpl implements Announcement
     public String getEntityId()
     {
         return _model.getEntityId();
+    }
+
+    @Override
+    public String getParent()
+    {
+        return _model.getParent();
     }
 
     @Override
@@ -155,7 +160,7 @@ public class AnnouncementImpl implements Announcement
     @Override
     public @NotNull List<Integer> getMemberListIds()
     {
-        return _model.getMemberListIds() != null ? _model.getMemberListIds() : Collections.emptyList();
+        return _model.getMemberListIds();
     }
 
     // This needs to be filled out more completely

--- a/announcements/src/org/labkey/announcements/api/AnnouncementImpl.java
+++ b/announcements/src/org/labkey/announcements/api/AnnouncementImpl.java
@@ -20,6 +20,7 @@ import org.labkey.announcements.model.AnnouncementModel;
 import org.labkey.api.announcements.api.Announcement;
 import org.labkey.api.attachments.Attachment;
 import org.labkey.api.data.Container;
+import org.labkey.api.security.User;
 import org.labkey.api.wiki.WikiRendererType;
 
 import java.util.Collection;
@@ -136,6 +137,12 @@ public class AnnouncementImpl implements Announcement
     }
 
     @Override
+    public int getCreatedBy()
+    {
+        return _model.getCreatedBy();
+    }
+
+    @Override
     public Date getModified()
     {
         return _model.getModified();
@@ -144,6 +151,12 @@ public class AnnouncementImpl implements Announcement
     public void setModified(Date modified)
     {
         _model.setModified(modified);
+    }
+
+    @Override
+    public int getModifiedBy()
+    {
+        return _model.getModifiedBy();
     }
 
     @Override

--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -302,7 +302,7 @@ public class AnnouncementManager
             notifyDiscussionProviderOfChange(c, ann, Change.Insert);
         }
 
-        // The approval state, attachments, etc may have changed after insert.
+        // The approval state, attachments, etc. may have changed after insert.
         // Return an up-to-date copy of the model.
         return getAnnouncement(c, ann.getRowId());
     }
@@ -311,7 +311,17 @@ public class AnnouncementManager
     {
         DiscussionSrcTypeProvider typeProvider = AnnouncementService.get().getDiscussionSrcTypeProvider(ann.getDiscussionSrcEntityType());
         if (null != typeProvider)
-            typeProvider.discussionChanged(c, ann.getDiscussionSrcIdentifier(), change, new AnnouncementImpl(ann));
+        {
+            try
+            {
+                typeProvider.discussionChanged(c, ann.getDiscussionSrcIdentifier(), change, new AnnouncementImpl(ann));
+            }
+            catch (Throwable e)
+            {
+                // Don't allow providers to fail the current operation
+                ExceptionUtil.logExceptionToMothership(null, e);
+            }
+        }
     }
 
     public static void approve(Container c, User user, boolean sendEmailNotifications, AnnouncementModel ann, Date date)

--- a/api/src/org/labkey/api/announcements/DiscussionService.java
+++ b/api/src/org/labkey/api/announcements/DiscussionService.java
@@ -18,6 +18,7 @@ package org.labkey.api.announcements;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.ReturnUrlForm;
+import org.labkey.api.announcements.api.Announcement;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.Sort;
 import org.labkey.api.security.User;
@@ -96,6 +97,8 @@ public interface DiscussionService
     void deleteDiscussions(Container container, User user, Collection<String> identifiers);
 
     boolean hasDiscussions(Container container, String identifier);
+
+    Collection<? extends Announcement> getDiscussions(Container container, String identifier, boolean includeResponses);
 
     void unlinkDiscussions(Container container, String identifier, User user);
 

--- a/api/src/org/labkey/api/announcements/api/Announcement.java
+++ b/api/src/org/labkey/api/announcements/api/Announcement.java
@@ -18,6 +18,7 @@ package org.labkey.api.announcements.api;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.attachments.Attachment;
 import org.labkey.api.data.Container;
+import org.labkey.api.security.User;
 import org.labkey.api.wiki.WikiRendererType;
 
 import java.util.Collection;
@@ -41,7 +42,9 @@ public interface Announcement
     Collection<Attachment> getAttachments();
     String getStatus();
     Date getCreated();
+    int getCreatedBy();
     Date getModified();
+    int getModifiedBy();
     WikiRendererType getRendererType();
     @NotNull List<Integer> getMemberListIds();
 }

--- a/api/src/org/labkey/api/announcements/api/Announcement.java
+++ b/api/src/org/labkey/api/announcements/api/Announcement.java
@@ -36,6 +36,7 @@ public interface Announcement
     Date getExpires();
     int getRowId();
     String getEntityId();
+    String getParent();
     Container getContainer();
     Collection<Attachment> getAttachments();
     String getStatus();

--- a/api/src/org/labkey/api/announcements/api/DiscussionSrcTypeProvider.java
+++ b/api/src/org/labkey/api/announcements/api/DiscussionSrcTypeProvider.java
@@ -23,4 +23,9 @@ public interface DiscussionSrcTypeProvider
     {
         return new HashSet<>();
     }
+
+    // Called any time a discussion thread is changed (insert, update, or delete)
+    default void discussionChanged(Container container, String discussionSrcIdentifier)
+    {
+    }
 }

--- a/api/src/org/labkey/api/announcements/api/DiscussionSrcTypeProvider.java
+++ b/api/src/org/labkey/api/announcements/api/DiscussionSrcTypeProvider.java
@@ -30,7 +30,7 @@ public interface DiscussionSrcTypeProvider
     }
 
     // Called any time a discussion thread is changed (insert, update, or delete)
-    default void discussionChanged(Container container, String discussionSrcIdentifier, Change change, Announcement ann)
+    default void discussionChanged(Container container, User user, String discussionSrcIdentifier, Change change, Announcement ann)
     {
     }
 }

--- a/api/src/org/labkey/api/announcements/api/DiscussionSrcTypeProvider.java
+++ b/api/src/org/labkey/api/announcements/api/DiscussionSrcTypeProvider.java
@@ -24,8 +24,13 @@ public interface DiscussionSrcTypeProvider
         return new HashSet<>();
     }
 
+    enum Change
+    {
+        Insert, Update, Delete
+    }
+
     // Called any time a discussion thread is changed (insert, update, or delete)
-    default void discussionChanged(Container container, String discussionSrcIdentifier)
+    default void discussionChanged(Container container, String discussionSrcIdentifier, Change change, Announcement ann)
     {
     }
 }


### PR DESCRIPTION
#### Rationale
Need a server-side mechanism for retrieving the contents of discussions

#### Related Pull Requests
* https://github.com/LabKey/platform/issues/4031

#### Changes
* Add `DiscussionService.getDiscussions()`
* Add `Announcement.getParent()`
* Add `DiscussionSrcTypeProvider.discussionChanged()` so providers are notified and can take action (e.g., reindex, audit, email notifications) when discussions are changed
