### PR TITLE
Remove LastLogin field from LKSM profile page

### DIFF
--- a/core/resources/schemas/core.xml
+++ b/core/resources/schemas/core.xml
@@ -341,6 +341,7 @@
       <column columnName="LastActivity">
         <formatString>DateTime</formatString>
         <isReadOnly>true</isReadOnly>
+        <isUserEditable>false</isUserEditable>
         <description>The date and time for the most recent activity other than login, e.g., reactivation by an administrator.</description>
       </column>
       <column columnName="HasPassword">


### PR DESCRIPTION
#### Rationale
LKSM profile page was displaying and (ostensibly) allowing editing of the LastActivity field, which is read-only. This blocked all saves of the profile page. Marking the field as `UserEditable == false` causes the profile page logic to exclude it.