### PR TITLE
Separate user menu retrieval from product menu retrieval

### DIFF
--- a/core/api-src/org/labkey/api/products/ProductMenuProvider.java
+++ b/core/api-src/org/labkey/api/products/ProductMenuProvider.java
@@ -18,7 +18,6 @@ package org.labkey.api.products;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
-import org.labkey.api.util.CPUTimer;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;

--- a/core/api-src/org/labkey/api/products/ProductMenuProvider.java
+++ b/core/api-src/org/labkey/api/products/ProductMenuProvider.java
@@ -18,6 +18,7 @@ package org.labkey.api.products;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.util.CPUTimer;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
@@ -33,11 +34,6 @@ public abstract class ProductMenuProvider
     public String getDocumentationUrl()
     {
         return "https://www.labkey.org/Documentation/wiki-page.view?name=default&referrer=" + HelpTopic.Referrer.docMenu;
-    }
-
-    public String getDocumentationLabel()
-    {
-        return "Help";
     }
 
     public @NotNull List<MenuItem> getUserMenuItems(ViewContext context)

--- a/core/api-src/org/labkey/api/products/UserInfoMenuSection.java
+++ b/core/api-src/org/labkey/api/products/UserInfoMenuSection.java
@@ -50,7 +50,7 @@ public class UserInfoMenuSection extends MenuSection
         String docUrl = _provider.getDocumentationUrl();
         if (docUrl != null)
         {
-            items.add(new MenuItem(_provider.getDocumentationLabel(), docUrl, 0, DOCS_KEY, null, null));
+            items.add(new MenuItem("Help", docUrl, 0, DOCS_KEY, null, null));
         }
         items.addAll(_provider.getUserMenuItems(_context));
 


### PR DESCRIPTION
#### Rationale
The product menu no longer includes a User section, so there's no need to retrieve that data for rendering the product menu, and there's no need to retrieve all of the product menu data for showing the user menu. Here we add a separate action for getting just the User section, and remove it from the general product menu retrieval.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1093 

#### Changes
* Add separate action and method for getting user menu
