### PR TITLE
Move VARCHAR cast to ExprColumn

### DIFF
--- a/api/src/org/labkey/api/data/ContainerTable.java
+++ b/api/src/org/labkey/api/data/ContainerTable.java
@@ -145,7 +145,7 @@ public class ContainerTable extends FilteredTable<UserSchema>
             if (cType.equalsIgnoreCase(NormalContainerType.NAME))
                 continue;
             containerTypeSQL = containerTypeSQL.
-                    append("WHEN ").append(ExprColumn.STR_TABLE_ALIAS).append(".Type = ").appendValue(cType,dialect).append(" THEN ").appendValue(cType,dialect);
+                    append("WHEN ").append(ExprColumn.STR_TABLE_ALIAS).append(".Type = ").appendValue(cType,dialect).append(" THEN ").appendValue(cType,dialect).append(" ");
         }
         containerTypeSQL = containerTypeSQL.append(
                     "WHEN "+ExprColumn.STR_TABLE_ALIAS+".entityid = ? THEN 'root' " +

--- a/api/src/org/labkey/api/data/SQLFragment.java
+++ b/api/src/org/labkey/api/data/SQLFragment.java
@@ -613,6 +613,8 @@ public class SQLFragment implements Appendable, CharSequence
             append(d.getVarcharCast(new SQLFragment("NULL")));
         else
             getStringBuilder().append(d.getStringHandler().quoteStringLiteral(s.toString()));
+        // NOTE: I tried putting this into the StringHandler. That broke other code paths.
+        // NOTE: May still want to consider that in the future
         if (d.isPostgreSQL())
             getStringBuilder().append("::VARCHAR");
         return this;

--- a/api/src/org/labkey/api/data/SQLFragment.java
+++ b/api/src/org/labkey/api/data/SQLFragment.java
@@ -607,11 +607,14 @@ public class SQLFragment implements Appendable, CharSequence
     }
 
     /* like appendValue(CharSequence s), but force use of literal syntax */
-    public SQLFragment appendStringLiteral(CharSequence s, SqlDialect d)
+    public SQLFragment appendStringLiteral(CharSequence s, @NotNull SqlDialect d)
     {
         if (null==s)
-            return append(d.getVarcharCast(new SQLFragment("NULL")));
-        getStringBuilder().append(d.getStringHandler().quoteStringLiteral(s.toString()));
+            append(d.getVarcharCast(new SQLFragment("NULL")));
+        else
+            getStringBuilder().append(d.getStringHandler().quoteStringLiteral(s.toString()));
+        if (d.isPostgreSQL())
+            getStringBuilder().append("::VARCHAR");
         return this;
     }
 

--- a/api/src/org/labkey/api/data/SQLFragment.java
+++ b/api/src/org/labkey/api/data/SQLFragment.java
@@ -610,6 +610,8 @@ public class SQLFragment implements Appendable, CharSequence
      * CAUTIONARY NOTE: String literals in PostgresSQL are tricky because of overloaded functions
      *    array_agg('string') fails array_agg('string'::VARCHAR) works
      *    json_object('{}) works json_object('string'::VARCHAR) fails
+     *
+     * In the case of json_object() it expects TEXT. Postgres  will promote 'json' to TEXT, but not 'json'::VARCHAR
      */
     public SQLFragment appendStringLiteral(CharSequence s, @NotNull SqlDialect d)
     {

--- a/api/src/org/labkey/api/data/SQLFragment.java
+++ b/api/src/org/labkey/api/data/SQLFragment.java
@@ -606,17 +606,16 @@ public class SQLFragment implements Appendable, CharSequence
         return this;
     }
 
-    /* like appendValue(CharSequence s), but force use of literal syntax */
+    /** This is like appendValue(CharSequence s), but force use of literal syntax
+     * CAUTIONARY NOTE: String literals in PostgresSQL are tricky because of overloaded functions
+     *    array_agg('string') fails array_agg('string'::VARCHAR) works
+     *    json_object('{}) works json_object('string'::VARCHAR) fails
+     */
     public SQLFragment appendStringLiteral(CharSequence s, @NotNull SqlDialect d)
     {
         if (null==s)
-            append(d.getVarcharCast(new SQLFragment("NULL")));
-        else
-            getStringBuilder().append(d.getStringHandler().quoteStringLiteral(s.toString()));
-        // NOTE: I tried putting this into the StringHandler. That broke other code paths.
-        // NOTE: May still want to consider that in the future
-        if (d.isPostgreSQL())
-            getStringBuilder().append("::VARCHAR");
+            return appendNull();
+        getStringBuilder().append(d.getStringHandler().quoteStringLiteral(s.toString()));
         return this;
     }
 

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -120,6 +120,7 @@ import org.labkey.query.reports.getdata.AggregateQueryDataTransform;
 import org.labkey.query.reports.getdata.FilterClauseBuilder;
 import org.labkey.query.reports.view.ReportAndDatasetChangeDigestEmailTemplate;
 import org.labkey.query.reports.view.ReportUIProvider;
+import org.labkey.query.sql.Method;
 import org.labkey.query.sql.QNode;
 import org.labkey.query.sql.SqlParser;
 import org.labkey.query.view.InheritedQueryDataViewProvider;
@@ -378,6 +379,7 @@ public class QueryModule extends DefaultModule
             JdbcType.TestCase.class,
             MemberSet.TestCase.class,
             MetadataElementBase.TestCase.class,
+            Method.TestCase.class,
             QNode.TestCase.class,
             ReportsController.SerializationTest.class,
             SqlParser.SqlParserTestCase.class,

--- a/query/src/org/labkey/query/sql/Method.java
+++ b/query/src/org/labkey/query/sql/Method.java
@@ -1445,6 +1445,8 @@ public abstract class Method
             return f.getParams().get(0) instanceof String;
         if (f.getParams().size() > 0)
             return false;
+        if (s.endsWith("::VARCHAR"))
+            s = s.substring(0, s.length()-"::VARCHAR".length());
         // am I 'normal' SQL String with no embedded single-quotes?
         if (s.length() >= 2 && s.startsWith("'"))
             return s.length()-1 == s.indexOf('\'',1);
@@ -1454,7 +1456,7 @@ public abstract class Method
         return false;
     }
 
-
+    /** see {@link #isSimpleString(SQLFragment)} */
     public static String toSimpleString(SQLFragment f)
     {
         if (!isSimpleString(f))
@@ -1462,7 +1464,10 @@ public abstract class Method
         String s = f.getSQL();
         if ("?".equals(s) && f.getParams().size()==1)
             return (String)f.getParams().get(0);
-        assert(s.endsWith("'"));
+        assert(s.startsWith("'") || s.startsWith("N'"));
+        assert(s.endsWith("'") || s.endsWith("'::VARCHAR"));
+        if (s.endsWith("::VARCHAR"))
+            s = s.substring(0, s.length()-"::VARCHAR".length());
         if (s.startsWith("'"))
             return s.substring(1,s.length()-1);
         if (s.startsWith("N'"))

--- a/query/src/org/labkey/query/sql/Method.java
+++ b/query/src/org/labkey/query/sql/Method.java
@@ -1556,13 +1556,12 @@ public abstract class Method
                     public SQLFragment getSQL(SqlDialect dialect, SQLFragment[] arguments)
                     {
                         SQLFragment rawOperator = arguments[1];
-                        String operatorRawString = rawOperator.getSQL();
-                        if (!rawOperator.getParams().isEmpty() || !operatorRawString.startsWith("'") || !operatorRawString.endsWith("'"))
+                        String strippedOperator = isSimpleString(rawOperator) ? toSimpleString(rawOperator) : null;
+                        if (StringUtils.isBlank(strippedOperator))
                         {
                             throw new QueryParseException("Unsupported JSON operator: " + rawOperator, null, 0, 0);
                         }
 
-                        String strippedOperator = operatorRawString.substring(1, operatorRawString.length() - 1);
                         if (!ALLOWED_OPERATORS.contains(strippedOperator))
                         {
                             throw new QueryParseException("Unsupported JSON operator: " + rawOperator, null, 0, 0);


### PR DESCRIPTION
#### Rationale
We can't make both array_agg() and json_object() work at the same time with "auto" casting here.  This gets us back to where we were.  We may need to add more smarts about generating SQL for overloaded methods in postgres.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
