### PR TITLE
Issue 47836: Skip the "temp" schema in getProvisioningReport()

### DIFF
--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -52,6 +52,7 @@ import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainKind;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.PropertyService;
+import org.labkey.api.exp.property.TestDomainKind;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.AliasManager;
 import org.labkey.api.query.AliasedColumn;
@@ -1306,9 +1307,12 @@ public class StorageProvisionerImpl implements StorageProvisioner
         {
             for (DomainKind<?> dk : PropertyService.get().getDomainKinds())
             {
+                if (dk instanceof TestDomainKind)
+                    continue;
                 String schemaName = dk.getStorageSchemaName();
                 if (null != schemaName)
                 {
+                    assert !"temp".equalsIgnoreCase(schemaName);
                     Path path = new Path(schemaName);
                     schemaNames.add(path);
                     nonProvisionedTableMap.put(path, dk.getNonProvisionedTableNames());


### PR DESCRIPTION
#### Rationale
Incorrectly checking for domains on temp schema causing database consistency warnings.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47836

#### Related
https://github.com/LabKey/platform/pull/4382

#### Changes
* Backport Matt's change to skip temp tables
