### PR TITLE
Issue 46744: Row selectors in QueryWebPart with study schema

### DIFF
--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -414,12 +414,6 @@ public class DatasetQueryView extends StudyQueryView
         List<String> recordSelectorColumns = view.getDataRegion().getRecordSelectorValueColumns();
         bar.add(createExportButton(recordSelectorColumns));
 
-        // Duplicates logic from super.populateButtonBar(), but we need selectors
-        if ((recordSelectorColumns != null && !recordSelectorColumns.isEmpty()) || (getTable() != null && !getTable().getPkColumns().isEmpty()))
-        {
-            bar.setAlwaysShowRecordSelectors(true);
-        }
-
         User user = getUser();
         var table = getTable();
         boolean canImport = null != table && table.hasPermission(user, InsertPermission.class);


### PR DESCRIPTION
#### Rationale
Currently, it is not possible to use LabKey.QueryWebPart with a study dataset and specify that you do not want selectors to appear. This fix resolves that issue while not appearing to affect default dataset row selection behavior.

#### Related Pull Requests
* N/A

#### Changes
* Remove code block setting selector override
