### PR TITLE
Allow "Move to Project" for LKB mixture batches

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -981,7 +981,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
      */
     int removeEdges(ExpLineageEdge.FilterOptions options);
 
-    void updateExpObjectContainers(TableInfo tableInfo, List<Integer> rowIds, Container targetContainer);
+    int updateExpObjectContainers(TableInfo tableInfo, List<Integer> rowIds, Container targetContainer);
 
     int moveExperimentRuns(List<ExpRun> runs, Container targetContainer, User user);
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8330,6 +8330,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Override
     public int updateExpObjectContainers(TableInfo tableInfo, List<Integer> rowIds, Container targetContainer)
     {
+        if (rowIds == null || rowIds.isEmpty())
+            return 0;
+
         TableInfo objectTable = OntologyManager.getTinfoObject();
         SQLFragment objectUpdate = new SQLFragment("UPDATE ").append(objectTable).append(" SET container = ").appendValue(targetContainer.getEntityId())
                 .append(" WHERE objectid IN (SELECT objectid FROM ").append(tableInfo).append(" WHERE rowid ");
@@ -8340,6 +8343,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
     private int updateExpObjectContainers(List<String> lsids, Container targetContainer)
     {
+        if (lsids == null || lsids.isEmpty())
+            return 0;
+
         TableInfo objectTable = OntologyManager.getTinfoObject();
         SQLFragment objectUpdate = new SQLFragment("UPDATE ").append(objectTable).append(" SET container = ").appendValue(targetContainer.getEntityId())
                 .append(" WHERE objecturi ");
@@ -8350,6 +8356,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Override
     public int aliasMapRowContainerUpdate(TableInfo aliasMapTable, List<Integer> dataIds, Container targetContainer)
     {
+        if (dataIds == null || dataIds.isEmpty())
+            return 0;
+
         SQLFragment aliasMapUpdate = new SQLFragment("UPDATE ").append(aliasMapTable).append(" SET container = ").appendValue(targetContainer.getEntityId())
                 .append(" WHERE lsid IN (SELECT lsid FROM ").append(getTinfoData()).append(" WHERE rowid ");
         aliasMapTable.getSchema().getSqlDialect().appendInClauseSql(aliasMapUpdate, dataIds);
@@ -8533,7 +8542,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         ExperimentService.get().updateExpObjectContainers(getTinfoExperimentRun(), runRowIds, targetContainer);
 
         // LKB media have object properties associated with the protocol applications of the run
-        // and object properties associated with the data inputs for those protocol applications //DataInput.lsid(6897, 274047)
+        // and object properties associated with the material and data inputs for those protocol applications
         List<String> lsidsToUpdate = new ArrayList<>();
         for (ExpRun run : runs)
         {
@@ -8542,6 +8551,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 lsidsToUpdate.add(pa.getLSID());
                 for (ExpDataRunInput dataInput : pa.getDataInputs())
                     lsidsToUpdate.add(DataInput.lsid(dataInput.getData().getRowId(), pa.getRowId()));
+                for (ExpMaterialRunInput materialInput : pa.getMaterialInputs())
+                    lsidsToUpdate.add(MaterialInput.lsid(materialInput.getMaterial().getRowId(), pa.getRowId()));
             }
         }
         updateExpObjectContainers(lsidsToUpdate, targetContainer);


### PR DESCRIPTION
#### Rationale
We recently added the UI and backend support for moving samples to different containers (i.e. projects) within the LKB and LKSM apps. We held off on enabling this for LKB mixture batches until the dev was complete. The related PR enables the "Move to Project" UI for mixture batches from the grid Edit button and from a batch details Manage menu. This PR adds code to update the container value for a few additional object property rows related to the ExperimentRun's protocolapplications and datainputs.

#### Related Pull Requests
- https://github.com/LabKey/biologics/pull/2124

#### Changes
- during moveExperimentRuns, also move any object properties for the run's protocolapplications, datainputs, and materialinputs
