### PR TITLE
Audit log maintenance

### DIFF
--- a/api/src/org/labkey/api/audit/AuditLogService.java
+++ b/api/src/org/labkey/api/audit/AuditLogService.java
@@ -22,14 +22,12 @@ import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
-import org.labkey.api.data.TableInfo;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.view.ActionURL;
-import org.labkey.api.view.ViewContext;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/api/src/org/labkey/api/audit/AuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AuditTypeProvider.java
@@ -25,10 +25,6 @@ import org.labkey.api.view.ActionURL;
 
 import java.util.Map;
 
-/**
- * User: klum
- * Date: 7/8/13
- */
 public interface AuditTypeProvider
 {
     /**
@@ -58,4 +54,13 @@ public interface AuditTypeProvider
     Map<FieldKey, String> legacyNameMap();
 
     ActionURL getAuditUrl();
+
+    /**
+     * Does this provider let the retention time feature delete old rows? Most providers should return true, but when
+     * data from an audit table supports a product feature (e.g., sample timeline) consider returning false.
+     */
+    default boolean canDeleteOldRows()
+    {
+        return true;
+    }
 }

--- a/api/src/org/labkey/api/data/TSVGridWriter.java
+++ b/api/src/org/labkey/api/data/TSVGridWriter.java
@@ -17,6 +17,7 @@
 package org.labkey.api.data;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.ResultSetRowMapFactory;
@@ -90,13 +91,16 @@ public class TSVGridWriter extends TSVColumnWriter implements ExportWriter
     }
 
     @Override
-    protected void write()
+    protected int write()
     {
+        MutableInt ret = new MutableInt();
         setResultsHandleAndClose(results -> {
             _results = results; // TODO: Change write() signature to take context and stop setting member variable
-            TSVGridWriter.super.write();
+            ret.setValue(TSVGridWriter.super.write());
             return null;
         });
+
+        return ret.getValue();
     }
 
     private interface ResultsHandler<T>
@@ -135,12 +139,12 @@ public class TSVGridWriter extends TSVColumnWriter implements ExportWriter
     }
 
     @Override
-    protected void writeBody()
+    protected int writeBody()
     {
-        writeBody(_results);
+        return writeBody(_results);
     }
 
-    private void writeBody(Results results)
+    private int writeBody(Results results)
     {
         try
         {
@@ -149,12 +153,16 @@ public class TSVGridWriter extends TSVColumnWriter implements ExportWriter
 
             // Output all the data cells
             ResultSetRowMapFactory factory = ResultSetRowMapFactory.create(results);
+            int rows = 0;
 
             while (results.next())
             {
                 ctx.setRow(factory.getRowMap(results));
                 writeRow(ctx, _displayColumns);
+                rows++;
             }
+
+            return rows;
         }
         catch (SQLException ex)
         {

--- a/api/src/org/labkey/api/data/TSVMapWriter.java
+++ b/api/src/org/labkey/api/data/TSVMapWriter.java
@@ -16,8 +16,6 @@
 
 package org.labkey.api.data;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.iterator.MarkableIterator;
@@ -78,31 +76,31 @@ public class TSVMapWriter extends TSVWriter
 
     // Make public
     @Override
-    public void write()
+    public int write()
     {
-        super.write();
+        return super.write();
     }
 
     @Override
-    protected void writeBody()
+    protected int writeBody()
     {
+        int rowCount = 0;
+
         while (_rows.hasNext())
         {
             writeRow(_rows.next());
+            rowCount++;
         }
+
+        return rowCount;
     }
 
     protected void writeRow(final Map<String, Object> row)
     {
-        Iterable<String> values = Iterables.transform(_columns, new Function<String, String>()
-        {
-            @Override
-            public String apply(String col)
-            {
-                Object o = row.get(col);
-                return o == null ? "" : String.valueOf(o);
-            }
-        });
+        Iterable<String> values = _columns.stream().map(col -> {
+            Object o = row.get(col);
+            return o == null ? "" : String.valueOf(o);
+        }).toList();
 
         writeLine(values);
     }

--- a/api/src/org/labkey/api/data/TableSelector.java
+++ b/api/src/org/labkey/api/data/TableSelector.java
@@ -363,7 +363,7 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
      */
     public TableSelector setForceSortForDisplay(boolean forceSort)
     {
-        _forceSortForDisplay = true;
+        _forceSortForDisplay = forceSort;
         return this;
     }
 

--- a/api/src/org/labkey/api/data/TextWriter.java
+++ b/api/src/org/labkey/api/data/TextWriter.java
@@ -30,8 +30,6 @@ import java.io.PrintWriter;
 
 /**
  * Base class for exports that generate text-based representations of their content, such as TSV, CSV, or FASTA.
- * User: adam
- * Date: Dec 30, 2010
  */
 public abstract class TextWriter implements AutoCloseable
 {

--- a/api/src/org/labkey/api/data/TextWriter.java
+++ b/api/src/org/labkey/api/data/TextWriter.java
@@ -41,7 +41,9 @@ public abstract class TextWriter implements AutoCloseable
     protected PrintWriter _pw = null;
 
     protected abstract String getFilename();
-    protected abstract void write();
+
+    // Write the contents and return the number of rows that were written
+    protected abstract int write();
 
     /**
      * Override to return a different content type
@@ -103,37 +105,37 @@ public abstract class TextWriter implements AutoCloseable
     }
 
     // Create a file and stream it to the browser.
-    public void write(HttpServletResponse response) throws IOException
+    public int write(HttpServletResponse response) throws IOException
     {
         prepare(response);
-        write();
+        return write();
     }
 
     // Write a newly created file to the file system.
-    public void write(File file) throws IOException
+    public int write(File file) throws IOException
     {
         prepare(file);
-        write();
+        return write();
     }
 
-    public void write(OutputStream os) throws IOException
+    public int write(OutputStream os) throws IOException
     {
         prepare(os);
-        write();
+        return write();
     }
 
     // Write a newly created file to the PrintWriter.
-    public void write(PrintWriter pw) throws IOException
+    public int write(PrintWriter pw) throws IOException
     {
         _pw = pw;
-        write();
+        return write();
     }
 
     // Write content to a string builder.
-    public void write(StringBuilder builder) throws IOException
+    public int write(StringBuilder builder) throws IOException
     {
         prepare(builder);
-        write();
+        return write();
     }
 
     @Override

--- a/api/src/org/labkey/api/data/queryprofiler/QueryProfiler.java
+++ b/api/src/org/labkey/api/data/queryprofiler/QueryProfiler.java
@@ -464,7 +464,7 @@ public class QueryProfiler
     public static class QueryStatTsvWriter extends TSVWriter
     {
         @Override
-        protected void write()
+        protected int write()
         {
             QueryTrackerSet export = new InvocationQueryTrackerSet() {
                 @Override
@@ -500,6 +500,8 @@ public class QueryProfiler
                 for (QueryTracker tracker : export.descendingSet())
                     tracker.exportRow(_pw);
             }
+
+            return export.size();
         }
     }
 

--- a/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
+++ b/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
@@ -740,7 +740,7 @@ public class TsvDataExchangeHandler implements DataExchangeHandler
         return new TSVWriter()
         {
             @Override
-            protected void write()
+            protected int write()
             {
                 throw new UnsupportedOperationException();
             }

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -649,7 +649,7 @@ public interface QueryService
         SelectBuilder distinct(boolean b);
 
         SQLFragment buildSqlFragment();
-        SqlSelector buildSqlSelector(Map<String, Object> parameters);
+        SqlSelector buildSqlSelector(@Nullable Map<String, Object> parameters);
         Results select(@Nullable Map<String, Object> parameters, boolean cache);
         default Results select()
         {

--- a/api/src/org/labkey/api/study/security/SecurityEscalationAuditProvider.java
+++ b/api/src/org/labkey/api/study/security/SecurityEscalationAuditProvider.java
@@ -22,6 +22,7 @@ import org.labkey.api.audit.AuditTypeEvent;
 import org.labkey.api.audit.AuditTypeProvider;
 import org.labkey.api.audit.query.AbstractAuditDomainKind;
 import org.labkey.api.audit.query.DefaultAuditTypeTable;
+import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.MutableColumnInfo;
@@ -31,6 +32,7 @@ import org.labkey.api.exp.PropertyType;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.User;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -281,32 +283,29 @@ public abstract class SecurityEscalationAuditProvider extends AbstractAuditTypeP
      */
     public static abstract class SecurityEscalationAuditDomainKind extends AbstractAuditDomainKind
     {
-        private String eventType;
-        public static String NAMESPACE_PREFIX = "Audit-";
-
+        private static final String NAMESPACE_PREFIX = "Audit-";
         private static Set<PropertyDescriptor> _fields = null;
+
+        private final String _eventType;
+        private final String _tableName;
 
         /**
          * To be called by {@link AbstractAuditTypeProvider#getDomainKind()}.
          *
          * @param eventType This should match its parent's {@link SecurityEscalationAuditProvider#getEventType()}.
+         * @param tableName The table name to use when constructing the domain URI. We use this instead of the event
+         *                  type because we've switched to a more user-friendly event name but use the old, ugly name
+         *                  internally to stay backwards compatible.
          */
-        public SecurityEscalationAuditDomainKind(String eventType) {
+        public SecurityEscalationAuditDomainKind(String eventType, String tableName) {
             super(eventType);
-            this.eventType = eventType;
+            _eventType = eventType;
+            _tableName = tableName;
         }
-
-        /**
-         * Returns the domain name of this audit type.  This is generally this class's name without
-         * the "kind" at the end.
-         *
-         * @return The class's name without the "kind" ending.
-         */
-        public abstract String getDomainName();
 
         @Override
         public String getKindName() {
-            return eventType;
+            return _eventType;
         }
 
         @Override
@@ -332,6 +331,12 @@ public abstract class SecurityEscalationAuditProvider extends AbstractAuditTypeP
             }
 
             return _fields;
+        }
+
+        @Override
+        public String generateDomainURI(String schemaName, String tableName, Container c, User u)
+        {
+            return super.generateDomainURI(schemaName, _tableName, c, u);
         }
     }
 }

--- a/api/src/org/labkey/api/study/security/StudySecurityEscalationAuditProvider.java
+++ b/api/src/org/labkey/api/study/security/StudySecurityEscalationAuditProvider.java
@@ -15,13 +15,12 @@
  */
 package org.labkey.api.study.security;
 
-import org.labkey.api.audit.query.AbstractAuditDomainKind;
-
 /**
  * @see SecurityEscalationAuditProvider
  */
-public class StudySecurityEscalationAuditProvider extends SecurityEscalationAuditProvider {
-    public static String EVENT_TYPE = StudySecurityEscalationEvent.class.getName();
+public class StudySecurityEscalationAuditProvider extends SecurityEscalationAuditProvider
+{
+    public static String EVENT_TYPE = StudySecurityEscalationEvent.class.getSimpleName();
     public static String AUDIT_LOG_TITLE = "Study Security Escalations";
 
     @Override
@@ -59,12 +58,7 @@ public class StudySecurityEscalationAuditProvider extends SecurityEscalationAudi
 
     public static class StudySecurityEscalationDomain extends SecurityEscalationAuditDomainKind {
         public StudySecurityEscalationDomain() {
-            super(EVENT_TYPE);
-        }
-
-        @Override
-        public String getDomainName() {
-            return StudySecurityEscalationDomain.class.getName();
+            super(EVENT_TYPE, StudySecurityEscalationEvent.class.getName());
         }
     }
 }

--- a/api/src/org/labkey/api/writer/FastaWriter.java
+++ b/api/src/org/labkey/api/writer/FastaWriter.java
@@ -42,21 +42,26 @@ public class FastaWriter<E extends FastaEntry> extends TextWriter
         return _filename;
     }
 
-    public void write(HttpServletResponse response, String filename) throws IOException
+    public int write(HttpServletResponse response, String filename) throws IOException
     {
         _filename = filename;
-        write(response);
+        return write(response);
     }
 
     // Always closes the PrintWriter
     @Override
-    public void write()
+    public int write()
     {
+        int entryCount = 0;
+
         while (_generator.hasNext())
         {
             E entry = _generator.next();
             writeEntry(_pw, entry);
+            entryCount++;
         }
+
+        return entryCount;
     }
 
     protected void writeEntry(PrintWriter pw, E entry)

--- a/api/src/org/labkey/api/writer/PrintWriters.java
+++ b/api/src/org/labkey/api/writer/PrintWriters.java
@@ -26,12 +26,11 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 
 /**
  * Factory methods to create PrintWriters, ensuring standard character sets and buffering by default.
- *
- * Created by adam on 6/6/2015.
  */
 public class PrintWriters
 {
@@ -52,9 +51,9 @@ public class PrintWriters
      * @param file File destination for the new PrintWriter
      * @return A standard, buffered PrintWriter targeting the File
      */
-    public static PrintWriter getPrintWriter(File file) throws FileNotFoundException
+    public static PrintWriter getPrintWriter(File file, OpenOption... options) throws FileNotFoundException
     {
-        return getPrintWriter(file.toPath());
+        return getPrintWriter(file.toPath(), options);
     }
 
     /**
@@ -63,11 +62,11 @@ public class PrintWriters
      * @param file Path destination for the new PrintWriter
      * @return A standard, buffered PrintWriter targeting the File
      */
-    public static PrintWriter getPrintWriter(Path file)
+    public static PrintWriter getPrintWriter(Path file, OpenOption... options)
     {
         try
         {
-            return new StandardPrintWriter(Files.newOutputStream(file));
+            return new StandardPrintWriter(Files.newOutputStream(file, options));
         }
         catch (IOException e)
         {

--- a/core/src/org/labkey/core/admin/ActionsTsvWriter.java
+++ b/core/src/org/labkey/core/admin/ActionsTsvWriter.java
@@ -33,8 +33,10 @@ public class ActionsTsvWriter extends TSVWriter
     }
 
     @Override
-    protected void writeBody()
+    protected int writeBody()
     {
+        int ret = 0;
+
         try
         {
             Map<String, Map<String, Map<String, SpringActionController.ActionStats>>> modules = ActionsHelper.getActionStatistics();
@@ -70,6 +72,8 @@ public class ActionsTsvWriter extends TSVWriter
                         _pw.print(0 == stats.getCount() ? 0 : stats.getElapsedTime() / stats.getCount());
                         _pw.print('\t');
                         _pw.println(stats.getMaxTime());
+
+                        ret++;
                     }
                 }
             }
@@ -78,5 +82,7 @@ public class ActionsTsvWriter extends TSVWriter
         {
             throw new RuntimeException(e);
         }
+
+        return ret;
     }
 }

--- a/core/src/org/labkey/core/admin/ActionsTsvWriter.java
+++ b/core/src/org/labkey/core/admin/ActionsTsvWriter.java
@@ -24,11 +24,6 @@ import org.labkey.api.data.TSVWriter;
 import java.util.Arrays;
 import java.util.Map;
 
-/*
-* User: adam
-* Date: Oct 21, 2009
-* Time: 8:24:21 PM
-*/
 public class ActionsTsvWriter extends TSVWriter
 {
     @Override

--- a/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
@@ -139,6 +139,11 @@ public class SampleTimelineAuditProvider extends AbstractAuditTypeProvider
         return defaultVisibleColumns;
     }
 
+    @Override
+    public boolean canDeleteOldRows()
+    {
+        return false;
+    }
 
     public static class SampleTimelineAuditDomainKind extends AbstractAuditDomainKind
     {

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -2737,7 +2737,7 @@ public class QueryServiceImpl implements QueryService
         }
 
         @Override
-        public SqlSelector buildSqlSelector(Map<String, Object> parameters)
+        public SqlSelector buildSqlSelector(@Nullable Map<String, Object> parameters)
         {
             SQLFragment sql = buildSqlFragment();
             bindNamedParameters(sql, parameters);
@@ -2747,7 +2747,7 @@ public class QueryServiceImpl implements QueryService
         }
 
         @Override
-        public Results select(Map<String, Object> parameters, boolean cache)
+        public Results select(@Nullable Map<String, Object> parameters, boolean cache)
         {
             SqlSelector selector = buildSqlSelector(parameters);
             ResultSet rs = selector.getResultSet(cache, cache);

--- a/search/src/org/labkey/search/model/IndexInspector.java
+++ b/search/src/org/labkey/search/model/IndexInspector.java
@@ -91,7 +91,7 @@ public class IndexInspector
         }
 
         @Override
-        protected void writeBody()
+        protected int writeBody()
         {
             try (Directory directory = WritableIndexManagerImpl.openDirectory(getIndexDirectory());
                  IndexReader reader = DirectoryReader.open(directory))
@@ -123,8 +123,10 @@ public class IndexInspector
                     }
                 }
 
+                int docCount = reader.maxDoc();
+
                 // The stored terms are much easier to get. For each document, output stored fields plus the statistics computed above
-                for (int i = 0; i < reader.maxDoc(); i++)
+                for (int i = 0; i < docCount; i++)
                 {
                     Document doc = reader.document(i);
                     String[] titles = doc.getValues("title");
@@ -149,6 +151,8 @@ public class IndexInspector
 
                     writeLine(Arrays.asList(titles[0], type, path, urls[0], navtrail, uniqueIds[0], String.valueOf(termCountPerDoc[i]), summary));
                 }
+
+                return docCount;
             }
             catch (IOException e)
             {


### PR DESCRIPTION
#### Rationale
Support for administrative option that allows setting a retention time for audit events

#### Related Pull Requests
* https://github.com/LabKey/professional/pull/16

#### Changes
* `AuditTypeProvider.canDeleteOldRows()` to allow providers to opt out
* Fix bad event names in `SecurityEscalationAuditDomainKind`
* Support specifying `OpenOption`s (e.g., `APPEND`) when calling `getPrintWriter()`
* Exclude `SampleTimelineAuditProvider` from audit log maintenance