### PR TITLE
Issue 47661: Assay run sample lookup issue trying to resolve sample for empty string value

### DIFF
--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -606,7 +606,8 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
         // Find lookups to a SampleType and add the resolved material as an input sample
         for (Map.Entry<DomainProperty, String> entry : context.getRunProperties().entrySet())
         {
-            if (entry.getValue() == null)
+            String value = entry.getValue();
+            if (value == null || value.isEmpty())
                 continue;
 
             DomainProperty dp = entry.getKey();
@@ -622,7 +623,6 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
             // Use the DomainProperty name as the role
             String role = dp.getName();
 
-            String value = entry.getValue();
             if (pt.getJdbcType().isText())
             {
                 addMaterialByName(context, inputMaterials, value, role, searchContainers, st, cache, materialCache);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47661

When an assay design has a run domain lookup field to a sample type, we correctly skip trying to resolve the sample if the lookup is to an integer key of the sample and no value is provided. However, if the lookup is to a string name of the sample, we attempt to resolve a sample when the value provided is an empty string. This PR fixes that so we skip sample resolution when the run value is null or empty.

#### Changes
* DefaultAssayRunCreator.addInputMaterials - skip sample resolution when the run value is null or empty
