### PR TITLE
Implement TableResultSet.getWrapped() as better alternative to type cast

### DIFF
--- a/api/src/org/labkey/api/data/ResultsImpl.java
+++ b/api/src/org/labkey/api/data/ResultsImpl.java
@@ -148,6 +148,20 @@ public class ResultsImpl implements Results, DataIterator
         }
     }
 
+
+    @Override
+    public <T> T getWrapped(Class<T> clz)
+    {
+        if (clz.isAssignableFrom(this.getClass()))
+            return (T)this;
+        if (clz.isAssignableFrom(_rs.getClass()))
+            return (T)_rs;
+        if (_rs instanceof TableResultSet trs)
+            return trs.getWrapped(clz);
+        return null;
+    }
+
+
     @Override
     public @NotNull Connection getConnection()
     {

--- a/api/src/org/labkey/api/data/TableResultSet.java
+++ b/api/src/org/labkey/api/data/TableResultSet.java
@@ -53,4 +53,11 @@ public interface TableResultSet extends ResultSet, Iterable<Map<String, Object>>
      * more context. */
     @Nullable
     Connection getConnection() throws SQLException;
+
+    default <T> T getWrapped(Class<T> clz)
+    {
+        if (clz.isAssignableFrom(this.getClass()))
+            return (T)this;
+        return null;
+    };
 }

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -650,7 +650,7 @@ public interface QueryService
 
         SQLFragment buildSqlFragment();
         SqlSelector buildSqlSelector(Map<String, Object> parameters);
-        Results select(Map<String, Object> parameters, boolean cache);
+        Results select(@Nullable Map<String, Object> parameters, boolean cache);
         default Results select()
         {
             return select(Map.of(), true);


### PR DESCRIPTION
#### Rationale
Adding getWrapped() is a small step to break implementation expectations about ResultSet implemention returned by QueryService methods (or SelectBuilder).

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
