### PR TITLE
Always use Jackson serialization for SimpleResponse

### DIFF
--- a/api/src/org/labkey/api/action/ApiJsonWriter.java
+++ b/api/src/org/labkey/api/action/ApiJsonWriter.java
@@ -200,13 +200,14 @@ public class ApiJsonWriter extends ApiResponseWriter
         {
             jg.writeString(DateUtil.formatJsonDateTime((Date) value));
         }
-        else if (!isSerializeViaJacksonAnnotations())
+        // Always use Jackson serialization for SimpleResponse, Issue 47216
+        else if (isSerializeViaJacksonAnnotations() || value instanceof SimpleResponse<?>)
         {
-            jg.writeString(value.toString());
+            jg.writeObject(value);
         }
         else
         {
-            jg.writeObject(value);
+            jg.writeString(value.toString());
         }
 
         // 21112: Malformed JSON response in production environments


### PR DESCRIPTION
#### Rationale
Nothing good will come from returning `SimpleResponse.toString()` to callers. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47216

#### Changes
* Always use Jackson serialization for SimpleResponse
* Invert `if/else` for readability