### PR TITLE
Issue 47841: Project menu bar webparts are lost on folder import or create from template project/folder

### DIFF
--- a/core/src/org/labkey/core/admin/importer/PageImporterFactory.java
+++ b/core/src/org/labkey/core/admin/importer/PageImporterFactory.java
@@ -226,6 +226,14 @@ public class PageImporterFactory extends AbstractFolderImportFactory
                 // We found both the legacy name and the default tab for this folder
                 if (portalDefaultTabXml != null && folderDefaultTabXml != null)
                 {
+                    // Issue 47841: if the portalDefaultTabXml contains only menu bar webparts, keep them both
+                    if (!portalDefaultTabXml.getWebpartList().isEmpty())
+                    {
+                        boolean allMenuBarParts = portalDefaultTabXml.getWebpartList().stream().allMatch(webpart -> WebPartFactory.LOCATION_MENUBAR.equalsIgnoreCase(webpart.getLocation()));
+                        if (allMenuBarParts)
+                            return;
+                    }
+
                     // The folder's default tab is empty
                     if (folderDefaultTabXml.getWebpartArray().length == 0)
                     {


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47841

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4091 
* https://github.com/LabKey/testAutomation/pull/1502

#### Changes
* PageImportFactor.dedupePortalTabs() to check for "portal.default" with all menubar webparts
