### PR TITLE
Handle DefaultFolderType subclass default portal page

### DIFF
--- a/api/src/org/labkey/api/module/CustomFolderType.java
+++ b/api/src/org/labkey/api/module/CustomFolderType.java
@@ -250,7 +250,7 @@ public class CustomFolderType implements FolderType
     }
 
     @Override
-    public String getDefaultPageId(ViewContext ctx)
+    public String getDefaultPageId(Container container)
     {
         return Portal.DEFAULT_PORTAL_PAGE_ID;
     }

--- a/api/src/org/labkey/api/module/DefaultFolderType.java
+++ b/api/src/org/labkey/api/module/DefaultFolderType.java
@@ -193,23 +193,27 @@ public class DefaultFolderType implements FolderType
         active.addAll(requiredActive);
         c.setActiveModules(active, user);
 
-        // Split out any menu bar items which are stored in the "portal.default" portal page
-        List<WebPart> menuParts = new ArrayList<>();
-        for (WebPart webPart : all)
+        String mainTabId = getDefaultPageId(c);
+        if (!Portal.DEFAULT_PORTAL_PAGE_ID.equals(mainTabId))
         {
-            if (WebPartFactory.LOCATION_MENUBAR.equalsIgnoreCase(webPart.getLocation()))
+            // Split out any menu bar items which are stored in the "portal.default" portal page
+            List<WebPart> menuParts = new ArrayList<>();
+            for (WebPart webPart : all)
             {
-                menuParts.add(webPart);
+                if (WebPartFactory.LOCATION_MENUBAR.equalsIgnoreCase(webPart.getLocation()))
+                {
+                    menuParts.add(webPart);
+                }
+            }
+            if (!menuParts.isEmpty())
+            {
+                Portal.saveParts(c, Portal.DEFAULT_PORTAL_PAGE_ID, menuParts);
+                // Remove any menu items so we can save the rest
+                all.removeAll(menuParts);
             }
         }
-        if (!menuParts.isEmpty())
-        {
-            Portal.saveParts(c, Portal.DEFAULT_PORTAL_PAGE_ID, menuParts);
-        }
 
-        // Remove any menu items and save the rest
-        all.removeAll(menuParts);
-        Portal.saveParts(c, getDefaultTab().getName(), all);
+        Portal.saveParts(c, mainTabId, all);
 
         // A few things left to do; ordering is important
 
@@ -501,7 +505,7 @@ public class DefaultFolderType implements FolderType
     }
 
     @Override
-    public String getDefaultPageId(ViewContext ctx)
+    public String getDefaultPageId(Container c)
     {
         return Portal.DEFAULT_PORTAL_PAGE_ID;
     }

--- a/api/src/org/labkey/api/module/FolderType.java
+++ b/api/src/org/labkey/api/module/FolderType.java
@@ -182,10 +182,10 @@ public interface FolderType
     boolean hasContainerTabs();
 
     /**
-     * @return The pageId, which is primarily intended to support tabbed folders.  By default it will return
+     * @return The pageId, which is primarily intended to support tabbed folders.  By default, it will return
      * Portal.DEFAULT_PORTAL_PAGE_ID
      */
-    String getDefaultPageId(ViewContext ctx);
+    String getDefaultPageId(Container container);
 
     /**
      * Clear active portal page if there is one

--- a/api/src/org/labkey/api/module/MultiPortalFolderType.java
+++ b/api/src/org/labkey/api/module/MultiPortalFolderType.java
@@ -354,7 +354,7 @@ public abstract class MultiPortalFolderType extends DefaultFolderType
 
 
     @Override
-    public String getDefaultPageId(ViewContext ctx)
+    public String getDefaultPageId(Container container)
     {
         String result = null;
         if (_activePortalPage != null)
@@ -364,7 +364,7 @@ public abstract class MultiPortalFolderType extends DefaultFolderType
         }
         else
         {
-            List<Portal.PortalPage> activeTabs = Portal.getTabPages(ctx.getContainer());
+            List<Portal.PortalPage> activeTabs = Portal.getTabPages(container);
 
             // Use the left-most tab as the default
             for (Portal.PortalPage tab : activeTabs)

--- a/core/src/org/labkey/core/portal/ProjectController.java
+++ b/core/src/org/labkey/core/portal/ProjectController.java
@@ -362,7 +362,7 @@ public class ProjectController extends SpringActionController
 
             if (pageId == null)
             {
-                pageId = folderType.getDefaultPageId(getViewContext());
+                pageId = folderType.getDefaultPageId(getContainer());
             }
             Portal.populatePortalView(getViewContext(), pageId, template, isPrint());
 


### PR DESCRIPTION
#### Rationale
Previous followup for initializing portal pages handled menu bars correctly but still didn't default to the correct page ID for direct subclasses of `DefaultFolderType` (ones that aren't also subclasses of MultiPortalFolderType)

#### Changes
* Use `getDefaultPageId()` which seems to work for file-based folder types and other subclasses too