### PR TITLE
Add public getter for average and calls to CPUTimer

### DIFF
--- a/api/src/org/labkey/api/util/CPUTimer.java
+++ b/api/src/org/labkey/api/util/CPUTimer.java
@@ -131,7 +131,7 @@ public class CPUTimer
 
     public float getAverage()
     {
-        return (_calls == 0 ? 0 : (float)getTotalMilliseconds() / _calls);
+        return _calls == 0 ? 0 : (float)getTotalMilliseconds() / _calls;
     }
 
     public long getCalls()

--- a/api/src/org/labkey/api/util/CPUTimer.java
+++ b/api/src/org/labkey/api/util/CPUTimer.java
@@ -129,9 +129,9 @@ public class CPUTimer
     }
     
 
-    public long getAverage()
+    public float getAverage()
     {
-        return (_calls == 0 ? 0 : getTotalMilliseconds() / _calls);
+        return (_calls == 0 ? 0 : (float)getTotalMilliseconds() / _calls);
     }
 
     public long getCalls()
@@ -178,7 +178,7 @@ public class CPUTimer
                 ms,
                 t._min * msFactor,
                 t._max * msFactor,
-                (t._calls == 0 ? 0 : ms / t._calls),
+                t.getAverage(),
                 t._calls);
     }
 

--- a/api/src/org/labkey/api/util/CPUTimer.java
+++ b/api/src/org/labkey/api/util/CPUTimer.java
@@ -129,6 +129,16 @@ public class CPUTimer
     }
     
 
+    public long getAverage()
+    {
+        return (_calls == 0 ? 0 : getTotalMilliseconds() / _calls);
+    }
+
+    public long getCalls()
+    {
+        return _calls;
+    }
+
     public static String dumpAllTimers()
     {
 		synchronized(timers)


### PR DESCRIPTION
#### Rationale
CPUTimer had public getters for all the values it collected except average and the number of calls made. If you wanted those you had to get the string output from the timer then parse the string, etc...

#### Related Pull Requests
* None.

#### Changes
* Added getAverage()
* Added getCalls()
