### PR TITLE
ExpMaterialTableImpl optimization to skip the INNER JOIN to the provisioned table when no columns from that domain are selected

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1097,7 +1097,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         return sql;
     }
 
-    // if all selectedColumns are in the root table, no need to join to the provisioned table (i.e. example is the COUNT(*) case)
+    // if all selectedColumns are in the root table, no need to join to the provisioned table (e.g., in the COUNT(*) case)
     private boolean checkSelectedColumnsFromRootOnly(Set<FieldKey> selectedColumns, Set<String> rootColNames)
     {
         boolean selectedRootOnly = true;

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1026,10 +1026,12 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     {
         TableInfo provisioned = null == _ss ? null : _ss.getTinfo();
 
-        selectedColumns = computeInnerSelectedColumns(selectedColumns);
-
         // all columns from exp.material except lsid
         Set<String> dataCols = new CaseInsensitiveHashSet(_rootTable.getColumnNameSet());
+
+        boolean skipProvisionedJoin = checkSelectedColumnsFromRootOnly(selectedColumns, dataCols);
+
+        selectedColumns = computeInnerSelectedColumns(selectedColumns);
 
         SQLFragment sql = new SQLFragment();
         sql.appendComment("<ExpMaterialTableImpl.getFromSQL()>", getSqlDialect());
@@ -1081,7 +1083,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         }
         sql.append(" FROM ");
         sql.append(_rootTable, "m");
-        if (null != provisioned)
+        if (null != provisioned && !skipProvisionedJoin)
         {
             sql.append(" INNER JOIN ").append(provisioned, "self").append(" ON m.lsid = self.lsid")
                     .append(" LEFT JOIN ").append(provisioned, "root").append(" ON m.rootMaterialLsid = root.lsid");
@@ -1093,6 +1095,32 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         sql.appendComment("</ExpMaterialTableImpl.getFromSQL()>", getSqlDialect());
 
         return sql;
+    }
+
+    // if all selectedColumns are in the root table, no need to join to the provisioned table (i.e. example is the COUNT(*) case)
+    private boolean checkSelectedColumnsFromRootOnly(Set<FieldKey> selectedColumns, Set<String> rootColNames)
+    {
+        boolean selectedRootOnly = true;
+        if (selectedColumns != null)
+        {
+            for (FieldKey selectedColumn : selectedColumns)
+            {
+                String rootFKName = selectedColumn.getRootFieldKey().getName();
+                String selectedName = rootFKName.equalsIgnoreCase("folder") ? "container" : rootFKName;
+                boolean colNameFound = rootColNames.contains(selectedName);
+                if (!colNameFound)
+                {
+                    selectedRootOnly = false;
+                    break;
+                }
+            }
+        }
+        else
+        {
+            selectedRootOnly = false;
+        }
+
+        return selectedRootOnly;
     }
 
     private class IdColumnRendererFactory implements DisplayColumnFactory


### PR DESCRIPTION
#### Rationale
While triaging the app grid loading times for a sample type with 500k rows, I noticed that most of the time was being spent on two queries: one to get the total row count of the sample type and the other to get the selected keys for the query / user session. When profiling both of these queries, I found that they were both doing an INNER JOIN from the exp.materials table to the provisioned table for the given sample type. In both of these cases the INNER JOIN wasn't needed as no columns were being selected from that provisioned table. This PR uses the `selectedColumns` param of `getFromSQL` method to determine if that join is needed or can be skipped.

#### Changes
* add a `checkSelectedColumnsFromRootOnly` method to ExpMaterialTableImpl that when true can be used to skip the INNER JOIN for the generated SQL
