### PR TITLE
Update data generator to support folders, assay designs, and storage hierarchy

### DIFF
--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -3,6 +3,7 @@ package org.labkey.api.data.generator;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -189,7 +190,7 @@ public class DataGenerator<T extends DataGenerator.Config>
         }
         CPUTimer timer = addTimer(String.format("%d sub-folders", numFolders));
         timer.start();
-        Set<String> currentChildren = ContainerManager.getChildren(getContainer()).stream().map(Container::getName).collect(Collectors.toSet());
+        Set<String> currentChildren = new CaseInsensitiveHashSet(ContainerManager.getChildren(getContainer()).stream().map(Container::getName).collect(Collectors.toSet()));
         int i = 1;
         int numCreated = 0;
         while (numCreated < numFolders)
@@ -682,20 +683,20 @@ public class DataGenerator<T extends DataGenerator.Config>
         public static final String MIN_NUM_FIELDS = "minFields";
         public static final String MAX_NUM_FIELDS = "maxFields";
 
-        int _numFolders = 0;
-        int _numSampleTypes = 0;
-        int _minSamples = 0;
-        int _maxSamples = 0;
-        float _pctAliquots = 0;
-        float _pctPooled = 0;
-        float _pctDerived = 0;
-        float _pctDerivedFromSamples = 1;
-        int _maxPoolSize = 2;
-        int _maxGenerations = 1;
-        int _maxAliquotsPerParent = 0;
-        int _maxChildrenPerParent = 0;
-        int _minFields = 1;
-        int _maxFields = 1;
+        int _numFolders;
+        int _numSampleTypes;
+        int _minSamples;
+        int _maxSamples;
+        float _pctAliquots;
+        float _pctPooled;
+        float _pctDerived;
+        float _pctDerivedFromSamples;
+        int _maxPoolSize;
+        int _maxGenerations;
+        int _maxAliquotsPerParent;
+        int _maxChildrenPerParent;
+        int _minFields;
+        int _maxFields;
 
         public Config(Properties properties)
         {

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -56,17 +56,17 @@ public class DataGenerator<T extends DataGenerator.Config>
     protected Container _container;
     protected final User _user;
     protected final Logger _log;
-    protected  final PipelineJob _job;
-    protected T  _config;
+    protected final PipelineJob _job;
+    protected T _config;
 
-    // Keep the set of timers so we can produce a report of all times at the end
+    // Keep the set of timers, so we can produce a report of all times at the end
     protected final List<CPUTimer> _timers = new ArrayList<>();
 
     protected List<ExpSampleType> _sampleTypes = new ArrayList<>();
 
     public record NamingPatternData(String prefix, Long startGenId) {};
 
-    // Map from type name to pair of name prefix and suffix (genId) start value
+    // Map from type name to a pair of name prefix and suffix (genId) start value
     protected final Map<String, NamingPatternData> _nameData = new HashMap<>();
 
     protected List<ExpDataClass> _customDataClasses = new ArrayList<>();
@@ -77,20 +77,13 @@ public class DataGenerator<T extends DataGenerator.Config>
     record FieldPrefix(String uri, String namePrefix) { }
 
     private static final List<FieldPrefix> fieldPrefixes = new ArrayList<>();
-    static {
+
+    static
+    {
         fieldPrefixes.add(new FieldPrefix("string", "TextField"));
         fieldPrefixes.add(new FieldPrefix("int", "IntField"));
         fieldPrefixes.add(new FieldPrefix("float", "FloatField"));
         fieldPrefixes.add(new FieldPrefix("date", "DateField"));
-    }
-
-    public DataGenerator(Container container, User user, T config, Logger log)
-    {
-        _container = container;
-        _user = user;
-        _log = log;
-        _config = config;
-        _job = null;
     }
 
     public DataGenerator(PipelineJob job, T config)
@@ -110,6 +103,16 @@ public class DataGenerator<T extends DataGenerator.Config>
     public void setContainer(Container container)
     {
         _container = container;
+    }
+
+    public User getUser()
+    {
+        return _user;
+    }
+
+    public List<CPUTimer> getTimers()
+    {
+        return _timers;
     }
 
     public static void checkAlive(PipelineJob job)
@@ -179,6 +182,11 @@ public class DataGenerator<T extends DataGenerator.Config>
     {
         checkAlive(_job);
         int numFolders = _config.getNumFolders();
+        if (numFolders <= 0)
+        {
+            _log.info(String.format("No folders generated because %s=%d", Config.NUM_FOLDERS, numFolders));
+            return;
+        }
         CPUTimer timer = addTimer(String.format("%d sub-folders", numFolders));
         timer.start();
         Set<String> currentChildren = ContainerManager.getChildren(getContainer()).stream().map(Container::getName).collect(Collectors.toSet());
@@ -202,10 +210,14 @@ public class DataGenerator<T extends DataGenerator.Config>
     {
         checkAlive(_job);
         int numSampleTypes = _config.getNumSampleTypes();
+        if (numSampleTypes <= 0) {
+            _log.info(String.format("No sample types generated because %s=%d", Config.NUM_SAMPLE_TYPES, numSampleTypes));
+            return;
+        }
         int minFields = _config.getMinFields();
         int maxFields = _config.getMaxFields();
 
-        int fieldIncrement = numSampleTypes <= 1 ? 0 : (maxFields - minFields)/(numSampleTypes-1);
+        int fieldIncrement = numSampleTypes <= 1 ? 0 : (maxFields - minFields) / (numSampleTypes - 1);
         SampleTypeService service = SampleTypeService.get();
         CPUTimer timer = addTimer(String.format("%d sample types", numSampleTypes));
         timer.start();
@@ -214,10 +226,12 @@ public class DataGenerator<T extends DataGenerator.Config>
         for (int i = 0; i < numSampleTypes; i++)
         {
             String sampleTypeName;
-            do {
+            do
+            {
                 typeIndex++;
                 sampleTypeName = namePrefix + typeIndex;
-            } while (service.getSampleType(_container, _user, sampleTypeName) != null);
+            }
+            while (service.getSampleType(_container, _user, sampleTypeName) != null);
             String prefixWithIndex = namingPatternPrefix + typeIndex + "_";
             String namingPattern = prefixWithIndex + "${genId}";
             ExpSampleType sampleType = generateSampleType(sampleTypeName, namingPattern, numFields);
@@ -246,8 +260,13 @@ public class DataGenerator<T extends DataGenerator.Config>
     {
         DataGenerator.Config config = getConfig();
 
-        int sampleIncrement = config.getNumSampleTypes() <= 1 ? 0 : (config.getMaxSamples() - config.getMinSamples())/(config.getNumSampleTypes()-1);
+        int sampleIncrement = config.getNumSampleTypes() <= 1 ? 0 : (config.getMaxSamples() - config.getMinSamples()) / (config.getNumSampleTypes() - 1);
         int numSamples = config.getMinSamples();
+        if (numSamples <= 0 && config.getMaxSamples() <= 0)
+        {
+            _log.info(String.format("No samples generated because %s=%d and %s=%d", Config.MIN_SAMPLES, numSamples, Config.MAX_SAMPLES, config.getMaxSamples()));
+            return;
+        }
         List<String> parentTypes = new ArrayList<>();
         for (ExpSampleType sampleType : _sampleTypes)
         {
@@ -323,11 +342,12 @@ public class DataGenerator<T extends DataGenerator.Config>
         do
         {
             checkAlive(_job);
-            List<Map<String, Object>> parents = getRandomSamples(sampleType, Math.min(10, Math.max(quantity, quantity/100)));
+            List<Map<String, Object>> parents = getRandomSamples(sampleType, Math.min(10, Math.max(quantity, quantity / 100)));
             numGenerated = generateAliquotsForParents(parents, svc, quantity - totalAliquots, 0, 1, randomInt(1, _config.getMaxGenerations()));
             totalAliquots += numGenerated;
             iterations++;
-        } while (totalAliquots < quantity && numGenerated > 0);
+        }
+        while (totalAliquots < quantity && numGenerated > 0);
         timer.stop();
         if (totalAliquots < quantity)
             _log.warn(String.format("Generated only %d aliquots after %d iterations", totalAliquots, iterations));
@@ -375,7 +395,7 @@ public class DataGenerator<T extends DataGenerator.Config>
         // for some of the aliquots, possibly generate further aliquot generations
         if (generatedCount < quantity && generation < maxGenerations)
         {
-            generatedCount += generateAliquotsForParents(aliquots.subList(randomInt(0, aliquots.size()/2), randomInt(aliquots.size()/2, aliquots.size())), svc, quantity-generatedCount, numGenerated + generatedCount, generation+1, maxGenerations);
+            generatedCount += generateAliquotsForParents(aliquots.subList(randomInt(0, aliquots.size() / 2), randomInt(aliquots.size() / 2, aliquots.size())), svc, quantity - generatedCount, numGenerated + generatedCount, generation + 1, maxGenerations);
         }
         return generatedCount;
     }
@@ -456,7 +476,7 @@ public class DataGenerator<T extends DataGenerator.Config>
     }
 
 
-   public ExpDataClass generateDataClass(String dataClassName, @Nullable String namingPattern, int numFields, Logger log, @Nullable String category) throws ExperimentException
+    public ExpDataClass generateDataClass(String dataClassName, @Nullable String namingPattern, int numFields, Logger log, @Nullable String category) throws ExperimentException
     {
         List<GWTPropertyDescriptor> props = new ArrayList<>();
         addDomainProperties(props, numFields);
@@ -465,8 +485,8 @@ public class DataGenerator<T extends DataGenerator.Config>
 
         log.info(String.format("Creating Data Class '%s' with %d fields", dataClassName, numFields));
         return service.createDataClass(_container, _user, dataClassName, "Custom data class with " + numFields + " fields",
-                    props, List.of(), null,
-                    namingPattern, null, category);
+                props, List.of(), null,
+                namingPattern, null, category);
     }
 
 
@@ -510,8 +530,8 @@ public class DataGenerator<T extends DataGenerator.Config>
             int numRows = Math.min(batchSize, quantity - totalImported);
             List<Map<String, Object>> rows = createRows(numRows, sampleType.getDomain());
             // choose a random set of object names from the parent type
-           List<Map<String, Object>> parents = isDataClass ?
-                    getRandomDataClassObjects((ExpDataClass) parentObject, batchSize):
+            List<Map<String, Object>> parents = isDataClass ?
+                    getRandomDataClassObjects((ExpDataClass) parentObject, batchSize) :
                     getRandomSamples((ExpSampleType) parentObject, batchSize);
             int rowNum = 0;
             int p = 0;
@@ -578,7 +598,7 @@ public class DataGenerator<T extends DataGenerator.Config>
         return numImported;
     }
 
-    private void addDomainProperties(List<GWTPropertyDescriptor> props, int numFields)
+    protected void addDomainProperties(List<GWTPropertyDescriptor> props, int numFields)
     {
         for (int i = 0; i < numFields; i++)
         {
@@ -625,7 +645,7 @@ public class DataGenerator<T extends DataGenerator.Config>
 
     public static String randomDouble(int min, int max)
     {
-        double random = Math.random() < 0.5 ? ((1-Math.random()) * (max-min) + min) : (Math.random() * (max-min) + min);
+        double random = Math.random() < 0.5 ? ((1 - Math.random()) * (max - min) + min) : (Math.random() * (max - min) + min);
         return String.format("%.2f", random);
     }
 
@@ -661,7 +681,6 @@ public class DataGenerator<T extends DataGenerator.Config>
         public static final String MAX_GENERATIONS = "maxGenerations";
         public static final String MIN_NUM_FIELDS = "minFields";
         public static final String MAX_NUM_FIELDS = "maxFields";
-        public static final String NUM_ASSAY_DESIGNS = "numAssayDesigns";
 
         int _numFolders = 0;
         int _numSampleTypes = 0;
@@ -840,4 +859,9 @@ public class DataGenerator<T extends DataGenerator.Config>
         }
     }
 
+    public interface DataGenerationDriver
+    {
+        List<CPUTimer> generateData(PipelineJob job, Properties properties) throws Exception;
+
+    }
 }

--- a/api/src/org/labkey/api/data/generator/DataGeneratorRegistry.java
+++ b/api/src/org/labkey/api/data/generator/DataGeneratorRegistry.java
@@ -10,7 +10,7 @@ public class DataGeneratorRegistry
         Storage,
     };
 
-    private static Map<DataType, DataGenerator.DataGenerationDriver> _dataGeneratorMap = new HashMap<>();
+    private static final Map<DataType, DataGenerator.DataGenerationDriver> _dataGeneratorMap = new HashMap<>();
 
     public static void registerGenerator(DataType type, DataGenerator.DataGenerationDriver generator)
     {

--- a/api/src/org/labkey/api/data/generator/DataGeneratorRegistry.java
+++ b/api/src/org/labkey/api/data/generator/DataGeneratorRegistry.java
@@ -1,0 +1,24 @@
+package org.labkey.api.data.generator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DataGeneratorRegistry
+{
+    public enum DataType {
+        AssayDesigns,
+        Storage,
+    };
+
+    private static Map<DataType, DataGenerator.DataGenerationDriver> _dataGeneratorMap = new HashMap<>();
+
+    public static void registerGenerator(DataType type, DataGenerator.DataGenerationDriver generator)
+    {
+        _dataGeneratorMap.put(type, generator);
+    }
+
+    public static DataGenerator.DataGenerationDriver getGenerator(DataType type)
+    {
+        return _dataGeneratorMap.get(type);
+    }
+}

--- a/api/src/org/labkey/api/inventory/InventoryService.java
+++ b/api/src/org/labkey/api/inventory/InventoryService.java
@@ -30,7 +30,6 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
-import org.labkey.api.settings.ExperimentalFeatureService;
 
 import java.sql.SQLException;
 import java.util.List;
@@ -87,5 +86,4 @@ public interface InventoryService
         Set<Module> moduleSet = c.getActiveModules();
         return moduleSet.contains(ModuleLoader.getInstance().getModule("Inventory"));
     }
-
 }

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -33,6 +33,7 @@ import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ContainerType;
+import org.labkey.api.data.generator.DataGeneratorRegistry;
 import org.labkey.api.exp.ExperimentRunType;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExperimentService;
@@ -51,7 +52,6 @@ import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.roles.RoleManager;
-import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.JspTestCase;
 import org.labkey.api.util.PageFlowUtil;
@@ -59,6 +59,7 @@ import org.labkey.api.util.StartupListener;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.WebPartFactory;
+import org.labkey.assay.data.generator.AssayDesignGenerator;
 import org.labkey.assay.pipeline.AssayImportRunTask;
 import org.labkey.assay.plate.AssayPlateDataDomainKind;
 import org.labkey.assay.plate.AssayPlateMetadataServiceImpl;
@@ -153,6 +154,8 @@ public class AssayModule extends SpringModule
         ParamReplacementSvc.get().registerDeprecated(LEGACY_SESSION_ID_REPLACEMENT, ValidationException.SEVERITY.WARN, "Use '" + SecurityManager.API_KEY + "' instead");
 
         RoleManager.registerRole(new AssayDesignerRole());
+
+        DataGeneratorRegistry.registerGenerator(DataGeneratorRegistry.DataType.AssayDesigns, new AssayDesignGenerator.Driver());
     }
 
     @Override

--- a/assay/src/org/labkey/assay/data/generator/AssayDesignGenerator.java
+++ b/assay/src/org/labkey/assay/data/generator/AssayDesignGenerator.java
@@ -1,0 +1,122 @@
+package org.labkey.assay.data.generator;
+
+import org.labkey.api.assay.AssayDomainService;
+import org.labkey.api.data.generator.DataGenerator;
+import org.labkey.api.exp.query.ExpSchema;
+import org.labkey.api.gwt.client.assay.AssayException;
+import org.labkey.api.gwt.client.assay.model.GWTProtocol;
+import org.labkey.api.gwt.client.model.GWTDomain;
+import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
+import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.query.ValidationException;
+import org.labkey.api.util.CPUTimer;
+import org.labkey.api.view.ViewBackgroundInfo;
+import org.labkey.api.view.ViewContext;
+import org.labkey.assay.AssayDomainServiceImpl;
+import org.labkey.assay.AssayManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+public class AssayDesignGenerator extends DataGenerator<AssayDesignGenerator.Config>
+{
+
+    public AssayDesignGenerator(PipelineJob job, Config config)
+    {
+        super(job, config);
+    }
+
+    public void generateAssayDesigns(String namePrefix) throws ValidationException, AssayException
+    {
+        int numAssayDesigns = _config.getNumAssayDesigns();
+        if (numAssayDesigns <= 0)
+        {
+            _log.info(String.format("No assay designs generated because %s=%d", Config.NUM_ASSAY_DESIGNS, numAssayDesigns));
+            return;
+        }
+        checkAlive(_job);
+        CPUTimer timer = addTimer(String.format("%d assay designs", numAssayDesigns));
+        timer.start();
+        int numGenerated = 0;
+        int index = 1;
+        while (numGenerated < numAssayDesigns)
+        {
+            String name = String.format("%s%d", namePrefix, index);
+            if (AssayManager.get().getAssayProtocolByName(getContainer(),name) == null)
+            {
+                createStandardAssayDesign(name);
+                numGenerated++;
+            }
+            index++;
+        }
+        timer.stop();
+        _log.info(String.format("Generating %d assay designs took %s", numAssayDesigns, timer.getDuration() + "."));
+    }
+
+    private void createStandardAssayDesign(String name) throws ValidationException, AssayException
+    {
+        // create assay design
+        AssayDomainService assayDomainService = new AssayDomainServiceImpl(new ViewContext(new ViewBackgroundInfo(getContainer(), getUser(), null)));
+
+        GWTProtocol assayTemplate = assayDomainService.getAssayTemplate("General");
+        assayTemplate.setName(name);
+        List<GWTDomain<GWTPropertyDescriptor>> domains = assayTemplate.getDomains();
+
+        // clear the batch domain fields
+        GWTDomain<GWTPropertyDescriptor> batchDomain = domains.stream().filter(d -> "Batch Fields".equals(d.getName())).findFirst().orElseThrow();
+        batchDomain.getFields().clear();
+
+        // clear the run domain fields
+        GWTDomain<GWTPropertyDescriptor> runDomain = domains.stream().filter(d -> "Run Fields".equals(d.getName())).findFirst().orElseThrow();
+        runDomain.getFields().clear();
+
+        // clear the result domain fields and add a sample lookup
+        GWTDomain<GWTPropertyDescriptor> resultDomain = domains.stream().filter(d -> "Data Fields".equals(d.getName())).findFirst().orElseThrow();
+        resultDomain.getFields().clear();
+        GWTPropertyDescriptor sampleLookup = new GWTPropertyDescriptor("SampleLookup", "int");
+        sampleLookup.setLookupSchema(ExpSchema.SCHEMA_NAME);
+        sampleLookup.setLookupQuery(ExpSchema.TableType.Materials.name());
+        List<GWTPropertyDescriptor> props = new ArrayList<>();
+        props.add(sampleLookup);
+        addDomainProperties(props, randomInt(_config.getMinFields(), _config.getMaxFields()));
+        resultDomain.getFields().addAll(props);
+
+        // create the assay
+        assayDomainService.saveChanges(assayTemplate, true);
+    }
+
+    public static class Config extends DataGenerator.Config
+    {
+        public static final String NUM_ASSAY_DESIGNS = "numAssayDesigns";
+        int _numAssayDesigns = 0;
+
+        public Config(Properties properties)
+        {
+            super(properties);
+            _numAssayDesigns = Integer.parseInt(properties.getProperty(NUM_ASSAY_DESIGNS, "0"));
+        }
+
+
+        public int getNumAssayDesigns()
+        {
+            return _numAssayDesigns;
+        }
+
+        public void setNumAssayDesigns(int numAssayDesigns)
+        {
+            _numAssayDesigns = numAssayDesigns;
+        }
+    }
+
+    public static class Driver implements DataGenerationDriver
+    {
+        @Override
+        public List<CPUTimer> generateData(PipelineJob job, Properties properties) throws ValidationException, AssayException
+        {
+            AssayDesignGenerator generator = new AssayDesignGenerator(job, new AssayDesignGenerator.Config(properties));
+            generator.generateAssayDesigns("Assay Design ");
+            return generator.getTimers();
+        }
+    }
+}

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -3819,7 +3819,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         if (includeProjectAndShared)
         {
             Container project = container.getProject();
-            if (project != null && project.hasPermission(user, ReadPermission.class))
+            if (project != null && project.getEntityId() != container.getEntityId() && project.hasPermission(user, ReadPermission.class))
             {
                 containerIds.add(project.getId());
             }


### PR DESCRIPTION
#### Rationale
Here we beef up our capabilities for generating data at scale to include the generation of folders, assay designs, and storage hierarchies. This PR does not include the generation of data within any of these entities, only the definition of the entities themselves.

#### Related Pull Requests
- https://github.com/LabKey/inventory/pull/707
- https://github.com/LabKey/biologics/pull/1891

#### Changes
* add `DataGeneratorRegistry` and `DataGenerationDriver` interface
* add `generateFolders` method to `DataGenerator`
* add `AssayDesignGenerator`
* In `createContainerList`, don't add the current container more than once.
