### PR TITLE
Adjust logic for when to hide the sample status column

### DIFF
--- a/api/src/org/labkey/api/qc/SampleStatusService.java
+++ b/api/src/org/labkey/api/qc/SampleStatusService.java
@@ -3,6 +3,7 @@ package org.labkey.api.qc;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.security.User;
 import org.labkey.api.view.ActionURL;
@@ -45,6 +46,8 @@ public interface SampleStatusService
 
     @NotNull List<DataState> getStates(Container container);
 
+    @NotNull List<DataState> getAllProjectStates(Container container);
+
     boolean isOperationPermitted(Container container, Integer stateId, @NotNull SampleTypeService.SampleOperations operation);
 
     boolean isOperationPermitted(DataState status, @NotNull SampleTypeService.SampleOperations operation);
@@ -74,6 +77,18 @@ public interface SampleStatusService
         public @NotNull List<DataState> getStates(Container container)
         {
             return SampleStateManager.getInstance().getStates(container);
+        }
+
+        @Override
+        public @NotNull List<DataState> getAllProjectStates(Container container)
+        {
+            SampleStateManager sampleStateManager = SampleStateManager.getInstance();
+            List<DataState> states = sampleStateManager.getStates(container);
+            if (!container.isProject())
+                states.addAll(sampleStateManager.getStates(container.getProject()));
+            if (container != ContainerManager.getSharedContainer())
+                states.addAll(sampleStateManager.getStates(ContainerManager.getSharedContainer()));
+            return states;
         }
 
         @Override

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -443,7 +443,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             }
             case SampleState ->
             {
-                boolean statusEnabled = SampleStatusService.get().supportsSampleStatus() && SampleStatusService.get().getStates(getContainer()).size() > 0;
+                boolean statusEnabled = SampleStatusService.get().supportsSampleStatus() && SampleStatusService.get().getAllProjectStates(getContainer()).size() > 0;
                 var ret = wrapColumn(alias, _rootTable.getColumn(column.name()));
                 ret.setLabel("Status");
                 ret.setHidden(!statusEnabled);
@@ -730,7 +730,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         addColumn(ExpMaterialTable.Column.Flag);
 
         var statusColInfo = addColumn(ExpMaterialTable.Column.SampleState);
-        boolean statusEnabled = SampleStatusService.get().supportsSampleStatus() && SampleStatusService.get().getStates(getContainer()).size() > 0;
+        boolean statusEnabled = SampleStatusService.get().supportsSampleStatus() && SampleStatusService.get().getAllProjectStates(getContainer()).size() > 0;
         statusColInfo.setShownInDetailsView(statusEnabled);
         statusColInfo.setShownInInsertView(statusEnabled);
         statusColInfo.setShownInUpdateView(statusEnabled);


### PR DESCRIPTION
#### Rationale
Previously, we had been creating sample statuses for each folder that was created and limiting the user to choosing only statuses from the current folder, resulting in an overabundance of the default statuses and no way to unify the statuses for shared sample type.  With this PR, we make the adjustment to show the statuses from the current, project and shared containers and allow them to be used when creating and updating samples.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1148
- https://github.com/LabKey/biologics/pull/2023
- https://github.com/LabKey/sampleManagement/pull/1702
- https://github.com/LabKey/inventory/pull/787

#### Changes
* Hide the sample status column if there are no sample statuses in the current folder's hierarchy (current + project + /Shared)
