### PR TITLE
Add data generator for adding samples to storage

### DIFF
--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -53,6 +53,29 @@ import java.util.stream.Collectors;
 
 public class DataGenerator<T extends DataGenerator.Config>
 {
+    private static final List<String> UNITS = List.of("g", "mg", "uL", "mL", "unit");
+    private static final List<String> LABEL_COLORS = new ArrayList<>();
+    static {
+        LABEL_COLORS.add("#800000"); // maroon,
+        LABEL_COLORS.add("#B22222"); // firebrick
+        LABEL_COLORS.add("#DC143C"); // crimson
+        LABEL_COLORS.add("#FA8072"); // salmon
+        LABEL_COLORS.add("#FFD700"); // gold
+        LABEL_COLORS.add("#808000"); // olive
+        LABEL_COLORS.add("#9ACD32"); // yellow green
+        LABEL_COLORS.add("#6B8E23"); // olive drab
+        LABEL_COLORS.add("#008000"); // olive
+        LABEL_COLORS.add("#556B2F"); // dark olive green
+        LABEL_COLORS.add("#008080"); // teal
+        LABEL_COLORS.add("#00FFFF"); // aqua
+        LABEL_COLORS.add("#4682B4"); // steel blue
+        LABEL_COLORS.add("#1E90FF"); // dodger blue
+        LABEL_COLORS.add("#0000CD"); // medium blue
+        LABEL_COLORS.add("#8A2BE2"); // blue violet
+        LABEL_COLORS.add("#4B0082"); // indigo
+        LABEL_COLORS.add("#8B008B"); // dark magenta
+        LABEL_COLORS.add("#D2691E"); // chocolate
+    }
     protected static final int MAX_BATCH_SIZE = 10000;
     protected Container _container;
     protected final User _user;
@@ -254,7 +277,8 @@ public class DataGenerator<T extends DataGenerator.Config>
         SampleTypeService service = SampleTypeService.get();
         _log.info(String.format("Creating Sample Type '%s' with %d fields", sampleTypeName, numFields));
         return service.createSampleType(_container, _user, sampleTypeName,
-                "Generated sample type", props, List.of(), namingPattern);
+                "Generated sample type", props, List.of(), -1, -1, -1, -1, namingPattern, null, null, null,
+                LABEL_COLORS.get(randomInt(0, LABEL_COLORS.size())), UNITS.get(randomInt(0, UNITS.size())), null, null, null);
     }
 
     public void generateSamplesForAllTypes(List<String> dataClassParents) throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -278,7 +278,7 @@ public class DataGenerator<T extends DataGenerator.Config>
         _log.info(String.format("Creating Sample Type '%s' with %d fields", sampleTypeName, numFields));
         return service.createSampleType(_container, _user, sampleTypeName,
                 "Generated sample type", props, List.of(), -1, -1, -1, -1, namingPattern, null, null, null,
-                LABEL_COLORS.get(randomInt(0, LABEL_COLORS.size())), UNITS.get(randomInt(0, UNITS.size())), null, null, null);
+                randomIndex(LABEL_COLORS), randomIndex(UNITS), null, null, null);
     }
 
     public void generateSamplesForAllTypes(List<String> dataClassParents) throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException
@@ -672,6 +672,11 @@ public class DataGenerator<T extends DataGenerator.Config>
     {
         double random = Math.random() < 0.5 ? ((1 - Math.random()) * (max - min) + min) : (Math.random() * (max - min) + min);
         return String.format("%.2f", random);
+    }
+
+    public static <T> T randomIndex(List<T> list)
+    {
+        return list.get(randomInt(0, list.size()));
     }
 
     public static <T> T randomIndex(T[] array)

--- a/api/src/org/labkey/api/data/generator/DataGeneratorRegistry.java
+++ b/api/src/org/labkey/api/data/generator/DataGeneratorRegistry.java
@@ -7,7 +7,8 @@ public class DataGeneratorRegistry
 {
     public enum DataType {
         AssayDesigns,
-        Storage,
+        StorageHierarchy,
+        SamplesInStorage,
     };
 
     private static final Map<DataType, DataGenerator.DataGenerationDriver> _dataGeneratorMap = new HashMap<>();

--- a/api/src/org/labkey/api/exp/api/ExpSampleType.java
+++ b/api/src/org/labkey/api/exp/api/ExpSampleType.java
@@ -48,16 +48,16 @@ public interface ExpSampleType extends ExpObject
     String getMaterialLSIDPrefix();
 
 
-    /** pass in a container to request a set of samples*/
+    /** Returns all samples in the given container */
     List<? extends ExpMaterial> getSamples(Container c);
 
-    /** pass in a container to request a set of samples*/
+    /** Returns all samples in the given container using the given container filter. */
     List<? extends ExpMaterial> getSamples(Container c, @Nullable ContainerFilter cf);
 
     /** number of samples in the given container **/
     public long getSamplesCount(Container c, @Nullable ContainerFilter cf);
 
-    /** pass in a container to request a sample */
+    /** Returns the sample in the given container with the given name */
     ExpMaterial getSample(Container c, String name);
 
     /** get the sample with name at a specific time */

--- a/api/src/org/labkey/api/exp/api/ExpSampleType.java
+++ b/api/src/org/labkey/api/exp/api/ExpSampleType.java
@@ -48,8 +48,14 @@ public interface ExpSampleType extends ExpObject
     String getMaterialLSIDPrefix();
 
 
-    /** pass in a container to request a sample */
+    /** pass in a container to request a set of samples*/
     List<? extends ExpMaterial> getSamples(Container c);
+
+    /** pass in a container to request a set of samples*/
+    List<? extends ExpMaterial> getSamples(Container c, @Nullable ContainerFilter cf);
+
+    /** number of samples in the given container **/
+    public long getSamplesCount(Container c, @Nullable ContainerFilter cf);
 
     /** pass in a container to request a sample */
     ExpMaterial getSample(Container c, String name);

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -681,7 +681,8 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
         if (cf != null)
             filter.addCondition(cf.createFilterClause(ExperimentServiceImpl.get().getExpSchema(), FieldKey.fromParts("Container")));
 
-        return new TableSelector(ExperimentServiceImpl.get().getTinfoMaterial(), filter, null).getRowCount();
+        TableInfo tInfo = ExperimentServiceImpl.get().getTinfoMaterial();
+        return new TableSelector(tInfo, tInfo.getPkColumns(), filter, null).getRowCount();
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -658,10 +658,30 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
     @Override
     public List<ExpMaterialImpl> getSamples(Container c)
     {
+        return getSamples(c, null);
+    }
+
+    @Override
+    public List<ExpMaterialImpl> getSamples(Container c, @Nullable ContainerFilter cf)
+    {
         SimpleFilter filter = SimpleFilter.createContainerFilter(c);
         filter.addCondition(FieldKey.fromParts("CpasType"), getLSID());
+        if (cf != null)
+            filter.addCondition(cf.createFilterClause(ExperimentServiceImpl.get().getExpSchema(), FieldKey.fromParts("Container")));
+
         Sort sort = new Sort("Name");
         return ExpMaterialImpl.fromMaterials(new TableSelector(ExperimentServiceImpl.get().getTinfoMaterial(), filter, sort).getArrayList(Material.class));
+    }
+
+    @Override
+    public long getSamplesCount(Container c, @Nullable ContainerFilter cf)
+    {
+        SimpleFilter filter = SimpleFilter.createContainerFilter(c);
+        filter.addCondition(FieldKey.fromParts("CpasType"), getLSID());
+        if (cf != null)
+            filter.addCondition(cf.createFilterClause(ExperimentServiceImpl.get().getExpSchema(), FieldKey.fromParts("Container")));
+
+        return new TableSelector(ExperimentServiceImpl.get().getTinfoMaterial(), filter, null).getRowCount();
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
For the next round of data generation, we want to put samples into storage, so we need some utility methods to help find the samples that are not already in storage.  We also modify a few data generation method signatures in preparation for generating data within folders.

#### Related Pull Requests
* https://github.com/LabKey/inventory/pull/716
* https://github.com/LabKey/biologics/pull/1908

#### Changes
* Add new data generation type: `SamplesInStorage`
* Add label colors when generating sample types
* Add metric units when generating sample types
* Update some method signatures to take container as an argument, in preparation for generating samples in folders
* Add new utility methods for getting the count of samples in a container (with a container filter) and the sample of a particular sample type using a container filter.
