### PR TITLE
Update tests to not assume 'labkey' context path

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/AncillaryStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AncillaryStudyTest.java
@@ -20,6 +20,7 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.tests.StudyBaseTest;
 import org.labkey.test.util.DataRegionTable;
@@ -304,7 +305,7 @@ public class AncillaryStudyTest extends StudyBaseTest
         waitForElement(Locator.name("Label"), WAIT_FOR_JAVASCRIPT);
         setFormElement(Locator.name("Label"), "Extra " + STUDY_NAME);
         setFormElement(Locator.name("Description"), "Extra " + STUDY_DESCRIPTION);
-        click(Locator.tag("img").withAttributeContaining("src", "/labkey/_images/paperclip.gif")); //Attach a file
+        click(Locator.tag("img").withAttribute("src", WebTestHelper.getContextPath() + "/_images/paperclip.gif")); //Attach a file
         waitForElement(Locator.xpath("//div[contains(@class, 'protocolPanel')]//input[@type='file']"), WAIT_FOR_JAVASCRIPT);
         setFormElement(Locator.xpath("//div[contains(@class, 'protocolPanel')]//input[@type='file']"), PROTOCOL_DOC2.toString());
         clickButton("Submit");

--- a/study/test/src/org/labkey/test/tests/study/StudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyTest.java
@@ -320,7 +320,7 @@ public class StudyTest extends StudyBaseTest
     {
         clickFolder(getFolderName());
         portalHelper.addWebPart("Study Data Tools");
-        clickAndWait(Locator.linkWithImage("/labkey/study/tools/participant_report.png"));
+        clickAndWait(Locator.linkWithImage(WebTestHelper.getContextPath() + "/study/tools/participant_report.png"));
         clickButton("Choose Measures", 0);
         _extHelper.waitForExtDialog("Add Measure");
         _extHelper.waitForLoadingMaskToDisappear(WAIT_FOR_JAVASCRIPT);


### PR DESCRIPTION
#### Rationale
Remote instances and servers with embedded tomcat don't have a context path. Tests shouldn't assume the server under test has a particular context path.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/1452

#### Changes
- Update tests to not assume 'labkey' context path