### PR TITLE
Issue 46951: clear domain cache early in process of updating the domain

### DIFF
--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -725,6 +725,10 @@ public class DomainUtil
         {
             if (validationException.getErrors().isEmpty())
             {
+                // Issue 46951: be sure the domain is invalidated early in the process of updating so we don't get
+                // a mismatched tableInfo and domain
+                OntologyManager.clearCaches();
+
                 // Reorder the properties based on what we got from GWT
                 Map<String, DomainProperty> dps = new HashMap<>();
                 for (DomainProperty dp : d.getProperties())


### PR DESCRIPTION
#### Rationale
When in the process of updating a domain, if the domain cache is cleared too late it can happen that the tableInfo and the domain get out of sync, resulting in an incomplete/incorrect domain for fields that have been added.  Here we add a sometimes-redundant call to clear the domain cache early in the process of updating the domain so this mismatch doesn't happen.


#### Changes
* Clear the domain cache held by `OntologyManager` earlier
