### PR TITLE
Fix setRecomputeFlagForSampleNames and QueryWebPart test

### DIFF
--- a/experiment/resources/schemas/exp.xml
+++ b/experiment/resources/schemas/exp.xml
@@ -247,7 +247,7 @@
           <column columnName="FileAttachmentIndex"/>
       </columns>
   </table>
-    <table tableName="Material" tableDbType="TABLE">
+  <table tableName="Material" tableDbType="TABLE">
     <columns>
       <column columnName="RowId">
           <description>Contains the unique identifier for this sample</description>

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -342,7 +342,6 @@ public class ExpDataIterators
                 Double existingAmount = null;
                 String existingUnits = null;
                 Set<String> aliquotParentLsids = new HashSet<>();
-                Set<String> aliquotParentNames = new HashSet<>();
                 if (existingMap != null)
                 {
                     existingAmount = (Double) existingMap.get("StoredAmount");
@@ -356,21 +355,18 @@ public class ExpDataIterators
                 Double newAmount = _storedAmountCol == null ? null : (Double) get(_storedAmountCol);
                 String newUnits = _unitsCol == null ? null : (String) get(_unitsCol);
                 Measurement newMeasurement = new Measurement(newAmount, newUnits, _sampleType.getMetricUnit());
+                boolean amountMayHaveChanged = (existingMap == null || !newMeasurement.equals(existingMeasurement));
 
                 // check for aliquotedFromLsidCol first since, for updateOnly cases, we prefer data in this
                 // column over aliquotedFrom; we ignore any user-supplied value in aliquotedFrom
                 if (_aliquotedFromLsidCol != null && get(_aliquotedFromLsidCol) != null)
                     aliquotParentLsids.add((String) get(_aliquotedFromLsidCol));
-                else if (_aliquotedFromCol != null && get(_aliquotedFromCol) != null)
-                    aliquotParentNames.add(String.valueOf(get(_aliquotedFromCol)));
+                else if (_aliquotedFromCol != null && get(_aliquotedFromCol) != null && amountMayHaveChanged)
+                    updatedSampleNames.add(String.valueOf(get(_aliquotedFromCol)));
 
-
-                boolean amountMayHaveChanged = (existingMap == null || !newMeasurement.equals(existingMeasurement));
                 if (!aliquotParentLsids.isEmpty() && amountMayHaveChanged)
                     updatedSampleLsids.addAll(aliquotParentLsids);
 
-                if (!aliquotParentNames.isEmpty() && amountMayHaveChanged)
-                    updatedSampleNames.addAll(aliquotParentNames);
                 return true;
             }
             else

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -295,6 +295,10 @@ public class ExpDataIterators
         public DataIterator getDataIterator(DataIteratorContext context)
         {
             DataIterator pre = _in.getDataIterator(context);
+
+            if (!context.getInsertOption().allowUpdate)
+                return pre; // recompute for new insert are already handled in ExperimentalServiceImpl.saveExpMaterialAliquotOutputs
+
             return LoggingDataIterator.wrap(new AliquotRollupDataIterator(pre, context, _sampleType));
         }
     }

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -483,7 +483,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             {
                 var ret = wrapColumn(alias, _rootTable.getColumn("MaterialExpDate"));
                 ret.setLabel("Expiration Date");
-                ret.setHidden(false); // TODO: true until system fields can be disabled
                 ret.setShownInDetailsView(true);
                 ret.setShownInInsertView(true);
                 ret.setShownInUpdateView(true);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1402,7 +1402,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     {
         DbScope scope = ExperimentService.get().getSchema().getScope();
         TableInfo materialTable = ExperimentService.get().getTinfoMaterial();
-        String updateSqlStr = "UPDATE " + materialTable.getSelectName() + " SET RecomputeRollup = ? WHERE LSID AND RecomputeRollup = ?";
+        String updateSqlStr = "UPDATE " + materialTable.getSelectName() + " SET RecomputeRollup = ? WHERE RecomputeRollup = ? AND LSID ";
 
         SQLFragment updateSQL = new SQLFragment(updateSqlStr);
         updateSQL.add(Boolean.TRUE);
@@ -1417,12 +1417,12 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     {
         DbScope scope = ExperimentService.get().getSchema().getScope();
         TableInfo materialTable = ExperimentService.get().getTinfoMaterial();
-        String updateSqlStr = "UPDATE " + materialTable.getSelectName() + " SET RecomputeRollup = ? WHERE CpasType = ? AND Name AND RecomputeRollup = ?";
+        String updateSqlStr = "UPDATE " + materialTable.getSelectName() + " SET RecomputeRollup = ? WHERE CpasType = ? AND RecomputeRollup = ? AND Name ";
 
         SQLFragment updateSQL = new SQLFragment(updateSqlStr);
         updateSQL.add(Boolean.TRUE);
-        updateSQL.add(Boolean.FALSE);
         updateSQL.add(sampleType.getLSID());
+        updateSQL.add(Boolean.FALSE);
         scope.getSqlDialect().appendInClauseSql(updateSQL, sampleNames);
 
         new SqlExecutor(materialTable.getSchema()).execute(updateSQL);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1402,10 +1402,11 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     {
         DbScope scope = ExperimentService.get().getSchema().getScope();
         TableInfo materialTable = ExperimentService.get().getTinfoMaterial();
-        String updateSqlStr = "UPDATE " + materialTable.getSelectName() + " SET RecomputeRollup = ? WHERE LSID ";
+        String updateSqlStr = "UPDATE " + materialTable.getSelectName() + " SET RecomputeRollup = ? WHERE LSID AND RecomputeRollup = ?";
 
         SQLFragment updateSQL = new SQLFragment(updateSqlStr);
         updateSQL.add(Boolean.TRUE);
+        updateSQL.add(Boolean.FALSE);
         scope.getSqlDialect().appendInClauseSql(updateSQL, sampleLSIDs);
 
         new SqlExecutor(materialTable.getSchema()).execute(updateSQL);
@@ -1416,10 +1417,11 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     {
         DbScope scope = ExperimentService.get().getSchema().getScope();
         TableInfo materialTable = ExperimentService.get().getTinfoMaterial();
-        String updateSqlStr = "UPDATE " + materialTable.getSelectName() + " SET RecomputeRollup = ? WHERE CpasType = ? AND Name ";
+        String updateSqlStr = "UPDATE " + materialTable.getSelectName() + " SET RecomputeRollup = ? WHERE CpasType = ? AND Name AND RecomputeRollup = ?";
 
         SQLFragment updateSQL = new SQLFragment(updateSqlStr);
         updateSQL.add(Boolean.TRUE);
+        updateSQL.add(Boolean.FALSE);
         updateSQL.add(sampleType.getLSID());
         scope.getSqlDialect().appendInClauseSql(updateSQL, sampleNames);
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1416,7 +1416,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     {
         DbScope scope = ExperimentService.get().getSchema().getScope();
         TableInfo materialTable = ExperimentService.get().getTinfoMaterial();
-        String updateSqlStr = "UPDATE " + materialTable.getSelectName() + " SET RecomputeRollup = ? WHERE CpasType = ? AND LSID ";
+        String updateSqlStr = "UPDATE " + materialTable.getSelectName() + " SET RecomputeRollup = ? WHERE CpasType = ? AND Name ";
 
         SQLFragment updateSQL = new SQLFragment(updateSqlStr);
         updateSQL.add(Boolean.TRUE);

--- a/query/webapp/QWPDemo.js
+++ b/query/webapp/QWPDemo.js
@@ -777,7 +777,7 @@
                 title: 'Filter on "Sort" column (Regression #33536)',
                 schemaName: 'Samples',
                 queryName: 'sampleDataTest1',
-                columns: ['Name', 'id', 'sort', 'tag'],
+                columns: 'Name, id, sort, tag',
                 renderTo: RENDERTO,
                 filterArray: [
                     LABKEY.Filter.create('Sort', '50;60;70', LABKEY.Filter.Types.EQUALS_ONE_OF)

--- a/query/webapp/QWPDemo.js
+++ b/query/webapp/QWPDemo.js
@@ -195,7 +195,7 @@
             new LABKEY.QueryWebPart({
                 title: 'Sort by Tag',
                 schemaName: 'Samples',
-                columns: ['Name', 'id', 'sort', 'tag'],
+                columns: 'Name,id,sort,tag',
                 queryName: 'sampleDataTest1',
                 sort: 'tag',
                 renderTo: RENDERTO,


### PR DESCRIPTION
#### Rationale
- `setRecomputeFlagForSampleNames` was looking for LSIDs not names.
- `columns` parameter for `LABKEY.QueryWebPart` should be a comma-separated string not an array

#### Related Pull Requests
* #4130 

#### Changes
* Fixes for the above.
