### PR TITLE
Don't show AliquotCreateCount and AliquotVolume columns in default view

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -465,14 +465,12 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             {
                 var ret = wrapColumn(alias, _rootTable.getColumn("AliquotCount"));
                 ret.setLabel("Aliquots Created Count");
-                ret.setShownInDetailsView(false);
                 return ret;
             }
             case AliquotVolume ->
             {
                 var ret = wrapColumn(alias, _rootTable.getColumn("AliquotVolume"));
                 ret.setLabel("Aliquot Total Amount");
-                ret.setShownInDetailsView(false);
                 return ret;
             }
             case AliquotUnit ->

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -465,17 +465,21 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             {
                 var ret = wrapColumn(alias, _rootTable.getColumn("AliquotCount"));
                 ret.setLabel("Aliquots Created Count");
+                ret.setShownInDetailsView(false);
                 return ret;
             }
             case AliquotVolume ->
             {
                 var ret = wrapColumn(alias, _rootTable.getColumn("AliquotVolume"));
                 ret.setLabel("Aliquot Total Amount");
+                ret.setShownInDetailsView(false);
                 return ret;
             }
             case AliquotUnit ->
             {
-                return wrapColumn(alias, _rootTable.getColumn("AliquotUnit"));
+                var ret =  wrapColumn(alias, _rootTable.getColumn("AliquotUnit"));
+                ret.setShownInDetailsView(false);
+                return ret;
             }
             case MaterialExpDate ->
             {
@@ -761,9 +765,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         if (st == null || !st.isMedia())
         {
             addColumn(Column.AliquotCount);
-            defaultCols.add(FieldKey.fromParts(ExpMaterialTable.Column.AliquotCount));
             addColumn(Column.AliquotVolume);
-            defaultCols.add(FieldKey.fromParts(ExpMaterialTable.Column.AliquotVolume));
             addColumn(Column.AliquotUnit);
             addColumn(Column.RecomputeRollup);
 


### PR DESCRIPTION
#### Rationale
This adjusts the default grid views for sample type tables to be consistent with previous behavior that did not include the AliquotCreateCount and AliquotVolume columns. These are added separately by the applications.  Most clients don't currently have aliquots and they can't be created in LKS UI, so leaving them out of the default grids makes the most sense at the moment.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4130
* https://github.com/LabKey/sampleManagement/pull/1659
* https://github.com/LabKey/inventory/pull/766
* https://github.com/LabKey/testAutomation/pull/1401
* https://github.com/LabKey/premium/pull/376
* https://github.com/LabKey/biologics/pull/1984


#### Changes
* Don't add Aliquot-related columns to default view
