### PR TITLE
Create "Created/CreatedBy/Modified/ModifiedBy" for Assay data rows - fix clear flag

### DIFF
--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -1459,7 +1459,9 @@ public class AssayController extends SpringActionController
                 for (Integer id : form.getRowList())
                 {
                     // assuming that column in storage table has same name
-                    Table.update(getUser(), ti, new HashMap<>(Map.of(flagCol.getColumnName(), comment)), id);
+                    Map<String, Object> flagComment = new HashMap<>();
+                    flagComment.put(flagCol.getColumnName(), comment);
+                    Table.update(getUser(), ti, flagComment, id);
                     rowsAffected++;
                 }
                 transaction.commit();


### PR DESCRIPTION
#### Rationale
To allow setting system fields values on update, https://github.com/LabKey/platform/pull/4358 changed to use a mutable hashmap from Collections.singletonMap for flag values to update. However, the use of Map.of for the initial constructor is problematic for clearing flag value case because flag value is null and Map.of doesn't accept null value.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* don't use Map.of since it doesn't accept null value
