### PR TITLE
Fix windows-specific issue in RhinoService$Test

### DIFF
--- a/api/src/org/labkey/api/reports/report/r/ParamReplacementSvc.java
+++ b/api/src/org/labkey/api/reports/report/r/ParamReplacementSvc.java
@@ -460,6 +460,7 @@ public class ParamReplacementSvc
         {
             throw new IllegalArgumentException("There was a syntax error with the substitution parameter in your script.\n"
                     + (StringUtils.isEmpty(token) ? "" : "Substitution token \"" + token + "\" is used incorrectly.\n")
+                    + (StringUtils.isEmpty(replacementStr) ? "" : "Replacement string was: \"" + replacementStr + "\"\n")
                     + "Error message: " + e.getMessage(), e);
         }
     }
@@ -528,6 +529,10 @@ public class ParamReplacementSvc
                     {
                         resultFileName = resultFile.getAbsolutePath().replaceAll("\\\\", "/");
                     }
+
+                    // NOTE: dollar signs in the path will cause "java.lang.IllegalArgumentException: Illegal group reference" from Matcher.appendReplacement
+                    resultFileName = resultFileName.replaceAll("\\$", "\\\\\\$");
+
                     _log.debug("Found output parameter '" + param.getName() + "'.  Mapping local file '" + resultFile.getAbsolutePath() + "' to '" + resultFileName + "'");
                 }
                 String replacementStr = pattern.getReplacementStr(resultFileName, m.group(0), param.getName());


### PR DESCRIPTION
This is related to a relatively long standing TeamCity windows agent-specific failure in RhinoService$Test, such as:

 https://teamcity.labkey.org/test/-693611466596297028?currentProjectId=LabkeyTrunk&expandTestHistoryChartSection=true&branch=%3Cdefault%3E

https://teamcity.labkey.org/test/-693611466596297028?currentProjectId=LabkeyTrunk&expandTestHistoryChartSection=true&branch=%3Cdefault%3E&expandedTest=build%3A%28id%3A2423836%29%2Cid%3A7097

That test is using parameter substitution in an R script to poke in a filepath. Tests will show if I'm right, but what I think is happening is that these windows agents have a filepath with a dollar sign in the name. As a result, the regex replacement string has that dollar sign, and the Matcher is interpreting this as a bad group reference. 

I dont know if there is a more general-purpose regex escape method to use, but this PR will at least handle the dollar sign case by escaping those in the file path string. 

This needs to run on a windows agent to see if my theory is right and if the tests will pass now.