### PR TITLE
Support explicit domain listing of shapes for plot points

### DIFF
--- a/core/webapp/vis/src/plot.js
+++ b/core/webapp/vis/src/plot.js
@@ -1630,6 +1630,7 @@ boxPlot.render();
  * @param {String} [config.properties.color] (Optional) The data property name for the color to be used for the data point.
  * @param {Array} [config.properties.colorRange] (Optional) The array of color values to use for the data points.
  * @param {Array} [config.properties.shapeRange] (Optional) The array of shape values to use for the data points.
+ * @param {Array} [config.properties.shapeDomain] (Optional) The domain of shape values to match with the provided shapeRange.
  * @param {Function} [config.properties.pointSize] (Optional) The LABKEY.vis.Geom.Point size.
  * @param {Function} [config.properties.pointOpacityFn] (Optional) A function to be called with the point data to
  *                  return an opacity value for that point.
@@ -2061,7 +2062,8 @@ boxPlot.render();
             },
             shape: {
                 scaleType: 'discrete',
-                range: config.properties.shapeRange
+                range: config.properties.shapeRange,
+                domain: config.properties.shapeDomain
             },
             x: {
                 scaleType: 'discrete',


### PR DESCRIPTION
#### Rationale
We've always auto-assigned point shapes for our plots but in some scenarios it's useful to be specific about what shapes correspond with specific values. This is in support of a Panorama story.

#### Changes
* Accept a new optional `shapeDomain` parameter