### PR TITLE
Cache provisioned tables in a DatabaseCache

### DIFF
--- a/announcements/src/org/labkey/announcements/model/TourCache.java
+++ b/announcements/src/org/labkey/announcements/model/TourCache.java
@@ -41,7 +41,7 @@ public class TourCache
     public static class TourCacheLoader implements CacheLoader<Container, TourCollections>
     {
         @Override
-        public TourCollections load(Container c, Object argument)
+        public TourCollections load(@NotNull Container c, Object argument)
         {
             Selector selector = new TableSelector(_comm.getTableInfoTours(), SimpleFilter.createContainerFilter(c), null);
             Collection<TourModel> tours = selector.getCollection(TourModel.class);

--- a/api/src/org/labkey/api/attachments/PortalBackgroundImageCache.java
+++ b/api/src/org/labkey/api/attachments/PortalBackgroundImageCache.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.attachments;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.cache.BlockingCache;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
@@ -44,7 +45,7 @@ public class PortalBackgroundImageCache
     private static class ImageLoader implements CacheLoader<String, CacheableWriter>
     {
         @Override
-        public CacheableWriter load(String key, Object argument)
+        public CacheableWriter load(@NotNull String key, Object argument)
         {
             @SuppressWarnings("unchecked")
             Pair<AttachmentParent, String> pair = (Pair<AttachmentParent, String>) argument;

--- a/api/src/org/labkey/api/cache/Cache.java
+++ b/api/src/org/labkey/api/cache/Cache.java
@@ -69,7 +69,7 @@ public interface Cache<K, V>
     void clear();
 
     /**
-     * Some CacheProviders (e.g., Ehcache) hold on to the caches they create.  close() lets us discard temporary
+     * Some CacheProviders (e.g., Ehcache) hold on to the caches they create. close() lets us discard temporary
      * caches when we're done with them (e.g., after a transaction is complete) so we don't leak them.
      */
     void close();

--- a/api/src/org/labkey/api/cache/CacheLoader.java
+++ b/api/src/org/labkey/api/cache/CacheLoader.java
@@ -21,8 +21,6 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Something that knows how to fetch a value when it's not yet available from a cache.
- * User: matthewb
- * Date: Sep 16, 2010
  */
 public interface CacheLoader<K, V>
 {

--- a/api/src/org/labkey/api/cache/CacheManager.java
+++ b/api/src/org/labkey/api/cache/CacheManager.java
@@ -77,7 +77,7 @@ public class CacheManager
 
     public static <V> Cache<String, V> getStringKeyCache(int limit, long defaultTimeToLive, String debugName)
     {
-        return CacheManager.createCache(limit, defaultTimeToLive, debugName);
+        return createCache(limit, defaultTimeToLive, debugName);
     }
 
     public static <K, V> BlockingCache<K, V> getBlockingCache(int limit, long defaultTimeToLive, String debugName, @Nullable CacheLoader<K, V> loader)

--- a/api/src/org/labkey/api/cache/TransactionCache.java
+++ b/api/src/org/labkey/api/cache/TransactionCache.java
@@ -23,8 +23,8 @@ import java.util.Set;
 
 /**
  * A read-through, transaction-specific cache. Reads through to the shared cache until any write occurs, at which point
- * it switches to using a private cache for the remainder of the transaction. This avoids polluting the shared cache if
- * the transaction is rolled back for any reason.
+ * it switches to using a private cache for the remainder of the transaction. This avoids polluting the shared cache
+ * during the transaction and in the case of a rollback.
  * User: adam
  * Date: Nov 9, 2009
  */
@@ -35,7 +35,7 @@ public class TransactionCache<K, V> implements Cache<K, V>
     /** Our own private, transaction-specific cache, which may contain database changes that have not yet been committed */
     private final Cache<K, V> _privateCache;
 
-    /** Whether or not we've written to our private, transaction-specific cache */
+    /** Whether we've written to our private, transaction-specific cache */
     private boolean _hasWritten = false;
 
     public TransactionCache(Cache<K, V> sharedCache, Cache<K, V> privateCache)
@@ -56,7 +56,6 @@ public class TransactionCache<K, V> implements Cache<K, V>
 
         return v;
     }
-
 
     @Override
     public V get(@NotNull K key, Object arg, CacheLoader<K, V> loader)

--- a/api/src/org/labkey/api/cache/TransactionCache.java
+++ b/api/src/org/labkey/api/cache/TransactionCache.java
@@ -22,9 +22,9 @@ import org.labkey.api.util.Filter;
 import java.util.Set;
 
 /**
- * A read-through, transaction-specific cache.  Reads through to the shared cache until any write occurs,
- * at which point it switches to using a private cache for the remainder of the transaction. This avoids polluting
- * the shared cache if the transaction is rolled back for any reason.
+ * A read-through, transaction-specific cache. Reads through to the shared cache until any write occurs, at which point
+ * it switches to using a private cache for the remainder of the transaction. This avoids polluting the shared cache if
+ * the transaction is rolled back for any reason.
  * User: adam
  * Date: Nov 9, 2009
  */

--- a/api/src/org/labkey/api/data/AbstractPropertyStore.java
+++ b/api/src/org/labkey/api/data/AbstractPropertyStore.java
@@ -211,7 +211,7 @@ public abstract class AbstractPropertyStore implements PropertyStore
     protected class PropertyLoader implements CacheLoader<String, PropertyManager.PropertyMap>
     {
         @Override
-        public PropertyManager.PropertyMap load(String key, Object argument)
+        public PropertyManager.PropertyMap load(@NotNull String key, Object argument)
         {
             Object[] params = (Object[])argument;
             User user = (User)params[1];

--- a/api/src/org/labkey/api/data/DatabaseCache.java
+++ b/api/src/org/labkey/api/data/DatabaseCache.java
@@ -63,7 +63,7 @@ public class DatabaseCache<K, V> implements Cache<K, V>
 
     protected Cache<K, V> createSharedCache(int maxSize, long defaultTimeToLive, String debugName)
     {
-        return (Cache<K, V>)CacheManager.getStringKeyCache(maxSize, defaultTimeToLive, debugName);
+        return CacheManager.getCache(maxSize, defaultTimeToLive, debugName);
     }
 
     @Override

--- a/api/src/org/labkey/api/data/DbSchemaCache.java
+++ b/api/src/org/labkey/api/data/DbSchemaCache.java
@@ -53,26 +53,28 @@ public class DbSchemaCache
         _cache = new DbSchemaBlockingCache(_scope.getDisplayName());
     }
 
+    public static DbSchemaType getSchemaType(DbScope scope, String schemaName)
+    {
+        DbSchemaType type = ModuleLoader.getInstance().getSchemaType(scope, schemaName);
+
+        if (null == type)
+            type = DbSchemaType.Bare;  // Schema isn't claimed by any module
+
+        return type;
+    }
+
     @NotNull DbSchema get(String schemaName, DbSchemaType type)
     {
         // Infer type if it's unknown... should be rare
         if (DbSchemaType.Unknown == type)
-        {
-            type = ModuleLoader.getInstance().getSchemaType(_scope, schemaName);
-
-            if (null == type)
-                type = DbSchemaType.Bare;  // Schema isn't claimed by a module
-        }
+            type = getSchemaType(_scope, schemaName);
 
         return _cache.get(getKey(schemaName, type), new SchemaDetails(schemaName, type));
     }
 
     void remove(String schemaName, DbSchemaType type)
     {
-        if (type == DbSchemaType.Module)
-            LOG.debug("removing module schema: " + schemaName, new Throwable("removing module schema: " + schemaName));
-        else
-            LOG.debug("remove " + type + " schema: " + schemaName);
+        LOG.debug("remove " + type + " schema: " + schemaName);
         _cache.removeUsingFilter(new Cache.StringPrefixFilter(getKey(schemaName, type)));
     }
 
@@ -82,7 +84,7 @@ public class DbSchemaCache
     }
 
 
-    private class SchemaDetails
+    private static class SchemaDetails
     {
         private final String _schemaName;
         private final DbSchemaType _type;

--- a/api/src/org/labkey/api/data/DbSchemaCache.java
+++ b/api/src/org/labkey/api/data/DbSchemaCache.java
@@ -110,7 +110,7 @@ public class DbSchemaCache
     private class DbSchemaLoader implements CacheLoader<String, DbSchema>
     {
         @Override
-        public DbSchema load(String key, Object schemaDetails)
+        public DbSchema load(@NotNull String key, Object schemaDetails)
         {
             try
             {
@@ -123,7 +123,6 @@ public class DbSchemaCache
             }
         }
     }
-
 
     private class DbSchemaBlockingCache extends BlockingCache<String, DbSchema>
     {

--- a/api/src/org/labkey/api/data/DbSchemaType.java
+++ b/api/src/org/labkey/api/data/DbSchemaType.java
@@ -84,20 +84,6 @@ public enum DbSchemaType
             return new DbSchema(metaDataName, Fast, scope, tableInfoFactoryMap, module);
         }
     },
-    All("", 0, false)
-    {
-        @Override
-        protected long getCacheTimeToLive()
-        {
-            throw new IllegalStateException("Should not be caching a schema of this type");
-        }
-
-        @Override
-        DbSchema createDbSchema(DbScope scope, String metaDataName, Module module)
-        {
-            throw new IllegalStateException("Should not be creating a schema of type " + All);
-        }
-    },
     // This is a marker type that tells DbScope to infer the actual DbSchemaType, for the (very rare) case when the caller doesn't know
     Unknown("", 0, false)
     {

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -128,7 +128,7 @@ public class DbScope
     private final String _driverVersion;
     private final String _driverLocation;
     private final DbSchemaCache _schemaCache;
-    private final SchemaTableInfoCache _tableCache;
+    private final Map<DbSchemaType, SchemaTableInfoCache> _tableCaches = new ConcurrentHashMap<>(5);
     private final Map<Thread, List<TransactionImpl>> _transaction = new WeakHashMap<>();
     private final Map<Thread, ConnectionHolder> _threadConnections = new WeakHashMap<>();
     private final boolean _rds;
@@ -265,7 +265,6 @@ public class DbScope
         _driverVersion = null;
         _driverLocation = null;
         _schemaCache = null;
-        _tableCache = null;
         _rds = false;
         _escape = null;
     }
@@ -358,7 +357,6 @@ public class DbScope
             _driverVersion = dbmd.getDriverVersion();
             _driverLocation = determineDriverLocation();
             _schemaCache = new DbSchemaCache(this);
-            _tableCache = new SchemaTableInfoCache(this);
             _rds = _dialect.isRds(this);
             _escape = dbmd.getSearchStringEscape();
         }
@@ -1181,7 +1179,7 @@ public class DbScope
         return (useCache ? SCHEMA_XML_CACHE.getResourceMap(module).keySet() : SchemaXmlCacheHandler.getFilenames(module)).stream()
             .map(filename -> filename.substring(0, filename.length() - ".xml".length()))
             .sorted()
-            .collect(Collectors.toUnmodifiableList());
+            .toList();
     }
 
     // Verify that the two ways for determining schema names yield identical results
@@ -1201,7 +1199,6 @@ public class DbScope
         return _schemaCache.get(schemaName, type);
     }
 
-
     // Get the special "labkey" schema created in each module data source
     @JsonIgnore
     public @NotNull DbSchema getLabKeySchema()
@@ -1209,12 +1206,16 @@ public class DbScope
         return getSchema("labkey", DbSchemaType.Module);
     }
 
-
-    // Each scope holds the cache for all its tables. This makes it easier to 1) configure that cache on a per-scope
-    // basis and 2) invalidate schemas and their tables together
+    // Each scope holds a map with a table cache for each DbSchemaType. This makes it easier to 1) configure that cache
+    // on a per-scope and per-DbSchemaType basis and 2) invalidate schemas and their tables together
     public <OptionType extends SchemaTableOptions> SchemaTableInfo getTable(OptionType options)
     {
-        return _tableCache.get(options);
+        return getTableInfoCache(options.getSchema().getType()).get(options);
+    }
+
+    private SchemaTableInfoCache getTableInfoCache(DbSchemaType type)
+    {
+        return _tableCaches.computeIfAbsent(type, t -> new SchemaTableInfoCache(this, t));
     }
 
     // Collection of schema names in this scope, in no particular order.
@@ -1223,13 +1224,11 @@ public class DbScope
         return SchemaNameCache.get().getSchemaNameMap(this).values();
     }
 
-
     /** Invalidates this schema and all its associated tables */
     public void invalidateSchema(DbSchema schema)
     {
         invalidateSchema(schema.getName(), schema.getType());
     }
-
 
     /** Invalidates this schema and all its associated tables */
     public void invalidateSchema(String schemaName, DbSchemaType type)
@@ -1239,21 +1238,24 @@ public class DbScope
         invalidateAllTables(schemaName, type);
     }
 
-
-    // Invalidates all tables in the table cache. Careful: callers probably need to invalidate the schema as well (it holds a list of table names)
-    void invalidateAllTables(String schemaName, DbSchemaType type)
+    // Invalidates all tables in the table cache. Careful: callers probably need to invalidate the schema as well (it holds a list of table names).
+    private void invalidateAllTables(String schemaName, DbSchemaType type)
     {
-        _tableCache.removeAllTables(schemaName, type);
+        // If caller doesn't know the schema type then clear the schema tables from all caches
+        if (type == DbSchemaType.Unknown)
+            type = DbSchemaCache.getSchemaType(this, schemaName);
+
+        getTableInfoCache(type).removeAllTables(schemaName);
     }
 
-    // DbSchema holds a hard-coded list of table names, so we need to invalidate the DbSchema to update this list.
-    // Note that all other TableInfos remain cached; this is simply invalidating the schema info and reloading the
-    // meta data XML. If this is too heavyweight, we could instead cache and invalidate the list of table names separate
-    // from the DbSchema.
+    // DbSchema holds a list of table names, so we need to invalidate the DbSchema to update this list. Note that all
+    // other TableInfos remain cached; this is simply invalidating the schema info and reloading the metadata XML. If
+    // this is too heavyweight, we could instead cache and invalidate the list of table names separate from the
+    // DbSchema.
     public void invalidateTable(String schemaName, String tableName, DbSchemaType type)
     {
         QueryService.get().updateLastModified();
-        _tableCache.remove(schemaName, tableName, type);
+        getTableInfoCache(type).remove(schemaName, tableName);
         _schemaCache.remove(schemaName, type);
     }
 

--- a/api/src/org/labkey/api/data/SchemaNameCache.java
+++ b/api/src/org/labkey/api/data/SchemaNameCache.java
@@ -56,7 +56,7 @@ public class SchemaNameCache
     }
 
     /**
-     * Returns a map of all schema names in this scope. The map has case-insensitive keys and values that are the canonical meta data names.
+     * Returns a map of all schema names in this scope. The map has case-insensitive keys and values that are the canonical metadata names.
      */
     public Map<String, String> getSchemaNameMap(DbScope scope)
     {

--- a/api/src/org/labkey/api/data/SchemaTableInfoCache.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfoCache.java
@@ -137,6 +137,6 @@ public class SchemaTableInfoCache
 
     private static Cache<String, Wrapper<SchemaTableInfo>> createCache(DbScope scope)
     {
-        return CacheManager.getStringKeyCache(10000, CacheManager.UNLIMITED, "SchemaTableInfos for " + scope.getDisplayName());
+        return new DatabaseCache<>(scope, 10000, CacheManager.UNLIMITED, "SchemaTableInfos for " + scope.getDisplayName());
     }
 }

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -2818,6 +2818,14 @@ public class OntologyManager
         }
     }
 
+
+    public static void invalidateDomain(Domain d)
+    {
+        // TODO can we please implement a surgical version of this
+        clearCaches();
+    }
+
+
     public static void clearCaches()
     {
         _log.debug("Clearing caches");

--- a/api/src/org/labkey/api/security/UserCache.java
+++ b/api/src/org/labkey/api/security/UserCache.java
@@ -230,7 +230,7 @@ class UserCache
     private static class UserCollectionsLoader implements CacheLoader<String, UserCollections>
     {
         @Override
-        public UserCollections load(String key, @Nullable Object argument)
+        public UserCollections load(@NotNull String key, @Nullable Object argument)
         {
             Collection<User> allUsers = new TableSelector(CORE.getTableInfoUsers(), null, new Sort("Email")).getCollection(User.class);
 

--- a/bigiron/src/org/labkey/bigiron/mssql/synonym/SynonymManager.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/synonym/SynonymManager.java
@@ -180,7 +180,7 @@ public class SynonymManager
     private static class SynonymLoader implements CacheLoader<String, Pair<Map<String, Map<String, Synonym>>, Map<String, Map<String, MultiValuedMap<String, Synonym>>>>>
     {
         @Override
-        public Pair<Map<String, Map<String, Synonym>>, Map<String, Map<String, MultiValuedMap<String, Synonym>>>> load(String key, @Nullable Object argument)
+        public Pair<Map<String, Map<String, Synonym>>, Map<String, Map<String, MultiValuedMap<String, Synonym>>>> load(@NotNull String key, @Nullable Object argument)
         {
             DbScope scope = DbScope.getDbScope(key);
 

--- a/core/src/org/labkey/core/thumbnail/ThumbnailCache.java
+++ b/core/src/org/labkey/core/thumbnail/ThumbnailCache.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.core.thumbnail;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.attachments.Attachment;
 import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.cache.BlockingCache;
@@ -72,7 +73,7 @@ public class ThumbnailCache
     private static class DynamicThumbnailLoader implements CacheLoader<String, CacheableWriter>
     {
         @Override
-        public CacheableWriter load(String key, Object argument)
+        public CacheableWriter load(@NotNull String key, Object argument)
         {
             @SuppressWarnings("unchecked")
             Pair<ThumbnailProvider, ImageType> pair = (Pair<ThumbnailProvider, ImageType>) argument;

--- a/query/src/org/labkey/query/olap/ServerManager.java
+++ b/query/src/org/labkey/query/olap/ServerManager.java
@@ -173,7 +173,7 @@ public class ServerManager
     private static class OlapCacheLoader implements CacheLoader<Container, Map<String, OlapSchemaDescriptor>>
     {
         @Override
-        public Map<String, OlapSchemaDescriptor> load(Container c, @Nullable Object argument)
+        public Map<String, OlapSchemaDescriptor> load(@NotNull Container c, @Nullable Object argument)
         {
             Map<String, OlapSchemaDescriptor> map = new HashMap<>();
             SimpleFilter filter = SimpleFilter.createContainerFilter(c);

--- a/wiki/src/org/labkey/wiki/WikiCache.java
+++ b/wiki/src/org/labkey/wiki/WikiCache.java
@@ -16,6 +16,7 @@
 
 package org.labkey.wiki;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.cache.BlockingCache;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheLoader;
@@ -31,7 +32,7 @@ public class WikiCache
 {
     private static final String WIKI_COLLECTIONS_KEY = "~~wiki_collections~~";
     private static final boolean useCache = "true".equals(System.getProperty("wiki.cache", "true"));
-    private static final BlockingCache<String, Object> BLOCKING_CACHE = CacheManager.getBlockingStringKeyCache(50000, CacheManager.DAY, "Wikis and wiki collections", null);
+    private static final BlockingCache<String, Object> BLOCKING_CACHE = CacheManager.getBlockingStringKeyCache(100000, CacheManager.DAY, "Wikis and wiki collections", null);
 
     // Passing in Container as "argument" eliminates need to create loader instances when caching collections (but doesn't help with individual wikis)
     public abstract static class WikiCacheLoader<V> implements CacheLoader<String, V>
@@ -39,7 +40,7 @@ public class WikiCache
         abstract V load(String key, Container c);
 
         @Override
-        public V load(String key, Object argument)
+        public V load(@NotNull String key, Object argument)
         {
             return load(key, (Container)argument);
         }


### PR DESCRIPTION
#### Rationale
We update provisioned tables inside of transactions. Caching their `TableInfo`s in a `DatabaseCache` helps with proper invalidation.

This PR also addresses https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46951

#### Changes
* Partition the schema TableInfo caches by `DbSchemaType`. Use normal caches for Module and Bare schemas, but a DatabaseCache for Provisioned schemas.
