### PR TITLE
Performance Evaluation for Data at Scale - sample detailed audit logging

### DIFF
--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
@@ -56,6 +57,7 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
     final boolean useMark;
     int lastPrefetchRowNumber = -1;
     final HashMap<Integer,Map<String,Object>> existingRecords = new HashMap<>();
+    final Set<String> _dataColumnNames = new CaseInsensitiveHashSet();
 
     final User user;
     final Container c;
@@ -90,6 +92,9 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
         containerCol = map.get("Container");
 
         Collection<String> keyNames = null==keys ? target.getPkColumnNames() : keys;
+
+        _dataColumnNames.addAll(detailed ? map.keySet() : keyNames);
+
         for (String name : keyNames)
         {
             Integer index = map.get(name);
@@ -372,7 +377,7 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
                 }
                 while (--rowsToFetch > 0 && _delegate.next());
 
-                Map<Integer, Map<String, Object>> rowsMap = qus.getExistingRows(user, c, keysMap, _checkCrossFolderData, _verifyExisting, _getDetailedData);
+                Map<Integer, Map<String, Object>> rowsMap = qus.getExistingRows(user, c, keysMap, _checkCrossFolderData, _verifyExisting, _dataColumnNames);
                 for (Map.Entry<Integer, Map<String, Object>> rowMap : rowsMap.entrySet())
                 {
                     Map<String, Object> map = rowMap.getValue();

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -173,7 +173,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
     }
 
     @Override
-    public Map<Integer, Map<String, Object>> getExistingRows(User user, Container container, Map<Integer, Map<String, Object>> keys, boolean verifyNoCrossFolderData, boolean verifyExisting, boolean getDetails)
+    public Map<Integer, Map<String, Object>> getExistingRows(User user, Container container, Map<Integer, Map<String, Object>> keys, boolean verifyNoCrossFolderData, boolean verifyExisting, @Nullable Set<String> columns)
             throws InvalidKeyException, QueryUpdateServiceException, SQLException
     {
         if (!hasPermission(user, ReadPermission.class))

--- a/api/src/org/labkey/api/query/CacheClearingQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/CacheClearingQueryUpdateService.java
@@ -26,6 +26,7 @@ import org.labkey.api.security.permissions.Permission;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A simple wrapper around another QueryUpdateService. All of the real work is delegated through, but
@@ -59,10 +60,10 @@ public abstract class CacheClearingQueryUpdateService implements QueryUpdateServ
     }
 
     @Override
-    public Map<Integer, Map<String, Object>> getExistingRows(User user, Container container, Map<Integer, Map<String, Object>> keys, boolean verifyNoCrossFolderData, boolean verifyExisting, boolean getDetails)
+    public Map<Integer, Map<String, Object>> getExistingRows(User user, Container container, Map<Integer, Map<String, Object>> keys, boolean verifyNoCrossFolderData, boolean verifyExisting, Set<String> columns)
             throws InvalidKeyException, QueryUpdateServiceException, SQLException
     {
-        var ret = _service.getExistingRows(user, container, keys, verifyNoCrossFolderData, verifyExisting, getDetails);
+        var ret = _service.getExistingRows(user, container, keys, verifyNoCrossFolderData, verifyExisting, columns);
         clearCache();
         return ret;
     }

--- a/api/src/org/labkey/api/query/QueryUpdateService.java
+++ b/api/src/org/labkey/api/query/QueryUpdateService.java
@@ -25,6 +25,8 @@ import org.labkey.api.security.User;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 /**
  * This interface should be implemented by modules that expose queries
  * that can be updated by the HTTP-based APIs, or any other code that
@@ -133,13 +135,13 @@ public interface QueryUpdateService extends HasPermission
      * @param keys      A map of primary key values for each rowNumber.
      * @param verifyNoCrossFolderData      Throw exception if any key belongs to data outside the desired container.
      * @param verifyExisting      Throw exception if no existing record is found for any row.
-     * @param getDetails      If true, get extra lookup/lineage data
+     * @param columns      Columns that should be included in the result
      * @return The rows data as maps for each rowNumber.
      * @throws InvalidKeyException         Thrown if the key value(s) is(are) not valid.
      * @throws SQLException                Thrown if there was an error communicating with the database.
      * @throws QueryUpdateServiceException Thrown for implementation-specific exceptions.
      */
-    Map<Integer, Map<String, Object>> getExistingRows(User user, Container container, Map<Integer, Map<String, Object>> keys, boolean verifyNoCrossFolderData, boolean verifyExisting, boolean getDetails)
+    Map<Integer, Map<String, Object>> getExistingRows(User user, Container container, Map<Integer, Map<String, Object>> keys, boolean verifyNoCrossFolderData, boolean verifyExisting, @Nullable Set<String> columns)
             throws InvalidKeyException, QueryUpdateServiceException, SQLException;
 
     boolean hasExistingRowsInOtherContainers(Container container, Map<Integer, Map<String, Object>> keys);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -98,8 +98,11 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+import static org.labkey.api.data.TableSelector.ALL_COLUMNS;
 import static org.labkey.api.exp.api.ExpRunItem.PARENT_IMPORT_ALIAS_MAP_PROP;
 import static org.labkey.api.exp.api.SampleTypeService.ConfigParameters.SkipAliquotRollup;
 import static org.labkey.api.exp.api.SampleTypeService.ConfigParameters.SkipMaxSampleCounterFunction;
@@ -837,10 +840,10 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
     }
 
     @Override
-    public Map<Integer, Map<String, Object>> getExistingRows(User user, Container container, Map<Integer, Map<String, Object>> keys, boolean verifyNoCrossFolderData, boolean verifyExisting, boolean getDetails)
+    public Map<Integer, Map<String, Object>> getExistingRows(User user, Container container, Map<Integer, Map<String, Object>> keys, boolean verifyNoCrossFolderData, boolean verifyExisting, @Nullable Set<String> columns)
             throws InvalidKeyException, QueryUpdateServiceException, SQLException
     {
-        return getMaterialMapsWithInput(keys, user, container, verifyNoCrossFolderData, verifyExisting, !getDetails);
+        return getMaterialMapsWithInput(keys, user, container, verifyNoCrossFolderData, verifyExisting, columns);
     }
 
     private ContainerFilter getSampleDataCF(Container container, User user)
@@ -856,10 +859,62 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         return ContainerFilter.current(container);
     }
 
-    private Map<Integer, Map<String, Object>> getMaterialMapsWithInput(Map<Integer, Map<String, Object>> keys, User user, Container container, boolean checkCrossFolderData, boolean verifyExisting, boolean skipDetails)
+    public record ExistingRowSelect(TableInfo tableInfo, Set<String> columns, boolean includeParent) {}
+
+    public @NotNull ExistingRowSelect getExistingRowSelect(@Nullable Set<String> dataColumns)
+    {
+        if (!(getQueryTable() instanceof UpdateableTableInfo updatable) || dataColumns == null)
+            return new ExistingRowSelect(getQueryTable(), ALL_COLUMNS, true);
+
+        CaseInsensitiveHashMap<String> remap = updatable.remapSchemaColumns();
+        if (null == remap)
+            remap = CaseInsensitiveHashMap.of();
+
+        Set<String> includedColumns = new CaseInsensitiveHashSet("name", "lsid", "rowid");
+        for (ColumnInfo column : getQueryTable().getColumns())
+        {
+            if (dataColumns.contains(column.getColumnName()))
+                includedColumns.add(column.getColumnName());
+            else if (dataColumns.contains(remap.get(column.getColumnName())))
+                includedColumns.add(remap.get(column.getColumnName()));
+        }
+
+        boolean isAllFromMaterialTable = true;
+        Set<String> materialColNames = new CaseInsensitiveHashSet(Stream.of(ExpMaterialTable.Column.values())
+                .map(Enum::name)
+                .collect(Collectors.toSet()));
+        for (String column : includedColumns)
+            isAllFromMaterialTable = isAllFromMaterialTable && materialColNames.contains(column);
+        TableInfo selectTable = isAllFromMaterialTable ? ExperimentService.get().getTinfoMaterial() : getQueryTable();
+
+        boolean hasParentInput = false;
+        if (_sampleType != null)
+        {
+            try
+            {
+                Map<String, String> importAliases = _sampleType.getImportAliasMap();
+                for (String col : dataColumns)
+                {
+                    if (!hasParentInput && ExperimentService.isInputOutputColumn(col) || equalsIgnoreCase("parent",col) || (importAliases != null && importAliases.containsKey(col)))
+                        hasParentInput = true;
+                }
+            }
+            catch (IOException e)
+            {
+            }
+
+        }
+
+        return new ExistingRowSelect(selectTable, includedColumns, hasParentInput);
+    }
+
+    private Map<Integer, Map<String, Object>> getMaterialMapsWithInput(Map<Integer, Map<String, Object>> keys, User user, Container container, boolean checkCrossFolderData, boolean verifyExisting, @Nullable Set<String> columns)
             throws QueryUpdateServiceException, InvalidKeyException
     {
-        TableInfo queryTableInfo = skipDetails ? ExperimentService.get().getTinfoMaterial() : getQueryTable();
+        ExistingRowSelect existingRowSelect = getExistingRowSelect(columns);
+        TableInfo queryTableInfo = existingRowSelect.tableInfo;
+        Set<String> selectColumns = existingRowSelect.columns;
+
         Map<Integer, Map<String, Object>> sampleRows = new LinkedHashMap<>();
         Map<Integer, String> rowNumLsid = new HashMap<>();
 
@@ -895,7 +950,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         if (!rowIdRowNumMap.isEmpty())
         {
             Filter filter = new SimpleFilter(FieldKey.fromParts(ExpMaterialTable.Column.RowId), rowIdRowNumMap.keySet(), CompareType.IN);
-            Map<String, Object>[] rows = new TableSelector(queryTableInfo, filter, null).getMapArray();
+            Map<String, Object>[] rows = new TableSelector(queryTableInfo, selectColumns, filter, null).getMapArray();
             for (Map<String, Object> row : rows)
             {
                 Integer rowId = (Integer) row.get("rowid");
@@ -916,7 +971,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             allKeys.addAll(lsidRowNumMap.keySet());
 
             Filter filter = new SimpleFilter(FieldKey.fromParts(ExpMaterialTable.Column.LSID), lsidRowNumMap.keySet(), CompareType.IN);
-            Map<String, Object>[] rows = new TableSelector(queryTableInfo, filter, null).getMapArray();
+            Map<String, Object>[] rows = new TableSelector(queryTableInfo, selectColumns, filter, null).getMapArray();
             for (Map<String, Object> row : rows)
             {
                 String sampleLsid = (String) row.get("lsid");
@@ -933,7 +988,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("MaterialSourceId"), sampleTypeId);
             filter.addCondition(FieldKey.fromParts("Name"), nameRowNumMap.keySet(), CompareType.IN);
 
-            Map<String, Object>[] rows = new TableSelector(queryTableInfo, filter, null).getMapArray();
+            Map<String, Object>[] rows = new TableSelector(queryTableInfo, selectColumns, filter, null).getMapArray();
             for (Map<String, Object> row : rows)
             {
                 String name = (String) row.get("name");
@@ -949,7 +1004,10 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         if (checkCrossFolderData && !allKeys.isEmpty())
         {
             SimpleFilter existingDataFilter = new SimpleFilter(FieldKey.fromParts("MaterialSourceId"), sampleTypeId);
-            TableInfo tInfo = QueryService.get().getUserSchema(user, container, SamplesSchema.SCHEMA_NAME).getTable(getQueryTable().getName(), getSampleDataCF(container, user));
+            TableInfo tInfo = QueryService.get().getUserSchema(user, container, SamplesSchema.SCHEMA_NAME).getTable(getQueryTable().getName(), getSampleDataCF(container, user)); // don't use TinfoMaterial here since UserSchema is needed
+            if (tInfo == null)
+                throw new QueryUpdateServiceException("Unable to get the existing sample record");
+
             existingDataFilter.addCondition(FieldKey.fromParts(useLsid? "LSID" : "Name"), allKeys, CompareType.IN);
             Map<String, Object>[] cfRows = new TableSelector(tInfo, existingDataFilter, null).getMapArray();
             for (Map<String, Object> row : cfRows)
@@ -964,7 +1022,8 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         if (verifyExisting && !allKeys.isEmpty())
             throw new InvalidKeyException("Sample does not exist: " + allKeys.iterator().next() + ".");
 
-        if (skipDetails)
+        boolean includeParent = existingRowSelect.includeParent;
+        if (!includeParent)
             return sampleRows;
 
         List<ExpMaterialImpl> materials = ExperimentServiceImpl.get().getExpMaterialsByLSID(rowNumLsid.values());


### PR DESCRIPTION
#### Rationale
Detail audit log is enabled for sample CUD actions for generating timelines. ExistingRecordDataIterator is used to query the previous sample detail so that the comparison against the updates can be generated. When merge/update samples, ExistingRecordDataIterator queries for the full sample details, including exp.material, joined by samples.sampleprovisioned, joined by calculated inventory storage tables. Then, the sample's lineage is queried for generating audit log for parent events. Often times during an update, only a small subset of columns are included in the rows data. For columns that aren't updated, there is no need to query for them in ExistingRecordDataIterator. 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* determine queryTable for existing sample based on update columns
* only query for columns that are needed
* only query for lineage when needed.
