### PR TITLE
Issue 47495: respect lookup column provided by established foreign key

### DIFF
--- a/api/src/org/labkey/api/data/ColumnInfo.java
+++ b/api/src/org/labkey/api/data/ColumnInfo.java
@@ -56,7 +56,6 @@ public interface ColumnInfo extends ColumnRenderProperties
                 return new AttachmentDisplayColumn(colInfo);
             }
 
-
             DataColumn dataColumn = new DataColumn(colInfo);
             if (colInfo.getPropertyType() == PropertyType.MULTI_LINE)
                 dataColumn.setPreserveNewlines(true);
@@ -72,9 +71,8 @@ public interface ColumnInfo extends ColumnRenderProperties
         {
             if (col.getJdbcType() != JdbcType.INTEGER)
                 return false;
-            if (col.getFk() instanceof PdLookupForeignKey)
+            if (col.getFk() instanceof PdLookupForeignKey lfk)
             {
-                PdLookupForeignKey lfk = (PdLookupForeignKey)col.getFk();
                 if ("core".equalsIgnoreCase(lfk.getLookupSchemaName()) && ("siteusers".equalsIgnoreCase(lfk.getLookupTableName()) || "users".equalsIgnoreCase(lfk.getLookupTableName())))
                     return true;
             }

--- a/query/src/org/labkey/query/MetadataTableJSON.java
+++ b/query/src/org/labkey/query/MetadataTableJSON.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlOptions;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.BaseColumnInfo;
@@ -395,7 +396,8 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
 
                 // Check if it's the same FK, based on schema, query, and container
                 if (lookup == null ||
-                        !metadataColumnJSON.getLookupSchema().equals(lookup.first.getSchemaKey()) ||
+                        // Note, getLookupSchema() is a String so it must be compared against a String here hence the use of getSchemaName()
+                        !metadataColumnJSON.getLookupSchema().equals(lookup.first.getSchemaName()) ||
                         !metadataColumnJSON.getLookupQuery().equals(lookup.first.getQueryName()) ||
                         !Objects.equals(metadataColumnJSON.getLookupContainer(), lookup.first.getContainer() != null ? lookup.first.getContainer().getPath() : null))
                 {
@@ -498,7 +500,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
                 NodeList childNodes = xmlColumn.getDomNode().getChildNodes();
                 // May be empty, or may have empty text between the start and end tags
                 if (childNodes.getLength() == 0 ||
-                        (childNodes.getLength() == 1 && childNodes.item(0) instanceof Text && ((Text)childNodes.item(0)).getData().trim().length() == 0))
+                        (childNodes.getLength() == 1 && childNodes.item(0) instanceof Text txt && txt.getData().trim().length() == 0))
                 {
                     // Remove columns that no longer have any metadata set on them
                     removeColumn(xmlTable, xmlColumn);
@@ -536,6 +538,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
         aliasesSet.forEach(importAliasesXml::addImportAlias);
     }
 
+    @Nullable
     private static TableType getTableType(String name, TablesDocument doc)
     {
         if (doc != null && doc.getTables() != null)
@@ -569,6 +572,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
         }
     }
 
+    @Nullable
     public static MetadataTableJSON getMetadata(String schemaName, String tableName, User user, Container container) throws MetadataUnavailableException
     {
         Map<String, MetadataColumnJSON> columnInfos = new CaseInsensitiveHashMap<>();
@@ -834,6 +838,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
         return result;
     }
 
+    @Nullable
     private static Pair<Lookup, Boolean> createLookup(ForeignKey fk, Container currentContainer)
     {
         if (fk == null)
@@ -879,6 +884,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
         return Pair.of(lookup, custom);
     }
 
+    @Nullable
     private static TablesDocument parseDocument(String xml) throws XmlException
     {
         if (xml == null)

--- a/query/src/org/labkey/query/sql/QuerySelectView.java
+++ b/query/src/org/labkey/query/sql/QuerySelectView.java
@@ -338,11 +338,13 @@ public class QuerySelectView extends AbstractQueryRelation
 
         if (filter != null)
         {
-            if (filter instanceof SimpleFilter)
+            if (filter instanceof SimpleFilter simpleFilter)
             {
-                for (var c : ((SimpleFilter) filter).getClauses())
+                for (var c : simpleFilter.getClauses())
+                {
                     if (c instanceof QueryServiceImpl.QueryCompareClause qcc)
                         qcc.setQuery(_query);
+                }
             }
             filterFrag = filter.getSQLFragment(dialect, "x", columnMap);
         }


### PR DESCRIPTION
#### Rationale
This addresses [Issue 47495](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47495) by updating the Query XML metadata generation to respect the lookup column name on an established `ForeignKey` if provided. Formerly, the metadata generator would configure all lookup metadata to only be to a primary key which is not always the case.

#### Changes
* Respect the `ForeignKey.getLookupColumnName()` if available when generating Query XML metadata.
* Fix up some usages of `instanceof` casts
* Revert FK equivalency check to a String to String comparison. Greatly reduces the amount of XML generated for most columns with an FK where the FK is not modified by the user. Reverted from change in #3156.
