### PR TITLE
Fix class cast exception in SurveyManager

### DIFF
--- a/api/src/org/labkey/api/data/JsonWriter.java
+++ b/api/src/org/labkey/api/data/JsonWriter.java
@@ -19,8 +19,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONArray;
-import org.json.old.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.labkey.api.compliance.PhiTransformedColumnInfo;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.property.IPropertyValidator;
@@ -287,7 +287,7 @@ public class JsonWriter
 
         if (includeLookup && cinfo != null)
         {
-            Map<String, Object> lookupJSON = getLookupInfo(cinfo, includeDomainFormat);
+            JSONObject lookupJSON = getLookupInfo(cinfo, includeDomainFormat);
             if (lookupJSON != null)
             {
                 props.put("lookup", lookupJSON);

--- a/query/src/org/labkey/query/persist/QueryManager.java
+++ b/query/src/org/labkey/query/persist/QueryManager.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONObject;
+import org.json.JSONObject;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;

--- a/survey/src/org/labkey/survey/SurveyManager.java
+++ b/survey/src/org/labkey/survey/SurveyManager.java
@@ -116,7 +116,7 @@ public class SurveyManager
     }
 
     @Nullable
-    public org.json.JSONObject createSurveyTemplate(ViewContext context, String schemaName, String queryName)
+    public JSONObject createSurveyTemplate(ViewContext context, String schemaName, String queryName)
     {
         BindException errors = new NullSafeBindException(this, "form");
         UserSchema schema = QueryService.get().getUserSchema(context.getUser(), context.getContainer(), schemaName);
@@ -177,7 +177,7 @@ public class SurveyManager
                 survey.put("sections", Collections.singletonList(panel));
             }
         }
-        return new org.json.JSONObject(survey);
+        return new JSONObject(survey);
     }
 
     public List<String> getKeyMetaDataProps()

--- a/visualization/src/org/labkey/visualization/VisualizationServiceImpl.java
+++ b/visualization/src/org/labkey/visualization/VisualizationServiceImpl.java
@@ -300,7 +300,7 @@ public class VisualizationServiceImpl implements VisualizationService
         props.put("isRecommendedVariable", col.isRecommendedVariable());
         props.put("defaultScale", col.getDefaultScale().name());
 
-        Map<String, Object> lookupJSON = JsonWriter.getLookupInfo(col, false);
+        org.json.JSONObject lookupJSON = JsonWriter.getLookupInfo(col, false);
         if (lookupJSON != null)
         {
             props.put("lookup", lookupJSON);


### PR DESCRIPTION
#### Rationale
`SurveyTest` is failing due to a class cast exception.

This test pointed out that `SurveyManager` was incorrectly casting the "lookup" entry in the map returned by `JsonWriter.getMetaData()` to a new `JSONObject`. Fix by switching JsonWriter to use the new library. I could have gone with a more targeted fix, but this is the direction we want to move.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4296