### PR TITLE
Transaction cache optimization

### DIFF
--- a/api/src/org/labkey/api/cache/TransactionCache.java
+++ b/api/src/org/labkey/api/cache/TransactionCache.java
@@ -25,7 +25,7 @@ import java.util.Set;
 /**
  * A read-through, transaction-specific cache. Reads through to the shared cache for each entry until a write operation
  * (put or remove) occurs on that entry, at which point only the private cache is consulted for this entry for the
- * remainder of the transaction. This should provide for good performance while avoiding pollution of the shared cache
+ * remainder of the transaction. This should provide good performance while avoiding pollution of the shared cache
  * during the transaction and in the case of a rollback.
  * User: adam
  * Date: Nov 9, 2009
@@ -40,7 +40,6 @@ public class TransactionCache<K, V> implements Cache<K, V>
 
     /** Cache shared by other threads */
     private final Cache<K, V> _sharedCache;
-    private final @Nullable CacheLoader<K, V> _privateCacheLoader;
 
     /** Our own private, transaction-specific cache, which may contain database changes that have not yet been committed */
     private final Cache<K, V> _privateCache;
@@ -48,19 +47,16 @@ public class TransactionCache<K, V> implements Cache<K, V>
     /** Whether the cache has been cleared. Once clear() is invoked, the shared cache is ignored. */
     private boolean _hasBeenCleared = false;
 
-    public TransactionCache(Cache<K, V> sharedCache, Cache<K, V> privateCache, @Nullable CacheLoader<K, V> privateCacheLoader)
+    public TransactionCache(Cache<K, V> sharedCache, Cache<K, V> privateCache)
     {
-        assert !(privateCache instanceof BlockingCache<K,V>) || null != privateCacheLoader : "Using a BlockingCache requires passing the private cache CacheLoader into DatabaseCache()";
-
         _privateCache = privateCache;
         _sharedCache = sharedCache;
-        _privateCacheLoader = privateCacheLoader;
     }
 
     @Override
     public V get(@NotNull K key)
     {
-        return get(key, null, _privateCacheLoader);
+        return get(key, null, null);
     }
 
     @Override

--- a/api/src/org/labkey/api/cache/TransactionCache.java
+++ b/api/src/org/labkey/api/cache/TransactionCache.java
@@ -65,21 +65,21 @@ public class TransactionCache<K, V> implements Cache<K, V>
 
         if (v == REMOVED_MARKER)
         {
-            v = null; // Entry has been removed from private cache; treat as missing.
+            v = null; // Entry has been removed from private cache, so treat as missing
         }
         else if (null == v && !_hasBeenCleared)
         {
-            v = _sharedCache.get(key); // Never written to; read-through to shared cache.
+            v = _sharedCache.get(key); // Entry has never been modified, read-through to shared cache
         }
 
-        // If removed/cleared from private cache or missing from both caches, attempt to load and put into private cache.
+        // If removed/cleared from private cache or missing from both caches, attempt to load and put into private cache
         if (null == v && null != loader)
         {
             v = loader.load(key, arg);
             put(key, v);
         }
 
-        return (v == NULL_MARKER || v == REMOVED_MARKER) ? null : v;
+        return v == NULL_MARKER ? null : v;
     }
 
     @Override

--- a/api/src/org/labkey/api/cache/TransactionCache.java
+++ b/api/src/org/labkey/api/cache/TransactionCache.java
@@ -109,8 +109,8 @@ public class TransactionCache<K, V> implements Cache<K, V>
     public int removeUsingFilter(Filter<K> filter)
     {
         return (int)(
-            _privateCache.getKeys().stream().peek(this::remove).count() +
-            _sharedCache.getKeys().stream().peek(this::remove).count()
+            _privateCache.getKeys().stream().filter(filter::accept).peek(this::remove).count() +
+            _sharedCache.getKeys().stream().filter(filter::accept).peek(this::remove).count()
         );
     }
 

--- a/api/src/org/labkey/api/cache/TransactionCache.java
+++ b/api/src/org/labkey/api/cache/TransactionCache.java
@@ -62,6 +62,8 @@ public class TransactionCache<K, V> implements Cache<K, V>
     @Override
     public V get(@NotNull K key, Object arg, @Nullable CacheLoader<K, V> loader)
     {
+        // No locks or synchronization below because we're always single-threaded (unlike BlockingCache)
+
         V v = _privateCache.get(key);
 
         if (v == REMOVED_MARKER)
@@ -70,7 +72,7 @@ public class TransactionCache<K, V> implements Cache<K, V>
         }
         else if (null == v && !_hasBeenCleared)
         {
-            v = _sharedCache.get(key); // Entry has never been modified, read-through to shared cache
+            v = _sharedCache.get(key); // Entry has never been modified, so read-through to shared cache
         }
 
         // If removed/cleared from private cache or missing from both caches, attempt to load and put into private cache

--- a/api/src/org/labkey/api/cache/TransactionCache.java
+++ b/api/src/org/labkey/api/cache/TransactionCache.java
@@ -40,22 +40,25 @@ public class TransactionCache<K, V> implements Cache<K, V>
 
     /** Cache shared by other threads */
     private final Cache<K, V> _sharedCache;
+    private final @Nullable CacheLoader<K, V> _privateCacheLoader;
+
     /** Our own private, transaction-specific cache, which may contain database changes that have not yet been committed */
     private final Cache<K, V> _privateCache;
 
     /** Whether the cache has been cleared. Once clear() is invoked, the shared cache is ignored. */
     private boolean _hasBeenCleared = false;
 
-    public TransactionCache(Cache<K, V> sharedCache, Cache<K, V> privateCache)
+    public TransactionCache(Cache<K, V> sharedCache, Cache<K, V> privateCache, @Nullable CacheLoader<K, V> privateCacheLoader)
     {
         _privateCache = privateCache;
         _sharedCache = sharedCache;
+        _privateCacheLoader = privateCacheLoader;
     }
 
     @Override
     public V get(@NotNull K key)
     {
-        return get(key, null, null);
+        return get(key, null, _privateCacheLoader);
     }
 
     @Override

--- a/api/src/org/labkey/api/cache/TransactionCache.java
+++ b/api/src/org/labkey/api/cache/TransactionCache.java
@@ -50,6 +50,8 @@ public class TransactionCache<K, V> implements Cache<K, V>
 
     public TransactionCache(Cache<K, V> sharedCache, Cache<K, V> privateCache, @Nullable CacheLoader<K, V> privateCacheLoader)
     {
+        assert !(privateCache instanceof BlockingCache<K,V>) || null != privateCacheLoader : "Using a BlockingCache requires passing the private cache CacheLoader into DatabaseCache()";
+
         _privateCache = privateCache;
         _sharedCache = sharedCache;
         _privateCacheLoader = privateCacheLoader;

--- a/api/src/org/labkey/api/data/DatabaseCache.java
+++ b/api/src/org/labkey/api/data/DatabaseCache.java
@@ -44,19 +44,11 @@ public class DatabaseCache<K, V> implements Cache<K, V>
 {
     protected final Cache<K, V> _sharedCache;
     private final DbScope _scope;
-    private final CacheLoader<K, V> _privateCacheLoader;
-
-    // Callers that set a CacheLoader on the private cache must pass that loader into DatabaseCache
-    public DatabaseCache(DbScope scope, int maxSize, long defaultTimeToLive, String debugName, @Nullable CacheLoader<K, V> privateCacheLoader)
-    {
-        _sharedCache = createSharedCache(maxSize, defaultTimeToLive, debugName);
-        _scope = scope;
-        _privateCacheLoader = privateCacheLoader;
-    }
 
     public DatabaseCache(DbScope scope, int maxSize, long defaultTimeToLive, String debugName)
     {
-        this(scope, maxSize, defaultTimeToLive, debugName, null);
+        _sharedCache = createSharedCache(maxSize, defaultTimeToLive, debugName);
+        _scope = scope;
     }
 
     public DatabaseCache(DbScope scope, int maxSize, String debugName)
@@ -76,7 +68,8 @@ public class DatabaseCache<K, V> implements Cache<K, V>
         return createTemporaryCache(getTrackingCache());
     }
 
-    // Note: If you want to set a default CacheLoader then wrap the DatabaseCache with a BlockingCache
+    // Note: No need to subclass and override this method. If you want to set a default CacheLoader then wrap the
+    // DatabaseCache with a BlockingCache
     protected final Cache<K, V> createTemporaryCache(TrackingCache<K, V> trackingCache)
     {
         return CacheManager.getTemporaryCache(trackingCache.getLimit(), trackingCache.getDefaultExpires(), "transaction cache: " + trackingCache.getDebugName(), trackingCache.getTransactionStats());
@@ -92,7 +85,7 @@ public class DatabaseCache<K, V> implements Cache<K, V>
 
             if (null == transactionCache)
             {
-                transactionCache = new TransactionCache<>(_sharedCache, createTemporaryCache(_sharedCache.getTrackingCache()), _privateCacheLoader);
+                transactionCache = new TransactionCache<>(_sharedCache, createTemporaryCache(_sharedCache.getTrackingCache()));
                 t.addCache(this, transactionCache);
             }
 

--- a/api/src/org/labkey/api/data/DbSchemaCache.java
+++ b/api/src/org/labkey/api/data/DbSchemaCache.java
@@ -53,21 +53,16 @@ public class DbSchemaCache
         _cache = new DbSchemaBlockingCache(_scope.getDisplayName());
     }
 
-    public static DbSchemaType getSchemaType(DbScope scope, String schemaName)
-    {
-        DbSchemaType type = ModuleLoader.getInstance().getSchemaType(scope, schemaName);
-
-        if (null == type)
-            type = DbSchemaType.Bare;  // Schema isn't claimed by any module
-
-        return type;
-    }
-
     @NotNull DbSchema get(String schemaName, DbSchemaType type)
     {
         // Infer type if it's unknown... should be rare
         if (DbSchemaType.Unknown == type)
-            type = getSchemaType(_scope, schemaName);
+        {
+            type = ModuleLoader.getInstance().getSchemaType(_scope, schemaName);
+
+            if (null == type)
+                type = DbSchemaType.Bare;  // Schema isn't claimed by any module
+        }
 
         return _cache.get(getKey(schemaName, type), new SchemaDetails(schemaName, type));
     }

--- a/api/src/org/labkey/api/data/DbSchemaType.java
+++ b/api/src/org/labkey/api/data/DbSchemaType.java
@@ -100,7 +100,7 @@ public enum DbSchemaType
         }
     };
 
-    private final String _cacheKeyPostFix;  // Postfix makes it easy for All type to remove all versions of a schema from the cache
+    private final String _cacheKeySuffix;  // Suffix makes it easy for Unknown type to remove all versions of a schema from the cache
     private final long _cacheTimeToLive;
     private final boolean _applyXmlMetaData;
 
@@ -120,16 +120,19 @@ public enum DbSchemaType
         XML_META_DATA_TYPES = Collections.unmodifiableCollection(metaDataTypes);
     }
 
-    DbSchemaType(String cacheKeyPostFix, long cacheTimeToLive, boolean applyXmlMetaData)
+    DbSchemaType(String cacheKeySuffix, long cacheTimeToLive, boolean applyXmlMetaData)
     {
-        _cacheKeyPostFix = cacheKeyPostFix;
+        _cacheKeySuffix = cacheKeySuffix;
         _cacheTimeToLive = cacheTimeToLive;
         _applyXmlMetaData = applyXmlMetaData;
     }
 
+    // Note: _cacheKeySuffix is used because a single database schema could be cached under multiple different types,
+    // e.g., Module, Bare, Fast. Some invalidation callers don't know the type which is why Unknown has an empty suffix
+    // and SchemaTableInfoCache & DbSchemaCache invalidate using removeUsingPrefix().
     String getCacheKey(String schemaName)
     {
-        return schemaName.toLowerCase() + "|" + _cacheKeyPostFix;
+        return schemaName.toLowerCase() + "|" + _cacheKeySuffix;
     }
 
     long getCacheTimeToLive()

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1246,10 +1246,6 @@ public class DbScope
     // Invalidates all tables in the table cache. Careful: callers probably need to invalidate the schema as well (it holds a list of table names).
     private void invalidateAllTables(String schemaName, DbSchemaType type)
     {
-        // If caller doesn't know the schema type then clear the schema tables from all caches
-        if (type == DbSchemaType.Unknown)
-            type = DbSchemaCache.getSchemaType(this, schemaName);
-
         getTableInfoCache(type).removeAllTables(schemaName, type);
     }
 

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -461,7 +461,7 @@ public class DbScope
 
     /**
      * Ensures that there is an active database transaction. If one is already in progress for this DbScope, it is
-     * joined (and a counter is incremented) such that the outer-most commit() attempt actually performs the commit.
+     * joined (and a counter is incremented) such that the outermost commit() attempt actually performs the commit.
      *
      * The preferred usage pattern is:
      * <pre>
@@ -471,7 +471,7 @@ public class DbScope
      *     } // Transaction.close() automatically invoked by auto-closeable.
      * </pre>
      *
-     * Note that if there are multiple exit points from inside of the try-block (such as return statements),
+     * Note that if there are multiple exit points from inside the try-block (such as return statements),
      * they should all call commit() first if the transaction should be persisted.
      *
      * @param locks locks which should be acquired AFTER a connection has been retrieved from the connection pool,
@@ -485,7 +485,7 @@ public class DbScope
 
     /**
      * Ensures that there is an active database transaction. If one is already in progress for this DbScope, it is
-     * joined (and a counter is incremented) such that the outer-most commit() attempt actually performs the commit.
+     * joined (and a counter is incremented) such that the outermost commit() attempt actually performs the commit.
      * The preferred usage pattern is:
      * <pre>
      *     try (DbScope.Transaction transaction = scope.ensureTransaction()) {
@@ -494,11 +494,11 @@ public class DbScope
      *     } // Transaction.close() automatically invoked by auto-closeable.
      * </pre>
      *
-     * Note that if there are multiple exit points from inside of the try-block (such as return statements),
-     * they should all call commit() first if the transaction should be persisted.
+     * Note that if there are multiple exit points from inside the try-block (such as return statements), they should
+     * all call commit() first if the transaction should be persisted.
      *
-     * @param transactionKind indication of the purpose of this usage. If it doesn't match an existing transaction's kind,
-     *                        a new Connection is handed out and used until it is committed/rolled back.
+     * @param transactionKind indication of the purpose of this usage. If it doesn't match an existing transaction's
+     *                        kind, a new Connection is handed out and used until it is committed/rolled back.
      * @param locks locks which should be acquired AFTER a connection has been retrieved from the connection pool,
      *              which prevents Java/connection pool deadlocks by always taking the locks in the same order.
      *              Locks will be released when close() is called on the Transaction.
@@ -533,7 +533,7 @@ public class DbScope
      *     } // Transaction.close() automatically invoked by auto-closeable.
      * </pre>
      *
-     * Note that if there are multiple exit points from inside of the try-block (such as return statements),
+     * Note that if there are multiple exit points from inside the try-block (such as return statements),
      * they should all call commit() first if the transaction should be persisted.
      *
      * @param locks locks which should be acquired AFTER a connection has been retrieved from the connection pool,
@@ -555,7 +555,7 @@ public class DbScope
      *     } // Transaction.close() automatically invoked by auto-closeable.
      * </pre>
      *
-     * Note that if there are multiple exit points from inside of the try-block (such as return statements),
+     * Note that if there are multiple exit points from inside the try-block (such as return statements),
      * they should all call commit() first if the transaction should be persisted.
      *
      * @param transactionKind indication of the purpose of this usage. If it doesn't match an existing transaction's kind,
@@ -598,15 +598,15 @@ public class DbScope
                     // Acquire the requested locks BEFORE entering the synchronized block for mapping the transaction
                     // to the current thread
                     List<Lock> serverLocks = Arrays.stream(locks)
-                            .filter((l) -> l instanceof ServerLock)
-                            .collect(Collectors.toList());
+                        .filter((l) -> l instanceof ServerLock)
+                        .toList();
                     List<Lock> memoryLocks;
                     if (serverLocks.isEmpty())
                         memoryLocks = Arrays.asList(locks);
                     else
                         memoryLocks = Arrays.stream(locks)
-                                .filter((l) -> !(l instanceof ServerLock))
-                                .collect(Collectors.toList());
+                            .filter((l) -> !(l instanceof ServerLock))
+                            .collect(Collectors.toList());
 
                     boolean createdTransactionObject = false;
                     try
@@ -1931,7 +1931,7 @@ public class DbScope
 
     public enum CommitTaskOption
     {
-        /** Run inside of the same transaction, immediately before committing it */
+        /** Run inside the same transaction, immediately before committing it */
         PRECOMMIT
         {
             @Override
@@ -2017,8 +2017,8 @@ public class DbScope
         void commit();
 
         /**
-         * Commit the current transaction, running pre and post commit tasks, but don't close the connection
-         * or remove transaction from thread pool. Effectively starts new transaction with same pre and post commit tasks.
+         * Commit the current transaction, running pre- and post-commit tasks, but don't close the connection or remove
+         * transaction from thread pool. Effectively starts new transaction with same pre- and post-commit tasks.
          */
         void commitAndKeepConnection();
 

--- a/api/src/org/labkey/api/data/SchemaTableInfoCache.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfoCache.java
@@ -63,6 +63,7 @@ public class SchemaTableInfoCache
         LOG.debug("remove all " + type + " schema tables: " + schemaName);
         final String prefix = type.getCacheKey(schemaName);
 
+        // Note: A single database schema could be cached under multiple types, e.g., Module, Bare, Fast
         _blockingCache.removeUsingFilter(new Cache.StringPrefixFilter(prefix));
     }
 


### PR DESCRIPTION
#### Rationale
`TransactionCache` holds a shared cache and a private cache specific to the current thread's transaction. Previously, it would read through to the shared cache until _any_ write operation occurred within the transaction, at which point it would switch exclusively to the private cache for the remainder of the transaction; this often meant many queries to populate the initially empty private cache. This new implementation reads through or delegates to the private cache on an entry-by-entry basis; a write operation on a specific entry blocks read-through for only that key. `clear()` is the only operation that causes a hard switchover to the private cache. (As always, avoid using `clear()`!)

#### Changes
* Optimize TransactionCache to use per-entry read-through and delegation
* Restore previous `DbSchemaType` cache key behavior and add comments
* Switch `UserCache` from a `DatabaseCache` subclass that sets up shared and private caches as `BlockingCaches` to a `BlockingCache` that wraps a `DatabaseCache`. This is cleaner, standard practice and avoid the need for `TransactionCache` to jump through hoops to get ahold of the needed `CacheLoader`.