### PR TITLE
remove extra option from combo box property

### DIFF
--- a/core/webapp/ModulePropertiesAdminPanel.js
+++ b/core/webapp/ModulePropertiesAdminPanel.js
@@ -221,10 +221,11 @@ Ext4.define('LABKEY.ext.ModulePropertiesAdminPanel', {
     },
 
     createOptionStore: function(options) {
-        options.unshift({"display":"\xa0", "value":null});
+        let select = Ext4.Array.clone(options);
+        select.unshift({"display":"\xa0", "value":null});
         return Ext4.create('Ext.data.Store', {
             fields: ['display', 'value'],
-            data: options
+            data: select
         })
     },
 


### PR DESCRIPTION
#### Rationale
The module property types : `combo` and `select` inject a blank option to allow users to reset a property back to blank. However we end up with two blank options because the function : `createOptionStore` gets invoked twice per prop, if the per-container option is enabled. The bug occurs because the function mutates the list of options passed in.