### PR TITLE
Move getReportInfos.api to reports controller since it does not rely on study module

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.18.0",
-        "@labkey/components": "2.280.0",
+        "@labkey/components": "2.288.0-fb-getReportInfosAction.0",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3057,11 +3057,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.280.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.280.0.tgz",
-      "integrity": "sha512-BtG3zfXkOaGuAEXUm3/9cfNDp5QMLr065jK6liBKXunOXv07odbmAy1FGgFN84ZfK9gUkigYbhgOHxsht98kxw==",
+      "version": "2.288.0-fb-getReportInfosAction.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.288.0-fb-getReportInfosAction.0.tgz",
+      "integrity": "sha512-CQDU3Na1wKIPCFi7MvL7fcpO/2U1oWPD93ZVIcxHGv52cQKfarZ49WDTXfH27ZosVY6L5aamuPB3Ty7WFqRESg==",
       "dependencies": {
-        "@labkey/api": "1.18.1",
+        "@labkey/api": "1.18.2",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",
@@ -3097,9 +3097,9 @@
       }
     },
     "node_modules/@labkey/components/node_modules/@labkey/api": {
-      "version": "1.18.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.1.tgz",
-      "integrity": "sha512-KaRMFTGoOinZRsPuqrLOskLPNFdK9MX0feO4S5tRGlcZmBpld29UeKQoNJkNCwx8dCdbpkVTZMaWlvDQrA1s+Q=="
+      "version": "1.18.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.2.tgz",
+      "integrity": "sha512-svYswPh//qO4wthlAMjdBM5oApV7aLxAb2YDNOseaDX0K7SeijRiOx2McmAEUsfMRh4ggL4NlLo8YYYv0nsPqA=="
     },
     "node_modules/@labkey/eslint-config-base": {
       "version": "0.0.12",
@@ -17250,11 +17250,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.280.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.280.0.tgz",
-      "integrity": "sha512-BtG3zfXkOaGuAEXUm3/9cfNDp5QMLr065jK6liBKXunOXv07odbmAy1FGgFN84ZfK9gUkigYbhgOHxsht98kxw==",
+      "version": "2.288.0-fb-getReportInfosAction.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.288.0-fb-getReportInfosAction.0.tgz",
+      "integrity": "sha512-CQDU3Na1wKIPCFi7MvL7fcpO/2U1oWPD93ZVIcxHGv52cQKfarZ49WDTXfH27ZosVY6L5aamuPB3Ty7WFqRESg==",
       "requires": {
-        "@labkey/api": "1.18.1",
+        "@labkey/api": "1.18.2",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",
@@ -17284,9 +17284,9 @@
       },
       "dependencies": {
         "@labkey/api": {
-          "version": "1.18.1",
-          "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.1.tgz",
-          "integrity": "sha512-KaRMFTGoOinZRsPuqrLOskLPNFdK9MX0feO4S5tRGlcZmBpld29UeKQoNJkNCwx8dCdbpkVTZMaWlvDQrA1s+Q=="
+          "version": "1.18.2",
+          "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.2.tgz",
+          "integrity": "sha512-svYswPh//qO4wthlAMjdBM5oApV7aLxAb2YDNOseaDX0K7SeijRiOx2McmAEUsfMRh4ggL4NlLo8YYYv0nsPqA=="
         }
       }
     },

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.18.0",
-        "@labkey/components": "2.290.0",
+        "@labkey/components": "2.290.1",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3057,9 +3057,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.290.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.290.0.tgz",
-      "integrity": "sha512-ranYAvKn6B7yPAxeHKy/Fa5UxE9255en7sIbJ6b2ZZz+yw0VUOEHHgKwwhELkY4PUXR1G6tzU7bAFqVisQ9Seg==",
+      "version": "2.290.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.290.1.tgz",
+      "integrity": "sha512-m8VFeCuBvG57DVWzuGQHkw9/NL+r84yIADMbxzG3MM1QhHJuZFZhcyrw46++bL7N4dQ4jTgWAnM0GGMgYjLHEg==",
       "dependencies": {
         "@labkey/api": "1.18.3",
         "bootstrap": "~3.4.1",
@@ -17250,9 +17250,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.290.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.290.0.tgz",
-      "integrity": "sha512-ranYAvKn6B7yPAxeHKy/Fa5UxE9255en7sIbJ6b2ZZz+yw0VUOEHHgKwwhELkY4PUXR1G6tzU7bAFqVisQ9Seg==",
+      "version": "2.290.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.290.1.tgz",
+      "integrity": "sha512-m8VFeCuBvG57DVWzuGQHkw9/NL+r84yIADMbxzG3MM1QhHJuZFZhcyrw46++bL7N4dQ4jTgWAnM0GGMgYjLHEg==",
       "requires": {
         "@labkey/api": "1.18.3",
         "bootstrap": "~3.4.1",

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.18.0",
-    "@labkey/components": "2.280.0",
+    "@labkey/components": "2.288.0-fb-getReportInfosAction.0",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.18.0",
-    "@labkey/components": "2.290.0",
+    "@labkey/components": "2.290.1",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -4020,6 +4020,63 @@ public class ReportsController extends SpringActionController
         }
     }
 
+    @RequiresPermission(ReadPermission.class)
+    public class GetReportInfosAction extends ReadOnlyApiAction<GetReportInfosForm>
+    {
+        @Override
+        public ApiResponse execute(GetReportInfosForm form, BindException errors) throws Exception
+        {
+            ApiSimpleResponse response = new ApiSimpleResponse();
+            List<JSONObject> json = new ArrayList<>();
+
+            DataViewProvider.Type type = DataViewService.get().getDataTypeByName("reports");
+            if (type != null)
+            {
+                DataViewProvider provider = DataViewService.get().getProvider(type, getViewContext());
+                if (provider != null)
+                {
+                    List<DataViewInfo> reports = provider.getViews(getViewContext(), form.getSchemaName(), form.getQueryName());
+                    for (DataViewInfo report : reports)
+                    {
+                        json.add(DataViewService.get().toJSON(getContainer(), getUser(), report));
+                    }
+                }
+            }
+
+            response.put("schemaName", form.getSchemaName());
+            response.put("queryName", form.getQueryName());
+            response.put("reports", json);
+            response.put("success", true);
+            return response;
+        }
+    }
+
+    private static class GetReportInfosForm
+    {
+        private String _schemaName;
+        private String _queryName;
+
+        public String getSchemaName()
+        {
+            return _schemaName;
+        }
+
+        public void setSchemaName(String schemaName)
+        {
+            _schemaName = schemaName;
+        }
+
+        public String getQueryName()
+        {
+            return _queryName;
+        }
+
+        public void setQueryName(String queryName)
+        {
+            _queryName = queryName;
+        }
+    }
+
     public static class ParticipantViewReportForm extends ReportForm
     {
         private boolean _showInParticipantView;

--- a/study/src/org/labkey/study/controllers/reports/ReportsController.java
+++ b/study/src/org/labkey/study/controllers/reports/ReportsController.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.Nullable;
 import org.json.old.JSONArray;
 import org.json.old.JSONException;
-import org.json.old.JSONObject;
 import org.labkey.api.action.Action;
 import org.labkey.api.action.ActionType;
 import org.labkey.api.action.ApiResponse;
@@ -38,9 +37,6 @@ import org.labkey.api.data.BeanViewForm;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DisplayColumn;
-import org.labkey.api.data.views.DataViewInfo;
-import org.labkey.api.data.views.DataViewProvider;
-import org.labkey.api.data.views.DataViewService;
 import org.labkey.api.query.QueryParam;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
@@ -1679,64 +1675,6 @@ public class ReportsController extends BaseStudyController
                 }
             }
             return response;
-        }
-    }
-
-
-    @RequiresPermission(ReadPermission.class)
-    public class GetReportInfosAction extends ReadOnlyApiAction<GetReportInfosForm>
-    {
-        @Override
-        public ApiResponse execute(GetReportInfosForm form, BindException errors) throws Exception
-        {
-            ApiSimpleResponse response = new ApiSimpleResponse();
-            List<JSONObject> json = new ArrayList<>();
-
-            DataViewProvider.Type type = DataViewService.get().getDataTypeByName("reports");
-            if (type != null)
-            {
-                DataViewProvider provider = DataViewService.get().getProvider(type, getViewContext());
-                if (provider != null)
-                {
-                    List<DataViewInfo> reports = provider.getViews(getViewContext(), form.getSchemaName(), form.getQueryName());
-                    for (DataViewInfo report : reports)
-                    {
-                        json.add(DataViewService.get().toJSON(getContainer(), getUser(), report));
-                    }
-                }
-            }
-
-            response.put("schemaName", form.getSchemaName());
-            response.put("queryName", form.getQueryName());
-            response.put("reports", json);
-            response.put("success", true);
-            return response;
-        }
-    }
-
-    private static class GetReportInfosForm
-    {
-        private String _schemaName;
-        private String _queryName;
-
-        public String getSchemaName()
-        {
-            return _schemaName;
-        }
-
-        public void setSchemaName(String schemaName)
-        {
-            _schemaName = schemaName;
-        }
-
-        public String getQueryName()
-        {
-            return _queryName;
-        }
-
-        public void setQueryName(String queryName)
-        {
-            _queryName = queryName;
         }
     }
 }


### PR DESCRIPTION
#### Rationale
This was discovered because of a 22.11 > Trial LIMS Integration Test > BiologicsReportTest.testOpenReportInBiologics test failure. The study module does not exist on this instance so the query to get the report infos for a given grid never happens. This query actually has nothing to do with the study module, so the action is being moved to the ReportsController in the query module instead.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4083
* https://github.com/LabKey/labkey-ui-components/pull/1096
* https://github.com/LabKey/biologics/pull/1906
* https://github.com/LabKey/inventory/pull/715
* https://github.com/LabKey/sampleManagement/pull/1585

#### Changes
* move GetReportInfosAction from study module to query module ReportsController
* update @labkey/components package version
