### PR TITLE
CrosstabTableInfo.isCrosstab()

### DIFF
--- a/api/src/org/labkey/api/data/CrosstabTable.java
+++ b/api/src/org/labkey/api/data/CrosstabTable.java
@@ -103,6 +103,12 @@ public class CrosstabTable extends VirtualTable implements CrosstabTableInfo
                                             _settings.getMeasures());
     } //c-tor
 
+    @Override
+    public boolean isCrosstab()
+    {
+        return true;
+    }
+
     /**
      * Sets the aggregate filters. Aggregate filters are applied post-aggregation, but
      * pre-pivoting, so they can filter out rows with aggregates that do not match the filters.

--- a/api/src/org/labkey/api/data/CrosstabTableInfo.java
+++ b/api/src/org/labkey/api/data/CrosstabTableInfo.java
@@ -23,6 +23,8 @@ import java.util.List;
  */
 public interface CrosstabTableInfo extends TableInfo
 {
+    boolean isCrosstab();
+
     /**
      * Returns the {@link org.labkey.api.data.CrosstabSettings} object passed to the constructor.
      *

--- a/api/src/org/labkey/api/query/CrosstabView.java
+++ b/api/src/org/labkey/api/query/CrosstabView.java
@@ -89,10 +89,8 @@ public class CrosstabView extends QueryView
     @Override
     protected DataRegion createDataRegion()
     {
-        if (getTable() instanceof CrosstabTableInfo)
+        if (getTable() instanceof CrosstabTableInfo table && table.isCrosstab())
         {
-            CrosstabTableInfo table = (CrosstabTableInfo)getTable();
-
             //get the display columns
             //this will also adjust _numRowAxisCols and _numMeasures based on
             //the selected display columns
@@ -110,7 +108,7 @@ public class CrosstabView extends QueryView
     @Override
     public List<DisplayColumn> getDisplayColumns()
     {
-        assert getTable() instanceof CrosstabTableInfo;
+        assert getTable() instanceof CrosstabTableInfo && ((CrosstabTableInfo) getTable()).isCrosstab();
         CrosstabTableInfo table = (CrosstabTableInfo)getTable();
 
         List<FieldKey> selectedFieldKeys = null;
@@ -200,7 +198,7 @@ public class CrosstabView extends QueryView
     {
         DataView view = super.createDataView();
 
-        assert getTable() instanceof CrosstabTableInfo;
+        assert getTable() instanceof CrosstabTableInfo && ((CrosstabTableInfo) getTable()).isCrosstab();
         CrosstabTableInfo table = (CrosstabTableInfo)getTable();
 
         // set the default base sort (remove non-existent sort columns), merging with any existing base sort from the

--- a/api/src/org/labkey/api/query/CrosstabView.java
+++ b/api/src/org/labkey/api/query/CrosstabView.java
@@ -108,7 +108,8 @@ public class CrosstabView extends QueryView
     @Override
     public List<DisplayColumn> getDisplayColumns()
     {
-        assert getTable() instanceof CrosstabTableInfo && ((CrosstabTableInfo) getTable()).isCrosstab();
+        assert getTable() instanceof CrosstabTableInfo cti && cti.isCrosstab();
+
         CrosstabTableInfo table = (CrosstabTableInfo)getTable();
 
         List<FieldKey> selectedFieldKeys = null;

--- a/api/src/org/labkey/api/query/CrosstabView.java
+++ b/api/src/org/labkey/api/query/CrosstabView.java
@@ -199,7 +199,8 @@ public class CrosstabView extends QueryView
     {
         DataView view = super.createDataView();
 
-        assert getTable() instanceof CrosstabTableInfo && ((CrosstabTableInfo) getTable()).isCrosstab();
+        assert getTable() instanceof CrosstabTableInfo cti && cti.isCrosstab();
+
         CrosstabTableInfo table = (CrosstabTableInfo)getTable();
 
         // set the default base sort (remove non-existent sort columns), merging with any existing base sort from the

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -439,7 +439,8 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
         if (qdef != null)
         {
             TableInfo tableInfo = qdef.getTable(this, new ArrayList<>(), true);
-            if (tableInfo instanceof CrosstabTableInfo && ((CrosstabTableInfo) tableInfo).isCrosstab())
+            if (tableInfo instanceof CrosstabTableInfo cti && cti.isCrosstab())
+
                 return new CrosstabView(this, settings, errors);
         }
 

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -439,8 +439,8 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
         if (qdef != null)
         {
             TableInfo tableInfo = qdef.getTable(this, new ArrayList<>(), true);
-            if (tableInfo instanceof CrosstabTableInfo)
-                return new CrosstabView(this, settings, errors);
+            assert tableInfo instanceof CrosstabTableInfo && ((CrosstabTableInfo) tableInfo).isCrosstab();
+            return new CrosstabView(this, settings, errors);
         }
 
         return new QueryView(this, settings, errors);

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -439,8 +439,8 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
         if (qdef != null)
         {
             TableInfo tableInfo = qdef.getTable(this, new ArrayList<>(), true);
-            assert tableInfo instanceof CrosstabTableInfo && ((CrosstabTableInfo) tableInfo).isCrosstab();
-            return new CrosstabView(this, settings, errors);
+            if (tableInfo instanceof CrosstabTableInfo && ((CrosstabTableInfo) tableInfo).isCrosstab())
+                return new CrosstabView(this, settings, errors);
         }
 
         return new QueryView(this, settings, errors);

--- a/query/src/org/labkey/query/QueryTestCase.jsp
+++ b/query/src/org/labkey/query/QueryTestCase.jsp
@@ -341,6 +341,15 @@ d,seven,twelve,day,month,date,duration,guid
         private final JdbcType _type;
         private final Object _value;
         private final Callable<Object> _call;
+        private static final Object NOCHECK = new Object();
+
+        MethodSqlTest(String sql, JdbcType type)
+        {
+            super(sql, 1, 1);
+            _type = type;
+            _value = NOCHECK;
+            _call = null;
+        }
 
         MethodSqlTest(String sql, JdbcType type, Object value)
         {
@@ -364,6 +373,8 @@ d,seven,twelve,day,month,date,duration,guid
             assertTrue("Expected one row: " + _sql, rs.next());
             Object o = rs.getObject(1);
             assertFalse("Expected one row: " + _sql, rs.next());
+            if (NOCHECK == _value)
+                return;
             Object value = null == _call ? _value : _call.call();
             assertSqlEquals(value, o);
         }
@@ -687,6 +698,7 @@ d,seven,twelve,day,month,date,duration,guid
                     new MethodSqlTest("SELECT concat('concat', concat('in', concat('the', 'hat'))) FROM R WHERE rowid=1", JdbcType.VARCHAR, "concatinthehat"),
                     new MethodSqlTest("SELECT contextPath()", JdbcType.VARCHAR, () -> new ActionURL().getContextPath()),
                     new MethodSqlTest("SELECT CONVERT(123, VARCHAR) FROM R WHERE rowid=1", JdbcType.VARCHAR, "123"),
+                    new MethodSqlTest("SELECT COUNT(R.twelve) as cnt FROM R", JdbcType.INTEGER),
                     // TODO: cos
                     // TODO: cot
                     // TODO: curdate
@@ -699,6 +711,7 @@ d,seven,twelve,day,month,date,duration,guid
                     new MethodSqlTest("SELECT folderName()", JdbcType.VARCHAR, () -> JunitUtil.getTestContainer().getName()),
                     new MethodSqlTest("SELECT folderPath()", JdbcType.VARCHAR, () -> JunitUtil.getTestContainer().getPath()),
                     new MethodSqlTest("SELECT GREATEST(0, 2, 1)", JdbcType.INTEGER, 2),
+                    new MethodSqlTest("SELECT GROUP_CONCAT(R.twelve) as gc FROM R", JdbcType.VARCHAR),
                     // TODO: hour
                     new MethodSqlTest("SELECT IFNULL(NULL, 'empty') FROM R WHERE rowid=1", JdbcType.VARCHAR, "empty"),
                     new MethodSqlTest("SELECT ISEQUAL(NULL, NULL) FROM R WHERE rowid=1", JdbcType.BOOLEAN, true),

--- a/query/src/org/labkey/query/sql/QAggregate.java
+++ b/query/src/org/labkey/query/sql/QAggregate.java
@@ -46,7 +46,7 @@ public class QAggregate extends QExpr
         MIN(true, true),
         MAX(true, true),
         AVG(true, true),
-        GROUP_CONCAT(true, true),
+        GROUP_CONCAT(false, true),
         STDDEV(true, false)
             {
                 @Override

--- a/query/src/org/labkey/query/sql/QueryColumnLogging.java
+++ b/query/src/org/labkey/query/sql/QueryColumnLogging.java
@@ -59,8 +59,9 @@ public class QueryColumnLogging extends ColumnLogging
     @Override
     public ColumnLogging remapFieldKeys(FieldKey baseFieldKey, Map<FieldKey, FieldKey> remap, Set<String> remapWarnings)
     {
-        // see QueryTableInfo.remapFieldKeys().
-        throw new UnsupportedOperationException();
+        // This call should be followed up by remapQueryFieldKeys()
+        // e.g. see QueryTableInfo.remapFieldKeys().
+        return this;
     }
 
 

--- a/query/src/org/labkey/query/sql/QueryLookupWrapper.java
+++ b/query/src/org/labkey/query/sql/QueryLookupWrapper.java
@@ -235,7 +235,7 @@ public class QueryLookupWrapper extends AbstractQueryRelation implements QueryRe
         @Override
         public boolean isCrosstab()
         {
-            return _crosstabTableInfo.isCrosstab();
+            return null != _crosstabTableInfo && _crosstabTableInfo.isCrosstab();
         }
 
         @Override

--- a/query/src/org/labkey/query/sql/QueryLookupWrapper.java
+++ b/query/src/org/labkey/query/sql/QueryLookupWrapper.java
@@ -27,6 +27,11 @@ import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ColumnLogging;
 import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.CrosstabMeasure;
+import org.labkey.api.data.CrosstabMember;
+import org.labkey.api.data.CrosstabSettings;
+import org.labkey.api.data.CrosstabTableInfo;
+import org.labkey.api.data.Filter;
 import org.labkey.api.data.ForeignKey;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PHI;
@@ -177,25 +182,7 @@ public class QueryLookupWrapper extends AbstractQueryRelation implements QueryRe
         if (keys.size() == 1)
             key = new FieldKey(null, keys.iterator().next());
 
-        var ret = new QueryTableInfo(this, getAlias())
-        {
-            @Override
-            protected void afterInitializeColumns()
-            {
-                remapSelectFieldKeys(true);
-            }
-
-            @Override
-            public String getTitleColumn()
-            {
-                RelationColumn titleColumn = null;
-                if (_source instanceof QuerySelect select)
-                    titleColumn = select.getTitleColumn();
-                if (null != titleColumn && titleColumn.getFieldKey().size() == 1)
-                    return titleColumn.getFieldKey().getName();
-                return super.getTitleColumn();
-            }
-        };
+        var ret = new QLWTableInfo();
         for (var col : _selectedColumns.values())
         {
             RelationColumnInfo ci = new RelationColumnInfo(ret, col);
@@ -211,6 +198,75 @@ public class QueryLookupWrapper extends AbstractQueryRelation implements QueryRe
         ret.afterInitializeColumns();
         MemTracker.getInstance().put(ret);
         return ret;
+    }
+
+
+    private class QLWTableInfo extends QueryTableInfo implements CrosstabTableInfo
+    {
+        CrosstabTableInfo _crosstabTableInfo;
+
+        QLWTableInfo()
+        {
+            super(QueryLookupWrapper.this, QueryLookupWrapper.this.getAlias());
+            if (_source instanceof QueryPivot)
+                _crosstabTableInfo = (CrosstabTableInfo)_source.getTableInfo();
+        }
+
+        @Override
+        protected void afterInitializeColumns()
+        {
+            remapSelectFieldKeys(true);
+        }
+
+        @Override
+        public String getTitleColumn()
+        {
+            RelationColumn titleColumn = null;
+            if (_source instanceof QuerySelect select)
+                titleColumn = select.getTitleColumn();
+            if (null != titleColumn && titleColumn.getFieldKey().size() == 1)
+                return titleColumn.getFieldKey().getName();
+            return super.getTitleColumn();
+        }
+
+        // CrosstabTableInfo
+
+
+        @Override
+        public boolean isCrosstab()
+        {
+            return _crosstabTableInfo.isCrosstab();
+        }
+
+        @Override
+        public CrosstabSettings getSettings()
+        {
+            return _crosstabTableInfo.getSettings();
+        }
+
+        @Override
+        public List<CrosstabMember> getColMembers()
+        {
+            return _crosstabTableInfo.getColMembers();
+        }
+
+        @Override
+        public CrosstabMeasure getMeasureFromKey(String fieldKey)
+        {
+            return _crosstabTableInfo.getMeasureFromKey(fieldKey);
+        }
+
+        @Override
+        public void setAggregateFilter(Filter filter)
+        {
+            _crosstabTableInfo.setAggregateFilter(filter);
+        }
+
+        @Override
+        public Sort getDefaultSort()
+        {
+            return _crosstabTableInfo.getDefaultSort();
+        }
     }
 
 

--- a/query/src/org/labkey/query/sql/QueryPivot.java
+++ b/query/src/org/labkey/query/sql/QueryPivot.java
@@ -887,6 +887,12 @@ public class QueryPivot extends AbstractQueryRelation
         }
 
         @Override
+        public boolean isCrosstab()
+        {
+            return true;
+        }
+
+        @Override
         protected void initializeColumns()
         {
             for (RelationColumn col : getAllColumns().values())


### PR DESCRIPTION
#### Rationale
Avoid bug due to TableInfo instanceof CrosstabTableInfo.  
Solution is to add a capability bit to interface.  
Callers must now check instanceof CrosstabTableInfo and .isCrosstab().

CONSIDER: move to TableInfo.getInterface(CrosstabTableInfo.class) pattern?

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
