### PR TITLE
Fix transaction/close() exception

### DIFF
--- a/api/src/org/labkey/api/data/SchemaColumnMetaData.java
+++ b/api/src/org/labkey/api/data/SchemaColumnMetaData.java
@@ -28,7 +28,6 @@ import org.labkey.api.util.Pair;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.data.xml.ColumnType;
 import org.labkey.data.xml.TableType;
-import org.springframework.dao.DeadlockLoserDataAccessException;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -39,7 +38,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -196,9 +194,9 @@ public class SchemaColumnMetaData
         {
             // With the Microsoft JDBC driver we're seeing more deadlocks loading schema metadata so try multiple
             // times when possible
-            ti.getSchema().getScope().executeWithRetry(createRetryWrapper((tx) -> loadColumnsFromMetaData(ti)));
-            ti.getSchema().getScope().executeWithRetry(createRetryWrapper((tx) -> loadPkColumns(ti)));
-            ti.getSchema().getScope().executeWithRetry(createRetryWrapper((tx) -> loadIndices(ti)));
+            ti.getSchema().getScope().executeWithRetryReadOnly(createRetryWrapper((tx) -> loadColumnsFromMetaData(ti)));
+            ti.getSchema().getScope().executeWithRetryReadOnly(createRetryWrapper((tx) -> loadPkColumns(ti)));
+            ti.getSchema().getScope().executeWithRetryReadOnly(createRetryWrapper((tx) -> loadIndices(ti)));
         }
         catch (RuntimeSQLException e)
         {

--- a/issues/src/org/labkey/issue/IssueServiceImpl.java
+++ b/issues/src/org/labkey/issue/IssueServiceImpl.java
@@ -47,6 +47,7 @@ public class IssueServiceImpl implements IssueService
     {
         Container container = context.getContainer();
         User user = context.getUser();
+        Integer issueId = null;
 
         try (DbScope.Transaction transaction = IssuesSchema.getInstance().getSchema().getScope().ensureTransaction())
         {
@@ -163,8 +164,8 @@ public class IssueServiceImpl implements IssueService
 
                 if (!errors.hasErrors())
                 {
+                    issueId = issueObject.getIssueId();
                     transaction.commit();
-                    return IssueManager.getIssue(container, user, issueObject.getIssueId());
                 }
             }
         }
@@ -172,10 +173,9 @@ public class IssueServiceImpl implements IssueService
         {
             String message = x.getMessage() == null ? x.toString() : x.getMessage();
             errors.reject(ERROR_MSG, message);
-
-            return null;
         }
-        return null;
+
+        return null != issueId ? IssueManager.getIssue(container, user, issueId) : null;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
After related PR, `IssuesAttachmentTest.testAttachmentInjection` started throwing exceptions related to not calling `close()` after committing the outermost transaction. See stack trace below.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4045

#### Changes
* Switch metadata queries to non-transacted retries
* The real culprit: `IssueServiceImpl.saveIssue()` committed its transaction but then invoked `getIssue()` before closing its connection. Depending on cache state, that call could invoke transacted metadata queries which would `commit()` and make DbScope upset.

```
ERROR ExceptionUtil            2023-01-30T21:07:29,943     http-nio-8111-exec-6 : Exception detected
java.lang.IllegalStateException: SPID=56 DbScope=labkey Missing expected call to close after prior commit
	at org.labkey.api.data.DbScope.createIllegalStateException(DbScope.java:238) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.data.DbScope$TransactionImpl.commit(DbScope.java:2278) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.data.DbScope._executeWithRetry(DbScope.java:722) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.data.DbScope.executeWithRetry(DbScope.java:695) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.data.SchemaColumnMetaData.loadFromMetaData(SchemaColumnMetaData.java:199) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.data.SchemaColumnMetaData.<init>(SchemaColumnMetaData.java:71) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.data.SchemaTableInfo.createSchemaColumnMetaData(SchemaTableInfo.java:448) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.data.SchemaTableInfo.getColumnMetaData(SchemaTableInfo.java:427) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.data.SchemaTableInfo.getColumn(SchemaTableInfo.java:406) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.experiment.api.property.StorageProvisionerImpl.fixupProvisionedDomain(StorageProvisionerImpl.java:1135) ~[experiment-23.2-SNAPSHOT.jar:?]
	at org.labkey.experiment.api.property.StorageProvisionerImpl$ProvisionedSchemaOptions.afterLoadTable(StorageProvisionerImpl.java:1559) ~[experiment-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.data.DbSchema.loadTable(DbSchema.java:292) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.data.SchemaTableInfoCache$SchemaTableLoader.load(SchemaTableInfoCache.java:84) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.data.SchemaTableInfoCache$SchemaTableLoader.load(SchemaTableInfoCache.java:74) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.cache.BlockingCache.get(BlockingCache.java:162) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.cache.BlockingCache.get(BlockingCache.java:92) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.data.SchemaTableInfoCache.get(SchemaTableInfoCache.java:51) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.data.DbScope.getTable(DbScope.java:1218) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.data.DbSchema.getTable(DbSchema.java:427) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.experiment.api.property.StorageProvisionerImpl.getSchemaTableInfo(StorageProvisionerImpl.java:620) ~[experiment-23.2-SNAPSHOT.jar:?]
	at org.labkey.experiment.api.property.StorageProvisionerImpl.getSchemaTableInfo(StorageProvisionerImpl.java:1066) ~[experiment-23.2-SNAPSHOT.jar:?]
	at org.labkey.experiment.api.property.StorageProvisionerImpl.createTableInfoImpl(StorageProvisionerImpl.java:596) ~[experiment-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.exp.api.StorageProvisioner.createTableInfo(StorageProvisioner.java:71) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.issue.model.IssueListDef.createTable(IssueListDef.java:111) ~[issues-23.2-SNAPSHOT.jar:?]
	at org.labkey.issue.query.IssuesTable.addAllColumns(IssuesTable.java:247) ~[issues-23.2-SNAPSHOT.jar:?]
	at org.labkey.issue.query.IssuesTable.<init>(IssuesTable.java:124) ~[issues-23.2-SNAPSHOT.jar:?]
	at org.labkey.issue.query.IssuesQuerySchema.getIssueTable(IssuesQuerySchema.java:237) ~[issues-23.2-SNAPSHOT.jar:?]
	at org.labkey.issue.query.IssuesQuerySchema.createTable(IssuesQuerySchema.java:170) ~[issues-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.query.UserSchema._getTableOrQuery(UserSchema.java:281) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.query.UserSchema.getTable(UserSchema.java:199) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.query.UserSchema.getTable(UserSchema.java:179) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.query.UserSchema.getTable(UserSchema.java:173) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.query.QuerySchema.getTable(QuerySchema.java:50) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.issue.model.IssueManager.getIssue(IssueManager.java:209) ~[issues-23.2-SNAPSHOT.jar:?]
	at org.labkey.issue.IssueServiceImpl.saveIssue(IssueServiceImpl.java:167) ~[issues-23.2-SNAPSHOT.jar:?]
	at org.labkey.issue.IssuesController$AbstractIssueAction.handlePost(IssuesController.java:914) ~[issues-23.2-SNAPSHOT.jar:?]
	at org.labkey.issue.IssuesController$InsertAction.handlePost(IssuesController.java:572) ~[issues-23.2-SNAPSHOT.jar:?]
	at org.labkey.issue.IssuesController$AbstractIssueAction.handlePost(IssuesController.java:896) ~[issues-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.action.FormViewAction.handleRequest(FormViewAction.java:96) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.action.FormViewAction.handleRequest(FormViewAction.java:75) ~[api-23.2-SNAPSHOT.jar:?]
	at org.labkey.api.action.BaseViewAction.handleRequest(BaseViewAction.java:195) ~[api-23.2-SNAPSHOT.jar:?]
```