### PR TITLE
null check

### DIFF
--- a/api/src/org/labkey/api/data/ILineageDisplayColumn.java
+++ b/api/src/org/labkey/api/data/ILineageDisplayColumn.java
@@ -1,7 +1,11 @@
 package org.labkey.api.data;
 
+import org.jetbrains.annotations.Nullable;
+
 public interface ILineageDisplayColumn
 {
     DisplayColumn getInnerDisplayColumn();
+
+    @Nullable
     ColumnInfo getInnerBoundColumn();
 }

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -1716,17 +1716,20 @@ public class StudyPublishManager implements StudyPublishService
                     col = ((ILineageDisplayColumn) dc).getInnerBoundColumn();
                 }
 
-                if (org.labkey.api.gwt.client.ui.PropertyType.VISIT_CONCEPT_URI.equalsIgnoreCase(col.getConceptURI()))
+                if (col != null)
                 {
-                    if (!fieldKeyMap.containsKey(LinkToStudyKeys.VisitId) && col.getJdbcType().isReal())
-                        fieldKeyMap.put(LinkToStudyKeys.VisitId, ci.getFieldKey());
-                    if (!fieldKeyMap.containsKey(LinkToStudyKeys.Date) && col.getJdbcType().isDateOrTime())
-                        fieldKeyMap.put(LinkToStudyKeys.Date, ci.getFieldKey());
-                }
+                    if (org.labkey.api.gwt.client.ui.PropertyType.VISIT_CONCEPT_URI.equalsIgnoreCase(col.getConceptURI()))
+                    {
+                        if (!fieldKeyMap.containsKey(LinkToStudyKeys.VisitId) && col.getJdbcType().isReal())
+                            fieldKeyMap.put(LinkToStudyKeys.VisitId, ci.getFieldKey());
+                        if (!fieldKeyMap.containsKey(LinkToStudyKeys.Date) && col.getJdbcType().isDateOrTime())
+                            fieldKeyMap.put(LinkToStudyKeys.Date, ci.getFieldKey());
+                    }
 
-                if (!fieldKeyMap.containsKey(LinkToStudyKeys.ParticipantId) && org.labkey.api.gwt.client.ui.PropertyType.PARTICIPANT_CONCEPT_URI.equalsIgnoreCase(col.getConceptURI()))
-                {
-                    fieldKeyMap.put(LinkToStudyKeys.ParticipantId, ci.getFieldKey());
+                    if (!fieldKeyMap.containsKey(LinkToStudyKeys.ParticipantId) && org.labkey.api.gwt.client.ui.PropertyType.PARTICIPANT_CONCEPT_URI.equalsIgnoreCase(col.getConceptURI()))
+                    {
+                        fieldKeyMap.put(LinkToStudyKeys.ParticipantId, ci.getFieldKey());
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Rationale
An error reported in the field indicates an NPE when trying to auto-link sample row(s) to a study. Since this occurs in a post commit task, the overall insert works, but blows up collecting field keys for an attempted auto-link.

```
  "org.labkey.study.assay.StudyPublishManager.getSamplePublishFieldKeys(StudyPublishManager.java:1719)",
  "org.labkey.study.assay.StudyPublishManager.autoLinkDerivedSamples(StudyPublishManager.java:1158)",
  "org.labkey.experiment.ExpDataIterators$AutoLinkToStudyDataIterator.lambda$next$0(ExpDataIterators.java:450)",
  "org.labkey.api.data.DbScope$CommitTaskOption.run(DbScope.java:1984)",
  "org.labkey.api.data.DbScope$TransactionImpl.commit(DbScope.java:2300)",
  "org.labkey.query.controllers.QueryController$BaseSaveRowsAction.executeJson(QueryController.java:4298)",
  "org.labkey.query.controllers.QueryController$InsertRowsAction.execute(QueryController.java:4411)",
  "org.labkey.query.controllers.QueryController$InsertRowsAction.execute(QueryController.java:4404)",
  "org.labkey.api.action.BaseApiAction.handlePost(BaseApiAction.java:211)",
  "org.labkey.api.action.BaseApiAction.handleRequest(BaseApiAction.java:126)",
  "org.labkey.api.action.BaseViewAction.handleRequest(BaseViewAction.java:195)",
```

Adding a null check to fix the problem.

[related issue](https://www.labkey.org/Upside%20Foods/Support%20Tickets/issues-details.view?issueId=47274)