### PR TITLE
Generalize wrapped column info

### DIFF
--- a/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
@@ -45,6 +45,17 @@ public abstract class AbstractWrappedColumnInfo implements ColumnInfo
     }
 
     @Override
+    public @Nullable String getWrappedColumnName()
+    {
+        if (delegate != null)
+        {
+            if (!getName().equalsIgnoreCase(delegate.getName()))
+                return delegate.getName();
+        }
+        return null;
+    }
+
+    @Override
     public FieldKey getFieldKey()
     {
         return delegate.getFieldKey();

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -2073,6 +2073,12 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     }
 
     @Override
+    public @Nullable String getWrappedColumnName()
+    {
+        return null;
+    }
+
+    @Override
     public Object getValue(ResultSet rs) throws SQLException
     {
         if (rs == null)

--- a/api/src/org/labkey/api/data/ColumnInfo.java
+++ b/api/src/org/labkey/api/data/ColumnInfo.java
@@ -294,6 +294,9 @@ public interface ColumnInfo extends ColumnRenderProperties
 
     String getColumnName();
 
+    @Nullable
+    String getWrappedColumnName();
+
     Object getValue(ResultSet rs) throws SQLException;
 
     int getIntValue(ResultSet rs) throws SQLException;

--- a/api/src/org/labkey/api/data/WrappedColumn.java
+++ b/api/src/org/labkey/api/data/WrappedColumn.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.data;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.query.ExprColumn;
 
 /**
@@ -55,4 +56,9 @@ public class WrappedColumn extends ExprColumn
         return _col.getValueSql(tableAlias);
     }
 
+    @Override
+    public @Nullable String getWrappedColumnName()
+    {
+        return _col != null ? _col.getName() : null;
+    }
 }

--- a/api/src/org/labkey/api/data/WrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/WrappedColumnInfo.java
@@ -124,6 +124,17 @@ public class WrappedColumnInfo
             {
                 sourceColumnInfo.declareJoins(parentAlias, map);
             }
+
+            @Override
+            public @Nullable String getWrappedColumnName()
+            {
+                if (sourceColumnInfo != null)
+                {
+                    if (!getName().equalsIgnoreCase(sourceColumnInfo.getName()))
+                        return sourceColumnInfo.getName();
+                }
+                return null;
+            }
         };
         ret.copyAttributesFrom(sourceColumnInfo);
         ret.copyURLFrom(sourceColumnInfo, null, null);

--- a/query/src/org/labkey/query/MetadataTableJSON.java
+++ b/query/src/org/labkey/query/MetadataTableJSON.java
@@ -619,12 +619,8 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             metadataColumnJSON.setURL(columnInfo.getURL() == null ? null : columnInfo.getURL().toString());
             metadataColumnJSON.setRangeURI(PropertyType.getFromClass(columnInfo.getJavaObjectClass()).getTypeUri());
 
-            if (columnInfo instanceof WrappedColumn wc)
-            {
-                ColumnInfo wrappedCol = wc.getWrappedColumn();
-                if (wrappedCol != null)
-                    metadataColumnJSON.setWrappedColumnName(wrappedCol.getColumnName());
-            }
+            if (columnInfo.getWrappedColumnName() != null)
+                metadataColumnJSON.setWrappedColumnName(columnInfo.getWrappedColumnName());
 
             if (columnInfo.getFk() != null)
             {


### PR DESCRIPTION
#### Rationale
The UI metadata editor doesn't always translate `ColumnInfo` properties to `MetadataColumnJSON` properly, in this case not preserving the name of the wrapped column. A previous commit helped improve this for a few cases,  but this applies a general fix to the problem.

This may lead to more columns in the metadata editor displaying the wrapped column name, we think this is okay but plan to monitor the change on the develop branch.

#### Related PR
https://github.com/LabKey/platform/pull/4162

[Related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46498)