### PR TITLE
Issue 47509: Resolve sample names that are integers during assay data import

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -18,7 +18,6 @@ package org.labkey.api.assay;
 
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -446,7 +445,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
             final ContainerFilter cf = QueryService.get().getContainerFilterForLookups(container, user);
             final TableInfo dataTable = provider.createProtocolSchema(user, container, protocol, null).createDataTable(cf);
 
-            Map<ExpMaterial, String> inputMaterials = checkData(container, user, dataTable, dataDomain, rawData, settings, resolver, cf);
+            Map<ExpMaterial, String> inputMaterials = checkData(container, user, dataTable, dataDomain, rawData, settings, resolver);
 
             // Issue 47509: When samples have names that are numbers, they can be incorrectly interpreted as rowIds during the insert.
             // inputMaterials will have been mapped by first using the input value as a name and then interpreting it as a rowId, so
@@ -734,8 +733,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                                                Domain dataDomain,
                                                List<Map<String, Object>> rawData,
                                                DataLoaderSettings settings,
-                                               ParticipantVisitResolver resolver,
-                                               ContainerFilter containerFilter)
+                                               ParticipantVisitResolver resolver)
             throws ValidationException, ExperimentException
     {
         final ExperimentService exp = ExperimentService.get();
@@ -1046,7 +1044,6 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                 if (o != null && ((byNameSS != null || lookupToAllSamplesByName.contains(pd)) ||
                         lookupToSampleTypeById.containsKey(pd) || lookupToAllSamplesById.contains(pd)))
                 {
-                    // TODO container filter?
                     String ssName = byNameSS != null ? byNameSS.getName() : null;
                     Container lookupContainer = byNameSS != null ? byNameSS.getContainer() : container;
                     ExpMaterial material = exp.findExpMaterial(lookupContainer, user, byNameSS, ssName, o.toString(), cache, materialCache);

--- a/api/src/org/labkey/api/assay/plate/PlateMetadataDataHandler.java
+++ b/api/src/org/labkey/api/assay/plate/PlateMetadataDataHandler.java
@@ -1,6 +1,7 @@
 package org.labkey.api.assay.plate;
 
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.AbstractAssayTsvDataHandler;
 import org.labkey.api.assay.AssayDataType;
 import org.labkey.api.exp.ExperimentException;
@@ -56,7 +57,7 @@ public class PlateMetadataDataHandler extends AbstractAssayTsvDataHandler
     }
 
     @Override
-    public void importFile(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context) throws ExperimentException
+    public void importFile(ExpData data, File dataFile, @NotNull ViewBackgroundInfo info, @NotNull Logger log, @NotNull XarContext context) throws ExperimentException
     {
         // this is just a noop data handler, the actual parsing and importing of the plate metadata needs to happen in
         // AbstractAssayTsvDataHandler.addAssayPlateMetadata because we need to access the inserted result data to get at the


### PR DESCRIPTION
#### Rationale
[Issue 47509](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47509)

Sometimes sample names are composed of only integers. These are difficult to distinguish from rowIds when resolving the lookup to a sample during assay import.  In related issues for sample import using integer-name samples, we updated the logic for resolving samples to first look for the sample assuming the integer value is its name instead of rowId.  We adopt similar logic here when importing via a file since it is rare that users will provide rowId values for the samples being referenced. If they do, they will surely also have the name of the sample available to use during assay data import in cases where there might be ambiguities based on numeric naming patterns.


#### Related Pull Requests

- https://github.com/LabKey/sampleManagement/pull/1757


#### Changes
* Update `checkData` method in `AbstractAssayTsvDataHandler` to go through `exp.findExpMaterial` even for integer values
* Update `AbstractAssayTsvDataHandler.importFile` to make sure the sampleId data being imported matches the resolved MaterialInputs from `checkData`.
