### PR TITLE
Issue 47276: Bootstrap server does not contain Project web part on home page

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -593,7 +593,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
         synchronized (_modulesLock)
         {
             for (ModuleContext context : getAllModuleContexts())
-                _moduleContextMap.put(context.getName(), context);
+                _moduleContextMap.putIfAbsent(context.getName(), context); // Don't replace the "Core" context otherwise we'll overwrite its _newInstall and _originalVersion properties
 
             // Refresh our list of modules as some may have been filtered out based on dependencies or DB platform
             modules = getModules();

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -608,23 +608,26 @@ public class ModuleLoader implements Filter, MemTrackerListener
                     _moduleContextMap.put(module.getName(), context);
                 }
 
-                if (context.needsUpgrade(module.getSchemaVersion()))
+                if (context.getModuleState() != ModuleState.ReadyToStart) // If upgraded, core module is ready-to-start
                 {
-                    context.setModuleState(ModuleState.InstallRequired);
-                    modulesRequiringUpgrade.add(context.getName());
-                }
-                else
-                {
-                    context.setModuleState(ModuleState.ReadyToStart);
+                    if (context.needsUpgrade(module.getSchemaVersion()))
+                    {
+                        context.setModuleState(ModuleState.InstallRequired);
+                        modulesRequiringUpgrade.add(context.getName());
+                    }
+                    else
+                    {
+                        context.setModuleState(ModuleState.ReadyToStart);
 
-                    // Module doesn't require an upgrade, but we still need to check if schemas in this module require upgrade.
-                    // The scenario is a schema in an external data source that needs to be installed or upgraded.
-                    List<String> schemasInThisModule = additionalSchemasRequiringUpgrade(module);
-                    additionalSchemasRequiringUpgrade.addAll(schemasInThisModule);
+                        // Module doesn't require an upgrade, but we still need to check if schemas in this module require upgrade.
+                        // The scenario is a schema in an external data source that needs to be installed or upgraded.
+                        List<String> schemasInThisModule = additionalSchemasRequiringUpgrade(module);
+                        additionalSchemasRequiringUpgrade.addAll(schemasInThisModule);
 
-                    // Also check for module "downgrades" so we can warn admins, #30773
-                    if (context.isDowngrade(module.getSchemaVersion()))
-                        downgradedModules.add(context.getName());
+                        // Also check for module "downgrades" so we can warn admins, #30773
+                        if (context.isDowngrade(module.getSchemaVersion()))
+                            downgradedModules.add(context.getName());
+                    }
                 }
             }
 

--- a/core/resources/schemas/dbscripts/postgresql/prop-23.002-23.003.sql
+++ b/core/resources/schemas/dbscripts/postgresql/prop-23.002-23.003.sql
@@ -14,7 +14,9 @@ WHERE PortalPageId IN (SELECT pp1.RowId
                                 INNER JOIN prop.PropertySets ps
                                            on ps.ObjectId = pp1.Container and ps.Category = 'folderType'
                                 INNER JOIN prop.Properties p
-                                           on ps."set" = p."set" and p.Name = 'name' and p.Value != 'None');
+                                           on ps."set" = p."set" and p.Name = 'name' and p.Value != 'None')
+-- Menu bars are always stored in 'portal.default' regardless of the rest of the portal layout
+AND Location != 'menubar';
 
 -- And then the page itself
 DELETE FROM core.PortalPages
@@ -27,4 +29,5 @@ WHERE RowId IN (SELECT pp1.RowId
                          INNER JOIN prop.PropertySets ps
                                     on ps.ObjectId = pp1.Container and ps.Category = 'folderType'
                          INNER JOIN prop.Properties p
-                                    on ps."set" = p."set" and p.Name = 'name' and p.Value != 'None');
+                                    on ps."set" = p."set" and p.Name = 'name' and p.Value != 'None')
+AND RowId NOT IN (SELECT pwp.PortalPageId FROM core.PortalWebparts pwp);

--- a/core/resources/schemas/dbscripts/sqlserver/prop-23.002-23.003.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/prop-23.002-23.003.sql
@@ -14,7 +14,9 @@ WHERE PortalPageId IN (SELECT pp1.RowId
                                 INNER JOIN prop.PropertySets ps
                                            on ps.ObjectId = pp1.Container and ps.Category = 'folderType'
                                 INNER JOIN prop.Properties p
-                                           on ps."set" = p."set" and p.Name = 'name' and p.Value != 'None');
+                                           on ps."set" = p."set" and p.Name = 'name' and p.Value != 'None')
+-- Menu bars are always stored in 'portal.default' regardless of the rest of the portal layout
+AND Location != 'menubar';
 
 -- And then the page itself
 DELETE FROM core.PortalPages
@@ -27,4 +29,5 @@ WHERE RowId IN (SELECT pp1.RowId
                          INNER JOIN prop.PropertySets ps
                                     on ps.ObjectId = pp1.Container and ps.Category = 'folderType'
                          INNER JOIN prop.Properties p
-                                    on ps."set" = p."set" and p.Name = 'name' and p.Value != 'None');
+                                    on ps."set" = p."set" and p.Name = 'name' and p.Value != 'None')
+AND RowId NOT IN (SELECT pwp.PortalPageId FROM core.PortalWebparts pwp);

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -294,6 +294,7 @@ import static org.labkey.api.settings.StashedStartupProperties.siteAvailableEmai
 public class CoreModule extends SpringModule implements SearchService.DocumentProvider
 {
     private static final Logger LOG = LogHelper.getLogger(CoreModule.class, "Errors during server startup and shut down");
+    public static final String PROJECTS_WEB_PART_NAME = "Projects";
 
     static
     {
@@ -309,6 +310,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
     }
 
     private CoreWarningProvider _warningProvider;
+    private boolean _bootstrapping = false;
 
     @Override
     public boolean hasScripts()
@@ -612,7 +614,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                     return false;
                 }
             },
-            new AlwaysAvailableWebPartFactory("Projects", WebPartFactory.LOCATION_BODY, WebPartFactory.LOCATION_RIGHT)
+            new AlwaysAvailableWebPartFactory(PROJECTS_WEB_PART_NAME, WebPartFactory.LOCATION_BODY, WebPartFactory.LOCATION_RIGHT)
             {
                 @Override
                 public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull WebPart webPart)
@@ -757,6 +759,11 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
 
     private void bootstrap()
     {
+        // We need to do some bootstrapping later in the process, after folder types have been registered in
+        // startupAfterSpringConfig(). By then the ModuleContext will no longer consider this a new install, so remember
+        // the state for ourselves
+        _bootstrapping = true;
+
         // Create the initial groups
         GroupManager.bootstrapGroup(Group.groupAdministrators, "Administrators");
         GroupManager.bootstrapGroup(Group.groupUsers, "Users");
@@ -785,7 +792,6 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         // Users & guests can read from /home
         Container home = ContainerManager.bootstrapContainer(ContainerManager.HOME_PROJECT_PATH, readerRole, readerRole, null);
         home.setFolderType(collaborationType, null);
-        addWebPart("Projects", home, HttpView.BODY, 0); // Wiki module used to do this, but it's optional now. If wiki isn't present, at least we'll have the projects webpart.
 
         ContainerManager.createDefaultSupportContainer().setFolderType(collaborationType, (User)null);
 
@@ -843,6 +849,18 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         SecurityManager.init();
         FolderTypeManager.get().registerFolderType(this, FolderType.NONE);
         FolderTypeManager.get().registerFolderType(this, new CollaborationFolderType());
+
+        if (_bootstrapping)
+        {
+            // In order to initialize the portal layout correctly, we need to add the web parts after the folder
+            // types have been registered. Thus, needs to be here in startupAfterSpringConfig() instead of grouped
+            // in bootstrap()
+            Container homeContainer = ContainerManager.getHomeContainer();
+            int count = Portal.getParts(homeContainer, homeContainer.getFolderType().getDefaultPageId(homeContainer)).size();
+            addWebPart(PROJECTS_WEB_PART_NAME, homeContainer, HttpView.BODY, count);
+            _bootstrapping = false;
+        }
+
         EmailService.setInstance(new EmailServiceImpl());
 
         if (null != AuditLogService.get() && AuditLogService.get().getClass() != DefaultAuditProvider.class)


### PR DESCRIPTION
#### Rationale
The portal page legacy code cleanup impacted the layout for bootstrapped servers too, due to the sequence in which the portal is initialized vs when folder types are registered.

Also fixes [Issue 47299: Custom header menus disappeared on upgrade to 23.2](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47299)

#### Changes
* Move adding the project web part a little later in the startup sequence so that folder types are available
* Don't delete menubar items from `portal.default` pages