### PR TITLE
Fix Locator for paperclip image

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/AncillaryStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AncillaryStudyTest.java
@@ -20,7 +20,6 @@ import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
-import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.tests.StudyBaseTest;
 import org.labkey.test.util.DataRegionTable;
@@ -305,7 +304,7 @@ public class AncillaryStudyTest extends StudyBaseTest
         waitForElement(Locator.name("Label"), WAIT_FOR_JAVASCRIPT);
         setFormElement(Locator.name("Label"), "Extra " + STUDY_NAME);
         setFormElement(Locator.name("Description"), "Extra " + STUDY_DESCRIPTION);
-        click(Locator.tag("img").withAttribute("src", WebTestHelper.getContextPath() + "/_images/paperclip.gif")); //Attach a file
+        click(Locator.tag("img").withAttributeContaining("src", "/_images/paperclip.gif")); //Attach a file
         waitForElement(Locator.xpath("//div[contains(@class, 'protocolPanel')]//input[@type='file']"), WAIT_FOR_JAVASCRIPT);
         setFormElement(Locator.xpath("//div[contains(@class, 'protocolPanel')]//input[@type='file']"), PROTOCOL_DOC2.toString());
         clickButton("Submit");


### PR DESCRIPTION
#### Rationale
The paperclip `src` has a cache busting parameter (e.g. `/labkey/_images/paperclip.gif?546890555`). Need to use a less specific locator.

#### Related Pull Requests
* #4251 

#### Changes
* Fix Locator for paperclip image
