### PR TITLE
Issue 46743: Include peptide/small molecule info in tooltip for QC plot line

### DIFF
--- a/core/webapp/vis/src/plot.js
+++ b/core/webapp/vis/src/plot.js
@@ -2254,7 +2254,7 @@ boxPlot.render();
                 var pathLayerConfig = {
                     geom: new LABKEY.vis.Geom.Path({
                         opacity: 1,
-                        size: 1,
+                        size: 1.5,
                         dashed: config.qcPlotType == LABKEY.vis.TrendingLinePlotType.CUSUM && !negativeCusum,
                         color: config.properties.lineColor
                     }),
@@ -2308,8 +2308,8 @@ boxPlot.render();
                     }
                 };
                 if (config.properties.hoverTextFn) {
-                    pathLayerConfig.aes.hoverText = function() {
-                        return config.properties.hoverTextFn.call(this);
+                    pathLayerConfig.aes.hoverText = function(event, pathData, layerSel) {
+                        return config.properties.hoverTextFn.call(this, event, pathData, layerSel, valueName, config);
                     };
                 }
 


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46743
This PR passes the data back from the LABKEY.vis.TrendingLinePlot hoverTextFn so that we can include the plotData.group name in the hover text display in the Panorama QC combined plot case.

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/688
* https://github.com/LabKey/platform/pull/4212

#### Changes
* LABKEY.vis.TrendingLinePlot hoverTextFn to pass through plotData and other props
* LABKEY.vis.TrendingLinePlot increase path line width by 50%
