### PR TITLE
Migrate timeline event classes to new JSONObject

### DIFF
--- a/api/src/org/labkey/api/audit/AbstractTimelineEvent.java
+++ b/api/src/org/labkey/api/audit/AbstractTimelineEvent.java
@@ -1,6 +1,6 @@
 package org.labkey.api.audit;
 
-import org.json.old.JSONObject;
+import org.json.JSONObject;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.LookAndFeelProperties;


### PR DESCRIPTION
#### Rationale
Rid sampleManagement of `org.json.old.JSONObject`

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/1559