### PR TITLE
SQLFragment: cast string literal NULL as VARCHAR

### DIFF
--- a/api/src/org/labkey/api/data/SQLFragment.java
+++ b/api/src/org/labkey/api/data/SQLFragment.java
@@ -610,7 +610,7 @@ public class SQLFragment implements Appendable, CharSequence
     public SQLFragment appendStringLiteral(CharSequence s, SqlDialect d)
     {
         if (null==s)
-            return appendNull();
+            return append(d.getVarcharCast(new SQLFragment("NULL")));
         getStringBuilder().append(d.getStringHandler().quoteStringLiteral(s.toString()));
         return this;
     }


### PR DESCRIPTION
#### Rationale
Fixes a scenario where `array_agg(null)` is unable to determine which implementation of `array_agg()` to use.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4229

#### Changes
* Casts NULL to VARCHAR in the event this value may be used by `array_agg()`
