### PR TITLE
Sample status validation on ExperimentController.MoveSamplesAction

### DIFF
--- a/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
+++ b/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.qc.DataState;
-import org.labkey.api.qc.DataStateManager;
+import org.labkey.api.qc.SampleStatusService;
 import org.labkey.api.query.QueryService;
 
 import java.util.LinkedHashMap;
@@ -251,7 +251,7 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
     {
         if (row.get("samplestate") != null && !StringUtils.isBlank(row.get("samplestate")))
         {
-            DataState status = DataStateManager.getInstance().getStateForRowId(container, Integer.parseInt(row.get("samplestate")));
+            DataState status = SampleStatusService.get().getStateForRowId(container, Integer.parseInt(row.get("samplestate")));
             if (status != null)
                 return status.getLabel();
         }

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -64,7 +64,8 @@ public interface SampleTypeService
         RemoveFromWorkflow("removing from a workflow"),
         AddAssayData("addition of associated assay data"),
         LinkToStudy("linking to study"),
-        RecallFromStudy("recalling from a study");
+        RecallFromStudy("recalling from a study"),
+        Move("moving to a different project");
 
         private final String _description; // used as a suffix in messaging users about what is not allowed
 

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -377,7 +377,8 @@ public class ExpSchema extends AbstractExpSchema
                 SampleTypeService.SampleOperations.RemoveFromWorkflow,
                 SampleTypeService.SampleOperations.AddAssayData,
                 SampleTypeService.SampleOperations.LinkToStudy,
-                SampleTypeService.SampleOperations.RecallFromStudy
+                SampleTypeService.SampleOperations.RecallFromStudy,
+                SampleTypeService.SampleOperations.Move
         )),
         Locked(Set.of(
                 SampleTypeService.SampleOperations.AddToPicklist

--- a/api/src/org/labkey/api/qc/SampleStateManager.java
+++ b/api/src/org/labkey/api/qc/SampleStateManager.java
@@ -2,6 +2,7 @@ package org.labkey.api.qc;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.exp.query.ExpSchema;
 
 import java.util.List;
@@ -34,6 +35,25 @@ public class SampleStateManager extends DataStateManager
                 return false;
             }
         }).collect(Collectors.toList());
+    }
+
+    public List<DataState> getAllProjectStates(Container container)
+    {
+        List<DataState> states = getStates(container);
+        if (!container.isProject())
+            states.addAll(getStates(container.getProject()));
+        if (container != ContainerManager.getSharedContainer())
+            states.addAll(getStates(ContainerManager.getSharedContainer()));
+        return states;
+    }
+
+    public DataState getState(Container container, Integer stateId)
+    {
+        if (stateId == null)
+            return null;
+
+        List<DataState> allStates = getAllProjectStates(container);
+        return allStates.stream().filter(state -> stateId.equals(state.getRowId())).findFirst().orElse(null);
     }
 
     @Override

--- a/api/src/org/labkey/api/qc/SampleStatusService.java
+++ b/api/src/org/labkey/api/qc/SampleStatusService.java
@@ -48,6 +48,8 @@ public interface SampleStatusService
 
     @NotNull List<DataState> getAllProjectStates(Container container);
 
+    DataState getStateForRowId(Container container, Integer stateId);
+
     boolean isOperationPermitted(Container container, Integer stateId, @NotNull SampleTypeService.SampleOperations operation);
 
     boolean isOperationPermitted(DataState status, @NotNull SampleTypeService.SampleOperations operation);
@@ -82,13 +84,13 @@ public interface SampleStatusService
         @Override
         public @NotNull List<DataState> getAllProjectStates(Container container)
         {
-            SampleStateManager sampleStateManager = SampleStateManager.getInstance();
-            List<DataState> states = sampleStateManager.getStates(container);
-            if (!container.isProject())
-                states.addAll(sampleStateManager.getStates(container.getProject()));
-            if (container != ContainerManager.getSharedContainer())
-                states.addAll(sampleStateManager.getStates(ContainerManager.getSharedContainer()));
-            return states;
+            return SampleStateManager.getInstance().getAllProjectStates(container);
+        }
+
+        @Override
+        public DataState getStateForRowId(Container container, Integer stateId)
+        {
+            return SampleStateManager.getInstance().getState(container, stateId);
         }
 
         @Override

--- a/experiment/src/client/test/integration/MoveSamplesAction.ispec.ts
+++ b/experiment/src/client/test/integration/MoveSamplesAction.ispec.ts
@@ -1,4 +1,4 @@
-import { hookServer, RequestOptions, SecurityRole, successfulResponse, TestUser } from '@labkey/test';
+import { hookServer, RequestOptions, SecurityRole, successfulResponse } from '@labkey/test';
 import { caseInsensitive } from '@labkey/components';
 
 const server = hookServer(process.env);
@@ -16,7 +16,7 @@ let subfolder2Options;
 
 beforeAll(async () => {
     await server.init(PROJECT_NAME, {
-        ensureModules: ['experiment']
+        ensureModules: ['experiment'],
     });
     topFolderOptions = { containerPath: PROJECT_NAME };
 
@@ -59,20 +59,11 @@ afterAll(async () => {
     return server.teardown();
 });
 
-async function createSample(sampleName: string, folderOptions: RequestOptions, sampleState?: number) {
+async function createSample(sampleName: string, folderOptions: RequestOptions) {
     const materialResponse = await server.post('query', 'insertRows', {
         schemaName: 'samples',
         queryName: SAMPLE_TYPE_NAME,
-        rows: [{ name: sampleName, sampleState }]
-    }, { ...folderOptions, ...editorUserOptions }).expect(successfulResponse);
-    return caseInsensitive(materialResponse.body.rows[0], 'rowId');
-}
-
-async function createStatus(label: string, folderOptions: RequestOptions, stateType = 'Available') {
-    const materialResponse = await server.post('query', 'insertRows', {
-        schemaName: 'core',
-        queryName: 'DataStates',
-        rows: [{ label, stateType, publicdata: true }]
+        rows: [{ name: sampleName }]
     }, { ...folderOptions, ...editorUserOptions }).expect(successfulResponse);
     return caseInsensitive(materialResponse.body.rows[0], 'rowId');
 }
@@ -88,6 +79,10 @@ async function sampleExists(sampleRowId: number, folderOptions: RequestOptions) 
 
 describe('ExperimentController', () => {
     describe('moveSamples.api', () => {
+        // NOTE: the MoveSamplesAction is in the experiment module, but the sample status related test cases won't
+        // work here because the sample status feature is only "enabled" when the sampleManagement module is available.
+        // See sampleManagement/src/client/test/integration/MoveSamplesAction.ispec.ts for additional test cases.
+
         it('requires POST', () => {
             server.get('experiment', 'moveSamples.api').expect(405);
         });
@@ -259,120 +254,9 @@ describe('ExperimentController', () => {
             expect(sampleExistsInSub1).toBe(true);
         });
 
-        it('error, cannot move locked subfolder sample, status in same container', async () => {
-            // Arrange
-            const statusRowId = await createStatus('sub-Locked-1', subfolder1Options, 'Locked');
-            const sampleRowId = await createSample('sub1-notmoved-3', subfolder1Options, statusRowId);
-
-            // Act
-            const response = await server.post('experiment', 'moveSamples.api', {
-                targetContainer: topFolderOptions.containerPath,
-                rowIds: [sampleRowId]
-            }, { ...subfolder1Options, ...editorUserOptions }).expect(400);
-
-            // Assert
-            const { exception, success } = response.body;
-            expect(success).toBe(false);
-            expect(exception).toEqual('Sample sub1-notmoved-3 has status sub-Locked-1, which prevents moving to a different project.');
-
-            const sampleExistsInTop = await sampleExists(sampleRowId, topFolderOptions);
-            expect(sampleExistsInTop).toBeFalsy();
-            const sampleExistsInSub1 = await sampleExists(sampleRowId, subfolder1Options);
-            expect(sampleExistsInSub1).toBeTruthy();
-        });
-
-        it('error, cannot move locked subfolder sample, status in parent container', async () => {
-            // Arrange
-            const statusRowId = await createStatus('parent-Locked-1', topFolderOptions, 'Locked');
-            const sampleRowId = await createSample('sub1-notmoved-4', subfolder1Options, statusRowId);
-
-            // Act
-            const response = await server.post('experiment', 'moveSamples.api', {
-                targetContainer: topFolderOptions.containerPath,
-                rowIds: [sampleRowId]
-            }, { ...subfolder1Options, ...editorUserOptions }).expect(400);
-
-            // Assert
-            const { exception, success } = response.body;
-            expect(success).toBe(false);
-            expect(exception).toEqual('Sample sub1-notmoved-4 has status parent-Locked-1, which prevents moving to a different project.');
-
-            const sampleExistsInTop = await sampleExists(sampleRowId, topFolderOptions);
-            expect(sampleExistsInTop).toBeFalsy();
-            const sampleExistsInSub1 = await sampleExists(sampleRowId, subfolder1Options);
-            expect(sampleExistsInSub1).toBeTruthy();
-        });
-
-        it('error, cannot move locked parent sample', async () => {
-            // Arrange
-            const statusRowId = await createStatus('parent-Locked-2', topFolderOptions, 'Locked')
-            const sampleRowId = await createSample('parent-notmoved-1', topFolderOptions, statusRowId);
-
-            // Act
-            const response = await server.post('experiment', 'moveSamples.api', {
-                targetContainer: subfolder1Options.containerPath,
-                rowIds: [sampleRowId]
-            }, { ...topFolderOptions, ...editorUserOptions }).expect(400);
-
-            // Assert
-            const { exception, success } = response.body;
-            expect(success).toBe(false);
-            expect(exception).toEqual('Sample parent-notmoved-1 has status parent-Locked-2, which prevents moving to a different project.');
-
-            const sampleExistsInTop = await sampleExists(sampleRowId, topFolderOptions);
-            expect(sampleExistsInTop).toBeTruthy();
-            const sampleExistsInSub1 = await sampleExists(sampleRowId, subfolder1Options);
-            expect(sampleExistsInSub1).toBeFalsy();
-        });
-
-        it('error, cannot move subfolder sample with status from subfolder, move to parent', async () => {
-            // Arrange
-            const statusRowId = await createStatus('sub-Available-2', subfolder1Options);
-            const sampleRowId = await createSample('sub1-notmoved-5', subfolder1Options, statusRowId);
-
-            // Act
-            const response = await server.post('experiment', 'moveSamples.api', {
-                targetContainer: topFolderOptions.containerPath,
-                rowIds: [sampleRowId]
-            }, { ...subfolder1Options, ...editorUserOptions }).expect(400);
-
-            // Assert
-            const { exception, success } = response.body;
-            expect(success).toBe(false);
-            expect(exception).toEqual('Sample sub1-notmoved-5 has status sub-Available-2, which prevents moving to a different project.');
-
-            const sampleExistsInTop = await sampleExists(sampleRowId, topFolderOptions);
-            expect(sampleExistsInTop).toBeFalsy();
-            const sampleExistsInSub1 = await sampleExists(sampleRowId, subfolder1Options);
-            expect(sampleExistsInSub1).toBeTruthy();
-        });
-
-        it('error, cannot move subfolder sample with status from subfolder, move to sibling', async () => {
-            // Arrange
-            const statusRowId = await createStatus('sub-Available-3', subfolder1Options);
-            const sampleRowId = await createSample('sub1-notmoved-6', subfolder1Options, statusRowId);
-
-            // Act
-            const response = await server.post('experiment', 'moveSamples.api', {
-                targetContainer: subfolder2Options.containerPath,
-                rowIds: [sampleRowId]
-            }, { ...subfolder1Options, ...editorUserOptions }).expect(400);
-
-            // Assert
-            const { exception, success } = response.body;
-            expect(success).toBe(false);
-            expect(exception).toEqual('Sample sub1-notmoved-6 has status sub-Available-3, which prevents moving to a different project.');
-
-            const sampleExistsInTop = await sampleExists(sampleRowId, topFolderOptions);
-            expect(sampleExistsInTop).toBeFalsy();
-            const sampleExistsInSub1 = await sampleExists(sampleRowId, subfolder1Options);
-            expect(sampleExistsInSub1).toBeTruthy();
-        });
-
         it('success, move sample from parent project to subfolder', async () => {
             // Arrange
-            const statusRowId = await createStatus('parent-Available-1', topFolderOptions);
-            const sampleRowId = await createSample('top-movetosub1-1', topFolderOptions, statusRowId);
+            const sampleRowId = await createSample('top-movetosub1-1', topFolderOptions);
 
             // Act
             const response = await server.post('experiment', 'moveSamples.api', {
@@ -393,8 +277,7 @@ describe('ExperimentController', () => {
 
         it('success, move sample from subfolder to parent project', async () => {
             // Arrange
-            const statusRowId = await createStatus('parent-Available-2', topFolderOptions);
-            const sampleRowId = await createSample('sub1-movetotop-1', subfolder1Options, statusRowId);
+            const sampleRowId = await createSample('sub1-movetotop-1', subfolder1Options);
 
             // Act
             const response = await server.post('experiment', 'moveSamples.api', {
@@ -415,8 +298,7 @@ describe('ExperimentController', () => {
 
         it('success, move sample from subfolder to sibling', async () => {
             // Arrange
-            const statusRowId = await createStatus('parent-Available-3', topFolderOptions);
-            const sampleRowId = await createSample('sub1-movetosub2-1', subfolder1Options, statusRowId);
+            const sampleRowId = await createSample('sub1-movetosub2-1', subfolder1Options);
 
             // Act
             const response = await server.post('experiment', 'moveSamples.api', {

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -215,7 +215,8 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
     {
         if (getSampleStateId() == null)
             return null;
-        return DataStateManager.getInstance().getStateForRowId(getContainer(), getSampleStateId());
+
+        return SampleStatusService.get().getStateForRowId(getContainer(), getSampleStateId());
     }
 
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -84,7 +84,7 @@ import org.labkey.api.inventory.InventoryService;
 import org.labkey.api.miniprofiler.MiniProfiler;
 import org.labkey.api.miniprofiler.Timing;
 import org.labkey.api.qc.DataState;
-import org.labkey.api.qc.DataStateManager;
+import org.labkey.api.qc.SampleStatusService;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryChangeListener;
 import org.labkey.api.query.QueryService;
@@ -486,7 +486,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     @Override
     public DataState getSampleState(Container container, Integer stateRowId)
     {
-        return DataStateManager.getInstance().getStateForRowId(container, stateRowId);
+        return SampleStatusService.get().getStateForRowId(container, stateRowId);
     }
 
     private ExpSampleTypeImpl _getSampleType(String lsid)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -529,9 +529,9 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
         // We need to allow updating from one locked status to another locked status, but without other changes
         // and updating from either locked or unlocked to something else while also updating other metadata
-        DataState oldStatus = DataStateManager.getInstance().getStateForRowId(getContainer(), (Integer) oldRow.get(ExpMaterialTable.Column.SampleState.name()));
+        DataState oldStatus = SampleStatusService.get().getStateForRowId(getContainer(), (Integer) oldRow.get(ExpMaterialTable.Column.SampleState.name()));
         boolean oldAllowsOp = SampleStatusService.get().isOperationPermitted(oldStatus, SampleTypeService.SampleOperations.EditMetadata);
-        DataState newStatus = DataStateManager.getInstance().getStateForRowId(getContainer(), (Integer) rowCopy.get(ExpMaterialTable.Column.SampleState.name()));
+        DataState newStatus = SampleStatusService.get().getStateForRowId(getContainer(), (Integer) rowCopy.get(ExpMaterialTable.Column.SampleState.name()));
         boolean newAllowsOp = SampleStatusService.get().isOperationPermitted(newStatus, SampleTypeService.SampleOperations.EditMetadata);
 
         Map<String, Object> ret = new CaseInsensitiveHashMap<>(super._update(user, c, rowCopy, oldRow, keys));
@@ -674,9 +674,10 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                 if (rowId == null)
                     throw new QueryUpdateServiceException("RowID is required to delete a Sample Type Material");
 
-                if (!SampleStatusService.get().isOperationPermitted(getContainer(), (Integer) map.get(ExpMaterialTable.Column.SampleState.name()), SampleTypeService.SampleOperations.Delete))
+                Integer sampleStateId = (Integer) map.get(ExpMaterialTable.Column.SampleState.name());
+                if (!SampleStatusService.get().isOperationPermitted(getContainer(), sampleStateId, SampleTypeService.SampleOperations.Delete))
                 {
-                    DataState dataState = DataStateManager.getInstance().getStateForRowId(container, (Integer) map.get(ExpMaterialTable.Column.SampleState.name()));
+                    DataState dataState = SampleStatusService.get().getStateForRowId(container, sampleStateId);
                     throw new QueryUpdateServiceException(String.format("Sample with RowID %d cannot be deleted due to its current status (%s)", rowId, dataState));
                 }
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -7782,7 +7782,7 @@ public class ExperimentController extends SpringActionController
 
         private void validateSampleIds(MoveSamplesForm form, Errors errors)
         {
-            Set<Integer> sampleIds = form.getIds(false);
+            Set<Integer> sampleIds = form.getIds(true);
             if (sampleIds == null || sampleIds.isEmpty())
             {
                 errors.reject(ERROR_MSG, "Sample IDs must be specified for the move operation.");

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -140,6 +140,7 @@ import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.pipeline.PipelineStatusFile;
 import org.labkey.api.pipeline.PipelineUrls;
 import org.labkey.api.pipeline.PipelineValidationException;
+import org.labkey.api.qc.DataState;
 import org.labkey.api.qc.SampleStatusService;
 import org.labkey.api.query.AbstractQueryImportAction;
 import org.labkey.api.query.BatchValidationException;
@@ -7709,8 +7710,6 @@ public class ExperimentController extends SpringActionController
         public void validateForm(MoveSamplesForm form, Errors errors)
         {
             validateTargetContainer(form, errors);
-
-            // TODO prevent moving if data QC states don't exist in target container scope
             validateSampleIds(form, errors);
         }
 
@@ -7800,6 +7799,31 @@ public class ExperimentController extends SpringActionController
             if (_materials.stream().anyMatch(material -> !material.getContainer().equals(getContainer())))
             {
                 errors.reject(ERROR_MSG, "All samples must be from the current container for the move operation.");
+                return;
+            }
+
+            // verify allowed moves based on sample statuses
+            List<ExpMaterial> invalidStatusSamples = new ArrayList<>();
+            for (ExpMaterial material : _materials)
+            {
+                DataState sampleStatus = material.getSampleState();
+                if (sampleStatus == null) continue;
+
+                // prevent move for locked samples
+                if (!material.isOperationPermitted(SampleTypeService.SampleOperations.Move))
+                {
+                    invalidStatusSamples.add(material);
+                }
+                // prevent moving samples if data QC state doesn't exist in target container scope (i.e. home project),
+                // only applies when moving from child to parent or child to sibling
+                else if (!getContainer().isProject() && sampleStatus.getContainer().equals(getContainer()))
+                {
+                    invalidStatusSamples.add(material);
+                }
+            }
+            if (!invalidStatusSamples.isEmpty())
+            {
+                errors.reject(ERROR_MSG, SampleTypeService.get().getOperationNotPermittedMessage(invalidStatusSamples, SampleTypeService.SampleOperations.Move));
                 return;
             }
 


### PR DESCRIPTION
#### Rationale
ExperimentController.MoveSamplesAction to check for invalid sample status
- don't allow move of Locked sample statuses
- don't allow move if the sample status would not be valid in the new container's scope

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/4289
- https://github.com/LabKey/sampleManagement/pull/1759

#### Changes
- ExperimentController.MoveSamplesAction updates to add validation based on the selected sample's status
- Replace usages of DataStateManager.getInstance().getStateForRowId() with version that uses getAllProjectStates()
