### PR TITLE
Move creation of audit events outside DomainImpl save() transaction (#4113)

### DIFF
--- a/api/src/org/labkey/api/data/SchemaTableInfoCache.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfoCache.java
@@ -111,7 +111,7 @@ public class SchemaTableInfoCache
 
     private static Cache<String, Wrapper<SchemaTableInfo>> createCache(DbScope scope, boolean provisioned)
     {
-        String comment = "SchemaTableInfos for " + (provisioned ? "provisioned" : "non-provisioned") + " schemas in scope \"" + scope.getDisplayName() + "\"";
+        String comment = "SchemaTableInfos for " + (provisioned ? "provisioned" : "non-provisioned") + " schemas in scope " + scope.getDisplayName();
 
         // We modify provisioned tables inside of transactions, so use a DatabaseCache to help with proper invalidation. See #46951.
         if (provisioned)


### PR DESCRIPTION
#### Rationale
Backport fix for deadlocks between domain save() and get()
Avoid quotes in cache names as it causes problems when exposed to JMX

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4113/files