### PR TITLE
Improve ETL support for remote data and delete sources

### DIFF
--- a/api/src/org/labkey/api/data/JsonWriter.java
+++ b/api/src/org/labkey/api/data/JsonWriter.java
@@ -101,6 +101,7 @@ public class JsonWriter
         props.put("jsonType", dc.getJsonTypeName());
         props.put("sqlType", cinfo == null ? null : cinfo.getSqlTypeName());
         props.put("defaultValue", cinfo == null ? null : cinfo.getDefaultValue());
+        props.put("jdbcType", cinfo == null ? null : cinfo.getJdbcType().name());
 
         if (includeDomainFormat)
         {

--- a/api/src/org/labkey/api/query/QuerySettings.java
+++ b/api/src/org/labkey/api/query/QuerySettings.java
@@ -649,7 +649,7 @@ public class QuerySettings
 
     public void setOffset(long offset)
     {
-        assert (offset == Table.NO_OFFSET && _showRows != ShowRows.PAGINATED) || _showRows == ShowRows.PAGINATED : "Can't set maxRows when not paginated";
+        assert (offset == Table.NO_OFFSET && _showRows != ShowRows.PAGINATED) || _showRows == ShowRows.PAGINATED : "Can't set offset when not paginated";
         _offset = offset;
     }
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -3166,7 +3166,8 @@ public class QueryController extends SpringActionController
         {
             QuerySettings results = super.createQuerySettings(schema);
 
-            boolean missingShowRows = null == getViewContext().getRequest().getParameter(getDataRegionName() + "." + QueryParam.showRows);
+            // See dataintegration/202: The java client api / remote ETL calls selectRows with showRows=all. We need to test _initParameters to properly read this
+            boolean missingShowRows = null == getViewContext().getRequest().getParameter(getDataRegionName() + "." + QueryParam.showRows) && null == _initParameters.getPropertyValue(getDataRegionName() + "." + QueryParam.showRows);
             if (null == getLimit() && !results.isMaxRowsSet() && missingShowRows)
             {
                 results.setShowRows(ShowRows.PAGINATED);


### PR DESCRIPTION
#### Rationale
Originally opened using the bbimber/platform, here: https://github.com/LabKey/platform/pull/4239

This is related to https://github.com/LabKey/dataintegration/pull/202, which is designed to refactor dataintegration to better support remote data sources. In platform, this change will include jdbcType in the column JSON, in addition to SqlType. This is needed to allow the server to interrogate the remote data source, because the existing sqlType property is not detailed enough. Column having sqlType = timestamp can be either binary or datetime. Knowing that difference is required in the ETL for incremental updates.
