### PR TITLE
Tika depends on ASM and is no longer getting it via Graal

### DIFF
--- a/search/build.gradle
+++ b/search/build.gradle
@@ -240,7 +240,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "org.ow2.asm:asm:9.5",
+            "org.ow2.asm:asm:${asmVersion}",
             "ASM",
             "ASM",
             "https://asm.ow2.io",

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -236,6 +236,19 @@ dependencies {
             "Needed to parse \"pages\" files for full-text search"
         )
     )
+
+    BuildUtils.addExternalDependency(
+        project,
+        new ExternalDependency(
+            "org.ow2.asm:asm:9.5",
+            "ASM",
+            "ASM",
+            "https://asm.ow2.io",
+            "New BSD License",
+            ExternalDependency.BSD_LICENSE_URL,
+            "All purpose Java bytecode manipulation and analysis framework"
+        )
+    )
 }
 
 // TODO move resources files into resources directory to avoid this overlap


### PR DESCRIPTION
#### Rationale
Tests are failing because Tika can't find org/objectweb/asm/ClassVisitor. It used to be available because Graal pulled it in, but its recent upgrade has dropped it from the classpath

https://teamcity.labkey.org/buildConfiguration/LabKey_233Release_Community_BvtBSqlserver/2351301?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true

#### Changes
* Add ASM as a direct dependency