### PR TITLE
Issue 47245: Samples with a recomputeRollup value of "true" remain in the system

### DIFF
--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -212,4 +212,7 @@ public interface SampleTypeService
 
     String getOperationNotPermittedMessage(Collection<? extends ExpMaterial> samples, SampleOperations operation);
 
+    int resetRecomputeFlagForNonParents(ExpSampleType sampleType, Container container) throws IllegalStateException, SQLException;
+
+    long getRecomputeRollupRowCount(ExpSampleType sampleType, Container container);
 }

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-23.000-23.001.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-23.000-23.001.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('cleanUpAliquotRecomputeFlag');

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-23.000-23.001.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-23.000-23.001.sql
@@ -1,0 +1,1 @@
+EXEC core.executeJavaUpgradeCode 'cleanUpAliquotRecomputeFlag';

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -164,7 +164,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     public Double getSchemaVersion()
     {
-        return 23.000;
+        return 23.001;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -21,6 +21,8 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.PropertyStorageSpec;
@@ -33,17 +35,22 @@ import org.labkey.api.data.TableChange;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.UpgradeCode;
+import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.PropertyService;
+import org.labkey.api.inventory.InventoryService;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.query.FieldKey;
 import org.labkey.experiment.api.ExpSampleTypeImpl;
 import org.labkey.experiment.api.ExperimentServiceImpl;
 import org.labkey.experiment.api.MaterialSource;
 import org.labkey.api.exp.api.SampleTypeDomainKind;
+import org.labkey.experiment.api.SampleTypeServiceImpl;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -235,4 +242,88 @@ public class ExperimentUpgradeCode implements UpgradeCode
         int count = new SqlExecutor(scope).execute(update);
         LOG.info("Sample type '" + st.getName() + "' (" + st.getRowId() + ") updated 'name' column, count=" + count);
     }
+
+    private static Map<String, List<String>> findContainersWithAliquotRecomputes()
+    {
+        SQLFragment sql = new SQLFragment()
+                .append("SELECT distinct cpastype, container\n")
+                .append("FROM ").append(ExperimentService.get().getTinfoMaterial(), "m").append("\n")
+                .append("WHERE m.recomputerollup = ?")
+                .add(true);
+
+        @NotNull Map<String, Object>[] results = new SqlSelector(ExperimentService.get().getSchema(), sql).getMapArray();
+        if (results.length > 0)
+        {
+            Map<String, List<String>> containerSampleTypes = new HashMap<>();
+            for (Map<String, Object> result : results)
+            {
+                String container = (String) result.get("container");
+                String cpastype = (String) result.get("cpastype");
+                containerSampleTypes.putIfAbsent(container, new ArrayList<>());
+                containerSampleTypes.get(container).add(cpastype);
+            }
+            return containerSampleTypes;
+        }
+
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Called from exp-22.003-20.004.sql
+     */
+    public static void cleanUpAliquotRecomputeFlag(ModuleContext context)
+    {
+        if (context.isNewInstall())
+            return;
+
+        DbScope scope = ExperimentService.get().getSchema().getScope();
+        try (DbScope.Transaction transaction = scope.ensureTransaction())
+        {
+            InventoryService inventoryService = InventoryService.get();
+            SampleTypeService sampleTypeService = SampleTypeService.get();
+            Map<String, List<String>> containerSampleTypes = findContainersWithAliquotRecomputes();
+            for (String containerId : containerSampleTypes.keySet())
+            {
+                Container container = ContainerManager.getForId(containerId);
+                if (container == null)
+                    continue;
+
+                List<String> sampleTypes = containerSampleTypes.get(containerId);
+                LOG.info("** starting cleaning up exp.material.recalcFlag in folder: " + container.getPath());
+
+                try
+                {
+                    for (String sampleTypeLsid : sampleTypes)
+                    {
+                        ExpSampleType sampleType = sampleTypeService.getSampleType(sampleTypeLsid);
+                        if (sampleType == null)
+                            continue;
+
+                        int cleanedUpCount = sampleTypeService.resetRecomputeFlagForNonParents(sampleType, container);
+                        if (cleanedUpCount > 0)
+                            LOG.info("*** cleaned up RecomputeRollup flag for " + cleanedUpCount + " " + sampleType.getName() + " sample(s) in folder: " + container.getPath());
+                        if (inventoryService != null)
+                        {
+                            int syncedCount = inventoryService.recomputeSampleTypeRollup(sampleType, container, false);
+                            if (syncedCount > 0)
+                                LOG.info("*** recalculated aliquot roll-up for " + cleanedUpCount + " " + sampleType.getName() + " sample(s) in folder: " + container.getPath());
+                        }
+                    }
+                }
+                catch (SQLException e)
+                {
+                    throw new RuntimeException(e);
+                }
+
+                LOG.info("** finished cleaning up exp.material.recalcFlag in folder: " + container.getPath());
+            }
+
+            transaction.commit();
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
 }

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -269,7 +269,7 @@ public class ExperimentUpgradeCode implements UpgradeCode
     }
 
     /**
-     * Called from exp-22.003-20.004.sql
+     * Called from exp-23.000-23.001.sql
      */
     public static void cleanUpAliquotRecomputeFlag(ModuleContext context)
     {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1286,7 +1286,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         return message + " " + operation.getDescription() + ".";
     }
 
-    private Collection<Integer> _getNonAliquotParentsWithRecalcSql(String sampleTypeLsid, Container container) throws SQLException
+    private Collection<Integer> getNonAliquotParentsWithRecalcSql(String sampleTypeLsid, Container container) throws SQLException
     {
         SQLFragment sql = new SQLFragment(
                 """
@@ -1298,7 +1298,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                             AND parent.cpastype = ?"""
         );
 
-        sql.add(container.getId());
+        sql.add(container);
         sql.add(true);
         sql.add(sampleTypeLsid);
 
@@ -1312,7 +1312,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         return parentIds;
     }
 
-    private int _resetRecomputeFlagForNonParents(Collection<Integer> parentIds)
+    private int resetRecomputeFlagForNonParents(Collection<Integer> parentIds)
     {
         if (!parentIds.isEmpty())
         {
@@ -1339,8 +1339,8 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     @Override
     public int resetRecomputeFlagForNonParents(ExpSampleType sampleType, Container container) throws IllegalStateException, SQLException
     {
-        Collection<Integer> parentIds = _getNonAliquotParentsWithRecalcSql(sampleType.getLSID(), container);
-        return _resetRecomputeFlagForNonParents(parentIds);
+        Collection<Integer> parentIds = getNonAliquotParentsWithRecalcSql(sampleType.getLSID(), container);
+        return resetRecomputeFlagForNonParents(parentIds);
     }
 
     @Override
@@ -1350,7 +1350,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         SQLFragment sql = new SQLFragment("SELECT DISTINCT rowId FROM exp.material WHERE RecomputeRollup=" + s.getSqlDialect().getBooleanTRUE());
         sql.append(" AND cpastype = ? AND container = ?");
         sql.add(sampleType.getLSID());
-        sql.add(container.getId());
+        sql.add(container);
         return new SqlSelector(s, sql).getRowCount();
     }
 


### PR DESCRIPTION
#### Rationale
Certain inventory insert/update events resulted in samples that are not aliquot parents being marked as need recalc. For those events, we indiscriminately marked a sample as need recalc, if itself is not an aliquot. In reality, only root samples with aliquots ever needs rollup recalc. On action complete, the code to recal only handled parent samples, resulting in orphaned true recomputeRollup samples in system. Those orphaned records slows down every sample insert/update actions, signaling the need to recalc, but never got cleaned up. 

This PR aim to prevent those orphaned records and clean up existing ones.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/4104
- https://github.com/LabKey/inventory/pull/725

#### Changes
- upgrade script to clean up orphaned recomputeRollup=true samples
- move RecomputeAliquotRollup here from InventoryController, with additional handling of clean up orphaned records
