### PR TITLE
Issue 45875: Filters on multiple grids on a page are removed when customizing one of the grids

### DIFF
--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -3163,7 +3163,8 @@ if (!LABKEY.DataRegions) {
 
                                     // Special prefix that should remove all filters, but no other parameters for the current grid
                                     if (skipPrefix.indexOf(ALL_FILTERS_SKIP_PREFIX) === (skipPrefix.length - 2)) {
-                                        if (key.indexOf(region.name) >= 0 && key.indexOf('~') > 0) {
+                                        if (key.indexOf(region.name + '.') == 0 && key.indexOf('~') > 0) {
+
                                             stop = true;
                                             return false;
                                         }

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -3163,7 +3163,7 @@ if (!LABKEY.DataRegions) {
 
                                     // Special prefix that should remove all filters, but no other parameters for the current grid
                                     if (skipPrefix.indexOf(ALL_FILTERS_SKIP_PREFIX) === (skipPrefix.length - 2)) {
-                                        if (key.indexOf(region.name + '.') == 0 && key.indexOf('~') > 0) {
+                                        if (key.indexOf(region.name + '.') === 0 && key.indexOf('~') > 0) {
 
                                             stop = true;
                                             return false;
@@ -3178,7 +3178,7 @@ if (!LABKEY.DataRegions) {
                                         }
                                         else if (key.toLowerCase().indexOf(skipPrefix.toLowerCase()) === 0) {
                                             // only skip filters, parameters, and sorts for the current grid
-                                            if (key.indexOf(region.name + '.') == 0 &&
+                                            if (key.indexOf(region.name + '.') === 0 &&
 
                                                     (key === skipPrefix ||
                                                     key.indexOf('~') > 0 ||

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -3178,7 +3178,8 @@ if (!LABKEY.DataRegions) {
                                         }
                                         else if (key.toLowerCase().indexOf(skipPrefix.toLowerCase()) === 0) {
                                             // only skip filters, parameters, and sorts for the current grid
-                                            if (key.indexOf(region.name) >= 0 &&
+                                            if (key.indexOf(region.name + '.') == 0 &&
+
                                                     (key === skipPrefix ||
                                                     key.indexOf('~') > 0 ||
                                                     key.indexOf(PARAM_PREFIX) > 0 ||

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -3161,9 +3161,9 @@ if (!LABKEY.DataRegions) {
                             $.each(skipPrefixSet, function (j, skipPrefix) {
                                 if (LABKEY.Utils.isString(skipPrefix)) {
 
-                                    // Special prefix that should remove all filters, but no other parameters
+                                    // Special prefix that should remove all filters, but no other parameters for the current grid
                                     if (skipPrefix.indexOf(ALL_FILTERS_SKIP_PREFIX) === (skipPrefix.length - 2)) {
-                                        if (key.indexOf('~') > 0) {
+                                        if (key.indexOf(region.name) >= 0 && key.indexOf('~') > 0) {
                                             stop = true;
                                             return false;
                                         }
@@ -3176,11 +3176,12 @@ if (!LABKEY.DataRegions) {
                                             }
                                         }
                                         else if (key.toLowerCase().indexOf(skipPrefix.toLowerCase()) === 0) {
-                                            // only skip filters, parameters, and sorts
-                                            if (key === skipPrefix ||
+                                            // only skip filters, parameters, and sorts for the current grid
+                                            if (key.indexOf(region.name) >= 0 &&
+                                                    (key === skipPrefix ||
                                                     key.indexOf('~') > 0 ||
                                                     key.indexOf(PARAM_PREFIX) > 0 ||
-                                                    key === (skipPrefix + 'sort')) {
+                                                    key === (skipPrefix + 'sort'))) {
                                                 stop = true;
                                                 return false;
                                             }


### PR DESCRIPTION
#### Rationale
Issue [45875](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45875): Filters on multiple grids on a page are removed when customizing one of the grids

#### Changes
* Only handle/skip filtering on the current grid that is being customized when multiple grids are present on the page