### PR TITLE
Redirect wiki-page.view to remove _docid parameter

### DIFF
--- a/wiki/src/org/labkey/wiki/WikiController.java
+++ b/wiki/src/org/labkey/wiki/WikiController.java
@@ -1151,6 +1151,10 @@ public class WikiController extends SpringActionController
             }
             else
             {
+                // Result was found; strip the "_docid" parameter and redirect as a convenience
+                if (null != getViewContext().getActionURL().getParameter("_docid"))
+                    throw new RedirectException(getViewContext().cloneActionURL().deleteParameter("_docid"));
+
                 int version = form.getVersion();
 
                 if (0 == version)


### PR DESCRIPTION
#### Rationale
The `_docid` parameter is for internal validation purposes. Users don't ever need to see it, so strip it and redirect after validation.