### PR TITLE
Fix data type exceptions during Excel export

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1740,7 +1740,7 @@ public class QueryController extends SpringActionController
                     // Split arrays into individual pairs to be bound (Issue #45452)
                     for (int i = 0; i < val.length(); i++)
                     {
-                        properties.add(new PropertyValue(key, val.getString(i)));
+                        properties.add(new PropertyValue(key, val.get(i).toString()));
                     }
                 }
                 else


### PR DESCRIPTION
#### Rationale
LKSM customers have occasionally seen data type exceptions when exporting to Excel: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47720

New `JSONArray.getString()` throws if the value is not a `String`. Old version of this method would `get().toString()`. Solution is to mimic the old code.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3955
