### PR TITLE
Increase width of filter dialog and its controls

### DIFF
--- a/api/webapp/clientapi/ext3/FilterDialog.js
+++ b/api/webapp/clientapi/ext3/FilterDialog.js
@@ -70,9 +70,9 @@ LABKEY.FilterDialog = Ext.extend(Ext.Window, {
                 scope: this
             }],
             width: this.isConceptColumnFilter() ?
-                    (Ext.isGecko ? 533 : 518) :
+                    (Ext.isGecko ? 613 : 598) :
                     // 24846
-                    (Ext.isGecko ? 425 : 410),
+                    (Ext.isGecko ? 505 : 490),
             // listeners
             listeners: {
                 destroy: function() {
@@ -605,8 +605,8 @@ LABKEY.FilterDialog.View.Default = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
             listWidth: (this.jsonType == 'date' || this.jsonType == 'boolean') ? null : 380,
             emptyText: idx === 0 ? 'Choose a filter:' : 'No other filter',
             autoSelect: false,
-            width: 250,
-            minListWidth: 250,
+            width: 330,
+            minListWidth: 330,
             triggerAction: 'all',
             fieldLabel: (idx === 0 ?'Filter Type' : 'and'),
             store: this.getSelectionStore(idx),
@@ -723,7 +723,7 @@ LABKEY.FilterDialog.View.Default = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
             itemId        : 'inputField' + idx,
             filterIndex   : idx,
             id            : 'value_'+(idx + 1),   //for compatibility with tests...
-            width         : 250,
+            width         : 330,
             blankText     : 'You must enter a value.',
             validateOnBlur: true,
             value         : null,

--- a/core/resources/scripts/labkey/Filter.js
+++ b/core/resources/scripts/labkey/Filter.js
@@ -368,7 +368,7 @@ LABKEY.Filter = new function()
         // - js: Filter.js
         // - R: makeFilter.R, makeFilter.Rd
         // - SAS: labkeymakefilter.sas, labkey.org SAS docs
-        // - Python & Perl don't have an filter operator enum
+        // - Python & Perl don't have a filter operator enum
         // - EXPERIMENTAL: Added an optional displaySymbol() for filters that want to support it
         Types : {
 


### PR DESCRIPTION
#### Rationale
We can afford to make the filter dialog and its filter type drop-down wide enough to display all the operators and their example usages. With this change, "Does Not Contain Any Of (example usage: a;b;c)" and a few others are no longer truncated.