### PR TITLE
Explicit cast to a VARCHAR to avoid JSONB problems

### DIFF
--- a/core/src/org/labkey/core/view/external/tools/ExternalToolsViewServiceImpl.java
+++ b/core/src/org/labkey/core/view/external/tools/ExternalToolsViewServiceImpl.java
@@ -4,12 +4,12 @@ import org.labkey.api.external.tools.ExternalToolsViewProvider;
 import org.labkey.api.external.tools.ExternalToolsViewService;
 
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class ExternalToolsViewServiceImpl implements ExternalToolsViewService
 {
-    private List<ExternalToolsViewProvider> _externalToolsViewProvider = new LinkedList<>();
+    private List<ExternalToolsViewProvider> _externalToolsViewProvider = new CopyOnWriteArrayList<>();
 
     @Override
     public void registerExternalAccessViewProvider(ExternalToolsViewProvider provider)

--- a/mothership/resources/queries/mothership/recentJsonMetricValues.sql
+++ b/mothership/resources/queries/mothership/recentJsonMetricValues.sql
@@ -28,7 +28,7 @@ SELECT
        DisplayKey,
        '{' || SelectKey || '}' AS SelectKey,
        Value,
-       CASE WHEN Type = 'string' THEN Value END AS StringValue,
+       CAST(CASE WHEN Type = 'string' THEN Value END AS VARCHAR) AS StringValue,
        CAST(CASE WHEN Type = 'number' THEN Value END AS DECIMAL) AS NumberValue,
        CAST(CASE WHEN Type = 'boolean' THEN Value END AS BOOLEAN) AS BooleanValue,
        CASE WHEN Type = 'object' THEN Value END AS ObjectValue,


### PR DESCRIPTION
#### Rationale
I sometimes get SQLExceptions when filtering on the StringValue column in recentJsonMetricValues, because Postgres is confused about JSONB vs VARCHAR

#### Changes
* Force to VARCHAR via a CAST