### PR TITLE
Issue 47330: quotation marks in JMX-exposed objects breaks datadog's …

### DIFF
--- a/api/src/org/labkey/api/mbean/LabKeyManagement.java
+++ b/api/src/org/labkey/api/mbean/LabKeyManagement.java
@@ -15,10 +15,8 @@
  */
 package org.labkey.api.mbean;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.util.logging.LogHelper;
 
 import javax.management.DynamicMBean;


### PR DESCRIPTION
…jmxfetch

#### Rationale
Developers may include problematic characters in cache names and other objects that are exposed via JMX

#### Changes
* Replace potentially problematic characters