### PR TITLE
Add document parser for plain text, Issue 43348. Fix greedy CSV parser, Issue 47814.

### DIFF
--- a/api/src/org/labkey/api/reader/TabFileType.java
+++ b/api/src/org/labkey/api/reader/TabFileType.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
  */
 class TabFileType extends FileType
 {
-    // Graphic char followed by graphic or space chacaters
+    // Graphic char followed by graphic or space characters
     private static final Pattern HEADER = Pattern.compile("^\\p{Graph}[\\p{Graph} ]*", Pattern.UNICODE_CHARACTER_CLASS);
 
     private final String delim;
@@ -106,5 +106,4 @@ class TabFileType extends FileType
 
         return HEADER.matcher(cs).matches();
     }
-
 }

--- a/api/src/org/labkey/api/util/FileType.java
+++ b/api/src/org/labkey/api/util/FileType.java
@@ -553,11 +553,8 @@ public class FileType implements Serializable
             }
         }
 
-        // Attempt to match using only the header.
-        if (header != null && isHeaderMatch(header))
-            return true;
-
-        return false;
+        // Attempt to match using just the header, but only if we don't have a content type, Issue 47814
+        return null == contentType && header != null && isHeaderMatch(header);
     }
 
     protected static String detectContentType(String fileName, byte[] header)

--- a/api/src/org/labkey/api/util/FileType.java
+++ b/api/src/org/labkey/api/util/FileType.java
@@ -511,6 +511,8 @@ public class FileType implements Serializable
      */
     public boolean isType(@Nullable String filePath, @Nullable String contentType, @Nullable byte[] header)
     {
+        String providedContentType = contentType; // Save it for later
+
         // avoid, for example, mistaking protxml ".pep-prot.xml" for pepxml ".xml"
         if (isAntiFileType(filePath, header))
         {
@@ -553,8 +555,8 @@ public class FileType implements Serializable
             }
         }
 
-        // Attempt to match using just the header, but only if we don't have a content type, Issue 47814
-        return null == contentType && header != null && isHeaderMatch(header);
+        // Attempt to match using just the header, but only if the original content type was null, Issue 47814
+        return null == providedContentType && header != null && isHeaderMatch(header);
     }
 
     protected static String detectContentType(String fileName, byte[] header)

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -429,7 +429,8 @@ public class ListManager implements SearchService.DocumentProvider
                 {
                     //Refresh list definition -- Issue #42207 - MSSQL server returns entityId as uppercase string
                     ListDefinition list = ListService.get().getList(c, def.getListId());
-                    indexList(task, list, designChange, false);
+                    if (null != list) // Could have just been deleted
+                        indexList(task, list, designChange, false);
                 }
             };
 

--- a/search/src/org/labkey/search/SearchModule.java
+++ b/search/src/org/labkey/search/SearchModule.java
@@ -52,6 +52,7 @@ import org.labkey.search.audit.SearchAuditProvider;
 import org.labkey.search.model.AbstractSearchService;
 import org.labkey.search.model.DavCrawler;
 import org.labkey.search.model.LuceneSearchServiceImpl;
+import org.labkey.search.model.PlainTextDocumentParser;
 import org.labkey.search.model.SearchStartupProperties;
 import org.labkey.search.view.SearchWebPartFactory;
 
@@ -172,6 +173,8 @@ public class SearchModule extends DefaultModule
                 SearchService._log.info("Purging SearchService queues");
                 ss.purgeQueues();
             });
+
+            ss.addDocumentParser(new PlainTextDocumentParser());
         }
 
         AuditLogService.get().registerAuditType(new SearchAuditProvider());

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -94,7 +94,6 @@ import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.JunitUtil;
-import org.labkey.api.util.MimeMap;
 import org.labkey.api.util.MinorConfigurationException;
 import org.labkey.api.util.MultiPhaseCPUTimer;
 import org.labkey.api.util.MultiPhaseCPUTimer.InvocationTimer;
@@ -992,8 +991,6 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
         DocumentParser p = detectParser(r, is);
         if (null != p)
         {
-            if (!p.getMediaType().equals(MimeMap.MimeType.PLAIN.getContentType()))
-                _log.info("Detected as " + p.getMediaType() + ". Inputs: " + r.getName() + ", " + r.getContentType());
             metadata.add(Metadata.CONTENT_TYPE, p.getMediaType());
             if (!tooBig)  //Check filesize even if parser set. Issue #40253
                 p.parse(is, handler);

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -1786,7 +1786,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
             for (File file : sampledata.listFiles(File::isFile))
             {
                 String docId = "testtika";
-                SimpleDocumentResource resource = new SimpleDocumentResource(new Path(docId), docId, null, "text/plain", null, null, null);
+                SimpleDocumentResource resource = new SimpleDocumentResource(new Path(file.getName()), docId, null, null, null, null, null);
                 ContentHandler handler = new BodyContentHandler(-1);
                 Metadata metadata = new Metadata();
 
@@ -1895,7 +1895,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
             Map<String, Pair<Integer, String[]>> map = new HashMap<>();
 
             add(map, "7z_sample.7z", 53, "7zSearchFile.txt", "This is a sample 7z test file.");
-            add(map, "cmd_sample.cmd", 844, "Delete SetupPolicies directory");
+            add(map, "cmd_sample.cmd", 843, "Delete SetupPolicies directory");
             add(map, "cpp_sample.cpp", 281, "Rcpp::NumericVector");
             add(map, "css_sample.css", 697, "math display", "fixes display issues");
             add(map, "csv_sample.csv", 690, "NpodDonorSamplesTest.testWizardCustomizationAndDataEntry");
@@ -1920,8 +1920,8 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
             add(map, "ppt_sample.ppt", 115, "Slide With Image", "Slide With Text", "Hello world", "How are you?");
             add(map, "pptx_sample.pptx", 122, "Slide With Image", "Slide With Text", "Hello world", "How are you?");
             add(map, "rtf_sample.rtf", 11, "One on One");
-            add(map, "sample.txt", 38, "Sample text file", "1", "2", "9");
-            add(map, "sql_sample.sql", 2233, "for JDBC Login support", "Container of parent, if parent has no ACLs");
+            add(map, "sample.txt", 37, "Sample text file", "1", "2", "9");
+            add(map, "sql_sample.sql", 2232, "for JDBC Login support", "Container of parent, if parent has no ACLs");
             add(map, "svg_sample.svg", 18, " "); // Not empty, but just a bunch of whitespace
             add(map, "tgz_sample.tgz", 7767, "assertthat is an extension", "Custom failure messages");
             add(map, "tif_sample.tif", 0);

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -94,6 +94,7 @@ import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.JunitUtil;
+import org.labkey.api.util.MimeMap;
 import org.labkey.api.util.MinorConfigurationException;
 import org.labkey.api.util.MultiPhaseCPUTimer;
 import org.labkey.api.util.MultiPhaseCPUTimer.InvocationTimer;
@@ -991,6 +992,8 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
         DocumentParser p = detectParser(r, is);
         if (null != p)
         {
+            if (!p.getMediaType().equals(MimeMap.MimeType.PLAIN.getContentType()))
+                _log.info("Detected as " + p.getMediaType() + ". Inputs: " + r.getName() + ", " + r.getContentType());
             metadata.add(Metadata.CONTENT_TYPE, p.getMediaType());
             if (!tooBig)  //Check filesize even if parser set. Issue #40253
                 p.parse(is, handler);

--- a/search/src/org/labkey/search/model/PlainTextDocumentParser.java
+++ b/search/src/org/labkey/search/model/PlainTextDocumentParser.java
@@ -1,0 +1,43 @@
+package org.labkey.search.model;
+
+import org.labkey.api.reader.Readers;
+import org.labkey.api.search.AbstractDocumentParser;
+import org.labkey.api.util.MimeMap;
+import org.labkey.api.webdav.WebdavResource;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class PlainTextDocumentParser extends AbstractDocumentParser
+{
+    @Override
+    public String getMediaType()
+    {
+        return MimeMap.MimeType.PLAIN.getContentType();
+    }
+
+    @Override
+    public boolean detect(WebdavResource resource, String contentType, byte[] buf)
+    {
+        return MimeMap.MimeType.PLAIN.getContentType().equals(contentType) || resource.getName().toLowerCase().endsWith(".txt");
+    }
+
+    @Override
+    protected void parseContent(InputStream stream, ContentHandler handler) throws IOException, SAXException
+    {
+        char[] buf = new char[1000];
+        BufferedReader reader = Readers.getReader(stream);
+        int chars;
+
+        do
+        {
+            chars = reader.read(buf);
+            if (chars != -1)
+                handler.characters(buf, 0, chars);
+        }
+        while (chars != -1);
+    }
+}


### PR DESCRIPTION
#### Rationale
[Issue 43348: Indexing perf: avoid autodetect parser for known text documents](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43348)
[Issue 47814: Wiki search results show HTML source when document includes a comma](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47814)
