### PR TITLE
Allow JSON comments in specific cases

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -111,8 +111,6 @@ import static org.labkey.api.settings.LookAndFeelProperties.Properties.applicati
 /**
  * {@link org.labkey.api.module.Module} implementation for the API module itself, registering some of the basic
  * resource types within LabKey Server.
- *
- * Created by susanh on 1/19/17.
  */
 public class ApiModule extends CodeOnlyModule
 {
@@ -188,6 +186,7 @@ public class ApiModule extends CodeOnlyModule
             JSONDataLoader.MetadataTest.class,
             JSONDataLoader.RowTest.class,
             JsonTest.class,
+            JsonUtil.TestCase.class,
             MarkableIterator.TestCase.class,
             MaterializedQueryHelper.TestCase.class,
             MemTracker.TestCase.class,

--- a/api/src/org/labkey/api/util/JsonUtil.java
+++ b/api/src/org/labkey/api/util/JsonUtil.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -263,9 +264,11 @@ public class JsonUtil
 
         private static final String JSON_ARRAY_WITH_COMMENTS = """
             /* Here's a block comment */
-            // Here's a line comment
+            // Here's a single-line comment
             ["Ford", "BMW", "Fiat"]
             """;
+
+        private static final String[] COMMENT_WORDS = new String[]{"//", "/*", "*/", "block", "single-line"};
 
         @Test
         public void testStripComments() throws JsonProcessingException
@@ -273,12 +276,12 @@ public class JsonUtil
             // Test JSONObject
             assertThrows(JSONException.class, () -> new JSONObject(JSON_WITH_COMMENTS));
 
-            Assert.assertTrue("Expected comments before stripping",
-                StringUtils.containsAny(JSON_WITH_COMMENTS, "//", "/*", "*/", "block", "horizontal"));
-            String strippedOfComments = stripComments(JSON_WITH_COMMENTS);
-            Assert.assertFalse("Expected no comments after stripping",
-                StringUtils.containsAny(strippedOfComments, "//", "/*", "*/", "block", "horizontal"));
-            JSONObject json = new JSONObject(strippedOfComments);
+            Assert.assertTrue("Expected all comment words before stripping",
+                Arrays.stream(COMMENT_WORDS).allMatch(JSON_WITH_COMMENTS::contains));
+            String strippedObjectJson = stripComments(JSON_WITH_COMMENTS);
+            Assert.assertFalse("Expected no comment words after stripping",
+                StringUtils.containsAny(strippedObjectJson, COMMENT_WORDS));
+            JSONObject json = new JSONObject(strippedObjectJson);
             JSONObject widget = json.getJSONObject("widget");
             Assert.assertEquals(4, widget.length());
             JSONObject window = widget.getJSONObject("window");
@@ -289,8 +292,12 @@ public class JsonUtil
             // Test JSONArray
             assertThrows(JSONException.class, () -> new JSONArray(JSON_ARRAY_WITH_COMMENTS));
 
-            Assert.assertFalse("Expected no comments after stripping",
-                StringUtils.containsAny(stripComments(JSON_ARRAY_WITH_COMMENTS), "//", "/*", "*/", "block", "line"));
+            Assert.assertTrue("Expected all comment words before stripping",
+                Arrays.stream(COMMENT_WORDS).allMatch(JSON_ARRAY_WITH_COMMENTS::contains));
+            String strippedArrayJson = stripComments(JSON_ARRAY_WITH_COMMENTS);
+            Assert.assertFalse("Expected no comment words after stripping",
+                StringUtils.containsAny(strippedArrayJson, COMMENT_WORDS));
+            Assert.assertEquals(3, new JSONArray(strippedArrayJson).length());
         }
     }
 }

--- a/api/src/org/labkey/api/util/JsonUtil.java
+++ b/api/src/org/labkey/api/util/JsonUtil.java
@@ -220,6 +220,7 @@ public class JsonUtil
     {
         ObjectMapper mapper = new ObjectMapper();
         mapper.enable(JsonParser.Feature.ALLOW_COMMENTS);
+        mapper.enable(JsonParser.Feature.ALLOW_TRAILING_COMMA); // NLP *.ctc.json files have trailing commas, so allow them
         return mapper.writeValueAsString(mapper.readTree(jsonWithComments));
     }
 
@@ -248,16 +249,7 @@ public class JsonUtil
                         "vOffset": 250,  // vertical offset
                         "alignment": "center"
                     },
-                    "text": {
-                        "data": "Click Here",
-                        "size": 36,
-                        "style": "bold",
-                        "name": "text1",
-                        "hOffset": 250,
-                        "vOffset": 100,
-                        "alignment": "center",
-                        "onMouseUp": "sun1.opacity = (sun1.opacity / 100) * 90;"
-                    }
+                    "text": ["also", "need", "to", "test", "trailing", "commas",],
                 }
             }
             """;
@@ -265,7 +257,7 @@ public class JsonUtil
         private static final String JSON_ARRAY_WITH_COMMENTS = """
             /* Here's a block comment */
             // Here's a single-line comment
-            ["Ford", "BMW", "Fiat"]
+            ["Ford", "BMW", "Fiat",] // Here's a trailing comma, which also need to be allowed
             """;
 
         private static final String[] COMMENT_WORDS = new String[]{"//", "/*", "*/", "block", "single-line"};


### PR DESCRIPTION
#### Rationale
Comments in JSON documents aren't part of the standard, but they're present in many documents and tolerated by some parsers, but not our current `JSONObject` library. New helper method `JsonUtil.stripComments()` can be used to strip these comments before using a strict parser.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47618

Also tolerate trailing commas, which are present in all the `*.ctc.json` files I've seen

#### Related Pull Requests
* https://github.com/LabKey/nlp/pull/214