### PR TITLE
Fix luminex tests and clean-up

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -1109,8 +1109,9 @@ public abstract class AbstractAssayProvider implements AssayProvider
         return new DetailsView(region, dataRowId);
     }
 
-    @Deprecated //Prefer overload that accepts the additional audit comment
-    public void deleteProtocol(ExpProtocol protocol, User user) throws ExperimentException
+    // Please use new overload with additional String parameter, this version is no longer called, so any custom implementation may get missed.
+    // Not sure how else to catch overrides as caller is modified. This should be a breaking change, to ensure any custom Assay Providers are updated.
+    final public void deleteProtocol(ExpProtocol protocol, User user) throws ExperimentException
     {
         deleteProtocol(protocol, user, null);
     }

--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -1109,13 +1109,6 @@ public abstract class AbstractAssayProvider implements AssayProvider
         return new DetailsView(region, dataRowId);
     }
 
-    // Please use new overload with additional String parameter, this version is no longer called, so any custom implementation may get missed.
-    // Not sure how else to catch overrides as caller is modified. This should be a breaking change, to ensure any custom Assay Providers are updated.
-    final public void deleteProtocol(ExpProtocol protocol, User user) throws ExperimentException
-    {
-        deleteProtocol(protocol, user, null);
-    }
-
     @Override
     public void deleteProtocol(ExpProtocol protocol, User user, @Nullable final String auditUserComment) throws ExperimentException
     {


### PR DESCRIPTION
#### Rationale
Test failures due to custom assay protocol clean up https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailySuites_DailyDPostgres/2250071?buildTab=tests&name=luminex&expandedTest=build%3A%28id%3A2250071%29%2Cid%3A719

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/569

#### Changes
* Made the old override of `deleteProtocol` final so we can catch any custom implementations since the original calling location uses the new signature.