### PR TITLE
Restore support for SimpleResponse(ApiSimpleResponse)

### DIFF
--- a/api/src/org/labkey/api/action/ApiSimpleResponse.java
+++ b/api/src/org/labkey/api/action/ApiSimpleResponse.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.action;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.commons.beanutils.BeanUtils;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
@@ -55,6 +56,7 @@ public class ApiSimpleResponse implements ApiResponse
         _json.put(key, value);
     }
 
+    @JsonValue // Tell Jackson that this is the serialization method
     public JSONObject getJson()
     {
         return _json;

--- a/api/src/org/labkey/api/action/BaseApiAction.java
+++ b/api/src/org/labkey/api/action/BaseApiAction.java
@@ -586,19 +586,25 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
     // Static helpers to create a simple response object for Jackson serialization
     //
 
-    public static SimpleResponse success()
+    public static SimpleResponse<Void> success()
     {
-        return new SimpleResponse(true);
+        return new SimpleResponse<>(true);
     }
 
-    public static SimpleResponse success(String message)
+    public static SimpleResponse<String> success(String message)
     {
-        return new SimpleResponse(true, message);
+        return new SimpleResponse<>(true, message);
     }
 
     public static <T> SimpleResponse<T> success(T data)
     {
         return new SimpleResponse<>(true, null, data);
+    }
+
+    // Wrapping an ApiSimpleResponse with a SimpleResponse is strange, but a few actions do it so make it work
+    public static SimpleResponse<?> success(ApiSimpleResponse data)
+    {
+        return success(data.getJson());
     }
 
     public static <T> SimpleResponse<T> success(String message, T data)
@@ -615,6 +621,5 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
     {
         throw new NotFoundException(message);
     }
-
 }
 

--- a/api/src/org/labkey/api/action/BaseApiAction.java
+++ b/api/src/org/labkey/api/action/BaseApiAction.java
@@ -601,12 +601,6 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
         return new SimpleResponse<>(true, null, data);
     }
 
-    // Wrapping an ApiSimpleResponse with a SimpleResponse is strange, but a few actions do it so make it work
-    public static SimpleResponse<?> success(ApiSimpleResponse data)
-    {
-        return success(data.getJson());
-    }
-
     public static <T> SimpleResponse<T> success(String message, T data)
     {
         return new SimpleResponse<>(true, message, data);

--- a/api/src/org/labkey/api/study/DataspaceContainerFilter.java
+++ b/api/src/org/labkey/api/study/DataspaceContainerFilter.java
@@ -184,7 +184,7 @@ public class DataspaceContainerFilter extends ContainerFilter.AllInProject
     */
     private static final Cache<String, Set<GUID>> studiesCache = CacheManager.getBlockingStringKeyCache(CacheManager.UNLIMITED, CacheManager.HOUR, "Dataspace study cache", new CacheLoader<String,Set<GUID>>(){
         @Override
-        public Set<GUID> load(String key, @Nullable Object argument)
+        public Set<GUID> load(@NotNull String key, @Nullable Object argument)
         {
             Container project = ContainerManager.getForId(key);
             if (null == project || !project.isProject())

--- a/query/src/org/labkey/query/persist/QueryManager.java
+++ b/query/src/org/labkey/query/persist/QueryManager.java
@@ -796,11 +796,11 @@ public class QueryManager
             return true;
 
         boolean isPublic = o.getBoolean("isPublic");
-        SchemaKey schemaPath = SchemaKey.fromString(o.getString("schemaName"));
+        SchemaKey schemaPath = SchemaKey.fromString(o.optString("schemaName"));
         String queryName = o.getString("queryName");
-        String displayColumn = o.getString("displayColumn");
-        String keyColumn = o.getString("keyColumn");
-        String containerPath = o.getString("containerPath");
+        String displayColumn = o.optString("displayColumn");
+        String keyColumn = o.optString("keyColumn");
+        String containerPath = o.optString("containerPath");
 
         Container lookupContainer = containerPath == null ? container : ContainerManager.getForPath(containerPath);
         if (lookupContainer == null)


### PR DESCRIPTION
#### Rationale
Failures in the `BiologicsApiTest` pointed out that some API actions return an `ApiSimpleResponse` wrapped with a `SimpleResponse`. This is probably not intentional, but it used to work. In the related PR, ApiSimpleResponse stopped implementing `Map`, so Jackson started serializing it as a bean... which mean its JSON got serialized under an unexpected "json" property.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4367