### PR TITLE
Update AbstractForeignKey to use the target container, rather than source, for ContainerFilter

### DIFF
--- a/api/src/org/labkey/api/data/AbstractForeignKey.java
+++ b/api/src/org/labkey/api/data/AbstractForeignKey.java
@@ -116,19 +116,26 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
             return new ContainerFilter.SimpleContainerFilterWithUser(getLookupUser(), c);
         }
         ContainerFilter cf = null;
+        QuerySchema targetSchema = getLookupSchema();
+        if (targetSchema == null)
+        {
+            targetSchema = getSourceSchema();
+        }
+
         if (null != _containerFilter)
             cf = _containerFilter;
-        else if (_sourceSchema instanceof UserSchema userSchema)
+        else if (targetSchema instanceof UserSchema userSchema)
             cf = userSchema.getDefaultLookupContainerFilter();
 
-        if (null != _sourceSchema && _sourceSchema.getContainer().isWorkbook())
+        if (null != targetSchema && targetSchema.getContainer().isWorkbook())
         {
             if (null == cf || cf.getType() == ContainerFilter.Type.Current)
-                cf = ContainerFilter.Type.CurrentOrParentAndWorkbooks.create(_sourceSchema);
+                cf = ContainerFilter.Type.CurrentOrParentAndWorkbooks.create(targetSchema);
         }
         return cf;
     }
 
+    @Override
     public SchemaKey getLookupSchemaKey()
     {
         if (_lookupSchemaKey == null)

--- a/api/src/org/labkey/api/data/AbstractForeignKey.java
+++ b/api/src/org/labkey/api/data/AbstractForeignKey.java
@@ -101,8 +101,19 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
     @Nullable
     protected User getLookupUser()
     {
-        if (null != _sourceSchema)
-            return _sourceSchema.getUser();
+        if (null != getSourceSchema())
+            return getSourceSchema().getUser();
+
+        return null;
+    }
+
+    protected QuerySchema getSourceSchema()
+    {
+        return _sourceSchema;
+    }
+
+    protected @Nullable QuerySchema getLookupSchema()
+    {
         return null;
     }
 

--- a/api/src/org/labkey/api/query/QueryForeignKey.java
+++ b/api/src/org/labkey/api/query/QueryForeignKey.java
@@ -342,17 +342,17 @@ public class QueryForeignKey extends AbstractForeignKey
     {
         if (null != _user)
             return _user;
-        if (null != getSchema())
-            return getSchema().getUser();
+        if (null != getLookupSchema())
+            return getLookupSchema().getUser();
         return super.getLookupUser();
     }
 
     @Override
     public TableInfo getLookupTableInfo()
     {
-        if (_table == null && getSchema() != null)
+        if (_table == null && getLookupSchema() != null)
         {
-            TableInfo t = getSchema().getTable(_tableName, getLookupContainerFilter());
+            TableInfo t = getLookupSchema().getTable(_tableName, getLookupContainerFilter());
             if (null != t && !t.hasPermission(getLookupUser(), ReadPermission.class))
                 t = null;
             _table = t;
@@ -360,7 +360,8 @@ public class QueryForeignKey extends AbstractForeignKey
         return _table;
     }
 
-    protected QuerySchema getSchema()
+    @Override
+    protected QuerySchema getLookupSchema()
     {
         if (_schema == null && _user != null && _lookupSchemaKey != null)
         {

--- a/api/src/org/labkey/api/query/UserIdQueryForeignKey.java
+++ b/api/src/org/labkey/api/query/UserIdQueryForeignKey.java
@@ -63,17 +63,17 @@ public class UserIdQueryForeignKey extends QueryForeignKey
     @Override
     public TableInfo getLookupTableInfo()
     {
-        if (_table == null && getSchema() != null)
+        if (_table == null && getLookupSchema() != null)
         {
             String cacheKey = this.getClass().getName() + "/" + _includeAllUsers;
-            _table = ((UserSchema) getSchema()).getCachedLookupTableInfo(cacheKey, this::createLookupTableInfo);
+            _table = ((UserSchema) getLookupSchema()).getCachedLookupTableInfo(cacheKey, this::createLookupTableInfo);
         }
         return _table;
     }
 
     private TableInfo createLookupTableInfo()
     {
-        TableInfo ret = ((UserSchema) getSchema()).getTable(_tableName, getLookupContainerFilter(), true, true);
+        TableInfo ret = ((UserSchema) getLookupSchema()).getTable(_tableName, getLookupContainerFilter(), true, true);
         if (null == ret)
             return null;
 


### PR DESCRIPTION
@labkey-jeckels: this is related to https://github.com/LabKey/ehrModules/pull/574

I believe this is probably longstanding behavior exposed when creating a cross-container FK in LabKey. If one does not specify the target container on creation, this code will default back to the container of the source schema, rather than the target schema.

Within this PR the actual change of consequence is really just one method in AbstractForeignKey. I renamed the getSchema() method to getLookupSchema() to make it more clear that it is different from the existing getSourceSchema() method. I dont know if this will break the build in other modules I dont have locally. There's one change in LaboratoryModule associated with the method name change.