### PR TITLE
SendMessageAction supports address or principalId as recipient

### DIFF
--- a/announcements/src/org/labkey/announcements/SendMessageAction.java
+++ b/announcements/src/org/labkey/announcements/SendMessageAction.java
@@ -180,7 +180,7 @@ public class SendMessageAction extends MutatingApiAction<SendMessageAction.Messa
 
     private String[] resolveEmailAddress(JSONObject recipient)
     {
-        String address = recipient.getString(MsgRecipient.address.name());
+        String address = recipient.optString(MsgRecipient.address.name());
         int principalId = recipient.optInt(MsgRecipient.principalId.name(), -100);
 
         if (address != null)


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_Bvt/2401619?hideProblemsFromDependencies=false&expandBuildTestsSection=true&hideTestsFromDependencies=false&expandBuildChangesSection=true

```
org.json.JSONException: JSONObject["address"] not found.
	at org.json.JSONObject.get(JSONObject.java:570) ~[json-20230227.jar:?]
	at org.json.JSONObject.getString(JSONObject.java:857) ~[json-20230227.jar:?]
	at org.labkey.announcements.SendMessageAction.resolveEmailAddress(SendMessageAction.java:183) ~[announcements-23.5-SNAPSHOT.jar:?]
	at org.labkey.announcements.SendMessageAction.addMsgRecipients(SendMessageAction.java:236) ~[announcements-23.5-SNAPSHOT.jar:?]
	at org.labkey.announcements.SendMessageAction.execute(SendMessageAction.java:119) ~[announcements-23.5-SNAPSHOT.jar:?]
```

#### Changes
* Treat `address` as an optional property