### PR TITLE
Issue 47735: QWP date filter not being formatted

### DIFF
--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -3814,7 +3814,18 @@ if (!LABKEY.DataRegions) {
                     else if (!LABKEY.Utils.isArray(params[pair[0]])) {
                         params[pair[0]] = [params[pair[0]]];
                     }
-                    params[pair[0]].push(pair[1]);
+
+                    // This needs to be formatted for the filter dialog to display correctly when retrieving
+                    // an existing date filter on an async loaded data region
+                    var value = pair[1];
+                    if (LABKEY.Utils.isDate(value)) {
+                        value = $.format.date(value, 'yyyy-MM-dd');
+                        if (LABKEY.Utils.endsWith(value, 'Z')) {
+                            value = value.substring(0, value.length - 1);
+                        }
+                    }
+
+                    params[pair[0]].push(value);
                 }
                 else {
                     params[pair[0]] = pair[1];

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -2931,6 +2931,17 @@ if (!LABKEY.DataRegions) {
         return newSorts.join(',');
     };
 
+    var _ensureFilterDateFormat = function(value) {
+        if (LABKEY.Utils.isDate(value)) {
+            value = $.format.date(value, 'yyyy-MM-dd');
+            if (LABKEY.Utils.endsWith(value, 'Z')) {
+                value = value.substring(0, value.length - 1);
+            }
+        }
+
+        return value;
+    }
+
     var _buildQueryString = function(region, pairs) {
         if (!LABKEY.Utils.isArray(pairs)) {
             return '';
@@ -2945,12 +2956,7 @@ if (!LABKEY.DataRegions) {
             queryParts.push(encodeURIComponent(key));
             if (LABKEY.Utils.isDefined(value)) {
 
-                if (LABKEY.Utils.isDate(value)) {
-                    value = $.format.date(value, 'yyyy-MM-dd');
-                    if (LABKEY.Utils.endsWith(value, 'Z')) {
-                        value = value.substring(0, value.length - 1);
-                    }
-                }
+                value = _ensureFilterDateFormat(value);
                 queryParts.push('=');
                 queryParts.push(encodeURIComponent(value));
             }
@@ -3817,14 +3823,10 @@ if (!LABKEY.DataRegions) {
 
                     var value = pair[1];
 
+                    // Issue 47735: QWP date filter not being formatted
                     // This needs to be formatted for the response passed back to the grid for the filter display and
                     // filter dialog to render correctly
-                    if (LABKEY.Utils.isDate(value)) {
-                        value = $.format.date(value, 'yyyy-MM-dd');
-                        if (LABKEY.Utils.endsWith(value, 'Z')) {
-                            value = value.substring(0, value.length - 1);
-                        }
-                    }
+                    value = _ensureFilterDateFormat(value);
 
                     params[pair[0]].push(value);
                 }

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -3815,9 +3815,10 @@ if (!LABKEY.DataRegions) {
                         params[pair[0]] = [params[pair[0]]];
                     }
 
-                    // This needs to be formatted for the filter dialog to display correctly when retrieving
-                    // an existing date filter on an async loaded data region
                     var value = pair[1];
+
+                    // This needs to be formatted for the response passed back to the grid for the filter display and
+                    // filter dialog to render correctly
                     if (LABKEY.Utils.isDate(value)) {
                         value = $.format.date(value, 'yyyy-MM-dd');
                         if (LABKEY.Utils.endsWith(value, 'Z')) {

--- a/query/resources/views/QWPDemo.html
+++ b/query/resources/views/QWPDemo.html
@@ -31,6 +31,7 @@
             <div class="tab"><a href="#testPagingConfig">Set Paging to 3 with config</a></div>
             <div class="tab"><a href="#testSetPaging">Set Paging to 2 with API</a></div>
             <div class="tab"><a href="#testParameterizedQueries">Parameterized Queries</a></div>
+            <div class="tab"><a href="#testDateFilterFormat">Issue #47735: Date filter format</a></div>
             <div class="tab"><a href="#test25337">Regression #25337</a></div>
             <div class="tab"><a href="#testPageOffset">Change Page Offset</a></div>
             <div class="tab"><a href="#testRemovableFilters">Keep Removable Filters</a></div>

--- a/query/webapp/QWPDemo.js
+++ b/query/webapp/QWPDemo.js
@@ -390,7 +390,7 @@
                         if (firstFilter) {
                             var firstDateFilter = [
                                 // Intentionally unformatted date
-                                LABKEY.Filter.create('MaterialExpDate', new Date('04-23-2023'))
+                                LABKEY.Filter.create('MaterialExpDate', new Date('2023, 04, 23'))
                             ];
                             qwp.replaceFilters(firstDateFilter);
                             firstFilter = false;

--- a/query/webapp/QWPDemo.js
+++ b/query/webapp/QWPDemo.js
@@ -18,6 +18,7 @@
             testHideColumns: testHideColumns,
             testPagingConfig: testPagingConfig,
             testSetPaging: testSetPaging,
+            testDateFilterFormat: testDateFilterFormat,
             test25337: test25337,
             testPageOffset: testPageOffset,
             testParameterizedQueries: testParameterizedQueries,
@@ -366,6 +367,44 @@
                             else {
                                 LABKEY.Utils.signalWebDriverTest('testSetPaging');
                             }
+                        }
+                    }
+                }
+            });
+        }
+
+        // Issue 47735: QWP date filter not being formatted
+        function testDateFilterFormat() {
+            var firstFilter = true;
+            var verifyFilter = false;
+            new LABKEY.QueryWebPart({
+                title: 'Issue #47735: Date filter format',
+                schemaName: 'Samples',
+                queryName: 'sampleDataTest1',
+                renderTo: RENDERTO,
+                failure: function () {
+                    alert('Failed test: Issue #47735');
+                },
+                listeners: {
+                    render: function (qwp) {
+                        if (firstFilter) {
+                            var firstDateFilter = [
+                                // Intentionally unformatted date
+                                LABKEY.Filter.create('MaterialExpDate', new Date('04-23-2023'))
+                            ];
+                            qwp.replaceFilters(firstDateFilter);
+                            firstFilter = false;
+                            verifyFilter = true;
+                        }
+                        else if (verifyFilter) {
+                            if ($('span:contains(Expiration Date = 2023-04-23)').length !== 1) {
+                                alert('Failed to properly format filter date.');
+                            }
+                            else {
+                                LABKEY.Utils.signalWebDriverTest("testDateFilterFormat");
+                            }
+
+                            verifyFilter = false;
                         }
                     }
                 }


### PR DESCRIPTION
#### Rationale
Data Region loading async, like any QWP, has format issues on date column filters. See related ticket for repro. This PR formats the date filter values for async load the same way it is formatted for the non-async load.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47735

#### Changes
* Add date format to DataRegion async load
* Add QWP test
