### PR TITLE
Issue 47255: Create a metric to differentiate Java and file-based modules

### DIFF
--- a/api/src/org/labkey/api/util/UsageReportingLevel.java
+++ b/api/src/org/labkey/api/util/UsageReportingLevel.java
@@ -261,6 +261,7 @@ public enum UsageReportingLevel implements SafeToRenderEnum
             moduleBuildInfo.put("vcsBranch", module.getVcsBranch());
             moduleBuildInfo.put("vcsRevision", module.getVcsRevision());
             moduleBuildInfo.put("vcsTag", module.getVcsTag());
+            moduleBuildInfo.put("moduleClass", module.getClass().getName());
             moduleBuildInfo.put("version", module.getFormattedSchemaVersion()); // TODO: call this "schemaVersion"? Also send "releaseVersion"?
 
             // Add to the module's info to be included in the submission


### PR DESCRIPTION
#### Rationale
We want more insight into what kinds of custom modules are getting built and deployed

#### Changes
* Track the main module class name. For file-based modules, it will be `org.labkey.api.module.SimpleModule`