### PR TITLE
improve error message for single row inserts

### DIFF
--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -438,7 +438,8 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
                 _datasetDefinition.checkForDuplicates(scrollable, indexLSID,
                         indexPTID, null == indexVisit ? -1 : indexVisit, null == indexKeyProperty ? -1 : indexKeyProperty, null == indexReplace ? -1 : indexReplace,
                         context, null,
-                        checkDuplicates);
+                        checkDuplicates,
+                        subjectCol, visitdateColumn, seqnumColumn);
                 scrollable.beforeFirst();
                 ret = scrollable;
             }

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -2095,7 +2095,8 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
 
     void checkForDuplicates(DataIterator data,
                                     int indexLSID, int indexPTID, int indexVisit, int indexKey, int indexReplace,
-                                    DataIteratorContext context, Logger logger, CheckForDuplicates checkDuplicates)
+                                    DataIteratorContext context, Logger logger, CheckForDuplicates checkDuplicates,
+                                    ColumnInfo subjectCol, ColumnInfo visitDateCol, ColumnInfo sequenceNumCol)
     {
         BatchValidationException errors = context.getErrors();
         HashMap<String, Object[]> failedReplaceMap = checkAndDeleteDupes(
@@ -2120,17 +2121,17 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
                 if (errorCount > 100)
                     break;
                 Object[] keys = e.getValue();
-                String err = "Duplicate: " + StudyService.get().getSubjectNounSingular(getContainer()) + " = " + keys[0];
+                StringBuilder err = new StringBuilder("Duplicate: ").append(subjectCol.getLabel()).append(" = ").append(keys[0]);
                 if (!isDemographicData())
                 {
                     if (!_study.getTimepointType().isVisitBased())
-                        err = err + ", Date = " + keys[1];
+                        err.append(", ").append(visitDateCol.getLabel()).append(" = ").append(keys[1]);
                     else
-                        err = err + ", VisitSequenceNum = " + keys[1];
+                        err.append(", ").append(sequenceNumCol.getLabel()).append(" = ").append(keys[1]);
                 }
                 if (0 < indexKey)
-                    err += ", " + data.getColumnInfo(indexKey).getName() + " = " + keys[2];
-                errors.addRowError(new ValidationException(err));
+                    err.append(", ").append(data.getColumnInfo(indexKey).getLabel()).append(" = ").append(keys[2]);
+                errors.addRowError(new ValidationException(err.toString()));
             }
         }
         if (logger != null) logger.debug("checked for duplicates");


### PR DESCRIPTION
#### Rationale
The insert form respects `columnTitle` overrides but the duplicate(s) error message has hard coded column names.

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47476)
