### PR TITLE
Tolerate malformed schema XML files better

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -102,10 +102,6 @@ import java.util.stream.Collectors;
  *
  * The DbScope.Transaction class implements AutoCloseable, so it will be cleaned up automatically by JDK 7's try {}
  * resource handling.
- *
- * User: migra
- * Date: Nov 16, 2005
- * Time: 10:20:54 AM
  */
 public class DbScope
 {
@@ -121,7 +117,7 @@ public class DbScope
     private static volatile DbScope _labkeyScope = null;
 
     private final DbScopeLoader _dbScopeLoader;
-    private final @Nullable String _databaseName;    // Possibly null, e.g., for SAS datasources
+    private final @Nullable String _databaseName;    // Possibly null, e.g., for SAS data sources
     private final String _databaseProductName;
     private final String _databaseProductVersion;
     private final String _driverName;
@@ -1181,9 +1177,13 @@ public class DbScope
 
     private static List<String> getSchemaNames(Module module, boolean useCache)
     {
-        return (useCache ? SCHEMA_XML_CACHE.getResourceMap(module).keySet() : SchemaXmlCacheHandler.getFilenames(module)).stream()
+        return
+        (
+            useCache ?
+                SCHEMA_XML_CACHE.getResourceMap(module).keySet().stream() :
+                SchemaXmlCacheHandler.getSchemaFilenames(module)
+        )
             .map(filename -> filename.substring(0, filename.length() - ".xml".length()))
-            .sorted()
             .toList();
     }
 

--- a/api/src/org/labkey/api/module/JavaVersion.java
+++ b/api/src/org/labkey/api/module/JavaVersion.java
@@ -73,7 +73,7 @@ public enum JavaVersion
 
     public static JavaVersion get()
     {
-        // Determine current Java specification version, normalized to an int (e.g., 10, 11, 12, 13, 14, 15, 16, 17...).
+        // Determine current Java specification version, normalized to an int (e.g., 17, 18, 19, 20...).
         // Commons lang methods like SystemUtils.isJavaVersionAtLeast() aren't an option because that library isn't
         // released often enough to keep up with the Java rapid release cadence.
         String[] versionArray = SystemUtils.JAVA_SPECIFICATION_VERSION.split("\\.");

--- a/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisProtocolFactory.java
+++ b/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisProtocolFactory.java
@@ -17,7 +17,6 @@ package org.labkey.api.pipeline.file;
 
 import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.pipeline.ParamParser;
@@ -28,9 +27,9 @@ import org.labkey.api.pipeline.PipelineProtocolFactory;
 import org.labkey.api.pipeline.PipelineProvider;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.pipeline.TaskPipeline;
-import org.labkey.api.reader.Readers;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -52,7 +51,7 @@ import java.util.List;
  */
 abstract public class AbstractFileAnalysisProtocolFactory<T extends AbstractFileAnalysisProtocol> extends PipelineProtocolFactory<T>
 {
-    private static Logger _log = LogManager.getLogger(AbstractFileAnalysisProtocolFactory.class);
+    private static final Logger _log = LogHelper.getLogger(AbstractFileAnalysisProtocolFactory.class, "Pipeline protocol and parameter errors");
 
     public static final String DEFAULT_PARAMETERS_NAME = "default";
 

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -17,7 +17,6 @@ package org.labkey.api.search;
 
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -41,8 +40,10 @@ import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.logging.LogHelper;
+import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.NavTree;
+import org.labkey.api.view.RedirectException;
 import org.labkey.api.view.WebPartView;
 import org.labkey.api.webdav.WebdavResource;
 import org.xml.sax.ContentHandler;
@@ -85,6 +86,13 @@ public interface SearchService
     default long getFileSizeLimit()
     {
         return DEFAULT_FILE_SIZE_LIMIT * (1024*1024);
+    }
+
+    // If "_docid" parameter is present, strip it and redirect as a convenience in the "result was found" case
+    static void stripDocIdParameterAndRedirect(@NotNull ActionURL url)
+    {
+        if (null != url.getParameter("_docid"))
+            throw new RedirectException(url.clone().deleteParameter("_docid"));
     }
 
     SearchCategory navigationCategory = new SearchCategory("navigation", "internal category", false);

--- a/api/src/org/labkey/api/util/GUID.java
+++ b/api/src/org/labkey/api/util/GUID.java
@@ -22,12 +22,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.Parameter;
+import org.labkey.api.reader.Readers;
 import org.labkey.api.security.Crypt;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
@@ -132,10 +132,9 @@ public class GUID implements Serializable, Parameter.JdbcParameterValue, SafeToR
 
         if (null != p)
         {
-            try (InputStream str = p.getInputStream())
+            try (InputStream str = p.getInputStream(); BufferedReader in = Readers.getReader(str))
             {
                 Pattern pattern = Pattern.compile(".*(\\p{XDigit}\\p{XDigit}(-|:)\\p{XDigit}\\p{XDigit}(-|:)\\p{XDigit}\\p{XDigit}(-|:)\\p{XDigit}\\p{XDigit}(-|:)\\p{XDigit}\\p{XDigit}(-|:)\\p{XDigit}\\p{XDigit}).*");
-                BufferedReader in = new BufferedReader(new InputStreamReader(str));
                 String line;
                 while (null != (line = in.readLine()))
                 {

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -88,6 +88,7 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.search.SearchResultTemplate;
 import org.labkey.api.search.SearchScope;
+import org.labkey.api.search.SearchService;
 import org.labkey.api.search.SearchUrls;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.MemberType;
@@ -442,6 +443,9 @@ public class IssuesController extends SpringActionController
             {
                 throw new NotFoundException("Unable to find " + names.singularName + " " + form.getIssueId());
             }
+
+            // Issue was found; strip _docId parameter and redirect
+            SearchService.stripDocIdParameterAndRedirect(getViewContext().getActionURL());
 
             IssuePage page = new IssuePage(getContainer(), getUser());
             page.setMode(DataRegion.MODE_DETAILS);

--- a/pipeline/src/org/labkey/pipeline/analysis/CommandTaskImpl.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/CommandTaskImpl.java
@@ -222,7 +222,7 @@ public class CommandTaskImpl extends WorkDirectoryTask<CommandTaskImpl.Factory> 
                 }
                 else
                 {
-                    // CONSIDER: More flexable input/output file naming -- perhaps a string expression with protocol, task, job-id available.
+                    // CONSIDER: More flexible input/output file naming -- perhaps a string expression with protocol, task, job-id available.
                     // CONSIDER: Or explicitly wire outputs from an upstream task as an input to this task which would make the baseName concept less important.
                     String baseName = support.getBaseName();
                     if (tp.isUseProtocolNameAsBaseName())
@@ -606,7 +606,7 @@ public class CommandTaskImpl extends WorkDirectoryTask<CommandTaskImpl.Factory> 
         return replacements;
     }
 
-    // CONDISER: Use PipelineJobService.get().getPathMapper() when translating paths
+    // CONSIDER: Use PipelineJobService.get().getPathMapper() when translating paths
     protected String rewritePath(String path)
     {
         return path;

--- a/pipeline/src/org/labkey/pipeline/api/AbstractWorkDirectory.java
+++ b/pipeline/src/org/labkey/pipeline/api/AbstractWorkDirectory.java
@@ -245,7 +245,7 @@ public abstract class AbstractWorkDirectory implements WorkDirectory
             baseNames = _support.getSplitBaseNames();
         else
         {
-            // CONSIDER: More flexable input/output file naming -- perhaps a string expression with protocol, task, job-id available.
+            // CONSIDER: More flexible input/output file naming -- perhaps a string expression with protocol, task, job-id available.
             // CONSIDER: Or explicitly wire outputs from an upstream task as an input to this task which would make the baseName concept less important.
             String baseName = _support.getBaseName();
             if (tp.isUseProtocolNameAsBaseName())

--- a/wiki/src/org/labkey/wiki/WikiController.java
+++ b/wiki/src/org/labkey/wiki/WikiController.java
@@ -58,7 +58,6 @@ import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.AppProps;
-import org.labkey.wiki.DiffMatchPatch.Diff;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
@@ -85,6 +84,7 @@ import org.labkey.api.view.template.PageConfig.Template;
 import org.labkey.api.wiki.FormattedHtml;
 import org.labkey.api.wiki.WikiPartFactory;
 import org.labkey.api.wiki.WikiRendererType;
+import org.labkey.wiki.DiffMatchPatch.Diff;
 import org.labkey.wiki.model.Wiki;
 import org.labkey.wiki.model.WikiEditModel;
 import org.labkey.wiki.model.WikiTree;
@@ -1152,8 +1152,7 @@ public class WikiController extends SpringActionController
             else
             {
                 // Result was found; strip the "_docid" parameter and redirect as a convenience
-                if (null != getViewContext().getActionURL().getParameter("_docid"))
-                    throw new RedirectException(getViewContext().cloneActionURL().deleteParameter("_docid"));
+                SearchService.stripDocIdParameterAndRedirect(getViewContext().getActionURL());
 
                 int version = form.getVersion();
 


### PR DESCRIPTION
#### Rationale
Inconsistency between the cached and non-cached versions of schema name retrieval can lead to persistent schema browser errors in the presence of a malformed schema XML file. Some discussion here: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47515

#### Changes
* Add null TableDocuments (representing malformed schema XML files) to the cached schema map to ensure the full list of schema names is present in the key set
* Push schema sorting into the cache loader
* Fix warnings and spelling
* Add standard method to strip `_docId` param and redirect. Use it for issues and wiki.