### PR TITLE
ELN: Global Attachments

### DIFF
--- a/api/src/org/labkey/api/attachments/AttachmentService.java
+++ b/api/src/org/labkey/api/attachments/AttachmentService.java
@@ -63,6 +63,8 @@ public interface AttachmentService
         return ServiceRegistry.get().getService(AttachmentService.class);
     }
 
+    void download(HttpServletResponse response, AttachmentParent parent, String filename, @Nullable String alias, boolean inlineIfPossible) throws ServletException, IOException;
+
     void download(HttpServletResponse response, AttachmentParent parent, String name, boolean inlineIfPossible) throws ServletException, IOException;
 
     HttpView getHistoryView(ViewContext context, AttachmentParent parent);

--- a/api/src/org/labkey/api/attachments/AttachmentService.java
+++ b/api/src/org/labkey/api/attachments/AttachmentService.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /**
  * User: adam
@@ -75,6 +76,13 @@ public interface AttachmentService
     void deleteAttachments(Collection<AttachmentParent> parents);
 
     /**
+     * Deletes the attachments with the given names from the given AttachmentParent.
+     * @param parent: The AttachmentParent to delete files from
+     * @param names: The file names to delete from the AttachmentParent
+     */
+    void deleteAttachments(AttachmentParent parent, Collection<String> names, @Nullable User auditUser);
+
+    /**
      * @param auditUser set to null to skip audit
      */
     void deleteAttachment(AttachmentParent parent, String name, @Nullable User auditUser);
@@ -84,6 +92,12 @@ public interface AttachmentService
     void copyAttachment(AttachmentParent parent, Attachment a, String newName, User auditUser) throws IOException;
 
     void moveAttachments(Container newContainer, List<AttachmentParent> parents, User auditUser) throws IOException;
+
+    /**
+     * You should not use this method. It only exists so an upgrade script that manually touches the attachment table
+     * can reset the caches of what it touched.
+     */
+    void clearCaches(Collection<String> containerIds);
 
     @NotNull
     List<AttachmentFile> getAttachmentFiles(AttachmentParent parent, Collection<Attachment> attachments) throws IOException;
@@ -100,6 +114,15 @@ public interface AttachmentService
 
     @Nullable
     Attachment getAttachment(AttachmentParent parent, String name);
+
+    /**
+     * Gets attachments from the given parent that match the given names. This method intentionally skips hitting the
+     * AttachmentCache in order to prevent very large AttachmentParents that would explode the cache with tens of
+     * thousands of items when we are only interested in a few.
+     * @param parent: The AttachmentParent to fetch attachments from
+     * @param names: The list of attachment names to fetch
+     */
+    Map<String, Attachment> getAttachments(AttachmentParent parent, Collection<String> names);
 
     void writeDocument(DocumentWriter writer, AttachmentParent parent, String name, boolean asAttachment) throws ServletException, IOException;
 

--- a/api/src/org/labkey/api/attachments/AttachmentService.java
+++ b/api/src/org/labkey/api/attachments/AttachmentService.java
@@ -93,12 +93,6 @@ public interface AttachmentService
 
     void moveAttachments(Container newContainer, List<AttachmentParent> parents, User auditUser) throws IOException;
 
-    /**
-     * You should not use this method. It only exists so an upgrade script that manually touches the attachment table
-     * can reset the caches of what it touched.
-     */
-    void clearCaches(Collection<String> containerIds);
-
     @NotNull
     List<AttachmentFile> getAttachmentFiles(AttachmentParent parent, Collection<Attachment> attachments) throws IOException;
 

--- a/api/src/org/labkey/api/attachments/BaseDownloadAction.java
+++ b/api/src/org/labkey/api/attachments/BaseDownloadAction.java
@@ -43,7 +43,7 @@ public abstract class BaseDownloadAction<FORM extends BaseDownloadAction.InlineD
         Pair<AttachmentParent, String> attachment = getAttachment(form);
 
         if (null != attachment)
-            AttachmentService.get().download(response, attachment.first, attachment.second, form.isInline());
+            AttachmentService.get().download(response, attachment.first, attachment.second, form.getAlias(), form.isInline());
     }
 
     public abstract @Nullable Pair<AttachmentParent, String> getAttachment(FORM form);
@@ -55,5 +55,10 @@ public abstract class BaseDownloadAction<FORM extends BaseDownloadAction.InlineD
     public interface InlineDownloader
     {
         default boolean isInline() { return true; }
+
+        default String getAlias()
+        {
+            return null;
+        }
     }
 }

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -116,7 +116,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -525,15 +525,6 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
         }
     }
 
-    @Override
-    public void clearCaches(Collection<String> containerIds)
-    {
-        for (String containerId : containerIds)
-        {
-            AttachmentCache.removeAttachments(Objects.requireNonNull(ContainerService.get().getForId(containerId)));
-        }
-    }
-
     /** may return fewer AttachmentFile than Attachment, if there have been deletions */
     @Override
     public @NotNull List<AttachmentFile> getAttachmentFiles(AttachmentParent parent, Collection<Attachment> attachments) throws IOException

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -129,7 +129,7 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
 {
     private static final String UPLOAD_LOG = ".upload.log";
     private static final Map<String, AttachmentType> ATTACHMENT_TYPE_MAP = new HashMap<>();
-    private static final Set<String> ATTACHMENT_COLUMNS = new CsvSet("Parent, Container, DocumentName, DocumentSize, DocumentType, Created, CreatedBy, LastIndexed");
+    private static final Set<String> ATTACHMENT_COLUMNS = Set.of("Parent", "Container", "DocumentName", "DocumentSize", "DocumentType", "Created", "CreatedBy", "LastIndexed");
 
     public AttachmentServiceImpl()
     {


### PR DESCRIPTION
#### Rationale
This PR adds a few methods to the AttachmentService that are needed by labbook in order to better support our "global attachments" optimization. See the related labbook PR for more information.

#### Related Pull Requests
* https://github.com/LabKey/labbook/pull/441

#### Changes
* AttachmentService: Add methods
  * add deleteAttachments(AttachmentParent parent, Collection<String> names, @Nullable User auditUser)
  * add download(HttpServletResponse response, AttachmentParent parent, String filename, @Nullable String alias, boolean inlineIfPossible)
  * add getAttachments(AttachmentParent parent, Collection<String> names)
BaseDownloadAction
  * Add getAlias to InlineDownloader interface
