### PR TITLE
Clear previously removed modules from database, #47703

### DIFF
--- a/api/src/org/labkey/api/module/ModuleContext.java
+++ b/api/src/org/labkey/api/module/ModuleContext.java
@@ -173,12 +173,9 @@ public class ModuleContext implements Cloneable
     }
 
     @SuppressWarnings({"UnusedDeclaration"})
-    public void setAutoUninstall(Boolean autoUninstall)
+    public void setAutoUninstall(boolean autoUninstall)
     {
-        if (autoUninstall != null)
-        {
-            _autoUninstall = autoUninstall;
-        }
+        _autoUninstall = autoUninstall;
     }
 
     public @Nullable String getSchemas()

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -1856,13 +1856,14 @@ public class ModuleLoader implements Filter, MemTrackerListener
             try
             {
                 Map<String, Object> map = new HashMap<>();
+                map.put("ClassName", module.getClass().getName());
                 map.put("AutoUninstall", module.isAutoUninstall());
                 map.put("Schemas", StringUtils.join(module.getSchemaNames(), ','));
                 Table.update(null, getTableInfoModules(), map, module.getName());
             }
             catch (RuntimeSQLException e)
             {
-                // This should be fixed now (see #24473), but leave detailed logging in place just in case
+                // This should be fixed now (see Issue 24473), but leave detailed logging in place just in case
                 ExceptionUtil.decorateException(e, ExceptionUtil.ExceptionInfo.ExtraMessage, module.getName(), false);
                 ExceptionUtil.logExceptionToMothership(null, e);
             }

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 23.005
+SchemaVersion: 23.006
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/core-23.005-23.006.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-23.005-23.006.sql
@@ -1,0 +1,2 @@
+-- Uninstall the previously removed "Internal" and "Synonym" modules, Issue 47703
+UPDATE core.Modules SET AutoUninstall = TRUE WHERE Name IN ('Internal', 'Synonym');

--- a/core/resources/schemas/dbscripts/sqlserver/core-23.005-23.006.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-23.005-23.006.sql
@@ -1,0 +1,2 @@
+-- Uninstall the previously removed "Internal" and "Synonym" modules, Issue 47703
+UPDATE core.modules SET AutoUninstall = 1 WHERE Name IN ('Internal', 'Synonym');


### PR DESCRIPTION
#### Rationale
Don't make admins do things that computers are good at. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47703

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4099
* https://github.com/LabKey/platform/pull/3535

#### Changes
* Fix loading of `AutoUninstall` boolean into ModuleContext (this has been broken for 10 years)
* Mark 'Internal' and 'Synonym' with auto-uninstall so they get deleted. In this case, a simple DELETE statement would have sufficed, but leveraging auto-uninstall is a good pattern to set for the future. Plus it was a good test of a rarely used feature.
* Update `ClassName` along with other module properties that might change