### PR TITLE
Issue 47504: Make sure there's a first comma after the parens before finding the second comma

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -470,9 +470,8 @@ public class NameGenerator
             errorMessages.add(String.format("No ending parentheses found for the '%s' substitution pattern starting at index %d.", SubstitutionValue.withCounter.name(), start));
         else
         {
-
             int commaIndex = nameExpression.indexOf(",", start);
-            int secondCommaIndex = nameExpression.indexOf(",", commaIndex + 1);
+            int secondCommaIndex = commaIndex >= 0 ? nameExpression.indexOf(",", commaIndex + 1) : -1;
             String startVal = null;
             String format = null;
             String thirdParam = null;


### PR DESCRIPTION
#### Rationale
Get an index out of bounds error if you find a comma that comes before the open parens.

#### Related Pull Requests
* #4175 

#### Changes
* Make sure the second comma comes after the parens in the naming pattern
