### PR TITLE
Restrict schema version upgrade check to modules in LabKey-managed repos

### DIFF
--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -23,7 +23,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.action.HasViewContext;
-import org.labkey.api.action.PermissionCheckable;
 import org.labkey.api.action.PermissionCheckableAction;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
@@ -92,8 +91,6 @@ import java.util.function.Supplier;
 
 /**
  * Standard base class for modules, supplies no-op implementations for many optional methods.
- * User: migra
- * Date: Jul 14, 2005
  */
 public abstract class DefaultModule implements Module, ApplicationContextAware
 {

--- a/api/src/org/labkey/api/security/AuthenticationLogoAttachmentParent.java
+++ b/api/src/org/labkey/api/security/AuthenticationLogoAttachmentParent.java
@@ -22,6 +22,9 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ContainerManager.ContainerParent;
 
 // Used for attaching SSO authentication logos to the root container
+// TODO: Previous comment is a lie... SSO logos are now attached to each authentication configuration. (We can have
+//  multiple SAML configurations and multiple CAS configurations, each with their own logo.) Anyway, this is no longer
+//  used, except for a junit test. Delete or rename to TestAttachmentParent?
 public class AuthenticationLogoAttachmentParent extends ContainerParent
 {
     private AuthenticationLogoAttachmentParent(Container c)


### PR DESCRIPTION
#### Rationale
Flagging old schema versions for all modules with `ManageVersion` set true is too strict, since this is the default value. Third-party modules that don't specify this value and use their own versioning schemes ran afoul of our check. See https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47369

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3950