### PR TITLE
Less restrictive projects

### DIFF
--- a/api/src/org/labkey/api/data/AbstractForeignKey.java
+++ b/api/src/org/labkey/api/data/AbstractForeignKey.java
@@ -49,10 +49,9 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
     protected String _displayColumnName;
     private boolean _showAsPublicDependency = false;
 
-
-    // foreignKey lazily creates the target tableinfo, in order to do that it needs to know the container filter to use
-    // Some tables may chose to ignore/modify this container filter, but this indicates what the parent table/query/schema
-    // is using, and the lookup tableinfo may want to use it as well.
+    // foreignKey lazily creates the target TableInfo, in order to do that it needs to know the container filter to use
+    // Some tables may choose to ignore/modify this container filter, but this indicates what the parent table/query/schema
+    // is using, and the lookup TableInfo may want to use it as well.
     protected @Nullable ContainerFilter _containerFilter;
 
     // We will also want a DefaultSchema to use to construct the target schema/table (and check permissions)
@@ -72,13 +71,13 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
         _containerFilter = cf;
     }
     
-    protected AbstractForeignKey(QuerySchema sourceSchema, ContainerFilter cf, String tableName, String columnName)
+    protected AbstractForeignKey(QuerySchema sourceSchema, @Nullable ContainerFilter cf, String tableName, String columnName)
     {
         this(sourceSchema, cf, (SchemaKey)null, tableName, columnName, null);
     }
 
     @Deprecated
-    protected AbstractForeignKey(QuerySchema sourceSchema, ContainerFilter cf, @Nullable String lookupSchemaName, String tableName, @Nullable String columnName)
+    protected AbstractForeignKey(QuerySchema sourceSchema, @Nullable ContainerFilter cf, @Nullable String lookupSchemaName, String tableName, @Nullable String columnName)
     {
         this(sourceSchema, cf, null==lookupSchemaName?null:SchemaKey.fromString(lookupSchemaName), tableName, columnName, null);
     }
@@ -99,13 +98,7 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
         _displayColumnName = displayColumnName;
     }
 
-    /* this builder-ish method is used to help convert old anonymous subclasses */
-    public AbstractForeignKey setContainerFilter(ContainerFilter cf)
-    {
-        _containerFilter = cf;
-        return this;
-    }
-
+    @Nullable
     protected User getLookupUser()
     {
         if (null != _sourceSchema)
@@ -125,8 +118,8 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
         ContainerFilter cf = null;
         if (null != _containerFilter)
             cf = _containerFilter;
-        else if (_sourceSchema instanceof UserSchema)
-            cf = ((UserSchema)_sourceSchema).getDefaultContainerFilter();
+        else if (_sourceSchema instanceof UserSchema userSchema)
+            cf = userSchema.getDefaultLookupContainerFilter();
 
         if (null != _sourceSchema && _sourceSchema.getContainer().isWorkbook())
         {
@@ -312,6 +305,7 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
     }
 
     @Override
+    @Nullable
     public Set<FieldKey> getSuggestedColumns()
     {
         if (_suggestedFields == null)

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1700,8 +1700,8 @@ public class Container implements Serializable, Comparable<Container>, Securable
         if (isProject())
             return new ContainerFilter.CurrentAndSubfoldersPlusShared(this, user);
 
-        if (getProject() != null && !QueryService.get().isProductProjectsAllFolderScopeEnabled())
-            return new ContainerFilter.CurrentPlusProjectAndShared(this, user);
+        if (getProject() != null && QueryService.get().isProductProjectsAllFolderScopeEnabled())
+            return new ContainerFilter.AllInProjectPlusShared(this, user);
 
         return ContainerFilter.current(this);
     }

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1697,11 +1697,18 @@ public class Container implements Serializable, Comparable<Container>, Securable
         if (!isProductProjectsEnabled())
             return ContainerFilter.current(this);
 
+        if (QueryService.get().isProductProjectsAllFolderScopeEnabled())
+        {
+            if (isProject() || getProject() != null)
+                return new ContainerFilter.AllInProjectPlusShared(this, user);
+            return ContainerFilter.current(this);
+        }
+
         if (isProject())
             return new ContainerFilter.CurrentAndSubfoldersPlusShared(this, user);
 
-        if (getProject() != null && QueryService.get().isProductProjectsAllFolderScopeEnabled())
-            return new ContainerFilter.AllInProjectPlusShared(this, user);
+        if (getProject() != null)
+            return new ContainerFilter.CurrentPlusProjectAndShared(this, user);
 
         return ContainerFilter.current(this);
     }

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -37,6 +37,7 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.portal.ProjectUrls;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.reports.Report;
 import org.labkey.api.reports.ReportService;
 import org.labkey.api.security.HasPermission;
@@ -1698,7 +1699,8 @@ public class Container implements Serializable, Comparable<Container>, Securable
 
         if (isProject())
             return new ContainerFilter.CurrentAndSubfoldersPlusShared(this, user);
-        else if (!isProject() && getProject() != null)
+
+        if (getProject() != null && !QueryService.get().isProductProjectsAllFolderScopeEnabled())
             return new ContainerFilter.CurrentPlusProjectAndShared(this, user);
 
         return ContainerFilter.current(this);

--- a/api/src/org/labkey/api/data/ContainerFilter.java
+++ b/api/src/org/labkey/api/data/ContainerFilter.java
@@ -490,6 +490,14 @@ public abstract class ContainerFilter
                     {
                         return new AllInProject(container, user);
                     }
+                },
+        AllInProjectPlusShared("Current project, Shared project, and all folders in the current project")
+                {
+                    @Override
+                    public ContainerFilter create(Container container, User user)
+                    {
+                        return new AllInProjectPlusShared(container, user);
+                    }
                 };
 
 
@@ -1193,6 +1201,32 @@ public abstract class ContainerFilter
         public Type getType()
         {
             return Type.AllInProject;
+        }
+    }
+
+    public static class AllInProjectPlusShared extends AllInProject
+    {
+        public AllInProjectPlusShared(Container c, User user)
+        {
+            super(c, user);
+        }
+
+        @Override
+        public Collection<GUID> generateIds(Container currentContainer, Class<? extends Permission> perm, Set<Role> roles)
+        {
+            Collection<GUID> containers = super.generateIds(currentContainer, perm, roles);
+            var shared = ContainerManager.getSharedContainer();
+
+            if (shared.hasPermission(_user, perm, roles))
+                containers.add(shared.getEntityId());
+
+            return containers;
+        }
+
+        @Override
+        public Type getType()
+        {
+            return Type.AllInProjectPlusShared;
         }
     }
 

--- a/api/src/org/labkey/api/data/ForeignKey.java
+++ b/api/src/org/labkey/api/data/ForeignKey.java
@@ -64,7 +64,7 @@ public interface ForeignKey
      * Return an URL expression for what the hyperlink for this column should be.  The hyperlink must be able to be
      * constructed knowing only the foreign key value, as other columns may not be available in the ResultSet.
      */
-    StringExpression getURL(ColumnInfo parent);
+    @Nullable StringExpression getURL(ColumnInfo parent);
 
     /**
      * Convenience for getLookupTableInfo.getSelectList(getLookupColumnName())

--- a/api/src/org/labkey/api/data/VirtualTable.java
+++ b/api/src/org/labkey/api/data/VirtualTable.java
@@ -89,12 +89,4 @@ public class VirtualTable<SchemaType extends UserSchema> extends AbstractContain
     {
         _containerFilter = filter;
     }
-
-    @Override
-    protected ContainerFilter getDefaultContainerFilter()
-    {
-        if (null != _userSchema)
-            return _userSchema.getDefaultContainerFilter();
-        return super.getDefaultContainerFilter();
-    }
 }

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -191,8 +191,10 @@ public interface ExperimentService extends ExperimentRunTypeSource
      */
     List<? extends ExpData> getExpDatas(ExpDataClass dataClass);
 
+    @Nullable
     ExpData getExpData(ExpDataClass dataClass, String name);
 
+    @Nullable
     ExpData getExpData(ExpDataClass dataClass, int rowId);
 
     /**

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -767,7 +767,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
         @NotNull String parameterValue,
         @Nullable Container c,
         @Nullable User user,
-        boolean includeProjectAndShared
+        @Nullable ContainerFilter cf
     );
 
     void registerRunEditor(ExpRunEditor editor);

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -517,6 +517,12 @@ public class ExpSchema extends AbstractExpSchema
             {
                 return getTable(TableType.Materials.toString(), cf);
             }
+
+            @Override
+            public StringExpression getURL(ColumnInfo parent)
+            {
+                return getURL(parent, true);
+            }
         };
     }
 

--- a/api/src/org/labkey/api/query/AbstractContainerFilterable.java
+++ b/api/src/org/labkey/api/query/AbstractContainerFilterable.java
@@ -65,14 +65,26 @@ public abstract class AbstractContainerFilterable extends AbstractTableInfo
     @NotNull
     public ContainerFilter getContainerFilter()
     {
-        if (_containerFilter == null)
-            return getDefaultContainerFilter();
-        return _containerFilter;
+        if (_containerFilter != null)
+            return _containerFilter;
+        return getDefaultContainerFilter();
     }
 
     protected ContainerFilter getDefaultContainerFilter()
     {
-        return ContainerFilter.current(getUserSchema().getContainer());
+        assert null != getUserSchema();
+        return getUserSchema().getDefaultContainerFilter();
+    }
+
+    protected ContainerFilter getLookupContainerFilter()
+    {
+        if (QueryService.get().isProductProjectsAllFolderScopeEnabled())
+        {
+            assert null != getUserSchema();
+            return getUserSchema().getDefaultLookupContainerFilter();
+        }
+
+        return getContainerFilter();
     }
 
     /**

--- a/api/src/org/labkey/api/query/FilteredTable.java
+++ b/api/src/org/labkey/api/query/FilteredTable.java
@@ -146,12 +146,6 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
         _rules = canApplyTableRules() ? TableRulesManager.get().getTableRules(getContainer(), userSchema.getUser()) : TableRules.NOOP_TABLE_RULES;
     }
 
-    @Override
-    protected ContainerFilter getDefaultContainerFilter()
-    {
-        return _userSchema.getDefaultContainerFilter();
-    }
-
     /**
      * Allow {@link TableRules} to be applied to this table.
      */

--- a/api/src/org/labkey/api/query/LookupForeignKey.java
+++ b/api/src/org/labkey/api/query/LookupForeignKey.java
@@ -57,7 +57,7 @@ abstract public class LookupForeignKey extends AbstractForeignKey implements Clo
 
     public LookupForeignKey(ActionURL baseURL, String paramName, String schemaName, String tableName, String pkColumnName, String titleColumn)
     {
-        this(null, baseURL, (Object)paramName, schemaName, tableName, pkColumnName, titleColumn);
+        this(null, baseURL, paramName, schemaName, tableName, pkColumnName, titleColumn);
     }
 
     public LookupForeignKey(ActionURL baseURL, String paramName, String tableName, String pkColumnName, String titleColumn)
@@ -90,7 +90,7 @@ abstract public class LookupForeignKey extends AbstractForeignKey implements Clo
         this(null, null, null, null, pkColumnName, null);
     }
 
-    public LookupForeignKey(ContainerFilter cf, @Nullable String pkColumnName, @Nullable String titleColumn)
+    public LookupForeignKey(@Nullable ContainerFilter cf, @Nullable String pkColumnName, @Nullable String titleColumn)
     {
         this(cf, null, null, null, null, pkColumnName, titleColumn);
     }
@@ -158,14 +158,14 @@ abstract public class LookupForeignKey extends AbstractForeignKey implements Clo
         return table.getColumn(getLookupColumnName());
     }
 
-
     @Override
+    @Nullable
     public StringExpression getURL(ColumnInfo parent)
     {
         return getURL(parent, false);
     }
 
-
+    @Nullable
     protected StringExpression getURL(ColumnInfo parent, boolean useDetailsURL)
     {
         if (null != _baseURL)
@@ -186,19 +186,18 @@ abstract public class LookupForeignKey extends AbstractForeignKey implements Clo
         return getDetailsURL(parent, lookupTable, getLookupColumnName());
     }
 
-
+    @Nullable
     public static StringExpression getDetailsURL(ColumnInfo parent, TableInfo lookupTable, String columnName)
     {
         StringExpression expr = lookupTable.getDetailsURL(null, null);
         if (expr == AbstractTableInfo.LINK_DISABLER)
             return AbstractTableInfo.LINK_DISABLER;
 
-        if (expr instanceof StringExpressionFactory.FieldKeyStringExpression)
+        if (expr instanceof StringExpressionFactory.FieldKeyStringExpression f)
         {
-            StringExpressionFactory.FieldKeyStringExpression f = (StringExpressionFactory.FieldKeyStringExpression)expr;
             StringExpressionFactory.FieldKeyStringExpression rewrite;
 
-            FieldKey columnKey = new FieldKey(null,columnName);
+            FieldKey columnKey = new FieldKey(null, columnName);
             Set<FieldKey> keys = Collections.singleton(columnKey);
 
             // If the URL only substitutes the PK we can rewrite as FK (does the DisplayColumn handle when the join fails?)
@@ -210,8 +209,8 @@ abstract public class LookupForeignKey extends AbstractForeignKey implements Clo
                 rewrite = f.remapFieldKeys(parent.getFieldKey(), null);
 
             // CONSIDER: set ContainerContext in AbstractForeignKey.getURL() so all subclasses can benefit
-            if (rewrite instanceof DetailsURL)
-                setURLContainerContext((DetailsURL)rewrite, lookupTable, parent);
+            if (rewrite instanceof DetailsURL rewriteDetailsURL)
+                setURLContainerContext(rewriteDetailsURL, lookupTable, parent);
 
             return rewrite;
         }
@@ -228,10 +227,9 @@ abstract public class LookupForeignKey extends AbstractForeignKey implements Clo
             // from the lookupTable and its FieldKeyContext has been fixed up.
             //if (!url.hasContainerContext())
             //    _log.warn("Table's DetailURL does not have a container context. Table: " + lookupTable.getPublicSchemaName() + "." + lookupTable.getName() + ", column: " + parent.getName());
-            if (null != parent && cc instanceof ContainerContext.FieldKeyContext)
+            if (null != parent && cc instanceof ContainerContext.FieldKeyContext fkc)
             {
-                ContainerContext.FieldKeyContext fkc = (ContainerContext.FieldKeyContext)cc;
-                cc = new ContainerContext.FieldKeyContext(FieldKey.fromParts(parent.getFieldKey(),fkc.getFieldKey()));
+                cc = new ContainerContext.FieldKeyContext(FieldKey.fromParts(parent.getFieldKey(), fkc.getFieldKey()));
             }
             url.setContainerContext(cc, false);
         }

--- a/api/src/org/labkey/api/query/PdLookupForeignKey.java
+++ b/api/src/org/labkey/api/query/PdLookupForeignKey.java
@@ -106,7 +106,9 @@ public class PdLookupForeignKey extends AbstractForeignKey
             }
             else if (allFolderScope && ContainerFilter.Type.Current.equals(cf.getType()))
             {
-                cf = new ContainerFilter.AllInProjectPlusShared(container, user);
+                ContainerFilter lookupCf = QueryService.get().getContainerFilterForLookups(container, user);
+                if (lookupCf != null)
+                    cf = lookupCf;
             }
         }
 

--- a/api/src/org/labkey/api/query/PdLookupForeignKey.java
+++ b/api/src/org/labkey/api/query/PdLookupForeignKey.java
@@ -95,9 +95,12 @@ public class PdLookupForeignKey extends AbstractForeignKey
             cf = new ContainerFilter.SimpleContainerFilterWithUser(user, targetContainer);
         else
         {
-            ContainerFilter lookupCf = QueryService.get().getContainerFilterForLookups(container, user);
-            if (lookupCf != null)
-                cf = lookupCf;
+            if (QueryService.get().isProductProjectsAllFolderScopeEnabled())
+            {
+                ContainerFilter lookupCf = QueryService.get().getContainerFilterForLookups(container, user);
+                if (lookupCf != null)
+                    cf = lookupCf;
+            }
 
             if (cf == null)
                 cf = new ContainerFilter.SimpleContainerFilterWithUser(user, container);

--- a/api/src/org/labkey/api/query/PdLookupForeignKey.java
+++ b/api/src/org/labkey/api/query/PdLookupForeignKey.java
@@ -95,21 +95,12 @@ public class PdLookupForeignKey extends AbstractForeignKey
             cf = new ContainerFilter.SimpleContainerFilterWithUser(user, targetContainer);
         else
         {
-            boolean allFolderScope = QueryService.get().isProductProjectsAllFolderScopeEnabled() && container.isProductProjectsEnabled();
+            ContainerFilter lookupCf = QueryService.get().getContainerFilterForLookups(container, user);
+            if (lookupCf != null)
+                cf = lookupCf;
 
             if (cf == null)
-            {
-                if (allFolderScope)
-                    cf = new ContainerFilter.AllInProjectPlusShared(container, user);
-                else
-                    cf = new ContainerFilter.SimpleContainerFilterWithUser(user, container);
-            }
-            else if (allFolderScope && ContainerFilter.Type.Current.equals(cf.getType()))
-            {
-                ContainerFilter lookupCf = QueryService.get().getContainerFilterForLookups(container, user);
-                if (lookupCf != null)
-                    cf = lookupCf;
-            }
+                cf = new ContainerFilter.SimpleContainerFilterWithUser(user, container);
         }
 
         return new PdLookupForeignKey(sourceSchema, container, user, cf, pd, lookupSchemaKey, lookupQuery, targetContainer);

--- a/api/src/org/labkey/api/query/PdLookupForeignKey.java
+++ b/api/src/org/labkey/api/query/PdLookupForeignKey.java
@@ -91,8 +91,24 @@ public class PdLookupForeignKey extends AbstractForeignKey
 
         if ("core".equalsIgnoreCase(null==lookupSchemaKey?null:lookupSchemaKey.getName()) && "Containers".equalsIgnoreCase(lookupQuery))
             cf = new ContainerFilter.AllFolders(user);
-        else if (targetContainer != null || cf == null)
-            cf = new ContainerFilter.SimpleContainerFilterWithUser(user, targetContainer != null ? targetContainer : container);
+        else if (targetContainer != null)
+            cf = new ContainerFilter.SimpleContainerFilterWithUser(user, targetContainer);
+        else
+        {
+            boolean allFolderScope = QueryService.get().isProductProjectsAllFolderScopeEnabled() && container.isProductProjectsEnabled();
+
+            if (cf == null)
+            {
+                if (allFolderScope)
+                    cf = new ContainerFilter.AllInProjectPlusShared(container, user);
+                else
+                    cf = new ContainerFilter.SimpleContainerFilterWithUser(user, container);
+            }
+            else if (allFolderScope && ContainerFilter.Type.Current.equals(cf.getType()))
+            {
+                cf = new ContainerFilter.AllInProjectPlusShared(container, user);
+            }
+        }
 
         return new PdLookupForeignKey(sourceSchema, container, user, cf, pd, lookupSchemaKey, lookupQuery, targetContainer);
     }

--- a/api/src/org/labkey/api/query/PropertyForeignKey.java
+++ b/api/src/org/labkey/api/query/PropertyForeignKey.java
@@ -54,8 +54,7 @@ public class PropertyForeignKey extends AbstractForeignKey implements PropertyCo
     Map<String, PropertyDescriptor> _pdMap;
     protected QuerySchema _schema;
     protected boolean _parentIsObjectId = false;
-
-    private List<PropertyColumnDecorator> _decorators = new ArrayList<>();
+    private final List<PropertyColumnDecorator> _decorators = new ArrayList<>();
 
     public PropertyForeignKey(QuerySchema schema, ContainerFilter cf, Map<String, PropertyDescriptor> pds)
     {
@@ -63,7 +62,6 @@ public class PropertyForeignKey extends AbstractForeignKey implements PropertyCo
         _pdMap = pds;
         _schema = schema;
     }
-
 
     /**
      * Creates a virtual table with columns for each of the property descriptors.
@@ -85,8 +83,6 @@ public class PropertyForeignKey extends AbstractForeignKey implements PropertyCo
         this(schema, cf, listProperties(domain));
     }
 
-
-    
     private static List<PropertyDescriptor> listProperties(Domain domain)
     {
         List<PropertyDescriptor> result = new ArrayList<>();
@@ -97,13 +93,10 @@ public class PropertyForeignKey extends AbstractForeignKey implements PropertyCo
         return result;
     }
 
-
     public void setParentIsObjectId(boolean id)
     {
         _parentIsObjectId = id;
     }
-
-
 
     @Override
     public ColumnInfo createLookupColumn(ColumnInfo parent, String displayField)
@@ -128,18 +121,15 @@ public class PropertyForeignKey extends AbstractForeignKey implements PropertyCo
         return constructColumnInfo(parent, decideColumnName(parent, displayField, pd), pd);
     }
 
-
     protected @NotNull FieldKey decideColumnName(@NotNull ColumnInfo parent, @NotNull String displayField, @NotNull PropertyDescriptor pd)
     {
         return new FieldKey(parent.getFieldKey(), "$P" + pd.getPropertyId());
     }
 
-
     static public SQLFragment getMvIndicatorSQL()
     {
         return new SQLFragment("exp.ObjectProperty.MvIndicator");
     }
-
 
     protected BaseColumnInfo constructColumnInfo(ColumnInfo parent, FieldKey name, PropertyDescriptor pd)
     {
@@ -160,7 +150,6 @@ public class PropertyForeignKey extends AbstractForeignKey implements PropertyCo
         return ret;
     }
 
-
     @Override
     public void decorateColumn(MutableColumnInfo columnInfo, PropertyDescriptor pd)
     {
@@ -170,7 +159,6 @@ public class PropertyForeignKey extends AbstractForeignKey implements PropertyCo
         }
     }
 
-    
     @Override
     public TableInfo getLookupTableInfo()
     {
@@ -194,19 +182,16 @@ public class PropertyForeignKey extends AbstractForeignKey implements PropertyCo
         return ret;
     }
 
-
     public void addDecorator(PropertyColumnDecorator decorator)
     {
         _decorators.add(decorator);
     }
-
 
     @Override
     public StringExpression getURL(ColumnInfo parent)
     {
         return null;
     }
-
 
     /**
      * Override this method to allow properties which might not have been
@@ -223,7 +208,6 @@ public class PropertyForeignKey extends AbstractForeignKey implements PropertyCo
         }
         return null;
     }
-
 
     private void initColumn(User user, BaseColumnInfo column, PropertyDescriptor pd)
     {

--- a/api/src/org/labkey/api/query/QueryForeignKey.java
+++ b/api/src/org/labkey/api/query/QueryForeignKey.java
@@ -57,7 +57,6 @@ public class QueryForeignKey extends AbstractForeignKey
     LookupColumn.JoinType _joinType = LookupColumn.JoinType.leftOuter;
     DetailsURL _url;
 
-    /* There are (were) way too many QueryForeignKey constructors, that's a sign we need a builder */
     public static class Builder implements org.labkey.api.data.Builder<ForeignKey>
     {
         QuerySchema sourceSchema;
@@ -90,8 +89,8 @@ public class QueryForeignKey extends AbstractForeignKey
         {
             sourceSchema = schema;
             containerFilter = cf;
-            if (schema instanceof UserSchema)
-                schema((UserSchema) schema);
+            if (schema instanceof UserSchema userSchema)
+                schema(userSchema);
             effectiveContainer = schema.getContainer();
             user = sourceSchema.getUser();
         }
@@ -111,7 +110,6 @@ public class QueryForeignKey extends AbstractForeignKey
             return this;
         }
 
-
         public Builder schema(String schemaName)
         {
             lookupSchemaKey = SchemaKey.fromString(schemaName);
@@ -119,7 +117,6 @@ public class QueryForeignKey extends AbstractForeignKey
             targetSchema = null;
             return this;
         }
-
 
         // effectiveContainer is the container used when resolving schemaName if there is not an explicit fkFolderPath defined
         public Builder schema(String schemaName, Container effectiveContainer)
@@ -158,12 +155,6 @@ public class QueryForeignKey extends AbstractForeignKey
             return this;
         }
 
-//        public Builder setTableName(String tableName)
-//        {
-//            this.lookupTableName = tableName;
-//            return this;
-//        }
-
         public Builder key(String name)
         {
             this.lookupKey = name;
@@ -181,18 +172,6 @@ public class QueryForeignKey extends AbstractForeignKey
             this.url = url;
             return this;
         }
-
-//        public Builder setLookupKey(String name)
-//        {
-//            this.lookupKey = name;
-//            return this;
-//        }
-
-//        public Builder setDisplayField(String field)
-//        {
-//            this.displayField = field;
-//            return this;
-//        }
 
         public Builder display(String field)
         {
@@ -358,15 +337,6 @@ public class QueryForeignKey extends AbstractForeignKey
         return _lookupContainer;
     }
 
-    private Container getEffectiveContainer()
-    {
-        if (null != _table)
-            return _table.getUserSchema().getContainer();
-        if (null != _schema)
-            return _schema.getContainer();
-        return _effectiveContainer;
-    }
-
     @Override
     protected User getLookupUser()
     {
@@ -394,9 +364,9 @@ public class QueryForeignKey extends AbstractForeignKey
     {
         if (_schema == null && _user != null && _lookupSchemaKey != null)
         {
-            DefaultSchema resolver = null;
-            if (null==_sourceSchema || !_effectiveContainer.equals(_sourceSchema.getContainer()))
-                resolver = DefaultSchema.get(_user,_effectiveContainer);
+            DefaultSchema resolver;
+            if (null == _sourceSchema || !_effectiveContainer.equals(_sourceSchema.getContainer()))
+                resolver = DefaultSchema.get(_user, _effectiveContainer);
             else
                 resolver = _sourceSchema.getDefaultSchema();
             _schema = DefaultSchema.resolve(resolver, _lookupSchemaKey);

--- a/api/src/org/labkey/api/query/QuerySchema.java
+++ b/api/src/org/labkey/api/query/QuerySchema.java
@@ -101,6 +101,18 @@ public interface QuerySchema extends SchemaTreeNode, ContainerUser
         return ContainerFilter.current(getContainer());
     }
 
+    default ContainerFilter getDefaultLookupContainerFilter()
+    {
+        if (QueryService.get().isProductProjectsAllFolderScopeEnabled())
+        {
+            ContainerFilter.Type cfType = QueryService.get().getContainerFilterTypeForLookups(getContainer());
+            if (cfType != null)
+                return cfType.create(this);
+        }
+
+        return this.getDefaultContainerFilter();
+    }
+
     Set<String> getTableNames();
 
     Collection<TableInfo> getTables();

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -627,7 +627,7 @@ public interface QueryService
     ContainerFilter getContainerFilterForLookups(Container container, User user);
 
     /**
-     * Resolves the ContainerFilter.Type to be used for lookups during insert/update of data in product projects.
+     * Resolves the ContainerFilter.Type to be used for lookups of data in product projects.
      * Defaults to null if product projects are not enabled in container scope.
      */
     @Nullable

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -634,9 +634,12 @@ public interface QueryService
     ContainerFilter.Type getContainerFilterTypeForLookups(Container container);
 
     /**
-     *
+     * Returns true if the "Less restrictive product project lookups" experimental feature is enabled.
      */
     boolean isProductProjectsAllFolderScopeEnabled();
 
+    /**
+     * Returns true if the "Product projects display project-specific data" experimental feature is enabled.
+     */
     boolean isProductProjectsDataListingScopedToProject();
 }

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -625,5 +625,8 @@ public interface QueryService
     @Nullable
     ContainerFilter getContainerFilterForLookups(Container container, User user);
 
+    @Nullable
+    ContainerFilter.Type getContainerFilterTypeForLookups(Container container);
+
     boolean isProductProjectsAllFolderScopeEnabled();
 }

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -70,6 +70,7 @@ public interface QueryService
 {
     String EXPERIMENTAL_LAST_MODIFIED = "queryMetadataLastModified";
     String EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS = "queryProductAllFolderLookups";
+    String EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED = "queryProductProjectDataListingScoped";
     String PRODUCT_PROJECTS_ENABLED = "isProductProjectsEnabled";
     String PRODUCT_PROJECTS_EXIST = "hasProductProjects";
     String USE_ROW_BY_ROW_UPDATE = "useLegacyUpdateRows";
@@ -625,8 +626,17 @@ public interface QueryService
     @Nullable
     ContainerFilter getContainerFilterForLookups(Container container, User user);
 
+    /**
+     * Resolves the ContainerFilter.Type to be used for lookups during insert/update of data in product projects.
+     * Defaults to null if product projects are not enabled in container scope.
+     */
     @Nullable
     ContainerFilter.Type getContainerFilterTypeForLookups(Container container);
 
+    /**
+     *
+     */
     boolean isProductProjectsAllFolderScopeEnabled();
+
+    boolean isProductProjectsDataListingScopedToProject();
 }

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -69,6 +69,7 @@ import java.util.Set;
 public interface QueryService
 {
     String EXPERIMENTAL_LAST_MODIFIED = "queryMetadataLastModified";
+    String EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS = "queryProductAllFolderLookups";
     String PRODUCT_PROJECTS_ENABLED = "isProductProjectsEnabled";
     String PRODUCT_PROJECTS_EXIST = "hasProductProjects";
     String USE_ROW_BY_ROW_UPDATE = "useLegacyUpdateRows";

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -620,7 +620,7 @@ public interface QueryService
     }
 
     /**
-     * Resolves the ContainerFilter to be used for lookups during insert/update of data in product projects.
+     * Resolves the ContainerFilter to be used for lookups of data in product projects.
      * Defaults to null if product projects are not enabled in container scope.
      */
     @Nullable

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -625,4 +625,5 @@ public interface QueryService
     @Nullable
     ContainerFilter getContainerFilterForLookups(Container container, User user);
 
+    boolean isProductProjectsAllFolderScopeEnabled();
 }

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -148,16 +148,9 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
             throw new UnauthorizedException("User cannot execute MDX against this schema: " + getName());
     }
 
-
     public ContainerFilter getOlapContainerFilter()
     {
         return null;
-    }
-
-    @Override
-    public @NotNull ContainerFilter getDefaultContainerFilter()
-    {
-        return ContainerFilter.current(getContainer());
     }
 
     @Nullable

--- a/assay/api-src/org/labkey/api/assay/AssayResultTable.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultTable.java
@@ -56,6 +56,7 @@ import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.PropertiesDisplayColumn;
 import org.labkey.api.query.QueryForeignKey;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.RowIdForeignKey;
 import org.labkey.api.query.column.BuiltInColumnTypes;
@@ -152,7 +153,8 @@ public class AssayResultTable extends FilteredTable<AssayProtocolSchema> impleme
                     ExpSampleType st = DefaultAssayRunCreator.getLookupSampleType(domainProperty, getContainer(), getUserSchema().getUser());
                     if (st != null || DefaultAssayRunCreator.isLookupToMaterials(domainProperty))
                     {
-                        col.setFk(new ExpSchema(_userSchema.getUser(), _userSchema.getContainer()).getMaterialIdForeignKey(st, domainProperty, cf));
+                        ContainerFilter lookupCf = QueryService.get().getContainerFilterForLookups(_userSchema.getContainer(), _userSchema.getUser());
+                        col.setFk(new ExpSchema(_userSchema.getUser(), _userSchema.getContainer()).getMaterialIdForeignKey(st, domainProperty, lookupCf == null ? cf : lookupCf));
                     }
                 }
                 addColumn(col);

--- a/assay/api-src/org/labkey/api/assay/AssayResultTable.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultTable.java
@@ -152,10 +152,7 @@ public class AssayResultTable extends FilteredTable<AssayProtocolSchema> impleme
 
                     ExpSampleType st = DefaultAssayRunCreator.getLookupSampleType(domainProperty, getContainer(), getUserSchema().getUser());
                     if (st != null || DefaultAssayRunCreator.isLookupToMaterials(domainProperty))
-                    {
-                        ContainerFilter lookupCf = QueryService.get().getContainerFilterForLookups(_userSchema.getContainer(), _userSchema.getUser());
-                        col.setFk(new ExpSchema(_userSchema.getUser(), _userSchema.getContainer()).getMaterialIdForeignKey(st, domainProperty, lookupCf == null ? cf : lookupCf));
-                    }
+                        col.setFk(new ExpSchema(_userSchema.getUser(), _userSchema.getContainer()).getMaterialIdForeignKey(st, domainProperty, getLookupContainerFilter()));
                 }
                 addColumn(col);
 

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,8 +8,8 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/api": "1.18.4",
-        "@labkey/components": "2.296.1",
+        "@labkey/api": "1.18.5",
+        "@labkey/components": "2.297.0",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3018,9 +3018,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.18.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.4.tgz",
-      "integrity": "sha512-p2Uvug7acByzhb5QB077r9emphZ6+wAwqN6vqIZcQLHxjoecMFJA5RRbfyEEPiY2ta8/hkaTalDhFpGL2YRr0Q=="
+      "version": "1.18.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.5.tgz",
+      "integrity": "sha512-vgjLTTE34wd1xUI1wsy5661SykxJ6KRdr25zNYb9EaFHhTBcrAQlIVucyqv3ZxRP0EuUQvM3+8/N3a3tOLXNsQ=="
     },
     "node_modules/@labkey/build": {
       "version": "6.9.0",
@@ -3057,11 +3057,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.296.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.296.1.tgz",
-      "integrity": "sha512-bb0LQ0Gl0Bv1/ODp5YBRrffAz22l8jMz2asRHoFJdm+Of0EDPYxfk3fDXdvb2j47QKlEyTVbK/NsSBzCrHscLw==",
+      "version": "2.297.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.297.0.tgz",
+      "integrity": "sha512-MFP8fk4b4F6MUHeiMrMXUsVQElHdc4jKAQTDQKLostzdN+cXDdpvRheDsGZs01PUbj7gcpDqUZtgWPk3Zor7xw==",
       "dependencies": {
-        "@labkey/api": "1.18.4",
+        "@labkey/api": "1.18.5",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",
@@ -17206,9 +17206,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.18.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.4.tgz",
-      "integrity": "sha512-p2Uvug7acByzhb5QB077r9emphZ6+wAwqN6vqIZcQLHxjoecMFJA5RRbfyEEPiY2ta8/hkaTalDhFpGL2YRr0Q=="
+      "version": "1.18.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.5.tgz",
+      "integrity": "sha512-vgjLTTE34wd1xUI1wsy5661SykxJ6KRdr25zNYb9EaFHhTBcrAQlIVucyqv3ZxRP0EuUQvM3+8/N3a3tOLXNsQ=="
     },
     "@labkey/build": {
       "version": "6.9.0",
@@ -17245,11 +17245,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.296.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.296.1.tgz",
-      "integrity": "sha512-bb0LQ0Gl0Bv1/ODp5YBRrffAz22l8jMz2asRHoFJdm+Of0EDPYxfk3fDXdvb2j47QKlEyTVbK/NsSBzCrHscLw==",
+      "version": "2.297.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.297.0.tgz",
+      "integrity": "sha512-MFP8fk4b4F6MUHeiMrMXUsVQElHdc4jKAQTDQKLostzdN+cXDdpvRheDsGZs01PUbj7gcpDqUZtgWPk3Zor7xw==",
       "requires": {
-        "@labkey/api": "1.18.4",
+        "@labkey/api": "1.18.5",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",

--- a/core/package.json
+++ b/core/package.json
@@ -54,8 +54,8 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "1.18.4",
-    "@labkey/components": "2.296.1",
+    "@labkey/api": "1.18.5",
+    "@labkey/components": "2.297.0",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -1506,20 +1506,22 @@ public class ExpDataIterators
      *                will be incorporated into the resolved inputs and outputs
      * @param entityNamePairs set of (parent column name, parent value) pairs.  Parent values that are empty
      *                    indicate the parent should be removed.
-     * @throws ExperimentException
+     * @throws ValidationException
      */
     @NotNull
-    private static Pair<RunInputOutputBean, RunInputOutputBean> resolveInputsAndOutputs(User user, Container c, @Nullable ExpRunItem runItem,
-                                                                                       Set<Pair<String, String>> entityNamePairs,
-                                                                                       RemapCache cache,
-                                                                                       Map<Integer, ExpMaterial> materialMap,
-                                                                                       Map<Integer, ExpData> dataMap,
-                                                                                       Map<String, ExpSampleType> sampleTypes,
-                                                                                       Map<String, ExpDataClass> dataClasses,
-                                                                                       @Nullable String aliquotedFrom,
-                                                                                       String dataType /*sample type or source type name*/,
-                                                                                       boolean updateOnly)
-            throws ValidationException, ExperimentException
+    private static Pair<RunInputOutputBean, RunInputOutputBean> resolveInputsAndOutputs(
+        User user, Container c,
+        @Nullable ExpRunItem runItem,
+        Set<Pair<String, String>> entityNamePairs,
+        RemapCache cache,
+        Map<Integer, ExpMaterial> materialMap,
+        Map<Integer, ExpData> dataMap,
+        Map<String, ExpSampleType> sampleTypes,
+        Map<String, ExpDataClass> dataClasses,
+        @Nullable String aliquotedFrom,
+        String dataType /*sample type or source type name*/,
+        boolean updateOnly
+    ) throws ValidationException
     {
         Map<ExpMaterial, String> parentMaterials = new LinkedHashMap<>();
         Map<ExpData, String> parentData = new LinkedHashMap<>();
@@ -1562,7 +1564,7 @@ public class ExpDataIterators
             String[] parts = entityColName.split("[./]");
             if (parts.length == 1)
             {
-                if (parts[0].equalsIgnoreCase("parent"))
+                if ("parent".equalsIgnoreCase(parts[0]))
                 {
                     if (!isEmptyEntity)
                     {
@@ -1573,7 +1575,7 @@ public class ExpDataIterators
                         }
 
                         if (skipExistingAliquotParents)
-                            continue;;
+                            continue;
 
                         ExpMaterial sample = ExperimentService.get().findExpMaterial(c, user, null, null, entityName, cache, materialMap);
                         if (sample != null)
@@ -1586,10 +1588,10 @@ public class ExpDataIterators
                     }
                 }
             }
-            if (parts.length == 2)
+            else if (parts.length == 2)
             {
                 String namePart = QueryKey.decodePart(parts[1]);
-                if (parts[0].equalsIgnoreCase(ExpMaterial.MATERIAL_INPUT_PARENT))
+                if (ExpMaterial.MATERIAL_INPUT_PARENT.equalsIgnoreCase(parts[0]))
                 {
                     if (isEmptyEntity)
                     {
@@ -1622,7 +1624,7 @@ public class ExpDataIterators
 
                     }
                 }
-                else if (parts[0].equalsIgnoreCase(ExpMaterial.MATERIAL_OUTPUT_CHILD))
+                else if (ExpMaterial.MATERIAL_OUTPUT_CHILD.equalsIgnoreCase(parts[0]))
                 {
                     ExpSampleType sampleType = sampleTypes.computeIfAbsent(namePart, (name) -> SampleTypeService.get().getSampleType(c, user, name));
                     if (sampleType == null)
@@ -1645,7 +1647,7 @@ public class ExpDataIterators
                             throw new ValidationException("Sample output '" + entityName + "' not found in Sample Type '" + namePart + "'.");
                     }
                 }
-                else if (parts[0].equalsIgnoreCase(ExpData.DATA_INPUT_PARENT))
+                else if (ExpData.DATA_INPUT_PARENT.equalsIgnoreCase(parts[0]))
                 {
                     if (isEmptyEntity)
                     {
@@ -1680,7 +1682,7 @@ public class ExpDataIterators
                         }
                     }
                 }
-                else if (parts[0].equalsIgnoreCase(ExpData.DATA_OUTPUT_CHILD))
+                else if (ExpData.DATA_OUTPUT_CHILD.equalsIgnoreCase(parts[0]))
                 {
                     ExpDataClass dataClass = dataClasses.computeIfAbsent(namePart, (name) -> ExperimentService.get().getDataClass(c, user, name));
                     if (dataClass == null)

--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -7,6 +7,7 @@ import org.labkey.api.data.AbstractForeignKey;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
@@ -26,6 +27,7 @@ import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QueryForeignKey;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
@@ -213,7 +215,13 @@ public class ClosureQueryHelper
         ret.setDisplayColumnFactory(AncestorLookupDisplayColumn::new);
         ret.setLabel(target.getName());
         UserSchema schema = Objects.requireNonNull(parentTable.getUserSchema());
-        var builder = new QueryForeignKey.Builder(schema, parentTable.getContainerFilter()).table(target.getName()).key("rowid");
+
+        // Determine the container scope of the lookup
+        ContainerFilter cf = QueryService.get().getContainerFilterForLookups(schema.getContainer(), schema.getUser());
+        if (cf == null)
+            cf = parentTable.getContainerFilter();
+
+        var builder = new QueryForeignKey.Builder(schema, cf).table(target.getName()).key("rowid");
         builder.schema(targetType.schemaKey);
         var qfk = new QueryForeignKey(builder) {
             @Override

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialInputTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialInputTableImpl.java
@@ -45,20 +45,23 @@ public class ExpMaterialInputTableImpl extends ExpInputTableImpl<ExpMaterialInpu
     {
         switch (column)
         {
-            case Material:
+            case Material ->
             {
                 var result = wrapColumn(alias, _rootTable.getColumn("MaterialId"));
-                result.setFk(getExpSchema().getMaterialIdForeignKey(null, null, getContainerFilter()));
+                result.setFk(getExpSchema().getMaterialIdForeignKey(null, null, getLookupContainerFilter()));
                 return result;
             }
-            case Role:
+            case Role ->
+            {
                 return wrapColumn(alias, _rootTable.getColumn("Role"));
-            case TargetProtocolApplication:
+            }
+            case TargetProtocolApplication ->
+            {
                 var result = wrapColumn(alias, _rootTable.getColumn("TargetApplicationId"));
-                result.setFk(getExpSchema().getProtocolApplicationForeignKey(getContainerFilter()));
+                result.setFk(getExpSchema().getProtocolApplicationForeignKey(getLookupContainerFilter()));
                 return result;
-
-            case LSID:
+            }
+            case LSID ->
             {
                 final SqlDialect dialect = getSqlDialect();
                 SQLFragment sql = new SQLFragment("" +
@@ -75,17 +78,14 @@ public class ExpMaterialInputTableImpl extends ExpInputTableImpl<ExpMaterialInpu
                 col.setReadOnly(true);
                 return col;
             }
-
-            case ProtocolInput:
+            case ProtocolInput ->
             {
                 var col = wrapColumn(alias, _rootTable.getColumn("ProtocolInputId"));
-                col.setFk(getExpSchema().getMaterialProtocolInputForeignKey(getContainerFilter()));
+                col.setFk(getExpSchema().getMaterialProtocolInputForeignKey(getLookupContainerFilter()));
                 col.setHidden(true);
                 return col;
             }
-
-            default:
-                throw new IllegalArgumentException("Unsupported column: " + column);
+            default -> throw new IllegalArgumentException("Unsupported column: " + column);
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -194,15 +194,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         }
     }
 
-    @NotNull
-    private ContainerFilter getLookupContainerFilter()
-    {
-        ContainerFilter cf = QueryService.get().getContainerFilterForLookups(getUserSchema().getContainer(), getUserSchema().getUser());
-        if (cf == null)
-            cf = getContainerFilter();
-        return cf;
-    }
-
     @Override
     public MutableColumnInfo createColumn(String alias, Column column)
     {
@@ -219,7 +210,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             case MaterialSourceId ->
             {
                 var columnInfo = wrapColumn(alias, _rootTable.getColumn("MaterialSourceId"));
-                columnInfo.setFk(new LookupForeignKey(getContainerFilter(), null, null, null, null, "RowId", "Name")
+                columnInfo.setFk(new LookupForeignKey(getLookupContainerFilter(), null, null, null, null, "RowId", "Name")
                 {
                     @Override
                     public TableInfo getLookupTableInfo()

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -423,7 +423,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 ret.setShownInInsertView(statusEnabled);
                 ret.setShownInUpdateView(statusEnabled);
                 ret.setRemapMissingBehavior(SimpleTranslator.RemapMissingBehavior.Error);
-                ret.setFk(new QueryForeignKey.Builder(getUserSchema(), getContainerFilter())
+                ret.setFk(new QueryForeignKey.Builder(getUserSchema(), getLookupContainerFilter())
                         .schema(getExpSchema()).table(ExpSchema.TableType.SampleStatus).display("Label"));
                 return ret;
             }
@@ -712,7 +712,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         statusColInfo.setRemapMissingBehavior(SimpleTranslator.RemapMissingBehavior.Error);
         if (statusEnabled)
             defaultCols.add(FieldKey.fromParts(ExpMaterialTable.Column.SampleState));
-        statusColInfo.setFk(new QueryForeignKey.Builder(getUserSchema(),getContainerFilter())
+        statusColInfo.setFk(new QueryForeignKey.Builder(getUserSchema(), getLookupContainerFilter())
                 .schema(getExpSchema()).table(ExpSchema.TableType.SampleStatus).display("Label"));
 
         // TODO is this a real Domain???
@@ -855,7 +855,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             if (null != dp)
             {
                 PropertyColumn.copyAttributes(schema.getUser(), propColumn, dp.getPropertyDescriptor(), schema.getContainer(),
-                    SchemaKey.fromParts("samples"), st.getName(), FieldKey.fromParts("RowId"), getContainerFilter());
+                    SchemaKey.fromParts("samples"), st.getName(), FieldKey.fromParts("RowId"), getLookupContainerFilter());
 
                 if (idCols.contains(dp))
                 {

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -745,25 +745,11 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             filter.addCondition(FieldKey.fromParts("CpasType"), sampleType.getLSID());
 
         // SampleType may live in different container
-        ContainerFilter.CurrentPlusProjectAndShared containerFilter = new ContainerFilter.CurrentPlusProjectAndShared(container, user);
+        ContainerFilter containerFilter = getContainerFilterTypeForFind(container).create(container, user);
         SimpleFilter.FilterClause clause = containerFilter.createFilterClause(getSchema(), FieldKey.fromParts("Container"));
         filter.addClause(clause);
 
-        return new TableSelector(getTinfoMaterial(), TableSelector.ALL_COLUMNS, filter, null)
-                .getArrayList(Material.class)
-                .stream()
-                .map(ExpMaterialImpl::new)
-                .collect(toList());
-    }
-
-    public List<ExpMaterialImpl> getExpMaterialsByNames(Container container, User user, Collection<String> names, @Nullable ExpSampleType sampleType)
-    {
-        SimpleFilter filter = SimpleFilter.createContainerFilter(container);
-        filter.addInClause(FieldKey.fromParts("Name"), names);
-        if (sampleType != null)
-            filter.addCondition(FieldKey.fromParts("CpasType"), sampleType.getLSID());
-
-        return new TableSelector(getTinfoMaterial(), TableSelector.ALL_COLUMNS, filter, null)
+        return new TableSelector(getTinfoMaterial(), filter, null)
                 .getArrayList(Material.class)
                 .stream()
                 .map(ExpMaterialImpl::new)
@@ -1521,6 +1507,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
+    @Nullable
     public ExpDataImpl getExpData(ExpDataClass dataClass, String name)
     {
         Domain d = dataClass.getDomain();
@@ -1544,6 +1531,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
+    @Nullable
     public ExpDataImpl getExpData(ExpDataClass dataClass, int rowId)
     {
         Domain d = dataClass.getDomain();
@@ -1592,20 +1580,31 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return null;
     }
 
+    @NotNull
+    private ContainerFilter.Type getContainerFilterTypeForFind(Container container)
+    {
+        ContainerFilter.Type type = QueryService.get().getContainerFilterTypeForLookups(container);
+        return type == null ? ContainerFilter.Type.CurrentPlusProjectAndShared : type;
+    }
+
     @Override
     @Nullable
-    public ExpData findExpData(Container c, User user,
-                            @NotNull ExpDataClass dataClass,
-                            @NotNull String dataClassName, String dataName,
-                            RemapCache cache, Map<Integer, ExpData> dataCache)
-            throws ValidationException
+    public ExpData findExpData(
+        Container c,
+        User user,
+        @NotNull ExpDataClass dataClass,
+        @NotNull String dataClassName,
+        String dataName,
+        RemapCache cache,
+        Map<Integer, ExpData> dataCache
+    ) throws ValidationException
     {
         StringBuilder errors = new StringBuilder();
         // Issue 44568, Issue 40302: Unable to use samples or data class with integer like names as material or data input
         // Attempt to resolve by name first.
         try
         {
-            Integer rowId = cache.remap(ExpSchema.SCHEMA_EXP_DATA, dataClassName, user, c, ContainerFilter.Type.CurrentPlusProjectAndShared, dataName);
+            Integer rowId = cache.remap(ExpSchema.SCHEMA_EXP_DATA, dataClassName, user, c, getContainerFilterTypeForFind(c), dataName);
             if (rowId != null)
                 return dataCache.computeIfAbsent(rowId, (x) -> getExpData(dataClass, rowId));
         }
@@ -1634,8 +1633,15 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public @Nullable ExpMaterial findExpMaterial(Container c, User user, ExpSampleType sampleType, String sampleTypeName, String sampleName, RemapCache cache, Map<Integer, ExpMaterial> materialCache)
-            throws ValidationException
+    public @Nullable ExpMaterial findExpMaterial(
+        Container c,
+        User user,
+        ExpSampleType sampleType,
+        String sampleTypeName,
+        String sampleName,
+        RemapCache cache,
+        Map<Integer, ExpMaterial> materialCache
+    ) throws ValidationException
     {
         StringBuilder errors = new StringBuilder();
         // Issue 44568, Issue 40302: Unable to use samples or data class with integer like names as material or data input
@@ -1645,8 +1651,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             // TODO, rowId is not found for samples newly created in the same import.
             // This is causing name patterns containing lineage lookup to fail to generate the correct names if the child samples and their parents are created from the same import file
             Integer rowId = (sampleTypeName == null) ?
-                    cache.remap(ExpSchema.SCHEMA_EXP, ExpSchema.TableType.Materials.name(), user, c, ContainerFilter.Type.CurrentPlusProjectAndShared, sampleName) :
-                    cache.remap(SamplesSchema.SCHEMA_SAMPLES, sampleTypeName, user, c, ContainerFilter.Type.CurrentPlusProjectAndShared, sampleName);
+                    cache.remap(ExpSchema.SCHEMA_EXP, ExpSchema.TableType.Materials.name(), user, c, getContainerFilterTypeForFind(c), sampleName) :
+                    cache.remap(SamplesSchema.SCHEMA_SAMPLES, sampleTypeName, user, c, getContainerFilterTypeForFind(c), sampleName);
 
             if (rowId != null)
                 return materialCache.computeIfAbsent(rowId, (x) -> getExpMaterial(c, user, rowId, sampleType));

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -7628,7 +7628,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         @NotNull String parameterValue,
         @Nullable Container c,
         @Nullable User user,
-        boolean includeProjectAndShared
+        @Nullable ContainerFilter cf
     )
     {
         SimpleFilter parameterFilter = new SimpleFilter()
@@ -7644,10 +7644,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             protocolFilter = new SimpleFilter(FieldKey.fromParts("rowId"), protocolIds, IN);
         else
         {
-            if (user != null && includeProjectAndShared)
+            if (user != null && cf != null)
             {
                 protocolFilter = new SimpleFilter(FieldKey.fromParts("rowId"), protocolIds, IN);
-                ContainerFilter cf = ContainerFilter.Type.CurrentPlusProjectAndShared.create(c, user);
                 protocolFilter.addCondition(cf.createFilterClause(getTinfoProtocol().getSchema(), FieldKey.fromParts("Container")));
             }
             else

--- a/experiment/src/org/labkey/experiment/api/LineageForeignKey.java
+++ b/experiment/src/org/labkey/experiment/api/LineageForeignKey.java
@@ -298,7 +298,6 @@ class LineageForeignKey extends AbstractForeignKey
 
         void addLineageColumn(String name, Integer depth, ExpLineageOptions.LineageExpType expType, String cpasType, String runProtocolLsid, String lookupColumnName)
         {
-//            SQLFragment sql = new SQLFragment(ExprColumn.STR_TABLE_ALIAS + ".objectid");
             SQLFragment sql = new SQLFragment("'#ERROR'");
             var col = new ExprColumn(this, FieldKey.fromParts(name), sql, JdbcType.INTEGER);
             col.setFk(new _MultiValuedForeignKey(cacheKeyPrefix, depth, expType, cpasType, runProtocolLsid, getContainerFilter()));
@@ -314,12 +313,14 @@ class LineageForeignKey extends AbstractForeignKey
         final ExpLineageOptions.LineageExpType expType;
         final String cpasType;
 
-        public _MultiValuedForeignKey(Path cacheKeyPrefix,
-                                      Integer depth,
-                                      ExpLineageOptions.LineageExpType expType,
-                                      String cpasType,
-                                      String runProtocolLsid,
-                                      @Nullable ContainerFilter cf)
+        public _MultiValuedForeignKey(
+            Path cacheKeyPrefix,
+            Integer depth,
+            ExpLineageOptions.LineageExpType expType,
+            String cpasType,
+            String runProtocolLsid,
+            @Nullable ContainerFilter cf
+        )
         {
             super(new LookupForeignKey(cf, "self", "Name")
             {
@@ -418,10 +419,8 @@ class LineageForeignKey extends AbstractForeignKey
                     return false;
                 }
             };
-
         }
     }
-
 
     private class ByTypeLineageForeignKey extends AbstractForeignKey
     {
@@ -467,7 +466,6 @@ class LineageForeignKey extends AbstractForeignKey
         }
     }
 
-
     private class ByTypeLineageForeignKeyLookupTable extends LineageForeignKeyLookupTable
     {
         private final @NotNull ExpLineageOptions.LineageExpType _expType;
@@ -511,7 +509,7 @@ class LineageForeignKey extends AbstractForeignKey
     // same as AliasedColumn, but avoids getDisplayField() noise
     public class _AliasedParentColumn extends AliasedColumn
     {
-        // lookupColumnName is for explictly selected lookup to column in target table (vs internal virtual column)
+        // lookupColumnName is for explicitly selected lookup to column in target table (vs internal virtual column)
         public _AliasedParentColumn(ColumnInfo parent, FieldKey key, Integer depth, ExpLineageOptions.LineageExpType expType, String cpasType, @Nullable String lookupColumnName)
         {
             super(parent.getParentTable(), key, parent, false);

--- a/query/src/org/labkey/query/LinkedSchema.java
+++ b/query/src/org/labkey/query/LinkedSchema.java
@@ -317,14 +317,6 @@ public class LinkedSchema extends ExternalSchema
     }
 
     @Override
-    public @NotNull ContainerFilter getDefaultContainerFilter()
-    {
-        return super.getDefaultContainerFilter();
-        // NOTE: The source table ContainerFilter is already set by _sourceSchema.getTable()
-//        return new ContainerFilter.InternalNoContainerFilter(getUser());
-    }
-
-    @Override
     protected LinkedTableInfo createWrappedTable(String name, @NotNull TableInfo sourceTable, ContainerFilter cf)
     {
         TableType metaData = getXbTable(name);

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -406,7 +406,7 @@ public class QueryModule extends DefaultModule
         boolean isProductProjectsEnabled = container != null && container.isProductProjectsEnabled();  // TODO: should these be moved to CoreModule?
         json.put(QueryService.PRODUCT_PROJECTS_ENABLED, container != null && container.isProductProjectsEnabled());
         json.put(QueryService.PRODUCT_PROJECTS_EXIST, isProductProjectsEnabled && container.hasProductProjects());
-        json.put(QueryService.EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS, AppProps.getInstance().isExperimentalFeatureEnabled(QueryService.EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS));
+        json.put(QueryService.EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS, QueryService.get().isProductProjectsAllFolderScopeEnabled());
 
         return json;
     }

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -72,6 +72,7 @@ import org.labkey.api.security.roles.PlatformDeveloperRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.settings.AdminConsole;
+import org.labkey.api.settings.AppProps;
 import org.labkey.api.stats.AnalyticsProviderRegistry;
 import org.labkey.api.stats.SummaryStatisticRegistry;
 import org.labkey.api.util.JspTestCase;
@@ -405,6 +406,7 @@ public class QueryModule extends DefaultModule
         boolean isProductProjectsEnabled = container != null && container.isProductProjectsEnabled();  // TODO: should these be moved to CoreModule?
         json.put(QueryService.PRODUCT_PROJECTS_ENABLED, container != null && container.isProductProjectsEnabled());
         json.put(QueryService.PRODUCT_PROJECTS_EXIST, isProductProjectsEnabled && container.hasProductProjects());
+        json.put(QueryService.EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS, AppProps.getInstance().isExperimentalFeatureEnabled(QueryService.EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS));
 
         return json;
     }

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -227,7 +227,8 @@ public class QueryModule extends DefaultModule
                 "For schema, query, and view metadata requests include a Last-Modified header such that the browser can cache the response. " +
                 "The metadata is invalidated when performing actions such as creating a new List or modifying the columns on a custom view", false);
         AdminConsole.addExperimentalFeatureFlag(USE_ROW_BY_ROW_UPDATE, "Use row-by-row update", "For Query.updateRows api, do row-by-row update, instead of using a prepared statement that updates rows in batches.", false);
-
+        AdminConsole.addExperimentalFeatureFlag(QueryServiceImpl.EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS, "Less restrictive product project lookups",
+                "Allow for lookup fields in product projects to query across all folders within the top-level folder.", false);
     }
 
 

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -229,6 +229,8 @@ public class QueryModule extends DefaultModule
         AdminConsole.addExperimentalFeatureFlag(USE_ROW_BY_ROW_UPDATE, "Use row-by-row update", "For Query.updateRows api, do row-by-row update, instead of using a prepared statement that updates rows in batches.", false);
         AdminConsole.addExperimentalFeatureFlag(QueryServiceImpl.EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS, "Less restrictive product project lookups",
                 "Allow for lookup fields in product projects to query across all folders within the top-level folder.", false);
+        AdminConsole.addExperimentalFeatureFlag(QueryServiceImpl.EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED, "Product projects display project-specific data",
+                "Only list project-specific data within product projects.", false);
     }
 
 

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -72,7 +72,6 @@ import org.labkey.api.security.roles.PlatformDeveloperRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.settings.AdminConsole;
-import org.labkey.api.settings.AppProps;
 import org.labkey.api.stats.AnalyticsProviderRegistry;
 import org.labkey.api.stats.SummaryStatisticRegistry;
 import org.labkey.api.util.JspTestCase;
@@ -407,6 +406,7 @@ public class QueryModule extends DefaultModule
         json.put(QueryService.PRODUCT_PROJECTS_ENABLED, container != null && container.isProductProjectsEnabled());
         json.put(QueryService.PRODUCT_PROJECTS_EXIST, isProductProjectsEnabled && container.hasProductProjects());
         json.put(QueryService.EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS, QueryService.get().isProductProjectsAllFolderScopeEnabled());
+        json.put(QueryService.EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED, QueryService.get().isProductProjectsDataListingScopedToProject());
 
         return json;
     }

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3232,6 +3232,7 @@ public class QueryServiceImpl implements QueryService
         return AppProps.getInstance().isExperimentalFeatureEnabled(EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS);
     }
 
+    @Override
     public boolean isProductProjectsDataListingScopedToProject()
     {
         return AppProps.getInstance().isExperimentalFeatureEnabled(EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED);

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3232,6 +3232,11 @@ public class QueryServiceImpl implements QueryService
         return AppProps.getInstance().isExperimentalFeatureEnabled(EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS);
     }
 
+    public boolean isProductProjectsDataListingScopedToProject()
+    {
+        return AppProps.getInstance().isExperimentalFeatureEnabled(EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED);
+    }
+
     public static class TestCase extends Assert
     {
         @Test

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3203,12 +3203,24 @@ public class QueryServiceImpl implements QueryService
     public ContainerFilter getContainerFilterForLookups(Container container, User user)
     {
         // Issue 45740: When inserting into a product project ensure the correct ContainerFilter scope
+        ContainerFilter.Type type = getContainerFilterTypeForLookups(container);
+
+        if (type == null)
+            return null;
+
+        return type.create(container, user);
+    }
+
+    @Override
+    @Nullable
+    public ContainerFilter.Type getContainerFilterTypeForLookups(Container container)
+    {
         if (container != null && container.isProductProjectsEnabled())
         {
             if (isProductProjectsAllFolderScopeEnabled())
-                return ContainerFilter.Type.AllInProjectPlusShared.create(container, user);
+                return ContainerFilter.Type.AllInProjectPlusShared;
 
-            return ContainerFilter.Type.CurrentPlusProjectAndShared.create(container, user);
+            return ContainerFilter.Type.CurrentPlusProjectAndShared;
         }
 
         return null;

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3205,13 +3205,19 @@ public class QueryServiceImpl implements QueryService
         // Issue 45740: When inserting into a product project ensure the correct ContainerFilter scope
         if (container != null && container.isProductProjectsEnabled())
         {
-            if (AppProps.getInstance().isExperimentalFeatureEnabled(EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS))
+            if (isProductProjectsAllFolderScopeEnabled())
                 return ContainerFilter.Type.AllInProjectPlusShared.create(container, user);
 
             return ContainerFilter.Type.CurrentPlusProjectAndShared.create(container, user);
         }
 
         return null;
+    }
+
+    @Override
+    public boolean isProductProjectsAllFolderScopeEnabled()
+    {
+        return AppProps.getInstance().isExperimentalFeatureEnabled(EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS);
     }
 
     public static class TestCase extends Assert

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3204,7 +3204,13 @@ public class QueryServiceImpl implements QueryService
     {
         // Issue 45740: When inserting into a product project ensure the correct ContainerFilter scope
         if (container != null && container.isProductProjectsEnabled())
+        {
+            if (AppProps.getInstance().isExperimentalFeatureEnabled(EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS))
+                return ContainerFilter.Type.AllInProjectPlusShared.create(container, user);
+
             return ContainerFilter.Type.CurrentPlusProjectAndShared.create(container, user);
+        }
+
         return null;
     }
 

--- a/study/src/org/labkey/study/query/BaseStudyTable.java
+++ b/study/src/org/labkey/study/query/BaseStudyTable.java
@@ -904,16 +904,6 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
         return super.supportsContainerFilter();
     }
 
-
-    @Override
-    @NotNull
-    public ContainerFilter getDefaultContainerFilter()
-    {
-        return getUserSchema().getDefaultContainerFilter();
-    }
-
-
-
     // for testing/breakpoints
 
     @Override

--- a/study/src/org/labkey/study/query/StudyQuerySchema.java
+++ b/study/src/org/labkey/study/query/StudyQuerySchema.java
@@ -1147,14 +1147,6 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
         return true;
     }
 
-    /** for tables that support container filter, the default container filter in this study */
-    @Override
-    @NotNull
-    public ContainerFilter getDefaultContainerFilter()
-    {
-        return ContainerFilter.current(getContainer());
-    }
-
     protected void initSessionParticipantGroup(StudyImpl study, User user)
     {
         if (study == null)


### PR DESCRIPTION
#### Rationale
This incorporates updates to make product projects less restrictive in terms of how referencing data across projects. There are two new experimental flags that introduce two new behaviors:

1. EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS - Allow for lookup fields in product projects to query across all folders within the top-level folder.
2. EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED - List only project-specific data within product projects.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/145
- https://github.com/LabKey/labkey-ui-components/pull/1114
- https://github.com/LabKey/labkey-ui-premium/pull/47
- https://github.com/LabKey/biologics/pull/1942
- https://github.com/LabKey/sampleManagement/pull/1617
- https://github.com/LabKey/inventory/pull/742
- https://github.com/LabKey/recipe/pull/81
- https://github.com/LabKey/platform/pull/4129

#### Changes
- Add new `AllInProjectPlusShared` container filter type. Current project, Shared project, and all folders in the current (LKS) project.
- Add new `getDefaultLookupContainerFilter` to `UserSchema` to support resolving container filter for lookups against a schema.
- Add `getLookupContainerFilter` to `AbstractContainerFilterable` for resolving container filter for lookups on columns.
- Override container filters in `PdLookupForeignKey` when experimental all folder lookups are enabled.
- Remove duplicate logic to declare default container filter (generally "current"). Resolve from `UserSchema`.
- Declare experimental flags and utility methods in Query module.
