### PR TITLE
Issue 47754: Provide user to resolve data class for lineage nodes

### DIFF
--- a/api/src/org/labkey/api/exp/Identifiable.java
+++ b/api/src/org/labkey/api/exp/Identifiable.java
@@ -47,12 +47,12 @@ public interface Identifiable
 
     default @Nullable QueryRowReference getQueryRowReference()
     {
-        return getQueryRowReference(null);
+        return null;
     }
 
     default @Nullable QueryRowReference getQueryRowReference(@Nullable User user)
     {
-        return null;
+        return getQueryRowReference();
     }
 
     /**

--- a/api/src/org/labkey/api/exp/Identifiable.java
+++ b/api/src/org/labkey/api/exp/Identifiable.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.query.QueryRowReference;
+import org.labkey.api.security.User;
 import org.labkey.api.view.ActionURL;
 
 /**
@@ -45,6 +46,11 @@ public interface Identifiable
     }
 
     default @Nullable QueryRowReference getQueryRowReference()
+    {
+        return getQueryRowReference(null);
+    }
+
+    default @Nullable QueryRowReference getQueryRowReference(@Nullable User user)
     {
         return null;
     }

--- a/api/src/org/labkey/api/exp/api/AssayJSONConverter.java
+++ b/api/src/org/labkey/api/exp/api/AssayJSONConverter.java
@@ -59,7 +59,7 @@ public class AssayJSONConverter
 
     public static JSONObject serializeBatch(ExpExperiment batch, AssayProvider provider, ExpProtocol protocol, User user, ExperimentJSONConverter.Settings settings)
     {
-        JSONObject jsonObject = ExperimentJSONConverter.serializeRunGroup(batch, provider != null ? provider.getBatchDomain(protocol) : null, settings);
+        JSONObject jsonObject = ExperimentJSONConverter.serializeRunGroup(batch, provider != null ? provider.getBatchDomain(protocol) : null, settings, user);
 
         JSONArray runsArray = new JSONArray();
         for (ExpRun run : batch.getRuns())

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -427,7 +427,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
                 if (material == null)
                     return null;
 
-                return ExperimentJSONConverter.serializeMaterial(material, ExperimentJSONConverter.DEFAULT_SETTINGS).toMap();
+                return ExperimentJSONConverter.serializeMaterial(material, user, ExperimentJSONConverter.DEFAULT_SETTINGS).toMap();
             }
 
             @Override
@@ -449,7 +449,10 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
                 Map<String, Map<String, Object>> searchJsonMap = new HashMap<>();
                 for (ExpMaterial material : ExperimentService.get().getExpMaterials(rowIds))
                 {
-                    searchJsonMap.put(rowIdIdentifierMap.get(material.getRowId()), ExperimentJSONConverter.serializeMaterial(material, ExperimentJSONConverter.DEFAULT_SETTINGS).toMap());
+                    searchJsonMap.put(
+                        rowIdIdentifierMap.get(material.getRowId()),
+                        ExperimentJSONConverter.serializeMaterial(material, user, ExperimentJSONConverter.DEFAULT_SETTINGS).toMap()
+                    );
                 }
 
                 return searchJsonMap;

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -371,7 +371,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
                 if (dataClass == null)
                     return null;
 
-                Map<String, Object> properties = ExperimentJSONConverter.serializeExpObject(dataClass, null, ExperimentJSONConverter.DEFAULT_SETTINGS).toMap();
+                Map<String, Object> properties = ExperimentJSONConverter.serializeExpObject(dataClass, null, ExperimentJSONConverter.DEFAULT_SETTINGS, user).toMap();
 
                 //Need to map to proper Icon
                 properties.put("type", "dataClass" + (dataClass.getCategory() != null ? ":" + dataClass.getCategory() : ""));
@@ -399,7 +399,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
                 if (sampleType == null)
                     return null;
 
-                Map<String, Object> properties = ExperimentJSONConverter.serializeExpObject(sampleType, null, ExperimentJSONConverter.DEFAULT_SETTINGS).toMap();
+                Map<String, Object> properties = ExperimentJSONConverter.serializeExpObject(sampleType, null, ExperimentJSONConverter.DEFAULT_SETTINGS, user).toMap();
 
                 //Need to map to proper Icon
                 properties.put("type", "sampleSet");

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -182,6 +182,12 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
     }
 
     @Override
+    public @Nullable QueryRowReference getQueryRowReference()
+    {
+        return getQueryRowReference(null);
+    }
+
+    @Override
     public @Nullable QueryRowReference getQueryRowReference(@Nullable User user)
     {
         ExpDataClassImpl dc = getDataClass(user);

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -182,9 +182,9 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
     }
 
     @Override
-    public @Nullable QueryRowReference getQueryRowReference()
+    public @Nullable QueryRowReference getQueryRowReference(@Nullable User user)
     {
-        ExpDataClassImpl dc = getDataClass();
+        ExpDataClassImpl dc = getDataClass(user);
         if (dc != null)
             return new QueryRowReference(getContainer(), ExpSchema.SCHEMA_EXP_DATA, dc.getName(), FieldKey.fromParts(ExpDataTable.Column.RowId), getRowId());
 


### PR DESCRIPTION
#### Rationale
This addresses [Issue 47754](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47754) where users are seeing an incorrect icon for certain lineage nodes in our applications. What is occurring for data class data nodes is that when they're declared in a container that differs from where the data class is defined then the definition is not found when serializing the nodes. This is due to the user not being available when resolving the data class definition for a node.

This change passes through the user for both experiment data and material serialization.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4333
* https://github.com/LabKey/biologics/pull/2103

#### Changes
* Accept a user parameter on `Indentifiable.getQueryRowReference`, `ExperimentJSONConverter.serializeExpObject` and `ExperimentJSONConverter.serializeMaterial`.
