### PR TITLE
Issue 46618: Add "hasSortKey" to column QueryInfo metadata

### DIFF
--- a/api/src/org/labkey/api/data/JsonWriter.java
+++ b/api/src/org/labkey/api/data/JsonWriter.java
@@ -166,6 +166,8 @@ public class JsonWriter
         props.put("phiProtected", cinfo instanceof PhiTransformedColumnInfo);
         props.put("excludeFromShifting", cinfo != null && cinfo.isExcludeFromShifting());
         props.put("sortable", dc.isSortable());
+        // Issue 46618: Indicate if this column has an additional sort key applied
+        props.put("hasSortKey", cinfo != null && cinfo.getSortFieldKeys() != null && !cinfo.getSortFieldKeys().isEmpty());
         props.put("filterable", dc.isFilterable());
         props.put("scannable", cinfo != null && cinfo.isScannable());
 


### PR DESCRIPTION
#### Rationale
This addresses [Issue 46618](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46618) where QuerySelect-based dropdowns in our applications were not respecting the `<sortColumn>` property that is definable on XML query metadata for a column. This adds a new property `hasSortKey` to the `query-getQueryDetails.api` endpoint for column metadata which can be relied upon to determine if a column has sort keys already applied at query time.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1098
- https://github.com/LabKey/labkey-ui-premium/pull/37
- https://github.com/LabKey/platform/pull/4095
- https://github.com/LabKey/biologics/pull/1910
- https://github.com/LabKey/inventory/pull/718
- https://github.com/LabKey/sampleManagement/pull/1591

#### Changes
* Add the `hasSortKey` property to the `query-getQueryDetails.api` endpoint as a part of column metadata.