### PR TITLE
Enable lineage relationship between custom data classes in apps

### DIFF
--- a/api/schemas/expTypes.xsd
+++ b/api/schemas/expTypes.xsd
@@ -465,6 +465,13 @@
 			<xs:element name="NameExpression" type="string" minOccurs="0" maxOccurs="1"/>
 			<xs:element name="Category" type="string" minOccurs="0" />
 			<xs:element name="SampleType" type="string" minOccurs="0" />
+			<xs:element name="ParentImportAlias" minOccurs="0" maxOccurs="1">
+				<xs:complexType>
+					<xs:choice minOccurs="0" maxOccurs="unbounded">
+						<xs:element name="alias" type="exp:ImportAlias"/>
+					</xs:choice>
+				</xs:complexType>
+			</xs:element>
 		</xs:sequence>
 		<xs:attribute ref="rdf:about" use="required"/>
 	</xs:complexType>

--- a/api/src/org/labkey/api/exp/api/DataClassDomainKindProperties.java
+++ b/api/src/org/labkey/api/exp/api/DataClassDomainKindProperties.java
@@ -3,6 +3,9 @@ package org.labkey.api.exp.api;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.IOException;
+import java.util.Map;
+
 public class DataClassDomainKindProperties
 {
     private int rowId;
@@ -14,6 +17,7 @@ public class DataClassDomainKindProperties
     private Integer sampleType;
     private String category;
     private boolean _strictFieldValidation = true; // Set as false to skip validation check in ExperimentServiceImpl.createDataClass (used in Rlabkey labkey.domain.createAndLoad)
+    private Map<String, String> importAliases;
 
     public DataClassDomainKindProperties()
     {}
@@ -38,6 +42,15 @@ public class DataClassDomainKindProperties
 
         if (dc.getDomain() != null)
             this.domainId = dc.getDomain().getTypeId();
+
+        try
+        {
+            this.importAliases = dc.getImportAliasMap();
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Unable to parse parent alias mappings: ", e);
+        }
     }
 
     public int getRowId()
@@ -141,4 +154,15 @@ public class DataClassDomainKindProperties
     {
         _strictFieldValidation = strictFieldValidation;
     }
+
+    public void setImportAliases(Map<String, String> importAliases)
+    {
+        this.importAliases = importAliases;
+    }
+
+    public Map<String, String> getImportAliases()
+    {
+        return this.importAliases;
+    }
+
 }

--- a/api/src/org/labkey/api/exp/api/ExpDataClass.java
+++ b/api/src/org/labkey/api/exp/api/ExpDataClass.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.exp.api;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.ExperimentException;
@@ -24,7 +25,9 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.writer.ContainerUser;
 import org.springframework.web.servlet.mvc.Controller;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -34,6 +37,7 @@ import java.util.function.Function;
  */
 public interface ExpDataClass extends ExpObject
 {
+    String NEW_DATA_CLASS_ALIAS_VALUE = "{{this_data_class}}";
     String SEQUENCE_PREFIX = "org.labkey.experiment.api.DataClass";
 
     String getDataLsidPrefix();
@@ -104,4 +108,8 @@ public interface ExpDataClass extends ExpObject
     long getCurrentGenId();
 
     void ensureMinGenId(long newSeqValue, Container c) throws ExperimentException;
+
+    @NotNull Map<String, String> getImportAliasMap() throws IOException;
+
+    void setImportAliasMap(Map<String, String> aliasMap);
 }

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -20,8 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.admin.FolderExportContext;
-import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSchema;
@@ -90,6 +89,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
+
+import static org.labkey.api.exp.api.ExpDataClass.NEW_DATA_CLASS_ALIAS_VALUE;
+import static org.labkey.api.exp.api.SampleTypeService.NEW_SAMPLE_TYPE_ALIAS_VALUE;
 
 public interface ExperimentService extends ExperimentRunTypeSource
 {
@@ -429,6 +431,50 @@ public interface ExperimentService extends ExperimentRunTypeSource
                ExpMaterial.MATERIAL_INPUT_PARENT.equalsIgnoreCase(prefix) ||
                ExpData.DATA_OUTPUT_CHILD.equalsIgnoreCase(prefix) ||
                ExpMaterial.MATERIAL_OUTPUT_CHILD.equalsIgnoreCase(prefix);
+    }
+    
+    static boolean parentAliasHasCorrectFormat(String parentAlias)
+    {
+        //check if it is of the expected format or targeting the to be created sample type or dataclass
+        if (!(ExperimentService.isInputOutputColumn(parentAlias) || NEW_SAMPLE_TYPE_ALIAS_VALUE.equals(parentAlias) || NEW_DATA_CLASS_ALIAS_VALUE.equals(parentAlias)))
+            throw new IllegalArgumentException(String.format("Invalid parent alias header: %1$s", parentAlias));
+
+        return true;
+    }
+    
+    static void validateParentAlias(Map<String, String> aliasMap, Set<String> reservedNames, Set<String> existingAliases, GWTDomain updatedDomainDesign, String dataTypeNoun)
+    {
+        Set<String> dupes = new CaseInsensitiveHashSet();
+        aliasMap.forEach((key, value) -> {
+            String trimmedKey = StringUtils.trimToNull(key);
+            String trimmedValue = StringUtils.trimToNull(value);
+            if (trimmedKey == null)
+                throw new IllegalArgumentException("Import alias heading cannot be blank");
+
+            if (trimmedValue == null)
+            {
+                throw new IllegalArgumentException("You must specify a valid parent type for the import alias.");
+            }
+
+            if (reservedNames.contains(trimmedKey))
+            {
+                throw new IllegalArgumentException(String.format("Parent alias header is reserved: %1$s", trimmedKey));
+            }
+
+            if (updatedDomainDesign != null && !existingAliases.contains(trimmedKey) && updatedDomainDesign.getFieldByName(trimmedKey) != null)
+            {
+                throw new IllegalArgumentException(String.format("An existing " + dataTypeNoun + " property conflicts with parent alias header: %1$s", trimmedKey));
+            }
+
+            if (!dupes.add(trimmedKey))
+            {
+                throw new IllegalArgumentException(String.format("Duplicate parent alias header found: %1$s", trimmedKey));
+            }
+
+            //Check if parent alias has correct format MaterialInput/<name> or NEW_SAMPLE_TYPE_ALIAS_VALUE, or DataInput/<name> or NEW_DATA_CLASS_ALIAS_VALUE
+            if (!ExperimentService.parentAliasHasCorrectFormat(trimmedValue))
+                throw new IllegalArgumentException(String.format("Invalid parent alias header: %1$s", trimmedValue));
+        });
     }
 
     /**

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -231,11 +231,15 @@ public interface ExperimentService extends ExperimentRunTypeSource
                                  List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, @Nullable TemplateInfo templateInfo)
             throws ExperimentException;
 
+    ExpDataClass createDataClass(@NotNull Container c, @NotNull User u, @NotNull String name, @Nullable DataClassDomainKindProperties options,
+                                 List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, @Nullable TemplateInfo templateInfo, @Nullable List<String> disabledSystemField)
+            throws ExperimentException;
+
     /**
      * Create a new DataClass with the provided domain properties and top level options.
      */
     ExpDataClass createDataClass(@NotNull Container c, @NotNull User u, @NotNull String name, @Nullable DataClassDomainKindProperties options,
-                                 List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, @Nullable TemplateInfo templateInfo, @Nullable List<String> disabledSystemField)
+                                            List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, @Nullable TemplateInfo templateInfo, @Nullable List<String> disabledSystemField, @Nullable Map<String, String> importAliases)
             throws ExperimentException;
 
     /**

--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -445,58 +445,27 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
             throw new IllegalArgumentException("Value for Category field may not exceed " + categoryMax + " characters.");
 
         Map<String, String> aliasMap = options.getImportAliases();
-        if (aliasMap == null || aliasMap.size() == 0)
-            return;
-
-        SampleTypeService ss = SampleTypeService.get();
-        ExpSampleType sampleType = options.getRowId() >= 0 ? ss.getSampleType(options.getRowId()) : null;
-        Domain stDomain = sampleType != null ? sampleType.getDomain() : null;
-        Set<String> reservedNames = new CaseInsensitiveHashSet(this.getReservedPropertyNames(stDomain, user));
-        Set<String> existingAliases = new CaseInsensitiveHashSet();
-        Set<String> dupes = new CaseInsensitiveHashSet();
-
-        try
+        if (aliasMap != null && aliasMap.size() > 0)
         {
-            if (sampleType != null)
-                existingAliases = new CaseInsensitiveHashSet(sampleType.getImportAliasMap().keySet());
+            SampleTypeService ss = SampleTypeService.get();
+            ExpSampleType sampleType = options.getRowId() >= 0 ? ss.getSampleType(options.getRowId()) : null;
+            Domain stDomain = sampleType != null ? sampleType.getDomain() : null;
+            Set<String> reservedNames = new CaseInsensitiveHashSet(this.getReservedPropertyNames(stDomain, user));
+            Set<String> existingAliases = new CaseInsensitiveHashSet();
+
+            try
+            {
+                if (sampleType != null)
+                    existingAliases = new CaseInsensitiveHashSet(sampleType.getImportAliasMap().keySet());
+            }
+            catch (IOException e)
+            {
+                e.printStackTrace();
+            }
+
+            final Set<String> finalExistingAliases = existingAliases;
+            ExperimentService.validateParentAlias(aliasMap, reservedNames, finalExistingAliases, updatedDomainDesign, "sample type");
         }
-        catch (IOException e)
-        {
-            e.printStackTrace();
-        }
-
-
-        final Set<String> finalExistingAliases = existingAliases;
-        aliasMap.forEach((key, value) -> {
-            String trimmedKey = StringUtils.trimToNull(key);
-            String trimmedValue = StringUtils.trimToNull(value);
-            if (trimmedKey == null)
-                throw new IllegalArgumentException("Import alias heading cannot be blank");
-
-            if (trimmedValue == null)
-            {
-                throw new IllegalArgumentException("You must specify a valid parent type for the import alias.");
-            }
-
-            if (reservedNames.contains(trimmedKey))
-            {
-                throw new IllegalArgumentException(String.format("Parent alias header is reserved: %1$s", trimmedKey));
-            }
-
-            if (updatedDomainDesign != null && !finalExistingAliases.contains(trimmedKey) && updatedDomainDesign.getFieldByName(trimmedKey) != null)
-            {
-                throw new IllegalArgumentException(String.format("An existing sample type property conflicts with parent alias header: %1$s", trimmedKey));
-            }
-
-            if (!dupes.add(trimmedKey))
-            {
-                throw new IllegalArgumentException(String.format("Duplicate parent alias header found: %1$s", trimmedKey));
-            }
-
-            //Check if parent alias has correct format MaterialInput/<name> or NEW_SAMPLE_TYPE_ALIAS_VALUE
-            if (!ss.parentAliasHasCorrectFormat(trimmedValue))
-                throw new IllegalArgumentException(String.format("Invalid parent alias header: %1$s", trimmedValue));
-        });
 
         List<? extends GWTPropertyDescriptor> properties = updatedDomainDesign.getFields();
 

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -208,8 +208,6 @@ public interface SampleTypeService
 
     ValidationException updateSampleType(GWTDomain<? extends GWTPropertyDescriptor> original, GWTDomain<? extends GWTPropertyDescriptor> update, SampleTypeDomainKindProperties options, Container container, User user, boolean includeWarnings);
 
-    boolean parentAliasHasCorrectFormat(String parentAlias);
-
     void addAuditEvent(User user, Container container, String comment, String userComment, ExpMaterial sample, Map<String, Object> metadata);
 
     void addAuditEvent(User user, Container container, String comment, String userComment, ExpMaterial sample, Map<String, Object> metadata, String updateType);

--- a/api/src/org/labkey/api/exp/query/ExpDataClassTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpDataClassTable.java
@@ -35,6 +35,7 @@ public interface ExpDataClassTable extends ExpTable<ExpDataClassTable.Column>
         NameExpression,
         SampleSet,
         Category,
-        DataCount
+        DataCount,
+        ImportAliases
     }
 }

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.18.8",
-        "@labkey/components": "2.311.0",
+        "@labkey/components": "2.320.0-fb-dataclassLineage.4",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3057,9 +3057,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.311.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.311.0.tgz",
-      "integrity": "sha512-O9szF00/5tVgRcXAsayeY1+3t9YYSXTIARTodB1zQNjcZxDZtiUiWqgZaddUcMMck9bF4X9UIFFedXT7pfvnqA==",
+      "version": "2.320.0-fb-dataclassLineage.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.4.tgz",
+      "integrity": "sha512-Pow1JcoVUyX+G0Y91KGxl5cUwM1sVWAoLVhyjRx5Ay/GVZnYkFMe6jMhzVsRtCFQTpp6v5gBOZ779Sx9UscxXg==",
       "dependencies": {
         "@labkey/api": "1.18.8",
         "bootstrap": "~3.4.1",
@@ -17228,9 +17228,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.311.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.311.0.tgz",
-      "integrity": "sha512-O9szF00/5tVgRcXAsayeY1+3t9YYSXTIARTodB1zQNjcZxDZtiUiWqgZaddUcMMck9bF4X9UIFFedXT7pfvnqA==",
+      "version": "2.320.0-fb-dataclassLineage.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.4.tgz",
+      "integrity": "sha512-Pow1JcoVUyX+G0Y91KGxl5cUwM1sVWAoLVhyjRx5Ay/GVZnYkFMe6jMhzVsRtCFQTpp6v5gBOZ779Sx9UscxXg==",
       "requires": {
         "@labkey/api": "1.18.8",
         "bootstrap": "~3.4.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.18.8",
-        "@labkey/components": "2.320.0-fb-dataclassLineage.4",
+        "@labkey/components": "2.320.0-fb-dataclassLineage.5",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3057,9 +3057,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.320.0-fb-dataclassLineage.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.4.tgz",
-      "integrity": "sha512-Pow1JcoVUyX+G0Y91KGxl5cUwM1sVWAoLVhyjRx5Ay/GVZnYkFMe6jMhzVsRtCFQTpp6v5gBOZ779Sx9UscxXg==",
+      "version": "2.320.0-fb-dataclassLineage.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.5.tgz",
+      "integrity": "sha512-xTtQuvay2s4VIwiXJpJ07e+mXYwSt75yOpXGlluAXxyCgnyloGg6gwB+8Gebmtijezh9j/oD4DsHR3lo04KM0Q==",
       "dependencies": {
         "@labkey/api": "1.18.8",
         "bootstrap": "~3.4.1",
@@ -17228,9 +17228,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.320.0-fb-dataclassLineage.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.4.tgz",
-      "integrity": "sha512-Pow1JcoVUyX+G0Y91KGxl5cUwM1sVWAoLVhyjRx5Ay/GVZnYkFMe6jMhzVsRtCFQTpp6v5gBOZ779Sx9UscxXg==",
+      "version": "2.320.0-fb-dataclassLineage.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.5.tgz",
+      "integrity": "sha512-xTtQuvay2s4VIwiXJpJ07e+mXYwSt75yOpXGlluAXxyCgnyloGg6gwB+8Gebmtijezh9j/oD4DsHR3lo04KM0Q==",
       "requires": {
         "@labkey/api": "1.18.8",
         "bootstrap": "~3.4.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/api": "1.18.8",
+        "@labkey/api": "1.19.0",
         "@labkey/components": "2.323.0",
         "@labkey/themes": "1.3.0"
       },
@@ -3018,9 +3018,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.18.8",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.8.tgz",
-      "integrity": "sha512-8yXPl/WBSGyyM+v2MglznGB2TKGu4iz0M4lwoSB9ibeSHTHOZKKTaNf5YQUfzTjdoySNFtyM4Uiu2z6/xEl5iA=="
+      "version": "1.19.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.19.0.tgz",
+      "integrity": "sha512-LkMWTo/8ScVsptNZvwRrEAx4V9set01HZzfjHIbyTCDQL9CeGhIDK4du+WYe2w9UNhdqOoa0cd/zkyGLMdmTHw=="
     },
     "node_modules/@labkey/build": {
       "version": "6.9.0",
@@ -3094,11 +3094,6 @@
         "react-bootstrap": "^0.33.1",
         "react-dom": "^16.0"
       }
-    },
-    "node_modules/@labkey/components/node_modules/@labkey/api": {
-      "version": "1.19.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.19.0.tgz",
-      "integrity": "sha512-LkMWTo/8ScVsptNZvwRrEAx4V9set01HZzfjHIbyTCDQL9CeGhIDK4du+WYe2w9UNhdqOoa0cd/zkyGLMdmTHw=="
     },
     "node_modules/@labkey/eslint-config-base": {
       "version": "0.0.12",
@@ -17194,9 +17189,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.18.8",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.8.tgz",
-      "integrity": "sha512-8yXPl/WBSGyyM+v2MglznGB2TKGu4iz0M4lwoSB9ibeSHTHOZKKTaNf5YQUfzTjdoySNFtyM4Uiu2z6/xEl5iA=="
+      "version": "1.19.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.19.0.tgz",
+      "integrity": "sha512-LkMWTo/8ScVsptNZvwRrEAx4V9set01HZzfjHIbyTCDQL9CeGhIDK4du+WYe2w9UNhdqOoa0cd/zkyGLMdmTHw=="
     },
     "@labkey/build": {
       "version": "6.9.0",
@@ -17263,13 +17258,6 @@
         "react-select": "~5.7.0",
         "react-treebeard": "~3.2.4",
         "vis-network": "~6.5.2"
-      },
-      "dependencies": {
-        "@labkey/api": {
-          "version": "1.19.0",
-          "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.19.0.tgz",
-          "integrity": "sha512-LkMWTo/8ScVsptNZvwRrEAx4V9set01HZzfjHIbyTCDQL9CeGhIDK4du+WYe2w9UNhdqOoa0cd/zkyGLMdmTHw=="
-        }
       }
     },
     "@labkey/eslint-config-base": {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.18.8",
-        "@labkey/components": "2.320.0-fb-dataclassLineage.5",
+        "@labkey/components": "2.323.0",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3057,11 +3057,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.320.0-fb-dataclassLineage.5",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.5.tgz",
-      "integrity": "sha512-xTtQuvay2s4VIwiXJpJ07e+mXYwSt75yOpXGlluAXxyCgnyloGg6gwB+8Gebmtijezh9j/oD4DsHR3lo04KM0Q==",
+      "version": "2.323.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.323.0.tgz",
+      "integrity": "sha512-cv/Cuf3vz50yxh9QrSnYfxPtIN5xbCC6AaooAGPIA31bFIDsccZSmDAZPBVa1rA3EP3b/WtyJLKHHflDc+aFjg==",
       "dependencies": {
-        "@labkey/api": "1.18.8",
+        "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",
@@ -3094,6 +3094,11 @@
         "react-bootstrap": "^0.33.1",
         "react-dom": "^16.0"
       }
+    },
+    "node_modules/@labkey/components/node_modules/@labkey/api": {
+      "version": "1.19.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.19.0.tgz",
+      "integrity": "sha512-LkMWTo/8ScVsptNZvwRrEAx4V9set01HZzfjHIbyTCDQL9CeGhIDK4du+WYe2w9UNhdqOoa0cd/zkyGLMdmTHw=="
     },
     "node_modules/@labkey/eslint-config-base": {
       "version": "0.0.12",
@@ -17228,11 +17233,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.320.0-fb-dataclassLineage.5",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.5.tgz",
-      "integrity": "sha512-xTtQuvay2s4VIwiXJpJ07e+mXYwSt75yOpXGlluAXxyCgnyloGg6gwB+8Gebmtijezh9j/oD4DsHR3lo04KM0Q==",
+      "version": "2.323.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.323.0.tgz",
+      "integrity": "sha512-cv/Cuf3vz50yxh9QrSnYfxPtIN5xbCC6AaooAGPIA31bFIDsccZSmDAZPBVa1rA3EP3b/WtyJLKHHflDc+aFjg==",
       "requires": {
-        "@labkey/api": "1.18.8",
+        "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",
@@ -17258,6 +17263,13 @@
         "react-select": "~5.7.0",
         "react-treebeard": "~3.2.4",
         "vis-network": "~6.5.2"
+      },
+      "dependencies": {
+        "@labkey/api": {
+          "version": "1.19.0",
+          "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.19.0.tgz",
+          "integrity": "sha512-LkMWTo/8ScVsptNZvwRrEAx4V9set01HZzfjHIbyTCDQL9CeGhIDK4du+WYe2w9UNhdqOoa0cd/zkyGLMdmTHw=="
+        }
       }
     },
     "@labkey/eslint-config-base": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "1.18.8",
+    "@labkey/api": "1.19.0",
     "@labkey/components": "2.323.0",
     "@labkey/themes": "1.3.0"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.18.8",
-    "@labkey/components": "2.311.0",
+    "@labkey/components": "2.320.0-fb-dataclassLineage.4",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.18.8",
-    "@labkey/components": "2.320.0-fb-dataclassLineage.5",
+    "@labkey/components": "2.323.0",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.18.8",
-    "@labkey/components": "2.320.0-fb-dataclassLineage.4",
+    "@labkey/components": "2.320.0-fb-dataclassLineage.5",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/core/src/client/LabKeyUIComponentsPage/LabKeyUIComponentsPage.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/LabKeyUIComponentsPage.tsx
@@ -391,6 +391,7 @@ export class App extends React.Component<any, State> {
                             summary={'Test search result summary text for the components page.'}
                             url={'#searchresultcard'}
                             iconUrl={'/labkey/_images/construct.svg'}
+                            isTopResult={true}
                         />
                     )
                 }

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.320.0-fb-dataclassLineage.4"
+        "@labkey/components": "2.320.0-fb-dataclassLineage.5"
       },
       "devDependencies": {
         "@labkey/build": "6.9.0",
@@ -2355,9 +2355,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.320.0-fb-dataclassLineage.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.4.tgz",
-      "integrity": "sha512-Pow1JcoVUyX+G0Y91KGxl5cUwM1sVWAoLVhyjRx5Ay/GVZnYkFMe6jMhzVsRtCFQTpp6v5gBOZ779Sx9UscxXg==",
+      "version": "2.320.0-fb-dataclassLineage.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.5.tgz",
+      "integrity": "sha512-xTtQuvay2s4VIwiXJpJ07e+mXYwSt75yOpXGlluAXxyCgnyloGg6gwB+8Gebmtijezh9j/oD4DsHR3lo04KM0Q==",
       "dependencies": {
         "@labkey/api": "1.18.8",
         "bootstrap": "~3.4.1",
@@ -11897,9 +11897,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.320.0-fb-dataclassLineage.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.4.tgz",
-      "integrity": "sha512-Pow1JcoVUyX+G0Y91KGxl5cUwM1sVWAoLVhyjRx5Ay/GVZnYkFMe6jMhzVsRtCFQTpp6v5gBOZ779Sx9UscxXg==",
+      "version": "2.320.0-fb-dataclassLineage.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.5.tgz",
+      "integrity": "sha512-xTtQuvay2s4VIwiXJpJ07e+mXYwSt75yOpXGlluAXxyCgnyloGg6gwB+8Gebmtijezh9j/oD4DsHR3lo04KM0Q==",
       "requires": {
         "@labkey/api": "1.18.8",
         "bootstrap": "~3.4.1",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.320.0-fb-dataclassLineage.5"
+        "@labkey/components": "2.323.0"
       },
       "devDependencies": {
         "@labkey/build": "6.9.0",
@@ -2316,9 +2316,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.18.8",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.8.tgz",
-      "integrity": "sha512-8yXPl/WBSGyyM+v2MglznGB2TKGu4iz0M4lwoSB9ibeSHTHOZKKTaNf5YQUfzTjdoySNFtyM4Uiu2z6/xEl5iA=="
+      "version": "1.19.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.19.0.tgz",
+      "integrity": "sha512-LkMWTo/8ScVsptNZvwRrEAx4V9set01HZzfjHIbyTCDQL9CeGhIDK4du+WYe2w9UNhdqOoa0cd/zkyGLMdmTHw=="
     },
     "node_modules/@labkey/build": {
       "version": "6.9.0",
@@ -2355,11 +2355,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.320.0-fb-dataclassLineage.5",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.5.tgz",
-      "integrity": "sha512-xTtQuvay2s4VIwiXJpJ07e+mXYwSt75yOpXGlluAXxyCgnyloGg6gwB+8Gebmtijezh9j/oD4DsHR3lo04KM0Q==",
+      "version": "2.323.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.323.0.tgz",
+      "integrity": "sha512-cv/Cuf3vz50yxh9QrSnYfxPtIN5xbCC6AaooAGPIA31bFIDsccZSmDAZPBVa1rA3EP3b/WtyJLKHHflDc+aFjg==",
       "dependencies": {
-        "@labkey/api": "1.18.8",
+        "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",
@@ -11858,9 +11858,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.18.8",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.8.tgz",
-      "integrity": "sha512-8yXPl/WBSGyyM+v2MglznGB2TKGu4iz0M4lwoSB9ibeSHTHOZKKTaNf5YQUfzTjdoySNFtyM4Uiu2z6/xEl5iA=="
+      "version": "1.19.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.19.0.tgz",
+      "integrity": "sha512-LkMWTo/8ScVsptNZvwRrEAx4V9set01HZzfjHIbyTCDQL9CeGhIDK4du+WYe2w9UNhdqOoa0cd/zkyGLMdmTHw=="
     },
     "@labkey/build": {
       "version": "6.9.0",
@@ -11897,11 +11897,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.320.0-fb-dataclassLineage.5",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.5.tgz",
-      "integrity": "sha512-xTtQuvay2s4VIwiXJpJ07e+mXYwSt75yOpXGlluAXxyCgnyloGg6gwB+8Gebmtijezh9j/oD4DsHR3lo04KM0Q==",
+      "version": "2.323.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.323.0.tgz",
+      "integrity": "sha512-cv/Cuf3vz50yxh9QrSnYfxPtIN5xbCC6AaooAGPIA31bFIDsccZSmDAZPBVa1rA3EP3b/WtyJLKHHflDc+aFjg==",
       "requires": {
-        "@labkey/api": "1.18.8",
+        "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.307.2"
+        "@labkey/components": "2.320.0-fb-dataclassLineage.4"
       },
       "devDependencies": {
         "@labkey/build": "6.9.0",
@@ -2355,9 +2355,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.307.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.307.2.tgz",
-      "integrity": "sha512-tPKhJMKZ852W1HpITvFvMfL6Z0b7CoIX/ISp9zLLsu4Uk5F0vZo4ap7V172sTi3rmbWcDENIE8aQ9S8Oqv+eAQ==",
+      "version": "2.320.0-fb-dataclassLineage.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.4.tgz",
+      "integrity": "sha512-Pow1JcoVUyX+G0Y91KGxl5cUwM1sVWAoLVhyjRx5Ay/GVZnYkFMe6jMhzVsRtCFQTpp6v5gBOZ779Sx9UscxXg==",
       "dependencies": {
         "@labkey/api": "1.18.8",
         "bootstrap": "~3.4.1",
@@ -11897,9 +11897,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.307.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.307.2.tgz",
-      "integrity": "sha512-tPKhJMKZ852W1HpITvFvMfL6Z0b7CoIX/ISp9zLLsu4Uk5F0vZo4ap7V172sTi3rmbWcDENIE8aQ9S8Oqv+eAQ==",
+      "version": "2.320.0-fb-dataclassLineage.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.320.0-fb-dataclassLineage.4.tgz",
+      "integrity": "sha512-Pow1JcoVUyX+G0Y91KGxl5cUwM1sVWAoLVhyjRx5Ay/GVZnYkFMe6jMhzVsRtCFQTpp6v5gBOZ779Sx9UscxXg==",
       "requires": {
         "@labkey/api": "1.18.8",
         "bootstrap": "~3.4.1",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.307.2"
+    "@labkey/components": "2.320.0-fb-dataclassLineage.4"
   },
   "devDependencies": {
     "@labkey/build": "6.9.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.320.0-fb-dataclassLineage.4"
+    "@labkey/components": "2.320.0-fb-dataclassLineage.5"
   },
   "devDependencies": {
     "@labkey/build": "6.9.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.320.0-fb-dataclassLineage.5"
+    "@labkey/components": "2.323.0"
   },
   "devDependencies": {
     "@labkey/build": "6.9.0",

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-23.005-23.006.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-23.005-23.006.sql
@@ -1,0 +1,2 @@
+ALTER TABLE exp.DataClass
+    ADD COLUMN dataparentimportaliasmap VARCHAR(4000) NULL;

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-23.005-23.006.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-23.005-23.006.sql
@@ -1,0 +1,2 @@
+ALTER TABLE exp.DataClass
+    ADD dataparentimportaliasmap NVARCHAR(4000) NULL;

--- a/experiment/resources/schemas/exp.xml
+++ b/experiment/resources/schemas/exp.xml
@@ -456,6 +456,11 @@
             <isUserEditable>false</isUserEditable>
             <isHidden>true</isHidden>
         </column>
+        <column columnName="DataParentImportAliasMap">
+            <description>Column holds json serialized blob of aliases to dataclass parents used for import</description>
+            <isUserEditable>false</isUserEditable>
+            <isHidden>true</isHidden>
+        </column>
     </columns>
   </table>
   <table tableName="PropertyDescriptor" tableDbType="TABLE">

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -156,7 +156,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     public Double getSchemaVersion()
     {
-        return 23.005;
+        return 23.006;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -683,6 +683,17 @@ public class XarReader extends AbstractXarImporter
                 getLog().warn("DataClass Sample Type : '" + dataClassType.getSampleType() + "' was not found.");
         }
 
+        DataClassType.ParentImportAlias parentImportAlias = dataClassType.getParentImportAlias();
+        if (parentImportAlias != null)
+        {
+            Map<String, String> aliasMap = new LinkedHashMap<>();
+            for (ImportAlias importAlias : parentImportAlias.getAliasArray())
+            {
+                aliasMap.put(importAlias.getName(), importAlias.getValue());
+            }
+            dataClass.setImportAliasMap(aliasMap);
+        }
+
         if (existingDataClass != null)
         {
             if (_strictValidateExistingSampleType)

--- a/experiment/src/org/labkey/experiment/api/DataClass.java
+++ b/experiment/src/org/labkey/experiment/api/DataClass.java
@@ -34,6 +34,7 @@ public class DataClass extends IdentifiableEntity implements Comparable<DataClas
     private String _nameExpression;
     private Integer _materialSourceId;
     private String _category;
+    private String _dataParentImportAliasMap;
 
     public String getDescription()
     {
@@ -74,6 +75,16 @@ public class DataClass extends IdentifiableEntity implements Comparable<DataClas
     public void setCategory(String category)
     {
         _category = category;
+    }
+
+    public String getDataParentImportAliasMap()
+    {
+        return _dataParentImportAliasMap;
+    }
+
+    public void setDataParentImportAliasMap(String dataParentImportAliasMap)
+    {
+        _dataParentImportAliasMap = dataParentImportAliasMap;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -352,7 +352,7 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
 
         try
         {
-            ExpDataClass dataClass = ExperimentService.get().createDataClass(container, user, name, options, properties, indices, templateInfo, domain.getDisabledSystemFields());
+            ExpDataClass dataClass = ExperimentService.get().createDataClass(container, user, name, options, properties, indices, templateInfo, domain.getDisabledSystemFields(), options.getImportAliases());
             return dataClass.getDomain();
         }
         catch (ExperimentException e)

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
@@ -160,6 +160,8 @@ public class ExpDataClassTableImpl extends ExpTableImpl<ExpDataClassTable.Column
                 col.setFk( fk );
                 return col;
             }
+            case ImportAliases:
+                return createImportAliasColumn("ImportAliases", null, "data class");
             default:
                 throw new IllegalArgumentException("Unknown column " + column);
         }
@@ -181,6 +183,7 @@ public class ExpDataClassTableImpl extends ExpTableImpl<ExpDataClassTable.Column
         addColumn(Column.Category).setHidden(true);
         addColumn(Column.SampleSet);
         addColumn(Column.DataCount);
+        addColumn(Column.ImportAliases);
 
         setDetailsURL(new DetailsURL(new ActionURL(ExperimentController.ShowDataClassAction.class, _userSchema.getContainer()),
                 Collections.singletonMap("rowId", "RowId")));

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -41,6 +41,7 @@ import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpSampleType;
+import org.labkey.api.exp.api.ExperimentJSONConverter;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.api.NameExpressionOptionService;
@@ -1003,7 +1004,7 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
     @Override
     public void setImportAliasMap(Map<String, String> aliasMap)
     {
-        _object.setMaterialParentImportAliasMap(SampleTypeServiceImpl.get().getAliasJson(aliasMap, _object.getName()));
+        _object.setMaterialParentImportAliasMap(ExperimentJSONConverter.getAliasJson(aliasMap, _object.getName()));
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTableImpl.java
@@ -105,11 +105,11 @@ public class ExpSampleTypeTableImpl extends ExpTableImpl<ExpSampleTypeTable.Colu
                 return sampleCountColumnInfo;
             }
             case ImportAliases:
-                return createImportAliasColumn("ImportAliases", null);
+                return createImportAliasColumn("ImportAliases", null, "sample type");
             case MaterialInputImportAliases:
-                return createImportAliasColumn("MaterialInputImportAliases", MATERIAL_INPUTS_PREFIX);
+                return createImportAliasColumn("MaterialInputImportAliases", MATERIAL_INPUTS_PREFIX, "sample type");
             case DataInputImportAliases:
-                return createImportAliasColumn("DataInputImportAliases", DATA_INPUTS_PREFIX);
+                return createImportAliasColumn("DataInputImportAliases", DATA_INPUTS_PREFIX, "sample type");
             case Properties:
                 return createPropertiesColumn(alias);
             case Category:
@@ -124,25 +124,6 @@ public class ExpSampleTypeTableImpl extends ExpTableImpl<ExpSampleTypeTable.Colu
             default:
                 throw new IllegalArgumentException("Unknown column " + column);
         }
-    }
-
-    private AliasedColumn createImportAliasColumn(String name, String prefix)
-    {
-        AliasedColumn aliasedColumn = new AliasedColumn(this, name, _rootTable.getColumn("RowId"))
-        {
-            @Override
-            public boolean isNumericType()
-            {
-                // Issue 45374: don't apply number format to the RowId
-                return false;
-            }
-        };
-        aliasedColumn.setDisplayColumnFactory(new ImportAliasesDisplayColumnFactory(prefix));
-        aliasedColumn.setDescription("Display column for sample type import alias key/value pairs.");
-        aliasedColumn.setKeyField(false);
-        aliasedColumn.setRequired(false);
-        aliasedColumn.setHidden(true);
-        return aliasedColumn;
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
@@ -469,6 +469,25 @@ abstract public class ExpTableImpl<C extends Enum>
         addMethod("expObject", new ExpObjectTableMethodInfo(expObjectColumnName), Set.of());
     }
 
+    protected AliasedColumn createImportAliasColumn(String name, String prefix, String dataType)
+    {
+        AliasedColumn aliasedColumn = new AliasedColumn(this, name, _rootTable.getColumn("RowId"))
+        {
+            @Override
+            public boolean isNumericType()
+            {
+                // Issue 45374: don't apply number format to the RowId
+                return false;
+            }
+        };
+        aliasedColumn.setDisplayColumnFactory(new ImportAliasesDisplayColumnFactory(prefix));
+        aliasedColumn.setDescription("Display column for " + dataType + " import alias key/value pairs.");
+        aliasedColumn.setKeyField(false);
+        aliasedColumn.setRequired(false);
+        aliasedColumn.setHidden(true);
+        return aliasedColumn;
+    }
+
     private class ExpObjectTableMethodInfo extends AbstractTableMethodInfo
     {
         private final String _expObjectColumnName;

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -7400,7 +7400,15 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
     @Override
     public ExpDataClassImpl createDataClass(@NotNull Container c, @NotNull User u, @NotNull String name, @Nullable DataClassDomainKindProperties options,
-                                        List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, @Nullable TemplateInfo templateInfo, @Nullable List<String> disabledSystemField)
+                                            List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, @Nullable TemplateInfo templateInfo, @Nullable List<String> disabledSystemField)
+            throws ExperimentException
+    {
+        return createDataClass(c, u, name, options, properties, indices, templateInfo, disabledSystemField, null);
+    }
+
+    @Override
+    public ExpDataClassImpl createDataClass(@NotNull Container c, @NotNull User u, @NotNull String name, @Nullable DataClassDomainKindProperties options,
+                                        List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, @Nullable TemplateInfo templateInfo, @Nullable List<String> disabledSystemField, @Nullable Map<String, String> importAliases)
             throws ExperimentException
     {
         name = StringUtils.trimToNull(name);
@@ -7448,10 +7456,13 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         }
         domain.setPropertyIndices(propertyIndices);
 
+        String importAliasJson = ExperimentJSONConverter.getAliasJson(importAliases, name);
+
         DataClass bean = new DataClass();
         bean.setContainer(c);
         bean.setName(name);
         bean.setLSID(lsid.toString());
+        bean.setDataParentImportAliasMap(importAliasJson);
         if (options != null)
         {
             String nameExpression = options.getNameExpression();
@@ -7525,6 +7536,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             dataClass.setNameExpression(options.getNameExpression());
             dataClass.setSampleType(options.getSampleType());
             dataClass.setCategory(options.getCategory());
+            dataClass.setImportAliasMap(options.getImportAliases());
 
             if (!NameExpressionOptionService.get().allowUserSpecifiedNames(c) && options.getNameExpression() == null)
             {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -40,7 +40,6 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
-import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.DbSequence;
 import org.labkey.api.data.DbSequenceManager;
@@ -67,6 +66,7 @@ import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpSampleType;
+import org.labkey.api.exp.api.ExperimentJSONConverter;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.NameExpressionOptionService;
 import org.labkey.api.exp.api.SampleTypeDomainKindProperties;
@@ -823,7 +823,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         if (hasNameProperty && idUri1 != null)
             throw new ExperimentException("Either a 'Name' property or idCols can be used, but not both");
 
-        String importAliasJson = getAliasJson(importAliases, name);
+        String importAliasJson = ExperimentJSONConverter.getAliasJson(importAliases, name);
 
         MaterialSource source = new MaterialSource();
         source.setLSID(lsid);
@@ -885,50 +885,6 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
         return st;
     }
-
-    public String getAliasJson(Map<String, String> importAliases, String currentAliasName)
-    {
-        if (importAliases == null || importAliases.size() == 0)
-            return null;
-
-        Map<String, String> aliases = sanitizeAliases(importAliases, currentAliasName);
-
-        try
-        {
-            ObjectMapper mapper = new ObjectMapper();
-            return mapper.writeValueAsString(aliases);
-        }
-        catch (JsonProcessingException e)
-        {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
-    private Map<String, String> sanitizeAliases(Map<String, String> importAliases, String currentAliasName)
-    {
-        Map<String, String> cleanAliases = new HashMap<>();
-        importAliases.forEach((key, value) -> {
-            String trimmedKey = StringUtils.trimToNull(key);
-            String trimmedVal = StringUtils.trimToNull(value);
-
-            //Sanity check this should be caught earlier
-            if (trimmedKey == null || trimmedVal == null)
-                throw new IllegalArgumentException("Parent aliases contain blanks");
-
-            //Substitute the currentAliasName for the placeholder value
-            if (trimmedVal.equalsIgnoreCase(NEW_SAMPLE_TYPE_ALIAS_VALUE) ||
-                trimmedVal.equalsIgnoreCase(MATERIAL_INPUTS_PREFIX + NEW_SAMPLE_TYPE_ALIAS_VALUE))
-            {
-                trimmedVal = MATERIAL_INPUTS_PREFIX + currentAliasName;
-            }
-
-            cleanAliases.put(trimmedKey, trimmedVal);
-        });
-
-        return cleanAliases;
-    }
-
 
     public enum SampleSequenceType
     {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1058,16 +1058,6 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         return errors;
     }
 
-    @Override
-    public boolean parentAliasHasCorrectFormat(String parentAlias)
-    {
-        //check if it is of the expected format or targeting the to be created sample type
-        if (!(ExperimentService.isInputOutputColumn(parentAlias) || NEW_SAMPLE_TYPE_ALIAS_VALUE.equals(parentAlias)))
-            throw new IllegalArgumentException(String.format("Invalid parent alias header: %1$s", parentAlias));
-
-        return true;
-    }
-
     public String getCommentDetailed(QueryService.AuditAction action, boolean isUpdate)
     {
         String comment = SampleTimelineAuditEvent.SampleTimelineEventType.getActionCommentDetailed(action, isUpdate);


### PR DESCRIPTION
#### Rationale
Adding support to allow data class to have import aliases, just like sample types. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1159
- https://github.com/LabKey/platform/pull/4255
- https://github.com/LabKey/sampleManagement/pull/1723
- https://github.com/LabKey/biologics/pull/2054

#### Changes
* schema change to add DataParentImportAliasMap to exp.dataclass table
* save/update dataclass domain with additional parent alias param
* update dataclass DIB to take parent alias as extra fn param
