### PR TITLE
Issue 47568: Cross-container wiki TOC is final web part exported

### DIFF
--- a/api/src/org/labkey/api/view/BaseWebPartFactory.java
+++ b/api/src/org/labkey/api/view/BaseWebPartFactory.java
@@ -243,10 +243,4 @@ public abstract class BaseWebPartFactory implements WebPartFactory
     {
         return propertyMap;
     }
-
-    @Override
-    public boolean includeInExport(FolderExportContext ctx, WebPart webPart)
-    {
-        return true;
-    }
 }

--- a/api/src/org/labkey/api/view/WebPartFactory.java
+++ b/api/src/org/labkey/api/view/WebPartFactory.java
@@ -87,11 +87,4 @@ public interface WebPartFactory
     Map<String, String> serializePropertyMap(FolderExportContext ctx, Map<String, String> propertyMap);
 
     Map<String, String> deserializePropertyMap(FolderImportContext ctx, Map<String, String> propertyMap);
-
-    /*
-     * This method is used to determine if the given web part should be included in folder
-     * export (e.g. in PageWriterFactory.addWebPartsToPage())
-     * It was added to fix Issue 22261: Incorrect links in the "Wiki Table of Contents" web part.
-     */
-    boolean includeInExport(FolderExportContext ctx, Portal.WebPart webPart);
 }

--- a/core/src/org/labkey/core/admin/writer/PageWriterFactory.java
+++ b/core/src/org/labkey/core/admin/writer/PageWriterFactory.java
@@ -107,11 +107,6 @@ public class PageWriterFactory implements FolderWriterFactory
                     factory = Portal.getPortalPart(webPart.getName());
                 }
 
-                if (factory != null && !factory.includeInExport(ctx, webPart))
-                {
-                    return;
-                }
-
                 PagesDocument.Pages.Page.Webpart webpartXml = pageXml.addNewWebpart();
                 webpartXml.setName(webPart.getName());
                 webpartXml.setIndex(webPart.getIndex());

--- a/wiki/src/org/labkey/wiki/WikiTOCFactory.java
+++ b/wiki/src/org/labkey/wiki/WikiTOCFactory.java
@@ -108,18 +108,4 @@ public class WikiTOCFactory extends BaseWebPartFactory
 
         return deserializedPropertyMap;
     }
-
-    @Override
-    public boolean includeInExport(FolderExportContext ctx, Portal.WebPart webPart)
-    {
-        String containerId = webPart.getPropertyMap().get("webPartContainer");
-        if (containerId != null)
-        {
-            // Return true if the "webPartContainer" property is the same as the container in the ImportContext.
-            // Issue 22261: Incorrect links in the "Wiki Table of Contents" web part.
-            Container webPartContainer = ContainerManager.getForId(containerId);
-            return null == webPartContainer || webPartContainer.equals(ctx.getContainer());
-        }
-        return true;
-    }
 }


### PR DESCRIPTION
#### Rationale
We certainly want to export the rest of the web parts, and can do better at supporting TOC, especially for template folder operations happening on the same server

#### Changes
* Always include the Wiki TOC in the folder archive, saving its containerPath (not ID) if it points to another container
