### PR TITLE
Fix many tests that create study folders

### DIFF
--- a/api/src/org/labkey/api/module/CustomFolderType.java
+++ b/api/src/org/labkey/api/module/CustomFolderType.java
@@ -250,7 +250,7 @@ public class CustomFolderType implements FolderType
     }
 
     @Override
-    public String getDefaultPageId(Container container)
+    public String getDefaultPageId(Container container, boolean considerActive)
     {
         return Portal.DEFAULT_PORTAL_PAGE_ID;
     }

--- a/api/src/org/labkey/api/module/DefaultFolderType.java
+++ b/api/src/org/labkey/api/module/DefaultFolderType.java
@@ -193,7 +193,7 @@ public class DefaultFolderType implements FolderType
         active.addAll(requiredActive);
         c.setActiveModules(active, user);
 
-        String mainTabId = getDefaultPageId(c);
+        String mainTabId = getDefaultPageId(c, false);
         if (!Portal.DEFAULT_PORTAL_PAGE_ID.equals(mainTabId))
         {
             // Split out any menu bar items which are stored in the "portal.default" portal page
@@ -505,7 +505,7 @@ public class DefaultFolderType implements FolderType
     }
 
     @Override
-    public String getDefaultPageId(Container c)
+    public String getDefaultPageId(Container c, boolean considerActive)
     {
         return Portal.DEFAULT_PORTAL_PAGE_ID;
     }

--- a/api/src/org/labkey/api/module/FolderType.java
+++ b/api/src/org/labkey/api/module/FolderType.java
@@ -185,7 +185,7 @@ public interface FolderType
      * @return The pageId, which is primarily intended to support tabbed folders.  By default, it will return
      * Portal.DEFAULT_PORTAL_PAGE_ID
      */
-    String getDefaultPageId(Container container);
+    String getDefaultPageId(Container container, boolean considerActive);
 
     /**
      * Clear active portal page if there is one

--- a/api/src/org/labkey/api/module/MultiPortalFolderType.java
+++ b/api/src/org/labkey/api/module/MultiPortalFolderType.java
@@ -375,6 +375,16 @@ public abstract class MultiPortalFolderType extends DefaultFolderType
                     break;
                 }
             }
+
+            if (null == result)
+            {
+                List<FolderTab> defaults = getDefaultTabs();
+                if (!defaults.isEmpty())
+                {
+                    result = defaults.get(0).getName();
+                }
+            }
+
             if (null == result)
                 result = Portal.DEFAULT_PORTAL_PAGE_ID;
         }

--- a/api/src/org/labkey/api/module/MultiPortalFolderType.java
+++ b/api/src/org/labkey/api/module/MultiPortalFolderType.java
@@ -354,10 +354,10 @@ public abstract class MultiPortalFolderType extends DefaultFolderType
 
 
     @Override
-    public String getDefaultPageId(Container container)
+    public String getDefaultPageId(Container container, boolean considerActive)
     {
         String result = null;
-        if (_activePortalPage != null)
+        if (_activePortalPage != null && considerActive)
         {
             // If we have an explicit selection, use that
             result = _activePortalPage;

--- a/core/src/org/labkey/core/portal/ProjectController.java
+++ b/core/src/org/labkey/core/portal/ProjectController.java
@@ -362,7 +362,7 @@ public class ProjectController extends SpringActionController
 
             if (pageId == null)
             {
-                pageId = folderType.getDefaultPageId(getContainer());
+                pageId = folderType.getDefaultPageId(getContainer(), true);
             }
             Portal.populatePortalView(getViewContext(), pageId, template, isPrint());
 


### PR DESCRIPTION
#### Rationale
We're being way too sticky remembering the "active" tab for a given folder type, and have been for 10+ years. That's the folder tab that was last accessed in a given folder.

It's being stored at the FolderType level, which means there's a single value across all containers of that type and all users.

Many tests that create study folders are failing at the moment because they're being influenced by previous study folder tab clicking.

Followup is needed to fix this state sharing. But first, let's get all these Study tests passing.

#### Changes
* Don't consider the active tab when initializing the tabs for a new container