### PR TITLE
23.3 fb real issue 47343

### DIFF
--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -280,7 +280,7 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
         // date
         //
 
-        if (!timetype.isVisitBased() && null == indexVisitDate && (_datasetDefinition.isDemographicData() || _datasetDefinition.isParticipantAliasDataset()))
+        if (!timetype.isVisitBased() && null == indexVisitDate && (!_datasetDefinition.isDemographicData() || _datasetDefinition.isParticipantAliasDataset()))
         {
             final Date start = _datasetDefinition.getStudy().getStartDate();
             indexVisitDate = it.addColumn(new BaseColumnInfo("Date", JdbcType.TIMESTAMP), new Callable()
@@ -402,9 +402,6 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
         // don't bother going on if we don't have these required columns
         if (null == indexPTIDInput) // input
             setupError("Missing required field " + _datasetDefinition.getStudy().getSubjectColumnName());
-
-        if (!timetype.isVisitBased() && null == indexVisitDate)
-            setupError("Missing required field Date");
 
         if (timetype.isVisitBased() && null == it.indexSequenceNumOutput)
             setupError("Missing required field SequenceNum");

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -280,7 +280,10 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
         // date
         //
 
-        if (!timetype.isVisitBased() && null == indexVisitDate && (!_datasetDefinition.isDemographicData() || _datasetDefinition.isParticipantAliasDataset()))
+        if (!timetype.isVisitBased()
+                && null == indexVisitDate
+                && (_datasetDefinition.isDemographicData() || _datasetDefinition.isParticipantAliasDataset())
+                && !context.getInsertOption().updateOnly)
         {
             final Date start = _datasetDefinition.getStudy().getStartDate();
             indexVisitDate = it.addColumn(new BaseColumnInfo("Date", JdbcType.TIMESTAMP), new Callable()


### PR DESCRIPTION
#### Rationale
Small change to not add the study `startDate` for demographics datasets if we are doing an update, since presumably the required field is already present.

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47343)
