### PR TITLE
Treat admin reactivation as recent user activity

### DIFF
--- a/api/src/org/labkey/api/data/SchemaXmlCacheHandler.java
+++ b/api/src/org/labkey/api/data/SchemaXmlCacheHandler.java
@@ -26,6 +26,7 @@ import org.labkey.api.resource.Resource;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.Pair;
+import org.labkey.api.view.template.WarningService;
 import org.labkey.data.xml.TablesDocument;
 
 import java.io.IOException;
@@ -33,13 +34,10 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
  * Manages caching for module XML-based schema-scoped metadata.
- * User: adam
- * Date: 5/10/2014
  */
 public class SchemaXmlCacheHandler implements ModuleResourceCacheHandler<Map<String, TablesDocument>>
 {
@@ -68,7 +66,7 @@ public class SchemaXmlCacheHandler implements ModuleResourceCacheHandler<Map<Str
         return null == schemas ? Collections.emptyList() : schemas.list().stream()
             .map(Resource::getName)
             .filter(SchemaXmlCacheHandler::isSchemaXmlFile)
-            .collect(Collectors.toUnmodifiableList());
+            .toList();
     }
 
     private static boolean isSchemaXmlFile(String filename)
@@ -171,6 +169,8 @@ public class SchemaXmlCacheHandler implements ModuleResourceCacheHandler<Map<Str
             // Invalidate all schemas with a type that uses XML metadata
             for (DbSchemaType type : DbSchemaType.getXmlMetaDataTypes())
                 scope.invalidateSchema(schemaName, type);
+
+            WarningService.get().rerunSchemaCheck();
         }
     };
 }

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -72,6 +72,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable
     private String _displayName = null;
     protected int[] _groups = null;
     private Date _lastLogin = null;
+    private Date _lastActivity = null;
     private boolean _active = false;
     private Date _expirationDate = null;
     private String _phone;
@@ -442,6 +443,16 @@ public class User extends UserPrincipal implements Serializable, Cloneable
     public void setLastLogin(Date lastLogin)
     {
         _lastLogin = lastLogin;
+    }
+
+    public Date getLastActivity()
+    {
+        return _lastActivity;
+    }
+
+    public void setLastActivity(Date lastActivity)
+    {
+        _lastActivity = lastActivity;
     }
 
     public void setImpersonationContext(ImpersonationContext impersonationContext)

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -942,9 +942,16 @@ public class UserManager
             Table.update(currentUser, CoreSchema.getInstance().getTableInfoPrincipals(),
                     Collections.singletonMap("Active", active), userId);
 
-            // update the modified bit on the users table
             Map<String, Object> map = new HashMap<>();
-            map.put("Modified", new Timestamp(System.currentTimeMillis()));
+
+            // Treat re-activation as an activity for the purpose of inactivity tracking, Issue 47471
+            if (active)
+            {
+                Timestamp now = new Timestamp(System.currentTimeMillis());
+                map.put("LastActivity", now);
+            }
+
+            // Call update unconditionally to ensure Modified & ModifiedBy are always updated
             Table.update(currentUser, CoreSchema.getInstance().getTableInfoUsers(), map, userId);
 
             removeRecentUser(userToAdjust);

--- a/api/src/org/labkey/api/util/BreakpointThread.java
+++ b/api/src/org/labkey/api/util/BreakpointThread.java
@@ -18,11 +18,8 @@ package org.labkey.api.util;
 
 /**
  * Starts a thread that can be used as a place to set a breakpoint when other "normal" threads are all blocked
- * or otherwise occupied. This is useful because some debugger functionality, such as a invoking methods through the
+ * or otherwise occupied. This is useful because some debugger functionality, such as invoking methods through the
  * watch window, is not available when the VM is paused separately from a breakpoint or step operation.
- *
- * User: jeckels
- * Date: Oct 27, 2006
  */
 public class BreakpointThread extends Thread implements ShutdownListener
 {

--- a/api/src/org/labkey/api/view/template/WarningService.java
+++ b/api/src/org/labkey/api/view/template/WarningService.java
@@ -45,4 +45,5 @@ public interface WarningService
     void forEachProvider(Consumer<WarningProvider> consumer);
     Warnings getWarnings(ViewContext context);
     HtmlString getWarningsHtml(Warnings warnings, ViewContext context);
+    void rerunSchemaCheck(); // Doesn't really fit on this service, but there's no better existing service
 }

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 23.003
+SchemaVersion: 23.004
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/core.xml
+++ b/core/resources/schemas/core.xml
@@ -182,6 +182,7 @@
       <column columnName="IM"/>
       <column columnName="Description"/>
       <column columnName="LastLogin"/>
+      <column columnName="LastActivity"/>
       <column columnName="DisplayName"/>
       <column columnName="ExpirationDate">
         <description>The expiration date for the account. If applicable compliance setting is enabled, account will be disabled after this date by nightly maintenance task.</description>
@@ -336,6 +337,11 @@
         <inputLength>23</inputLength>
         <isReadOnly>true</isReadOnly>
         <description>The date and time this user last logged in to the system.</description>
+      </column>
+      <column columnName="LastActivity">
+        <formatString>DateTime</formatString>
+        <isReadOnly>true</isReadOnly>
+        <description>The date and time for the most recent activity other than login, e.g., reactivation by an administrator.</description>
       </column>
       <column columnName="HasPassword">
         <description>True if this user has the ability to login via a hashed password stored in the database. If false, the user can login only via an external authentication mechanism that has been configured, such as an LDAP server, Active Directory, or a single-sign-on protocol like SAML or CAS. A site administrator can give a user the ability to create a database password by clicking the "Create Password" button on that user's details page.</description>
@@ -497,6 +503,7 @@
         <inputLength>23</inputLength>
       </column>
       <column columnName="System"/>
+      <column columnName="LastActivity"/>
     </columns>
     <tableTitle>Active Users</tableTitle>
     <pkColumnName>UserId</pkColumnName>

--- a/core/resources/schemas/dbscripts/postgresql/core-23.003-23.004.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-23.003-23.004.sql
@@ -1,0 +1,1 @@
+ALTER TABLE core.UsersData ADD LastActivity TIMESTAMP NULL;

--- a/core/resources/schemas/dbscripts/postgresql/core-create.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-create.sql
@@ -35,7 +35,8 @@ CREATE OR REPLACE RULE Users_Update AS
             LastLogin = NEW.LastLogin,
             DisplayName = NEW.DisplayName,
             ExpirationDate = NEW.ExpirationDate,
-            System = NEW.System
+            System = NEW.System,
+            LastActivity = NEW.LastActivity
         WHERE UserId = NEW.UserId;
 
 CREATE VIEW core.ActiveUsers AS

--- a/core/resources/schemas/dbscripts/sqlserver/core-23.003-23.004.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-23.003-23.004.sql
@@ -1,0 +1,1 @@
+ALTER TABLE core.UsersData ADD LastActivity DATETIME NULL;

--- a/core/resources/schemas/test.xml
+++ b/core/resources/schemas/test.xml
@@ -168,6 +168,7 @@
             <column columnName="HasPassword"/>
             <column columnName="ExpirationDate"/>
             <column columnName="System"/>
+            <column columnName="LastActivity"/>
         </columns>
     </table>
     <table tableName="a\b" tableDbType="VIEW">
@@ -195,6 +196,7 @@
             <column columnName="HasPassword"/>
             <column columnName="ExpirationDate"/>
             <column columnName="System"/>
+            <column columnName="LastActivity"/>
         </columns>
     </table>
 </tables>

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1121,7 +1121,8 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
     {
         SystemMaintenance.setTimer();
         ThumbnailServiceImpl.startThread();
-        _warningProvider.startSchemaCheck();
+        // Launch in the background, but delay by 10 seconds to reduce impact on other startup tasks
+        _warningProvider.startSchemaCheck(10);
 
         // Start up the default Quartz scheduler, used in many places
         try
@@ -1475,5 +1476,12 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         }
 
         return null;
+    }
+
+    public void rerunSchemaCheck()
+    {
+        // Queue a job without delay. This avoids executing multiple overlapping schema checks. Not bothering with a
+        // more surgical approach since this variant is likely being called during development.
+        _warningProvider.startSchemaCheck(0);
     }
 }

--- a/core/src/org/labkey/core/query/CoreQuerySchema.java
+++ b/core/src/org/labkey/core/query/CoreQuerySchema.java
@@ -106,7 +106,7 @@ public class CoreQuerySchema extends UserSchema
     }
 
     @Override
-    public QueryView createView(ViewContext context, @NotNull QuerySettings settings, BindException errors)
+    public @NotNull QueryView createView(ViewContext context, @NotNull QuerySettings settings, BindException errors)
     {
         if (WORKBOOKS_TABLE_NAME.equalsIgnoreCase(settings.getQueryName()))
         {
@@ -194,7 +194,7 @@ public class CoreQuerySchema extends UserSchema
     {
         TableInfo principalsBase = CoreSchema.getInstance().getTableInfoPrincipals();
         // We apply a special filter for containers below, so don't filter here too
-        FilteredTable groups = new FilteredTable<>(principalsBase, this)
+        FilteredTable<CoreQuerySchema> groups = new FilteredTable<>(principalsBase, this)
         {
             @Override
             public boolean supportsContainerFilter()
@@ -286,7 +286,7 @@ public class CoreQuerySchema extends UserSchema
         return users;
     }
 
-    private void toggleExpirationDateColumn(FilteredTable users)
+    private void toggleExpirationDateColumn(FilteredTable<UserSchema> users)
     {
         var expirationDateCol = users.getMutableColumn(FieldKey.fromParts("ExpirationDate"));
         if (expirationDateCol != null)
@@ -309,7 +309,7 @@ public class CoreQuerySchema extends UserSchema
     public TableInfo getPrincipals()
     {
         TableInfo principalsBase = CoreSchema.getInstance().getTableInfoPrincipals();
-        FilteredTable principals = new FilteredTable<>(principalsBase, this, ContainerFilter.EVERYTHING);
+        FilteredTable<CoreQuerySchema> principals = new FilteredTable<>(principalsBase, this, ContainerFilter.EVERYTHING);
 
         //we expose userid, name and type via query
         var col = principals.wrapColumn(principalsBase.getColumn("UserId"));
@@ -360,7 +360,7 @@ public class CoreQuerySchema extends UserSchema
     public TableInfo getMembers()
     {
         TableInfo membersBase = CoreSchema.getInstance().getTableInfoMembers();
-        FilteredTable members = new FilteredTable<>(membersBase, this);
+        FilteredTable<CoreQuerySchema> members = new FilteredTable<>(membersBase, this);
 
         var col = members.wrapColumn(membersBase.getColumn("UserId"));
         col.setKeyField(true);
@@ -454,7 +454,7 @@ public class CoreQuerySchema extends UserSchema
                     SecurityManager.getGroupMembers(siteAdminGroup, MemberType.ACTIVE_AND_INACTIVE_USERS)
                         .stream()
                         .map(UserPrincipal::getUserId)
-                        .collect(Collectors.toList())
+                        .toList()
                 );
 
                 // add all user with root container ApplicationAdminRole or SiteAdminRole assignments
@@ -462,15 +462,15 @@ public class CoreQuerySchema extends UserSchema
                 {
                     SecurityPolicy rootContainerPolicy = ContainerManager.getRoot().getPolicy();
                     List<RoleAssignment> assignments = rootContainerPolicy.getAssignments().stream()
-                            .filter(assignment -> adminRole.equals(assignment.getRole())).collect(Collectors.toList());
+                            .filter(assignment -> adminRole.equals(assignment.getRole())).toList();
                     assignments.forEach(assignment -> {
                         Group assignedGroup = SecurityManager.getGroup(assignment.getUserId());
                         if (assignedGroup != null)
                             _projectUserIds.addAll(
-                                    SecurityManager.getAllGroupMembers(assignedGroup, MemberType.ACTIVE_AND_INACTIVE_USERS)
-                                            .stream()
-                                            .map(UserPrincipal::getUserId)
-                                            .collect(Collectors.toList())
+                                SecurityManager.getAllGroupMembers(assignedGroup, MemberType.ACTIVE_AND_INACTIVE_USERS)
+                                    .stream()
+                                    .map(UserPrincipal::getUserId)
+                                    .toList()
                             );
 
                         _projectUserIds.add(assignment.getUserId());
@@ -539,7 +539,7 @@ public class CoreQuerySchema extends UserSchema
     protected TableInfo getMembersTable()
     {
         TableInfo membersBase = CoreSchema.getInstance().getTableInfoMembers();
-        FilteredTable result = new FilteredTable<>(membersBase, this);
+        FilteredTable<CoreQuerySchema> result = new FilteredTable<>(membersBase, this);
 
         var userColumn = result.wrapColumn("User", membersBase.getColumn("UserId"));
         result.addColumn(userColumn);

--- a/core/src/org/labkey/core/query/UsersTable.java
+++ b/core/src/org/labkey/core/query/UsersTable.java
@@ -84,12 +84,10 @@ import java.io.InputStream;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -105,16 +103,11 @@ public class UsersTable extends SimpleUserSchema.SimpleTable<UserSchema>
     private final boolean _canSeeDetails;
     private static final String EXPIRATION_DATE_KEY = "ExpirationDate";
     private static final String SYSTEM = "System";
-    private static final Set<FieldKey> ALWAYS_AVAILABLE_FIELDS;
-
-    static
-    {
-        ALWAYS_AVAILABLE_FIELDS = new HashSet<>();
-        ALWAYS_AVAILABLE_FIELDS.addAll(Arrays.asList(
-                FieldKey.fromParts("EntityId"),
-                FieldKey.fromParts("UserId"),
-                FieldKey.fromParts("DisplayName")));
-    }
+    private static final Set<FieldKey> ALWAYS_AVAILABLE_FIELDS = Set.of(
+        FieldKey.fromParts("EntityId"),
+        FieldKey.fromParts("UserId"),
+        FieldKey.fromParts("DisplayName")
+    );
 
     private final static Logger LOG = LogManager.getLogger(UsersTable.class);
 
@@ -159,7 +152,7 @@ public class UsersTable extends SimpleUserSchema.SimpleTable<UserSchema>
                 if (ALWAYS_AVAILABLE_FIELDS.contains(col.getFieldKey()))
                     wrapColumn(col);
                 else
-                    addUserDetailColumn( (BaseColumnInfo)col, isCanSeeDetails(), true);
+                    addUserDetailColumn((BaseColumnInfo)col, isCanSeeDetails(), true);
             }
         }
 
@@ -170,6 +163,7 @@ public class UsersTable extends SimpleUserSchema.SimpleTable<UserSchema>
         defaultColumns.add(FieldKey.fromParts("Active"));
         defaultColumns.add(FieldKey.fromParts("HasPassword"));
         defaultColumns.add(FieldKey.fromParts("LastLogin"));
+        defaultColumns.add(FieldKey.fromParts("LastActivity"));
         defaultColumns.add(FieldKey.fromParts("Created"));
 
         if (null != PropertyService.get())

--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -71,12 +71,13 @@ public class CoreWarningProvider implements WarningProvider
         AbstractImpersonationContextFactory.registerSessionAttributeToStash(SESSION_WARNINGS_BANNER_KEY);
     }
 
-    public void startSchemaCheck()
+    public void startSchemaCheck(int delaySeconds)
     {
         // Issue 46264 - proactively check all DB schemas against the schema XML
-        // Launch this in the background, but delay by 10 seconds to reduce impact on other startup tasks
-        JobRunner.getDefault().execute(TimeUnit.SECONDS.toMillis(10), () ->
+        JobRunner.getDefault().execute(TimeUnit.SECONDS.toMillis(delaySeconds), () ->
         {
+            _dbSchemaWarnings.clear();
+
             for (DbSchema schema : DbSchema.getAllSchemasToTest())
             {
                 var schemaWarnings = TableXmlUtils.compareXmlToMetaData(schema, false, false, true);

--- a/core/src/org/labkey/core/view/template/bootstrap/WarningServiceImpl.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/WarningServiceImpl.java
@@ -25,6 +25,7 @@ import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.template.WarningProvider;
 import org.labkey.api.view.template.WarningService;
 import org.labkey.api.view.template.Warnings;
+import org.labkey.core.CoreModule;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -150,5 +151,11 @@ public class WarningServiceImpl implements WarningService
                 html.endTag("ul");
             }
         }
+    }
+
+    @Override
+    public void rerunSchemaCheck()
+    {
+        ((CoreModule)ModuleLoader.getInstance().getCoreModule()).rerunSchemaCheck();
     }
 }


### PR DESCRIPTION
#### Rationale
When the disable inactive accounts compliance feature is enabled, reactivated user accounts are deactivated again unless the user manages to login before the next maintenance run. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47471

Also, we weren't re-running the schema validation check after schema XML files changed, leading to stale warnings.

#### Related Pull Requests
* https://github.com/LabKey/compliance/pull/183
