### PR TITLE
Issue 47755: Slow file upload via WebDav PUT

### DIFF
--- a/api/src/org/labkey/api/util/FileStream.java
+++ b/api/src/org/labkey/api/util/FileStream.java
@@ -16,8 +16,10 @@
 package org.labkey.api.util;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -45,6 +47,7 @@ import java.util.Date;
  */
 public interface FileStream
 {
+    Logger LOG = LogHelper.getLogger(FileStream.class, "File transfers");
     long getSize() throws IOException;
 
     @Nullable
@@ -79,7 +82,9 @@ public interface FileStream
              FileChannel cOut = fOut.getChannel();
         )
         {
+            LOG.debug("Starting to transfer to " + dest);
             cOut.transferFrom(cIn, 0, s.getSize());
+            LOG.debug("Finished transferring to " + dest);
         }
     }
 

--- a/api/src/org/labkey/api/util/FileStream.java
+++ b/api/src/org/labkey/api/util/FileStream.java
@@ -83,8 +83,8 @@ public interface FileStream
         )
         {
             LOG.debug("Starting to transfer to " + dest);
-            cOut.transferFrom(cIn, 0, s.getSize());
-            LOG.debug("Finished transferring to " + dest);
+            long bytes = cOut.transferFrom(cIn, 0, Long.MAX_VALUE);
+            LOG.debug("Finished transferring " + bytes + " bytes to " + dest);
         }
     }
 

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -127,6 +127,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.DataOutput;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FilterInputStream;
 import java.io.FilterWriter;
@@ -143,6 +144,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.SocketException;
 import java.net.URISyntaxException;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
@@ -3064,6 +3067,17 @@ public class DavController extends SpringActionController
                 public InputStream openInputStream() throws IOException
                 {
                     return SessionKeepAliveFilter.wrap(fis.openInputStream(), getRequest());
+                }
+
+                @Override
+                public @Nullable ReadableByteChannel getInputChannel() throws IOException
+                {
+                    InputStream in = fis.openInputStream();
+                    if (in instanceof FileInputStream fIn)
+                    {
+                        return fIn.getChannel();
+                    }
+                    return Channels.newChannel(SessionKeepAliveFilter.wrap(in, getRequest()));
                 }
 
                 @Override

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -3075,6 +3075,9 @@ public class DavController extends SpringActionController
                     InputStream in = fis.openInputStream();
                     if (in instanceof FileInputStream fIn)
                     {
+                        // This means the file is already on the server. That's usually the slowest part of the upload
+                        // sequence, so it's less important to keep the session alive as bytes are consumed from the
+                        // Channel. See issue 47755
                         return fIn.getChannel();
                     }
                     return Channels.newChannel(SessionKeepAliveFilter.wrap(in, getRequest()));


### PR DESCRIPTION
#### Rationale
Writing to a remote SMB mount is very slow with an 8KB array copy between InputStream and OutputStream. Channels are way faster.

#### Changes
* Use `Channel.transferTo()`