### PR TITLE
Issue 47654: Part of Filter section in the "Customize Grid" is cut off

### DIFF
--- a/core/webapp/internal/ViewDesigner/tab/FilterTab.js
+++ b/core/webapp/internal/ViewDesigner/tab/FilterTab.js
@@ -270,7 +270,7 @@ Ext4.define('LABKEY.internal.ViewDesigner.tab.FilterTab', {
                 store: this.getFilterStore(),
                 deferEmptyText: false,
                 multiSelect: true,
-                height: this.hideContainerFilterToolbar ? 166 : 136,
+                height: this.hideContainerFilterToolbar ? 320 : 290,
                 autoScroll: true,
                 overItemCls: 'x4-view-over',
                 itemSelector: '.labkey-customview-item',

--- a/core/webapp/internal/ViewDesigner/tab/SortTab.js
+++ b/core/webapp/internal/ViewDesigner/tab/SortTab.js
@@ -72,7 +72,7 @@ Ext4.define('LABKEY.internal.ViewDesigner.tab.SortTab', {
                 store: this.getSortStore(),
                 deferEmptyText: false,
                 multiSelect: true,
-                height: 166,
+                height: 320,
                 autoScroll: true,
                 overItemCls: 'x4-view-over',
                 itemSelector: '.labkey-customview-item',


### PR DESCRIPTION
#### Rationale
Panel sizes were changed for custom view by https://github.com/LabKey/platform/pull/526, but filter and sort tabs sizes were not adjusted.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/526

#### Changes
* modify filter and sort tab to match custom view panel size
