### PR TITLE
Add option to retry failed data source connections

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1721,6 +1721,13 @@ public class DbScope
         }
     }
 
+    public static @NotNull Set<String> getDataSourceNames()
+    {
+        return getLoaders().stream()
+            .map(DbScopeLoader::getDsName)
+            .collect(Collectors.toSet());
+    }
+
     /**
      * Ensures that initialization has been attempted on all DbScopes and returns those that were successfully initialized
      * @return A collection of DbScopes
@@ -1730,7 +1737,7 @@ public class DbScope
         return getLoaders().stream()
             .map(DbScopeLoader::get)
             .filter(Objects::nonNull)
-            .collect(Collectors.toUnmodifiableList());
+            .toList();
     }
 
     /**
@@ -1742,7 +1749,7 @@ public class DbScope
     {
         return getDbScopes().stream()
             .filter(scope->scope.getSqlDialect().shouldTest())
-            .collect(Collectors.toUnmodifiableList());
+            .toList();
     }
 
     /**
@@ -1754,7 +1761,18 @@ public class DbScope
         return getLoaders().stream()
             .map(DbScopeLoader::getIfPresent)
             .filter(Objects::nonNull)
-            .collect(Collectors.toUnmodifiableList());
+            .toList();
+    }
+
+    /**
+     * Clear out the DbScopeLoaders that previously failed to connect to their data source. Next call to getDbScopes()
+     * will attempt to retry those failed connections.
+     */
+    public static void clearFailedDbScopes()
+    {
+        getLoaders().stream()
+            .filter(DbScopeLoader::isFailed)
+            .forEach(DbScopeLoader::clearDbScope);
     }
 
     /** Shuts down any connections associated with DbScopes that have been handed out to the current thread */

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -478,12 +478,12 @@ public class QueryController extends SpringActionController
             return urlExternalSchemaAdmin(c, null);
         }
 
-        public ActionURL urlExternalSchemaAdmin(Container c, @Nullable String reloadedSchema)
+        public ActionURL urlExternalSchemaAdmin(Container c, @Nullable String message)
         {
             ActionURL url = new ActionURL(AdminAction.class, c);
 
-            if (null != reloadedSchema)
-                url.addParameter("reloadedSchema", reloadedSchema);
+            if (null != message)
+                url.addParameter("message", message);
 
             return url;
         }
@@ -5358,7 +5358,7 @@ public class QueryController extends SpringActionController
         @Override
         public ActionURL getSuccessURL(SchemaForm form)
         {
-            return new QueryUrlsImpl().urlExternalSchemaAdmin(getContainer(), _userSchemaName);
+            return new QueryUrlsImpl().urlExternalSchemaAdmin(getContainer(), "Schema " + _userSchemaName + " was reloaded successfully.");
         }
     }
 
@@ -5381,10 +5381,31 @@ public class QueryController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(Object o)
         {
-            return new QueryUrlsImpl().urlExternalSchemaAdmin(getContainer(), "ALL");
+            return new QueryUrlsImpl().urlExternalSchemaAdmin(getContainer(), "All schemas in this folder were reloaded successfully.");
         }
     }
 
+    @RequiresPermission(AdminPermission.class)
+    public static class ReloadFailedConnectionsAction extends FormHandlerAction<Object>
+    {
+        @Override
+        public void validateCommand(Object target, Errors errors)
+        {
+        }
+
+        @Override
+        public boolean handlePost(Object o, BindException errors)
+        {
+            DbScope.clearFailedDbScopes();
+            return true;
+        }
+
+        @Override
+        public URLHelper getSuccessURL(Object o)
+        {
+            return new QueryUrlsImpl().urlExternalSchemaAdmin(getContainer(), "Reconnection was attempted on all data sources that failed previous connection attempts.");
+        }
+    }
 
     @RequiresPermission(ReadPermission.class)
     public static class TableInfoAction extends SimpleViewAction<TableInfoForm>


### PR DESCRIPTION
#### Rationale
Up until now, LabKey would attempt one connection to each data source. If that connection failed (e.g., database not currently online) the data source would be unavailable until the server was restarted. This PR adds a link on the external schema admin page that tries to re-connect to every data source that failed previous connection attempts. This is useful for development and testing of external data sources, and may be occasionally useful on production servers. This also updates the external schema grid to distinguish data sources that don't exist in `labkey.xml` from those that exist but have failed their connection attempt(s).

![image](https://user-images.githubusercontent.com/5107383/216723462-86139d75-e151-4982-bf77-c479beb7c3dc.png)

