### PR TITLE
Simplify portal defaults, get rid of 10-year-old migration code

### DIFF
--- a/api/src/org/labkey/api/module/CustomFolderType.java
+++ b/api/src/org/labkey/api/module/CustomFolderType.java
@@ -250,7 +250,7 @@ public class CustomFolderType implements FolderType
     }
 
     @Override
-    public String getDefaultPageId(Container container, boolean considerActive)
+    public String getDefaultPageId(Container container)
     {
         return Portal.DEFAULT_PORTAL_PAGE_ID;
     }

--- a/api/src/org/labkey/api/module/DefaultFolderType.java
+++ b/api/src/org/labkey/api/module/DefaultFolderType.java
@@ -135,8 +135,10 @@ public class DefaultFolderType implements FolderType
             for (Portal.WebPart part : required)
                 part.setPermanent(true);
 
+        String mainTabId = getDefaultPageId(c);
+
         List<Portal.WebPart> all = new ArrayList<>();
-        List<Portal.WebPart> existingParts = Portal.getEditableParts(c);
+        List<Portal.WebPart> existingParts = Portal.getEditableParts(c, mainTabId);
 
         if (existingParts.isEmpty())
         {
@@ -193,7 +195,6 @@ public class DefaultFolderType implements FolderType
         active.addAll(requiredActive);
         c.setActiveModules(active, user);
 
-        String mainTabId = getDefaultPageId(c);
         if (!Portal.DEFAULT_PORTAL_PAGE_ID.equals(mainTabId))
         {
             // Split out any menu bar items which are stored in the "portal.default" portal page

--- a/api/src/org/labkey/api/module/DefaultFolderType.java
+++ b/api/src/org/labkey/api/module/DefaultFolderType.java
@@ -193,7 +193,7 @@ public class DefaultFolderType implements FolderType
         active.addAll(requiredActive);
         c.setActiveModules(active, user);
 
-        String mainTabId = getDefaultPageId(c, false);
+        String mainTabId = getDefaultPageId(c);
         if (!Portal.DEFAULT_PORTAL_PAGE_ID.equals(mainTabId))
         {
             // Split out any menu bar items which are stored in the "portal.default" portal page
@@ -505,7 +505,7 @@ public class DefaultFolderType implements FolderType
     }
 
     @Override
-    public String getDefaultPageId(Container c, boolean considerActive)
+    public String getDefaultPageId(Container c)
     {
         return Portal.DEFAULT_PORTAL_PAGE_ID;
     }

--- a/api/src/org/labkey/api/module/FolderType.java
+++ b/api/src/org/labkey/api/module/FolderType.java
@@ -185,7 +185,7 @@ public interface FolderType
      * @return The pageId, which is primarily intended to support tabbed folders.  By default, it will return
      * Portal.DEFAULT_PORTAL_PAGE_ID
      */
-    String getDefaultPageId(Container container, boolean considerActive);
+    String getDefaultPageId(Container container);
 
     /**
      * Clear active portal page if there is one

--- a/core/src/org/labkey/core/portal/ProjectController.java
+++ b/core/src/org/labkey/core/portal/ProjectController.java
@@ -362,7 +362,7 @@ public class ProjectController extends SpringActionController
 
             if (pageId == null)
             {
-                pageId = folderType.getDefaultPageId(getContainer(), true);
+                pageId = folderType.getDefaultPageId(getContainer());
             }
             Portal.populatePortalView(getViewContext(), pageId, template, isPrint());
 


### PR DESCRIPTION
#### Rationale
We've keep migration code for portal layouts for 10+ years. With my recent improvements to how we initialize portal pages, we can finally get rid of it.

We can also stop retaining site-wide state in `_activePortalPage` which is no longer needed to highlight the correct tab.

#### Related Pull Requests
* https://github.com/LabKey/immport/pull/85

#### Changes
* No need to copy across portal page names - we now create them correctly in the first place
* Convert side-wide member variable, `_activePortalPage` to a local variable