### PR TITLE
Eliminate QueryProfiler.ensureQueryListener()

### DIFF
--- a/api/src/org/labkey/api/data/AsyncQueryRequest.java
+++ b/api/src/org/labkey/api/data/AsyncQueryRequest.java
@@ -24,7 +24,6 @@ import io.opentracing.util.GlobalTracer;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.data.queryprofiler.QueryProfiler;
 import org.labkey.api.miniprofiler.MiniProfiler;
 import org.labkey.api.miniprofiler.RequestInfo;
 import org.labkey.api.query.QueryService;
@@ -99,8 +98,6 @@ public class AsyncQueryRequest<T>
     synchronized public T waitForResult(final Callable<T> callable) throws SQLException, IOException
     {
         final QueryService qs = QueryService.get();
-        QueryProfiler.getInstance().ensureListenerEnvironment();
-
         final Object state = qs.cloneEnvironment();
         final RequestInfo current = MemTracker.getInstance().current();
 

--- a/api/src/org/labkey/api/data/queryprofiler/DatabaseQueryListener.java
+++ b/api/src/org/labkey/api/data/queryprofiler/DatabaseQueryListener.java
@@ -23,11 +23,8 @@ import org.labkey.api.security.User;
 
 /**
  * Gets invoked when a query that matches its registered substring is run against the underlying database.
- *
- * User: jeckels
- * Date: 2/13/14
  */
-public interface DatabaseQueryListener<T>
+public interface DatabaseQueryListener
 {
     /**
      * @return whether this listener cares about the query based on sql string
@@ -62,11 +59,5 @@ public interface DatabaseQueryListener<T>
     }
 
     /** Called when a matching query is run against the database. */
-    void queryInvoked(DbScope scope, String sql, User user, Container container, @Nullable T environment, QueryLogging queryLogging);
-
-    /** @return a custom context, which will be provided if and when the queryInvoked() method is called. This will be called
-     * from the originating thread (not an asychronous thread that might actually be running the query), so it can
-     * gather information from ThreadLocals if needed */
-    @Nullable
-    T getEnvironment();
+    void queryInvoked(DbScope scope, String sql, User user, Container container, QueryLogging queryLogging);
 }

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.audit.AuditHandler;
 import org.labkey.api.audit.DetailedAuditTypeEvent;
-import org.labkey.api.query.column.ColumnInfoTransformer;
 import org.labkey.api.data.ColumnHeaderType;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
@@ -44,6 +43,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.module.Module;
+import org.labkey.api.query.column.ColumnInfoTransformer;
 import org.labkey.api.query.column.ConceptURIColumnInfoTransformer;
 import org.labkey.api.query.snapshot.QuerySnapshotDefinition;
 import org.labkey.api.security.User;
@@ -320,10 +320,9 @@ public interface QueryService
     {
         USER(JdbcType.OTHER),
         CONTAINER(JdbcType.OTHER),
-        ACTION(JdbcType.OTHER),
-        LISTENER_ENVIRONMENTS(JdbcType.OTHER);
+        ACTION(JdbcType.OTHER);
 
-        public JdbcType type;
+        public final JdbcType type;
 
         Environment(JdbcType type)
         {

--- a/query/src/org/labkey/query/controllers/OlapController.java
+++ b/query/src/org/labkey/query/controllers/OlapController.java
@@ -671,7 +671,6 @@ public class OlapController extends SpringActionController
                 OlapConnection conn = controller.getConnection(sd);
                 stmt = conn.createStatement();
                 String query = form.getQuery();
-                QueryProfiler.getInstance().ensureListenerEnvironment();
                 OlapController._log.debug("\nSTART executeOlapQuery: --------------------------    --------------------------    --------------------------\n" + query);
                 long ms = System.currentTimeMillis();
                 cs = stmt.executeOlapQuery(query);
@@ -876,7 +875,6 @@ public class OlapController extends SpringActionController
                 if (errors.hasErrors())
                     return null;
 
-                QueryProfiler.getInstance().ensureListenerEnvironment();
                 long start = 0, end = 0;
                 try
                 {

--- a/query/src/org/labkey/query/olap/rolap/RolapTestCase.java
+++ b/query/src/org/labkey/query/olap/rolap/RolapTestCase.java
@@ -25,7 +25,6 @@ import org.labkey.api.collections.CaseInsensitiveTreeMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
-import org.labkey.api.data.queryprofiler.QueryProfiler;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.UserSchema;
@@ -922,7 +921,6 @@ public class RolapTestCase extends Assert
             assertNotNull(conn);
             stmt = conn.createStatement();
             assertNotNull(stmt);
-            QueryProfiler.getInstance().ensureListenerEnvironment();
             //long ms = System.currentTimeMillis();
             cs = stmt.executeOlapQuery(mdx);
             //long d = System.currentTimeMillis() - ms;

--- a/query/src/org/labkey/query/sql/QueryPivot.java
+++ b/query/src/org/labkey/query/sql/QueryPivot.java
@@ -22,7 +22,6 @@ import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.collections.NamedObjectList;
 import org.labkey.api.data.*;
 import org.labkey.api.data.dialect.SqlDialect;
-import org.labkey.api.data.queryprofiler.QueryProfiler;
 import org.labkey.api.query.AliasManager;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryException;
@@ -296,10 +295,6 @@ public class QueryPivot extends AbstractQueryRelation
             assert !getParseErrors().isEmpty();
             return _pivotValues;
         }
-
-        // We've directly generated SQL instead of using QueryService, so be sure that the listeners
-        // get the context they need before trying to run it
-        QueryProfiler.getInstance().ensureListenerEnvironment();
 
         try
         {

--- a/query/src/org/labkey/query/sql/QuerySelectView.java
+++ b/query/src/org/labkey/query/sql/QuerySelectView.java
@@ -17,7 +17,6 @@ import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.WrappedColumn;
 import org.labkey.api.data.dialect.SqlDialect;
-import org.labkey.api.data.queryprofiler.QueryProfiler;
 import org.labkey.api.query.AliasManager;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QuerySchema;
@@ -191,8 +190,6 @@ public class QuerySelectView extends AbstractQueryRelation
                                     int maxRows, long offset, boolean forceSort, @NotNull QueryLogging queryLogging, boolean distinct)
     {
         assert Table.validMaxRows(maxRows) : maxRows + " is an illegal value for rowCount; should be positive, Table.ALL_ROWS or Table.NO_ROWS";
-
-        QueryProfiler.getInstance().ensureListenerEnvironment();
 
         if (null == selectColumns)
             selectColumns = table.getColumns();

--- a/study/src/org/labkey/study/visitmanager/VisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/VisitManager.java
@@ -38,7 +38,6 @@ import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
-import org.labkey.api.data.queryprofiler.QueryProfiler;
 import org.labkey.api.exceptions.TableNotFoundException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.search.SearchService;
@@ -79,11 +78,7 @@ import java.util.TimerTask;
 import java.util.TreeMap;
 
 /**
- * Handles the bookkeeping for some basic study tables based on inserts, updates, and deletes
- * on other tables.
- *
- * User: brittp
- * Created: Feb 29, 2008
+ * Handles the bookkeeping for some basic study tables based on inserts, updates, and deletes on other tables.
  */
 public abstract class VisitManager
 {
@@ -214,8 +209,6 @@ public abstract class VisitManager
 
     public Map<VisitMapKey, VisitStatistics> getVisitSummary(User user, CohortFilter cohortFilter, QCStateSet qcStates, Set<VisitStatistic> stats, boolean showAll) throws SQLException
     {
-        QueryProfiler.getInstance().ensureListenerEnvironment();
-
         Map<VisitMapKey, VisitStatistics> visitSummary = new HashMap<>();
         VisitMapKey key = null;
         VisitStatistics statistics = new VisitStatistics();


### PR DESCRIPTION
#### Rationale
The query listener environment mechanism is theoretically designed to convey context from query construction time to query invocation time, but no context is being pushed into it and all potential consumers of context ignore the environment values. Removing the mechanism will eliminate complexity and reduce confusion. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47403
