### PR TITLE
Issue 47509: Resolve sample names that are integers during assay data import

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -1051,7 +1051,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                         materialInputs.putIfAbsent(material, pd.getName());
                         rowInputLSIDs.add(material.getLSID());
                     }
-                    else
+                    else if (o instanceof Integer || !remappableLookup.containsKey(pd))
                     {
                         errors.add(new PropertyValidationError(  o + " not found in the current context.", pd.getName()));
                     }

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -18,8 +18,8 @@ package org.labkey.api.assay;
 
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.old.JSONArray;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
@@ -70,6 +70,7 @@ import org.labkey.api.study.publish.StudyPublishService;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.ResultSetUtil;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.springframework.jdbc.BadSqlGrammarException;
@@ -109,13 +110,13 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         }
     };
 
-    private static final Logger LOG = LogManager.getLogger(AbstractAssayTsvDataHandler.class);
+    private static final Logger LOG = LogHelper.getLogger(AbstractAssayTsvDataHandler.class, "Info related to assay data import");
     private Map<String, AssayPlateMetadataService.MetadataLayer> _rawPlateMetadata;
 
     protected abstract boolean allowEmptyData();
 
     @Override
-    public void importFile(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context) throws ExperimentException
+    public void importFile(ExpData data, File dataFile, @NotNull ViewBackgroundInfo info, @NotNull Logger log, @NotNull XarContext context) throws ExperimentException
     {
         ExpProtocolApplication sourceApplication = data.getSourceApplication();
         if (sourceApplication == null)
@@ -444,9 +445,32 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
             final ContainerFilter cf = QueryService.get().getContainerFilterForLookups(container, user);
             final TableInfo dataTable = provider.createProtocolSchema(user, container, protocol, null).createDataTable(cf);
 
-            Map<ExpMaterial, String> inputMaterials = checkData(container, user, dataTable, dataDomain, rawData, settings, resolver, cf);
+            Map<ExpMaterial, String> inputMaterials = checkData(container, user, dataTable, dataDomain, rawData, settings, resolver);
+
+            // Issue 47509: When samples have names that are numbers, they can be incorrectly interpreted as rowIds during the insert.
+            // inputMaterials will have been mapped by first using the input value as a name and then interpreting it as a rowId, so
+            // we employ this mapping here to adjust the data to be imported to the results table to use the rowIds of the input samples.
+
+            // key is the property name, value is a map from the name to the rowId
+            Map<String, Map<Integer, Integer>> nameMaterialMap = new HashMap<>();
+            inputMaterials.forEach((sample, fieldName) -> {
+                if (StringUtils.isNumeric(sample.getName()))
+                {
+                    Integer nameAsInt = Integer.parseInt(sample.getName());
+                    Map<Integer, Integer> idMap = nameMaterialMap.computeIfAbsent(fieldName, k -> new HashMap<>());
+                    idMap.put(nameAsInt, sample.getRowId());
+                }
+            });
 
             List<Map<String, Object>> fileData = convertPropertyNamesToURIs(rawData, dataDomain);
+            fileData.forEach(d -> {
+                nameMaterialMap.forEach((name, idMap)  -> {
+                    if (d.get(name) != null && idMap.containsKey(d.get(name)))
+                    {
+                        d.put(name, idMap.get(d.get(name)));
+                    }
+                });
+            });
 
             // Insert the data into the assay's data table.
             // On insert, the raw data will have the provisioned table's rowId added to the list of maps
@@ -700,7 +724,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
     /**
      * TODO: Replace with a DataIterator pipeline
      * NOTE: Mutates the rawData list in-place
-     * @return the set of materials that are inputs to this run
+     * @return the map of materials that are inputs to this run
      */
     private Map<ExpMaterial, String> checkData(Container container,
                                                User user,
@@ -708,8 +732,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                                                Domain dataDomain,
                                                List<Map<String, Object>> rawData,
                                                DataLoaderSettings settings,
-                                               ParticipantVisitResolver resolver,
-                                               ContainerFilter containerFilter)
+                                               ParticipantVisitResolver resolver)
             throws ValidationException, ExperimentException
     {
         final ExperimentService exp = ExperimentService.get();
@@ -1017,21 +1040,12 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                 // Collect sample names or ids for each of the SampleType lookup columns
                 // Add any sample inputs to the rowInputLSIDs
                 ExpSampleType byNameSS = lookupToSampleTypeByName.get(pd);
-                if (o instanceof String && (byNameSS != null || lookupToAllSamplesByName.contains(pd)))
+                if (o != null && ((byNameSS != null || lookupToAllSamplesByName.contains(pd)) ||
+                        lookupToSampleTypeById.containsKey(pd) || lookupToAllSamplesById.contains(pd)))
                 {
                     String ssName = byNameSS != null ? byNameSS.getName() : null;
                     Container lookupContainer = byNameSS != null ? byNameSS.getContainer() : container;
-                    ExpMaterial material = exp.findExpMaterial(lookupContainer, user, byNameSS, ssName, (String)o, cache, materialCache);
-                    if (material != null)
-                    {
-                        materialInputs.putIfAbsent(material, pd.getName());
-                        rowInputLSIDs.add(material.getLSID());
-                    }
-                }
-
-                if (o instanceof Integer && (lookupToSampleTypeById.containsKey(pd) || lookupToAllSamplesById.contains(pd)))
-                {
-                    ExpMaterial material = materialCache.computeIfAbsent((Integer)o, (id) -> exp.getExpMaterial(id, containerFilter));
+                    ExpMaterial material = exp.findExpMaterial(lookupContainer, user, byNameSS, ssName, o.toString(), cache, materialCache);
                     if (material != null)
                     {
                         materialInputs.putIfAbsent(material, pd.getName());
@@ -1213,7 +1227,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                 DomainProperty property = _importMap.get(key);
                 if (property != null)
                 {
-                    // Find all of the potential synonyms
+                    // Find all the potential synonyms
                     Set<String> allNames = _propToNames.get(property);
                     if (allNames != null)
                     {

--- a/api/src/org/labkey/api/assay/plate/PlateMetadataDataHandler.java
+++ b/api/src/org/labkey/api/assay/plate/PlateMetadataDataHandler.java
@@ -1,6 +1,7 @@
 package org.labkey.api.assay.plate;
 
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.AbstractAssayTsvDataHandler;
 import org.labkey.api.assay.AssayDataType;
 import org.labkey.api.exp.ExperimentException;
@@ -56,7 +57,7 @@ public class PlateMetadataDataHandler extends AbstractAssayTsvDataHandler
     }
 
     @Override
-    public void importFile(ExpData data, File dataFile, ViewBackgroundInfo info, Logger log, XarContext context) throws ExperimentException
+    public void importFile(ExpData data, File dataFile, @NotNull ViewBackgroundInfo info, @NotNull Logger log, @NotNull XarContext context) throws ExperimentException
     {
         // this is just a noop data handler, the actual parsing and importing of the plate metadata needs to happen in
         // AbstractAssayTsvDataHandler.addAssayPlateMetadata because we need to access the inserted result data to get at the


### PR DESCRIPTION
#### Rationale
[Issue 47509](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47509)

Sometimes sample names are composed of only integers. These are difficult to distinguish from rowIds when resolving the lookup to a sample during assay import.  In related issues for sample import using integer-name samples, we updated the logic for resolving samples to first look for the sample assuming the integer value is its name instead of rowId.  We adopt similar logic here when importing via a file since it is rare that users will provide rowId values for the samples being referenced. If they do, they will surely also have the name of the sample available to use during assay data import in cases where there might be ambiguities based on numeric naming patterns.

#### Related Pull Requests
- https://github.com/LabKey/sampleManagement/pull/1762

#### Changes
* Update `checkData` method in `AbstractAssayTsvDataHandler` to go through `exp.findExpMaterial` even for integer values
* Update `AbstractAssayTsvDataHandler.importFile` to make sure the sampleId data being imported matches the resolved MaterialInputs from `checkData`.