### PR TITLE
Issue 47404: Sample Manager: Property field containing '${}' should be disallowed

### DIFF
--- a/api/src/org/labkey/api/data/DisplayColumn.java
+++ b/api/src/org/labkey/api/data/DisplayColumn.java
@@ -1127,7 +1127,13 @@ public abstract class DisplayColumn extends RenderColumn
             return writer.toString();
         }
 
-        return _caption == null ? getName() : _caption.eval(ctx);
+        if (_caption == null)
+            return getName();
+
+        if (ctx != null || _caption instanceof StringExpressionFactory.ConstantStringExpression)
+            return _caption.eval(ctx);
+
+        return _caption.getSource();
     }
 
 

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -83,9 +83,11 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
 import static org.labkey.api.dataiterator.DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior;
+import static org.labkey.api.util.StringExpressionFactory.SUBSTITUTION_EXP_PATTERN;
 
 /**
  * User: jgarms
@@ -1156,6 +1158,13 @@ public class DomainUtil
             if (null == name || name.trim().length() == 0)
             {
                 exception.addError(new SimpleValidationError(getDomainErrorMessage(updates,"Please provide a name for each field.")));
+                continue;
+            }
+
+            Matcher expMatcher = SUBSTITUTION_EXP_PATTERN.matcher(name);
+            if (expMatcher.find())
+            {
+                exception.addFieldError(name, getDomainErrorMessage(updates, "The '${}' substitution token is reserved for system use."));
                 continue;
             }
 

--- a/api/src/org/labkey/api/util/StringExpressionFactory.java
+++ b/api/src/org/labkey/api/util/StringExpressionFactory.java
@@ -53,6 +53,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.labkey.api.data.AbstractTableInfo.LINK_DISABLER;
 
@@ -76,6 +78,8 @@ public class StringExpressionFactory
 
     public static final StringExpression EMPTY_STRING = new ConstantStringExpression("");
 
+    public static final String SUBSTITUTION_EXP_PREFIX = ".*\\$\\{.+}.*";
+    public static final Pattern SUBSTITUTION_EXP_PATTERN = Pattern.compile(SUBSTITUTION_EXP_PREFIX);
 
     public static StringExpression create(String str)
     {
@@ -98,7 +102,8 @@ public class StringExpressionFactory
         if (StringUtils.isEmpty(str))
             return EMPTY_STRING;
 
-        if (!str.contains("${"))
+        Matcher expMatcher = SUBSTITUTION_EXP_PATTERN.matcher(str);
+        if (!expMatcher.find())
             return new ConstantStringExpression(str);
 
         String key = "simple:" + str + "(" + urlEncodeSubstitutions + ")";


### PR DESCRIPTION
#### Rationale
When sample property field contains '${' substring, the column caption is not treated as a ConstantStringExpression, resulting in exception:
https://www.labkey.org/_mothership/mothership-showStackTraceDetail.view?exceptionStackTraceId=32066

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* better handling of DisplayColumn.getCaption to avoid NPE
* disallow domain field containing ${} pattern
