### PR TITLE
Issue 47431: Avoid NPE in audit logs when assay service is missing

### DIFF
--- a/api/src/org/labkey/api/audit/data/ProtocolColumn.java
+++ b/api/src/org/labkey/api/audit/data/ProtocolColumn.java
@@ -59,7 +59,7 @@ public class ProtocolColumn extends ExperimentAuditColumn<ExpProtocol>
                     protocol = ExperimentService.get().getExpProtocol(protocolId.toString());
 
                 AssayProvider provider = null;
-                if (protocol != null)
+                if (protocol != null && AssayService.get() != null)
                     provider = AssayService.get().getProvider(protocol);
 
                 ActionURL url = null;


### PR DESCRIPTION
#### Rationale
[Issue 47431](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47431): NullPointerException for ExperimentAudit log when assay service is missing

#### Changes
* Check for AssayService before using it
