### PR TITLE
Move ownership of compliance schema

### DIFF
--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 23.004
+SchemaVersion: 23.005
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/core-23.004-23.005.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-23.004-23.005.sql
@@ -1,0 +1,2 @@
+-- Compliance schema is now managed by the Signing module
+UPDATE core.modules SET Schemas = NULL WHERE Name = 'Compliance';

--- a/core/resources/schemas/dbscripts/sqlserver/core-23.004-23.005.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-23.004-23.005.sql
@@ -1,0 +1,2 @@
+-- Compliance schema is now managed by the Signing module
+UPDATE core.modules SET Schemas = NULL WHERE Name = 'Compliance';


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47547

Management of the "compliance" schema was moved to the Signing module, but nobody told the `core.Modules` table.

To prevent future problems related to schema moves, log an error if we detect a schema that's claimed by multiple rows in the Modules table and refuse to delete a schema that's claimed by a known module.

#### Related Pull Requests
* https://github.com/LabKey/signing/pull/1
