### PR TITLE
Issue 47867: Error Updating specimens using js api

### DIFF
--- a/study/api-src/org/labkey/api/specimen/query/SpecimenUpdateService.java
+++ b/study/api-src/org/labkey/api/specimen/query/SpecimenUpdateService.java
@@ -346,8 +346,8 @@ public class SpecimenUpdateService extends AbstractQueryUpdateService
         for (int i = 0; i < rows.size(); i++)
         {
             Map<String, Object> row = rows.get(i);
-            Map<String, Object> oldKey = oldKeys == null ? row : oldKeys.get(i);
-            long rowId = oldKey != null ? keyFromMap(oldKey) : keyFromMap(row);
+            Map<String, Object> keys = oldKeys == null ? row : oldKeys.get(i);
+            long rowId = keyFromMap(keys);
             rowIds.add(rowId);
             uniqueRows.put(rowId, row);
         }

--- a/study/api-src/org/labkey/api/specimen/query/SpecimenUpdateService.java
+++ b/study/api-src/org/labkey/api/specimen/query/SpecimenUpdateService.java
@@ -346,9 +346,8 @@ public class SpecimenUpdateService extends AbstractQueryUpdateService
         for (int i = 0; i < rows.size(); i++)
         {
             Map<String, Object> row = rows.get(i);
-            assert null != oldKeys;
-            Map<String, Object> oldRow = oldKeys.get(i);
-            long rowId = oldRow != null ? keyFromMap(oldRow) : keyFromMap(row);
+            Map<String, Object> oldKey = oldKeys == null ? row : oldKeys.get(i);
+            long rowId = oldKey != null ? keyFromMap(oldKey) : keyFromMap(row);
             rowIds.add(rowId);
             uniqueRows.put(rowId, row);
         }


### PR DESCRIPTION
#### Rationale
UpdateRows is used by both update and updateChangingKeys. the regular update is able to update any columns except key columns while updateChangingKeys allows updating key columns as well. For regular update, https://github.com/LabKey/platform/pull/4044 has changed oldKeys passed in from the new rows to null, to distinguish between regular updates vs updateChangingKeys. SpecimenQUS has been relying on oldKeys (I believe unintentionally) for update actions. This RP corrects the logic for SpecimenQUS that oldKeys should be optional. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4044

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
