### PR TITLE
Handle update and clarify merge - LKS

### DIFF
--- a/api/src/org/labkey/api/data/StatementUtils.java
+++ b/api/src/org/labkey/api/data/StatementUtils.java
@@ -82,6 +82,7 @@ public class StatementUtils
     private boolean _selectIds = false;
     private boolean _selectObjectUri = false;
     private boolean _allowUpdateAutoIncrement = false;
+    private boolean _preferPKOverObjectUriAsKey = false;
 
     // variable/parameter tracking helpers
     private boolean useVariables = false;
@@ -166,6 +167,12 @@ public class StatementUtils
     public StatementUtils setVocabularyProperties(Set<DomainProperty> vocabularyProperties)
     {
         _vocabularyProperties = vocabularyProperties;
+        return this;
+    }
+
+    public StatementUtils setPreferPKOverObjectUriAsKey(boolean preferPKOverObjectUriAsKey)
+    {
+        _preferPKOverObjectUriAsKey = preferPKOverObjectUriAsKey;
         return this;
     }
 
@@ -529,9 +536,6 @@ public class StatementUtils
         // Keys for UPDATE or MERGE
         //
 
-        // TODO more control/configuration
-        // using objectURIColumnName preferentially to be backward compatible with OntologyManager.saveTabDelimited
-        //    which in turn is only called by LuminexDataHandler.saveDataRows()
         LinkedHashMap<FieldKey,ColumnInfo> keys = new LinkedHashMap<>();
         ColumnInfo col = table.getColumn("Container");
         if (null != col)
@@ -548,8 +552,10 @@ public class StatementUtils
         }
         else
         {
+            // using objectURIColumnName preferentially to be backward compatible with OntologyManager.saveTabDelimited
+            //    which in turn is only called by LuminexDataHandler.saveDataRows()
             col = objectURIColumnName == null ? null : table.getColumn(objectURIColumnName);
-            if (null != col)
+            if (null != col && !_preferPKOverObjectUriAsKey)
                 keys.put(col.getFieldKey(), col);
             else
             {

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -892,6 +892,12 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                 for (Object o1 : ((JSONArray)o).toArray())
                     values.add(_c.convert(o1));
             }
+            else if (o instanceof org.json.JSONArray)
+            {
+                // Only supports array of simple values right now.
+                for (Object o1 : ((org.json.JSONArray) o).toList())
+                    values.add(_c.convert(o1));
+            }
             else if (o != null)
             {
                 values.add(_c.convert(o));

--- a/api/src/org/labkey/api/dataiterator/TableInsertUpdateDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/TableInsertUpdateDataIterator.java
@@ -47,6 +47,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.labkey.api.query.QueryUpdateService.ConfigParameters.PreferPKOverObjectUriAsKey;
+
 public class TableInsertUpdateDataIterator extends StatementDataIterator implements DataIteratorBuilder
 {
     private final TableInfo _table;
@@ -63,6 +65,8 @@ public class TableInsertUpdateDataIterator extends StatementDataIterator impleme
 
     private boolean _skipCurrentIterator = false; // if StatementUtils generates a bad or meaningless (empty) statement, skip this iterator
     private boolean _failOnEmptyUpdate;
+
+    private boolean _preferPKOverObjectUriAsKey = false;
 
     /**
      * Creates and configures a TableInsertDataIterator. DO NOT call this method directly.
@@ -140,6 +144,9 @@ public class TableInsertUpdateDataIterator extends StatementDataIterator impleme
         {
             ti.setAdhocPropColumns(vocabularyColumns);
         }
+
+        if (context.getConfigParameterBoolean(PreferPKOverObjectUriAsKey))
+            ti.setPreferPKOverObjectUriAsKey(true);
 
         return ret;
     }
@@ -340,6 +347,7 @@ public class TableInsertUpdateDataIterator extends StatementDataIterator impleme
                 .noupdate(_dontUpdate)
                 .updateBuiltinColumns(false)
                 .selectIds(_selectIds)
+                .setPreferPKOverObjectUriAsKey(_preferPKOverObjectUriAsKey)
                 .constants(constants)
                 .setVocabularyProperties(_adhocPropColumns);
         stmt = util.createStatement(_conn, _container, null, true);
@@ -443,6 +451,11 @@ public class TableInsertUpdateDataIterator extends StatementDataIterator impleme
     public void setAdhocPropColumns(Set<DomainProperty> adhocPropColumns)
     {
         _adhocPropColumns = adhocPropColumns;
+    }
+
+    public void setPreferPKOverObjectUriAsKey(boolean preferPKOverObjectUriAsKey)
+    {
+        _preferPKOverObjectUriAsKey = preferPKOverObjectUriAsKey;
     }
 
     public static class NoUpdatableColumnInDataException extends Exception

--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -99,7 +99,8 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         public List<Pair<String, String>> urlExcelTemplates = null;
         public String importMessage = null;
         public String successMessageSuffix = "inserted";
-        public boolean showImportOptions = false;
+        public boolean showMergeOption = false;
+        public boolean showUpdateOption = false;
         public boolean hideTsvCsvCombo = false;
         // extra EXT config to inject into the form
         public JSONArray extraFields = null;
@@ -175,10 +176,16 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         _importViewBean.importHelpDisplayText = displayText;
     }
 
-    protected void setShowImportOptions(boolean b)
+    protected void setShowMergeOption(boolean b)
     {
         if (b && canUpdate(getUser()))
-            _importViewBean.showImportOptions = true;
+            _importViewBean.showMergeOption = true;
+    }
+
+    protected void setShowUpdateOption(boolean b)
+    {
+        if (b && canUpdate(getUser()))
+            _importViewBean.showUpdateOption = true;
     }
 
     protected void setTypeName(String name)

--- a/api/src/org/labkey/api/query/ExtendedTableUpdateService.java
+++ b/api/src/org/labkey/api/query/ExtendedTableUpdateService.java
@@ -115,4 +115,11 @@ public class ExtendedTableUpdateService extends SimpleQueryUpdateService
     {
         return super.createImportDIB(user, container, data, context);
     }
+
+    @Override
+    protected boolean supportUpdateUsingDIB()
+    {
+        return false;
+    }
+
 }

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -71,7 +71,7 @@ public interface QueryService
     String EXPERIMENTAL_LAST_MODIFIED = "queryMetadataLastModified";
     String PRODUCT_PROJECTS_ENABLED = "isProductProjectsEnabled";
     String PRODUCT_PROJECTS_EXIST = "hasProductProjects";
-    String USE_BATCH_UPDATE_ROWS = "useBatchUpdateRows";
+    String USE_ROW_BY_ROW_UPDATE = "useLegacyUpdateRows";
 
     String MODULE_QUERIES_DIRECTORY = "queries";
     Path MODULE_QUERIES_PATH = Path.parse(MODULE_QUERIES_DIRECTORY);

--- a/api/src/org/labkey/api/query/QueryUpdateService.java
+++ b/api/src/org/labkey/api/query/QueryUpdateService.java
@@ -107,8 +107,7 @@ public interface QueryUpdateService extends HasPermission
         SkipRequiredFieldValidation,        // (Bool) skip validation of required fields, used during import when the import of data happens in two hitches (e.g., samples in one file and sample statuses in a second)
         BulkLoad,                // (Bool) skips detailed auditing
         CheckForCrossProjectData,                // (Bool) Check if data belong to other projects
-        SkipInsertOptionValidation,  // (Bool) Skip assert(supportsInsertOption(context.getInsertOption())) for special scenarios (e.g., folder import uses merge action that's otherwise not supported for a table),
-        SkipBatchUpdateRows     // (Bool) Update one row at a time, instead of using DIB
+        SkipInsertOptionValidation  // (Bool) Skip assert(supportsInsertOption(context.getInsertOption())) for special scenarios (e.g., folder import uses merge action that's otherwise not supported for a table),
     }
 
 

--- a/api/src/org/labkey/api/query/QueryUpdateService.java
+++ b/api/src/org/labkey/api/query/QueryUpdateService.java
@@ -107,7 +107,8 @@ public interface QueryUpdateService extends HasPermission
         SkipRequiredFieldValidation,        // (Bool) skip validation of required fields, used during import when the import of data happens in two hitches (e.g., samples in one file and sample statuses in a second)
         BulkLoad,                // (Bool) skips detailed auditing
         CheckForCrossProjectData,                // (Bool) Check if data belong to other projects
-        SkipInsertOptionValidation  // (Bool) Skip assert(supportsInsertOption(context.getInsertOption())) for special scenarios (e.g., folder import uses merge action that's otherwise not supported for a table),
+        SkipInsertOptionValidation,  // (Bool) Skip assert(supportsInsertOption(context.getInsertOption())) for special scenarios (e.g., folder import uses merge action that's otherwise not supported for a table),
+        PreferPKOverObjectUriAsKey    // (Bool) Prefer getPkColumnNames instead of getObjectURIColumnName to use as keys
     }
 
 

--- a/api/src/org/labkey/api/query/SimpleQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/SimpleQueryUpdateService.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static org.labkey.api.query.QueryService.USE_BATCH_UPDATE_ROWS;
+import static org.labkey.api.query.QueryService.USE_ROW_BY_ROW_UPDATE;
 
 /**
  * User: kevink
@@ -86,6 +86,9 @@ public class SimpleQueryUpdateService extends DefaultQueryUpdateService
     private boolean shouldUpdateUsingDIB(Container container, List<Map<String, Object>> rows, List<Map<String, Object>> oldKeys, @Nullable Map<Enum, Object> configParameters)
     {
         if (oldKeys != null) // could be called by updateChangingKeys
+            return false;
+
+        if (ExperimentalFeatureService.get().isFeatureEnabled(USE_ROW_BY_ROW_UPDATE))
             return false;
 
         if (!supportUpdateUsingDIB())

--- a/api/src/org/labkey/api/query/SimpleQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/SimpleQueryUpdateService.java
@@ -123,7 +123,7 @@ public class SimpleQueryUpdateService extends DefaultQueryUpdateService
             boolean hasObjectUriValue = false;
             Object objectUri = rows.get(0).get(objectURIColumnName);
             if (objectUri != null)
-                hasObjectUriValue = StringUtils.isEmpty((String) objectUri);
+                hasObjectUriValue = !StringUtils.isEmpty((String) objectUri);
 
             return !hasObjectUriValue;
         }

--- a/api/src/org/labkey/api/query/SimpleQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/SimpleQueryUpdateService.java
@@ -105,9 +105,6 @@ public class SimpleQueryUpdateService extends DefaultQueryUpdateService
         if (getQueryTable().hasTriggers(container)) // dib not yet supported for simple tables with triggers
             return false;
 
-        if (configParameters != null && Boolean.TRUE == configParameters.get(QueryUpdateService.ConfigParameters.SkipBatchUpdateRows))
-            return false;
-
         return hasUniformKeys(rows);
     }
 

--- a/api/src/org/labkey/api/query/SimpleQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/SimpleQueryUpdateService.java
@@ -18,6 +18,7 @@ package org.labkey.api.query;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.DatabaseTableType;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
@@ -77,12 +78,22 @@ public class SimpleQueryUpdateService extends DefaultQueryUpdateService
         return result;
     }
 
+    private boolean canUpdateUsingDIB()
+    {
+        if (getQueryTable() == null)
+            return false;
+
+        TableInfo table = getQueryTable().getSchemaTableInfo();
+
+        return table.getTableType() == DatabaseTableType.TABLE && null != table.getMetaDataName();
+    }
+
     @Override
     public List<Map<String, Object>> updateRows(User user, Container container, List<Map<String, Object>> rows, List<Map<String, Object>> oldKeys,
                                                 BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
             throws InvalidKeyException, BatchValidationException, QueryUpdateServiceException, SQLException
     {
-        boolean useDib = oldKeys == null;
+        boolean useDib = oldKeys == null && canUpdateUsingDIB();
         useDib = useDib && !(configParameters != null && Boolean.TRUE == configParameters.get(QueryUpdateService.ConfigParameters.SkipBatchUpdateRows));
         useDib = useDib && !getQueryTable().hasTriggers(container);
         useDib = useDib && hasUniformKeys(rows);

--- a/api/src/org/labkey/api/query/SimpleQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/SimpleQueryUpdateService.java
@@ -82,7 +82,7 @@ public class SimpleQueryUpdateService extends DefaultQueryUpdateService
                                                 BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
             throws InvalidKeyException, BatchValidationException, QueryUpdateServiceException, SQLException
     {
-        boolean useDib = oldKeys == null && ExperimentalFeatureService.get().isFeatureEnabled(USE_BATCH_UPDATE_ROWS);
+        boolean useDib = oldKeys == null;
         useDib = useDib && !(configParameters != null && Boolean.TRUE == configParameters.get(QueryUpdateService.ConfigParameters.SkipBatchUpdateRows));
         useDib = useDib && !getQueryTable().hasTriggers(container);
         useDib = useDib && hasUniformKeys(rows);

--- a/api/src/org/labkey/api/query/SimpleUserSchema.java
+++ b/api/src/org/labkey/api/query/SimpleUserSchema.java
@@ -544,7 +544,8 @@ public class SimpleUserSchema extends UserSchema
         @Override
         public DataIteratorBuilder persistRows(DataIteratorBuilder data, DataIteratorContext context)
         {
-            return new TableInsertDataIteratorBuilder(data, this);
+            return new TableInsertDataIteratorBuilder(data, this)
+                    .setKeyColumns(new CaseInsensitiveHashSet(getPkColumnNames()));
         }
 
         @Override

--- a/api/src/org/labkey/api/query/SimpleUserSchema.java
+++ b/api/src/org/labkey/api/query/SimpleUserSchema.java
@@ -544,8 +544,7 @@ public class SimpleUserSchema extends UserSchema
         @Override
         public DataIteratorBuilder persistRows(DataIteratorBuilder data, DataIteratorContext context)
         {
-            return new TableInsertDataIteratorBuilder(data, this)
-                    .setKeyColumns(new CaseInsensitiveHashSet(getPkColumnNames()));
+            return new TableInsertDataIteratorBuilder(data, this);
         }
 
         @Override

--- a/api/src/org/labkey/api/query/import.jsp
+++ b/api/src/org/labkey/api/query/import.jsp
@@ -376,7 +376,7 @@
                     },
                 },
                 items: [{
-                    boxLabel: 'Add ' + type,
+                    boxLabel: 'Add ' + type + ' ' + ((!helpTopic || !helpDisplayText) ? "" : <%=q(new HelpTopic(bean.importHelpTopic).getLinkHtml(bean.importHelpDisplayText))%>),
                     inputValue: 'IMPORT',
                     checked: true
                 },{

--- a/api/src/org/labkey/api/query/import.jsp
+++ b/api/src/org/labkey/api/query/import.jsp
@@ -412,9 +412,7 @@
                         listeners: {
                             change: function(field, newValue) {
                                 var insertOption = Ext4.getCmp('insertOptionHidden' + index);
-                                if (newValue) {
-                                    insertOption.setValue("MERGE");
-                                }
+                                insertOption.setValue(newValue ? "MERGE" : "UPDATE");
                             }
                         }
                     }]

--- a/api/src/org/labkey/api/query/import.jsp
+++ b/api/src/org/labkey/api/query/import.jsp
@@ -123,6 +123,8 @@
     var successMessageSuffix = <%=q(bean.successMessageSuffix)%>;
     var importTsvForm;
     var uploadFileForm;
+    var allowUpdate = <%=bean.showUpdateOption%>;
+    var allowMerge = <%=bean.showMergeOption%>;
 
     // attach listeners to the buttons
     var importTsvExpando = Ext4.get(<%=q(copyPasteDivId+"Expando")%>);
@@ -332,24 +334,115 @@
 
     function getImportOptions(index)
     {
-        <%
-        if (bean.showImportOptions) {
-        %>
+        if (allowUpdate) {
+            return [{
+                xtype: 'radiogroup',
+                id:'insertOptionUI' + index,
+                itemId: 'insertOptionUI' + index,
+                name: 'insertOptionUI',
+                submitValue: false,
+                preventMark: true,
+                fieldLabel: 'Import Options',
+                columns: 1,
+                helpPopup: LABKEY.Utils.encodeHtml(
+                        '<p>By default, import will insert new rows based on the data/file provided. The operation will fail ' +
+                        'if there are existing row identifiers that match those being imported.</p>' +
+                        '<p>When \'Update ' + type + '\' is selected, data will be updated for matching row identifiers. When \'Allow new ' + type + ' during update\' is checked, new ' + type + ' will be created for any that do not match.' +
+                        ' Data will not be changed for any columns not in the imported data/file.</p>'
+                ),
+                defaults: {
+                    name: 'insertOptionUI'
+                },
+                listeners: {
+                    scope : this,
+                    change: function(field, newValue) {
+                        var isUpdate = newValue.insertOptionUI === 'UPDATE';
+
+                        if (allowMerge) {
+                            var mergeField = Ext4.getCmp('allowMergeCheckbox' + index);
+                            mergeField.setDisabled(!isUpdate);
+                            if (!isUpdate) {
+                                mergeField.setValue(false);
+                            }
+                        }
+
+                        var insertOption = Ext4.getCmp('insertOptionHidden' + index);
+                        if (!isUpdate) {
+                            insertOption.setValue("IMPORT");
+                        }
+                        else {
+                            insertOption.setValue("UPDATE");
+                        }
+                    },
+                },
+                items: [{
+                    boxLabel: 'Add ' + type,
+                    inputValue: 'IMPORT',
+                    checked: true
+                },{
+                    boxLabel: 'Update ' + type,
+                    inputValue: 'UPDATE',
+
+                }]
+            },{
+                xtype: 'fieldcontainer',
+                fieldLabel: '&nbsp;',
+                defaultType: 'checkboxfield',
+                id:'allowMergeField' + index,
+                itemId: 'allowMergeField' + index,
+                name: 'allowMergeField',
+                defaults: {
+                    name: 'allowMergeField'
+                },
+                labelWidth: 135,
+                labelSeparator : "",
+                submitValue: false,
+                hidden: !allowMerge,
+                items: [
+                    {
+                        boxLabel  : 'Allow new ' + type + ' during update',
+                        defaults: {
+                            name: 'allowMerge'
+                        },
+                        inputValue: true,
+                        itemId    : 'allowMergeCheckbox' + index,
+                        id        : 'allowMergeCheckbox' + index,
+                        disabled  : true,
+                        submitValue: false,
+                        listeners: {
+                            change: function(field, newValue) {
+                                var insertOption = Ext4.getCmp('insertOptionHidden' + index);
+                                if (newValue) {
+                                    insertOption.setValue("MERGE");
+                                }
+                            }
+                        }
+                    }]
+            }, {
+                xtype   : 'hidden',
+                name    : 'insertOption',
+                itemId  : 'insertOptionHidden' + index,
+                id      : 'insertOptionHidden' + index,
+                value   : 'IMPORT',
+                submitValue: true
+            }];
+        }
+        else if (allowMerge) {
             return [{
                 xtype: 'checkbox',
-                id:'insertOption' + index,
+                id: 'insertOption' + index,
                 itemId: 'insertOption',
                 name: 'insertOption',
                 inputValue: <%=q(QueryUpdateService.InsertOption.MERGE.name())%>,
                 fieldLabel: 'Import Options',
                 boxLabel: 'Update data for existing ' + type + ' during import. ' +
-                        ((!helpTopic||!helpDisplayText) ? "" : <%=q(new HelpTopic(bean.importHelpTopic).getLinkHtml(bean.importHelpDisplayText))%>),
+                        ((!helpTopic || !helpDisplayText) ? "" : <%=q(new HelpTopic(bean.importHelpTopic).getLinkHtml(bean.importHelpDisplayText))%>),
                 preventMark: true,
                 helpPopup: LABKEY.Utils.encodeHtml(
-                    '<p>By default, import will insert new rows based on the data/file provided. The operation will fail ' +
-                    'if there are existing row identifiers that match those being imported.</p>' +
-                    '<p>When update is selected, data will be updated for matching row identifiers, and new rows will be created for any that do not match.' +
-                    ' Data will not be changed for any columns not in the imported data/file.</p>'
+                        '<p>By default, import will insert new rows based on the data/file provided. The operation will fail ' +
+                        'if there are existing row identifiers that match those being imported.</p>' +
+                        '<p>When update is selected, data will be updated for matching row identifiers, and new rows will be created for any that do not match.' +
+                        ' Data will not be changed for any columns not in the imported data/file.</p>'
                 ),
                 columns: 1,
                 defaults: {
@@ -368,14 +461,10 @@
                     }
                 ]
             }];
-        <%
         }
         else {
-        %>
             return [];
-        <%
         }
-        %>
     }
 
 

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -71,6 +71,7 @@ import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpDataClass;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.api.NameExpressionOptionService;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.ConceptURIVocabularyDomainProvider;
@@ -168,9 +169,8 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         _dataClassTableInfo = new CachingSupplier<>(_dataClass::getTinfo);
         addAllowablePermission(InsertPermission.class);
         addAllowablePermission(UpdatePermission.class);
-        // leaving commented out until branch that supports merge for data classes is merged
-//        ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getImportDataURL(getContainer(), _dataClass.getName());
-//        setImportURL(new DetailsURL(url));
+        ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getImportDataURL(getContainer(), _dataClass.getName());
+        setImportURL(new DetailsURL(url));
 
         // Filter exp.data to only those rows that are members of the DataClass
         addCondition(new SimpleFilter(FieldKey.fromParts("classId"), _dataClass.getRowId()));

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -1218,7 +1218,6 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             if (rows != null && !rows.isEmpty() && oldKeys == null)
                 useDib = rows.get(0).containsKey("lsid");
 
-            useDib = useDib && !(configParameters != null && Boolean.TRUE == configParameters.get(QueryUpdateService.ConfigParameters.SkipBatchUpdateRows));
             useDib = useDib && hasUniformKeys(rows);
 
             List<Map<String, Object>> results;

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -343,7 +343,6 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         if (rows != null && !rows.isEmpty() && oldKeys == null)
             useDib = rows.get(0).containsKey("lsid");
 
-        useDib = useDib && !(configParameters != null && Boolean.TRUE == configParameters.get(QueryUpdateService.ConfigParameters.SkipBatchUpdateRows));
         useDib = useDib && hasUniformKeys(rows);
 
         List<Map<String, Object>> results;

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4036,8 +4036,6 @@ public class ExperimentController extends SpringActionController
             initRequest(form);
             setHelpTopic("importSampleSets");           // page-wide help topic
             setImportHelpTopic("importSampleSets");     // importOptions help topic
-            setShowMergeOption(true);
-            setShowUpdateOption(true);
             setTypeName("samples");
             return getDefaultImportView(form, errors);
         }
@@ -4073,7 +4071,12 @@ public class ExperimentController extends SpringActionController
             if (!qpe.isEmpty())
                 throw qpe.get(0);
             if (null != t)
+            {
                 setTarget(t);
+                setShowMergeOption(t.supportsInsertOption(QueryUpdateService.InsertOption.MERGE));
+                setShowUpdateOption(t.supportsInsertOption(QueryUpdateService.InsertOption.UPDATE));
+            }
+
             _auditBehaviorType = form.getAuditBehavior();
         }
 
@@ -4158,8 +4161,6 @@ public class ExperimentController extends SpringActionController
             initRequest(form);
             setHelpTopic("dataClass");           // page wide help topic
             setImportHelpTopic("dataClass#ui");     // importOptions help topic
-            setShowMergeOption(true);
-            setShowUpdateOption(true);
             setTypeName("data");
             return getDefaultImportView(form, errors);
         }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4036,7 +4036,8 @@ public class ExperimentController extends SpringActionController
             initRequest(form);
             setHelpTopic("importSampleSets");           // page-wide help topic
             setImportHelpTopic("importSampleSets");     // importOptions help topic
-            setShowImportOptions(true);
+            setShowMergeOption(true);
+            setShowUpdateOption(true);
             setTypeName("samples");
             return getDefaultImportView(form, errors);
         }
@@ -4157,7 +4158,8 @@ public class ExperimentController extends SpringActionController
             initRequest(form);
             setHelpTopic("dataClass");           // page wide help topic
             setImportHelpTopic("dataClass#ui");     // importOptions help topic
-            setShowImportOptions(true);
+            setShowMergeOption(true);
+            setShowUpdateOption(true);
             setTypeName("data");
             return getDefaultImportView(form, errors);
         }

--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -720,7 +720,7 @@ public class ListController extends SpringActionController
         public ModelAndView getView(ListDefinitionForm form, BindException errors) throws Exception
         {
             initRequest(form);
-            setShowImportOptions(_list.getKeyType() != ListDefinition.KeyType.AutoIncrementInteger);
+            setShowMergeOption(_list.getKeyType() != ListDefinition.KeyType.AutoIncrementInteger);
             setSuccessMessageSuffix("imported");
             return getDefaultImportView(form, errors);
         }

--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -720,7 +720,9 @@ public class ListController extends SpringActionController
         public ModelAndView getView(ListDefinitionForm form, BindException errors) throws Exception
         {
             initRequest(form);
-            setShowMergeOption(_list.getKeyType() != ListDefinition.KeyType.AutoIncrementInteger);
+            boolean allowImportOptions = _list.getKeyType() != ListDefinition.KeyType.AutoIncrementInteger;
+            setShowMergeOption(allowImportOptions);
+            setShowUpdateOption(allowImportOptions);
             setSuccessMessageSuffix("imported");
             return getDefaultImportView(form, errors);
         }

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -226,7 +226,7 @@ public class QueryModule extends DefaultModule
         AdminConsole.addExperimentalFeatureFlag(QueryServiceImpl.EXPERIMENTAL_LAST_MODIFIED, "Include Last-Modified header on query metadata requests",
                 "For schema, query, and view metadata requests include a Last-Modified header such that the browser can cache the response. " +
                 "The metadata is invalidated when performing actions such as creating a new List or modifying the columns on a custom view", false);
-        AdminConsole.addExperimentalFeatureFlag(USE_ROW_BY_ROW_UPDATE, "Use row by row update", "For Query.updateRows api, do row by row update, instead of using prepared statement that update rows in a batch.", false);
+        AdminConsole.addExperimentalFeatureFlag(USE_ROW_BY_ROW_UPDATE, "Use row-by-row update", "For Query.updateRows api, do row-by-row update, instead of using a prepared statement that updates rows in batches.", false);
 
     }
 

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -72,7 +72,6 @@ import org.labkey.api.security.roles.PlatformDeveloperRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.settings.AdminConsole;
-import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.stats.AnalyticsProviderRegistry;
 import org.labkey.api.stats.SummaryStatisticRegistry;
 import org.labkey.api.util.JspTestCase;
@@ -132,7 +131,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import static org.labkey.api.query.QueryService.USE_BATCH_UPDATE_ROWS;
+import static org.labkey.api.query.QueryService.USE_ROW_BY_ROW_UPDATE;
 
 
 public class QueryModule extends DefaultModule
@@ -229,7 +228,7 @@ public class QueryModule extends DefaultModule
         AdminConsole.addExperimentalFeatureFlag(QueryServiceImpl.EXPERIMENTAL_LAST_MODIFIED, "Include Last-Modified header on query metadata requests",
                 "For schema, query, and view metadata requests include a Last-Modified header such that the browser can cache the response. " +
                 "The metadata is invalidated when performing actions such as creating a new List or modifying the columns on a custom view", false);
-        AdminConsole.addExperimentalFeatureFlag(USE_BATCH_UPDATE_ROWS, "Use batch update", "Use prepared statement to update a set of rows in a batch.", false);
+        AdminConsole.addExperimentalFeatureFlag(USE_ROW_BY_ROW_UPDATE, "Use row by row update", "For Query.updateRows api, do row by row update, instead of using prepared statement that update rows in a batch.", false);
 
     }
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4237,9 +4237,6 @@ public class QueryController extends SpringActionController
                     configParameters.put(DetailedAuditLogDataIterator.AuditConfigs.AuditUserComment, auditComment);
             }
 
-            if (json.optBoolean("SkipBatchUpdateRows", false))
-                configParameters.put(QueryUpdateService.ConfigParameters.SkipBatchUpdateRows, true);
-
             //set up the response, providing the schema name, query name, and operation
             //so that the client can sort out which request this response belongs to
             //(clients often submit these async)

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -2485,7 +2485,7 @@ public class StudyController extends BaseStudyController
             if (null == PipelineService.get().findPipelineRoot(getContainer()))
                 return new RequirePipelineView(_study, true, errors);
 
-            setShowImportOptions(_def.getKeyManagementType() == Dataset.KeyManagementType.None);
+            setShowMergeOption(_def.getKeyManagementType() == Dataset.KeyManagementType.None);
             setSuccessMessageSuffix("imported");  //Works for when the merge option is selected (may include updates) vs default "inserted"
             return getDefaultImportView(form, errors);
         }

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -2485,7 +2485,9 @@ public class StudyController extends BaseStudyController
             if (null == PipelineService.get().findPipelineRoot(getContainer()))
                 return new RequirePipelineView(_study, true, errors);
 
-            setShowMergeOption(_def.getKeyManagementType() == Dataset.KeyManagementType.None);
+            boolean showImportOptions = _def.getKeyManagementType() == Dataset.KeyManagementType.None;
+            setShowMergeOption(showImportOptions);
+            setShowUpdateOption(showImportOptions);
             setSuccessMessageSuffix("imported");  //Works for when the merge option is selected (may include updates) vs default "inserted"
             return getDefaultImportView(form, errors);
         }

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
@@ -28,9 +28,9 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.components.LookAndFeelScatterPlot;
 import org.labkey.test.components.LookAndFeelTimeChart;
 import org.labkey.test.components.domain.DomainFormPanel;
-import org.labkey.test.components.ext4.Checkbox;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.components.study.DatasetFacetPanel;
+import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.TimeChartWizard;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.util.DataRegionTable;
@@ -255,23 +255,14 @@ public class StudyDatasetsTest extends BaseWebDriverTest
             .selectDatasetByName(datasetName)
             .clickViewData();
         waitForText("All data");
-        new DataRegionTable("Dataset", getDriver()).clickImportBulkData();
+        ImportDataPage importDataPage = new DataRegionTable("Dataset", getDriver()).clickImportBulkData();
         waitForText("Copy/paste text");
 
-        setImportOption(checkMergeOption);
+        importDataPage.setCopyPasteMerge(checkMergeOption);
 
         setFormElement(Locator.xpath("//textarea"), header + tsv);
         clickButton("Submit", 0);
         waitForText(WAIT_FOR_PAGE, msg);
-    }
-
-    protected void setImportOption(boolean merge)
-    {
-        Checkbox checkbox = new Checkbox(Locator.inputById("insertOption1-inputEl").findWhenNeeded(this.getWrappedDriver()));
-        if (merge)
-            checkbox.check();
-        else
-            checkbox.uncheck();
     }
 
     @LogMethod


### PR DESCRIPTION
#### Rationale
The bulk update page for lists, datasets, samples and dataclasses now support an explicit UPDATE option. Additionally, batch update using prepared statement is now enabled by default for simple tables.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4089
* https://github.com/LabKey/testAutomation/pull/1369

#### Changes
* Use data iterator for updateRows api for simple tables by default
* add new "Use row by row update" experimental flag to switch back to row by row updates
* update bulk import pages for lists, datasets, samples and dataclass to clarify merge and support update
* Fix container handling for workbook folders during updates using DIB
