### PR TITLE
Issue 47362: Upgrade to FileUpload 1.5

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -120,6 +120,19 @@ dependencies {
     )
 
     BuildUtils.addExternalDependency(
+            project,
+            new ExternalDependency(
+                    "commons-fileupload:commons-fileupload:${commonsFileuploadVersion}",
+                    "Commons File Upload",
+                    "Apache",
+                    "http://jakarta.apache.org/commons/fileupload/",
+                    ExternalDependency.APACHE_2_LICENSE_NAME,
+                    ExternalDependency.APACHE_2_LICENSE_URL,
+                    "Parses HTTP multipart/form-data POSTs"
+            )
+    )
+
+    BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
             "org.apache.xmlgraphics:batik-codec:${batikVersion}",

--- a/api/src/org/labkey/api/premium/PremiumService.java
+++ b/api/src/org/labkey/api/premium/PremiumService.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.premium;
 
+import org.apache.commons.fileupload.FileUpload;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.services.ServiceRegistry;
@@ -43,7 +44,10 @@ public interface PremiumService
 
     default CommonsMultipartResolver getMultipartResolver(ViewBackgroundInfo info)
     {
-        return new CommonsMultipartResolver();
+        CommonsMultipartResolver result = new CommonsMultipartResolver();
+        // Issue 47362 - configure a limit for the number of files per request
+        result.getFileUpload().setFileCountMax(1_000);
+        return result;
     }
 
     void registerAntiVirusProvider(AntiVirusProvider avp);

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -21,19 +21,6 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "commons-fileupload:commons-fileupload:${commonsFileuploadVersion}",
-            "Commons File Upload",
-            "Apache",
-            "http://jakarta.apache.org/commons/fileupload/",
-            ExternalDependency.APACHE_2_LICENSE_NAME,
-            ExternalDependency.APACHE_2_LICENSE_URL,
-            "Parses HTTP multipart/form-data POSTs"
-        )
-    )
-
-    BuildUtils.addExternalDependency(
-        project,
-        new ExternalDependency(
             "org.apache.commons:commons-math3:${commonsMath3Version}",
             "Commons Math",
             "Apache",


### PR DESCRIPTION
#### Rationale
Update to the latest Apache Commons FileUpload release

#### Related Pull Requests
* https://github.com/LabKey/server/pull/404

#### Changes
* Move dependency to API module
* Cap total files per multipart request at 1,000
