### PR TITLE
Miscellaneous tweaks

### DIFF
--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -43,7 +43,6 @@ import org.labkey.api.query.AliasManager;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryParseException;
 import org.labkey.api.query.SchemaKey;
-import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.column.BuiltInColumnTypes;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringExpression;
@@ -1695,7 +1694,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
                     col._nullable = reader.isNullable();
                     col._jdbcDefaultValue = reader.getDefault();
 
-                    // isCalculated is typically an query-level ExprColumn, but in this case we have a real calculated column in the database
+                    // isCalculated is typically a query-level ExprColumn, but in this case we have a real calculated column in the database
                     col.setCalculated(reader.isGeneratedColumn());
 
                     inferMetadata(col);
@@ -1713,7 +1712,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
             JdbcMetaDataSelector keySelector = new JdbcMetaDataSelector(locator, (dbmd, locator1) -> dbmd.getImportedKeys(locator1.getCatalogName(), locator1.getSchemaName(), locator1.getTableName()));
 
             // load keys in two phases
-            // 1) combine multi column keys
+            // 1) combine multi-column keys
             // 2) update columns
 
             try (ResultSet rsKeys = keySelector.getResultSet())

--- a/api/src/org/labkey/api/data/JdbcMetaDataSelector.java
+++ b/api/src/org/labkey/api/data/JdbcMetaDataSelector.java
@@ -23,11 +23,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 /**
- * This class is used to read JDBC meta data via the standard DatabaseMetaData methods. It follows the basic Selector
+ * This class is used to read JDBC metadata via the standard DatabaseMetaData methods. It follows the basic Selector
  * pattern, but much simpler to keep it out of that class hierarchy.
- * User: adam
- * Date: 7/10/2014
- * Time: 8:52 AM
  */
 
 public class JdbcMetaDataSelector

--- a/core/src/org/labkey/core/junit/JunitRunner.java
+++ b/core/src/org/labkey/core/junit/JunitRunner.java
@@ -27,6 +27,7 @@ import org.junit.runner.Runner;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 import org.labkey.api.util.CPUTimer;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.TestContext;
 
 import java.util.ArrayList;
@@ -75,8 +76,7 @@ public class JunitRunner
 
         try
         {
-            if (desc.testCount() > 1)
-                LOG.info("Starting suite: " + description + " (" + desc.testCount() + " tests)");
+            LOG.info("Starting suite: " + description + " (" + StringUtilsLabKey.pluralize(desc.testCount(), "test") + ")");
 
             ArrayList<CPUTimer> allTimers = new ArrayList<>();
             Map<Description, ArrayList<CPUTimer>> testTimers = new LinkedHashMap<>();
@@ -118,8 +118,7 @@ public class JunitRunner
         finally
         {
             TestContext.get().clearPerfResults();
-            if (desc.testCount() > 1)
-                LOG.info("Completed suite: " + description);
+            LOG.info("Completed suite: " + description);
         }
     }
 }

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -1656,7 +1656,7 @@ public class UserController extends SpringActionController
 
             if (isUserManager)
             {
-                // Always display "Reset/Create Password" button (even for LDAP and OpenSSO users)... except for admin's own record
+                // Always display "Reset/Create Password" button (even for LDAP and SSO users)... except for admin's own record
                 if (null != detailsEmail && !isOwnRecord && canManageDetailsUser && !isLoginAutoRedirect)
                 {
                     // Allow admins to create a logins entry if it doesn't exist. Addresses scenario of user logging in

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -57,12 +57,12 @@ import org.labkey.api.reports.report.JavaScriptReport;
 import org.labkey.api.reports.report.JavaScriptReportDescriptor;
 import org.labkey.api.reports.report.QueryReport;
 import org.labkey.api.reports.report.QueryReportDescriptor;
-import org.labkey.api.reports.report.r.RReport;
-import org.labkey.api.reports.report.r.RReportDescriptor;
 import org.labkey.api.reports.report.ReportDescriptor;
 import org.labkey.api.reports.report.ReportUrls;
 import org.labkey.api.reports.report.python.IpynbReport;
 import org.labkey.api.reports.report.python.IpynbReportDescriptor;
+import org.labkey.api.reports.report.r.RReport;
+import org.labkey.api.reports.report.r.RReportDescriptor;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
@@ -72,7 +72,6 @@ import org.labkey.api.security.roles.PlatformDeveloperRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.settings.AdminConsole;
-import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.stats.AnalyticsProviderRegistry;
 import org.labkey.api.stats.SummaryStatisticRegistry;
 import org.labkey.api.util.JspTestCase;
@@ -184,8 +183,6 @@ public class QueryModule extends DefaultModule
         ExternalSchema.register();
         LinkedSchema.register();
 
-        ContainerManager.addContainerListener(QueryManager.CONTAINER_LISTENER, ContainerManager.ContainerListener.Order.Last);
-
         QueryService.get().addQueryListener(new CustomViewQueryChangeListener());
         QueryService.get().addQueryListener(new QuerySnapshotQueryChangeListener());
 
@@ -255,6 +252,8 @@ public class QueryModule extends DefaultModule
     @Override
     public void doStartup(ModuleContext moduleContext)
     {
+        ContainerManager.addContainerListener(QueryManager.CONTAINER_LISTENER, ContainerManager.ContainerListener.Order.Last);
+
         if (null != PipelineService.get())
             PipelineService.get().registerPipelineProvider(new ReportsPipelineProvider(this));
         QueryController.registerAdminConsoleLinks();


### PR DESCRIPTION
#### Changes
* Fix a few typos and misspellings in comments
* Register `QueryManager` container listener in startup(), consistent with all other container listeners. This ensures core container listener runs last.
* `CachingTestCase` shouldn't cache mutable maps
* Log the start and end of every junit suite, including those with only one test