### PR TITLE
Fix ReportThumbnailTest after JSONObject migration

### DIFF
--- a/api/src/org/labkey/api/data/views/DataViewService.java
+++ b/api/src/org/labkey/api/data/views/DataViewService.java
@@ -158,17 +158,17 @@ public class DataViewService
 
     public static final int DEFAULT_CATEGORY_DISPLAY_ORDER = 1000;
 
-    public JSONArray toJSON(Container container, User user, List<DataViewInfo> views)
+    public JSONArray toJSON(User user, List<DataViewInfo> views)
     {
         JSONArray jsonViews = new JSONArray();
 
         for (DataViewInfo info : views)
-            jsonViews.put(toJSON(container, user, info));
+            jsonViews.put(toJSON(user, info));
 
         return jsonViews;
     }
 
-    public JSONObject toJSON(Container container, User user, DataViewInfo info)
+    public JSONObject toJSON(User user, DataViewInfo info)
     {
         JSONObject o = new JSONObject();
 

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -2853,7 +2853,7 @@ public class ReportsController extends SpringActionController
                             category.setDisplayOrder(defaultCategoryMap.get(category.getLabel()));
                     }
                 }
-                response.put("data", DataViewService.get().toJSON(getContainer(), getUser(), views));
+                response.put("data", DataViewService.get().toJSON(getUser(), views));
             }
 
             return response;
@@ -3187,11 +3187,11 @@ public class ReportsController extends SpringActionController
             ArrayList<JSONObject> views = new ArrayList<>();
             for (DataViewInfo view : helper.views)
             {
-                JSONObject viewJson = DataViewService.get().toJSON(getContainer(), getUser(), view);
+                JSONObject viewJson = DataViewService.get().toJSON(getUser(), view);
                 viewJson.put("name", view.getName());
                 viewJson.put("leaf", true);
                 viewJson.put("icon", view.getIconUrl().getLocalURIString());
-                viewJson.put("iconCls", view.getIconCls());
+                viewJson.put("iconCls", view.getIconCls() == null ? JSONObject.NULL : view.getIconCls());
                 views.add(viewJson);
             }
             Comparator<JSONObject>naturalOrderComparator = (JSONObject a, JSONObject b) ->
@@ -4036,7 +4036,7 @@ public class ReportsController extends SpringActionController
                     List<DataViewInfo> reports = provider.getViews(getViewContext(), form.getSchemaName(), form.getQueryName());
                     for (DataViewInfo report : reports)
                     {
-                        json.add(DataViewService.get().toJSON(getContainer(), getUser(), report));
+                        json.add(DataViewService.get().toJSON(getUser(), report));
                     }
                 }
             }

--- a/study/src/org/labkey/study/designer/StudySchedule.java
+++ b/study/src/org/labkey/study/designer/StudySchedule.java
@@ -121,7 +121,7 @@ public class StudySchedule implements ApiJsonForm
         {
             DataViewInfo info = _viewInfo.get(ds.getEntityId());
 
-            o = DataViewService.get().toJSON(ds.getContainer(), user, info);
+            o = DataViewService.get().toJSON(user, info);
             o.put("entityId", ds.getEntityId());
         }
         o.put("label", ds.getLabel());


### PR DESCRIPTION
#### Rationale
The new JSONObject treats nulls different and this broke ReportThumbnailTest.

https://teamcity.labkey.org/viewLog.html?buildId=2413766&tab=buildResultsDiv&buildTypeId=LabkeyTrunk_DailyPostgres

#### Changes
* Put in the placeholder object for the `iconCls` value if needed.
