### PR TITLE
47210: NAb assays require specific template control well group names

### DIFF
--- a/assay/api-src/org/labkey/api/assay/plate/AbstractPlateTypeHandler.java
+++ b/assay/api-src/org/labkey/api/assay/plate/AbstractPlateTypeHandler.java
@@ -45,4 +45,10 @@ public abstract class AbstractPlateTypeHandler implements PlateTypeHandler
     {
         return true;
     }
+
+    @Override
+    public boolean canCreateNewGroups(WellGroup.Type type)
+    {
+        return true;
+    }
 }

--- a/assay/api-src/org/labkey/api/assay/plate/PlateTypeHandler.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateTypeHandler.java
@@ -46,6 +46,11 @@ public interface PlateTypeHandler
     List<WellGroup.Type> getWellGroupTypes();
 
     /**
+     * Issue 47210 : some assays don't support changing or adding new well groups
+     */
+    boolean canCreateNewGroups(WellGroup.Type type);
+
+    /**
      * Validate a new or edited plate template for handler specific errors.
      * @throws ValidationException
      */

--- a/assay/gwtsrc/gwt/client/org/labkey/plate/designer/client/GroupTypePanel.java
+++ b/assay/gwtsrc/gwt/client/org/labkey/plate/designer/client/GroupTypePanel.java
@@ -41,7 +41,6 @@ import org.labkey.api.gwt.client.util.StringProperty;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * User: brittp
@@ -56,6 +55,7 @@ public class GroupTypePanel extends ScrollPanel implements GroupChangeListener
     private String _newGroupFieldValue;
     private ImageButton _createButton;
     private ImageButton _multiCreateButton;
+    private boolean _allowNewGroups;
 
     public GroupTypePanel(TemplateView view, String type)
     {
@@ -74,14 +74,21 @@ public class GroupTypePanel extends ScrollPanel implements GroupChangeListener
         if (wellgroups != null)
         {
             int i=0;
+            _allowNewGroups = wellgroups.isEmpty();
             for (GWTWellGroup group : wellgroups)
             {
+                if (!_allowNewGroups && group.isAllowNewGroups())
+                    _allowNewGroups = true;
+
                 GroupTypePanelRow row = new GroupTypePanelRow(_view, group);
                 row.attach(groupList, i++);
             }
         }
         else
+        {
+            _allowNewGroups = true;
             groupList.setWidget(0, 1, new Label("No groups defined."));
+        }
         add(groupList);
 
         KeyDownHandler fieldKeyDownListener = new KeyDownHandler()
@@ -179,10 +186,13 @@ public class GroupTypePanel extends ScrollPanel implements GroupChangeListener
             newGroupField = selector;
         }
 
-        groupList.setWidget(groupList.getRowCount(), 0, new Label("New:"));
-        groupList.setWidget(groupList.getRowCount() - 1, 1, newGroupField);
-        groupList.setWidget(groupList.getRowCount() - 1, 2, _createButton);
-        groupList.setWidget(groupList.getRowCount() - 1, 3, _multiCreateButton);
+        if (_allowNewGroups)
+        {
+            groupList.setWidget(groupList.getRowCount(), 0, new Label("New:"));
+            groupList.setWidget(groupList.getRowCount() - 1, 1, newGroupField);
+            groupList.setWidget(groupList.getRowCount() - 1, 2, _createButton);
+            groupList.setWidget(groupList.getRowCount() - 1, 3, _multiCreateButton);
+        }
     }
 
     private static class MultiCreatePopupPanel extends DialogBox

--- a/assay/gwtsrc/gwt/client/org/labkey/plate/designer/client/GroupTypePanelRow.java
+++ b/assay/gwtsrc/gwt/client/org/labkey/plate/designer/client/GroupTypePanelRow.java
@@ -143,8 +143,12 @@ public class GroupTypePanelRow extends GroupChangeListenerAdapter
         if (_group == currentlyActive)
         {
             _radioButton.setChecked(true);
-            _deleteButton.setVisible(true);
-            _renameButton.setVisible(true);
+            // if this group is effectively not editable never show delete and rename buttons
+            if (_group.isAllowNewGroups())
+            {
+                _deleteButton.setVisible(true);
+                _renameButton.setVisible(true);
+            }
             DOM.setStyleAttribute(_tableRowElement, "backgroundColor", "#DDDDDD");
             DOM.setStyleAttribute(_tableRowElement, "border", "1px solid black");
         }

--- a/assay/gwtsrc/gwt/client/org/labkey/plate/designer/client/model/GWTWellGroup.java
+++ b/assay/gwtsrc/gwt/client/org/labkey/plate/designer/client/model/GWTWellGroup.java
@@ -32,6 +32,7 @@ public class GWTWellGroup implements IsSerializable
     private String _type;
     private String _name;
     private List<GWTPosition> _positions;
+    private boolean _allowNewGroups = true;         // issue 47210 : disallow creating/editing of well groups for specific types
 
     /**
      * This field is a Map that must always contain Strings.
@@ -96,6 +97,16 @@ public class GWTWellGroup implements IsSerializable
     public void setProperties(Map<String, Object> properties)
     {
         _properties = properties;
+    }
+
+    public boolean isAllowNewGroups()
+    {
+        return _allowNewGroups;
+    }
+
+    public void setAllowNewGroups(boolean allowNewGroups)
+    {
+        _allowNewGroups = allowNewGroups;
     }
 
     @Override

--- a/assay/src/org/labkey/assay/plate/PlateDataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateDataServiceImpl.java
@@ -100,7 +100,9 @@ public class PlateDataServiceImpl extends BaseRemoteService implements PlateData
 
                 // NOTE: Use negative rowId for unsaved well groups to support GWTWellGroup.equals()
                 int wellGroupId = copyTemplate || group.getRowId() == null ? -1 * (i+1) : group.getRowId();
-                translated.add(new GWTWellGroup(wellGroupId, group.getType().name(), group.getName(), positions, groupProperties));
+                GWTWellGroup gwtWellGroup = new GWTWellGroup(wellGroupId, group.getType().name(), group.getName(), positions, groupProperties);
+                gwtWellGroup.setAllowNewGroups(handler.canCreateNewGroups(group.getType()));
+                translated.add(gwtWellGroup);
             }
 
             int newPlateId = copyTemplate || template.getRowId() == null ? -1 : template.getRowId();


### PR DESCRIPTION
#### Rationale
The NAb assays rely on specific control well group names in order to identify the cell and virus control wells. A few clients have run into problems when they created their own control wells with different names and received errors in the run. 

The work to support arbitrary control well group names would have been more significant, so the recommended approach is:
- New control well groups cannot be created
- Cell and virus control well groups cannot be renamed or deleted

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47210)

#### Related Pull Requests
https://github.com/LabKey/commonAssays/pull/593