### PR TITLE
Issue 47750: LKSM auto-link to study ignores aliquots

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -408,10 +408,11 @@ public class ExpDataIterators
         final ExpSampleType _sampleType;
         final MapDataIterator _data;
         final List<Map<FieldKey, Object>> _rows = new ArrayList<>();
-        final List<Integer> _keys = new ArrayList<>();
+        final List<Integer> _derivativeKeys = new ArrayList<>();
         final UserSchema _schema;
-        private boolean _isDerivation = false;
+        private boolean _hasParentInput;
         final Integer _rowIdCol;
+        final List<Integer> _parentCols = new ArrayList<>();
 
         protected AutoLinkToStudyDataIterator(DataIterator di, DataIteratorContext context, UserSchema schema, Container container, User user,  ExpSampleType sampleType)
         {
@@ -430,10 +431,10 @@ public class ExpDataIterators
             {
                 if (ExperimentService.isInputOutputColumn(name) || equalsIgnoreCase("parent", name) || equalsIgnoreCase("AliquotedFrom", name))
                 {
-                    _isDerivation = true;
-                    break;
+                    _parentCols.add(nameMap.get(name));
                 }
             }
+            _hasParentInput = !_parentCols.isEmpty();
         }
 
         @Override
@@ -443,34 +444,51 @@ public class ExpDataIterators
 
             if (!hasNext)
             {
-                if (!_rows.isEmpty())
+                if (!_derivativeKeys.isEmpty())
                 {
-                    if (_isDerivation)
-                    {
-                        _schema.getDbSchema().getScope().getCurrentTransaction().addCommitTask(() -> {
-                            try
-                            {
-                                // derived samples can't be linked until after the transaction is committed
-                                StudyPublishService.get().autoLinkDerivedSamples(_sampleType, _keys, _container, _user);
-                            }
-                            catch (ExperimentException e)
-                            {
-                                throw new RuntimeException(e);
-                            }
-                        }, DbScope.CommitTaskOption.POSTCOMMIT);
-                    }
-                    else
-                        StudyPublishService.get().autoLinkSamples(_sampleType, _rows, _container, _user);
+                    _schema.getDbSchema().getScope().getCurrentTransaction().addCommitTask(() -> {
+                        try
+                        {
+                            // derived samples can't be linked until after the transaction is committed
+                            StudyPublishService.get().autoLinkDerivedSamples(_sampleType, _derivativeKeys, _container, _user);
+                        }
+                        catch (ExperimentException e)
+                        {
+                            throw new RuntimeException(e);
+                        }
+                    }, DbScope.CommitTaskOption.POSTCOMMIT);
                 }
+
+                if (!_rows.isEmpty())
+                    StudyPublishService.get().autoLinkSamples(_sampleType, _rows, _container, _user);
+
                 return false;
             }
-            Map<FieldKey, Object> row = new HashMap<>();
-            for (Map.Entry<String, Object> entry : _data.getMap().entrySet())
-                row.put(FieldKey.fromParts(entry.getKey()), entry.getValue());
-            _rows.add(row);
+            boolean isDerivative = false;
+            if (_hasParentInput)
+            {
+                for (Integer parentCol : _parentCols)
+                {
+                    if (get(parentCol) != null)
+                    {
+                        isDerivative = true;
+                        break;
+                    }
+                }
+            }
 
-            if (_isDerivation)
-                _keys.add((Integer)get(_rowIdCol));
+            if (!isDerivative)
+            {
+                Map<FieldKey, Object> row = new HashMap<>();
+                for (Map.Entry<String, Object> entry : _data.getMap().entrySet())
+                    row.put(FieldKey.fromParts(entry.getKey()), entry.getValue());
+                _rows.add(row);
+            }
+            else
+            {
+                _derivativeKeys.add((Integer)get(_rowIdCol));
+            }
+
 
             return true;
         }

--- a/experiment/src/org/labkey/experiment/api/MaterialSource.java
+++ b/experiment/src/org/labkey/experiment/api/MaterialSource.java
@@ -18,6 +18,7 @@ package org.labkey.experiment.api;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.exp.query.ExpSampleTypeTable;
 import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.query.FieldKey;
@@ -164,7 +165,9 @@ public class MaterialSource extends IdentifiableEntity implements Comparable<Mat
 
     public Container getAutoLinkTargetContainer()
     {
-        return _autoLinkTargetContainer;
+        if (_autoLinkTargetContainer == null)
+            return null;
+        return ContainerManager.getForId(_autoLinkTargetContainer.getId());
     }
     
     public void setAutoLinkTargetContainer(Container autoLinkTargetContainer)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -233,7 +233,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             if (InventoryService.get() != null)
                 dib = LoggingDataIterator.wrap(InventoryService.get().getPersistStorageItemDataIteratorBuilder(dib, userSchema.getContainer(), userSchema.getUser(), sampleType));
 
-            if (sampleType.getAutoLinkTargetContainer() != null && StudyPublishService.get() != null)
+            if (sampleType.getAutoLinkTargetContainer() != null && StudyPublishService.get() != null && !context.getInsertOption().updateOnly/* TODO support link to study on update? */)
                 dib = LoggingDataIterator.wrap(new ExpDataIterators.AutoLinkToStudyDataIteratorBuilder(dib, getSchema(), userSchema.getContainer(), userSchema.getUser(), sampleType));
         }
         return dib;

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -1158,7 +1158,9 @@ public class StudyPublishManager implements StudyPublishService
             Map<StudyPublishService.LinkToStudyKeys, FieldKey> fieldKeyMap = StudyPublishService.get().getSamplePublishFieldKeys(user, container, sampleType, qs);
             UserSchema userSchema = QueryService.get().getUserSchema(user, container, SamplesSchema.SCHEMA_NAME);
             QueryView view = new QueryView(userSchema, qs, null);
-
+            // Issue 45238 - configure as API style invocation to skip setting up buttons and other items that
+            // rely on being invoked inside an HTTP request/ViewContext
+            view.setApiResponseView(true);
             DataView dataView = view.createDataView();
             RenderContext ctx = dataView.getRenderContext();
             Map<FieldKey, ColumnInfo> selectColumns = dataView.getDataRegion().getSelectColumns();


### PR DESCRIPTION
#### Rationale
The AutoLinkToStudyDataIterator checks for the presence of a parent column to determine if autoLinkDerivedSamples or autoLinkSamples should be done. This is problematic because the presence of parent column doesn't mean every row in the  input have the parent column populated. The check for derivative should be done on each row's actual value, instead of the presence of column header.

Additionally, rowId is used to link to study, which is absent in UPDATE only mode. Changes made to skip linking in update mode. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4345
* https://github.com/LabKey/testAutomation/pull/1493
* https://github.com/LabKey/platform/pull/4332

#### Changes
* check for parent column's value for each row to determine if row is derivative, rather than the presence of a parent column
* skip auto-link in UPDATE mode, since rowId is absent from row
* use setApiResponseView to fix url error
