### PR TITLE
Issue 47195: Enterprise pipeline temp directories are not always cleaned up

### DIFF
--- a/api/src/org/labkey/api/pipeline/LocalDirectory.java
+++ b/api/src/org/labkey/api/pipeline/LocalDirectory.java
@@ -65,7 +65,7 @@ public class LocalDirectory implements Serializable
     {
         return !root.isCloudRoot() ?
                 new LocalDirectory(workingDir.toFile(), moduleName, baseLogFileName) :
-                new LocalDirectory(root.getContainer(), moduleName, root, baseLogFileName, workingDir);
+                new LocalDirectory(root.getContainer(), moduleName, root, baseLogFileName);
     }
 
     @JsonCreator

--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -1098,12 +1098,7 @@ abstract public class PipelineJob extends Job implements Serializable
         }
         finally
         {
-            // The non-enterprise pipeline will invoke this via JobRunner.afterExecute()
-            // This results in the done event being slightly out of order, but better than where it was.
-            if (PipelineService.get().isEnterprisePipeline())
-            {
-                done(null);
-            }
+            PipelineService.get().getPipelineQueue().almostDone(this);
 
             ThreadContext.remove(CorrelationIdentifier.getTraceIdKey());
             ThreadContext.remove(CorrelationIdentifier.getSpanIdKey());

--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -434,17 +434,6 @@ abstract public class PipelineJob extends Job implements Serializable
         return _pipeRoot;
     }
 
-    /**
-     * Set Log file path and clear/reset logger
-     */
-    private void updateLogFilePath(Path logFile)
-    {
-        _logger = null; //This should trigger getting the new Logger next time getLogger is called
-        _logFile = logFile;
-
-        // Intentionally leave any existing log output in the file
-    }
-
     @Deprecated //Please switch to the Path version
     public void setLogFile(File logFile)
     {
@@ -453,9 +442,9 @@ abstract public class PipelineJob extends Job implements Serializable
 
     public void setLogFile(Path logFile)
     {
-        Path normalizedPath = logFile.toAbsolutePath().normalize();
-        updateLogFilePath(normalizedPath);
-        _logFile = normalizedPath;
+        // Set Log file path and clear/reset logger
+        _logFile = logFile.toAbsolutePath().normalize();;
+        _logger = null; //This should trigger getting the new Logger next time getLogger is called
     }
 
     public File getLogFile()
@@ -1119,7 +1108,7 @@ abstract public class PipelineJob extends Job implements Serializable
     // Should be called in run()'s finally by any class that overrides run(), if class uses LocalDirectory
     protected void finallyCleanUpLocalDirectory()
     {
-        if (null != _localDirectory & isDone())
+        if (null != _localDirectory && isDone())
         {
             try
             {
@@ -1882,8 +1871,6 @@ abstract public class PipelineJob extends Job implements Serializable
         PipelineJobNotificationProvider notificationProvider = PipelineService.get().getPipelineJobNotificationProvider(getJobNotificationProvider(), this);
         if (notificationProvider != null)
             notificationProvider.onJobDone(this);
-
-        finallyCleanUpLocalDirectory();  //Since this potentially contains the job log, it should be run after the notifications tasks are executed
     }
 
     protected String getJobNotificationProvider()

--- a/api/src/org/labkey/api/pipeline/PipelineQueue.java
+++ b/api/src/org/labkey/api/pipeline/PipelineQueue.java
@@ -105,4 +105,9 @@ public interface PipelineQueue
     /** @return the position of each job in the queue, keyed by the job's GUID of the status file */
     @NotNull
     Map<String, Integer> getQueuePositions();
+
+    /**
+     * Queue event that should be called just prior to finishing a job
+     */
+    void almostDone(PipelineJob pipelineJob);
 }

--- a/api/src/org/labkey/api/util/Job.java
+++ b/api/src/org/labkey/api/util/Job.java
@@ -16,6 +16,8 @@
 
 package org.labkey.api.util;
 
+import org.labkey.api.pipeline.PipelineService;
+
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -68,7 +70,14 @@ public abstract class Job implements Future, Runnable
     @Override
     public boolean isDone()
     {
-        if (_task == null) throw new IllegalStateException("job has not been submitted");
+        if (_task == null)
+        {
+            // Override and return true for enterprise pipeline if there is no activeTaskId.
+            if (PipelineService.get().isEnterprisePipeline()) return true;
+
+            //Else throw an error.
+            throw new IllegalStateException("job has not been submitted");
+        }
         return _task.isDone();
     }
 

--- a/core/src/org/labkey/core/admin/CopyFileRootPipelineJob.java
+++ b/core/src/org/labkey/core/admin/CopyFileRootPipelineJob.java
@@ -158,12 +158,7 @@ public class CopyFileRootPipelineJob extends PipelineJob
         }
         finally
         {
-            // The non-enterprise pipeline will invoke this via JobRunner.afterExecute()
-            // This results in the done event being slightly out of order, but better than where it was.
-            if (PipelineService.get().isEnterprisePipeline())
-            {
-                done(null);
-            }
+            PipelineService.get().getPipelineQueue().almostDone(this);
         }
     }
 

--- a/core/src/org/labkey/core/admin/CopyFileRootPipelineJob.java
+++ b/core/src/org/labkey/core/admin/CopyFileRootPipelineJob.java
@@ -156,10 +156,6 @@ public class CopyFileRootPipelineJob extends PipelineJob
             error("Unexpected error; ending job.", e);
             setStatus(TaskStatus.error);
         }
-        finally
-        {
-            finallyCleanUpLocalDirectory();
-        }
     }
 
     private TaskStatus copyOneFolder(Container container, Path sourceDir, Path destDir, long startTime)

--- a/core/src/org/labkey/core/admin/CopyFileRootPipelineJob.java
+++ b/core/src/org/labkey/core/admin/CopyFileRootPipelineJob.java
@@ -156,6 +156,15 @@ public class CopyFileRootPipelineJob extends PipelineJob
             error("Unexpected error; ending job.", e);
             setStatus(TaskStatus.error);
         }
+        finally
+        {
+            // The non-enterprise pipeline will invoke this via JobRunner.afterExecute()
+            // This results in the done event being slightly out of order, but better than where it was.
+            if (PipelineService.get().isEnterprisePipeline())
+            {
+                done(null);
+            }
+        }
     }
 
     private TaskStatus copyOneFolder(Container container, Path sourceDir, Path destDir, long startTime)

--- a/pipeline/src/org/labkey/pipeline/api/PipelineQueueImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineQueueImpl.java
@@ -402,4 +402,10 @@ public class PipelineQueueImpl extends AbstractPipelineQueue
             assertEquals(jobs.length, counter.get());
         }
     }
+
+    @Override
+    public void almostDone(PipelineJob pipelineJob)
+    {
+        // Do nothing this should be handled by the Job's afterExecute event handlers
+    }
 }

--- a/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
@@ -228,12 +228,6 @@ public class PipelineStatusManager
         {
             // Count this error on the job.
             job.setErrors(job.getErrors() + 1);
-
-            // The non-enterprise pipeline will invoke this via JobRunner.afterExecute()
-            if (PipelineService.get().isEnterprisePipeline())
-            {
-                job.done(null);
-            }
         }
         else if (PipelineJob.TaskStatus.complete.matches(status))
         {
@@ -244,12 +238,6 @@ public class PipelineStatusManager
             // Notify if this is not a split job
             if (job.getParentGUID() == null)
                 PipelineManager.sendNotificationEmail(sfSet, job.getContainer(), user);
-
-            // The non-enterprise pipeline will invoke this via JobRunner.afterExecute()
-            if (PipelineService.get().isEnterprisePipeline())
-            {
-                job.done(null);
-            }
         }
         return true;
     }

--- a/pipeline/src/org/labkey/pipeline/mule/EPipelineQueueImpl.java
+++ b/pipeline/src/org/labkey/pipeline/mule/EPipelineQueueImpl.java
@@ -267,6 +267,7 @@ public class EPipelineQueueImpl extends AbstractPipelineQueue
         {
             try
             {
+                job.setSubmitted();  // Enterprise Pipeline jobs don't get submitted in the same fashion as the standard pipeline, so set the flag here
                 dispatchJob(job);
             }
             catch (UMOException e)

--- a/pipeline/src/org/labkey/pipeline/mule/EPipelineQueueImpl.java
+++ b/pipeline/src/org/labkey/pipeline/mule/EPipelineQueueImpl.java
@@ -370,4 +370,12 @@ public class EPipelineQueueImpl extends AbstractPipelineQueue
         }
         return result;
     }
+
+    @Override
+    public void almostDone(PipelineJob pipelineJob)
+    {
+        // The non-enterprise pipeline will invoke this via JobRunner.afterExecute()
+        // Calling this here results in the done event being slightly out of order, but better than where it was.
+        pipelineJob.done(null);
+    }
 }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47195

#### Related Pull Requests
* https://github.com/LabKey/MacCossLabModules/pull/311

#### Changes
* Removed cleanup call from done method
* Marked enterprise pipeline jobs submitted
* Adjusted LocalDirectory constructors
