### PR TITLE
Collect evidence to address domain-related deadlocks

### DIFF
--- a/api/src/org/labkey/api/util/DeadlockPreventingException.java
+++ b/api/src/org/labkey/api/util/DeadlockPreventingException.java
@@ -2,16 +2,25 @@ package org.labkey.api.util;
 
 /**
  * Thrown after a resource doesn't become available after a timeout in an attempt to avoid deadlocking the whole server.
+ * Dump threads at construction time since throwing this exception will likely release locks and destroy all evidence of
+ * the deadlock.
  */
 public class DeadlockPreventingException extends RuntimeException
 {
     public DeadlockPreventingException(String message)
     {
         super(message);
+        dumpThreads();
     }
 
     public DeadlockPreventingException(String message, Throwable cause)
     {
         super(message, cause);
+        dumpThreads();
+    }
+
+    private void dumpThreads()
+    {
+        DebugInfoDumper.dumpThreads(1);
     }
 }

--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -89,7 +89,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.WeakHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -103,7 +102,7 @@ public class ExceptionUtil
     private static final JobRunner JOB_RUNNER = new JobRunner("Mothership Reporting", 1);
     private static final Logger LOG = LogHelper.getLogger(ExceptionUtil.class, "Handles rendering of errors during requests");
     /**
-     * Remember all of the exceptions we've seen since the server started up.
+     * Remember all the exceptions we've seen since the server started up.
      * Key is the exception's hash as calculated by {@link #hashStackTrace(String)}.
      */
     private static final Map<String, ExceptionTally> EXCEPTION_TALLIES = Collections.synchronizedMap(new HashMap<>());


### PR DESCRIPTION
#### Rationale
We're seeing intermittent, but consistent "Cache timeout for Domain properties, exceeding 300000ms limit for cache key" errors on SQL Server. For example: https://teamcity.labkey.org/viewLog.html?buildId=2322519&tab=buildResultsDiv&buildTypeId=LabKey_233Release_Premium_ProductSuites_SampleManager_SampleManagerCSqlserver

These are nearly impossible to investigate because our code throws `DeadlockPreventingException` when time is up, which releases the lock(s) being held allowing blocked threads to proceed. The subsequent thread dumps no longer show the deadlocked state. So, dump all threads at DeadlockPreventingException construction time.

Also, push the queueing of `TransactionCache` commit tasks into TransactionCache. This approach eliminates all the unnecessary `null != transaction` checks in `DatabaseCache`, making the code easier to read and (slightly) more efficient. It's possible that we'll need to make changes to TransactionCache to resolve these deadlocks, so let's get it into reasonable shape before we collect thread dumps.