### PR TITLE
Issue 47189: Error moving Skyline documents across folders

### DIFF
--- a/experiment/src/org/labkey/experiment/XarExporter.java
+++ b/experiment/src/org/labkey/experiment/XarExporter.java
@@ -430,14 +430,18 @@ public class XarExporter
             }
             else
             {
-                dataLSID.setCpasType(data.getCpasType() == null ? ExpData.DEFAULT_CPAS_TYPE : _relativizedLSIDs.relativize(data.getCpasType()));
                 if (data.getCpasType() != null && !ExpData.DEFAULT_CPAS_TYPE.equalsIgnoreCase(data.getCpasType()))
                 {
+                    dataLSID.setCpasType(_relativizedLSIDs.relativize(data.getCpasType()));
                     ExpDataClass dataClass = ExperimentServiceImpl.get().getDataClass(data.getCpasType());
                     if (dataClass != null)
                     {
                         addDataClass(dataClass);
                     }
+                }
+                else
+                {
+                    dataLSID.setCpasType(ExpData.DEFAULT_CPAS_TYPE);
                 }
             }
         }
@@ -579,7 +583,7 @@ public class XarExporter
         logProgress("Adding material " + material.getLSID());
         addSampleType(material.getCpasType());
         xMaterial.setAbout(_relativizedLSIDs.relativize(material.getLSID()));
-        xMaterial.setCpasType(material.getCpasType() == null ? ExpMaterial.DEFAULT_CPAS_TYPE : _relativizedLSIDs.relativize(material.getCpasType()));
+        xMaterial.setCpasType(material.getCpasType() == null || ExpMaterial.DEFAULT_CPAS_TYPE.equals(material.getCpasType()) ? ExpMaterial.DEFAULT_CPAS_TYPE : _relativizedLSIDs.relativize(material.getCpasType()));
         xMaterial.setName(material.getName());
         if (material.getRootMaterialLSID() != null)
             xMaterial.setRootMaterialLSID(_relativizedLSIDs.relativize(material.getRootMaterialLSID()));
@@ -931,7 +935,7 @@ public class XarExporter
         logProgress("Adding data " + data.getLSID());
         xData.setName(data.getName());
         xData.setAbout(_relativizedLSIDs.relativize(data));
-        xData.setCpasType(data.getCpasType() == null ? ExpData.DEFAULT_CPAS_TYPE : _relativizedLSIDs.relativize(data.getCpasType()));
+        xData.setCpasType(data.getCpasType() == null || ExpData.DEFAULT_CPAS_TYPE .equals(data.getCpasType()) ? ExpData.DEFAULT_CPAS_TYPE : _relativizedLSIDs.relativize(data.getCpasType()));
 
         Path path = data.getFilePath();
         if (path != null)


### PR DESCRIPTION
#### Rationale
Our XAR export is mangling the CpasType value in the XML file when an exp.Data has the default value, "Data". This broke as part of a refactor to export the full data class definition for data rows that belong to a data class. A similar situation could happen for samples.

#### Changes
* Treat both null and the default value as `Data` and `Material`, not a sample type or data class LSID