### PR TITLE
Improve performance/caching of scriptContext for trigger scripts

### DIFF
--- a/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
+++ b/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
@@ -307,12 +307,11 @@ public class ScriptTrigger implements Trigger
 
     private Script getServerContext(Container c, User u)
     {
-        JSONObject json = PageFlowUtil.jsInitObject(ContainerUser.create(c, u), null, new LinkedHashSet<>(), false);
-
+        String jsCode = "org.labkey.api.util.PageFlowUtil.jsInitObject(org.labkey.api.writer.ContainerUser.create(org.labkey.api.data.ContainerManager.getForId('" + c.getId() + "'), org.labkey.api.security.UserManager.getUser(" + u.getUserId() + ")), null, null, false).toMap()";
         Context ctx = Context.enter();
         try
         {
-            return ctx.compileString("module.exports = " + json.toString(), "serverContext.js", 1, null);
+            return ctx.compileString("module.exports = " + jsCode, "serverContext.js", 1, null);
         }
         finally
         {


### PR DESCRIPTION
I noticed an ETL was taking much longer than previously. When I profiled it in Jprofiler, I saw that this is probably due to constantly recompiling serverContext in RhinoService, which was added in #3942.. 

I believe this PR addresses that, by calculating serverContext once, and caching this instead of just caching ContainerUser. When I tried this locally, it restored perf back to close to where it was before. 

@labkey-nicka: I think you reviewed the original feature - thoughts on this?