### PR TITLE
Create "Created/CreatedBy/Modified/ModifiedBy" for Assay data rows - bug fixes

### DIFF
--- a/api/src/org/labkey/api/assay/plate/PlateMetadataDataHandler.java
+++ b/api/src/org/labkey/api/assay/plate/PlateMetadataDataHandler.java
@@ -69,4 +69,10 @@ public class PlateMetadataDataHandler extends AbstractAssayTsvDataHandler
     {
         // see description above
     }
+
+    @Override
+    public void importFile(@NotNull ExpData data, File dataFile, @NotNull ViewBackgroundInfo info, @NotNull Logger log, @NotNull XarContext context, boolean allowLookupByAlternateKey, boolean autoFillDefaultResultColumns) throws ExperimentException
+    {
+        // see description above
+    }
 }

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -1459,7 +1459,7 @@ public class AssayController extends SpringActionController
                 for (Integer id : form.getRowList())
                 {
                     // assuming that column in storage table has same name
-                    Table.update(getUser(), ti, Collections.singletonMap(flagCol.getColumnName(),comment), id);
+                    Table.update(getUser(), ti, new HashMap<>(Map.of(flagCol.getColumnName(), comment)), id);
                     rowsAffected++;
                 }
                 transaction.commit();


### PR DESCRIPTION
#### Rationale
A few bugs are revealed by TC runs due to changes to assay result created/modified fields:
https://teamcity.labkey.org/viewLog.html?buildId=2415614&buildTypeId=LabkeyTrunk_DailyPostgres_2&fromSakuraUI=true#testNameId7873876115599485400
https://teamcity.labkey.org/viewLog.html?buildId=2415614&buildTypeId=LabkeyTrunk_DailyPostgres_2&fromSakuraUI=true#testNameId-4868277545473738935

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* add missing AssayDataHandler.importFile override
* Use HashMap instead of immutable map for Table.update call
