### PR TITLE
Fix participant report JSON id handling

### DIFF
--- a/study/src/org/labkey/study/reports/ParticipantReport.java
+++ b/study/src/org/labkey/study/reports/ParticipantReport.java
@@ -16,7 +16,6 @@
 package org.labkey.study.reports;
 
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.api.data.Container;
@@ -182,7 +181,7 @@ public class ParticipantReport extends AbstractReport
             {
                 String type = group.getString("type");
                 String label = group.getString("label");
-                int id = NumberUtils.toInt(group.getString("id"), -1);
+                int id = group.optInt("id", -1);
 
                 if (id == -1)
                 {


### PR DESCRIPTION
#### Rationale
`study.QuerySnapshotTest` is failing with a JSON error while parsing "id"

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4124