### PR TITLE
Make the demographics date field not required

### DIFF
--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -277,27 +277,6 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
          */
 
         //
-        // date
-        //
-
-        if (!timetype.isVisitBased()
-                && null == indexVisitDate
-                && (_datasetDefinition.isDemographicData() || _datasetDefinition.isParticipantAliasDataset())
-                && !context.getInsertOption().updateOnly)
-        {
-            final Date start = _datasetDefinition.getStudy().getStartDate();
-            indexVisitDate = it.addColumn(new BaseColumnInfo("Date", JdbcType.TIMESTAMP), new Callable()
-            {
-                @Override
-                public Object call()
-                {
-                    return start;
-                }
-            });
-            it.indexVisitDateOutput = indexVisitDate;
-        }
-
-        //
         // SequenceNum
         //
 

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1421,7 +1421,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
 
             var column = getStorageColumn("Date");
             var visitDateCol = newDatasetColumnInfo(this, column, getVisitDateURI());
-            if (!study.getTimepointType().isVisitBased())
+            if (!study.getTimepointType().isVisitBased() && !def.isDemographicData())
                 visitDateCol.setNullable(false);
 
             if (!study.getTimepointType().isVisitBased() && def.getUseTimeKeyField())

--- a/study/src/org/labkey/study/model/DatasetImportTestCase.jsp
+++ b/study/src/org/labkey/study/model/DatasetImportTestCase.jsp
@@ -769,11 +769,9 @@ private void _testImportDemographicDatasetData(Study study) throws Throwable
         try (ResultSet rs = new TableSelector(tt).getResultSet())
         {
             assertTrue(rs.next());
+            // issue 47344 : demographics date no longer required or initialized with the study start date
             if ("A2".equals(rs.getString("SubjectId")))
-                assertEquals(study.getStartDate(), new java.util.Date(rs.getTimestamp("date").getTime()));
-            assertTrue(rs.next());
-            if ("A2".equals(rs.getString("SubjectId")))
-                assertEquals(study.getStartDate(), new java.util.Date(rs.getTimestamp("date").getTime()));
+                assertEquals(null, rs.getTimestamp("date"));
         }
     }
 }


### PR DESCRIPTION
#### Rationale
For date based and continuous studies we no longer want the date field to be required for demographics datasets. Additionally we will remove the behavior that automatically inserted the start date into demographics (and participant alias datasets) if a value was not provided.

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47344)