### PR TITLE
Improve performance for trigger scripts and serverContext

### DIFF
--- a/api/src/org/labkey/api/data/JsonWriter.java
+++ b/api/src/org/labkey/api/data/JsonWriter.java
@@ -101,6 +101,7 @@ public class JsonWriter
         props.put("jsonType", dc.getJsonTypeName());
         props.put("sqlType", cinfo == null ? null : cinfo.getSqlTypeName());
         props.put("defaultValue", cinfo == null ? null : cinfo.getDefaultValue());
+        props.put("jdbcType", cinfo == null ? null : cinfo.getJdbcType().name());
 
         if (includeDomainFormat)
         {

--- a/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
+++ b/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
@@ -17,7 +17,6 @@ package org.labkey.api.data.triggers;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.JSONObject;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.PHI;
@@ -26,12 +25,10 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.script.ScriptReference;
 import org.labkey.api.security.User;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
-import org.labkey.api.writer.ContainerUser;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.commonjs.module.ModuleScript;
@@ -44,7 +41,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -305,7 +301,7 @@ public class ScriptTrigger implements Trigger
         }
     }
 
-    private Script getServerContext(Container c, User u)
+    public static Script getServerContext(Container c, User u)
     {
         String jsCode = "org.labkey.api.util.PageFlowUtil.jsInitObject(org.labkey.api.writer.ContainerUser.create(org.labkey.api.data.ContainerManager.getForId('" + c.getId() + "'), org.labkey.api.security.UserManager.getUser(" + u.getUserId() + ")), null, null, false).toMap()";
         Context ctx = Context.enter();

--- a/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
+++ b/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
@@ -18,6 +18,7 @@ package org.labkey.api.data.triggers;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.PHI;
 import org.labkey.api.data.TableInfo;
@@ -25,10 +26,13 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.script.ScriptReference;
 import org.labkey.api.security.User;
+import org.labkey.api.security.UserManager;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
+import org.labkey.api.writer.ContainerUser;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.commonjs.module.ModuleScript;
@@ -303,7 +307,7 @@ public class ScriptTrigger implements Trigger
 
     public static Script getServerContext(Container c, User u)
     {
-        String jsCode = "org.labkey.api.util.PageFlowUtil.jsInitObject(org.labkey.api.writer.ContainerUser.create(org.labkey.api.data.ContainerManager.getForId('" + c.getId() + "'), org.labkey.api.security.UserManager.getUser(" + u.getUserId() + ")), null, null, false).toMap()";
+        String jsCode = PageFlowUtil.class.getName() + ".jsInitObject(" + ContainerUser.class.getName() + ".create(" + ContainerManager.class.getName() + ".getForId(" + PageFlowUtil.jsString(c.getId()) + "), " + UserManager.class.getName() + ".getUser(" + u.getUserId() + ")), null, null, false).toMap()";
         Context ctx = Context.enter();
         try
         {

--- a/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
+++ b/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
@@ -307,12 +307,11 @@ public class ScriptTrigger implements Trigger
 
     private Script getServerContext(Container c, User u)
     {
-        JSONObject json = PageFlowUtil.jsInitObject(ContainerUser.create(c, u), null, new LinkedHashSet<>(), false);
-
+        String jsCode = "org.labkey.api.util.PageFlowUtil.jsInitObject(org.labkey.api.writer.ContainerUser.create(org.labkey.api.data.ContainerManager.getForId('" + c.getId() + "'), org.labkey.api.security.UserManager.getUser(" + u.getUserId() + ")), null, null, false).toMap()";
         Context ctx = Context.enter();
         try
         {
-            return ctx.compileString("module.exports = " + json.toString(), "serverContext.js", 1, null);
+            return ctx.compileString("module.exports = " + jsCode, "serverContext.js", 1, null);
         }
         finally
         {

--- a/api/src/org/labkey/api/query/QuerySettings.java
+++ b/api/src/org/labkey/api/query/QuerySettings.java
@@ -649,7 +649,7 @@ public class QuerySettings
 
     public void setOffset(long offset)
     {
-        assert (offset == Table.NO_OFFSET && _showRows != ShowRows.PAGINATED) || _showRows == ShowRows.PAGINATED : "Can't set maxRows when not paginated";
+        assert (offset == Table.NO_OFFSET && _showRows != ShowRows.PAGINATED) || _showRows == ShowRows.PAGINATED : "Can't set offset when not paginated";
         _offset = offset;
     }
 

--- a/core/src/org/labkey/core/script/RhinoService.java
+++ b/core/src/org/labkey/core/script/RhinoService.java
@@ -203,12 +203,13 @@ public final class RhinoService
         {
             Path js = Path.parse(ScriptService.SCRIPTS_DIR + "/validationTest/" + scriptName + ".js");
             ScriptReference script = ScriptService.get().compile(_module, js);
-            script.getContext().setAttribute("ContainerUser", HttpView.currentContext(), ScriptContext.ENGINE_SCOPE);
+
+            script.getContext().setAttribute(SERVER_CONTEXT_KEY, ScriptTrigger.ServerContextModuleScript.create(ScriptTrigger.getServerContext(HttpView.currentContext().getContainer(), HttpView.currentContext().getUser())), ScriptContext.ENGINE_SCOPE);
             script.invokeFn("doTest");
 
             // Now check the caches:
             script = ScriptService.get().compile(_module, js);
-            Assert.assertNull("Cached script should not store container", script.getContext().getAttribute("ContainerUser"));
+            Assert.assertNull("Cached script should not store serverContext", script.getContext().getAttribute(SERVER_CONTEXT_KEY));
         }
 
         @Test

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -3166,7 +3166,8 @@ public class QueryController extends SpringActionController
         {
             QuerySettings results = super.createQuerySettings(schema);
 
-            boolean missingShowRows = null == getViewContext().getRequest().getParameter(getDataRegionName() + "." + QueryParam.showRows);
+            // See dataintegration/202: The java client api / remote ETL calls selectRows with showRows=all. We need to test _initParameters to properly read this
+            boolean missingShowRows = null == getViewContext().getRequest().getParameter(getDataRegionName() + "." + QueryParam.showRows) && null == _initParameters.getPropertyValue(getDataRegionName() + "." + QueryParam.showRows);
             if (null == getLimit() && !results.isMaxRowsSet() && missingShowRows)
             {
                 results.setShowRows(ShowRows.PAGINATED);

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1740,7 +1740,7 @@ public class QueryController extends SpringActionController
                     // Split arrays into individual pairs to be bound (Issue #45452)
                     for (int i = 0; i < val.length(); i++)
                     {
-                        properties.add(new PropertyValue(key, val.getString(i)));
+                        properties.add(new PropertyValue(key, val.get(i).toString()));
                     }
                 }
                 else


### PR DESCRIPTION
I originally opened this PR using a branch on bbimber/platform, but now I can make branches here, so I'm closing that PR in favor of this.

Background:

I noticed an ETL was taking much longer than previously. When I profiled it in Jprofiler, I saw that this is probably due to constantly recompiling serverContext in RhinoService, which was added in https://github.com/LabKey/platform/pull/3942..

I believe this PR addresses that, by calculating serverContext once, and caching this instead of just caching ContainerUser. When I tried this locally, it restored perf back to close to where it was before.

I also took it a step further. Rather than request the entire jsInitObject and serialize to a string every single time, it makes a whole lot more sense to lazily call jsInitObject only when code requests serverContext. So in summary:

- Cache the compiled ModuleScript
- Within that script, lazily request jsInitObject, rather than request it upfront and store that big JSON string

@labkey-nicka: I think you reviewed the original feature - thoughts on this?