### PR TITLE
Issue 47311: Rewrite MultiValuedLookupColumn FieldKey

### DIFF
--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -303,11 +303,11 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
         setAutoIncrement(col.isAutoIncrement());
         setScale(col.getScale());
         setPrecision(col.getPrecision());
-        if (col instanceof BaseColumnInfo)
+        if (col instanceof BaseColumnInfo baseCol)
         {
-            _sqlTypeName = ((BaseColumnInfo) col)._sqlTypeName;
-            _jdbcType = ((BaseColumnInfo) col)._jdbcType;
-            _propertyType = ((BaseColumnInfo) col)._propertyType;
+            _sqlTypeName = baseCol._sqlTypeName;
+            _jdbcType = baseCol._jdbcType;
+            _propertyType = baseCol._propertyType;
         }
         else
         {

--- a/api/src/org/labkey/api/data/JsonWriter.java
+++ b/api/src/org/labkey/api/data/JsonWriter.java
@@ -86,7 +86,7 @@ public class JsonWriter
         @Nullable ColumnInfo cinfo = dc.getColumnInfo();
         Map<String, Object> props = new LinkedHashMap<>();
         JSONObject ext = new JSONObject();
-        props.put("ext",ext);
+        props.put("ext", ext);
 
         // Some DisplayColumns aren't backed by a ColumnInfo, so handle null when determining metadata
         String name = cinfo == null ? dc.getName() : cinfo.getName();
@@ -238,7 +238,7 @@ public class JsonWriter
                     if (rows > 0)
                         props.put("rows", Math.min(1000,rows));
                 }
-                ext.put("xtype","textarea");
+                ext.put("xtype", "textarea");
             }
 
             props.put("shortCaption", cinfo.getShortLabel());
@@ -373,7 +373,7 @@ public class JsonWriter
             String key = null;
             List<String> pks = lookupTable.getPkColumnNames();
 
-            //Issue 20092: the target column specified by the FK does not necessarily need to be a true PK
+            // Issue 20092: the target column specified by the FK does not necessarily need to be a true PK
             // PERF computing getLookupColumnName() can be expensive, but we only want to do this work when it is not == default pk
             // suggest having fk.getLookupColumnName() which returns explicitly set LookupColumnName, and fk.computeLookupColumnName()
             // NOTE: Don't try to resolve the lookup column on the lookup table because
@@ -381,15 +381,14 @@ public class JsonWriter
             if (fk.getLookupColumnName() != null && !(fk instanceof MultiValuedForeignKey))
             {
                 key = fk.getLookupColumnName();
-                if (lookupTable instanceof TableInfo)
+                if (lookupTable instanceof TableInfo lookupTableInfo)
                 {
                     //NOTE: the XML could specify a column with different casing than the canonical name.  this could be problematic for client side JS.  \
-                    ColumnInfo targetCol = ((TableInfo)lookupTable).getColumn(key);
+                    ColumnInfo targetCol = lookupTableInfo.getColumn(key);
                     if (targetCol != null)
                         key = targetCol.getName();
                     else
                     {
-                        //
                         TableInfo parentTable = columnInfo.getParentTable();
                         UserSchema userSchema = parentTable.getUserSchema();
                         String containerInfo = userSchema == null ? "" : " in container " + userSchema.getContainer().getPath();
@@ -411,9 +410,8 @@ public class JsonWriter
             }
             lookupInfo.put("keyColumn", key);
 
-            if (fk instanceof MultiValuedForeignKey)
+            if (fk instanceof MultiValuedForeignKey mvfk)
             {
-                MultiValuedForeignKey mvfk = (MultiValuedForeignKey)fk;
                 String junctionLookup = mvfk.getJunctionLookup();
                 lookupInfo.put("multiValued", junctionLookup != null ? "junction" : "value");
                 if (junctionLookup != null)

--- a/api/src/org/labkey/api/data/MultiValuedDisplayColumn.java
+++ b/api/src/org/labkey/api/data/MultiValuedDisplayColumn.java
@@ -55,16 +55,15 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
         super(dc);
 
         _boundCol = dc.getColumnInfo();
-        BaseColumnInfo lookupCol = null;
-        if (_boundCol.getFk() instanceof MultiValuedForeignKey)
+        ColumnInfo lookupCol = null;
+        if (_boundCol.getFk() instanceof MultiValuedForeignKey mvfk)
         {
             // Retrieve the value column so it can be used when rendering json or tsv values.
-            MultiValuedForeignKey mvfk = (MultiValuedForeignKey)_boundCol.getFk();
             ColumnInfo childKey = mvfk.createJunctionLookupColumn(_boundCol);
             if (childKey != null && childKey.getFk() != null)
             {
                 ForeignKey childKeyFk = childKey.getFk();
-                lookupCol = (BaseColumnInfo)childKeyFk.createLookupColumn(childKey, childKeyFk.getLookupColumnName());
+                lookupCol = childKeyFk.createLookupColumn(childKey, childKeyFk.getLookupColumnName());
                 if (lookupCol == null)
                 {
                     LOG.warn("Failed to create lookup column from '" + childKey.getName() + "' to '" + childKeyFk.getLookupSchemaName() + "." + childKeyFk.getLookupTableName() + "." + childKeyFk.getLookupColumnName() + "'");
@@ -72,7 +71,7 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
                 else
                 {
                     // Remove the intermediate junction table from the FieldKey
-                    lookupCol.setFieldKey(new FieldKey(_boundCol.getFieldKey(), lookupCol.getFieldKey().getName()));
+                    ((BaseColumnInfo) lookupCol).setFieldKey(new FieldKey(_boundCol.getFieldKey(), lookupCol.getFieldKey().getName()));
                     _additionalFieldKeys.add(lookupCol.getFieldKey());
                 }
             }
@@ -101,8 +100,8 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
         ArrayList<K> values = new ArrayList<>();
         try
         {
-            if (_lookupCol != null && _column instanceof DataColumn)
-                ((DataColumn)_column).setBoundColumn(_lookupCol);
+            if (_lookupCol != null && _column instanceof DataColumn dataColumn)
+                dataColumn.setBoundColumn(_lookupCol);
             MultiValuedRenderContext mvCtx = new MultiValuedRenderContext(ctx, _fieldKeys);
 
             while (mvCtx.next())
@@ -113,8 +112,8 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
         }
         finally
         {
-            if (_lookupCol != null && _column instanceof DataColumn)
-                ((DataColumn)_column).setBoundColumn(_boundCol);
+            if (_lookupCol != null && _column instanceof DataColumn dataColumn)
+                dataColumn.setBoundColumn(_boundCol);
         }
     }
 
@@ -129,8 +128,8 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
     {
         try
         {
-            if (_lookupCol != null && _column instanceof DataColumn)
-                ((DataColumn) _column).setBoundColumn(_lookupCol);
+            if (_lookupCol != null && _column instanceof DataColumn dataColumn)
+                dataColumn.setBoundColumn(_lookupCol);
             MultiValuedRenderContext mvCtx = new MultiValuedRenderContext(ctx, _fieldKeys);
             String sep = "";
 
@@ -143,8 +142,8 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
         }
         finally
         {
-            if (_lookupCol != null && _column instanceof DataColumn)
-                ((DataColumn)_column).setBoundColumn(_boundCol);
+            if (_lookupCol != null && _column instanceof DataColumn dataColumn)
+                dataColumn.setBoundColumn(_boundCol);
         }
 
         // TODO: Call super in empty values case?

--- a/api/src/org/labkey/api/data/MultiValuedDisplayColumn.java
+++ b/api/src/org/labkey/api/data/MultiValuedDisplayColumn.java
@@ -71,7 +71,7 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
                 else
                 {
                     // Remove the intermediate junction table from the FieldKey
-                    ((BaseColumnInfo) lookupCol).setFieldKey(new FieldKey(_boundCol.getFieldKey(), lookupCol.getFieldKey().getName()));
+                    ((MutableColumnInfo) lookupCol).setFieldKey(new FieldKey(_boundCol.getFieldKey(), lookupCol.getFieldKey().getName()));
                     _additionalFieldKeys.add(lookupCol.getFieldKey());
                 }
             }

--- a/api/src/org/labkey/api/data/MultiValuedForeignKey.java
+++ b/api/src/org/labkey/api/data/MultiValuedForeignKey.java
@@ -45,11 +45,13 @@ public class MultiValuedForeignKey implements ForeignKey
      * @param junctionLookup the name of the column in the junction table that points to the table that has multiple
      * matches to this table
      */
+    // TODO ContainerFilter
     public MultiValuedForeignKey(ForeignKey fk, String junctionLookup)
     {
         this(fk, junctionLookup, null);
     }
 
+    // TODO ContainerFilter
     public MultiValuedForeignKey(Builder<ForeignKey> fk, String junctionLookup)
     {
         this(fk.build(), junctionLookup, null);
@@ -61,6 +63,7 @@ public class MultiValuedForeignKey implements ForeignKey
      * matches to this table
      * @param displayField the name of the column in the value table to use as the display field.
      */
+    // TODO ContainerFilter
     public MultiValuedForeignKey(ForeignKey fk, String junctionLookup, @Nullable String displayField)
     {
         _fk = fk;
@@ -69,6 +72,7 @@ public class MultiValuedForeignKey implements ForeignKey
     }
 
     /* this is to help subclasses implement remapFieldKeys() */
+    // TODO ContainerFilter
     protected MultiValuedForeignKey(MultiValuedForeignKey source, FieldKey parent, Map<FieldKey, FieldKey> mapping)
     {
         _fk = source._fk.remapFieldKeys(parent, mapping);
@@ -76,6 +80,7 @@ public class MultiValuedForeignKey implements ForeignKey
         _displayField = source._displayField;
     }
 
+    //TODO ContainerFilter
     protected ContainerFilter getLookupContainerFilter()
     {
         return null;    // use default on target table
@@ -157,6 +162,18 @@ public class MultiValuedForeignKey implements ForeignKey
         {
             return null;
         }
+
+// TODO ContainerFilter _fk should already be holding onto it's ContainerFilter, verify this is the case
+//        // Pass the container filter through the lookup
+//        TableInfo lookupTable = lookupColumn.getParentTable();
+//        if (parent.getParentTable() != null && parent.getParentTable().supportsContainerFilter() && lookupTable != null && lookupTable.supportsContainerFilter())
+//        {
+//            ContainerFilterable table = (ContainerFilterable) lookupTable;
+//            if (table.hasDefaultContainerFilter())
+//            {
+//                table.setContainerFilter(new DelegatingContainerFilter(parent.getParentTable(), true));
+//            }
+//        }
 
         if (lookupColumn.getURL() instanceof StringExpressionFactory.FieldKeyStringExpression url)
         {

--- a/api/src/org/labkey/api/data/MultiValuedForeignKey.java
+++ b/api/src/org/labkey/api/data/MultiValuedForeignKey.java
@@ -181,7 +181,7 @@ public class MultiValuedForeignKey implements ForeignKey
             // expose the junction table itself as part of the Query tree of tables and columns
             if (url != AbstractTableInfo.LINK_DISABLER)
                 url = url.dropParent(junctionKey.getName());
-            ((BaseColumnInfo) lookupColumn).setURL(url);
+            ((MutableColumnInfo) lookupColumn).setURL(url);
         }
 
         return createMultiValuedLookupColumn(lookupColumn, parent, childKey, junctionKey, fk);

--- a/api/src/org/labkey/api/data/MultiValuedLookupColumn.java
+++ b/api/src/org/labkey/api/data/MultiValuedLookupColumn.java
@@ -43,6 +43,10 @@ public class MultiValuedLookupColumn extends LookupColumn
         _display = display;
         _rightFk = fk;
         _junctionKey = junctionKey;
+
+        // Issue 47311: Rewrite the lookup FieldKey to remove the intermediate table/query
+        setFieldKey(parentPkColumn.getFieldKey().append(display.getFieldKey().getName()));
+
         copyAttributesFrom(display);
         copyURLFrom(display, parentPkColumn.getFieldKey(), null);
         // NOTE: Changing the type to a VARCHAR causes MultiValueRenderContext.get() type conversion to be skipped and we don't want that.
@@ -75,13 +79,11 @@ public class MultiValuedLookupColumn extends LookupColumn
         return new SQLFragment(getTableAlias(tableAliasName) + "." + _display.getAlias());
     }
 
-
     @Override
     protected void addLookupSql(SQLFragment strJoin, TableInfo lookupTable, String alias)
     {
         strJoin.append(getLookupSql(lookupTable, alias));
     }
-
 
     protected SQLFragment getLookupSql(TableInfo lookupTable, String alias)
     {
@@ -193,7 +195,6 @@ public class MultiValuedLookupColumn extends LookupColumn
         return strJoin;
     }
     
-
     @Override
     // The multivalued column joins take place within the aggregate function sub-select; we don't want super class
     // including these columns as top-level joins.
@@ -209,5 +210,4 @@ public class MultiValuedLookupColumn extends LookupColumn
         // Can't sort because we need to make sure that all of the multi-value columns come back in the same order 
         return getSqlDialect().getGroupConcat(sql, false, false, "'" + MultiValuedRenderContext.VALUE_DELIMITER + "'");
     }
-
 }

--- a/api/src/org/labkey/api/data/ReportingWriter.java
+++ b/api/src/org/labkey/api/data/ReportingWriter.java
@@ -74,10 +74,6 @@ public class ReportingWriter
         props.put("sqlType", cinfo == null ? null : cinfo.getSqlTypeName());
         props.put("defaultValue", cinfo == null ? null : cinfo.getDefaultValue());
 
-        /////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Begin properties moved from columnModel section
-
-        // see  Ext.grid.ColumnModel Ext.grid.Column
         if (cinfo != null)
         {
             props.put("scale", cinfo.getScale());
@@ -92,25 +88,12 @@ public class ReportingWriter
                 //try to parse as integer (which is what Ext wants)
                props.put("width", Integer.parseInt(dc.getWidth()));
             }
-            catch(NumberFormatException e)
+            catch (NumberFormatException e)
             {
                 //include it as a string
                 props.put("width", dc.getWidth());
             }
         }
-
-        /* TODO: The remainder of these former columnModel properties seem to duplicate keys in the field object,
-            but the logic defining their values is slightly different. Which is correct?
-         */
-//        extGridColumn.put("editable", isEditable(dc));
-//        extGridColumn.put("hidden", colInfo != null && (colInfo.isHidden() || colInfo.isAutoIncrement())); //auto-incr list key columns return false for isHidden(), so check isAutoIncrement as well
-//        /** These are not part of Ext.Grid.Column, don't know why they are hear (MAB) */
-//        extGridColumn.put("required", colInfo != null && !colInfo.isNullable());
-//        if (colInfo != null && isEditable(dc) && null != colInfo.getDefaultValue())
-//            extGridColumn.put("defaultValue", colInfo.getDefaultValue());
-
-        // End propertiess moved from columnModel section
-        /////////////////////////////////////////////////////////////////////////////////////////////////////
 
         if (includeDomainFormat)
         {
@@ -159,7 +142,6 @@ public class ReportingWriter
 
         if (cinfo != null)
         {
-
             if (!cinfo.getImportAliasSet().isEmpty())
             {
                 props.put("importAliases", new ArrayList<>(cinfo.getImportAliasSet()));
@@ -199,14 +181,14 @@ public class ReportingWriter
 
             String inputType = cinfo.getInputType();
             props.put("inputType", inputType);
-            if ( ("textarea".equals(inputType) || "text".equals(inputType) ) && dc instanceof DataColumn)
+            if (("textarea".equals(inputType) || "text".equals(inputType)) && dc instanceof DataColumn dataColumn)
             {
-                int cols = ((DataColumn)dc).getInputLength();
+                int cols = dataColumn.getInputLength();
                 if (cols > 0)
                     props.put("cols", Math.min(1000,cols));
                 if ("textarea".equals(inputType))
                 {
-                    int rows = ((DataColumn)dc).getInputRows();
+                    int rows = dataColumn.getInputRows();
                     if (rows > 0)
                         props.put("rows", Math.min(1000,rows));
                 }
@@ -329,9 +311,8 @@ public class ReportingWriter
                 key = pks.get(1);
             lookupInfo.put("keyColumn", key);
 
-            if (fk instanceof MultiValuedForeignKey)
+            if (fk instanceof MultiValuedForeignKey mvfk)
             {
-                MultiValuedForeignKey mvfk = (MultiValuedForeignKey)fk;
                 String junctionLookup = mvfk.getJunctionLookup();
                 lookupInfo.put("multiValued", junctionLookup != null ? "junction" : "value");
                 if (junctionLookup != null)
@@ -343,6 +324,4 @@ public class ReportingWriter
 
         return null;
     }
-
-
 }

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -309,7 +309,6 @@ public class QueryServiceImpl implements QueryService
      *     Filter.create("RowId",  'SELECT SampleId FROM assay.General.assay1.Data WHERE field1 < 5 AND field2 NOT NULL', COLUMN_IN_FILTER_TYPE)
      * </code>
      */
-
     public static final CompareType COLUMN_IN = new CompareType("COLUMN IN", "columnin", "COLUMN_IN", true /* dataValueRequired */, "sql", null)
     {
         @Override
@@ -332,7 +331,6 @@ public class QueryServiceImpl implements QueryService
      *     Filter.create("RowId",  'SELECT SampleId FROM assay.General.assay1.Data WHERE field1 < 5 AND field2 NOT NULL', COLUMN_NOT_IN_FILTER_TYPE)
      * </code>
      */
-
     public static final CompareType COLUMN_NOT_IN = new CompareType("COLUMN NOT IN", "columnnotin", "COLUMN_NOT_IN", true /* dataValueRequired */, "sql", null)
     {
         @Override
@@ -525,9 +523,7 @@ public class QueryServiceImpl implements QueryService
         }
     }
 
-
     private static final FieldKey expObjectIdFieldKey = new FieldKey(null, BuiltInColumnTypes.EXPOBJECTID_CONCEPT_URI);
-
 
     /* It would be nice to put with class ChildOfMethod and class ParentOfMethod, but our build dependencies mean this goes here for now */
     private static class InLineageOfClause extends WhereClause
@@ -568,7 +564,6 @@ public class QueryServiceImpl implements QueryService
             return super.toSQLFragment(columnMap, dialect);
         }
     }
-
 
     public static class QColumnInfo extends QInternalExpr
     {
@@ -629,13 +624,12 @@ public class QueryServiceImpl implements QueryService
         _metadataLastModified.set(new Date().getTime());
     }
 
-
     @Override
     public UserSchema getUserSchema(User user, Container container, String schemaPath)
     {
         QuerySchema schema = DefaultSchema.get(user, container, schemaPath);
-        if (schema instanceof UserSchema && !((UserSchema) schema).isFolder())
-            return (UserSchema) schema;
+        if (schema instanceof UserSchema userSchema && !userSchema.isFolder())
+            return userSchema;
 
         return null;
     }
@@ -644,8 +638,8 @@ public class QueryServiceImpl implements QueryService
     public UserSchema getUserSchema(User user, Container container, SchemaKey schemaPath)
     {
         QuerySchema schema = DefaultSchema.get(user, container, schemaPath);
-        if (schema instanceof UserSchema && !((UserSchema) schema).isFolder())
-            return (UserSchema) schema;
+        if (schema instanceof UserSchema userSchema && !userSchema.isFolder())
+            return userSchema;
 
         return null;
     }
@@ -860,10 +854,6 @@ public class QueryServiceImpl implements QueryService
             QueryManager.get().getQueryDefs(ContainerManager.getSharedContainer(), schemaName, true, includeSnapshots, true)
                     .forEach(addQueryDefToMap);
         }
-        if (includeMetadataOverride)
-        {
-
-        }
         for (QueryDef queryDef : QueryManager.get().getQueryDefs(ContainerManager.getSharedContainer(), schemaName, true, includeSnapshots, true))
         {
             addCustomQueryDefToMap(user, container, ret, queryDef);
@@ -900,7 +890,6 @@ public class QueryServiceImpl implements QueryService
         MODULE_CUSTOM_VIEW_CACHE.onModuleChanged(module);
         INVALIDATE_QUERY_METADATA_HANDLER.moduleChanged(module);
     }
-
 
     private static class QueryDefResourceCacheHandler implements ModuleResourceCacheHandler<MultiValuedMap<Path, ModuleQueryDef>>
     {
@@ -1426,13 +1415,11 @@ public class QueryServiceImpl implements QueryService
         }
     }
 
-
     @Override
     public QueryDefinition saveSessionQuery(ViewContext context, Container container, String schemaName, String sql, String metadataXml)
     {
         return saveSessionQuery(context.getRequest().getSession(true), container, context.getUser(), schemaName, sql, metadataXml);
     }
-
 
     @Override
     public QueryDefinition saveSessionQuery(@NotNull HttpSession session, Container container, User user, String schemaName, String sql, String metadataXml)
@@ -1459,13 +1446,11 @@ public class QueryServiceImpl implements QueryService
         return getSessionQuery(session, container, user, schemaKey, queryName);
     }
 
-
     @Override
     public QueryDefinition saveSessionQuery(ViewContext context, Container container, String schemaName, String sql)
     {
         return saveSessionQuery(context, container, schemaName, sql, null);
     }
-
 
     private static final String PERSISTED_TEMP_QUERIES_KEY = "LABKEY.PERSISTED_TEMP_QUERIES";
 
@@ -1492,9 +1477,8 @@ public class QueryServiceImpl implements QueryService
         @Override
         public boolean equals(Object obj)
         {
-            if (obj instanceof SessionQuery)
+            if (obj instanceof SessionQuery sq)
             {
-                SessionQuery sq = (SessionQuery) obj;
                 if (!_sql.equals(sq._sql))
                     return false;
                 if (_metadata == null && sq._metadata != null)
@@ -1567,7 +1551,6 @@ public class QueryServiceImpl implements QueryService
         return createTempQueryDefinition(user, container, schemaName, queryName, query);
     }
 
-
     private QueryDefinition createTempQueryDefinition(User user, Container container, SchemaKey schemaName, String queryName, @NotNull SessionQuery query)
     {
         QueryDefinition qdef = createQueryDef(user, container, schemaName, queryName);
@@ -1615,9 +1598,8 @@ public class QueryServiceImpl implements QueryService
                 List<ColumnInfo> pkColumns = table.getPkColumns();
                 Set<FieldKey> pkColumnMap = new HashSet<>();
                 ContainerContext cc = table.getContainerContext();
-                if (cc instanceof ContainerContext.FieldKeyContext)
+                if (cc instanceof ContainerContext.FieldKeyContext fko)
                 {
-                    ContainerContext.FieldKeyContext fko = (ContainerContext.FieldKeyContext) cc;
                     pkColumnMap.add(fko.getFieldKey());
                 }
 
@@ -1712,7 +1694,6 @@ public class QueryServiceImpl implements QueryService
         return ret;
     }
 
-
     @Override
     public List<DisplayColumn> getDisplayColumns(@NotNull TableInfo table, Collection<Entry<FieldKey, Map<CustomView.ColumnProperty, String>>> fields)
     {
@@ -1743,16 +1724,12 @@ public class QueryServiceImpl implements QueryService
         return ret;
     }
 
-
     @Override
     public Collection<ColumnInfo> ensureRequiredColumns(@NotNull TableInfo table, @NotNull Collection<ColumnInfo> columns,
                                                         @Nullable Filter filter, @Nullable Sort sort, @Nullable Set<FieldKey> unresolvedColumns)
     {
-        HashMap<FieldKey, ColumnInfo> hm = new HashMap<>();
-        Set<ColumnInfo> involvedColumns = new HashSet<>();
-        return ensureRequiredColumns(table, columns, filter, sort, unresolvedColumns, hm);
+        return ensureRequiredColumns(table, columns, filter, sort, unresolvedColumns, new HashMap<>());
     }
-
 
     // mapping may include multiple fieldkeys pointing at same columninfo (see ColumnInfo.resolveColumn());
     public List<ColumnInfo> ensureRequiredColumns(@NotNull TableInfo table, @NotNull Collection<ColumnInfo> columns, @Nullable Filter filter,
@@ -1846,9 +1823,8 @@ public class QueryServiceImpl implements QueryService
 
             for (FieldKey field : unresolvedColumns)
             {
-                if (filter instanceof SimpleFilter)
+                if (filter instanceof SimpleFilter simpleFilter)
                 {
-                    SimpleFilter simpleFilter = (SimpleFilter) filter;
                     simpleFilter.deleteConditions(field);
                 }
 
@@ -1859,7 +1835,6 @@ public class QueryServiceImpl implements QueryService
 
         return new ArrayList<>(ret.values());
     }
-
 
     private void resolveSortColumns(ColumnInfo col, Map<FieldKey, ColumnInfo> columnMap, AliasManager manager,
                                                      LinkedHashMap<FieldKey,ColumnInfo> ret, boolean addSortKeysOnly)
@@ -1907,10 +1882,9 @@ public class QueryServiceImpl implements QueryService
         }
     }
 
-
     private ColumnInfo resolveFieldKey(FieldKey fieldKey, TableInfo table, Map<FieldKey, ColumnInfo> columnMap, Set<FieldKey> unresolvedColumns, AliasManager manager)
     {
-        if (fieldKey == null)
+        if (fieldKey == null) // TODO: Can this resolve "selectionMethods/selectionMethodId$Sname"?
             return null;
 
         // This could be made more general, but I don't think there's a need.  To reduce testing
@@ -1954,7 +1928,6 @@ public class QueryServiceImpl implements QueryService
         return null;
     }
 
-
     public Map<String, UserSchema> getExternalSchemas(User user, Container c)
     {
         Map<String, UserSchema> ret = new HashMap<>();
@@ -1969,7 +1942,7 @@ public class QueryServiceImpl implements QueryService
             }
             catch (Exception e)
             {
-                LogManager.getLogger(QueryServiceImpl.class).warn("Could not load schema " + def.getSourceSchemaName() + " from " + def.getDataSource(), e);
+                LOG.warn("Could not load schema " + def.getSourceSchemaName() + " from " + def.getDataSource(), e);
             }
         }
 
@@ -1988,7 +1961,7 @@ public class QueryServiceImpl implements QueryService
             }
             catch (Exception e)
             {
-                LogManager.getLogger(QueryServiceImpl.class).warn("Could not load schema " + def.getSourceSchemaName() + " from " + def.getDataSource(), e);
+                LOG.warn("Could not load schema " + def.getSourceSchemaName() + " from " + def.getDataSource(), e);
             }
         }
 
@@ -2010,7 +1983,7 @@ public class QueryServiceImpl implements QueryService
             }
             catch (Exception e)
             {
-                LogManager.getLogger(QueryServiceImpl.class).error("Error creating linked schema " + def.getUserSchemaName(), e);
+                LOG.error("Error creating linked schema " + def.getUserSchemaName(), e);
             }
         }
 
@@ -2030,7 +2003,7 @@ public class QueryServiceImpl implements QueryService
             }
             catch (Exception e)
             {
-                LogManager.getLogger(QueryServiceImpl.class).error("Error creating linked schema " + def.getUserSchemaName(), e);
+                LOG.error("Error creating linked schema " + def.getUserSchemaName(), e);
             }
         }
 
@@ -2062,7 +2035,7 @@ public class QueryServiceImpl implements QueryService
         }
         catch (Exception e)
         {
-            LogManager.getLogger(QueryServiceImpl.class).error("Error deleting linked schema " + name, e);
+            LOG.error("Error deleting linked schema " + name, e);
         }
     }
 
@@ -2612,20 +2585,16 @@ public class QueryServiceImpl implements QueryService
         }
     }
 
-
     // verify that named parameters have been bound
     @Override
     public void validateNamedParameters(SQLFragment frag)
     {
         for (Object o : frag.getParams())
         {
-            if (!(o instanceof ParameterDecl))
-                continue;
-            ParameterDecl p = (ParameterDecl) o;
-            throw new NamedParameterNotProvided(p.getName());
+            if (o instanceof ParameterDecl p)
+                throw new NamedParameterNotProvided(p.getName());
         }
     }
-
 
     @Override
     public Results select(TableInfo table, Collection<ColumnInfo> columns, @Nullable Filter filter, @Nullable Sort sort, Map<String, Object> parameters, boolean cache)
@@ -2675,7 +2644,6 @@ public class QueryServiceImpl implements QueryService
     {
         return new SelectBuilderImpl(table);
     }
-
 
     class SelectBuilderImpl implements SelectBuilder
     {
@@ -2907,7 +2875,6 @@ public class QueryServiceImpl implements QueryService
         env.putAll((HashMap<Environment, Object>) o);
     }
 
-
     @Override
     public void clearEnvironment()
     {
@@ -2999,7 +2966,6 @@ public class QueryServiceImpl implements QueryService
 
         AuditLogService.get().addEvent(user, event);
     }
-
 
     @Override
     public List<DetailedAuditTypeEvent> getQueryUpdateAuditRecords(User user, Container container, long transactionAuditId)
@@ -3144,24 +3110,6 @@ public class QueryServiceImpl implements QueryService
         return new ArrayList<>(def.getHierarchies());
     }
 
-    /*
-    public Set<ColumnInfo> getIncomingLookups(User user, Container c, TableInfo targetTable, Set<SchemaKey> schemaKeys)
-    {
-        Set<ColumnInfo> lookups = new HashSet<>();
-
-        Set<UserSchema> schemas = schemaKeys.stream().map(key -> getUserSchema(user, c, key)).collect(Collectors.toSet());
-        UserSchema schema = getUserSchema(user, c, schemaKey);
-        SchemaTreeWalker walk = new SchemaTreeWalker<ColumnInfo, Void>(true) {
-            @Override
-            public ColumnInfo visitTable(TableInfo table, Path path, Void param)
-            {
-                return super.visitTable(table, path, param);
-            }
-        };
-        Set<ColumnInfo> lookups = walk.visitTop(schemas, null);
-    }
-    */
-
     @Override
     public TableInfo analyzeQuery(
             UserSchema userSchema, String queryName,
@@ -3208,7 +3156,6 @@ public class QueryServiceImpl implements QueryService
         return _analyzeTableInfo(from, t, dependencyGraph);
     }
 
-
     private TableInfo _analyzeTableInfo(DependencyObject from, TableInfo source, SetValuedMap<DependencyObject,DependencyObject> dependencyGraph)
     {
         if (null == source)
@@ -3244,7 +3191,6 @@ public class QueryServiceImpl implements QueryService
         return source;
     }
 
-
     final static SchemaKey coreSchemaKey = SchemaKey.fromParts("core");
 
     private boolean _includeLookupDependency(TableInfo from, TableInfo to)
@@ -3265,7 +3211,6 @@ public class QueryServiceImpl implements QueryService
         return false;
     }
 
-
     @Override
     public void registerQueryAnalysisProvider(QueryAnalysisService provider)
     {
@@ -3277,9 +3222,6 @@ public class QueryServiceImpl implements QueryService
     {
         return _queryAnalysisService;
     }
-
-
-
 
     /* registry of ColumnInfoTransformer use to build common columns */
     Map<String, ColumnInfoTransformer> columnTransformerMap = Collections.synchronizedMap(new CaseInsensitiveHashMap<>());
@@ -3400,7 +3342,6 @@ public class QueryServiceImpl implements QueryService
                 }
 	        }
         }
-
 
         @Test
         public void testParameters() throws SQLException


### PR DESCRIPTION
#### Rationale
This addresses [Issue 47311](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47311) by rewriting the FieldKey for `MultiValuedLookupColumn` to be composed from the parent plus the display field name.

#### Changes
* Recompose the FieldKey for `MultiValuedLookupColumn` in it's constructor.
* Simplify various casting scenarios that use `instanceof`.
* Cleanup dead comments / commented out code.
