### PR TITLE
Support estimated query execution plan, Issue #47753

### DIFF
--- a/api/src/org/labkey/api/data/SqlExecutingSelector.java
+++ b/api/src/org/labkey/api/data/SqlExecutingSelector.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.dialect.SqlDialect;
+import org.labkey.api.data.dialect.SqlDialect.ExecutionPlanType;
 import org.labkey.api.data.dialect.StatementWrapper;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.MemTracker;
@@ -166,15 +167,16 @@ public abstract class SqlExecutingSelector<FACTORY extends SqlFactory, SELECTOR 
 
     /**
      *  Generates the current select SQL and returns the execution plan. SQL is generated as if getResultSet() had been
-     *  called, which means that TableSelector limit, offset, sort, filter, etc. are all respected.
+     *  called, which means that TableSelector limit, offset, sort, filter, etc. are all respected. Callers must test
+     *  canShowExecutionPlan() before invoking this method.
      */
-    Collection<String> getExecutionPlan()
+    Collection<String> getExecutionPlan(ExecutionPlanType type)
     {
         SqlDialect dialect = getScope().getSqlDialect();
 
-        if (dialect.canShowExecutionPlan())
+        if (dialect.canShowExecutionPlan(type))
         {
-            return dialect.getExecutionPlan(getScope(), getSqlFactory(true).getSql());
+            return dialect.getExecutionPlan(getScope(), getSqlFactory(true).getSql(), type);
         }
         else
         {
@@ -186,10 +188,10 @@ public abstract class SqlExecutingSelector<FACTORY extends SqlFactory, SELECTOR 
      *  Convenience method that generates select SQL and logs the execution plan to the passed in Logger (if non-null)
      */
     @SuppressWarnings("unused")
-    public SELECTOR logExecutionPlan(@Nullable Logger logger)
+    public SELECTOR logExecutionPlan(@Nullable Logger logger, ExecutionPlanType type)
     {
         if (null != logger)
-            logger.info(String.join("\n", getExecutionPlan()));
+            logger.info(String.join("\n", getExecutionPlan(type)));
 
         return getThis();
     }

--- a/api/src/org/labkey/api/data/SqlExecutor.java
+++ b/api/src/org/labkey/api/data/SqlExecutor.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.BaseSelector.ResultSetHandler;
 import org.labkey.api.data.dialect.SqlDialect;
+import org.labkey.api.data.dialect.SqlDialect.ExecutionPlanType;
 import org.labkey.api.util.ExceptionUtil;
 
 import java.sql.Connection;
@@ -74,13 +75,13 @@ public class SqlExecutor extends JdbcCommand<SqlExecutor>
         return execute(sql, NORMAL_EXECUTOR, null).intValue();
     }
 
-    public Collection<String> getExecutionPlan(SQLFragment sql)
+    public Collection<String> getExecutionPlan(SQLFragment sql, ExecutionPlanType type)
     {
         SqlDialect dialect = getScope().getSqlDialect();
 
-        if (dialect.canShowExecutionPlan())
+        if (dialect.canShowExecutionPlan(type))
         {
-            return dialect.getExecutionPlan(getScope(), sql);
+            return dialect.getExecutionPlan(getScope(), sql, type);
         }
         else
         {
@@ -91,10 +92,10 @@ public class SqlExecutor extends JdbcCommand<SqlExecutor>
     /**
      *  Convenience method that logs the plan to the passed in Logger (if non-null)
      */
-    public void logExecutionPlan(@Nullable Logger logger, SQLFragment sql)
+    public void logExecutionPlan(@Nullable Logger logger, SQLFragment sql, ExecutionPlanType type)
     {
         if (null != logger)
-            logger.info(String.join("\n", getExecutionPlan(sql)));
+            logger.info(String.join("\n", getExecutionPlan(sql, type)));
     }
 
     public <T> T executeWithResults(SQLFragment sql, ResultSetHandler<T> handler)

--- a/api/src/org/labkey/api/data/SqlSelectorTestCase.java
+++ b/api/src/org/labkey/api/data/SqlSelectorTestCase.java
@@ -17,6 +17,7 @@ package org.labkey.api.data;
 
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.junit.Test;
+import org.labkey.api.data.dialect.SqlDialect;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -26,11 +27,6 @@ import java.util.stream.Stream;
 import static java.sql.Connection.TRANSACTION_READ_COMMITTED;
 import static java.sql.Connection.TRANSACTION_READ_UNCOMMITTED;
 
-/**
- * User: adam
- * Date: 12/18/12
- * Time: 8:04 PM
- */
 public class SqlSelectorTestCase extends AbstractSelectorTestCase<SqlSelector>
 {
     @Test
@@ -57,9 +53,15 @@ public class SqlSelectorTestCase extends AbstractSelectorTestCase<SqlSelector>
             assertTrue(e.getMessage().startsWith("Must select at least two columns"));
         }
 
-        // Verify that we can generate some execution plan
-        Collection<String> executionPlan = selector.getExecutionPlan();
-        assertTrue(!executionPlan.isEmpty());
+        // Verify that we can generate the supported execution plans
+        for (SqlDialect.ExecutionPlanType type : SqlDialect.ExecutionPlanType.values())
+        {
+            if (CoreSchema.getInstance().getSqlDialect().canShowExecutionPlan(type))
+            {
+                Collection<String> executionPlan = selector.getExecutionPlan(type);
+                assertFalse(executionPlan.isEmpty());
+            }
+        }
     }
 
     @Override

--- a/api/src/org/labkey/api/data/TableSelectorTestCase.java
+++ b/api/src/org/labkey/api/data/TableSelectorTestCase.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.Level;
 import org.junit.Test;
 import org.labkey.api.collections.CsvSet;
 import org.labkey.api.data.Selector.ForEachBlock;
+import org.labkey.api.data.dialect.SqlDialect.ExecutionPlanType;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.security.User;
 import org.labkey.api.util.ExceptionUtil;
@@ -34,13 +35,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -428,11 +427,14 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
         test(selector, clazz);
         testOffsetAndLimit(selector, clazz);
 
-        // Verify that we can generate an execution plan (if supported)
-        if (table.getSqlDialect().canShowExecutionPlan())
+        // Verify that we can generate the supported execution plans
+        for (ExecutionPlanType type : ExecutionPlanType.values())
         {
-            Collection<String> executionPlan = selector.getExecutionPlan();
-            assertTrue(!executionPlan.isEmpty());
+            if (table.getSqlDialect().canShowExecutionPlan(type))
+            {
+                Collection<String> executionPlan = selector.getExecutionPlan(type);
+                assertFalse(executionPlan.isEmpty());
+            }
         }
     }
 

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -1784,16 +1784,16 @@ public abstract class PostgreSql91Dialect extends SqlDialect
 
 
     @Override
-    public boolean canShowExecutionPlan()
+    public boolean canShowExecutionPlan(ExecutionPlanType type)
     {
         return true;
     }
 
     @Override
-    protected Collection<String> getQueryExecutionPlan(Connection conn, DbScope scope, SQLFragment sql)
+    protected Collection<String> getQueryExecutionPlan(Connection conn, DbScope scope, SQLFragment sql, ExecutionPlanType type)
     {
         SQLFragment copy = new SQLFragment(sql);
-        copy.insert(0, "EXPLAIN ANALYZE ");
+        copy.insert(0, type == ExecutionPlanType.Estimated ? "EXPLAIN " : "EXPLAIN ANALYZE ");
 
         return new SqlSelector(scope, conn, copy).getCollection(String.class);
     }

--- a/api/src/org/labkey/api/data/dialect/SimpleSqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SimpleSqlDialect.java
@@ -115,13 +115,13 @@ public abstract class SimpleSqlDialect extends SqlDialect
     }
 
     @Override
-    public boolean canShowExecutionPlan()
+    public boolean canShowExecutionPlan(ExecutionPlanType type)
     {
         return false;
     }
 
     @Override
-    protected Collection<String> getQueryExecutionPlan(Connection conn, DbScope scope, SQLFragment sql)
+    protected Collection<String> getQueryExecutionPlan(Connection conn, DbScope scope, SQLFragment sql, ExecutionPlanType type)
     {
         throw new IllegalStateException("Should not call when canShowExecutionPlan() returns false");
     }

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1409,18 +1409,39 @@ public abstract class SqlDialect
         return _tableTypes;
     }
 
-    public abstract boolean canShowExecutionPlan();
-    protected abstract Collection<String> getQueryExecutionPlan(Connection conn, DbScope scope, SQLFragment sql);
+    public abstract boolean canShowExecutionPlan(ExecutionPlanType type);
+    protected abstract Collection<String> getQueryExecutionPlan(Connection conn, DbScope scope, SQLFragment sql, ExecutionPlanType type);
 
-    public final Collection<String> getExecutionPlan(DbScope scope, SQLFragment sql)
+    public enum ExecutionPlanType
     {
+        Estimated("Estimated Execution Plan"),
+        Actual("Execution Plan With Actual Timing");
+
+        private final String _description;
+
+        ExecutionPlanType(String description)
+        {
+            _description = description;
+        }
+
+        public String getDescription()
+        {
+            return _description;
+        }
+    }
+
+    public final Collection<String> getExecutionPlan(DbScope scope, SQLFragment sql, ExecutionPlanType type)
+    {
+        // Callers shouldn't be asking for an execution plan that the dialect doesn't support
+        assert canShowExecutionPlan(type);
+
         // Issue 35102 - use an unpooled connection so that nobody else tries to use this connection. Other code that
         // executes on this same thread (and therefore the scope's normal connection) could be trying to retrieve
         // properties, do logging, etc. This also ensures that unusual connection settings and other side effects are
         // always discarded.
         try (Connection conn = scope.getUnpooledConnection())
         {
-            return getQueryExecutionPlan(conn, scope, sql);
+            return getQueryExecutionPlan(conn, scope, sql, type);
         }
         catch (SQLException e)
         {

--- a/api/src/org/labkey/api/data/queryprofiler/QueryTracker.java
+++ b/api/src/org/labkey/api/data/queryprofiler/QueryTracker.java
@@ -24,6 +24,7 @@ import org.labkey.api.collections.ByteArrayHashKey;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.Table;
+import org.labkey.api.data.dialect.SqlDialect.ExecutionPlanType;
 import org.labkey.api.util.Compress;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.Formats;
@@ -44,8 +45,6 @@ import java.util.zip.DataFormatException;
 /**
  * Information about a specific query that has been issued against the database. Intended to have one instance
  * per unique SQL. Tracks information about executions to date, and code that invoked it.
- * User: jeckels
- * Date: 2/13/14
  */
 class QueryTracker
 {
@@ -122,9 +121,9 @@ class QueryTracker
         return _parameters;
     }
 
-    public boolean canShowExecutionPlan()
+    public boolean canShowExecutionPlan(ExecutionPlanType type)
     {
-        return null != _scope && _scope.getSqlDialect().canShowExecutionPlan() && _validSql && Table.isSelect(_sql);
+        return null != _scope && _scope.getSqlDialect().canShowExecutionPlan(type) && _validSql && Table.isSelect(_sql);
     }
 
     public long getCount()

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -1868,13 +1868,14 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
 
 
     @Override
-    public boolean canShowExecutionPlan()
+    public boolean canShowExecutionPlan(ExecutionPlanType type)
     {
-        return true;
+        // I don't think SQL Server provides actual times
+        return type == ExecutionPlanType.Estimated;
     }
 
     @Override
-    public Collection<String> getQueryExecutionPlan(Connection conn, DbScope scope, SQLFragment sql)
+    public Collection<String> getQueryExecutionPlan(Connection conn, DbScope scope, SQLFragment sql, ExecutionPlanType type)
     {
         try
         {

--- a/bigiron/src/org/labkey/bigiron/mysql/MySql80Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySql80Dialect.java
@@ -38,8 +38,15 @@ public class MySql80Dialect extends MySql57Dialect
     }
 
     // MySQL 8.0 introduced EXPLAIN ANALYZE
-    protected String getExplainPrefix()
+    @Override
+    public boolean canShowExecutionPlan(ExecutionPlanType type)
     {
-        return "EXPLAIN ANALYZE ";
+        return true;
+    }
+
+    @Override
+    protected String getExplainPrefix(ExecutionPlanType type)
+    {
+        return type == ExecutionPlanType.Estimated ? "EXPLAIN FORMAT = TREE " : "EXPLAIN ANALYZE ";
     }
 }

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -22,6 +22,7 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -67,6 +68,7 @@ import org.labkey.api.compliance.ComplianceService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.*;
 import org.labkey.api.data.Container.ContainerException;
+import org.labkey.api.data.dialect.SqlDialect.ExecutionPlanType;
 import org.labkey.api.data.queryprofiler.QueryProfiler;
 import org.labkey.api.data.queryprofiler.QueryProfiler.QueryStatTsvWriter;
 import org.labkey.api.exp.OntologyManager;
@@ -2560,12 +2562,17 @@ public class AdminController extends SpringActionController
     public class ExecutionPlanAction extends SimpleViewAction<QueryForm>
     {
         private int _hashCode;
+        private ExecutionPlanType _type;
 
         @Override
         public ModelAndView getView(QueryForm form, BindException errors)
         {
             _hashCode = form.getSqlHashCode();
-            return QueryProfiler.getInstance().getExecutionPlanView(form.getSqlHashCode());
+            _type = EnumUtils.getEnum(ExecutionPlanType.class, form.getType());
+            if (null == _type)
+                throw new NotFoundException("Unknown execution plan type");
+
+            return QueryProfiler.getInstance().getExecutionPlanView(form.getSqlHashCode(), _type);
         }
 
         @Override
@@ -2573,14 +2580,15 @@ public class AdminController extends SpringActionController
         {
             addAdminNavTrail(root, "Queries", QueriesAction.class);
             root.addChild("Query Stack Traces", getQueryStackTracesURL(_hashCode));
-            root.addChild("Execution Plan");
+            root.addChild(_type.getDescription());
         }
     }
 
 
     public static class QueryForm
     {
-        int _sqlHashCode;
+        private int _sqlHashCode;
+        private String _type = "Estimated"; // All dialects support Estimated
 
         public int getSqlHashCode()
         {
@@ -2591,6 +2599,17 @@ public class AdminController extends SpringActionController
         public void setSqlHashCode(int sqlHashCode)
         {
             _sqlHashCode = sqlHashCode;
+        }
+
+        public String getType()
+        {
+            return _type;
+        }
+
+        @SuppressWarnings({"UnusedDeclaration"})
+        public void setType(String type)
+        {
+            _type = type;
         }
     }
 


### PR DESCRIPTION
#### Rationale
The "Show Execution Plan" option executes the query and returns actual timings. For particularly poor performing queries, retrieving the execution plan can be blocked because of proxy timeouts, etc. This PR introduces the ability to retrieve estimated query plans (which should be returned very quickly) in addition to execution plans with actual timing. Each dialect determines which variants (if any) it supports.

#### Related Pull Requests
* https://github.com/LabKey/redshift/pull/38
