### PR TITLE
Issue 47189: Error moving Skyline documents across folders

### DIFF
--- a/experiment/src/org/labkey/experiment/XarExporter.java
+++ b/experiment/src/org/labkey/experiment/XarExporter.java
@@ -430,14 +430,18 @@ public class XarExporter
             }
             else
             {
-                dataLSID.setCpasType(data.getCpasType() == null ? ExpData.DEFAULT_CPAS_TYPE : _relativizedLSIDs.relativize(data.getCpasType()));
                 if (data.getCpasType() != null && !ExpData.DEFAULT_CPAS_TYPE.equalsIgnoreCase(data.getCpasType()))
                 {
+                    dataLSID.setCpasType(_relativizedLSIDs.relativize(data.getCpasType()));
                     ExpDataClass dataClass = ExperimentServiceImpl.get().getDataClass(data.getCpasType());
                     if (dataClass != null)
                     {
                         addDataClass(dataClass);
                     }
+                }
+                else
+                {
+                    dataLSID.setCpasType(ExpData.DEFAULT_CPAS_TYPE);
                 }
             }
         }
@@ -579,7 +583,7 @@ public class XarExporter
         logProgress("Adding material " + material.getLSID());
         addSampleType(material.getCpasType());
         xMaterial.setAbout(_relativizedLSIDs.relativize(material.getLSID()));
-        xMaterial.setCpasType(material.getCpasType() == null ? ExpMaterial.DEFAULT_CPAS_TYPE : _relativizedLSIDs.relativize(material.getCpasType()));
+        xMaterial.setCpasType(material.getCpasType() == null || ExpMaterial.DEFAULT_CPAS_TYPE.equals(material.getCpasType()) ? ExpMaterial.DEFAULT_CPAS_TYPE : _relativizedLSIDs.relativize(material.getCpasType()));
         xMaterial.setName(material.getName());
         if (material.getRootMaterialLSID() != null)
             xMaterial.setRootMaterialLSID(_relativizedLSIDs.relativize(material.getRootMaterialLSID()));
@@ -931,7 +935,7 @@ public class XarExporter
         logProgress("Adding data " + data.getLSID());
         xData.setName(data.getName());
         xData.setAbout(_relativizedLSIDs.relativize(data));
-        xData.setCpasType(data.getCpasType() == null ? ExpData.DEFAULT_CPAS_TYPE : _relativizedLSIDs.relativize(data.getCpasType()));
+        xData.setCpasType(data.getCpasType() == null || ExpData.DEFAULT_CPAS_TYPE .equals(data.getCpasType()) ? ExpData.DEFAULT_CPAS_TYPE : _relativizedLSIDs.relativize(data.getCpasType()));
 
         Path path = data.getFilePath();
         if (path != null)

--- a/experiment/src/org/labkey/experiment/XarExporter.java
+++ b/experiment/src/org/labkey/experiment/XarExporter.java
@@ -22,6 +22,7 @@ import org.apache.xmlbeans.XmlCursor;
 import org.apache.xmlbeans.XmlError;
 import org.apache.xmlbeans.XmlOptions;
 import org.fhcrc.cpas.exp.xml.*;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
@@ -430,7 +431,11 @@ public class XarExporter
             }
             else
             {
-                if (data.getCpasType() != null && !ExpData.DEFAULT_CPAS_TYPE.equalsIgnoreCase(data.getCpasType()))
+                if (isDefaultCpasType(data.getCpasType(), ExpData.DEFAULT_CPAS_TYPE))
+                {
+                    dataLSID.setCpasType(ExpData.DEFAULT_CPAS_TYPE);
+                }
+                else
                 {
                     dataLSID.setCpasType(_relativizedLSIDs.relativize(data.getCpasType()));
                     ExpDataClass dataClass = ExperimentServiceImpl.get().getDataClass(data.getCpasType());
@@ -438,10 +443,6 @@ public class XarExporter
                     {
                         addDataClass(dataClass);
                     }
-                }
-                else
-                {
-                    dataLSID.setCpasType(ExpData.DEFAULT_CPAS_TYPE);
                 }
             }
         }
@@ -578,12 +579,17 @@ public class XarExporter
         }
     }
 
+    private boolean isDefaultCpasType(String cpasType, @NotNull String defaultType)
+    {
+        return cpasType == null || defaultType.equals(cpasType);
+    }
+
     private void populateMaterial(MaterialBaseType xMaterial, ExpMaterial material) throws ExperimentException
     {
         logProgress("Adding material " + material.getLSID());
         addSampleType(material.getCpasType());
         xMaterial.setAbout(_relativizedLSIDs.relativize(material.getLSID()));
-        xMaterial.setCpasType(material.getCpasType() == null || ExpMaterial.DEFAULT_CPAS_TYPE.equals(material.getCpasType()) ? ExpMaterial.DEFAULT_CPAS_TYPE : _relativizedLSIDs.relativize(material.getCpasType()));
+        xMaterial.setCpasType(isDefaultCpasType(material.getCpasType(), ExpMaterial.DEFAULT_CPAS_TYPE) ? ExpMaterial.DEFAULT_CPAS_TYPE : _relativizedLSIDs.relativize(material.getCpasType()));
         xMaterial.setName(material.getName());
         if (material.getRootMaterialLSID() != null)
             xMaterial.setRootMaterialLSID(_relativizedLSIDs.relativize(material.getRootMaterialLSID()));
@@ -935,7 +941,7 @@ public class XarExporter
         logProgress("Adding data " + data.getLSID());
         xData.setName(data.getName());
         xData.setAbout(_relativizedLSIDs.relativize(data));
-        xData.setCpasType(data.getCpasType() == null || ExpData.DEFAULT_CPAS_TYPE .equals(data.getCpasType()) ? ExpData.DEFAULT_CPAS_TYPE : _relativizedLSIDs.relativize(data.getCpasType()));
+        xData.setCpasType(isDefaultCpasType(data.getCpasType(), ExpData.DEFAULT_CPAS_TYPE) ? ExpData.DEFAULT_CPAS_TYPE : _relativizedLSIDs.relativize(data.getCpasType()));
 
         Path path = data.getFilePath();
         if (path != null)

--- a/experiment/src/org/labkey/experiment/pipeline/MoveRunsTask.java
+++ b/experiment/src/org/labkey/experiment/pipeline/MoveRunsTask.java
@@ -151,8 +151,8 @@ public class MoveRunsTask extends PipelineJob.Task<MoveRunsTaskFactory>
         private final String _uploadTime;
 
         private String _experimentName;
-        private String _root;
-        private Container _sourceContainer;
+        private final String _root;
+        private final Container _sourceContainer;
 
         public MoveRunsXarSource(String xml, Path root, MoveRunsPipelineJob job) throws ExperimentException
         {


### PR DESCRIPTION
#### Rationale
Our XAR export is mangling the CpasType value in the XML file when an exp.Data has the default value, "Data". This broke as part of a refactor to export the full data class definition for data rows that belong to a data class. A similar situation could happen for samples.

#### Changes
* Treat both null and the default value as `Data` and `Material`, not a sample type or data class LSID