### PR TITLE
Issue 47202: Options to reduce payload of getContainers.api response

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1367,13 +1367,13 @@ public class Container implements Serializable, Comparable<Container>, Securable
         return toJSON(user, true, true);
     }
 
-    public Map<String, Object> toJSON(User user, boolean includePermissions, boolean includeAssortedProps)
+    public Map<String, Object> toJSON(User user, boolean includePermissions, boolean includeStandardProps)
     {
         Map<String, Object> containerProps = new HashMap<>();
         Container parent = getParent();
         containerProps.put("name", getName());
         containerProps.put("path", getPath());
-        if (includeAssortedProps)
+        if (includeStandardProps)
         {
             containerProps.put("parentPath", parent == null ? null : parent.getPath());
             containerProps.put("title", getTitle());
@@ -1396,7 +1396,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
                 containerProps.put("effectivePermissions", SecurityManager.getPermissionNames(getPolicy(), user));
             }
 
-            if (includeAssortedProps)
+            if (includeStandardProps)
             {
                 containerProps.put("parentId", parent == null ? null : parent.getId());
                 containerProps.put("startUrl", getStartURL(user).toString());

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -565,6 +565,7 @@ public class ModuleLoader implements Filter, MemTrackerListener
         // Issue 40422 - log server and session GUIDs during startup. Do it after the core module has
         // been bootstrapped/upgraded to ensure that AppProps is ready
         _log.info("Server installation GUID: " + AppProps.getInstance().getServerGUID() + ", server session GUID: " + AppProps.getInstance().getServerSessionGUID());
+        _log.info("Deploying to context path " + AppProps.getInstance().getContextPath());
 
         synchronized (_modulesLock)
         {

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -2313,7 +2313,7 @@ public class PageFlowUtil
 
         if (null != container)
         {
-            json.put("container", container.toJSON(user, config != null && config.isIncludePermissions()));
+            json.put("container", container.toJSON(user, config != null && config.isIncludePermissions(), true));
             json.put("demoMode", DemoMode.isDemoMode(container, user));
         }
 

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,8 +8,8 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/api": "1.18.7",
-        "@labkey/components": "2.301.0",
+        "@labkey/api": "1.18.7-fb-47202-getContainersAPIOptions.0",
+        "@labkey/components": "2.302.0-fb-47202-getContainersAPIOptions.0",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3018,9 +3018,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.18.7",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.7.tgz",
-      "integrity": "sha512-MNSiG2xz5RzDKtucXBo5QMsToa8wxVWZc08Leh4mK+e9AhP/Tq7CKOs/+1wZS/mAetbWwB3fBnrMRkeo9relXg=="
+      "version": "1.18.7-fb-47202-getContainersAPIOptions.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.7-fb-47202-getContainersAPIOptions.0.tgz",
+      "integrity": "sha512-CFRi+gnkAzt7J6vWaRtWzPP5sWAKYZubZsqTTj9Mdp9j1+l/VFUO2d9ypAvirWCiFXYzjZUCH1PrvLP7Nsowww=="
     },
     "node_modules/@labkey/build": {
       "version": "6.9.0",
@@ -3057,11 +3057,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.301.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.301.0.tgz",
-      "integrity": "sha512-I7ydUKeS5zkT9dfYzIs7a1QhABUZizykEUwphZwve6w1J7EAcehol0uyEX/NYI3mMBUexXFYiDI1pG9uHuGmiw==",
+      "version": "2.302.0-fb-47202-getContainersAPIOptions.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.302.0-fb-47202-getContainersAPIOptions.0.tgz",
+      "integrity": "sha512-xkWyh2cf3+UH6ugrSkV3KGBqsrqQpEQJsHU3cs4Z1QoMkxhReo3A6V3dlmQOCFEOHBGcvlJ+xyTxG2KsvRIc3Q==",
       "dependencies": {
-        "@labkey/api": "1.18.7",
+        "@labkey/api": "1.18.7-fb-47202-getContainersAPIOptions.0",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",
@@ -17206,9 +17206,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.18.7",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.7.tgz",
-      "integrity": "sha512-MNSiG2xz5RzDKtucXBo5QMsToa8wxVWZc08Leh4mK+e9AhP/Tq7CKOs/+1wZS/mAetbWwB3fBnrMRkeo9relXg=="
+      "version": "1.18.7-fb-47202-getContainersAPIOptions.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.7-fb-47202-getContainersAPIOptions.0.tgz",
+      "integrity": "sha512-CFRi+gnkAzt7J6vWaRtWzPP5sWAKYZubZsqTTj9Mdp9j1+l/VFUO2d9ypAvirWCiFXYzjZUCH1PrvLP7Nsowww=="
     },
     "@labkey/build": {
       "version": "6.9.0",
@@ -17245,11 +17245,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.301.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.301.0.tgz",
-      "integrity": "sha512-I7ydUKeS5zkT9dfYzIs7a1QhABUZizykEUwphZwve6w1J7EAcehol0uyEX/NYI3mMBUexXFYiDI1pG9uHuGmiw==",
+      "version": "2.302.0-fb-47202-getContainersAPIOptions.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.302.0-fb-47202-getContainersAPIOptions.0.tgz",
+      "integrity": "sha512-xkWyh2cf3+UH6ugrSkV3KGBqsrqQpEQJsHU3cs4Z1QoMkxhReo3A6V3dlmQOCFEOHBGcvlJ+xyTxG2KsvRIc3Q==",
       "requires": {
-        "@labkey/api": "1.18.7",
+        "@labkey/api": "1.18.7-fb-47202-getContainersAPIOptions.0",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,8 +8,8 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/api": "1.18.7-fb-47202-getContainersAPIOptions.0",
-        "@labkey/components": "2.302.0-fb-47202-getContainersAPIOptions.0",
+        "@labkey/api": "1.18.8",
+        "@labkey/components": "2.302.1",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3018,9 +3018,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.18.7-fb-47202-getContainersAPIOptions.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.7-fb-47202-getContainersAPIOptions.0.tgz",
-      "integrity": "sha512-CFRi+gnkAzt7J6vWaRtWzPP5sWAKYZubZsqTTj9Mdp9j1+l/VFUO2d9ypAvirWCiFXYzjZUCH1PrvLP7Nsowww=="
+      "version": "1.18.8",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.8.tgz",
+      "integrity": "sha512-8yXPl/WBSGyyM+v2MglznGB2TKGu4iz0M4lwoSB9ibeSHTHOZKKTaNf5YQUfzTjdoySNFtyM4Uiu2z6/xEl5iA=="
     },
     "node_modules/@labkey/build": {
       "version": "6.9.0",
@@ -3057,11 +3057,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.302.0-fb-47202-getContainersAPIOptions.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.302.0-fb-47202-getContainersAPIOptions.0.tgz",
-      "integrity": "sha512-xkWyh2cf3+UH6ugrSkV3KGBqsrqQpEQJsHU3cs4Z1QoMkxhReo3A6V3dlmQOCFEOHBGcvlJ+xyTxG2KsvRIc3Q==",
+      "version": "2.302.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.302.1.tgz",
+      "integrity": "sha512-cNJsh0j2h7wSM7KL46HJJx368xxb/oPxqelXvVUafsh9vusNzlGy5YajUOCSMIg3HvdnhvDElrBcFTrBr4Soag==",
       "dependencies": {
-        "@labkey/api": "1.18.7-fb-47202-getContainersAPIOptions.0",
+        "@labkey/api": "1.18.8",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",
@@ -17206,9 +17206,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.18.7-fb-47202-getContainersAPIOptions.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.7-fb-47202-getContainersAPIOptions.0.tgz",
-      "integrity": "sha512-CFRi+gnkAzt7J6vWaRtWzPP5sWAKYZubZsqTTj9Mdp9j1+l/VFUO2d9ypAvirWCiFXYzjZUCH1PrvLP7Nsowww=="
+      "version": "1.18.8",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.8.tgz",
+      "integrity": "sha512-8yXPl/WBSGyyM+v2MglznGB2TKGu4iz0M4lwoSB9ibeSHTHOZKKTaNf5YQUfzTjdoySNFtyM4Uiu2z6/xEl5iA=="
     },
     "@labkey/build": {
       "version": "6.9.0",
@@ -17245,11 +17245,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.302.0-fb-47202-getContainersAPIOptions.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.302.0-fb-47202-getContainersAPIOptions.0.tgz",
-      "integrity": "sha512-xkWyh2cf3+UH6ugrSkV3KGBqsrqQpEQJsHU3cs4Z1QoMkxhReo3A6V3dlmQOCFEOHBGcvlJ+xyTxG2KsvRIc3Q==",
+      "version": "2.302.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.302.1.tgz",
+      "integrity": "sha512-cNJsh0j2h7wSM7KL46HJJx368xxb/oPxqelXvVUafsh9vusNzlGy5YajUOCSMIg3HvdnhvDElrBcFTrBr4Soag==",
       "requires": {
-        "@labkey/api": "1.18.7-fb-47202-getContainersAPIOptions.0",
+        "@labkey/api": "1.18.8",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",

--- a/core/package.json
+++ b/core/package.json
@@ -54,8 +54,8 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "1.18.7-fb-47202-getContainersAPIOptions.0",
-    "@labkey/components": "2.302.0-fb-47202-getContainersAPIOptions.0",
+    "@labkey/api": "1.18.8",
+    "@labkey/components": "2.302.1",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,8 +54,8 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "1.18.7",
-    "@labkey/components": "2.301.0",
+    "@labkey/api": "1.18.7-fb-47202-getContainersAPIOptions.0",
+    "@labkey/components": "2.302.0-fb-47202-getContainersAPIOptions.0",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Rationale
Editing a lookup's target container on a server with tens of thousands of containers can crash or bog down the browser as it gets a huge response of mostly unneeded data

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/4159
- https://github.com/LabKey/labkey-api-js/pull/149
- https://github.com/LabKey/labkey-ui-components/pull/1129
- https://github.com/LabKey/sampleManagement/pull/1646
- https://github.com/LabKey/inventory/pull/756
- https://github.com/LabKey/biologics/pull/1973

#### Changes
* New optional parameters that filter out workbooks and unneeded properties when simply building the container hierarchy
* update @labkey/api and @labkey/components package version in core/package.json