### PR TITLE
Enable making audit comments for Samples, Sources, and Run deletes

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -1110,7 +1110,7 @@ public abstract class AbstractAssayProvider implements AssayProvider
     }
 
     @Override
-    public void deleteProtocol(ExpProtocol protocol, User user) throws ExperimentException
+    public void deleteProtocol(ExpProtocol protocol, User user, @Nullable final String auditUserComment) throws ExperimentException
     {
         List<Pair<Domain, Map<DomainProperty, Object>>> domainInfos =  getDomains(protocol);
         List<Domain> domains = new ArrayList<>();
@@ -1130,7 +1130,7 @@ public abstract class AbstractAssayProvider implements AssayProvider
             }
             try
             {
-                domain.delete(user);
+                domain.delete(user, auditUserComment);
             }
             catch (DomainNotFoundException e)
             {

--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -1109,6 +1109,12 @@ public abstract class AbstractAssayProvider implements AssayProvider
         return new DetailsView(region, dataRowId);
     }
 
+    @Deprecated //Prefer overload that accepts the additional audit comment
+    public void deleteProtocol(ExpProtocol protocol, User user) throws ExperimentException
+    {
+        deleteProtocol(protocol, user, null);
+    }
+
     @Override
     public void deleteProtocol(ExpProtocol protocol, User user, @Nullable final String auditUserComment) throws ExperimentException
     {

--- a/api/src/org/labkey/api/assay/AssayProvider.java
+++ b/api/src/org/labkey/api/assay/AssayProvider.java
@@ -202,7 +202,7 @@ public interface AssayProvider extends Handler<ExpProtocol>
 
     ModelAndView createResultDetailsView(ViewContext context, ExpProtocol protocol, ExpData data, Object dataRowId);
 
-    void deleteProtocol(ExpProtocol protocol, User user) throws ExperimentException;
+    void deleteProtocol(ExpProtocol protocol, User user, @Nullable String auditUserComment) throws ExperimentException;
 
     /**
      * Get the action that implements the assay designer for this type or null if the assay has no designer.

--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -375,7 +375,7 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
                         replacedRun.setReplacedByRun(run);
                         replacedRun.save(context.getUser());
                     }
-                    ExperimentService.get().auditRunEvent(context.getUser(), context.getProtocol(), replacedRun, null, "Run id " + replacedRun.getRowId() + " was replaced by run id " + run.getRowId());
+                    ExperimentService.get().auditRunEvent(context.getUser(), context.getProtocol(), replacedRun, null, "Run id " + replacedRun.getRowId() + " was replaced by run id " + run.getRowId(), null);
 
                     transaction.addCommitTask(() -> replacedRun.archiveDataFiles(context.getUser()), DbScope.CommitTaskOption.POSTCOMMIT);
                 }

--- a/api/src/org/labkey/api/audit/AuditTypeEvent.java
+++ b/api/src/org/labkey/api/audit/AuditTypeEvent.java
@@ -52,6 +52,7 @@ public class AuditTypeEvent
     private User _createdBy;
     private Date _modified;
     private User _modifiedBy;
+    private String userComment;
 
     public AuditTypeEvent(String eventType, Container container, String comment)
     {
@@ -165,6 +166,16 @@ public class AuditTypeEvent
     public void setModifiedBy(User modifiedBy)
     {
         _modifiedBy = modifiedBy;
+    }
+
+    public void setUserComment(String userComment)
+    {
+        this.userComment = userComment;
+    }
+
+    public String getUserComment()
+    {
+        return this.userComment;
     }
 
     protected String getContainerMessageElement(@NotNull String containerId)

--- a/api/src/org/labkey/api/audit/AuditTypeEvent.java
+++ b/api/src/org/labkey/api/audit/AuditTypeEvent.java
@@ -40,6 +40,7 @@ public class AuditTypeEvent
     protected static final String CONTAINER_KEY = "container";
     protected static final String PROJECT_KEY = "project";
     protected static final String COMMENT_KEY = "comment";
+    private static final String USER_COMMENT_KEY = "userComment";
 
     // long type used here to allow for DbSequences to supply the rowId
     private long _rowId;
@@ -226,6 +227,8 @@ public class AuditTypeEvent
             elements.put(PROJECT_KEY, getContainerMessageElement(projectId));
         if (getComment() != null)
             elements.put(COMMENT_KEY, getComment());
+        if (getUserComment() != null)
+            elements.put(USER_COMMENT_KEY, getUserComment());
 
         return elements;
     }

--- a/api/src/org/labkey/api/audit/DetailedAuditTypeEvent.java
+++ b/api/src/org/labkey/api/audit/DetailedAuditTypeEvent.java
@@ -6,7 +6,6 @@ public class DetailedAuditTypeEvent extends AuditTypeEvent
 {
     private String _oldRecordMap;
     private String _newRecordMap;
-    private String userComment;
 
     public DetailedAuditTypeEvent()
     {
@@ -50,15 +49,5 @@ public class DetailedAuditTypeEvent extends AuditTypeEvent
     public void setNewRecordMap(String newRecordMap)
     {
         _newRecordMap = newRecordMap;
-    }
-
-    public void setUserComment(String userComment)
-    {
-        this.userComment = userComment;
-    }
-
-    public String getUserComment()
-    {
-        return this.userComment;
     }
 }

--- a/api/src/org/labkey/api/audit/DetailedAuditTypeEvent.java
+++ b/api/src/org/labkey/api/audit/DetailedAuditTypeEvent.java
@@ -6,6 +6,7 @@ public class DetailedAuditTypeEvent extends AuditTypeEvent
 {
     private String _oldRecordMap;
     private String _newRecordMap;
+    private String userComment;
 
     public DetailedAuditTypeEvent()
     {
@@ -49,5 +50,15 @@ public class DetailedAuditTypeEvent extends AuditTypeEvent
     public void setNewRecordMap(String newRecordMap)
     {
         _newRecordMap = newRecordMap;
+    }
+
+    public void setUserComment(String userComment)
+    {
+        this.userComment = userComment;
+    }
+
+    public String getUserComment()
+    {
+        return this.userComment;
     }
 }

--- a/api/src/org/labkey/api/audit/ExperimentAuditEvent.java
+++ b/api/src/org/labkey/api/audit/ExperimentAuditEvent.java
@@ -13,6 +13,7 @@ public class ExperimentAuditEvent extends AuditTypeEvent
     private int _runGroup;
     private String _message;
     private Integer _qcState;
+    private String _userComment;
 
     public ExperimentAuditEvent()
     {
@@ -84,6 +85,16 @@ public class ExperimentAuditEvent extends AuditTypeEvent
         _qcState = qcState;
     }
 
+    public String getUserComment()
+    {
+        return _userComment;
+    }
+
+    public void setUserComment(String comment)
+    {
+        _userComment = comment;
+    }
+
     @Override
     public Map<String, Object> getAuditLogMessageElements()
     {
@@ -94,6 +105,7 @@ public class ExperimentAuditEvent extends AuditTypeEvent
         elements.put("runLsid", getRunLsid());
         elements.put("message", getMessage());
         elements.put("qcState", getQcState());
+        elements.put("userComment", getUserComment());
         elements.putAll(super.getAuditLogMessageElements());
         return elements;
     }

--- a/api/src/org/labkey/api/audit/ExperimentAuditEvent.java
+++ b/api/src/org/labkey/api/audit/ExperimentAuditEvent.java
@@ -13,7 +13,6 @@ public class ExperimentAuditEvent extends AuditTypeEvent
     private int _runGroup;
     private String _message;
     private Integer _qcState;
-    private String _userComment;
 
     public ExperimentAuditEvent()
     {
@@ -83,16 +82,6 @@ public class ExperimentAuditEvent extends AuditTypeEvent
     public void setQcState(Integer qcState)
     {
         _qcState = qcState;
-    }
-
-    public String getUserComment()
-    {
-        return _userComment;
-    }
-
-    public void setUserComment(String comment)
-    {
-        _userComment = comment;
     }
 
     @Override

--- a/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
+++ b/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
@@ -88,7 +88,6 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
     private String _metadata;
     private String _inventoryUpdateType;
     private Long _transactionId;
-    private String _userComment;
 
     public SampleTimelineAuditEvent()
     {
@@ -188,16 +187,6 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
     public void setTransactionId(Long transactionId)
     {
         _transactionId = transactionId;
-    }
-
-    public String getUserComment()
-    {
-        return _userComment;
-    }
-
-    public void setUserComment(String userComment)
-    {
-        _userComment = userComment;
     }
 
     @Override

--- a/api/src/org/labkey/api/exp/DeleteForm.java
+++ b/api/src/org/labkey/api/exp/DeleteForm.java
@@ -36,6 +36,19 @@ public class DeleteForm extends ProtocolIdForm implements DataRegionSelection.Da
     private Integer _singleObjectRowId;
     private List<Integer> _rowIds;
 
+    private String _userComment;
+
+
+    public void setUserComment(String userComment)
+    {
+        this._userComment = userComment;
+    }
+
+    public String getUserComment()
+    {
+        return this._userComment;
+    }
+
     @NotNull
     public Set<Integer> getIds(boolean clear)
     {

--- a/api/src/org/labkey/api/exp/DeleteForm.java
+++ b/api/src/org/labkey/api/exp/DeleteForm.java
@@ -35,9 +35,7 @@ public class DeleteForm extends ProtocolIdForm implements DataRegionSelection.Da
     private String _dataRegionSelectionKey;
     private Integer _singleObjectRowId;
     private List<Integer> _rowIds;
-
     private String _userComment;
-
 
     public void setUserComment(String userComment)
     {

--- a/api/src/org/labkey/api/exp/api/ExpObject.java
+++ b/api/src/org/labkey/api/exp/api/ExpObject.java
@@ -69,6 +69,10 @@ public interface ExpObject extends Identifiable, Comparable<ExpObject>
 
     void save(User user) throws BatchValidationException;
     void delete(User user);
+    default void delete(User user, String auditUserComment)
+    {
+        delete(user);
+    }
 
     /**
      * @return Map from PropertyURI to ObjectProperty

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -627,7 +627,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     void deleteExperimentRunsByRowIds(Container container, final User user, int... selectedRunIds);
 
-    void deleteExperimentRunsByRowIds(Container container, final User user, String userComment, @NotNull Collection<Integer> selectedRunIds);
+    void deleteExperimentRunsByRowIds(Container container, final User user, @Nullable String userComment, @NotNull Collection<Integer> selectedRunIds);
 
     void deleteExpExperimentByRowId(Container container, User user, int experimentId);
 

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -627,7 +627,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     void deleteExperimentRunsByRowIds(Container container, final User user, int... selectedRunIds);
 
-    void deleteExperimentRunsByRowIds(Container container, final User user, @NotNull Collection<Integer> selectedRunIds);
+    void deleteExperimentRunsByRowIds(Container container, final User user, String userComment, @NotNull Collection<Integer> selectedRunIds);
 
     void deleteExpExperimentByRowId(Container container, User user, int experimentId);
 
@@ -811,6 +811,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
     HttpView createFileExportView(Container container, String defaultFilenamePrefix);
 
     void auditRunEvent(User user, ExpProtocol protocol, ExpRun run, @Nullable ExpExperiment runGroup, String message);
+    void auditRunEvent(User user, ExpProtocol protocol, ExpRun run, @Nullable ExpExperiment runGroup, String message, String userComment);
 
     List<? extends ExpExperiment> getMatchingBatches(String name, Container container, ExpProtocol protocol);
 

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -192,7 +192,7 @@ public interface SampleTypeService
      */
     Function<Map<String,Long>,Map<String,Long>> getSampleCountsFunction(@Nullable Date counterDate);
 
-    void deleteSampleType(int rowId, Container c, User user, String auditUserComment) throws ExperimentException;
+    void deleteSampleType(int rowId, Container c, User user, @Nullable String auditUserComment) throws ExperimentException;
 
     // used by DomainKind.invalidate()
     void indexSampleType(ExpSampleType sampleType);

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -192,7 +192,7 @@ public interface SampleTypeService
      */
     Function<Map<String,Long>,Map<String,Long>> getSampleCountsFunction(@Nullable Date counterDate);
 
-    void deleteSampleType(int rowId, Container c, User user) throws ExperimentException;
+    void deleteSampleType(int rowId, Container c, User user, String auditUserComment) throws ExperimentException;
 
     // used by DomainKind.invalidate()
     void indexSampleType(ExpSampleType sampleType);

--- a/api/src/org/labkey/api/exp/property/Domain.java
+++ b/api/src/org/labkey/api/exp/property/Domain.java
@@ -78,6 +78,10 @@ public interface Domain extends IPropertyType
     Lock getDatabaseLock();
 
     void delete(@Nullable User user) throws DomainNotFoundException;
+    default void delete(@Nullable User user, @Nullable String auditUserComment) throws DomainNotFoundException
+    {
+        delete(user);
+    }
     void save(User user) throws ChangePropertyDescriptorException;
     void save(User user, boolean allowAddBaseProperty) throws ChangePropertyDescriptorException;
 

--- a/api/src/org/labkey/api/exp/property/DomainAuditProvider.java
+++ b/api/src/org/labkey/api/exp/property/DomainAuditProvider.java
@@ -68,6 +68,7 @@ public class DomainAuditProvider extends AbstractAuditTypeProvider implements Au
         defaultVisibleColumns.add(FieldKey.fromParts("ProjectId"));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_DOMAIN_URI));
         defaultVisibleColumns.add(FieldKey.fromParts("Comment"));
+        defaultVisibleColumns.add(FieldKey.fromParts("UserComment"));
     }
 
     public DomainAuditProvider()
@@ -106,6 +107,8 @@ public class DomainAuditProvider extends AbstractAuditTypeProvider implements Au
                     col.setLabel("Domain");
                     col.setDisplayColumnFactory(colInfo -> new DomainColumn(colInfo, "Container", "DomainName"));
                 }
+                else if (COLUMN_NAME_USER_COMMENT.equalsIgnoreCase(col.getName()))
+                    col.setLabel("User Comment");
             }
         };
     }
@@ -191,6 +194,7 @@ public class DomainAuditProvider extends AbstractAuditTypeProvider implements Au
             Set<PropertyDescriptor> fields = new LinkedHashSet<>();
             fields.add(createPropertyDescriptor(COLUMN_NAME_DOMAIN_URI, PropertyType.STRING));
             fields.add(createPropertyDescriptor(COLUMN_NAME_DOMAIN_NAME, PropertyType.STRING));
+            fields.add(createPropertyDescriptor(COLUMN_NAME_USER_COMMENT, PropertyType.STRING));
             _fields = Collections.unmodifiableSet(fields);
         }
 

--- a/audit/src/org/labkey/audit/AuditController.java
+++ b/audit/src/org/labkey/audit/AuditController.java
@@ -270,6 +270,8 @@ public class AuditController extends SpringActionController
                 response.put("comment", event.getComment());
                 response.put("eventUserId", event.getCreatedBy().getUserId());
                 response.put("eventDateFormatted", new SimpleDateFormat(LookAndFeelProperties.getInstance(getContainer()).getDefaultDateTimeFormat()).format(event.getCreated()));
+                if (event.getUserComment() != null)
+                    response.put("userComment", event.getUserComment());
 
                 String oldRecord = event.getOldRecordMap();
                 String newRecord = event.getNewRecordMap();

--- a/experiment/src/org/labkey/experiment/ExperimentAuditProvider.java
+++ b/experiment/src/org/labkey/experiment/ExperimentAuditProvider.java
@@ -47,6 +47,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.labkey.api.audit.AbstractAuditTypeProvider.COLUMN_NAME_USER_COMMENT;
+
 /**
  * User: klum
  * Date: 7/21/13
@@ -74,6 +76,7 @@ public class ExperimentAuditProvider extends AbstractAuditTypeProvider implement
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_MESSAGE));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_QCSTATE));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_COMMENT));
+        defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_USER_COMMENT));
     }
 
     public ExperimentAuditProvider()
@@ -176,7 +179,16 @@ public class ExperimentAuditProvider extends AbstractAuditTypeProvider implement
                 }
                 else if (COLUMN_NAME_QCSTATE.equalsIgnoreCase(col.getName()))
                 {
+                    col.setLabel("QC State");
                     col.setFk(new QueryForeignKey(CoreSchema.getInstance().getTableInfoDataStates(), null, "RowId", "Label"));
+                }
+                else if (COLUMN_NAME_MESSAGE.equalsIgnoreCase(col.getName()))
+                {
+                    col.setLabel("QC Message");
+                }
+                else if (COLUMN_NAME_USER_COMMENT.equalsIgnoreCase(col.getName()))
+                {
+                    col.setLabel("User Comment");
                 }
             }
         };
@@ -208,6 +220,7 @@ public class ExperimentAuditProvider extends AbstractAuditTypeProvider implement
             fields.add(createPropertyDescriptor(COLUMN_NAME_RUN_GROUP, PropertyType.INTEGER));
             fields.add(createPropertyDescriptor(COLUMN_NAME_MESSAGE, PropertyType.STRING));
             fields.add(createPropertyDescriptor(COLUMN_NAME_QCSTATE, PropertyType.INTEGER));
+            fields.add(createPropertyDescriptor(COLUMN_NAME_USER_COMMENT, PropertyType.STRING));
 
             _fields = Collections.unmodifiableSet(fields);
         }

--- a/experiment/src/org/labkey/experiment/SampleTypeAuditProvider.java
+++ b/experiment/src/org/labkey/experiment/SampleTypeAuditProvider.java
@@ -59,6 +59,7 @@ public class SampleTypeAuditProvider extends AbstractAuditTypeProvider implement
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_PROJECT_ID));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_CONTAINER));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_COMMENT));
+        defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_USER_COMMENT));
     }
 
     public SampleTypeAuditProvider()
@@ -94,6 +95,8 @@ public class SampleTypeAuditProvider extends AbstractAuditTypeProvider implement
             {
                 if (COLUMN_NAME_SAMPLE_TYPE_NAME.equalsIgnoreCase(col.getName()))
                     col.setLabel("Sample Type");
+                else if (COLUMN_NAME_USER_COMMENT.equalsIgnoreCase(col.getName()))
+                    col.setLabel("User Comment");
             }
         };
     }
@@ -175,6 +178,7 @@ public class SampleTypeAuditProvider extends AbstractAuditTypeProvider implement
             elements.put("sampleSetName", getSampleSetName());
             elements.put("insertUpdateChoice", getInsertUpdateChoice());
             elements.put("transactionId", getTransactionId());
+            elements.put("userComment", getUserComment());
             elements.putAll(super.getAuditLogMessageElements());
             return elements;
         }
@@ -195,6 +199,7 @@ public class SampleTypeAuditProvider extends AbstractAuditTypeProvider implement
             fields.add(createPropertyDescriptor(COLUMN_NAME_SAMPLE_TYPE_NAME, PropertyType.STRING));
             fields.add(createPropertyDescriptor(COLUMN_NAME_INSERT_UPDATE_CHOICE, PropertyType.STRING));
             fields.add(createPropertyDescriptor(COLUMN_NAME_TRANSACTION_ID, PropertyType.BIGINT));
+            fields.add(createPropertyDescriptor(COLUMN_NAME_USER_COMMENT, PropertyType.STRING));
             _fields = Collections.unmodifiableSet(fields);
         }
 

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
@@ -279,9 +279,15 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
     @Override
     public void delete(User user)
     {
+        delete(user, null);
+    }
+
+    @Override
+    public void delete(User user, @Nullable String auditUserComment)
+    {
         try
         {
-            ExperimentServiceImpl.get().deleteDataClass(getRowId(), getContainer(), user);
+            ExperimentServiceImpl.get().deleteDataClass(getRowId(), getContainer(), user, auditUserComment);
         }
         catch (ExperimentException e)
         {

--- a/experiment/src/org/labkey/experiment/api/ExpProtocolImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpProtocolImpl.java
@@ -234,9 +234,14 @@ public class ExpProtocolImpl extends ExpIdentifiableEntityImpl<Protocol> impleme
     @Override
     public void delete(User user)
     {
+        delete(user, null);
+    }
+
+    public void delete(User user, @Nullable final String auditUserComment )
+    {
         try
         {
-            ExperimentServiceImpl.get().deleteProtocolByRowIds(getContainer(), user, getRowId());
+            ExperimentServiceImpl.get().deleteProtocolByRowIds(getContainer(), user, auditUserComment, getRowId());
         }
         catch (ExperimentException e)
         {

--- a/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
@@ -70,6 +70,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -328,11 +329,17 @@ public class ExpRunImpl extends ExpIdentifiableEntityImpl<ExperimentRun> impleme
     @Override
     public void delete(User user)
     {
+        delete(user, null);
+    }
+
+    @Override
+    public void delete(User user, @Nullable final String auditUserComment)
+    {
         if (!canDelete(user))
         {
             throw new UnauthorizedException();
         }
-        ExperimentServiceImpl.get().deleteExperimentRunsByRowIds(getContainer(), user, getRowId());
+        ExperimentServiceImpl.get().deleteExperimentRunsByRowIds(getContainer(), user, auditUserComment, Arrays.asList(getRowId()));
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -803,11 +803,18 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
     }
 
     @Override
+    @Deprecated // Prefer to use the version that provides an audit comment
     public void delete(User user)
+    {
+        delete(user, null);
+    }
+
+    @Override
+    public void delete(User user, String auditUserComment)
     {
         try
         {
-            SampleTypeService.get().deleteSampleType(getRowId(), getContainer(), user);
+            SampleTypeService.get().deleteSampleType(getRowId(), getContainer(), user, auditUserComment);
         }
         catch (ExperimentException e)
         {

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -5645,7 +5645,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return count;
     }
 
-    public void deleteDataClass(int rowId, Container c, User user) throws ExperimentException
+    public void deleteDataClass(int rowId, Container c, User user, @Nullable final String auditUserComment) throws ExperimentException
     {
         ExpDataClassImpl dataClass = getDataClass(rowId);
         if (null == dataClass)
@@ -5664,7 +5664,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         {
             truncateDataClass(dataClass, user, null);
 
-            d.delete(user);
+            d.delete(user, auditUserComment);
 
             deleteDomainObjects(dcContainer, dataClass.getLSID());
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4075,7 +4075,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public void deleteExperimentRunsByRowIds(Container container, final User user, final String userComment, @NotNull Collection<Integer> selectedRunIds)
+    public void deleteExperimentRunsByRowIds(Container container, final User user, @Nullable final String userComment, @NotNull Collection<Integer> selectedRunIds)
     {
         if (selectedRunIds.isEmpty())
             return;

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -543,7 +543,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     }
 
     @Override
-    public void deleteSampleType(int rowId, Container c, User user, String auditUserComment) throws ExperimentException
+    public void deleteSampleType(int rowId, Container c, User user, @Nullable String auditUserComment) throws ExperimentException
     {
         CPUTimer timer = new CPUTimer("delete sample type");
         timer.start();
@@ -612,20 +612,20 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         LOG.info("Deleted SampleType '" + source.getName() + "' from '" + c.getPath() + "' in " + timer.getDuration());
     }
 
-    private void addSampleTypeAuditEvent(User user, Container c, ExpSampleTypeImpl source, Long txAuditId, String auditUserComment)
+    private void addSampleTypeAuditEvent(User user, Container c, ExpSampleTypeImpl sampleType, Long txAuditId, String auditUserComment)
     {
-        SampleTypeAuditProvider.SampleTypeAuditEvent event = new SampleTypeAuditProvider.SampleTypeAuditEvent(c.getId(), String.format("Sample Type deleted: %1$s", source.getName()));
+        SampleTypeAuditProvider.SampleTypeAuditEvent event = new SampleTypeAuditProvider.SampleTypeAuditEvent(c.getId(), String.format("Sample Type deleted: %1$s", sampleType.getName()));
         event.setUserComment(auditUserComment);
 
         if (txAuditId != null)
             event.setTransactionId(txAuditId);
 
-        if (source != null)
+        if (sampleType != null)
         {
-            event.setSourceLsid(source.getLSID());
-            event.setSampleSetName(source.getName());
+            event.setSourceLsid(sampleType.getLSID());
+            event.setSampleSetName(sampleType.getName());
         }
-        event.setInsertUpdateChoice("Delete Type");
+        event.setInsertUpdateChoice("delete type");
         AuditLogService.get().addEvent(user, event);
     }
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -94,6 +94,7 @@ import org.labkey.api.study.publish.StudyPublishService;
 import org.labkey.api.util.CPUTimer;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringUtilsLabKey;
+import org.labkey.experiment.SampleTypeAuditProvider;
 
 import java.sql.SQLException;
 import java.time.LocalDateTime;
@@ -542,7 +543,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     }
 
     @Override
-    public void deleteSampleType(int rowId, Container c, User user) throws ExperimentException
+    public void deleteSampleType(int rowId, Container c, User user, String auditUserComment) throws ExperimentException
     {
         CPUTimer timer = new CPUTimer("delete sample type");
         timer.start();
@@ -582,6 +583,8 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             executor.execute("UPDATE " + getTinfoProtocolInput() + " SET materialSourceId = NULL WHERE materialSourceId = ?", source.getRowId());
             executor.execute("DELETE FROM " + getTinfoMaterialSource() + " WHERE RowId = ?", rowId);
 
+            addSampleTypeAuditEvent(user, c, source, transaction.getAuditId(), auditUserComment);
+
             transaction.addCommitTask(() -> clearMaterialSourceCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
             transaction.commit();
         }
@@ -607,6 +610,23 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
         timer.stop();
         LOG.info("Deleted SampleType '" + source.getName() + "' from '" + c.getPath() + "' in " + timer.getDuration());
+    }
+
+    private void addSampleTypeAuditEvent(User user, Container c, ExpSampleTypeImpl source, Long txAuditId, String auditUserComment)
+    {
+        SampleTypeAuditProvider.SampleTypeAuditEvent event = new SampleTypeAuditProvider.SampleTypeAuditEvent(c.getId(), String.format("Sample Type deleted: %1$s", source.getName()));
+        event.setUserComment(auditUserComment);
+
+        if (txAuditId != null)
+            event.setTransactionId(txAuditId);
+
+        if (source != null)
+        {
+            event.setSourceLsid(source.getLSID());
+            event.setSampleSetName(source.getName());
+        }
+        event.setInsertUpdateChoice("Delete Type");
+        AuditLogService.get().addEvent(user, event);
     }
 
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -1194,7 +1194,7 @@ public class ExperimentController extends SpringActionController
             }
             for (ExpDataClass dataClass : dataClasses)
             {
-                dataClass.delete(getUser());
+                dataClass.delete(getUser(), deleteForm.getUserComment());
             }
         }
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3362,7 +3362,7 @@ public class ExperimentController extends SpringActionController
         {
             for (ExpProtocol protocol : getProtocolsForDeletion(form))
             {
-                protocol.delete(getUser());
+                protocol.delete(getUser(), form.getUserComment());
             }
 
             return new ApiSimpleResponse();
@@ -3433,7 +3433,7 @@ public class ExperimentController extends SpringActionController
         {
             for (ExpProtocol protocol : getProtocolsForDeletion(form))
             {
-                protocol.delete(getUser());
+                protocol.delete(getUser(), form.getUserComment());
             }
         }
     }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3786,7 +3786,7 @@ public class ExperimentController extends SpringActionController
                     throw new UnauthorizedException();
                 }
 
-                source.delete(getUser());
+                source.delete(getUser(), deleteForm.getUserComment());
             }
         }
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3179,7 +3179,7 @@ public class ExperimentController extends SpringActionController
         @Override
         protected void deleteObjects(DeleteForm deleteForm)
         {
-            ExperimentServiceImpl.get().deleteExperimentRunsByRowIds(getContainer(), getUser(), deleteForm.getIds(false));
+            ExperimentServiceImpl.get().deleteExperimentRunsByRowIds(getContainer(), getUser(), deleteForm.getUserComment(), deleteForm.getIds(false));
         }
     }
 
@@ -3244,7 +3244,7 @@ public class ExperimentController extends SpringActionController
                     runIdsToDelete.addAll(runIdsCascadeDeleted);
             }
 
-            ExperimentService.get().deleteExperimentRunsByRowIds(getContainer(), getUser(), runIdsToDelete);
+            ExperimentService.get().deleteExperimentRunsByRowIds(getContainer(), getUser(), form.getUserComment(), runIdsToDelete);
 
             ApiSimpleResponse response = new ApiSimpleResponse("success", true);
             response.put("runIdsDeleted", runIdsToDelete);

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -2816,13 +2816,17 @@ public class QueryServiceImpl implements QueryService
             @Override
             protected AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tinfo, AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row)
             {
-                return createAuditRecord(c, tinfo, String.format(action.getCommentSummary(), rowCount), row);
+                DetailedAuditTypeEvent event = createAuditRecord(c, tinfo, String.format(action.getCommentSummary(), rowCount), row);
+                event.setUserComment(userComment);
+                return event;
             }
 
             @Override
             protected DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tinfo, AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> updatedRow, Map<String, Object> existingRow)
             {
-                return createAuditRecord(c, tinfo, action.getCommentDetailed(), updatedRow);
+                DetailedAuditTypeEvent event = createAuditRecord(c, tinfo, action.getCommentDetailed(), updatedRow);
+                event.setUserComment(userComment);
+                return event;
             }
 
             private QueryUpdateAuditProvider.QueryUpdateAuditEvent createAuditRecord(Container c, AuditConfigurable tinfo, String comment, @Nullable Map<String, Object> row)

--- a/query/src/org/labkey/query/audit/QueryUpdateAuditProvider.java
+++ b/query/src/org/labkey/query/audit/QueryUpdateAuditProvider.java
@@ -70,6 +70,7 @@ public class QueryUpdateAuditProvider extends AbstractAuditTypeProvider implemen
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_SCHEMA_NAME));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_QUERY_NAME));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_COMMENT));
+        defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_USER_COMMENT));
     }
 
     public QueryUpdateAuditProvider()
@@ -128,6 +129,10 @@ public class QueryUpdateAuditProvider extends AbstractAuditTypeProvider implemen
                 else if (COLUMN_NAME_QUERY_NAME.equalsIgnoreCase(col.getName()))
                 {
                     col.setLabel("Query Name");
+                }
+                else if (COLUMN_NAME_USER_COMMENT.equalsIgnoreCase(col.getName()))
+                {
+                    col.setLabel("User Comment");
                 }
             }
         };

--- a/query/src/org/labkey/query/audit/QueryUpdateAuditProvider.java
+++ b/query/src/org/labkey/query/audit/QueryUpdateAuditProvider.java
@@ -252,6 +252,7 @@ public class QueryUpdateAuditProvider extends AbstractAuditTypeProvider implemen
             elements.put("schemaName", getSchemaName());
             elements.put("queryName", getQueryName());
             elements.put("transactionId", getTransactionId());
+            elements.put("userComment", getUserComment());
             // N.B. oldRecordMap and newRecordMap are potentially very large (and are not displayed in the default grid view)
             elements.putAll(super.getAuditLogMessageElements());
             return elements;
@@ -276,6 +277,7 @@ public class QueryUpdateAuditProvider extends AbstractAuditTypeProvider implemen
             fields.add(createOldDataMapPropertyDescriptor());
             fields.add(createNewDataMapPropertyDescriptor());
             fields.add(createPropertyDescriptor(COLUMN_NAME_TRANSACTION_ID, PropertyType.BIGINT));
+            fields.add(createPropertyDescriptor(COLUMN_NAME_USER_COMMENT, PropertyType.STRING));
             _fields = Collections.unmodifiableSet(fields);
         }
 


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/sampleManagement/issues/1485
[Spec](https://docs.google.com/document/d/1LwKCiLhWoa7xPwyOxBxKN4VGEOCUvw9njdDHHRobKEM/edit#heading=h.rbo1k9dupcqe)
[Github epic](https://github.com/LabKey/sampleManagement/issues/1483)

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4037
* https://github.com/LabKey/labkey-ui-components/pull/1087
* https://github.com/LabKey/labkey-ui-premium/pull/21
* https://github.com/LabKey/inventory/pull/698
* https://github.com/LabKey/biologics/pull/1872
* https://github.com/LabKey/sampleManagement/pull/1555
* https://github.com/LabKey/labbook/pull/389

#### Changes
* Add delete overload that takes a comment parameter
* Pushed UserComment property into AuditTypeEvent
* Added UserComment property to some AuditDomains
* adjusted column labels
