### PR TITLE
47653: Survey combos don't support multiple lookups that differ by view name

### DIFF
--- a/api/webapp/clientapi/ext4/Util.js
+++ b/api/webapp/clientapi/ext4/Util.js
@@ -869,7 +869,8 @@
                     c.lookup.schemaName || c.lookup.schema,
                     c.lookup.queryName || c.lookup.table,
                     c.lookup.keyColumn,
-                    c.lookup.displayColumn
+                    c.lookup.displayColumn,
+                    c.lookup.viewName
                 ].join('||');
             }
 


### PR DESCRIPTION
#### Rationale
The ext4 utility that helps create client side stores will generate a unique store ID to allow reuse of configurations which have identical lookups. Upon investigation of the related issue, if the lookup had a view name specified, it was not being used in the generation of the ID.

The solution is to add the view name to the ID. In the event a view name is not specified the ID will have a trailing `||` which seems okay since we never need to decode the ID just ensure uniqueness.

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47653)