### PR TITLE
Don't allow NULL values for pipeline.StatusFiles.FilePath

### DIFF
--- a/pipeline/resources/schemas/dbscripts/postgresql/pipeline-23.001-23.002.sql
+++ b/pipeline/resources/schemas/dbscripts/postgresql/pipeline-23.001-23.002.sql
@@ -1,0 +1,3 @@
+DELETE FROM pipeline.StatusFiles WHERE FilePath IS NULL;
+
+ALTER TABLE pipeline.StatusFiles ALTER COLUMN FilePath SET NOT NULL;

--- a/pipeline/resources/schemas/dbscripts/sqlserver/pipeline-23.001-23.002.sql
+++ b/pipeline/resources/schemas/dbscripts/sqlserver/pipeline-23.001-23.002.sql
@@ -1,0 +1,8 @@
+DELETE FROM pipeline.StatusFiles WHERE FilePath IS NULL;
+
+-- Make pipeline.StatusFiles.FilePath NOT NULL, dropping and recreating unique constraint
+ALTER TABLE pipeline.StatusFiles DROP CONSTRAINT UQ_StatusFiles_FilePath;
+
+ALTER TABLE pipeline.StatusFiles ALTER COLUMN FilePath NVARCHAR(1024) NOT NULL;
+
+ALTER TABLE pipeline.StatusFiles ADD CONSTRAINT UQ_StatusFiles_FilePath UNIQUE (FilePath);

--- a/pipeline/src/org/labkey/pipeline/PipelineModule.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineModule.java
@@ -112,7 +112,7 @@ public class PipelineModule extends SpringModule implements ContainerManager.Con
     @Override
     public Double getSchemaVersion()
     {
-        return 23.001;
+        return 23.002;
     }
 
     @Override

--- a/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
@@ -380,6 +380,11 @@ public class PipelineStatusManager
      */
     public static void updateStatusFile(PipelineStatusFileImpl sf, StatusFileField ... fields)
     {
+        if (sf.getFilePath() == null)
+        {
+            throw new IllegalArgumentException("Status file paths cannot be null, but was for entry with RowId " + sf.getRowId() + " and GUID " + sf.getJobId());
+        }
+
         DbScope scope = PipelineSchema.getInstance().getSchema().getScope();
         try (DbScope.Transaction transaction = scope.ensureTransaction(PipelineStatusManager.TRANSACTION_KIND))
         {


### PR DESCRIPTION
#### Rationale
We've never wanted to have null values in pipeline.StatusFile's FilePath column, but we've never explicitly prevented it. A recent support ticket had errors related to a null value. This won't prevent the root cause there, but it may make it easier to track down.

#### Changes
* Fail before attempting to update the value to null with other info about the row
* Make the column NOT NULL in the DB