### PR TITLE
Fix more portal page issues - FolderExportTest, EvalContent, etc

### DIFF
--- a/api/src/org/labkey/api/view/Portal.java
+++ b/api/src/org/labkey/api/view/Portal.java
@@ -745,7 +745,9 @@ public class Portal implements ModuleChangeListener
 
     public static WebPart addPart(Container c, WebPartFactory desc, @Nullable String location, int partIndex, @Nullable Map<String, String> properties)
     {
-        return addPart(c, DEFAULT_PORTAL_PAGE_ID, desc, location, partIndex, properties);
+        // Add to the default portal tab for the container
+        String defaultPage = c.getFolderType().getDefaultPageId(c);
+        return addPart(c, defaultPage, desc, location, partIndex, properties);
     }
 
     // Add a web part to the container at the specified index, with properties

--- a/api/src/org/labkey/api/view/Portal.java
+++ b/api/src/org/labkey/api/view/Portal.java
@@ -803,7 +803,8 @@ public class Portal implements ModuleChangeListener
 
     public static void saveParts(Container c, Collection<WebPart> newParts)
     {
-        saveParts(c, DEFAULT_PORTAL_PAGE_ID, newParts.toArray(new WebPart[0]));
+        String defaultPage = c.getFolderType().getDefaultPageId(c);
+        saveParts(c, defaultPage, newParts.toArray(new WebPart[0]));
     }
 
     public static void saveParts(Container c, String pageId, Collection<WebPart> newParts)


### PR DESCRIPTION
#### Rationale
Many existing folder archives have overlapping `portal.default` and `DefaultDashboard` or `Overview` portal page definitions, which have been silently lurking. They're sometimes identical, and sometimes one is the desired one.

Also, improve the default behavior of `Portal.addPart` and `Portal.saveParts` to route to the default portal for the container, which may not always be `portal.default`. We used to silently move them to the "real" portal on every portal page load.

#### Changes
* Improve heuristics for default portal page imports from folder archives based on the current folder type
* Default to update the portal default for the container, not assuming it's always `portal.default`
