### PR TITLE
Display errors on clone permissions page again

### DIFF
--- a/core/src/org/labkey/core/security/clonePermissions.jsp
+++ b/core/src/org/labkey/core/security/clonePermissions.jsp
@@ -33,17 +33,34 @@
 %>
 <%
     SecurityController.ClonePermissionsForm form = (SecurityController.ClonePermissionsForm)HttpView.currentModel();
-    User target = form.getTargetUserValidated();
+    User target = form.getTargetUserObject();
     boolean excludeSiteAdmins = !getUser().hasSiteAdminPermission(); // App admins can't clone permissions from site admins
+
+    if (null != target)
+    {
 %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
     Ext4.onReady(function(){
         createCloneUserField(false, true, <%=excludeSiteAdmins%>, <%=target.getUserId()%>);
     });
 </script>
-
+<%
+    }
+%>
 <labkey:form action="<%=urlFor(ClonePermissionsAction.class)%>" method="POST">
     <table>
+        <%
+            if (getErrors("form").hasErrors());
+            {
+        %>
+        <tr><td><labkey:errors /></td></tr>
+        <tr><td>&nbsp;</td></tr>
+        <%
+            }
+
+            if (null != target)
+            {
+        %>
         <tr>
             <td>
                 Warning! Cloning permissions will delete <strong>all</strong> group memberships and direct role assignments for <strong><%=h(target.getDisplayName(getUser()) + " (" + target.getEmail() + ")")%></strong>
@@ -64,6 +81,8 @@
                 <%=button("Cancel").href(form.getReturnURLHelper())%>
             </td>
         </tr>
+        <%
+            }
+        %>
     </table>
-
 </labkey:form>


### PR DESCRIPTION
#### Rationale
Related PR took the error handling easy route: show any errors via a `SpringErrorView`. While this is probably okay for a missing / unknown target user (which should happen only to the crawler and crawler-like hackers), permissions and missing/unknown clone user errors are very possible to encounter in normal use. Better to display these on the clone permissions page and give the admin a chance to correct them. It's also more consistent with the current test expectations.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4392
