### PR TITLE
Fix ContainerContextText - one more -1 -> NULL parent update

### DIFF
--- a/announcements/resources/schemas/dbscripts/postgresql/comm-create.sql
+++ b/announcements/resources/schemas/dbscripts/postgresql/comm-create.sql
@@ -49,7 +49,7 @@ CREATE VIEW comm.PagePaths AS
       CAST(p.Name AS VARCHAR(2000)) AS PathParts,
       0 AS Depth
     FROM comm.Pages p
-      WHERE p.Parent = -1
+      WHERE p.Parent IS NULL
 
     UNION ALL
 

--- a/announcements/resources/schemas/dbscripts/sqlserver/comm-create.sql
+++ b/announcements/resources/schemas/dbscripts/sqlserver/comm-create.sql
@@ -50,7 +50,7 @@ CREATE VIEW comm.PagePaths AS
       CAST(p.Name AS VARCHAR(2000)) AS PathParts,
       0 AS Depth
     FROM comm.Pages p
-      WHERE p.Parent = -1
+      WHERE p.Parent IS NULL
 
     UNION ALL
 

--- a/announcements/src/org/labkey/announcements/AnnouncementModule.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementModule.java
@@ -96,7 +96,7 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 23.001;
+        return 23.002;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
I just changed wikis to use -1 instead of null for a Parent value. I missed this additional place that hard-coded -1

https://teamcity.labkey.org/buildConfiguration/bt20/2424266?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true

#### Changes
* Update CTE to use NULL as the Parent value for top-level wikis