### PR TITLE
fix expected text

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
@@ -473,7 +473,7 @@ public class SharedStudyTest extends BaseWebDriverTest
         new DataRegionTable("Dataset", getDriver()).clickInsertNewRow();
         new DatasetInsertPage(this.getDriver(), SHARED_DEMOGRAPHICS).insertExpectingError(Maps.of("PandaId", overlappingParticipant));
 
-        assertElementPresent(Locators.labkeyError.containing("Duplicate: Panda = " + overlappingParticipant));
+        assertElementPresent(Locators.labkeyError.containing("Duplicate: Panda Id = " + overlappingParticipant));
     }
 
     @Test @Ignore("Planned feature")


### PR DESCRIPTION
#### Rationale
A recent change to improve the error message on the single row insert/update form broke this test. Just needed to change the expectations.