### PR TITLE
Configure all code-only modules to auto-uninstall

### DIFF
--- a/api/src/org/labkey/api/module/CodeOnlyModule.java
+++ b/api/src/org/labkey/api/module/CodeOnlyModule.java
@@ -89,4 +89,10 @@ public abstract class CodeOnlyModule extends DefaultModule
     {
         return null;
     }
+
+    @Override
+    public final boolean isAutoUninstall()
+    {
+        return true;
+    }
 }

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 23.006
+SchemaVersion: 23.007
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \


### PR DESCRIPTION
#### Rationale
Auto uninstalling code-only modules should be safe and will reduce admin busy work

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4388