### PR TITLE
Issue 46590: Fix links from columns in Ancestry lookups

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -222,6 +222,8 @@ public class ClosureQueryHelper
                 var ret = (MutableColumnInfo) super.createLookupColumn(foreignKey, displayField);
                 if (ret != null)
                 {
+                    if (ret.getConceptURI() == null)
+                        ret.setConceptURI(CONCEPT_URI);
                     ret.setDisplayColumnFactory(colInfo -> new AncestorLookupDisplayColumn(foreignKey, colInfo));
                 }
                 return ret;

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -494,9 +494,8 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         DetailsURL detailsURL = new DetailsURL(actionURL, Collections.singletonMap("rowId", "rowId"));
         setDetailsURL(detailsURL);
 
-        StringExpression url = StringExpressionFactory.create(detailsURL.getActionURL().getLocalURIString(true));
-        rowIdCol.setURL(url);
-        nameCol.setURL(url);
+        rowIdCol.setURL(detailsURL);
+        nameCol.setURL(detailsURL);
 
         if (canUserAccessPhi())
         {


### PR DESCRIPTION
#### Rationale
Because the rowId and name column URLs were being set to a SimpleStringExpression instead of a FieldKeyStringExpression, the remapFieldKeys method does no remapping of the `${rowId}` in the URLs that are generated, resulting in the rowId referencing the current sample's row instead of the id of the ancestor.  We can fix this by using the DetailURL for the links from rowId and column (as is done for Samples). It's not clear why the extra StringExpression was created for these URLs.


#### Changes
* Update urls for data class objects.
