### PR TITLE
Quote exported queries to make TSV legible

### DIFF
--- a/api/src/org/labkey/api/data/queryprofiler/QueryProfiler.java
+++ b/api/src/org/labkey/api/data/queryprofiler/QueryProfiler.java
@@ -498,7 +498,7 @@ public class QueryProfiler
                 QueryTracker.exportRowHeader(_pw);
 
                 for (QueryTracker tracker : export.descendingSet())
-                    tracker.exportRow(_pw);
+                    tracker.exportRow(this);
             }
 
             return export.size();

--- a/api/src/org/labkey/api/data/queryprofiler/QueryTracker.java
+++ b/api/src/org/labkey/api/data/queryprofiler/QueryTracker.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.ByteArrayHashKey;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.TSVWriter;
 import org.labkey.api.data.Table;
 import org.labkey.api.util.Compress;
 import org.labkey.api.util.ExceptionUtil;
@@ -306,8 +307,10 @@ class QueryTracker
         out.println("</tr>");
     }
 
-    public void exportRow(PrintWriter out)
+    public void exportRow(TSVWriter tsvWriter)
     {
+        PrintWriter out = tsvWriter.getPrintWriter();
+
         String tab = "";
 
         for (QueryTrackerSet set : QueryProfiler.getInstance().getTrackerSets())
@@ -319,7 +322,8 @@ class QueryTracker
             }
         }
 
-        out.print(tab + getSql().trim().replaceAll("(\\s)+", " "));
+        out.print(tab);
+        out.print(tsvWriter.quoteValue(getSql()));
         out.print('\n');
     }
 }


### PR DESCRIPTION
#### Rationale
Flattening the SQL into a single line for the exported query stats makes anything but the most simple query barely legible. Especially if there if there are any full line comments (`--`), which many queries start with.

#### Related Pull Requests
* N/A

#### Changes
* Use TsvWriter to format exported query tracker rows
