### PR TITLE
Allow 'null' file status in 'GetFileStatus' JSON response

### DIFF
--- a/pipeline/src/org/labkey/pipeline/analysis/AnalysisController.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/AnalysisController.java
@@ -214,7 +214,7 @@ public class AnalysisController extends SpringActionController
             {
                 JSONObject o = new JSONObject();
                 o.put("name", form.getFile()[i]);
-                o.put("status", form.getFileInputStatus()[i]);
+                o.put("status", JSONObject.wrap(form.getFileInputStatus()[i])); // Wrap to allow 'null' status
                 isRetry |= form.getFileInputStatus()[i] != null;
                 files.put(o);
             }


### PR DESCRIPTION
#### Rationale
The RLabKey API test expects an explicit `NULL` status value for non-existent status files.
This could break API consumers that see a distinction between `NULL` and undefined.

#### Related Pull Requests
* #4315 

#### Changes
* Wrap file status to allow `NULL` value in JSONObject
