### PR TITLE
Fix test failures trying to reference files in S3

### DIFF
--- a/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
+++ b/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
@@ -494,7 +494,8 @@ abstract public class AbstractFileAnalysisJob extends PipelineJob implements Fil
         if (!inputFiles.isEmpty())
         {
             description.append(" (");
-            description.append(inputFiles.stream().map(p -> p.getFileName().toString()).collect(Collectors.joining(",")));
+            //p.getFileName returns the full S3 path -- S3fs bug?
+            description.append(inputFiles.stream().map(p -> p.getName(p.getNameCount() - 1).toString()).collect(Collectors.joining(",")));
             description.append(")");
         }
         return description.toString();

--- a/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
+++ b/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
@@ -495,7 +495,7 @@ abstract public class AbstractFileAnalysisJob extends PipelineJob implements Fil
         {
             description.append(" (");
             //p.getFileName returns the full S3 path -- S3fs bug?
-            description.append(inputFiles.stream().map(p -> p.getName(p.getNameCount() - 1).toString()).collect(Collectors.joining(",")));
+            description.append(inputFiles.stream().map(FileUtil::getFileName).collect(Collectors.joining(",")));
             description.append(")");
         }
         return description.toString();

--- a/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
+++ b/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
@@ -443,7 +443,7 @@ abstract public class AbstractFileAnalysisJob extends PipelineJob implements Fil
     @Override
     public String getDescription()
     {
-        return getDataDescription(getDataDirectoryPath(), getBaseName(), getJoinedBaseName(), getProtocolName(), getInputFiles());
+        return getDataDescription(getDataDirectoryPath(), getBaseName(), getJoinedBaseName(), getProtocolName(), getInputFilePaths());
     }
 
     @Override
@@ -464,7 +464,7 @@ abstract public class AbstractFileAnalysisJob extends PipelineJob implements Fil
         return getDataDescription(dirData.toPath(), baseName, joinedBaseName, protocolName, Collections.emptyList());
     }
 
-    public static String getDataDescription(Path dirData, String baseName, String joinedBaseName, String protocolName, List<File> inputFiles)
+    public static String getDataDescription(Path dirData, String baseName, String joinedBaseName, String protocolName, List<Path> inputFiles)
     {
         String dataName = "";
         if (dirData != null)
@@ -494,7 +494,7 @@ abstract public class AbstractFileAnalysisJob extends PipelineJob implements Fil
         if (!inputFiles.isEmpty())
         {
             description.append(" (");
-            description.append(String.join(",", inputFiles.stream().map(f -> f.getName()).collect(Collectors.toList())));
+            description.append(inputFiles.stream().map(p -> p.getFileName().toString()).collect(Collectors.joining(",")));
             description.append(")");
         }
         return description.toString();


### PR DESCRIPTION
#### Rationale
Test failures related to this PR https://github.com/LabKey/platform/pull/4173. The test is failing when it tries to invoke AbstractFileAnalysisJob.getInputFiles, specifically S3Path.toFile is throwing an UnsupportedOperationException.
https://teamcity.labkey.org/buildConfiguration/LabKey_233Release_Premium_ModulesSuites_CloudPostgres/2319320?buildTab=overview&hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4173
* https://github.com/LabKey/premium/pull/378

#### Changes
* Use nio.Path instead of io.File
