### PR TITLE
Issue 47750: LKSM auto-link to study ignores aliquots

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -428,7 +428,7 @@ public class ExpDataIterators
 
             for (String name : nameMap.keySet())
             {
-                if (ExperimentService.isInputOutputColumn(name) || equalsIgnoreCase("parent", name))
+                if (ExperimentService.isInputOutputColumn(name) || equalsIgnoreCase("parent", name) || equalsIgnoreCase("AliquotedFrom", name))
                 {
                     _isDerivation = true;
                     break;


### PR DESCRIPTION
#### Rationale
Issue [47750](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47750): LKSM auto-link to study ignores aliquots

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* include aliquot parent check for derivatives
