### PR TITLE
Fix async detection of closed client

### DIFF
--- a/api/src/org/labkey/api/data/AsyncQueryRequest.java
+++ b/api/src/org/labkey/api/data/AsyncQueryRequest.java
@@ -236,17 +236,9 @@ public class AsyncQueryRequest<T>
     {
         try
         {
-            // Issue 37051: don't write to the response unless committed (status code and http headers have been written)
-            if (_rootResponse.isCommitted())
-            {
-                _rootResponse.getWriter().write(" ");
-                _rootResponse.flushBuffer();
-                _log.debug("ping client: success");
-            }
-            else
-            {
-                _log.debug("ping client: skipped, not yet committed");
-            }
+            _rootResponse.getWriter().write(" ");
+            _rootResponse.flushBuffer();
+            _log.trace("ping client: success");
         }
         catch (IOException ioe)
         {


### PR DESCRIPTION
#### Rationale
This addresses the orphaned long running queries seen in test suites.  If the original bug can be reporoduced there should be better fixes than the fixed that caused this problem.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
