### PR TITLE
 PassThroughColumn.copyColumnAttributesTo()

### DIFF
--- a/query/src/org/labkey/query/sql/QueryLookupWrapper.java
+++ b/query/src/org/labkey/query/sql/QueryLookupWrapper.java
@@ -800,6 +800,18 @@ public class QueryLookupWrapper extends AbstractQueryRelation implements QueryRe
             _foreignKey.addRef(refer);
             return super.addRef(refer);
         }
+
+        @Override
+        PHI getPHI()
+        {
+            return _lkCol.getPHI();
+        }
+
+        @Override
+        ColumnLogging getColumnLogging()
+        {
+            return _lkCol.getColumnLogging();
+        }
     }
 
 


### PR DESCRIPTION
#### Rationale
This addresses but where URL was not getting properly fixed up.

PassThroughColumn.copyColumnAttributesTo() needs to do remapFieldKey() because it implements ColumnResolvingRelation but may not be at the root of the query.  In this case, it still needs to propagate columninfo that is consistent WRT the other columns returned by QueryLookupWrapper.

There may be a little follow on work to see if the code in QueryTableInfo is actually redundant now. 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
