### PR TITLE
More problems with parsing commas in naming patterns

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -475,7 +475,7 @@ public class NameGenerator
             String startVal = null;
             String format = null;
             String thirdParam = null;
-            if (secondCommaIndex > -1)
+            if (secondCommaIndex > -1 && secondCommaIndex < endParen)
             {
                 // 3 arguments
                 startVal = nameExpression.substring(startParen+1, commaIndex).trim();


### PR DESCRIPTION
#### Rationale
More testing revealed another problem with the parsing logic related to commas in naming patterns. If the comma occurs after a `withCounter()` usage that itself doesn't have multiple arguments, we also get an index out of bounds error.

#### Related Pull Requests
* #4203 

#### Changes
* Update parsing logic.
