### PR TITLE
Issue 47229: Support all characters within aliases

### DIFF
--- a/api/src/org/labkey/api/util/StringUtilsLabKey.java
+++ b/api/src/org/labkey/api/util/StringUtilsLabKey.java
@@ -391,7 +391,6 @@ public class StringUtilsLabKey
 
         return original.replaceAll("[\\u2018\\u2019]", "'")
                         .replaceAll("[\\u201C\\u201D]", "\"");
-
     }
 
     public static String unquoteString(@Nullable String original)
@@ -399,11 +398,12 @@ public class StringUtilsLabKey
         if (original == null)
             return null;
 
-        if (original.startsWith("\"") && original.endsWith("\""))
+        if (original.length() > 1 && original.startsWith("\"") && original.endsWith("\""))
         {
-            String stripped = original.replaceAll("\"\"", "\"");
-            return stripped.substring(1, stripped.length()-1);
+            String stripped = original.substring(1, original.length() - 1);
+            return stripped.replaceAll("\"\"", "\"");
         }
+
         return original;
     }
 
@@ -639,6 +639,7 @@ public class StringUtilsLabKey
         {
             assertNull(unquoteString(null));
             assertEquals("", unquoteString(""));
+            assertEquals("\"", unquoteString("\""));
             assertEquals("abc", unquoteString("abc"));
             assertEquals("abc", unquoteString("\"abc\""));
             assertEquals("ab\"c", unquoteString("ab\"c"));

--- a/experiment/src/org/labkey/experiment/api/AliasInsertHelper.java
+++ b/experiment/src/org/labkey/experiment/api/AliasInsertHelper.java
@@ -15,8 +15,8 @@
  */
 package org.labkey.experiment.api;
 
-import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
+import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SQLFragment;
@@ -28,13 +28,14 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
 
 public class AliasInsertHelper
 {
@@ -45,17 +46,42 @@ public class AliasInsertHelper
         Set<Integer> aliasIds = new HashSet<>();
         parseValue(value, aliasNames, aliasIds);
 
-        aliasNames.forEach(s -> {
-            if ((s.startsWith("'") && s.endsWith("'")) || (s.startsWith("\"") && s.endsWith("\"")))
-                throw new IllegalArgumentException("Alias values must not be surrounded by quote characters: " + s);
-        });
-
         // ensure the alias exist collect the alias' rowId
         aliasIds.addAll(ensureAliases(user, aliasNames));
 
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("LSID"), lsid);
         Table.delete(aliasMapTable, filter);
         insertMapEntries(container, user, aliasMapTable, aliasIds, lsid);
+    }
+
+    private static void cleanValueAndAdd(String input, Set<String> aliasNames)
+    {
+        if (input == null)
+            return;
+
+        input = input.trim();
+        if (input.isEmpty())
+            return;
+
+        // remove wrapping quotes
+        if (input.length() >= 2 && input.charAt(0) == '\"' && input.charAt(input.length() - 1) == '\"')
+            input = input.substring(1, input.length() - 1);
+
+        // trim again after removing wrapping quotes
+        input = input.trim();
+
+        if (!input.isEmpty())
+            aliasNames.add(input);
+    }
+
+    private static void parseItemValue(Object value, Set<String> aliasNames, Set<Integer> aliasIds)
+    {
+        if (value instanceof String s)
+            cleanValueAndAdd(s, aliasNames);
+        else if (value instanceof Integer i)
+            aliasIds.add(i);
+        else
+            throw new IllegalArgumentException("Unsupported item value for column 'Alias': " + value);
     }
 
     private static void parseValue(Object value, Set<String> aliasNames, Set<Integer> aliasIds)
@@ -66,25 +92,33 @@ public class AliasInsertHelper
         if (value instanceof String[] aa)
         {
             for (String a : aa)
-                parseValue(a, aliasNames, aliasIds); // recurse
+                cleanValueAndAdd(a, aliasNames);
         }
         else if (value instanceof JSONArray array)
         {
             // LABKEY.Query.updateRows passes a JSONArray of individual alias names.
             for (Object o : array.toList())
-                parseValue(o.toString(), aliasNames, aliasIds); // recurse
+                parseItemValue(o, aliasNames, aliasIds);
         }
         else if (value instanceof Collection<?> col)
         {
-            // Generic query insert form and Excel/tsv import passes an ArrayList with a single String element containing the comma-separated list of values: "abc,def"
-            // LABKEY.Query.insertRows passes an ArrayList containing individual alias names.
-            for (Object o : col)
-                parseValue(o, aliasNames, aliasIds); // recurse
+            if (col.size() == 1)
+            {
+                // Generic query insert form and Excel/tsv import passes an ArrayList with a single String element
+                // containing the comma-separated list of values: "abc,def"
+                // LABKEY.Query.insertRows passes an ArrayList containing individual alias names.
+                parseValue(col.stream().findFirst().get(), aliasNames, aliasIds);
+            }
+            else
+            {
+                for (Object o : col)
+                    parseItemValue(o, aliasNames, aliasIds);
+            }
         }
-        else if (value instanceof String)
+        else if (value instanceof String s)
         {
             // Parse the single string element value submitted by the generic query insert and the tsv import forms.
-            aliasNames.addAll(splitAliases((String) value));
+            aliasNames.addAll(splitAliases(s));
         }
         else if (value instanceof Integer i)
         {
@@ -96,46 +130,22 @@ public class AliasInsertHelper
         }
     }
 
-    public static Set<String> splitAliases(String aliases)
+    private static Set<String> splitAliases(String aliases)
     {
         if (aliases == null)
             return Collections.emptySet();
 
         aliases = aliases.trim();
-        if (aliases.length() == 0)
+        if (aliases.isEmpty())
             return Collections.emptySet();
 
-        // If the user entered a string formatted as a JSONArray, parse it now.
-        if (aliases.startsWith("[") && aliases.endsWith("]"))
-        {
-            Set<String> parts = new HashSet<>();
-            JSONArray a = new JSONArray(aliases);
-            for (Object o : a.toList())
-            {
-                if (o == null)
-                    continue;
-                String s = StringUtils.trim(String.valueOf(o));
-                if (s.length() == 0)
-                    continue;
+        Set<String> aliasNames = new HashSet<>();
+        String[] tokens = aliases.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)", -1);
 
-                parts.add(s);
-            }
+        for (String token : tokens)
+            cleanValueAndAdd(token, aliasNames);
 
-            return parts;
-        }
-
-        if (aliases.contains(","))
-        {
-            // The user entered a comma-separated list of values
-            return Arrays.stream(aliases.split(","))
-                .map(String::trim)
-                .filter(StringUtils::isNotEmpty)
-                .collect(Collectors.toSet());
-        }
-        else
-        {
-            return Collections.singleton(aliases);
-        }
+        return aliasNames;
     }
 
     private static void insertMapEntries(Container container, User user, TableInfo aliasMapTable, Set<Integer> aliasIds, String lsid)
@@ -165,5 +175,57 @@ public class AliasInsertHelper
             .add(lsid);
 
         return new SqlSelector(ExperimentService.get().getSchema(), sql).getCollection(String.class);
+    }
+
+    public static class TestCase
+    {
+        private Set<String> parseValueWrapper(Object value)
+        {
+            Set<String> names = new HashSet<>();
+            parseValue(value, names, new HashSet<>());
+            return names;
+        }
+
+        @Test
+        public void testParseValueString()
+        {
+            assertEquals("string", Set.of("bob"), parseValueWrapper("bob"));
+            assertEquals("string with commas", Set.of("bob", "mike"), parseValueWrapper("bob,mike"));
+            assertEquals("quoted string with commas", Set.of("bob,mike"), parseValueWrapper("\"bob,mike\""));
+            assertEquals("string with semicolon", Set.of("bob;mike"), parseValueWrapper("bob;mike"));
+            assertEquals("quoted string with semicolon", Set.of("bob;mike"), parseValueWrapper("\"bob;mike\""));
+            assertEquals("json array-like string", Set.of("[bob", "mike]"), parseValueWrapper("[bob, mike]"));
+            assertEquals("grouped quoted string with commas", Set.of("bob", "mike"), parseValueWrapper("\"bob\", \"mike\""));
+            assertEquals("grouped quoted string with commas inside", Set.of("bo,b", "m,ike"), parseValueWrapper("\"bo,b \", \" m,ike\""));
+            assertEquals("json array-like prefix partial string", Set.of("[bob"), parseValueWrapper("[bob,"));
+            assertEquals("json array-like suffix partial string", Set.of("bob]"), parseValueWrapper(", bob]"));
+            assertEquals("json array-like string empty", Set.of("[]"), parseValueWrapper("[]"));
+            assertEquals("unbalanced quotes", Set.of("b\"ob", "mi,ke", "steve"), parseValueWrapper("b\"ob,\"mi,ke\",\"steve\""));
+        }
+
+        @Test
+        public void testParseValueList()
+        {
+            assertEquals("list with string", Set.of("bob"), parseValueWrapper(List.of("bob")));
+            assertEquals("list with single item", Set.of("bob,mike", "steve"), parseValueWrapper(List.of("\"bob,mike\", steve")));
+            assertEquals("list with multiple items", Set.of("\"bob\",mike", "steve"), parseValueWrapper(List.of("\"bob\",mike", "steve")));
+        }
+
+        @Test
+        public void testParseValueStringArray()
+        {
+            assertEquals("array with string", Set.of("bob"), parseValueWrapper(new String[] { "bob" }));
+            assertEquals("array with single item", Set.of("\"bob,mike\", steve"), parseValueWrapper(new String[] { "\"bob,mike\", steve" }));
+            assertEquals("list with multiple items", Set.of("\"bob\",mike", "steve"), parseValueWrapper(new String[] { "\"bob\",mike", "steve", "", "\"\"" }));
+        }
+
+        @Test
+        public void testParseValueJSONArray()
+        {
+            assertEquals("empty JSONArray", Collections.emptySet(), parseValueWrapper(new JSONArray()));
+            assertEquals("JSONArray with single item", Set.of("bob"), parseValueWrapper(new JSONArray("[bob]")));
+            assertEquals("JSONArray with multiple items", Set.of("bob", "mike"), parseValueWrapper(new JSONArray("[bob, mike]")));
+            assertEquals("JSONArray with multiple items and commas", Set.of("bob", "mike", "ste,ve"), parseValueWrapper(new JSONArray("[bob, mike, \"ste,ve\"]")));
+        }
     }
 }

--- a/experiment/src/org/labkey/experiment/api/AliasInsertHelper.java
+++ b/experiment/src/org/labkey/experiment/api/AliasInsertHelper.java
@@ -65,10 +65,12 @@ public class AliasInsertHelper
 
         // remove wrapping quotes
         if (input.length() >= 2 && input.charAt(0) == '\"' && input.charAt(input.length() - 1) == '\"')
+        {
             input = input.substring(1, input.length() - 1);
 
-        // trim again after removing wrapping quotes
-        input = input.trim();
+            // trim again after removing wrapping quotes
+            input = input.trim();
+        }
 
         if (!input.isEmpty())
             aliasNames.add(input);

--- a/experiment/src/org/labkey/experiment/api/AliasInsertHelper.java
+++ b/experiment/src/org/labkey/experiment/api/AliasInsertHelper.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.labkey.api.util.StringUtilsLabKey.unquoteString;
 
 public class AliasInsertHelper
 {
@@ -63,14 +64,7 @@ public class AliasInsertHelper
         if (input.isEmpty())
             return;
 
-        // remove wrapping quotes
-        if (input.length() >= 2 && input.charAt(0) == '\"' && input.charAt(input.length() - 1) == '\"')
-        {
-            input = input.substring(1, input.length() - 1);
-
-            // trim again after removing wrapping quotes
-            input = input.trim();
-        }
+        input = unquoteString(input).trim();
 
         if (!input.isEmpty())
             aliasNames.add(input);
@@ -109,7 +103,7 @@ public class AliasInsertHelper
                 // Generic query insert form and Excel/tsv import passes an ArrayList with a single String element
                 // containing the comma-separated list of values: "abc,def"
                 // LABKEY.Query.insertRows passes an ArrayList containing individual alias names.
-                parseValue(col.stream().findFirst().get(), aliasNames, aliasIds);
+                parseValue(col.iterator().next(), aliasNames, aliasIds);
             }
             else
             {
@@ -141,9 +135,11 @@ public class AliasInsertHelper
         if (aliases.isEmpty())
             return Collections.emptySet();
 
-        Set<String> aliasNames = new HashSet<>();
+        // Split around a comma only if there are no double quotes or if there is an even number of double quotes ahead
+        // of the comma. From: https://www.baeldung.com/java-split-string-commas#1-string-split-method
         String[] tokens = aliases.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)", -1);
 
+        Set<String> aliasNames = new HashSet<>();
         for (String token : tokens)
             cleanValueAndAdd(token, aliasNames);
 


### PR DESCRIPTION
#### Rationale
This addresses [Issue 47229](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47229) by refactoring the handling of alias value parsing to respect quoted values. The `AliasInputHelper` is responsible for all code paths (API, Excel Import, XAR import, etc) for parsing Alias input. Here is a brief set of examples and how they would parse after these changes:

```
Alias
bob              // 1 "bob"
bob,mike         // 2 "bob" and "mike"
"bob,mike"       // 1 "bob,mike"
bob;mike         // 1 "bob;mike"
"bob;mike"       // 1 "bob;mike"
[bob,mike]       // 2 "[bob" and "mike]"
"bob","mike"     // 2 "bob" and "mike"
"bo,b","m,ike"   // 2 "bo,b" and "m,ike"
[bob,            // 1 "[bob"
,bob]            // 1 "bob]"
[]               // 1 "[]"
```

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4217
* https://github.com/LabKey/labkey-ui-components/pull/1145
* https://github.com/LabKey/biologics/pull/2017
* https://github.com/LabKey/sampleManagement/pull/1697
* https://github.com/LabKey/inventory/pull/782

#### Changes
* Refactor `AliasInputHelper.splitAliases()` to account for quoted characters. Remove special handling for `[`, `]`, and `,` as these are now supported characters.
* Remove recursive aspect of parsing alias values instead opting for a pattern where only primitives (strings and integers) are supported as values within collection-like types.
* Add unit tests.
