### PR TITLE
Wiki perf improvements: add DB indices, avoid locking on shared set for table of contents

### DIFF
--- a/announcements/resources/schemas/dbscripts/postgresql/comm-23.000-23.001.sql
+++ b/announcements/resources/schemas/dbscripts/postgresql/comm-23.000-23.001.sql
@@ -1,0 +1,16 @@
+-- Add missing indices on comm.Pages
+CREATE INDEX IDX_Pages_PageVersionId ON comm.Pages(PageVersionId);
+CREATE INDEX IDX_Pages_Parent ON comm.Pages(Parent);
+CREATE UNIQUE INDEX UQ_Pages_RowId ON comm.Pages(RowId);
+
+-- Switch from -1 to NULL for no parent
+ALTER TABLE comm.Pages ALTER COLUMN Parent DROP NOT NULL;
+UPDATE comm.Pages SET Parent = NULL WHERE Parent = -1;
+
+-- Clean up any pages that point at a parent that doesn't exist anymore
+UPDATE comm.Pages SET Parent = NULL WHERE Parent NOT IN (SELECT RowId FROM comm.Pages);
+
+-- Add a FK
+ALTER TABLE comm.Pages
+    ADD CONSTRAINT FK_Pages_Parent FOREIGN KEY (Parent)
+        REFERENCES comm.Pages (RowId);

--- a/announcements/resources/schemas/dbscripts/sqlserver/comm-23.000-23.001.sql
+++ b/announcements/resources/schemas/dbscripts/sqlserver/comm-23.000-23.001.sql
@@ -1,0 +1,16 @@
+-- Add missing indices on comm.Pages
+CREATE INDEX IDX_Pages_PageVersionId ON comm.Pages(PageVersionId);
+CREATE INDEX IDX_Pages_Parent ON comm.Pages(Parent);
+CREATE UNIQUE INDEX UQ_Pages_RowId ON comm.Pages(RowId);
+
+-- Switch from -1 to NULL for no parent
+ALTER TABLE comm.Pages ALTER COLUMN Parent INT NULL;
+UPDATE comm.Pages SET Parent = NULL WHERE Parent = -1;
+
+-- Clean up any pages that point at a parent that doesn't exist anymore
+UPDATE comm.Pages SET Parent = NULL WHERE Parent NOT IN (SELECT RowId FROM comm.Pages);
+
+-- Add a FK
+ALTER TABLE comm.Pages
+    ADD CONSTRAINT FK_Pages_Parent FOREIGN KEY (Parent)
+        REFERENCES comm.Pages (RowId);

--- a/announcements/src/org/labkey/announcements/AnnouncementModule.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementModule.java
@@ -96,7 +96,7 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 23.000;
+        return 23.001;
     }
 
     @Override

--- a/api/src/org/labkey/api/view/NavTreeManager.java
+++ b/api/src/org/labkey/api/view/NavTreeManager.java
@@ -83,9 +83,10 @@ public class NavTreeManager
         //Each navtreeid has a set of expanded paths...
         Map<String, Set<String>> treeMap = (Map<String, Set<String>>)
                 SessionHelper.getAttribute(viewContext.getRequest(), EXPAND_CONTAINERS_KEY, allocTreeMap);
-        // treeMap should never be null, unless we can't create a session
+        // treeMap could be null if we failed to create a session
+        // Wrap in a synchronized set to prevent everyone from trying to synchronize on the singleton emptySet()
         if (null == treeMap)
-            return Collections.emptySet();
+            return Collections.synchronizedSet(Collections.emptySet());
 
         return treeMap.computeIfAbsent(navTreeId, k -> Collections.synchronizedSet(new HashSet<>()));
     }

--- a/wiki/src/org/labkey/wiki/WikiCollections.java
+++ b/wiki/src/org/labkey/wiki/WikiCollections.java
@@ -95,7 +95,11 @@ public class WikiCollections
         new SqlSelector(CommSchema.getInstance().getSchema(), new SQLFragment(SQL, c)).forEach(rs -> {
             int rowId = rs.getInt(1);
             String name = rs.getString(2);
-            int parentId = rs.getInt(3);
+            Integer parentId = rs.getInt(3);
+            if (rs.wasNull())
+            {
+                parentId = null;
+            }
             String title = rs.getString(4);
 
             assert !name.isEmpty();
@@ -228,7 +232,7 @@ public class WikiCollections
     }
 
     // Returns null for non-existent wiki
-    @Nullable WikiTree getWikiTree(int rowId)
+    @Nullable WikiTree getWikiTree(Integer rowId)
     {
         return _treesByRowId.get(rowId);
     }

--- a/wiki/src/org/labkey/wiki/WikiController.java
+++ b/wiki/src/org/labkey/wiki/WikiController.java
@@ -1017,7 +1017,7 @@ public class WikiController extends SpringActionController
                 //map source page row ids to new page row ids
                 Map<Integer, Integer> pageIdMap = new HashMap<>();
                 //shortcut for root topics
-                pageIdMap.put(-1, -1);
+                pageIdMap.put(null, null);
 
                 //copy each page in the list
                 for (String name : srcPageNames)
@@ -1620,7 +1620,7 @@ public class WikiController extends SpringActionController
     {
         private String _name;
         private String _title;
-        private int _parent;
+        private Integer _parent;
         private String _siblingOrder;
         private String _nextAction;
         private boolean _shouldIndex;
@@ -1692,13 +1692,13 @@ public class WikiController extends SpringActionController
             _title = title;
         }
 
-        public int getParent()
+        public Integer getParent()
         {
             return _parent;
         }
 
         @SuppressWarnings({"UnusedDeclaration"})
-        public void setParent(int parent)
+        public void setParent(Integer parent)
         {
             _parent = parent;
         }
@@ -2044,7 +2044,7 @@ public class WikiController extends SpringActionController
         private String _name;
         private String _title;
         private String _body;
-        private Integer _parent = -1;
+        private Integer _parent;
         private Integer _pageVersionId;
         private String _rendererType;
         private String _pageId;
@@ -2126,9 +2126,9 @@ public class WikiController extends SpringActionController
             _pageVersionId = pageVersionId;
         }
 
-        public int getParentId()
+        public Integer getParentId()
         {
-            return null == _parent ? -1 : _parent;
+            return _parent;
         }
 
         public String getRendererType()
@@ -2366,7 +2366,7 @@ public class WikiController extends SpringActionController
                     (null != wikiversion.getBody() && null == form.getBody()) ||
                     (null != wikiversion.getBody() && null != form.getBody() && wikiversion.getBody().compareTo(form.getBody().trim()) != 0) ||
                     !wikiversion.getRendererTypeEnum().equals(currentRendererType) ||
-                    wikiUpdate.getParent() != form.getParentId() ||
+                    !Objects.equals(wikiUpdate.getParent(), form.getParentId()) ||
                     wikiUpdate.isShowAttachments() != form.isShowAttachments() ||
                     wikiUpdate.isShouldIndex() != form.isShouldIndex())
             {

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -430,7 +430,7 @@ public class WikiManager implements WikiService
             else
             {
                 Wiki parent = wiki.getParentWiki();
-                int parentId = -1;
+                Integer parentId = null;
                 float wikiDisplay = wiki.getDisplayOrder();
                 Wiki nextWiki = null;
 

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -558,7 +558,7 @@ public class WikiManager implements WikiService
             if (destParentId != null)
                 newWikiPage.setParent(destParentId);
             else
-                newWikiPage.setParent(-1);
+                newWikiPage.setParent(null);
         }
 
         //get wiki & attachments

--- a/wiki/src/org/labkey/wiki/WikiSelectManager.java
+++ b/wiki/src/org/labkey/wiki/WikiSelectManager.java
@@ -206,7 +206,7 @@ public class WikiSelectManager
     }
 
 
-    public static @NotNull Collection<WikiTree> getChildren(Container c, int rowId)
+    public static @NotNull Collection<WikiTree> getChildren(Container c, Integer rowId)
     {
         WikiTree tree = getWikiCollections(c).getWikiTree(rowId);
 
@@ -217,7 +217,7 @@ public class WikiSelectManager
 
 
     // Only use if a full wiki is needed (otherwise, use WikiTree)
-    public static @NotNull List<Wiki> getChildWikis(Container c, int rowId)
+    public static @NotNull List<Wiki> getChildWikis(Container c, Integer rowId)
     {
         List<Wiki> wikis = new LinkedList<>();
 

--- a/wiki/src/org/labkey/wiki/model/Wiki.java
+++ b/wiki/src/org/labkey/wiki/model/Wiki.java
@@ -37,7 +37,6 @@ import java.util.List;
 /**
  * User: mbellew
  * Date: Jan 13, 2005
- * Time: 10:28:24 AM
  */
 
 public class Wiki extends Entity implements Serializable
@@ -49,7 +48,7 @@ public class Wiki extends Entity implements Serializable
 
     private int _rowId;
     private String _name;
-    private int _parent = -1;
+    private Integer _parent;
     private float _displayOrder = 0;
     private Integer _pageVersionId;
     private boolean _showAttachments = true;
@@ -125,15 +124,19 @@ public class Wiki extends Entity implements Serializable
 
     public Wiki getParentWiki()
     {
+        if (getParent() == null)
+        {
+            return null;
+        }
         return WikiSelectManager.getWiki(ContainerManager.getForId(getContainerId()), getParent());
     }
 
-    public int getParent()
+    public Integer getParent()
     {
         return _parent;
     }
 
-    public void setParent(int parent)
+    public void setParent(Integer parent)
     {
         _parent = parent;
     }

--- a/wiki/src/org/labkey/wiki/model/Wiki.java
+++ b/wiki/src/org/labkey/wiki/model/Wiki.java
@@ -138,6 +138,10 @@ public class Wiki extends Entity implements Serializable
 
     public void setParent(Integer parent)
     {
+        if (parent != null && parent.intValue() < 0)
+        {
+            throw new IllegalArgumentException("Bad parent ID: " + parent);
+        }
         _parent = parent;
     }
 

--- a/wiki/src/org/labkey/wiki/model/WikiEditModel.java
+++ b/wiki/src/org/labkey/wiki/model/WikiEditModel.java
@@ -101,9 +101,9 @@ public class WikiEditModel
         return null == _wiki ? null : _wiki.getRowId();
     }
 
-    public int getParent()
+    public Integer getParent()
     {
-        return null == _wiki ? -1 : _wiki.getParent();
+        return null == _wiki ? null : _wiki.getParent();
     }
 
     public int getPageVersionId()

--- a/wiki/src/org/labkey/wiki/model/WikiTree.java
+++ b/wiki/src/org/labkey/wiki/model/WikiTree.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 
 /*
 * User: adam
@@ -30,7 +31,7 @@ import java.util.LinkedHashSet;
 // Represents a tree or sub-tree of wiki objects.  Used for caching TOC, children, siblings, etc.
 public class WikiTree
 {
-    private final int _rowId;
+    private final Integer _rowId;
     private final String _name;
     private final String _title;
     private final Collection<WikiTree> _children;
@@ -40,10 +41,10 @@ public class WikiTree
 
     public static WikiTree createRootWikiTree()
     {
-        return new WikiTree(-1, null, null);
+        return new WikiTree(null, null, null);
     }
 
-    public WikiTree(int rowId, String name, String title)
+    public WikiTree(Integer rowId, String name, String title)
     {
         _rowId = rowId;
         _name = name;
@@ -51,7 +52,7 @@ public class WikiTree
         _children = new LinkedHashSet<>();
     }
 
-    public int getRowId()
+    public Integer getRowId()
     {
         return _rowId;
     }
@@ -95,7 +96,7 @@ public class WikiTree
 
         WikiTree wikiTree = (WikiTree) o;
 
-        if (_rowId != wikiTree._rowId) return false;
+        if (Objects.equals(_rowId, wikiTree._rowId)) return false;
 
         return true;
     }
@@ -103,6 +104,6 @@ public class WikiTree
     @Override
     public int hashCode()
     {
-        return _rowId;
+        return Objects.hash(_rowId);
     }
 }

--- a/wiki/src/org/labkey/wiki/view/wikiEdit.jsp
+++ b/wiki/src/org/labkey/wiki/view/wikiEdit.jsp
@@ -146,7 +146,7 @@
                             .name("parent")
                             .id(ID_PREFIX + "parent")
                             .addStyle("width:600px");
-                        parentBuilder.addOption(new OptionBuilder().value("-1").label("[none]").selected(model.getParent() == -1).build());
+                        parentBuilder.addOption(new OptionBuilder().value("").label("[none]").selected(model.getParent() == null).build());
                         model.getPossibleParents().forEach(pp->{
                             StringBuilder indent = new StringBuilder();
                             int depth = pp.getDepth();

--- a/wiki/src/org/labkey/wiki/view/wikiManage.jsp
+++ b/wiki/src/org/labkey/wiki/view/wikiManage.jsp
@@ -30,6 +30,7 @@
 <%@ page import="org.labkey.wiki.model.Wiki" %>
 <%@ page import="org.springframework.validation.Errors" %>
 <%@ page import="org.springframework.validation.FieldError" %>
+<%@ page import="java.util.Objects" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
@@ -146,7 +147,7 @@
                     .id("parent")
                     .addStyle("width:420px")
                     .onChange("document.manage.nextAction.value = " + q(NextAction.manage.name()) + "; submit();");
-                parentBuilder.addOption(new OptionBuilder().value("-1").label("[none]").selected(wiki.getParent() == -1).build());
+                parentBuilder.addOption(new OptionBuilder().value("").label("[none]").selected(wiki.getParent() == null).build());
                 bean.possibleParents.forEach(pp->{
                     StringBuilder indent = new StringBuilder();
                     int depth = pp.getDepth();
@@ -157,7 +158,7 @@
                     parentBuilder.addOption(new OptionBuilder()
                         .value(String.valueOf(pp.getRowId()))
                         .label(label)
-                        .selected(pp.getRowId() == wiki.getParent())
+                        .selected(Objects.equals(pp.getRowId(), wiki.getParent()))
                         .build()
                     );
                 });


### PR DESCRIPTION
#### Rationale
We do a CTE over the wiki table where neither column involved in the recursion has an index. That translates to a lot of SeqScans.

https://explain.depesz.com/s/Pk3E

Additionally, I'm seeing lock contention when traversing the table of contents tree. I think it's because we sometimes return Collections.emptySet() and synchronize on it, meaning that many threads may be locking on the same object.

#### Changes
* Add missing indices
* Switch from using -1 to null as parent for top-level wikis in the tree, letting us also add a FK
* Wrap the emptySet() with a synchronizedSet() so threads don't compete for the same lock