### PR TITLE
Reject mutating SQL in GETs in prod mode too

### DIFF
--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -1275,17 +1275,7 @@ public abstract class SpringActionController implements Controller, HasViewConte
             String message = "MUTATING SQL executed as part of handling action: " +
                     (null == vc ? "" : vc.getRequest().getMethod()) + " " +
                     c.getName() + (verbose ? ("\n" + sql) : "");
-            IllegalStateException e = new IllegalStateException(message);
-
-            if (AppProps.getInstance().isDevMode())
-            {
-                throw e;
-            }
-            else
-            {
-                HttpServletRequest request = null != vc ? vc.getRequest() : null;
-                ExceptionUtil.logExceptionToMothership(request, e);
-            }
+            throw new IllegalStateException(message);
         }
     }
 


### PR DESCRIPTION
#### Rationale
Since 2019 we've detected and rejected mutating SQL in dev mode. We presumably allowed it in prod mode because we were worried we had missed something in our CSRF protection updates. I think we should be safe now.

#### Changes
* Throw IllegalStateExceptions in both dev and prod modes