### PR TITLE
47368: File Watchers : add the input file name to the pipeline job description field

### DIFF
--- a/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
+++ b/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
@@ -443,7 +443,7 @@ abstract public class AbstractFileAnalysisJob extends PipelineJob implements Fil
     @Override
     public String getDescription()
     {
-        return getDataDescription(getDataDirectoryPath(), getBaseName(), getJoinedBaseName(), getProtocolName());
+        return getDataDescription(getDataDirectoryPath(), getBaseName(), getJoinedBaseName(), getProtocolName(), getInputFiles());
     }
 
     @Override
@@ -461,10 +461,10 @@ abstract public class AbstractFileAnalysisJob extends PipelineJob implements Fil
     @Deprecated //prefer Path version
     public static String getDataDescription(File dirData, String baseName, String joinedBaseName, String protocolName)
     {
-        return getDataDescription(dirData.toPath(), baseName, joinedBaseName, protocolName);
+        return getDataDescription(dirData.toPath(), baseName, joinedBaseName, protocolName, Collections.emptyList());
     }
 
-    public static String getDataDescription(Path dirData, String baseName, String joinedBaseName, String protocolName)
+    public static String getDataDescription(Path dirData, String baseName, String joinedBaseName, String protocolName, List<File> inputFiles)
     {
         String dataName = "";
         if (dirData != null)
@@ -489,6 +489,14 @@ abstract public class AbstractFileAnalysisJob extends PipelineJob implements Fil
             description.append(baseName);
         }
         description.append(" (").append(protocolName).append(")");
+
+        // input files
+        if (!inputFiles.isEmpty())
+        {
+            description.append(" (");
+            description.append(String.join(",", inputFiles.stream().map(f -> f.getName()).collect(Collectors.toList())));
+            description.append(")");
+        }
         return description.toString();
     }
 


### PR DESCRIPTION
#### Rationale
This change adds the name of the input file(s) to the description of pipeline job for `FileAnalysisJobs`

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47368)

#### Related Pull Requests
https://github.com/LabKey/premium/pull/377