### PR TITLE
Issue 47674: NPE collecting metrics when unable to query DB size

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -150,7 +150,12 @@ public class DbScope
         SQLFragment sql = getSqlDialect().getDatabaseSizeSql(getDatabaseName());
         if (sql != null)
         {
-            return new SqlSelector(this, sql).getObject(Long.class);
+            Long result = new SqlSelector(this, sql).getObject(Long.class);
+            // Check for null as we might not have permission in the DB to find the size. See issue 47674
+            if (result != null)
+            {
+                return result.longValue();
+            }
         }
         return -1;
     }


### PR DESCRIPTION
#### Rationale
The configured DB user many not have permission to fetch the size of the current DB. The query will return zero rows on SQLServer, which ends up returning `null`

#### Changes
* Null check... to avoid NPE!