### PR TITLE
Fix ETL failure running with enterprise pipeline introduced by fix 47195

### DIFF
--- a/api/src/org/labkey/api/util/Job.java
+++ b/api/src/org/labkey/api/util/Job.java
@@ -63,8 +63,7 @@ public abstract class Job implements Future, Runnable
     @Override
     public boolean isCancelled()
     {
-        if (_task == null) throw new IllegalStateException("job has not been submitted");
-        return _task.isCancelled();
+        return _task != null && _task.isCancelled();
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
The fix for Issue 47195: Enterprise pipeline temp directories are not always cleaned up, https://github.com/LabKey/platform/pull/4110, introduced a failure when running ETLs with the enterprise pipeline configured

#### Changes
* If we don't have a task, we're done and know we haven't been cancelled