### PR TITLE
Update merge participants page to also look for datasets by label

### DIFF
--- a/study/src/org/labkey/study/view/mergeParticipants.jsp
+++ b/study/src/org/labkey/study/view/mergeParticipants.jsp
@@ -199,7 +199,7 @@
         LABKEY.Query.selectRows({
             schemaName : 'study',
             queryName : 'Datasets',
-            columns: 'Name, DataSetId',
+            columns: 'Name, Label, DataSetId',
             sort: 'Name',
             success : function(details){
                 var rows = details.rows;
@@ -207,8 +207,10 @@
                 this.numDatasets = rows.length;
                 for (var i = 0; i < rows.length; i++) {
                     var name = rows[i].Name;
+                    var label = rows[i].Label;
                     this.tables[name] = {
                         name: name,
+                        label: label,
                         htmlName: Ext4.util.Format.htmlEncode(name),
                         datasetId : rows[i].DataSetId,
                         oldIds : [],
@@ -310,6 +312,14 @@
                 success: function (data)
                 {
                     var table = this.tables[data.queryName];
+                    if (!table) {
+                        table = Object.values(this.tables).find(v => v.label === data.queryName);
+                    }
+                    if (!table) {
+                        console.error("Dataset: " + tableName + " not found.");
+                        return;
+                    }
+
                     gatherIds(table, data.rows, checkTable.oldId, checkTable.newId);
                     table.hasConflict = false;
                     // if table has old ids, we know there's work that could be done and allow a merge


### PR DESCRIPTION
#### Rationale
mergeParticipants.jsp queries study.Datasets for datasets to check for Id updates and then perform the update using the dataset names.  When checking for the Id, selectRows returns the dataset title/label, if defined, so need to identify the table by the label if not found by name.

#### Changes
* Get dataset label
* Identify dataset by title/label if not found by name
