### PR TITLE
"permission" and "permissionClass" properties are optional

### DIFF
--- a/api/src/org/labkey/api/data/ButtonBarConfig.java
+++ b/api/src/org/labkey/api/data/ButtonBarConfig.java
@@ -90,32 +90,39 @@ public class ButtonBarConfig
                     }
                     catch (Exception ignore) {}
 
-                    String permissionString = obj.getString("permission");
+                    String permissionString = obj.optString("permission", null);
 
-                    if ("READ".equalsIgnoreCase(permissionString))
+                    if (null != permissionString)
                     {
-                        button.setPermission(ReadPermission.class);
+                        if ("READ".equalsIgnoreCase(permissionString))
+                        {
+                            button.setPermission(ReadPermission.class);
+                        }
+                        else if ("INSERT".equalsIgnoreCase(permissionString))
+                        {
+                            button.setPermission(InsertPermission.class);
+                        }
+                        else if ("UPDATE".equalsIgnoreCase(permissionString))
+                        {
+                            button.setPermission(UpdatePermission.class);
+                        }
+                        else if ("DELETE".equalsIgnoreCase(permissionString))
+                        {
+                            button.setPermission(DeletePermission.class);
+                        }
+                        else if ("ADMIN".equalsIgnoreCase(permissionString))
+                        {
+                            button.setPermission(AdminPermission.class);
+                        }
                     }
-                    else if ("INSERT".equalsIgnoreCase(permissionString))
+
+                    // permission has precedence, but if it's not specified or invalid, look for permissionClass
+                    if (null == button.getPermission())
                     {
-                        button.setPermission(InsertPermission.class);
-                    }
-                    else if ("UPDATE".equalsIgnoreCase(permissionString))
-                    {
-                        button.setPermission(UpdatePermission.class);
-                    }
-                    else if ("DELETE".equalsIgnoreCase(permissionString))
-                    {
-                        button.setPermission(DeletePermission.class);
-                    }
-                    else if ("ADMIN".equalsIgnoreCase(permissionString))
-                    {
-                        button.setPermission(AdminPermission.class);
-                    }
-                    else if (json.getString("permissionClass") != null)
-                    {
-                        // permission has precedence, but if it's not specified look at permissionClass instead
-                        button.setPermission(getPermissionClass(json.getString("permissionClass")));
+                        String permissionClass = json.optString("permissionClass", null);
+
+                        if (null != permissionClass)
+                            button.setPermission(getPermissionClass(permissionClass));
                     }
 
                     //if the object has an "items" prop, load those as NavTree

--- a/api/src/org/labkey/api/query/QueryWebPart.java
+++ b/api/src/org/labkey/api/query/QueryWebPart.java
@@ -28,7 +28,6 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.DataRegion;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.security.User;
-import org.labkey.api.util.JsonUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HtmlView;
@@ -44,7 +43,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -534,7 +534,7 @@ public class DomainImpl implements Domain
             // or using LSID as the primary key on DomainDescriptor?
             if (scope.getSqlDialect().isSqlServer())
             {
-                String sql = " SELECT * FROM " + OntologyManager.getTinfoDomainDescriptor() + " WITH (UPDLOCK)";
+                String sql = "SELECT * FROM " + OntologyManager.getTinfoDomainDescriptor() + " WITH (UPDLOCK)";
                 new SqlSelector(schema, sql).getArrayList(DomainDescriptor.class);
             }
 


### PR DESCRIPTION
#### Rationale
`get` --> `opt` correction for new `JSONObject` use.

Also, micro-optimize "permission" value conversion given that the property is usually null.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4124
