### PR TITLE
Schema browser: avoid connecting to data sources that aren't needed

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1725,7 +1725,7 @@ public class DbScope
     {
         return getLoaders().stream()
             .map(DbScopeLoader::getDsName)
-            .collect(Collectors.toSet());
+            .collect(Collectors.toCollection(LinkedHashSet::new)); // Keep them in labkey.xml order for schema browser, etc.
     }
 
     /**


### PR DESCRIPTION
#### Rationale
`GetSchemaQueryTreeAction` was enumerating all `DbScope`s and then pruning to only the ones being used. This can be unnecessarily expensive, for example, first visit to the schema browser after startup with a data source that's unreachable or misconfigured. Better approach is to determine the data sources that are needed and resolve only those to DbScopes.
