### PR TITLE
Issue 46449: Push inactive users to the bottom of the impersonate user drop-down list

### DIFF
--- a/core/webapp/Impersonate.js
+++ b/core/webapp/Impersonate.js
@@ -15,6 +15,9 @@ Ext4.define('LABKEY.Security.ImpersonateUser', {
     impersonatePath: LABKEY.user.isAdmin || LABKEY.project === undefined ? LABKEY.container.path : LABKEY.project.path,
 
     initComponent : function() {
+        Ext4.tip.QuickTipManager.init();
+        Ext4.apply(Ext4.tip.QuickTipManager.getQuickTip(), { minWidth: 275 });
+
         this.buttons = ['->', {
             text: 'Cancel',
             scope: this,
@@ -66,7 +69,7 @@ Ext4.define('LABKEY.Security.ImpersonateUser', {
                     '<tpl if="active">',
                         '<div class="x4-boundlist-item">{email:htmlEncode} ({displayName:htmlEncode})</div>',
                     '<tpl else>',
-                        '<div data-qtip="Inactive users can\'t be impersonated" class="x4-boundlist-item x4-item-disabled" style="color: #999999;">{email:htmlEncode} ({displayName:htmlEncode})</div>',
+                        '<div data-qtip="Inactive users can\'t be impersonated." class="x4-boundlist-item x4-item-disabled" style="color: #999999;">{email:htmlEncode} ({displayName:htmlEncode})</div>',
                     '</tpl>',
                 '</tpl>')
         });


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46449
Changes from the related PR made improvements to the display of inactive users in the impersonate users modal dropdown input. This PR increases the width of the hover tooltip that is displayed when you hover over an inactive users in the dropdown so that the text is not truncated to a single line.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/3918

#### Changes
- increase width of hover tooltip for inactive users in impersonate users modal dropdown
