### PR TITLE
Allow passing DataIteratorContext to AbstractQueryImport.importData

### DIFF
--- a/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
@@ -50,7 +50,7 @@ public class DataIteratorContext
     boolean _allowImportLookupByAlternateKey = false;
     private final Set<String> _passThroughBuiltInColumnNames = new CaseInsensitiveHashSet();
     private final Set<String> _dontUpdateColumnNames = new CaseInsensitiveHashSet();
-    private final Set<String> _alternateKeys = new CaseInsensitiveHashSet();
+    private Set<String> _alternateKeys = new CaseInsensitiveHashSet();
     private String _dataSource;
 
     int _maxRowErrors = 1;
@@ -178,6 +178,11 @@ public class DataIteratorContext
     public Set<String> getAlternateKeys()
     {
         return _alternateKeys;
+    }
+
+    public void setAlternateKeys(Set<String> alternateKeys)
+    {
+        _alternateKeys = alternateKeys;
     }
 
     /** if this etl should be killed, will execute <code>throw _errors;</code> */

--- a/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
@@ -50,7 +50,7 @@ public class DataIteratorContext
     boolean _allowImportLookupByAlternateKey = false;
     private final Set<String> _passThroughBuiltInColumnNames = new CaseInsensitiveHashSet();
     private final Set<String> _dontUpdateColumnNames = new CaseInsensitiveHashSet();
-    private Set<String> _alternateKeys = new CaseInsensitiveHashSet();
+    private final Set<String> _alternateKeys = new CaseInsensitiveHashSet();
     private String _dataSource;
 
     int _maxRowErrors = 1;
@@ -178,11 +178,6 @@ public class DataIteratorContext
     public Set<String> getAlternateKeys()
     {
         return _alternateKeys;
-    }
-
-    public void setAlternateKeys(Set<String> alternateKeys)
-    {
-        _alternateKeys = alternateKeys;
     }
 
     /** if this etl should be killed, will execute <code>throw _errors;</code> */


### PR DESCRIPTION
#### Rationale
Provide a version of AbstractQueryImportAction.importData that takes a DataIteratorContext parameter instead of a handful of the parameters that are saved in the context. This is needed in EHR to pass in more options for the import.

A next iteration on this would probably be to factor out usages of the other importData functions to use a DataIteratorContext, but that is out of scope for this budget/feature.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/549

#### Changes
* Factor the current implementation to take a DataIteratorContext parameter
* Move the current creation of DataIteratorContext to another importData version