### PR TITLE
handle new study export option

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
@@ -882,7 +882,8 @@ public class StudyPublishTest extends StudyPHIExportTest
 
         // Study Objects
         waitForElement(Locator.xpath("//div[@class = 'labkey-nav-page-header'][text() = 'Study Objects']"));
-        verifyPublishWizardSelectedCheckboxes(StudyHelper.Panel.studyObjects, "Assay Schedule", "Cohort Settings", "Custom Participant View", "Participant Comment Settings", "Protocol Documents", "Treatment Data");
+        verifyPublishWizardSelectedCheckboxes(StudyHelper.Panel.studyObjects, "Assay Schedule", "Cohort Settings", "Custom Participant View",
+                "Participant Comment Settings", "Permissions for Custom Study Security", "Protocol Documents", "Treatment Data");
         clickButton("Next", 0);
 
         // Lists


### PR DESCRIPTION
#### Rationale
The `StudyPublishTest` started failing because there is a new, unexpected, export option showing up in the wizard related to the recent work to support round-tripping the custom study security settings.