### PR TITLE
Better search categories and post-commit search indexing

### DIFF
--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -1364,7 +1364,7 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
             if (null == cat)
                 setSearchCategory(SearchService.fileCategory);
             else
-                setSearchProperty(SearchService.PROPERTY.categories, SearchService.fileCategory.toString() + " " + cat.toString());
+                setSearchProperty(SearchService.PROPERTY.categories, SearchService.fileCategory.toString() + StringUtils.capitalize(cat.toString()));
         }
 
         AttachmentResource(@NotNull WebdavResource folder, @NotNull AttachmentParent parent, @NotNull Attachment attachment)

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -589,7 +589,7 @@ public class ExpDataIterators
                 row.put(FieldKey.fromParts(entry.getKey()), entry.getValue());
             _rows.add(row);
 
-            if (_isDerivation)
+            if (_isDerivation && _rowIdCol != null)
                 _keys.add((Integer)get(_rowIdCol));
 
             return true;

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -112,7 +112,6 @@ import org.labkey.api.study.assay.FileLinkDisplayColumn;
 import org.labkey.api.util.CachingSupplier;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
-import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
@@ -150,7 +149,7 @@ import static org.labkey.api.exp.query.ExpDataClassDataTable.Column.QueryableInp
 public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassDataTable.Column> implements ExpDataClassDataTable
 {
     private final @NotNull ExpDataClassImpl _dataClass;
-    private final Supplier<TableInfo> _dataClassTableInfo;
+    private final Supplier<TableInfo> _dataClassDataTableSupplier;
     public static final String DATA_COUNTER_SEQ_PREFIX = "DataNameGenCounter-";
 
     public static final Set<String> DATA_CLASS_ALT_MERGE_KEYS;
@@ -168,7 +167,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
     {
         super(name, ExperimentService.get().getTinfoData(), schema, cf);
         _dataClass = dataClass;
-        _dataClassTableInfo = new CachingSupplier<>(_dataClass::getTinfo);
+        _dataClassDataTableSupplier = new CachingSupplier<>(_dataClass::getTinfo);
         addAllowablePermission(InsertPermission.class);
         addAllowablePermission(UpdatePermission.class);
         ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getImportDataURL(getContainer(), _dataClass.getName());
@@ -363,7 +362,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         else
             setDescription("Contains one row per registered data in the " + _dataClass.getName() + " data class");
 
-        TableInfo extTable = _dataClassTableInfo.get();
+        TableInfo extTable = _dataClassDataTableSupplier.get();
 
         LinkedHashSet<FieldKey> defaultVisible = new LinkedHashSet<>();
         defaultVisible.add(FieldKey.fromParts(Column.Name));
@@ -554,7 +553,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         if (_vocabularyDomainProviders != null)
             return _vocabularyDomainProviders;
 
-        TableInfo extTable = _dataClassTableInfo.get();
+        TableInfo extTable = _dataClassDataTableSupplier.get();
         _vocabularyDomainProviders = new CaseInsensitiveHashMap<>();
 
         for (ColumnInfo col : extTable.getColumns())
@@ -668,7 +667,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
     public SQLFragment getFromSQL(String alias, Set<FieldKey> selectedColumns)
     {
         checkReadBeforeExecute();
-        TableInfo provisioned = _dataClassTableInfo.get();
+        TableInfo provisioned = _dataClassDataTableSupplier.get();
         SqlDialect dialect = _rootTable.getSqlDialect();
 
         Set<String> dataCols = new CaseInsensitiveHashSet(_rootTable.getColumnNameSet());
@@ -762,7 +761,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
     public Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices()
     {
         Map<String, Pair<IndexType, List<ColumnInfo>>> indices = new HashMap<>(super.getUniqueIndices());
-        indices.putAll(wrapTableIndices(_dataClassTableInfo.get()));
+        indices.putAll(wrapTableIndices(_dataClassDataTableSupplier.get()));
 
         // Issue 46948: RemapCache unable to resolve ExpData objects with addition of ClassId column
         // RemapCache is used to findExpData using name/rowId remap.
@@ -796,14 +795,14 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
     public Map<String, Pair<IndexType, List<ColumnInfo>>> getAllIndices()
     {
         Map<String, Pair<IndexType, List<ColumnInfo>>> indices = new HashMap<>(super.getAllIndices());
-        indices.putAll(wrapTableIndices(_dataClassTableInfo.get()));
+        indices.putAll(wrapTableIndices(_dataClassDataTableSupplier.get()));
         return Collections.unmodifiableMap(indices);
     }
 
     @Override
     public boolean hasDbTriggers()
     {
-        return super.hasDbTriggers() || _dataClassTableInfo.get().hasDbTriggers();
+        return super.hasDbTriggers() || _dataClassDataTableSupplier.get().hasDbTriggers();
     }
 
     @Override
@@ -859,28 +858,27 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
     @Override
     public DataIteratorBuilder persistRows(DataIteratorBuilder data, DataIteratorContext context)
     {
-        TableInfo propertiesTable = _dataClassTableInfo.get();
+        TableInfo propertiesTable = _dataClassDataTableSupplier.get();
         try
         {
             PersistDataIteratorBuilder step0 = new ExpDataIterators.PersistDataIteratorBuilder(data, this, propertiesTable, _dataClass, getUserSchema().getContainer(), getUserSchema().getUser(), _dataClass.getImportAliasMap(), null);
-            SearchService ss = SearchService.get();
-            if (null != ss)
+            SearchService searchService = SearchService.get();
+            if (null != searchService)
             {
                 // Queue indexing after committing
-                propertiesTable.getSchema().getScope().addCommitTask(() ->
-                {
-                    step0.setIndexFunction(lsids -> () ->
-                            ListUtils.partition(lsids, 100).forEach(sublist ->
-                                    ss.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
-                                    {
-                                        for (ExpDataImpl expData : ExperimentServiceImpl.get().getExpDatasByLSID(sublist))
-                                            expData.index(ss.defaultTask(), this);
-                                    })
-                            )
-                    );
-                }, DbScope.CommitTaskOption.POSTCOMMIT);
+                step0.setIndexFunction(lsids ->  propertiesTable.getSchema().getScope().addCommitTask(() -> {
+                        ListUtils.partition(lsids, 100).forEach(sublist ->
+                                searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
+                                {
+                                    for (ExpDataImpl expData : ExperimentServiceImpl.get().getExpDatasByLSID(sublist))
+                                        expData.index(searchService.defaultTask(), this);
+                                })
+                        );
+                    }, DbScope.CommitTaskOption.POSTCOMMIT)
+                );
             }
-            return new AliasDataIteratorBuilder(step0, getUserSchema().getContainer(), getUserSchema().getUser(), ExperimentService.get().getTinfoDataAliasMap());
+            DataIteratorBuilder builder = LoggingDataIterator.wrap(step0);
+            return LoggingDataIterator.wrap(new AliasDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser(), ExperimentService.get().getTinfoDataAliasMap()));
         }
         catch (IOException e)
         {
@@ -943,7 +941,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
             // Ensure we have a dataClass column and it is of the right value
             // use materialized classId so that parameter binding works for both exp.data as well as materialized table
-            ColumnInfo classIdCol = _dataClassTableInfo.get().getColumn("classId");
+            ColumnInfo classIdCol = _dataClassDataTableSupplier.get().getColumn("classId");
             step0.addColumn(classIdCol, new SimpleTranslator.ConstantColumn(_dataClass.getRowId()));
 
             // Ensure we have a cpasType column and it is of the right value
@@ -1128,7 +1126,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 return null;
 
             TableInfo d = getDbTable();
-            TableInfo t = _dataClassTableInfo.get();
+            TableInfo t = _dataClassDataTableSupplier.get();
 
             SQLFragment sql = new SQLFragment()
                     .append("SELECT t.*, d.RowId, d.Name, d.ClassId, d.Container, d.Description, d.CreatedBy, d.Created, d.ModifiedBy, d.Modified")
@@ -1192,7 +1190,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
             // update provisioned table -- note that LSID isn't the PK so we need to use the filter to update the correct row instead
             keys = new Object[] {lsid};
-            TableInfo t = _dataClassTableInfo.get();
+            TableInfo t = _dataClassDataTableSupplier.get();
             if (t.getColumnNameSet().stream().anyMatch(rowStripped::containsKey))
             {
                 ret.putAll(Table.update(user, t, rowStripped, t.getColumn("lsid"), keys, null, Level.DEBUG));

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -754,11 +754,12 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
 
         StringBuilder body = new StringBuilder();
 
-        // Name is an identifier with highest weight
+        // Name is an identifier with the highest weight
         identifiersHi.add(getName());
+        keywordsMed.add(getName()); // also add to keywords since those are stemmed
 
         // Description is added as a keywordsLo -- in Biologics it is common for the description to
-        // contain names of other DataClasses, e.g., "Mature desK of PS-10", which would will be tokenized as
+        // contain names of other DataClasses, e.g., "Mature desK of PS-10", which would be tokenized as
         // [mature, desk, ps, 10] if added it as a keyword so we lower its priority to avoid useless results.
         // CONSIDER: tokenize the description and extract identifiers
         if (null != getDescription())
@@ -768,7 +769,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         if (comment != null)
             keywordsMed.add(comment);
 
-        // Add aliases in parenthesis in the title
+        // Add aliases in parentheses in the title
         StringBuilder title = new StringBuilder(getName());
         Collection<String> aliases = this.getAliases();
         if (!aliases.isEmpty())

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -434,10 +434,10 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
         Map<String, Object> props = new HashMap<>();
         Set<String> identifiersHi = new HashSet<>();
 
-        // Name is identifier with highest weight
+        // Name is identifier with the highest weight
         identifiersHi.add(getName());
 
-        // Add aliases in parenthesis in the title
+        // Add aliases in parentheses in the title
         StringBuilder title = new StringBuilder("Sample - " + getName());
         Collection<String> aliases = this.getAliases();
         if (!aliases.isEmpty())

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1266,15 +1266,15 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         {
             var persist = new ExpDataIterators.PersistDataIteratorBuilder(data, this, propertiesTable, _ss, getUserSchema().getContainer(), getUserSchema().getUser(), _ss.getImportAliasMap(), sampleTypeObjectId)
                     .setFileLinkDirectory("sampletype");
-            SearchService ss = SearchService.get();
-            if (null != ss)
+            SearchService searchService = SearchService.get();
+            if (null != searchService)
             {
                 persist.setIndexFunction(lsids -> () ->
                     ListUtils.partition(lsids, 100).forEach(sublist ->
-                        ss.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
+                        searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
                         {
                             for (ExpMaterialImpl expMaterial : ExperimentServiceImpl.get().getExpMaterialsByLSID(sublist))
-                                expMaterial.index(ss.defaultTask());
+                                expMaterial.index(searchService.defaultTask());
                         })
                     )
                 );

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -31,6 +31,7 @@ import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.DataRegion;
+import org.labkey.api.data.DbScope;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.ImportAliasable;
@@ -1269,14 +1270,15 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             SearchService searchService = SearchService.get();
             if (null != searchService)
             {
-                persist.setIndexFunction(lsids -> () ->
+                persist.setIndexFunction(lsids -> propertiesTable.getSchema().getScope().addCommitTask(() -> {
                     ListUtils.partition(lsids, 100).forEach(sublist ->
                         searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
                         {
                             for (ExpMaterialImpl expMaterial : ExperimentServiceImpl.get().getExpMaterialsByLSID(sublist))
                                 expMaterial.index(searchService.defaultTask());
                         })
-                    )
+                    );
+                }, DbScope.CommitTaskOption.POSTCOMMIT)
                 );
             }
 


### PR DESCRIPTION
#### Rationale
Search indexing for data class objects was

#### Related Pull Requests
- https://github.com/LabKey/inventory/pull/835
- https://github.com/LabKey/biologics/pull/2109
- https://github.com/LabKey/sampleManagement/pull/1799
- https://github.com/LabKey/labkey-ui-components/pull/1181

#### Changes
* Update data class object search indexing to include the name of the object as a (stemmed) keyword
* Update persist data iterators for samples and data class objects so the index function becomes a post-commit task

