### PR TITLE
Fix occasional "Expected a QueryDefinition object" error with temp queries

### DIFF
--- a/api/src/org/labkey/api/query/QueryForm.java
+++ b/api/src/org/labkey/api/query/QueryForm.java
@@ -297,6 +297,12 @@ public class QueryForm extends ReturnUrlForm implements HasViewContext, HasBindP
         return _schemaName == null ? "" : _schemaName.toString();
     }
 
+    @Nullable
+    public SchemaKey getSchemaKey()
+    {
+        return _schemaName;
+    }
+
     public final @Nullable UserSchema getSchema()
     {
         init();

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -100,7 +100,6 @@ public interface QueryService
 
     QueryDefinition getQueryDef(User user, Container container, String schema, String name);
 
-    @Deprecated /** Use SchemaKey form instead. */ QueryDefinition createQueryDef(User user, Container container, String schema, String name);
     QueryDefinition createQueryDef(User user, Container container, SchemaKey schema, String name);
     QueryDefinition createQueryDef(User user, Container container, UserSchema schema, String name);
     QueryDefinition createQueryDefForTable(UserSchema schema, String tableName);
@@ -113,7 +112,7 @@ public interface QueryService
     QueryDefinition saveSessionQuery(ViewContext context, Container container, String schema, String sql);
     QueryDefinition saveSessionQuery(ViewContext context, Container container, String schema, String sql, String metadataXml);
     QueryDefinition saveSessionQuery(HttpSession session, Container container, User user, String schema, String sql, @Nullable String xml);
-    QueryDefinition getSessionQuery(ViewContext context, Container container, String schema, String queryName);
+    QueryDefinition getSessionQuery(ViewContext context, Container container, SchemaKey schema, String queryName);
 
     ActionURL urlQueryDesigner(User user, Container container, String schema);
     ActionURL urlFor(User user, Container container, QueryAction action, String schema, String queryName);

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -1515,6 +1515,7 @@ public class QueryServiceImpl implements QueryService
 
         Map<ContainerSchemaKey, Map<String, SessionQuery>> containerQueries;
 
+        // Synchronize to avoid problems with multiple concurrent HTTP requests trying to create the query map
         synchronized (PERSISTED_TEMP_QUERIES_KEY)
         {
             containerQueries = (Map<ContainerSchemaKey, Map<String, SessionQuery>>) session.getAttribute(PERSISTED_TEMP_QUERIES_KEY);

--- a/query/src/org/labkey/query/QueryTestCase.jsp
+++ b/query/src/org/labkey/query/QueryTestCase.jsp
@@ -326,7 +326,7 @@ d,seven,twelve,day,month,date,duration,guid
             }
             catch (Exception x)
             {
-                Assert.fail(x.toString() + "\n" + _sql);
+                Assert.fail(x + "\n" + _sql);
             }
         }
 
@@ -1443,8 +1443,10 @@ d,seven,twelve,day,month,date,duration,guid
         //    exists (subquery)
         //
 
+        SchemaKey schemaKey = SchemaKey.fromString("issues");
+
         // Query.setContainerFilter()
-        QueryDefinition q = QueryService.get().createQueryDef(user, c, "issues", "testquery");
+        QueryDefinition q = QueryService.get().createQueryDef(user, c, schemaKey, "testquery");
         q.setContainerFilter(custom);
         q.setSql("SELECT DISTINCT label, container.name\n" +
                 "FROM (SELECT DISTINCT rowid, container, label FROM issuelistdef WHERE EXISTS (SELECT * FROM issuelistdef WHERE rowid=5)) x");
@@ -1460,7 +1462,7 @@ d,seven,twelve,day,month,date,duration,guid
         assertEquals(2, StringUtils.countMatches(debugSql, "CONTAINERFILTER"));
 
         // TableInfo.setContainerFilter()
-        q = QueryService.get().createQueryDef(user, c, "issues", "testquery");
+        q = QueryService.get().createQueryDef(user, c, schemaKey, "testquery");
         q.setSql("SELECT DISTINCT label, container.name\n" +
                 "FROM (SELECT DISTINCT rowid, container, label FROM issuelistdef WHERE EXISTS (SELECT * FROM issuelistdef WHERE rowid=5)) x");
         errors = new ArrayList<>();

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -886,7 +886,7 @@ public class QueryController extends SpringActionController
                     errors.reject(ERROR_MSG, "The query '" + newQueryName + "' already exists as a table");
                     return false;
                 }
-                QueryDefinition newDef = QueryService.get().createQueryDef(getUser(), getContainer(), form.getSchemaName(), form.ff_newQueryName);
+                QueryDefinition newDef = QueryService.get().createQueryDef(getUser(), getContainer(), form.getSchemaKey(), form.ff_newQueryName);
                 Query query = new Query(schema);
                 query.setRootTable(FieldKey.fromParts(form.ff_baseTableName));
                 String sql = query.getQueryText();

--- a/study/api-src/org/labkey/api/specimen/query/SpecimenReportQuery.java
+++ b/study/api-src/org/labkey/api/specimen/query/SpecimenReportQuery.java
@@ -181,7 +181,7 @@ public class SpecimenReportQuery
 
         String query = String.format(sql_pivotRequestedByLocation, subjectCol, visitCol, subjectCol, visitCol, subjectCol, visitCol);
 
-        QueryDefinition qdef = QueryService.get().createQueryDef(schema.getUser(), container, schema.getName(), PIVOT_BY_REQUESTING_LOCATION);
+        QueryDefinition qdef = QueryService.get().createQueryDef(schema.getUser(), container, schema.getSchemaPath(), PIVOT_BY_REQUESTING_LOCATION);
         qdef.setSql(query);
         qdef.setIsHidden(true);
 


### PR DESCRIPTION
#### Rationale
I occasionally see "Expected a QueryDefinition object" errors when loading pages with multiple grids backed by QueryWebParts that pass SQL instead of referencing a saved query. There's a race condition with setting up the session-backed storage of the temp queries

#### Changes
* Synchronize around the critical section for creating the session query storage
* Migrate more calls to use SchemaKey instead of String for schema names