### PR TITLE
Fix handling of JSONObject.NULL in ExcelFactory

### DIFF
--- a/api/src/org/labkey/api/reader/ExcelFactory.java
+++ b/api/src/org/labkey/api/reader/ExcelFactory.java
@@ -315,7 +315,8 @@ public class ExcelFactory
 
                 for (int colIndex = 0; colIndex < rowArray.length(); colIndex++)
                 {
-                    Object value = rowArray.get(colIndex);
+                    // NOTE: if the value is null, it is stored as JSONObject.NULL. check for this:
+                    Object value = rowArray.isNull(colIndex) ? null : rowArray.get(colIndex);
                     JSONObject metadataObject = null;
                     CellStyle cellStyle = defaultStyle;
                     if (value instanceof JSONObject)


### PR DESCRIPTION
#### Rationale
Need to handle `JSONObject.NULL`
