### PR TITLE
Move samples between project updates and containerFilter changes

### DIFF
--- a/api/src/org/labkey/api/data/DataRegionSelection.java
+++ b/api/src/org/labkey/api/data/DataRegionSelection.java
@@ -275,6 +275,21 @@ public class DataRegionSelection
         return selectedValues.size();
     }
 
+    /**
+     * Clear any session attributes that match the given container path, as the prefix, and the selection key, as the suffix
+     */
+    public static void clearRelatedByContainerPath(ViewContext context, String key)
+    {
+        if (key == null || context.getRequest() == null)
+            return;
+
+        HttpSession session = context.getRequest().getSession(false);
+        String containerPath = context.getContainer().getPath();
+        Collections.list(session.getAttributeNames()).stream()
+            .filter(name -> name.startsWith(containerPath) && (name.endsWith(key + SNAPSHOT_SELECTED_VALUES) || name.endsWith(key + SELECTED_VALUES)))
+            .forEach(session::removeAttribute);
+    }
+
     private static void clearAll(HttpSession session, String path, String key, boolean isSnapshot)
     {
         assert path != null : "DataRegion container path required";

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -7740,7 +7740,15 @@ public class ExperimentController extends SpringActionController
         {
             String selectionKey = form.getDataRegionSelectionKey();
             if (selectionKey != null)
+            {
                 DataRegionSelection.setSelected(getViewContext(), selectionKey, _materials.stream().map(material -> Integer.toString(material.getRowId())).collect(Collectors.toSet()), false);
+
+                // if moving samples from a sample type, the selections from other selectionKeys in that container will
+                // possibly be holding onto invalid keys after the move, so clear them based on the containerPath and selectionKey suffix
+                String[] keyParts = selectionKey.split("|");
+                if (keyParts.length > 1)
+                    DataRegionSelection.clearRelatedByContainerPath(getViewContext(), keyParts[keyParts.length - 1]);
+            }
         }
 
         private void validateTargetContainer(MoveSamplesForm form, Errors errors)


### PR DESCRIPTION
#### Rationale
See related PRs for rationale regarding picklist container filter changes. This PR fixes the issue that if you have selected samples for a given sample type in the app in various different contexts (i.e. source samples, job samples, sample type grid, etc.) and then you move a sample, those other selectionKeys might be invalid if they are holding onto a sample ID for the given container that has now been moved. We fix that here by clearing selectionKeys for related sample types within the container on move.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1182

#### Changes
* Add DataRegionSelection. clearRelatedByContainerPath and call it on successful move samples API call
