### PR TITLE
Fix folder types that don't use the default portal page as their primary tab

### DIFF
--- a/api/src/org/labkey/api/module/DefaultFolderType.java
+++ b/api/src/org/labkey/api/module/DefaultFolderType.java
@@ -134,7 +134,7 @@ public class DefaultFolderType implements FolderType
             for (Portal.WebPart part : required)
                 part.setPermanent(true);
 
-        List<Portal.WebPart> all = new ArrayList<>();
+        ArrayList<Portal.WebPart> all = new ArrayList<>();
         List<Portal.WebPart> existingParts = Portal.getEditableParts(c);
 
         if (existingParts.isEmpty())
@@ -191,7 +191,7 @@ public class DefaultFolderType implements FolderType
 
         active.addAll(requiredActive);
         c.setActiveModules(active, user);
-        Portal.saveParts(c, DEFAULT_DASHBOARD, all);
+        Portal.saveParts(c, getDefaultTab().getName(), all);
 
         // A few things left to do; ordering is important
 

--- a/api/src/org/labkey/api/module/DefaultFolderType.java
+++ b/api/src/org/labkey/api/module/DefaultFolderType.java
@@ -30,6 +30,7 @@ import org.labkey.api.view.NavTree;
 import org.labkey.api.view.Portal;
 import org.labkey.api.view.Portal.WebPart;
 import org.labkey.api.view.ViewContext;
+import org.labkey.api.view.WebPartFactory;
 import org.labkey.api.view.template.AppBar;
 import org.labkey.api.view.template.PageConfig;
 
@@ -112,7 +113,7 @@ public class DefaultFolderType implements FolderType
         return _folderTabs;
     }
 
-    @Override
+    @Override @NotNull
     public FolderTab getDefaultTab()
     {
         return getDefaultTabs().get(0);
@@ -134,7 +135,7 @@ public class DefaultFolderType implements FolderType
             for (Portal.WebPart part : required)
                 part.setPermanent(true);
 
-        ArrayList<Portal.WebPart> all = new ArrayList<>();
+        List<Portal.WebPart> all = new ArrayList<>();
         List<Portal.WebPart> existingParts = Portal.getEditableParts(c);
 
         if (existingParts.isEmpty())
@@ -191,6 +192,23 @@ public class DefaultFolderType implements FolderType
 
         active.addAll(requiredActive);
         c.setActiveModules(active, user);
+
+        // Split out any menu bar items which are stored in the "portal.default" portal page
+        List<WebPart> menuParts = new ArrayList<>();
+        for (WebPart webPart : all)
+        {
+            if (WebPartFactory.LOCATION_MENUBAR.equalsIgnoreCase(webPart.getLocation()))
+            {
+                menuParts.add(webPart);
+            }
+        }
+        if (!menuParts.isEmpty())
+        {
+            Portal.saveParts(c, Portal.DEFAULT_PORTAL_PAGE_ID, menuParts);
+        }
+
+        // Remove any menu items and save the rest
+        all.removeAll(menuParts);
         Portal.saveParts(c, getDefaultTab().getName(), all);
 
         // A few things left to do; ordering is important
@@ -320,7 +338,7 @@ public class DefaultFolderType implements FolderType
     public String getStartPageLabel(ViewContext ctx)
     {
         FolderTab folderTab = getDefaultTab();
-        if (null != folderTab && folderTab.isDefaultTab())
+        if (folderTab.isDefaultTab())
         {
             String caption = folderTab.getCaption(ctx);
             if (null != caption)

--- a/api/src/org/labkey/api/module/FolderType.java
+++ b/api/src/org/labkey/api/module/FolderType.java
@@ -165,6 +165,7 @@ public interface FolderType
     List<FolderTab> getDefaultTabs();
 
     /** @return The default tab to select, which defaults to the first (including for non-tabbed folders) */
+    @Nullable
     FolderTab getDefaultTab();
 
     /** @return the folder tab in htis folder type's default tabs whose name matches the tabName; null if none found */

--- a/api/src/org/labkey/api/module/MultiPortalFolderType.java
+++ b/api/src/org/labkey/api/module/MultiPortalFolderType.java
@@ -395,7 +395,7 @@ public abstract class MultiPortalFolderType extends DefaultFolderType
         return true;
     }
 
-    @Override @Nullable
+    @Override @NotNull
     public FolderTab getDefaultTab()
     {
         return _defaultTab == null ? getDefaultTabs().get(0) : _defaultTab;


### PR DESCRIPTION
#### Rationale
My fix to avoid double-creating portal page definitions didn't handle folder types that opt out of the default portal, `DefaultDashboard`

https://github.com/LabKey/platform/pull/4052

#### Changes
* Use `getDefaultTab()` when initializing the portal's web parts to pick up whatever the FolderType subclass wants to use