### PR TITLE
Use non-deprecated JSON-related method and interface names

### DIFF
--- a/announcements/src/org/labkey/announcements/SendMessageAction.java
+++ b/announcements/src/org/labkey/announcements/SendMessageAction.java
@@ -17,7 +17,6 @@
 package org.labkey.announcements;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -182,7 +181,7 @@ public class SendMessageAction extends MutatingApiAction<SendMessageAction.Messa
     private String[] resolveEmailAddress(JSONObject recipient)
     {
         String address = recipient.getString(MsgRecipient.address.name());
-        int principalId = NumberUtils.toInt(recipient.getString(MsgRecipient.principalId.name()), -100);
+        int principalId = recipient.optInt(MsgRecipient.principalId.name(), -100);
 
         if (address != null)
         {

--- a/announcements/src/org/labkey/announcements/SendMessageAction.java
+++ b/announcements/src/org/labkey/announcements/SendMessageAction.java
@@ -22,9 +22,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONArray;
-import org.json.old.JSONException;
-import org.json.old.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
 import org.labkey.api.action.MutatingApiAction;
@@ -39,6 +39,7 @@ import org.labkey.api.security.ValidEmail;
 import org.labkey.api.security.permissions.CanUseSendMessageApiPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.roles.EmailNonUsersPermission;
+import org.labkey.api.util.JsonUtil;
 import org.labkey.api.util.MailHelper;
 import org.labkey.api.view.NotFoundException;
 import org.springframework.validation.BindException;
@@ -61,7 +62,7 @@ import static java.lang.Boolean.TRUE;
 public class SendMessageAction extends MutatingApiAction<SendMessageAction.MessageForm>
 {
     private static final Logger _log = LogManager.getLogger(SendMessageAction.class);
-    private Map<String, Set<String>> _recipientMap = new HashMap<>();
+    private final Map<String, Set<String>> _recipientMap = new HashMap<>();
 
     enum Props
     {
@@ -93,33 +94,21 @@ public class SendMessageAction extends MutatingApiAction<SendMessageAction.Messa
         if (!getContainer().hasPermission(getUser(), CanUseSendMessageApiPermission.class) && !getUser().hasRootPermission(CanUseSendMessageApiPermission.class))
             throw new IllegalArgumentException("The current user does not have permission to use the SendMessage API.");
 
-        JSONObject json = form.getOldJsonObject();
+        JSONObject json = form.getJsonObject();
         if (null == json)
             json = new JSONObject();
-        String from = json.getString(Props.msgFrom.name());
-        String subject = json.getString(Props.msgSubject.name());
-        JSONArray recipients;
-        JSONArray contents;
+        String from = json.optString(Props.msgFrom.name());
+        String subject = json.optString(Props.msgSubject.name());
 
         if (from == null)
             throw new IllegalArgumentException("You must supply a msgFrom value.");
 
-        if (json.containsKey(Props.msgRecipients.name()))
-        {
-            recipients = json.getJSONArray(Props.msgRecipients.name());
-            if (recipients == null || recipients.length() < 1)
-                throw new IllegalArgumentException("No message recipients supplied.");
-        }
-        else
+        JSONArray recipients = json.optJSONArray(Props.msgRecipients.name());
+        if (recipients == null || recipients.length() < 1)
             throw new IllegalArgumentException("No message recipients supplied.");
 
-        if (json.containsKey(Props.msgContent.name()))
-        {
-            contents = json.getJSONArray(Props.msgContent.name());
-            if (contents == null || contents.length() < 1)
-                throw new IllegalArgumentException("No message contents supplied.");
-        }
-        else
+        JSONArray contents = json.optJSONArray(Props.msgContent.name());
+        if (contents == null || contents.length() < 1)
             throw new IllegalArgumentException("No message contents supplied.");
 
         MailHelper.MultipartMessage msg = MailHelper.createMultipartMessage();
@@ -230,9 +219,8 @@ public class SendMessageAction extends MutatingApiAction<SendMessageAction.Messa
     {
         try
         {
-            for (int i=0; i < recipients.length(); i++)
+            for (JSONObject recipient : JsonUtil.toJSONObjectList(recipients))
             {
-                JSONObject recipient = recipients.getJSONObject(i);
                 String type = recipient.getString(MsgRecipient.type.name());
                 Message.RecipientType rtype = Message.RecipientType.TO;
 
@@ -269,12 +257,11 @@ public class SendMessageAction extends MutatingApiAction<SendMessageAction.Messa
 
     private void addMsgContents(MailHelper.MultipartMessage msg, JSONArray contents) throws Exception
     {
-        for (int i=0; i < contents.length(); i++)
+        for (JSONObject part : JsonUtil.toJSONObjectList(contents))
         {
             try
             {
-                JSONObject part = contents.getJSONObject(i);
-                if (part.getString(MsgContent.type.name()) != null && part.getString(MsgContent.type.name()).trim().toLowerCase().startsWith("text/plain"))
+                if (part.optString(MsgContent.type.name(), null) != null && part.getString(MsgContent.type.name()).trim().toLowerCase().startsWith("text/plain"))
                 {
                     msg.setTextContent(part.getString(MsgContent.content.name()));
                 }

--- a/api/src/org/labkey/api/action/SimpleApiJsonForm.java
+++ b/api/src/org/labkey/api/action/SimpleApiJsonForm.java
@@ -28,12 +28,6 @@ public class SimpleApiJsonForm implements ApiJsonForm
     }
 
     @Deprecated
-    public org.json.old.JSONObject getOldJsonObject()
-    {
-        return null != _json ? new org.json.old.JSONObject(_json.toString()) : null;
-    }
-
-    @Deprecated
     public JSONObject getNewJsonObject()
     {
         return _json;

--- a/api/src/org/labkey/api/pipeline/PipelineProtocolFactory.java
+++ b/api/src/org/labkey/api/pipeline/PipelineProtocolFactory.java
@@ -145,12 +145,6 @@ public abstract class PipelineProtocolFactory<T extends PipelineProtocol>
         return getProtocolDir(root, archived).resolve(name + ".xml");
     }
 
-    @Deprecated //Prefer the Path version
-    public String[] getProtocolNames(PipeRoot root, File dirData, boolean archived)
-    {
-        return getProtocolNames(root, dirData.toPath(), archived);
-    }
-
     /** @return sorted list of protocol names */
     public String[] getProtocolNames(PipeRoot root, Path dirData, boolean archived)
     {

--- a/assay/src/org/labkey/assay/actions/GetAssayBatchAction.java
+++ b/assay/src/org/labkey/assay/actions/GetAssayBatchAction.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.assay.actions;
 
+import org.json.JSONObject;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.SimpleApiJsonForm;
 import org.labkey.api.assay.DefaultAssaySaveHandler;
@@ -25,10 +26,6 @@ import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.springframework.validation.BindException;
 
-/**
- * User: jeckels
- * Date: Jan 15, 2009
- */
 @RequiresPermission(ReadPermission.class)
 public class GetAssayBatchAction extends BaseProtocolAPIAction<SimpleApiJsonForm>
 {
@@ -36,9 +33,10 @@ public class GetAssayBatchAction extends BaseProtocolAPIAction<SimpleApiJsonForm
     public ApiResponse executeAction(ExpProtocol protocol, SimpleApiJsonForm form, BindException errors)
     {
         ExpExperiment batch = null;
-        if (form.getOldJsonObject().has(AssayJSONConverter.BATCH_ID))
+        JSONObject json = form.getJsonObject();
+        if (json.has(AssayJSONConverter.BATCH_ID))
         {
-            int batchId = form.getOldJsonObject().getInt(AssayJSONConverter.BATCH_ID);
+            int batchId = json.getInt(AssayJSONConverter.BATCH_ID);
             batch = DefaultAssaySaveHandler.lookupBatch(getContainer(), batchId);
         }
 

--- a/assay/src/org/labkey/assay/actions/GetAssayBatchesAction.java
+++ b/assay/src/org/labkey/assay/actions/GetAssayBatchesAction.java
@@ -15,7 +15,8 @@
  */
 package org.labkey.assay.actions;
 
-import org.json.old.JSONArray;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.SimpleApiJsonForm;
 import org.labkey.api.assay.DefaultAssaySaveHandler;
@@ -36,9 +37,10 @@ public class GetAssayBatchesAction extends BaseProtocolAPIAction<SimpleApiJsonFo
     public ApiResponse executeAction(ExpProtocol protocol, SimpleApiJsonForm form, BindException errors)
     {
         List<ExpExperiment> batches = new ArrayList<>();
-        if (form.getOldJsonObject().has(AssayJSONConverter.BATCH_IDS))
+        JSONObject json = form.getJsonObject();
+        if (json.has(AssayJSONConverter.BATCH_IDS))
         {
-            JSONArray batchIds = form.getOldJsonObject().getJSONArray(AssayJSONConverter.BATCH_IDS);
+            JSONArray batchIds = json.getJSONArray(AssayJSONConverter.BATCH_IDS);
             for (int idx = 0; idx < batchIds.length(); idx++)
             {
                 int batchId = batchIds.getInt(idx);

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -19,7 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONArray;
+import org.json.JSONArray;
 import org.labkey.api.attachments.AttachmentFile;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
@@ -877,13 +877,13 @@ public class ExpDataIterators
                             }
                         }
                     }
-                    else if (o instanceof JSONArray)
+                    else if (o instanceof org.json.old.JSONArray ja)
                     {
-                        parentNames = Arrays.stream(((JSONArray) o).toArray()).map(String::valueOf).collect(Collectors.toSet());
+                        parentNames = Arrays.stream(ja.toArray()).map(String::valueOf).collect(Collectors.toSet());
                     }
-                    else if (o instanceof org.json.JSONArray)
+                    else if (o instanceof JSONArray ja)
                     {
-                        parentNames = ((org.json.JSONArray) o).toList().stream().map(String::valueOf).collect(Collectors.toSet());
+                        parentNames = ja.toList().stream().map(String::valueOf).collect(Collectors.toSet());
                     }
                     else if (o instanceof Collection)
                     {

--- a/pipeline/src/org/labkey/pipeline/analysis/AnalysisController.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/AnalysisController.java
@@ -23,8 +23,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONArray;
-import org.json.old.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
 import org.labkey.api.action.ApiUsageException;
@@ -262,9 +262,9 @@ public class AnalysisController extends SpringActionController
                                 continue;
                         }
 
-                        for (String protocolName : props.getFactory().getProtocolNames(wbRoot, wbDirData, false))
+                        for (String protocolName : props.getFactory().getProtocolNames(wbRoot, wbDirData.toPath(), false))
                         {
-                            protocols.put(getProtocolJson(protocolName, wbRoot, wbDirData, props.getFactory()));
+                            protocols.put(getProtocolJson(protocolName, wbRoot, wbDirData.toPath(), props.getFactory()));
                         }
                     }
                 }
@@ -274,12 +274,6 @@ public class AnalysisController extends SpringActionController
             result.put("protocols", protocols);
             result.put("defaultProtocolName", PipelineService.get().getLastProtocolSetting(props.getFactory(), getContainer(), getUser()));
             return new ApiSimpleResponse(result);
-        }
-
-        @Deprecated //Prefer the Path version
-        protected JSONObject getProtocolJson(String protocolName, PipeRoot root, File dirData, AbstractFileAnalysisProtocolFactory<?> factory) throws NotFoundException
-        {
-            return getProtocolJson(protocolName, root, dirData.toPath(), factory);
         }
 
         protected JSONObject getProtocolJson(String protocolName, PipeRoot root, @Nullable Path dirData, AbstractFileAnalysisProtocolFactory<?> factory) throws NotFoundException


### PR DESCRIPTION
#### Rationale
`getNewJsonObject()` and `NewCustomApiForm` have replacements with better names

Also, remove some File-taking methods in favor of Path-taking variants and clean up a few miscellaneous old JSONObject references