### PR TITLE
EntityInsertPanel: move to entities subpackage, utilize API wrappers

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.307.0"
+        "@labkey/components": "2.325.1-fb-entity-insert-api.0"
       },
       "devDependencies": {
         "@labkey/build": "6.10.0",
@@ -2316,9 +2316,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.18.7",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.7.tgz",
-      "integrity": "sha512-MNSiG2xz5RzDKtucXBo5QMsToa8wxVWZc08Leh4mK+e9AhP/Tq7CKOs/+1wZS/mAetbWwB3fBnrMRkeo9relXg=="
+      "version": "1.19.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.19.0.tgz",
+      "integrity": "sha512-LkMWTo/8ScVsptNZvwRrEAx4V9set01HZzfjHIbyTCDQL9CeGhIDK4du+WYe2w9UNhdqOoa0cd/zkyGLMdmTHw=="
     },
     "node_modules/@labkey/build": {
       "version": "6.10.0",
@@ -2355,11 +2355,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.307.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.307.0.tgz",
-      "integrity": "sha512-V8bRPLqhKqV1JJXOIuLS54o5rk83VohHpBa7iwgmHJ7BqgTX0se06lO/8Pox3xw2buqvS5Wbr98M3guNHaj4Fw==",
+      "version": "2.325.1-fb-entity-insert-api.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
+      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
       "dependencies": {
-        "@labkey/api": "1.18.7",
+        "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",
@@ -11858,9 +11858,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.18.7",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.7.tgz",
-      "integrity": "sha512-MNSiG2xz5RzDKtucXBo5QMsToa8wxVWZc08Leh4mK+e9AhP/Tq7CKOs/+1wZS/mAetbWwB3fBnrMRkeo9relXg=="
+      "version": "1.19.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.19.0.tgz",
+      "integrity": "sha512-LkMWTo/8ScVsptNZvwRrEAx4V9set01HZzfjHIbyTCDQL9CeGhIDK4du+WYe2w9UNhdqOoa0cd/zkyGLMdmTHw=="
     },
     "@labkey/build": {
       "version": "6.10.0",
@@ -11897,11 +11897,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.307.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.307.0.tgz",
-      "integrity": "sha512-V8bRPLqhKqV1JJXOIuLS54o5rk83VohHpBa7iwgmHJ7BqgTX0se06lO/8Pox3xw2buqvS5Wbr98M3guNHaj4Fw==",
+      "version": "2.325.1-fb-entity-insert-api.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
+      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
       "requires": {
-        "@labkey/api": "1.18.7",
+        "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.325.1-fb-entity-insert-api.0"
+        "@labkey/components": "2.325.1-fb-entity-insert-api.1"
       },
       "devDependencies": {
         "@labkey/build": "6.10.0",
@@ -2355,9 +2355,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
-      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
+      "version": "2.325.1-fb-entity-insert-api.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
+      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
       "dependencies": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
@@ -11897,9 +11897,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
-      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
+      "version": "2.325.1-fb-entity-insert-api.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
+      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
       "requires": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.325.1-fb-entity-insert-api.1"
+        "@labkey/components": "2.326.0"
       },
       "devDependencies": {
         "@labkey/build": "6.10.0",
@@ -2355,9 +2355,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
-      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
+      "version": "2.326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.326.0.tgz",
+      "integrity": "sha512-y+0UQi2cLhwja852JVHIFzleQn9d47seWK//LHArvwU8v+b/N+Mk3hxgsn02yZY5N+lk/3RsR8TGPZeSiyg1og==",
       "dependencies": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
@@ -11897,9 +11897,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
-      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
+      "version": "2.326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.326.0.tgz",
+      "integrity": "sha512-y+0UQi2cLhwja852JVHIFzleQn9d47seWK//LHArvwU8v+b/N+Mk3hxgsn02yZY5N+lk/3RsR8TGPZeSiyg1og==",
       "requires": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.325.1-fb-entity-insert-api.0"
+    "@labkey/components": "2.325.1-fb-entity-insert-api.1"
   },
   "devDependencies": {
     "@labkey/build": "6.10.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.307.0"
+    "@labkey/components": "2.325.1-fb-entity-insert-api.0"
   },
   "devDependencies": {
     "@labkey/build": "6.10.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.325.1-fb-entity-insert-api.1"
+    "@labkey/components": "2.326.0"
   },
   "devDependencies": {
     "@labkey/build": "6.10.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.19.0",
-        "@labkey/components": "2.325.1-fb-entity-insert-api.0",
+        "@labkey/components": "2.325.1-fb-entity-insert-api.1",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3057,9 +3057,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
-      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
+      "version": "2.325.1-fb-entity-insert-api.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
+      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
       "dependencies": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
@@ -17228,9 +17228,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
-      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
+      "version": "2.325.1-fb-entity-insert-api.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
+      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
       "requires": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.19.0",
-        "@labkey/components": "2.323.4",
+        "@labkey/components": "2.325.1-fb-entity-insert-api.0",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3057,9 +3057,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.323.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.323.4.tgz",
-      "integrity": "sha512-oLElOi2e90WboxXybSEOUTGb8NFTdY3798BzL0hRjBQrNjrs0qpndwY/SXd3sDQxulAqSyo6tPObDsrOB08/og==",
+      "version": "2.325.1-fb-entity-insert-api.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
+      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
       "dependencies": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
@@ -17228,9 +17228,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.323.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.323.4.tgz",
-      "integrity": "sha512-oLElOi2e90WboxXybSEOUTGb8NFTdY3798BzL0hRjBQrNjrs0qpndwY/SXd3sDQxulAqSyo6tPObDsrOB08/og==",
+      "version": "2.325.1-fb-entity-insert-api.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
+      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
       "requires": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.19.0",
-        "@labkey/components": "2.325.1-fb-entity-insert-api.1",
+        "@labkey/components": "2.326.0",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3057,9 +3057,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
-      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
+      "version": "2.326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.326.0.tgz",
+      "integrity": "sha512-y+0UQi2cLhwja852JVHIFzleQn9d47seWK//LHArvwU8v+b/N+Mk3hxgsn02yZY5N+lk/3RsR8TGPZeSiyg1og==",
       "dependencies": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
@@ -17228,9 +17228,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
-      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
+      "version": "2.326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.326.0.tgz",
+      "integrity": "sha512-y+0UQi2cLhwja852JVHIFzleQn9d47seWK//LHArvwU8v+b/N+Mk3hxgsn02yZY5N+lk/3RsR8TGPZeSiyg1og==",
       "requires": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.19.0",
-    "@labkey/components": "2.323.4",
+    "@labkey/components": "2.325.1-fb-entity-insert-api.0",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.19.0",
-    "@labkey/components": "2.325.1-fb-entity-insert-api.1",
+    "@labkey/components": "2.326.0",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.19.0",
-    "@labkey/components": "2.325.1-fb-entity-insert-api.0",
+    "@labkey/components": "2.325.1-fb-entity-insert-api.1",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/core/src/client/LabKeyUIComponentsPage/SampleInsertPage.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/SampleInsertPage.tsx
@@ -3,14 +3,11 @@
  * any form or by any electronic or mechanical means without written permission from LabKey Corporation.
  */
 import React, { FC, memo, useCallback, useEffect, useState } from 'react';
-import {
-    Alert,
-    EntityInsertPanel,
-    initQueryGridState,
-    SampleTypeDataType,
-    Location,
-} from '@labkey/components';
-
+import { Alert, initQueryGridState, SampleTypeDataType, Location } from '@labkey/components';
+// EntityInsertPanel has been moved to the entities subpackage in preparation for migration to @labkey/premium.
+// This import remains here due to test coverage within the core-components.view which will be moved to the application
+// suites when the EntityInsertPanel is migrated.
+import { EntityInsertPanel } from '@labkey/components/entities';
 
 interface Props {
     isUpdate?: boolean;

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.325.1-fb-entity-insert-api.1"
+        "@labkey/components": "2.326.0"
       },
       "devDependencies": {
         "@labkey/build": "6.10.0",
@@ -3023,9 +3023,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
-      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
+      "version": "2.326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.326.0.tgz",
+      "integrity": "sha512-y+0UQi2cLhwja852JVHIFzleQn9d47seWK//LHArvwU8v+b/N+Mk3hxgsn02yZY5N+lk/3RsR8TGPZeSiyg1og==",
       "dependencies": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
@@ -16120,9 +16120,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
-      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
+      "version": "2.326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.326.0.tgz",
+      "integrity": "sha512-y+0UQi2cLhwja852JVHIFzleQn9d47seWK//LHArvwU8v+b/N+Mk3hxgsn02yZY5N+lk/3RsR8TGPZeSiyg1og==",
       "requires": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.325.1-fb-entity-insert-api.0"
+        "@labkey/components": "2.325.1-fb-entity-insert-api.1"
       },
       "devDependencies": {
         "@labkey/build": "6.10.0",
@@ -3023,9 +3023,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
-      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
+      "version": "2.325.1-fb-entity-insert-api.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
+      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
       "dependencies": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
@@ -16120,9 +16120,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
-      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
+      "version": "2.325.1-fb-entity-insert-api.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
+      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
       "requires": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.323.2"
+        "@labkey/components": "2.325.1-fb-entity-insert-api.0"
       },
       "devDependencies": {
         "@labkey/build": "6.10.0",
@@ -3023,9 +3023,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.323.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.323.2.tgz",
-      "integrity": "sha512-Bv+fv0ZnuF2MkTQ+4Kk1So35DxS+ke8S20Gk9TtK1dnllNn+MQ5cTrGpIjp9Qn7LWEDFEkpmLEsxmkdlT5zUWg==",
+      "version": "2.325.1-fb-entity-insert-api.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
+      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
       "dependencies": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
@@ -16120,9 +16120,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.323.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.323.2.tgz",
-      "integrity": "sha512-Bv+fv0ZnuF2MkTQ+4Kk1So35DxS+ke8S20Gk9TtK1dnllNn+MQ5cTrGpIjp9Qn7LWEDFEkpmLEsxmkdlT5zUWg==",
+      "version": "2.325.1-fb-entity-insert-api.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
+      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
       "requires": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand --silent -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "2.323.2"
+    "@labkey/components": "2.325.1-fb-entity-insert-api.0"
   },
   "devDependencies": {
     "@labkey/build": "6.10.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand --silent -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "2.325.1-fb-entity-insert-api.1"
+    "@labkey/components": "2.326.0"
   },
   "devDependencies": {
     "@labkey/build": "6.10.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand --silent -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "2.325.1-fb-entity-insert-api.0"
+    "@labkey/components": "2.325.1-fb-entity-insert-api.1"
   },
   "devDependencies": {
     "@labkey/build": "6.10.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.325.1-fb-entity-insert-api.1"
+        "@labkey/components": "2.326.0"
       },
       "devDependencies": {
         "@labkey/build": "6.10.0",
@@ -2429,9 +2429,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
-      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
+      "version": "2.326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.326.0.tgz",
+      "integrity": "sha512-y+0UQi2cLhwja852JVHIFzleQn9d47seWK//LHArvwU8v+b/N+Mk3hxgsn02yZY5N+lk/3RsR8TGPZeSiyg1og==",
       "dependencies": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
@@ -13322,9 +13322,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
-      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
+      "version": "2.326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.326.0.tgz",
+      "integrity": "sha512-y+0UQi2cLhwja852JVHIFzleQn9d47seWK//LHArvwU8v+b/N+Mk3hxgsn02yZY5N+lk/3RsR8TGPZeSiyg1og==",
       "requires": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.307.0"
+        "@labkey/components": "2.325.1-fb-entity-insert-api.0"
       },
       "devDependencies": {
         "@labkey/build": "6.10.0",
@@ -2390,9 +2390,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.18.7",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.7.tgz",
-      "integrity": "sha512-MNSiG2xz5RzDKtucXBo5QMsToa8wxVWZc08Leh4mK+e9AhP/Tq7CKOs/+1wZS/mAetbWwB3fBnrMRkeo9relXg=="
+      "version": "1.19.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.19.0.tgz",
+      "integrity": "sha512-LkMWTo/8ScVsptNZvwRrEAx4V9set01HZzfjHIbyTCDQL9CeGhIDK4du+WYe2w9UNhdqOoa0cd/zkyGLMdmTHw=="
     },
     "node_modules/@labkey/build": {
       "version": "6.10.0",
@@ -2429,11 +2429,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.307.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.307.0.tgz",
-      "integrity": "sha512-V8bRPLqhKqV1JJXOIuLS54o5rk83VohHpBa7iwgmHJ7BqgTX0se06lO/8Pox3xw2buqvS5Wbr98M3guNHaj4Fw==",
+      "version": "2.325.1-fb-entity-insert-api.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
+      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
       "dependencies": {
-        "@labkey/api": "1.18.7",
+        "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",
@@ -13283,9 +13283,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.18.7",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.18.7.tgz",
-      "integrity": "sha512-MNSiG2xz5RzDKtucXBo5QMsToa8wxVWZc08Leh4mK+e9AhP/Tq7CKOs/+1wZS/mAetbWwB3fBnrMRkeo9relXg=="
+      "version": "1.19.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.19.0.tgz",
+      "integrity": "sha512-LkMWTo/8ScVsptNZvwRrEAx4V9set01HZzfjHIbyTCDQL9CeGhIDK4du+WYe2w9UNhdqOoa0cd/zkyGLMdmTHw=="
     },
     "@labkey/build": {
       "version": "6.10.0",
@@ -13322,11 +13322,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.307.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.307.0.tgz",
-      "integrity": "sha512-V8bRPLqhKqV1JJXOIuLS54o5rk83VohHpBa7iwgmHJ7BqgTX0se06lO/8Pox3xw2buqvS5Wbr98M3guNHaj4Fw==",
+      "version": "2.325.1-fb-entity-insert-api.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
+      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
       "requires": {
-        "@labkey/api": "1.18.7",
+        "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
         "classnames": "~2.3.2",
         "enzyme": "~3.11.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.325.1-fb-entity-insert-api.0"
+        "@labkey/components": "2.325.1-fb-entity-insert-api.1"
       },
       "devDependencies": {
         "@labkey/build": "6.10.0",
@@ -2429,9 +2429,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
-      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
+      "version": "2.325.1-fb-entity-insert-api.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
+      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
       "dependencies": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",
@@ -13322,9 +13322,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.325.1-fb-entity-insert-api.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.0.tgz",
-      "integrity": "sha512-e5jYrHR2iFhUgWFNayN7mdlch/FJYSahEpMZnM3ekqiXM7i64q5ppU8XoKrvxIyb0GeBl3dRvJPP96W1G6X2nQ==",
+      "version": "2.325.1-fb-entity-insert-api.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.325.1-fb-entity-insert-api.1.tgz",
+      "integrity": "sha512-bCE3Gx1bC/k5f+cSLBUiKcX9k3AV0sRY3VMoe0eREsD6abE6Gjy/5m7EiIGKnE5JR5hZI/MOqVcKaisoEXhVag==",
       "requires": {
         "@labkey/api": "1.19.0",
         "bootstrap": "~3.4.1",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "2.325.1-fb-entity-insert-api.0"
+    "@labkey/components": "2.325.1-fb-entity-insert-api.1"
   },
   "devDependencies": {
     "@labkey/build": "6.10.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "2.307.0"
+    "@labkey/components": "2.325.1-fb-entity-insert-api.0"
   },
   "devDependencies": {
     "@labkey/build": "6.10.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "2.325.1-fb-entity-insert-api.1"
+    "@labkey/components": "2.326.0"
   },
   "devDependencies": {
     "@labkey/build": "6.10.0",


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/labkey-ui-components/pull/1173 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1173
- https://github.com/LabKey/labkey-ui-premium/pull/78
- https://github.com/LabKey/sampleManagement/pull/1770
- https://github.com/LabKey/biologics/pull/2093
- https://github.com/LabKey/inventory/pull/823
- https://github.com/LabKey/platform/pull/4301

#### Changes
- Bump `@labkey/components`.
- Update import paths for migrated components.
- `EntityInsertPanel` now resides in `@labkey/components/entities`. This is still accessible from the import of `@labkey/components` so continuing to utilize here. There is open discussion on if/when tests should be migrated and to where.
