### PR TITLE
Migrate luceneVersion to top-level gradle.properties so other modules can use it

### DIFF
--- a/api/src/org/labkey/api/reports/report/r/ParamReplacementSvc.java
+++ b/api/src/org/labkey/api/reports/report/r/ParamReplacementSvc.java
@@ -460,7 +460,7 @@ public class ParamReplacementSvc
         {
             throw new IllegalArgumentException("There was a syntax error with the substitution parameter in your script.\n"
                     + (StringUtils.isEmpty(token) ? "" : "Substitution token \"" + token + "\" is used incorrectly.\n")
-                    + "Error message: " + e.getMessage());
+                    + "Error message: " + e.getMessage(), e);
         }
     }
 

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -5,7 +5,6 @@ plugins {
     id 'org.labkey.build.module'
 }
 
-ext.luceneVersion="9.4.2"
 ext.mime4jVersion="0.8.7"
 
 dependencies {


### PR DESCRIPTION
As-is, luceneVersion is set in the search module's build.gradle. This PR moves it to the top-level, so other modules can share it. 

See also: https://github.com/LabKey/server/pull/463