### PR TITLE
Data container when updating using DIB

### DIFF
--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -224,7 +224,8 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
         ExistingDataIteratorsTableInfo(CachingDataIterator in, TableInfo target, @Nullable Set<String> keys, DataIteratorContext context, boolean detailed)
         {
             super(in, target, keys, true, context, detailed);
-            allowedContainers.add(c.getId());
+            if (c != null)
+                allowedContainers.add(c.getId());
         }
 
         private Pair<SQLFragment, Set<Integer>> getSelectExistingSql(int rows) throws BatchValidationException

--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -751,8 +751,6 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
             DataIteratorContext context = new DataIteratorContext(errors);
             context.setInsertOption(insertOption);
             context.setAllowImportLookupByAlternateKey(importLookupByAlternateKey);
-            if (insertOption.updateOnly) // for "update from file", fail if new records are found
-                context.putConfigParameter(QueryUpdateService.ConfigParameters.VerifyExistingData, true);
             if (auditBehaviorType != null)
             {
                 context.putConfigParameter(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior, auditBehaviorType);

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -1258,7 +1258,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
             // test existing row value is not updated/erased
             assertEquals(2, rows.get(2).get("i"));
 
-            // update should fail if a new record is provided and VerifyExistingData = true
+            // update should fail if a new record is provided
             updateRows = new ArrayList<Map<String,Object>>();
             updateRows.add(CaseInsensitiveHashMap.of(pkName,123,colName,"NEW"));
             updateRows.add(CaseInsensitiveHashMap.of(pkName,2,colName,"TWO-UP-2"));

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -1258,20 +1258,11 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
             // test existing row value is not updated/erased
             assertEquals(2, rows.get(2).get("i"));
 
-            // update should skip the new record row silently and update the rest rows successfully
+            // update should fail if a new record is provided and VerifyExistingData = true
             updateRows = new ArrayList<Map<String,Object>>();
             updateRows.add(CaseInsensitiveHashMap.of(pkName,123,colName,"NEW"));
             updateRows.add(CaseInsensitiveHashMap.of(pkName,2,colName,"TWO-UP-2"));
             count = qus.loadRows(user, c, new ListofMapsDataIterator(updateRows.get(0).keySet(), updateRows), context, null);
-            assertFalse(context.getErrors().hasErrors());
-            assertEquals(count,2);
-            rows = getRows();
-            assertEquals(rows.size(),3);
-            assertEquals("TWO-UP-2", rows.get(2).get("s"));
-
-            // update should fail if a new record is provided and VerifyExistingData = true
-            context.putConfigParameter(QueryUpdateService.ConfigParameters.VerifyExistingData, true); // simulate file import
-            qus.loadRows(user, c, new ListofMapsDataIterator(updateRows.get(0).keySet(), updateRows), context, null);
             assertTrue(context.getErrors().hasErrors());
         }
 

--- a/api/src/org/labkey/api/query/QueryUpdateService.java
+++ b/api/src/org/labkey/api/query/QueryUpdateService.java
@@ -107,7 +107,6 @@ public interface QueryUpdateService extends HasPermission
         SkipRequiredFieldValidation,        // (Bool) skip validation of required fields, used during import when the import of data happens in two hitches (e.g., samples in one file and sample statuses in a second)
         BulkLoad,                // (Bool) skips detailed auditing
         CheckForCrossProjectData,                // (Bool) Check if data belong to other projects
-        VerifyExistingData,      // (Bool) Validate that data is not new but existing data
         SkipInsertOptionValidation,  // (Bool) Skip assert(supportsInsertOption(context.getInsertOption())) for special scenarios (e.g., folder import uses merge action that's otherwise not supported for a table),
         SkipBatchUpdateRows     // (Bool) Update one row at a time, instead of using DIB
     }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -1317,10 +1317,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         public void configureDataIteratorContext(DataIteratorContext context)
         {
             if (context.getInsertOption().allowUpdate)
-            {
                 context.putConfigParameter(QueryUpdateService.ConfigParameters.CheckForCrossProjectData, true);
-                context.putConfigParameter(QueryUpdateService.ConfigParameters.VerifyExistingData, context.getInsertOption().updateOnly);
-            }
         }
 
         @Override

--- a/experiment/src/org/labkey/experiment/pipeline/SampleReloadTask.java
+++ b/experiment/src/org/labkey/experiment/pipeline/SampleReloadTask.java
@@ -198,11 +198,7 @@ public class SampleReloadTask extends PipelineJob.Task<SampleReloadTask.Factory>
                             DataIteratorContext context = new DataIteratorContext(errors);
 
                             if (_insertOption != null)
-                            {
-                                if (_insertOption.updateOnly) // fail if new records are found
-                                    context.putConfigParameter(QueryUpdateService.ConfigParameters.VerifyExistingData, true);
                                 context.setInsertOption(_insertOption);
-                            }
 
                             if (_auditBehavior != null)
                                 context.putConfigParameter(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior, DETAILED);


### PR DESCRIPTION
#### Rationale
When updating using DIB, update should fail when data container is different from current container. 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* make sure validateExistingData is always true for update actions
* fix container validation for samples when updating using lsid
