### PR TITLE
Issue 47801: Sample status lookup field should resolve to statuses defined in the current, project, or shared containers

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -454,7 +454,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 ret.setShownInInsertView(statusEnabled);
                 ret.setShownInUpdateView(statusEnabled);
                 ret.setRemapMissingBehavior(SimpleTranslator.RemapMissingBehavior.Error);
-                ret.setFk(new QueryForeignKey.Builder(getUserSchema(), getLookupContainerFilter())
+                ret.setFk(new QueryForeignKey.Builder(getUserSchema(), getSampleStatusLookupContainerFilter())
                         .schema(getExpSchema()).table(ExpSchema.TableType.SampleStatus).display("Label"));
                 return ret;
             }
@@ -741,7 +741,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         statusColInfo.setRemapMissingBehavior(SimpleTranslator.RemapMissingBehavior.Error);
         if (statusEnabled)
             defaultCols.add(FieldKey.fromParts(ExpMaterialTable.Column.SampleState));
-        statusColInfo.setFk(new QueryForeignKey.Builder(getUserSchema(), getLookupContainerFilter())
+        statusColInfo.setFk(new QueryForeignKey.Builder(getUserSchema(), getSampleStatusLookupContainerFilter())
                 .schema(getExpSchema()).table(ExpSchema.TableType.SampleStatus).display("Label"));
 
         // TODO is this a real Domain???
@@ -859,6 +859,13 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             MutableColumnInfo lineageLookup = ClosureQueryHelper.createLineageLookupColumnInfo("Ancestors", this, _rootTable.getColumn("rowid"), _ss);
             addColumn(lineageLookup);
         }
+    }
+
+    private ContainerFilter getSampleStatusLookupContainerFilter()
+    {
+        ContainerFilter.Type type = QueryService.get().getContainerFilterTypeForLookups(getContainer());
+        type = type == null ? ContainerFilter.Type.CurrentPlusProjectAndShared : type;
+        return type.create(getUserSchema());
     }
 
     private void addAvailableAliquotCountColumn()

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -863,6 +863,9 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
     private ContainerFilter getSampleStatusLookupContainerFilter()
     {
+        // The default lookup container filter is Current, but we want to have the default be CurrentPlusProjectAndShared
+        // for the sample status lookup since in the app project context we want to share status definitions accross
+        // a given project instead of creating duplicate statuses in each subfolder project.
         ContainerFilter.Type type = QueryService.get().getContainerFilterTypeForLookups(getContainer());
         type = type == null ? ContainerFilter.Type.CurrentPlusProjectAndShared : type;
         return type.create(getUserSchema());


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47801

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4224

#### Changes
* Change default sample status lookup from the exp.materials table to be CurrentPlusProjectAndShared
