### PR TITLE
Detect query recursion caused by a Filter object that compiles a query

### DIFF
--- a/query/src/org/labkey/query/sql/QuerySelect.java
+++ b/query/src/org/labkey/query/sql/QuerySelect.java
@@ -1345,14 +1345,17 @@ public class QuerySelect extends AbstractQueryRelation implements Cloneable
             @Override
             public SQLFragment getFromSQL(String alias)
             {
-                SQLFragment f = new SQLFragment();
-                if (_sqlAllColumns == null)
+                try (var recursion = _query.queryRecursionCheck("Too many tables used in this query.  Query may be recursive.", null))
                 {
-                    markAllSelected(_query);
-                    _sqlAllColumns = getSql();
+                    SQLFragment f = new SQLFragment();
+                    if (_sqlAllColumns == null)
+                    {
+                        markAllSelected(_query);
+                        _sqlAllColumns = getSql();
+                    }
+                    f.append("(").append(_sqlAllColumns).append(") ").append(alias);
+                    return f;
                 }
-                f.append("(").append(_sqlAllColumns).append(") ").append(alias);
-                return f;
             }
 
             @NotNull

--- a/query/src/org/labkey/query/sql/QueryTableInfo.java
+++ b/query/src/org/labkey/query/sql/QueryTableInfo.java
@@ -70,17 +70,20 @@ public class QueryTableInfo extends AbstractTableInfo implements ContainerFilter
     @Override
     public SQLFragment getFromSQL(String alias)
     {
-        SQLFragment sql = _relation.getSql();
-        if (null == sql)
+        try (var recursion = _relation._query.queryRecursionCheck("Too many tables used in this query.  Query may be recursive.", null))
         {
-            if (!_relation._query.getParseErrors().isEmpty())
-                throw _relation._query.getParseErrors().get(0);
-            else
-                throw new QueryException("Error generating SQL");
+            SQLFragment sql = _relation.getSql();
+            if (null == sql)
+            {
+                if (!_relation._query.getParseErrors().isEmpty())
+                    throw _relation._query.getParseErrors().get(0);
+                else
+                    throw new QueryException("Error generating SQL");
+            }
+            SQLFragment f = new SQLFragment();
+            f.append("(").append(sql).append(") ").append(alias);
+            return f;
         }
-        SQLFragment f = new SQLFragment();
-        f.append("(").append(sql).append(") ").append(alias);
-        return f;
     }
 
 


### PR DESCRIPTION
#### Rationale
This fixes a round-about way to create a recursive query.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
