### PR TITLE
ColumnLogging.remapFieldKeys()

### DIFF
--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -134,7 +134,11 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     {
         _fieldKey = key;
         _parentTable = parentTable;
-        _columnLogging = new ColumnLogging(key, parentTable);
+
+        // I'd kind of prefer using null here.  But this is currently used to column matching in the column logging code using ColumnLogging.equals()
+        // See QuerySelectView.getRequiredDataLoggingColumns()
+        if (null != getParentTable())
+            _columnLogging = ColumnLogging.defaultLogging(this);
     }
 
     public BaseColumnInfo(FieldKey key, JdbcType t)
@@ -2059,7 +2063,8 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     {
         checkLocked();
         _parentTable = parentTable;
-        _columnLogging.setOriginalTableName(null != parentTable ? parentTable.getName() : "");
+        if (null == getColumnLogging())
+            setColumnLogging(ColumnLogging.defaultLogging(this));
     }
 
     @Override

--- a/api/src/org/labkey/api/data/ColumnLogging.java
+++ b/api/src/org/labkey/api/data/ColumnLogging.java
@@ -117,7 +117,7 @@ public class ColumnLogging implements Comparable<ColumnLogging>
     @Override
     public int compareTo(@NotNull ColumnLogging o)
     {
-        int ret = this._originalSchemaName.compareTo(o._originalSchemaName);
+        int ret = this._originalSchemaName.compareToIgnoreCase(o._originalSchemaName);
         if (0 == ret)
             ret = this.getOriginalTableName().compareToIgnoreCase(o.getOriginalTableName());
         if (0 == ret)

--- a/api/src/org/labkey/api/data/ColumnLogging.java
+++ b/api/src/org/labkey/api/data/ColumnLogging.java
@@ -20,6 +20,8 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.query.FieldKey;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -27,32 +29,62 @@ import java.util.Set;
  */
 public class ColumnLogging implements Comparable<ColumnLogging>
 {
+    private final String _originalSchemaName;
+    private final String _originalTableName;
+    private final FieldKey _originalColumnFieldKey;
     private final boolean _shouldLogName;
     private final Set<FieldKey> _dataLoggingColumns;
     private final String _loggingComment;
-    private final FieldKey _originalColumnFieldKey;
-    private String _originalTableName;
-    private SelectQueryAuditProvider _selectQueryAuditProvider;
+    private final SelectQueryAuditProvider _selectQueryAuditProvider;
 
-    public ColumnLogging(boolean shouldLogName, FieldKey columnFieldKey, TableInfo parentTable, Set<FieldKey> dataLoggingColumns, String loggingComment, SelectQueryAuditProvider selectQueryAuditProvider)
+    public static ColumnLogging defaultLogging(ColumnInfo col)
     {
+        var parent = col.getParentTable();
+        var tableName = null == parent ? "" : parent.getName();
+        var schemaName = null == parent ? "" : parent.getPublicSchemaName();
+        return new ColumnLogging(schemaName, tableName, col.getFieldKey(), false, Set.of(), "", null);
+    }
+
+
+    public ColumnLogging remapFieldKeys(FieldKey baseFieldKey, Map<FieldKey,FieldKey> remap)
+    {
+        if (null == baseFieldKey && (null == remap || remap.isEmpty()))
+            return this;
+        if (_dataLoggingColumns.isEmpty())
+            return this;
+        Set<FieldKey> dataLoggingColumns = new HashSet<>();
+        for (FieldKey fk : _dataLoggingColumns)
+            dataLoggingColumns.add(FieldKey.remap(fk, baseFieldKey, remap));
+        return new ColumnLogging(_originalSchemaName, _originalTableName, _originalColumnFieldKey, _shouldLogName, dataLoggingColumns, _loggingComment, _selectQueryAuditProvider);
+    }
+
+
+    // we don't usually want to change the original table, but if we do here you go
+    public ColumnLogging reparent(TableInfo table)
+    {
+        return new ColumnLogging(table.getSchema().getName(), table.getName(), _originalColumnFieldKey, _shouldLogName, _dataLoggingColumns, _loggingComment, _selectQueryAuditProvider);
+    }
+
+
+    public ColumnLogging(String schemaName, String tableName, FieldKey originalColumnFieldKey, boolean shouldLogName, Set<FieldKey> dataLoggingColumns, String loggingComment, SelectQueryAuditProvider selectQueryAuditProvider)
+    {
+        _originalSchemaName = schemaName;
+        _originalTableName = tableName;
+        _originalColumnFieldKey = originalColumnFieldKey;
         _shouldLogName = shouldLogName;
-        _dataLoggingColumns = dataLoggingColumns;
+        _dataLoggingColumns = Collections.unmodifiableSet(dataLoggingColumns);
         _loggingComment = loggingComment;
-        _originalColumnFieldKey = columnFieldKey;
-        _originalTableName = null != parentTable ? parentTable.getName() : "";
         _selectQueryAuditProvider = selectQueryAuditProvider;
     }
 
-    public ColumnLogging(boolean shouldLogName, FieldKey columnFieldKey, TableInfo parentTable, Set<FieldKey> dataLoggingColumns, String loggingComment)
+
+    @Deprecated
+    public ColumnLogging(boolean shouldLogName, FieldKey columnFieldKey, TableInfo parentTable, Set<FieldKey> dataLoggingColumns, String loggingComment, SelectQueryAuditProvider selectQueryAuditProvider)
     {
-        this(shouldLogName, columnFieldKey, parentTable, dataLoggingColumns, loggingComment, null);
+        this(parentTable.getSchema().getName(), parentTable.getName(), columnFieldKey, shouldLogName, dataLoggingColumns, loggingComment, selectQueryAuditProvider);
     }
 
-    public ColumnLogging(FieldKey columnFieldKey, TableInfo parentTable)
-    {
-        this(false, columnFieldKey, parentTable, Collections.emptySet(), "");
-    }
+
 
     /** If true, then this column's name should be logged when used in a query */
     public boolean shouldLogName()
@@ -82,15 +114,12 @@ public class ColumnLogging implements Comparable<ColumnLogging>
         return _originalTableName;
     }
 
-    public void setOriginalTableName(String originalTableName)
-    {
-        _originalTableName = originalTableName;
-    }
-
     @Override
     public int compareTo(@NotNull ColumnLogging o)
     {
-        int ret = this.getOriginalTableName().compareToIgnoreCase(o.getOriginalTableName());
+        int ret = this._originalSchemaName.compareTo(o._originalSchemaName);
+        if (0 == ret)
+            ret = this.getOriginalTableName().compareToIgnoreCase(o.getOriginalTableName());
         if (0 == ret)
             ret = this.getOriginalColumnFieldKey().compareTo(o.getOriginalColumnFieldKey());
         return ret;
@@ -100,5 +129,4 @@ public class ColumnLogging implements Comparable<ColumnLogging>
     {
         return _selectQueryAuditProvider;
     }
-
 }

--- a/api/src/org/labkey/api/data/LookupColumn.java
+++ b/api/src/org/labkey/api/data/LookupColumn.java
@@ -79,20 +79,6 @@ public class LookupColumn extends BaseColumnInfo
         LookupColumn ret = new LookupColumn(foreignKey, lookupKey, lookupColumn, joinType);
         ret.copyAttributesFrom(lookupColumn);
 
-        // ColumnLogging: make fieldkeys include the lookup
-        if (!lookupColumn.getColumnLogging().getDataLoggingColumns().isEmpty())
-        {
-            ColumnLogging columnLogging = lookupColumn.getColumnLogging();
-            Set<FieldKey> dataLoggingFieldKeys = new HashSet<>();
-            columnLogging.getDataLoggingColumns().forEach(fieldKey -> {
-                dataLoggingFieldKeys.add(FieldKey.fromParts(foreignKey.getFieldKey(), fieldKey));
-            });
-
-            ret.setColumnLogging(new ColumnLogging(columnLogging.shouldLogName(), FieldKey.fromParts(foreignKey.getFieldKey(), lookupColumn.getFieldKey()),
-                            foreignKey.getParentTable(), dataLoggingFieldKeys, columnLogging.getLoggingComment(), columnLogging.getSelectQueryAuditProvider()));
-        }
-
-
         // Copy the URL but don't reparent the FieldKey
         ret.copyURLFrom(lookupColumn, null, null);
         // Reparent all column FieldKeys including the URL just copied and DisplayColumnFactories

--- a/api/src/org/labkey/api/data/MutableColumnInfo.java
+++ b/api/src/org/labkey/api/data/MutableColumnInfo.java
@@ -138,6 +138,7 @@ public interface MutableColumnInfo extends MutableColumnRenderProperties, Column
         remapForeignKeyFieldKeys(parent, remap);
         remapSortFieldKeys(parent, remap);
         remapDisplayColumnFactory(parent, remap);
+        remapColumnLogging(parent, remap);
     }
 
 
@@ -194,5 +195,14 @@ public interface MutableColumnInfo extends MutableColumnRenderProperties, Column
 
         RemappingDisplayColumnFactory remapped = ((RemappingDisplayColumnFactory) factory).remapFieldKeys(parent, remap);
         setDisplayColumnFactory(remapped);
+    }
+
+    default void remapColumnLogging(@Nullable FieldKey parent, @Nullable Map<FieldKey, FieldKey> remap)
+    {
+        ColumnLogging logging = getColumnLogging();
+        if (logging == null)
+            return;
+        ColumnLogging remapped = logging.remapFieldKeys(parent, remap);
+        setColumnLogging(remapped);
     }
 }

--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -402,7 +402,9 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
     public MutableColumnInfo wrapColumn(ColumnInfo underlyingColumn)
     {
         var col = super.wrapColumn(underlyingColumn);
-        col.getColumnLogging().setOriginalTableName(getName());
+        var logging = underlyingColumn.getColumnLogging();
+        if (null != logging)
+            col.setColumnLogging(logging.reparent(this));
         return col;
     }
 
@@ -413,7 +415,9 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
     public MutableColumnInfo addWrapColumn(ColumnInfo column)
     {
         var col = super.addWrapColumn(column);
-        col.getColumnLogging().setOriginalTableName(getName());
+        var logging = column.getColumnLogging();
+        if (null != logging)
+            col.setColumnLogging(logging.reparent(this));
         return col;
     }
 

--- a/query/src/org/labkey/query/sql/QueryTableInfo.java
+++ b/query/src/org/labkey/query/sql/QueryTableInfo.java
@@ -154,7 +154,8 @@ public class QueryTableInfo extends AbstractTableInfo implements ContainerFilter
                 Map<FieldKey,FieldKey> flippedMap = new TreeMap<>();
                 for (Map.Entry<FieldKey,QueryRelation.RelationColumn> e : map.entrySet())
                 {
-                    flippedMap.put(e.getValue().getFieldKey(), e.getKey());
+                    if (!e.getValue().getFieldKey().equals(e.getKey()))
+                        flippedMap.put(e.getValue().getFieldKey(), e.getKey());
                     mapFieldKeyToSiblings.put(e.getKey(), flippedMap);
                 }
             }


### PR DESCRIPTION
#### Rationale
ColumnLogging participating in remapFieldKeys() makes for much more consistent behavior
Also Junit tests

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
