### PR TITLE
Require the professional module for Jupyter reports

### DIFF
--- a/api/src/org/labkey/api/reports/report/python/IpynbReport.java
+++ b/api/src/org/labkey/api/reports/report/python/IpynbReport.java
@@ -121,7 +121,7 @@ public class IpynbReport extends DockerScriptReport
 
     public static boolean isEnabled()
     {
-        if (PremiumService.get().isEnabled())
+        if (PremiumService.get().isEnabled() && ModuleLoader.getInstance().hasModule("professional"))
         {
             LabKeyScriptEngineManager mgr = LabKeyScriptEngineManager.get();
             List<ExternalScriptEngineDefinition> defs = mgr.getEngineDefinitions(ExternalScriptEngineDefinition.Type.Jupyter);


### PR DESCRIPTION
#### Rationale
We want to limit Jupyter reports to professional edition subscriptions.

[related issue](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47400)
