### PR TITLE
Issue 47849: Using import to update samples should fail if a sample in the import file does not belong to the current project.

### DIFF
--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -859,12 +859,12 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         return ContainerFilter.current(container);
     }
 
-    public record ExistingRowSelect(TableInfo tableInfo, Set<String> columns, boolean includeParent) {}
+    public record ExistingRowSelect(TableInfo tableInfo, Set<String> columns, boolean includeParent, boolean addContainerFilter) {}
 
     public @NotNull ExistingRowSelect getExistingRowSelect(@Nullable Set<String> dataColumns)
     {
         if (!(getQueryTable() instanceof UpdateableTableInfo updatable) || dataColumns == null)
-            return new ExistingRowSelect(getQueryTable(), ALL_COLUMNS, true);
+            return new ExistingRowSelect(getQueryTable(), ALL_COLUMNS, true, false);
 
         CaseInsensitiveHashMap<String> remap = updatable.remapSchemaColumns();
         if (null == remap)
@@ -907,7 +907,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
         }
 
-        return new ExistingRowSelect(selectTable, includedColumns, hasParentInput);
+        return new ExistingRowSelect(selectTable, includedColumns, hasParentInput, isAllFromMaterialTable /* Unlike samples table, Materials table doesn't have container filter applied*/);
     }
 
     private Map<Integer, Map<String, Object>> getMaterialMapsWithInput(Map<Integer, Map<String, Object>> keys, User user, Container container, boolean checkCrossFolderData, boolean verifyExisting, @Nullable Set<String> columns)
@@ -916,6 +916,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         ExistingRowSelect existingRowSelect = getExistingRowSelect(columns);
         TableInfo queryTableInfo = existingRowSelect.tableInfo;
         Set<String> selectColumns = existingRowSelect.columns;
+        boolean filterToCurrentContainer = existingRowSelect.addContainerFilter;
 
         Map<Integer, Map<String, Object>> sampleRows = new LinkedHashMap<>();
         Map<Integer, String> rowNumLsid = new HashMap<>();
@@ -951,7 +952,9 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
         if (!rowIdRowNumMap.isEmpty())
         {
-            Filter filter = new SimpleFilter(FieldKey.fromParts(ExpMaterialTable.Column.RowId), rowIdRowNumMap.keySet(), CompareType.IN);
+            SimpleFilter filter = new SimpleFilter(FieldKey.fromParts(ExpMaterialTable.Column.RowId), rowIdRowNumMap.keySet(), CompareType.IN);
+            if (filterToCurrentContainer)
+                filter.addCondition(FieldKey.fromParts("Container"), container);
             Map<String, Object>[] rows = new TableSelector(queryTableInfo, selectColumns, filter, null).getMapArray();
             for (Map<String, Object> row : rows)
             {
@@ -972,7 +975,9 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             useLsid = true;
             allKeys.addAll(lsidRowNumMap.keySet());
 
-            Filter filter = new SimpleFilter(FieldKey.fromParts(ExpMaterialTable.Column.LSID), lsidRowNumMap.keySet(), CompareType.IN);
+            SimpleFilter filter = new SimpleFilter(FieldKey.fromParts(ExpMaterialTable.Column.LSID), lsidRowNumMap.keySet(), CompareType.IN);
+            if (filterToCurrentContainer)
+                filter.addCondition(FieldKey.fromParts("Container"), container);
             Map<String, Object>[] rows = new TableSelector(queryTableInfo, selectColumns, filter, null).getMapArray();
             for (Map<String, Object> row : rows)
             {
@@ -989,6 +994,8 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             allKeys.addAll(nameRowNumMap.keySet());
             SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("MaterialSourceId"), sampleTypeId);
             filter.addCondition(FieldKey.fromParts("Name"), nameRowNumMap.keySet(), CompareType.IN);
+            if (filterToCurrentContainer)
+                filter.addCondition(FieldKey.fromParts("Container"), container);
 
             Map<String, Object>[] rows = new TableSelector(queryTableInfo, selectColumns, filter, null).getMapArray();
             for (Map<String, Object> row : rows)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -859,9 +859,9 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         return ContainerFilter.current(container);
     }
 
-    public record ExistingRowSelect(TableInfo tableInfo, Set<String> columns, boolean includeParent, boolean addContainerFilter) {}
+    private record ExistingRowSelect(TableInfo tableInfo, Set<String> columns, boolean includeParent, boolean addContainerFilter) {}
 
-    public @NotNull ExistingRowSelect getExistingRowSelect(@Nullable Set<String> dataColumns)
+    private @NotNull ExistingRowSelect getExistingRowSelect(@Nullable Set<String> dataColumns)
     {
         if (!(getQueryTable() instanceof UpdateableTableInfo updatable) || dataColumns == null)
             return new ExistingRowSelect(getQueryTable(), ALL_COLUMNS, true, false);

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4129,12 +4129,6 @@ public class ExperimentController extends SpringActionController
         protected void initRequest(QueryForm form) throws ServletException
         {
             QueryDefinition query = form.getQueryDef();
-            if (query.getContainerFilter() == null)
-            {
-                ContainerFilter cf = QueryService.get().getContainerFilterForLookups(getContainer(), getUser());
-                if (cf != null)
-                    query.setContainerFilter(cf);
-            }
             List<QueryException> qpe = new ArrayList<>();
             TableInfo t = query.getTable(form.getSchema(), qpe, true);
             if (!qpe.isEmpty())

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4126,14 +4126,23 @@ public class ExperimentController extends SpringActionController
         protected QueryForm _form;
 
         @Override
+        public void validateForm(QueryForm form, Errors errors)
+        {
+            QueryDefinition query = form.getQueryDef();
+            if (query.getContainerFilter() != null && query.getContainerFilter().getType() != null)
+            {
+                // cross folder import not supported
+                if (query.getContainerFilter().getType() != ContainerFilter.Type.Current)
+                    errors.reject(ERROR_MSG, "ContainerFilter is not supported for import actions.");
+            }
+        }
+
+        @Override
         protected void initRequest(QueryForm form) throws ServletException
         {
             QueryDefinition query = form.getQueryDef();
             List<QueryException> qpe = new ArrayList<>();
             TableInfo t = query.getTable(form.getSchema(), qpe, true);
-
-            if (query.getContainerFilter() != null) // cross folder import not supported
-                query.setContainerFilter(ContainerFilter.Type.Current.create(getContainer(), getUser()));
 
             if (!qpe.isEmpty())
                 throw qpe.get(0);

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4131,6 +4131,10 @@ public class ExperimentController extends SpringActionController
             QueryDefinition query = form.getQueryDef();
             List<QueryException> qpe = new ArrayList<>();
             TableInfo t = query.getTable(form.getSchema(), qpe, true);
+
+            if (query.getContainerFilter() != null) // cross folder import not supported
+                query.setContainerFilter(ContainerFilter.Type.Current.create(getContainer(), getUser()));
+
             if (!qpe.isEmpty())
                 throw qpe.get(0);
             if (null != t)


### PR DESCRIPTION
#### Rationale
Import (insert/merge/update) operates on data that exist in the current folder only. StatementUtils checks that  an existing record to be updated has a container that equals the current container during merge/update, without that data permission/security would be compromised. Insert also always insert into the current context container only. [Issue 47849](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47849).

The CF for import target shouldn't be relaxed. Perhaps we should always force CF to be Current.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3479

#### Changes
* remove CF override for import taget tableInfo
