### PR TITLE
Add support for round tripping of study custom security settings

### DIFF
--- a/api/schemas/study.xsd
+++ b/api/schemas/study.xsd
@@ -315,6 +315,17 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>
+                <xs:element name="studySecurity" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                        <xs:attribute name="file" type="xs:string">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    Indicates the "file" (string) that contains the study security policy. The file must follow the study security policy (studySecurityPolicy.xsd) XML format.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
             </xs:all>
             <xs:attribute name="allowDataspace" type="xs:boolean" default="false">
                 <xs:annotation>
@@ -533,5 +544,4 @@
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
-
 </xs:schema>

--- a/study/src/org/labkey/study/controllers/security/SecurityController.java
+++ b/study/src/org/labkey/study/controllers/security/SecurityController.java
@@ -206,7 +206,7 @@ public class SecurityController extends SpringActionController
                 }
 
                 StudyPermissionExporter exporter = new StudyPermissionExporter();
-                StudySecurityPolicyDocument doc = exporter.getStudySecurityPolicyDocument(study);
+                StudySecurityPolicyDocument doc = exporter.getStudySecurityPolicyDocument(study, true);
 
                 XmlOptions xmlOptions = new XmlOptions();
                 xmlOptions.setSavePrettyPrint();

--- a/study/src/org/labkey/study/importer/CreateChildStudyPipelineJob.java
+++ b/study/src/org/labkey/study/importer/CreateChildStudyPipelineJob.java
@@ -361,7 +361,6 @@ public class CreateChildStudyPipelineJob extends AbstractStudyPipelineJob
         dataTypes.add(StudyArchiveDataTypes.STUDY_DATASETS_DEFINITIONS);
         dataTypes.add(StudyArchiveDataTypes.DATASET_DATA);
         dataTypes.add(StudyArchiveDataTypes.PARTICIPANT_GROUPS);
-        dataTypes.add(StudyArchiveDataTypes.STUDY_SECURITY_POLICY);
 
         dataTypes.add(FolderArchiveDataTypes.VIEW_CATEGORIES);
 
@@ -447,6 +446,10 @@ public class CreateChildStudyPipelineJob extends AbstractStudyPipelineJob
             // custom participant view
             StudyViewsImporter viewsImporter = new StudyViewsImporter();
             viewsImporter.process(importContext, studyDir, errors);
+
+            // custom security policy
+            StudySecurityPolicyImporter policyImporter = new StudySecurityPolicyImporter();
+            policyImporter.process(importContext, studyDir, errors);
 
             if (errors.hasErrors())
                 throw new RuntimeException("Error importing study objects : " + errors.getMessage());

--- a/study/src/org/labkey/study/importer/CreateChildStudyPipelineJob.java
+++ b/study/src/org/labkey/study/importer/CreateChildStudyPipelineJob.java
@@ -361,6 +361,7 @@ public class CreateChildStudyPipelineJob extends AbstractStudyPipelineJob
         dataTypes.add(StudyArchiveDataTypes.STUDY_DATASETS_DEFINITIONS);
         dataTypes.add(StudyArchiveDataTypes.DATASET_DATA);
         dataTypes.add(StudyArchiveDataTypes.PARTICIPANT_GROUPS);
+        dataTypes.add(StudyArchiveDataTypes.STUDY_SECURITY_POLICY);
 
         dataTypes.add(FolderArchiveDataTypes.VIEW_CATEGORIES);
 

--- a/study/src/org/labkey/study/importer/StudyImportFinalTask.java
+++ b/study/src/org/labkey/study/importer/StudyImportFinalTask.java
@@ -69,6 +69,7 @@ public class StudyImportFinalTask
 
             // TreatmentVisitMap needs to import after cohort info is loaded (issue 19947)
             internalImporters.add(new TreatmentVisitMapImporter());
+            internalImporters.add(new StudySecurityPolicyImporter());
 
             VirtualFile vf = ctx.getRoot();
             for (InternalStudyImporter importer : internalImporters)

--- a/study/src/org/labkey/study/importer/StudySecurityPolicyImporter.java
+++ b/study/src/org/labkey/study/importer/StudySecurityPolicyImporter.java
@@ -1,0 +1,73 @@
+package org.labkey.study.importer;
+
+import org.apache.xmlbeans.XmlObject;
+import org.labkey.api.admin.ImportException;
+import org.labkey.api.query.ValidationException;
+import org.labkey.api.util.XmlBeansUtil;
+import org.labkey.api.util.XmlValidationException;
+import org.labkey.api.writer.VirtualFile;
+import org.labkey.study.security.permissions.StudyPermissionExporter;
+import org.labkey.study.writer.StudyArchiveDataTypes;
+import org.labkey.study.xml.StudyDocument;
+import org.labkey.studySecurityPolicy.xml.StudySecurityPolicyDocument;
+import org.springframework.validation.BindException;
+
+import java.io.IOException;
+import java.util.List;
+
+public class StudySecurityPolicyImporter implements InternalStudyImporter
+{
+    @Override
+    public String getDescription()
+    {
+        return getDataType();
+    }
+
+    @Override
+    public String getDataType() { return StudyArchiveDataTypes.STUDY_SECURITY_POLICY; }
+
+    @Override
+    public void process(StudyImportContext ctx, VirtualFile root, BindException errors) throws IOException, ValidationException, ImportException
+    {
+        if (!ctx.isDataTypeSelected(getDataType()))
+            return;
+
+        if (isValidForImportArchive(ctx, root))
+        {
+            ctx.getLogger().info("Loading " + getDescription());
+
+            StudyDocument.Study.StudySecurity studySecurity = ctx.getXml().getStudySecurity();
+            String policyFileName = studySecurity.getFile();
+            ctx.getLogger().info("Loading security policy file from " + policyFileName);
+
+            if (policyFileName != null)
+            {
+                try
+                {
+                    XmlObject doc = root.getXmlBean(policyFileName);
+                    if (doc instanceof StudySecurityPolicyDocument spd)
+                    {
+                        XmlBeansUtil.validateXmlDocument(doc, "security policy file");
+                        StudyPermissionExporter exporter = new StudyPermissionExporter();
+                        List<String> errorMsg = exporter.loadSecurityPolicyDocument(ctx.getStudyImpl(), ctx.getUser(), spd);
+                        errorMsg.forEach(errors::reject);
+                    }
+                }
+                catch (XmlValidationException e)
+                {
+                    throw new ImportException("Invalid study security policy document");
+                }
+            }
+            else
+                ctx.getLogger().error("Security policy file is not set");
+
+            ctx.getLogger().info("Done importing " + getDescription());
+        }
+    }
+
+    @Override
+    public boolean isValidForImportArchive(StudyImportContext ctx, VirtualFile root) throws ImportException
+    {
+        return ctx.getXml() != null && ctx.getXml().getStudySecurity() != null;
+    }
+}

--- a/study/src/org/labkey/study/importer/StudySecurityPolicyImporter.java
+++ b/study/src/org/labkey/study/importer/StudySecurityPolicyImporter.java
@@ -38,10 +38,10 @@ public class StudySecurityPolicyImporter implements InternalStudyImporter
 
             StudyDocument.Study.StudySecurity studySecurity = ctx.getXml().getStudySecurity();
             String policyFileName = studySecurity.getFile();
-            ctx.getLogger().info("Loading security policy file from " + policyFileName);
 
             if (policyFileName != null)
             {
+                ctx.getLogger().info("Loading security policy file from " + policyFileName);
                 try
                 {
                     XmlObject doc = root.getXmlBean(policyFileName);

--- a/study/src/org/labkey/study/writer/StudyArchiveDataTypes.java
+++ b/study/src/org/labkey/study/writer/StudyArchiveDataTypes.java
@@ -39,6 +39,7 @@ public class StudyArchiveDataTypes
     public static final String TOP_LEVEL_STUDY_PROPERTIES = "Top-level Study Properties";
     public static final String TREATMENT_DATA = "Treatment Data";
     public static final String VISIT_MAP = "Visit Map";
+    public static final String STUDY_SECURITY_POLICY = "Permissions for Custom Study Security";
 
     private StudyArchiveDataTypes() {}
 }

--- a/study/src/org/labkey/study/writer/StudySecurityPolicyWriter.java
+++ b/study/src/org/labkey/study/writer/StudySecurityPolicyWriter.java
@@ -1,0 +1,33 @@
+package org.labkey.study.writer;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.writer.VirtualFile;
+import org.labkey.study.model.StudyImpl;
+import org.labkey.study.security.permissions.StudyPermissionExporter;
+import org.labkey.study.xml.StudyDocument;
+import org.labkey.studySecurityPolicy.xml.StudySecurityPolicyDocument;
+
+public class StudySecurityPolicyWriter implements InternalStudyWriter
+{
+    public static final String FILENAME = "security_policy.xml";
+
+    @Nullable
+    @Override
+    public String getDataType()
+    {
+        return StudyArchiveDataTypes.STUDY_SECURITY_POLICY;
+    }
+
+    @Override
+    public void write(StudyImpl study, StudyExportContext ctx, VirtualFile root) throws Exception
+    {
+        StudyDocument.Study studyXml = ctx.getXml();
+        StudyDocument.Study.StudySecurity securityXml = studyXml.addNewStudySecurity();
+        securityXml.setFile(FILENAME);
+
+        StudyPermissionExporter exporter = new StudyPermissionExporter();
+        StudySecurityPolicyDocument policyDocument = exporter.getStudySecurityPolicyDocument(study, StudyWriter.includeDatasetMetadata(ctx));
+
+        root.saveXmlBean(FILENAME, policyDocument);
+    }
+}

--- a/study/src/org/labkey/study/writer/StudySerializationRegistry.java
+++ b/study/src/org/labkey/study/writer/StudySerializationRegistry.java
@@ -27,6 +27,7 @@ import org.labkey.study.importer.InternalStudyImporter;
 import org.labkey.study.importer.ParticipantCommentImporter;
 import org.labkey.study.importer.ParticipantGroupImporter;
 import org.labkey.study.importer.ProtocolDocumentImporter;
+import org.labkey.study.importer.StudySecurityPolicyImporter;
 import org.labkey.study.importer.StudyQcStatesImporter;
 import org.labkey.study.importer.StudyViewsImporter;
 import org.labkey.study.importer.TopLevelStudyPropertiesImporter;
@@ -71,6 +72,7 @@ public class StudySerializationRegistry
             new TreatmentDataWriter(),
             new VisitMapWriter(),
             new StudyViewsWriter(),
+            new StudySecurityPolicyWriter(),
             new StudyXmlWriter()  // Note: Must be the last study writer since it writes out the study.xml file (to which other writers contribute)
         );
     }
@@ -97,6 +99,7 @@ public class StudySerializationRegistry
             new VisitImporter(),
             new VisitCohortAssigner(),
             new StudyViewsImporter(),
+            new StudySecurityPolicyImporter(),
             new TopLevelStudyPropertiesImporter()
         );
     }

--- a/study/src/org/labkey/study/writer/StudyWriter.java
+++ b/study/src/org/labkey/study/writer/StudyWriter.java
@@ -62,18 +62,11 @@ public class StudyWriter implements Writer<StudyImpl, StudyExportContext>
             // Support '<X> Dataset Definition' and '<X> Dataset Data' options
             DatasetDefinitionWriter definitionWriter = new DatasetDefinitionWriter();
             InternalStudyWriter datasetDataWriter = new DatasetDataWriter();
-            boolean hasDatasetDefinition = dataTypes.contains(StudyArchiveDataTypes.ASSAY_DATASET_DEFINITIONS) || dataTypes.contains(StudyArchiveDataTypes.SAMPLE_TYPE_DATASET_DEFINITIONS) || dataTypes.contains(StudyArchiveDataTypes.STUDY_DATASETS_DEFINITIONS);
-            boolean hasDatasetData = dataTypes.contains(StudyArchiveDataTypes.DATASET_DATA) || dataTypes.contains(StudyArchiveDataTypes.ASSAY_DATASET_DATA) || dataTypes.contains(StudyArchiveDataTypes.SAMPLE_TYPE_DATASET_DATA) || dataTypes.contains(StudyArchiveDataTypes.STUDY_DATASETS_DATA);
 
-            if (hasDatasetData)
-            {
+            if (includeDatasetMetadata(ctx))
                 definitionWriter.write(study, ctx, vf);
+            if (includeDatasetData(ctx))
                 datasetDataWriter.write(study, ctx, vf);
-            }
-            else if (hasDatasetDefinition)
-            {
-                definitionWriter.write(study, ctx, vf);
-            }
 
             // Call all the writers defined in the study module.
             for (Writer<StudyImpl, StudyExportContext> writer : StudySerializationRegistry.get().getInternalStudyWriters())
@@ -97,5 +90,25 @@ public class StudyWriter implements Writer<StudyImpl, StudyExportContext>
         }
 
         LOG.info("Done exporting study to " + vf.getLocation());
+    }
+
+    public static boolean includeDatasetMetadata(StudyExportContext ctx)
+    {
+        Set<String> dataTypes = ctx.getDataTypes();
+
+        return includeDatasetData(ctx) ||
+                dataTypes.contains(StudyArchiveDataTypes.ASSAY_DATASET_DEFINITIONS) ||
+                dataTypes.contains(StudyArchiveDataTypes.SAMPLE_TYPE_DATASET_DEFINITIONS) ||
+                dataTypes.contains(StudyArchiveDataTypes.STUDY_DATASETS_DEFINITIONS);
+     }
+
+    public static boolean includeDatasetData(StudyExportContext ctx)
+    {
+        Set<String> dataTypes = ctx.getDataTypes();
+
+        return dataTypes.contains(StudyArchiveDataTypes.DATASET_DATA) ||
+                dataTypes.contains(StudyArchiveDataTypes.ASSAY_DATASET_DATA) ||
+                dataTypes.contains(StudyArchiveDataTypes.SAMPLE_TYPE_DATASET_DATA) ||
+                dataTypes.contains(StudyArchiveDataTypes.STUDY_DATASETS_DATA);
     }
 }


### PR DESCRIPTION
#### Rationale
Folder export/import did not support the specific study security settings which maps groups as well as per dataset permissions. Some groups would work around this by using the import/export policy file that exists on the page, but it would be better if these settings could be handled automatically in the export/import workflow.

![image](https://user-images.githubusercontent.com/5741543/213552755-67bd7a45-529a-4cc1-8005-527a11965475.png)

#### Changes
- Introduce an option under study export options to serialize the custom security policy settings
- Refactor the `StudyPermissionExporter` to handle export and import. This class did most of the work for the existing UI based capabilities

![image](https://user-images.githubusercontent.com/5741543/213553212-052cba48-e757-4778-bd16-31c9642af054.png)
