### PR TITLE
Move derivative and parent link both to postcommit

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -444,23 +444,20 @@ public class ExpDataIterators
 
             if (!hasNext)
             {
-                if (!_derivativeKeys.isEmpty())
-                {
-                    _schema.getDbSchema().getScope().getCurrentTransaction().addCommitTask(() -> {
-                        try
-                        {
-                            // derived samples can't be linked until after the transaction is committed
+                _schema.getDbSchema().getScope().getCurrentTransaction().addCommitTask(() -> {
+                    try
+                    {
+                        if (!_derivativeKeys.isEmpty())
                             StudyPublishService.get().autoLinkDerivedSamples(_sampleType, _derivativeKeys, _container, _user);
-                        }
-                        catch (ExperimentException e)
-                        {
-                            throw new RuntimeException(e);
-                        }
-                    }, DbScope.CommitTaskOption.POSTCOMMIT);
-                }
 
-                if (!_rows.isEmpty())
-                    StudyPublishService.get().autoLinkSamples(_sampleType, _rows, _container, _user);
+                        if (!_rows.isEmpty())
+                            StudyPublishService.get().autoLinkSamples(_sampleType, _rows, _container, _user);
+                    }
+                    catch (ExperimentException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                }, DbScope.CommitTaskOption.POSTCOMMIT);
 
                 return false;
             }


### PR DESCRIPTION
#### Rationale
When link to study is happening in the same transaction as sample type creation, such as doing folder import, StudyPublishService.autoLinkDerivedSamples and autoLinkSamples calls should be done in the same transaction so the committed dataset row id is used for linking. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4345
* https://github.com/LabKey/testAutomation/pull/1493
* https://github.com/LabKey/platform/pull/4332

#### Changes
* move autoLinkSamples to POSTCOMMIT as well
