### PR TITLE
Fix 'DataRegionTest' failures

### DIFF
--- a/query/webapp/QWPDemo.js
+++ b/query/webapp/QWPDemo.js
@@ -206,12 +206,20 @@
                         var result2 = results[1].lastChild.innerHTML;
                         var result3 = results[2].lastChild.innerHTML;
 
-                        if (result1.localeCompare(result2) >= 0 || result2.localeCompare(result3) >= 0) {
+                        var tableHeader = $('.labkey-data-region thead tr:nth-child(1)')[0].lastChild.title;
+                        if (tableHeader === 'tag') {
+                            alert('Failed test: Sort by Tag. "tag" is not the rightmost column');
+                        }
+
+                        if (result1.localeCompare(result2) > 0 || result2.localeCompare(result3) > 0) {
                             alert('Failed test: Sort by Tag. Expected "tag" column to be sorted ascending');
                         }
                         else {
                             LABKEY.Utils.signalWebDriverTest("testSort");
                         }
+                    }
+                    else {
+                        alert("Didn't find enough results row");
                     }
                 },
                 failure: function() {

--- a/query/webapp/QWPDemo.js
+++ b/query/webapp/QWPDemo.js
@@ -218,7 +218,7 @@
                         }
                     }
                     else {
-                        alert("Didn't find enough results row");
+                        alert("Didn't find enough results rows");
                     }
                 },
                 failure: function() {

--- a/query/webapp/QWPDemo.js
+++ b/query/webapp/QWPDemo.js
@@ -142,7 +142,7 @@
                     }
                 },
                 failure: function() {
-                   alert('Failed test: List out all queries in schema');
+                    alert('Failed test: List out all queries in schema');
                 }
             });
         }
@@ -195,6 +195,7 @@
             new LABKEY.QueryWebPart({
                 title: 'Sort by Tag',
                 schemaName: 'Samples',
+                columns: ['Name', 'id', 'sort', 'tag'],
                 queryName: 'sampleDataTest1',
                 sort: 'tag',
                 renderTo: RENDERTO,
@@ -205,7 +206,7 @@
                         var result2 = results[1].lastChild.innerHTML;
                         var result3 = results[2].lastChild.innerHTML;
 
-                        if (result1.localeCompare(result2) > 0 || result2.localeCompare(result3) > 0) {
+                        if (result1.localeCompare(result2) >= 0 || result2.localeCompare(result3) >= 0) {
                             alert('Failed test: Sort by Tag. Expected "tag" column to be sorted ascending');
                         }
                         else {
@@ -769,6 +770,7 @@
                 title: 'Filter on "Sort" column (Regression #33536)',
                 schemaName: 'Samples',
                 queryName: 'sampleDataTest1',
+                columns: ['Name', 'id', 'sort', 'tag'],
                 renderTo: RENDERTO,
                 filterArray: [
                     LABKEY.Filter.create('Sort', '50;60;70', LABKEY.Filter.Types.EQUALS_ONE_OF)

--- a/query/webapp/QWPDemo.js
+++ b/query/webapp/QWPDemo.js
@@ -207,7 +207,7 @@
                         var result3 = results[2].lastChild.innerHTML;
 
                         var tableHeader = $('.labkey-data-region thead tr:nth-child(1)')[0].lastChild.title;
-                        if (tableHeader === 'tag') {
+                        if (tableHeader !== 'tag') {
                             alert('Failed test: Sort by Tag. Expected "tag" to be the rightmost column; Found ' + tableHeader);
                         }
                         else if (result1.localeCompare(result2) > 0 || result2.localeCompare(result3) > 0) {

--- a/query/webapp/QWPDemo.js
+++ b/query/webapp/QWPDemo.js
@@ -810,6 +810,11 @@
                                 return;
                             }
 
+                            var tableHeader = $('.labkey-data-region thead tr:nth-child(1)')[0].lastChild.title;
+                            if (tableHeader !== 'tag') {
+                                alert('Failed test: Filter on "Sort" column. Expected "tag" to be the rightmost column; Found ' + tableHeader);
+                            }
+
                             var tagRowValue = rowElements[0].lastChild.innerHTML;
 
                             if (tagRowValue !== 'white') {

--- a/query/webapp/QWPDemo.js
+++ b/query/webapp/QWPDemo.js
@@ -208,10 +208,9 @@
 
                         var tableHeader = $('.labkey-data-region thead tr:nth-child(1)')[0].lastChild.title;
                         if (tableHeader === 'tag') {
-                            alert('Failed test: Sort by Tag. "tag" is not the rightmost column');
+                            alert('Failed test: Sort by Tag. Expected "tag" to be the rightmost column; Found ' + tableHeader);
                         }
-
-                        if (result1.localeCompare(result2) > 0 || result2.localeCompare(result3) > 0) {
+                        else if (result1.localeCompare(result2) > 0 || result2.localeCompare(result3) > 0) {
                             alert('Failed test: Sort by Tag. Expected "tag" column to be sorted ascending');
                         }
                         else {


### PR DESCRIPTION
#### Rationale
`qwpDemo.js` (used by `DataRegionTest`) makes some assumptions about what columns will be present in the Samples grids it creates. These tests started failing when some columns got added to the default view.

#### Related Pull Requests
* #4130 

#### Changes
* Explicitly specify columns for queries that care about them
