### PR TITLE
fix for MS2 nested dataregion

### DIFF
--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -348,8 +348,15 @@ public class DataRegion extends DisplayElement
 
     public void setDisplayColumns(List<DisplayColumn> displayColumns)
     {
-        clearColumns();
-        displayColumns.forEach(this::addDisplayColumn);
+        /** NOTE - the cleaner thing to do here would be
+         *         clearColumns();
+         *         displayColumns.forEach(this::addDisplayColumn);
+         * however, this breaks MS2 which seems to funny things with nested RenderContexts
+         */
+        _displayColumns = displayColumns;
+        if (null != _inputPrefix)
+            for (DisplayColumn dc : _displayColumns)
+                dc.setInputPrefix(_inputPrefix);
     }
 
     public void removeColumns(String... columns)

--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -351,7 +351,7 @@ public class DataRegion extends DisplayElement
         /** NOTE - the cleaner thing to do here would be
          *         clearColumns();
          *         displayColumns.forEach(this::addDisplayColumn);
-         * however, this breaks MS2 which seems to funny things with nested RenderContexts
+         * however, this breaks MS2 which seems to do funny things with nested RenderContexts
          */
         _displayColumns = displayColumns;
         if (null != _inputPrefix)

--- a/api/src/org/labkey/api/query/ReexecutableRenderContext.java
+++ b/api/src/org/labkey/api/query/ReexecutableRenderContext.java
@@ -41,7 +41,8 @@ public class ReexecutableRenderContext extends RenderContext
             TableSelector selector = new TableSelector(table, columns, filter, sort)
                     .setNamedParameters(null)       // leave named parameters in SQLFragment
                     .setMaxRows(maxRows)
-                    .setOffset(offset);
+                    .setOffset(offset)
+                    .setForceSortForDisplay(true);
             var sqlfWithCTE = selector.getSql();
             // flatten out CTEs
             SQLFragment sqlf = new SQLFragment(sqlfWithCTE.getSQL(), sqlfWithCTE.getParams());


### PR DESCRIPTION
#### Rationale
Undo change to RenderContext.addDisplayColumns().  Restore behavior that MS2 nested data regions depends on.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
