### PR TITLE
fix bug in StringHandler construction

### DIFF
--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -91,12 +91,14 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     // standard) or as escape characters (old, non-standard behavior). As of PostgreSQL 9.1, the setting
     // standard_conforming_strings in on by default; before 9.1, it was off by default. We check the server setting
     // when we prepare a new DbScope and use this when we escape and parse string literals.
-    private boolean _standardConformingStrings = true;
+    private Boolean _standardConformingStrings = Boolean.TRUE;
     private PostgreSqlServerType _serverType = PostgreSqlServerType.PostgreSQL;
 
     public boolean getStandardConformingStrings()
     {
-        return _standardConformingStrings;
+        // make sure we're not calling this before finishing instance init
+        assert _standardConformingStrings != null;
+        return _standardConformingStrings == null || _standardConformingStrings;
     }
 
     public void setStandardConformingStrings(boolean standardConformingStrings)

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -41,6 +41,7 @@ import org.labkey.api.audit.provider.FileSystemAuditProvider;
 import org.labkey.api.audit.provider.GroupAuditProvider;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.*;
+import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.dialect.SqlDialectManager;
 import org.labkey.api.data.dialect.SqlDialectRegistry;
 import org.labkey.api.data.statistics.StatsService;
@@ -1212,6 +1213,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             SchemaXMLTestCase.class,
             SecurityApiActions.TestCase.class,
             SecurityController.TestCase.class,
+            SqlDialect.DialectTestCase.class,
             SqlScriptController.TestCase.class,
             TableViewFormTestCase.class,
             UserController.TestCase.class


### PR DESCRIPTION
#### Rationale
Fix construction of StringHandler 
don't call createStringHandler() before instance is fully constructed
call again after prepare()

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
