### PR TITLE
Clean up file-based folder type handling

### DIFF
--- a/api/schemas/folderType.xsd
+++ b/api/schemas/folderType.xsd
@@ -17,11 +17,10 @@
         <xsd:element ref="ft:preferredWebParts" minOccurs="0" maxOccurs="1"/>
         <xsd:element ref="ft:folderTabs" minOccurs="0" maxOccurs="1"/>
         <xsd:element ref="ft:modules"  minOccurs="1" maxOccurs="1"/>
-        <xsd:element ref="ft:defaultModule" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="ft:defaultModule" minOccurs="0" maxOccurs="1"/>
         <xsd:element ref="ft:workbookType" minOccurs="0" maxOccurs="1" />
         <xsd:element ref="ft:forceAssayUploadIntoWorkbooks" minOccurs="0" maxOccurs="1"/>
         <xsd:element ref="ft:folderIconPath" minOccurs="0" maxOccurs="1"/>
-        <xsd:element ref="ft:menubarEnabled" minOccurs="0" maxOccurs="1"/>
       </xsd:sequence>
     </xsd:complexType>
 
@@ -69,8 +68,6 @@
     </xsd:element>
 
   <xsd:element name="description" type="xsd:string"/>
-
-  <xsd:element name="menubarEnabled" type="xsd:boolean"/>
 
   <xsd:element name="caption" type="xsd:string"/>
 

--- a/api/src/org/labkey/api/exp/property/TestDomainKind.java
+++ b/api/src/org/labkey/api/exp/property/TestDomainKind.java
@@ -16,7 +16,7 @@
 package org.labkey.api.exp.property;
 
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONObject;
+import org.json.JSONObject;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;

--- a/api/src/org/labkey/api/module/CustomFolderType.java
+++ b/api/src/org/labkey/api/module/CustomFolderType.java
@@ -244,12 +244,6 @@ public class CustomFolderType implements FolderType
     }
 
     @Override
-    public boolean isMenubarEnabled()
-    {
-        return false;
-    }
-
-    @Override
     public String getDefaultPageId(Container container)
     {
         return Portal.DEFAULT_PORTAL_PAGE_ID;

--- a/api/src/org/labkey/api/module/DefaultFolderType.java
+++ b/api/src/org/labkey/api/module/DefaultFolderType.java
@@ -59,7 +59,6 @@ public class DefaultFolderType implements FolderType
     protected boolean workbookType = false;
     protected String folderIconPath = DEFAULT_FOLDER_ICON_PATH;
     protected boolean forceAssayUploadIntoWorkbooks = false;
-    protected boolean menubarEnabled = false;
     protected List<FolderTab> _folderTabs = null;
 
     public static String DEFAULT_DASHBOARD = "DefaultDashboard";
@@ -497,12 +496,6 @@ public class DefaultFolderType implements FolderType
             if (tab.getLegacyNames().contains(caption))
                 return tab;
         return null;
-    }
-
-    @Override
-    public boolean isMenubarEnabled()
-    {
-        return menubarEnabled;
     }
 
     @Override

--- a/api/src/org/labkey/api/module/FolderType.java
+++ b/api/src/org/labkey/api/module/FolderType.java
@@ -117,11 +117,6 @@ public interface FolderType
     @Nullable String getHelpTopic();
 
     /**
-     * Whether the menu bar should be shown by default.
-     */
-    boolean isMenubarEnabled();
-
-    /**
      * Module that *owns* this folder. Used in constructing navigation paths. If current URL's module is NOT part of the owning module
      * extra links will be added to automatically generated nav path
      * @return Owning module. May be null

--- a/api/src/org/labkey/api/module/FolderTypeManager.java
+++ b/api/src/org/labkey/api/module/FolderTypeManager.java
@@ -271,7 +271,7 @@ public class FolderTypeManager
         {
             return unmodifiable(resources
                 .filter(getFilter(SIMPLE_TYPE_FILE_EXTENSION))
-                .map(SimpleFolderType::create)
+                .map(r -> SimpleFolderType.create(r, module))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList()));
         }

--- a/api/src/org/labkey/api/module/FolderTypeManager.java
+++ b/api/src/org/labkey/api/module/FolderTypeManager.java
@@ -37,6 +37,7 @@ import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -271,6 +272,7 @@ public class FolderTypeManager
             return unmodifiable(resources
                 .filter(getFilter(SIMPLE_TYPE_FILE_EXTENSION))
                 .map(SimpleFolderType::create)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList()));
         }
 

--- a/api/src/org/labkey/api/module/MultiPortalFolderType.java
+++ b/api/src/org/labkey/api/module/MultiPortalFolderType.java
@@ -30,6 +30,7 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.FolderTab;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.Portal;
+import org.labkey.api.view.Portal.WebPart;
 import org.labkey.api.view.SimpleFolderTab;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.menu.FolderAdminMenu;
@@ -51,12 +52,12 @@ public abstract class MultiPortalFolderType extends DefaultFolderType
     private final String _startUrl;
     protected FolderTab _defaultTab = null;
 
-    public MultiPortalFolderType(String name, String description, @Nullable List<Portal.WebPart> requiredParts, @Nullable List<Portal.WebPart> preferredParts, Set<Module> activeModules, Module defaultModule)
+    public MultiPortalFolderType(String name, String description, @Nullable List<WebPart> requiredParts, @Nullable List<WebPart> preferredParts, Set<Module> activeModules, Module defaultModule)
     {
         this(name, description, requiredParts, preferredParts, activeModules, defaultModule, null);
     }
 
-    public MultiPortalFolderType(String name, String description, @Nullable List<Portal.WebPart> requiredParts, @Nullable List<Portal.WebPart> preferredParts, Set<Module> activeModules, Module defaultModule, String startUrl)
+    public MultiPortalFolderType(String name, String description, @Nullable List<WebPart> requiredParts, @Nullable List<WebPart> preferredParts, Set<Module> activeModules, Module defaultModule, String startUrl)
     {
         super(name, description, requiredParts, preferredParts, activeModules, defaultModule);
         _startUrl = startUrl;
@@ -246,7 +247,8 @@ public abstract class MultiPortalFolderType extends DefaultFolderType
     }
 
     protected String getFolderTitle(ViewContext context)
-    {   // Default; often overridden
+    {
+        // Default; often overridden
         return context.getContainer().getTitle();
     }
 

--- a/core/src/org/labkey/core/admin/writer/FolderTypeWriterFactory.java
+++ b/core/src/org/labkey/core/admin/writer/FolderTypeWriterFactory.java
@@ -38,7 +38,7 @@ public class FolderTypeWriterFactory implements FolderWriterFactory
         return new FolderTypeWriter();
     }
 
-    public class FolderTypeWriter extends BaseFolderWriter
+    public static class FolderTypeWriter extends BaseFolderWriter
     {
         @Override
         public String getDataType()
@@ -64,6 +64,5 @@ public class FolderTypeWriterFactory implements FolderWriterFactory
                 modulesXml.addModuleName(module.getName());
             }
         }
-
     }
 }

--- a/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
+++ b/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
@@ -1452,7 +1452,7 @@ public class PropertyController extends SpringActionController
     /** @return Errors encountered during the save attempt */
     @NotNull
     private static ValidationException updateDomain(GWTDomain<? extends GWTPropertyDescriptor> original, GWTDomain<? extends GWTPropertyDescriptor> update,
-                                            @Nullable Object options, Container container, User user, boolean includeWarnings)
+                                            @Nullable JSONObject options, Container container, User user, boolean includeWarnings)
     {
         DomainKind kind = PropertyService.get().getDomainKind(original.getDomainURI());
         if (kind == null)
@@ -1465,9 +1465,14 @@ public class PropertyController extends SpringActionController
         if (!kind.canEditDefinition(user, domain))
             throw new UnauthorizedException("You don't have permission to edit this domain.");
 
-        if (JSONObject.class == kind.getTypeClass())
+        if (JSONObject.class == kind.getTypeClass()) // Old JSONObject. TODO: Remove this once all DomainKinds use new JSONObject
         {
             return kind.updateDomain(original, update, options, container, user, includeWarnings);
+        }
+        else if (org.json.JSONObject.class == kind.getTypeClass()) // New JSONObject
+        {
+            Object props = null != options ? options.toNewJSONObject() : null; // TODO: Remove this once new JSONObject is passed in
+            return kind.updateDomain(original, update, props, container, user, includeWarnings);
         }
         else
         {


### PR DESCRIPTION
#### Rationale
The `<menubarEnabled>` element of folder type XML files and `isMenubarEnabled()` method have been unused for years. We've never validated folder type XML files. And `SimpleFolderType` needed some improvement.

#### Changes
* Validate folder type XML files for XSD conformance. Validation failure results in a logged warning and unavailability of that folder type.
* Remove the unused `<menubarEnabled>` element and `isMenubarEnabled()` method.
* Stop requiring a `<defaultModule>` element. Default to the module providing this folder type.
* Clean up SimpleFolderType: stop parsing the XML twice, eliminate unnecessary getter overrides (just pass properties to `super` and use its getters).