### PR TITLE
Strip quotes from JSON string

### DIFF
--- a/mothership/resources/queries/mothership/recentJsonMetricValues.sql
+++ b/mothership/resources/queries/mothership/recentJsonMetricValues.sql
@@ -28,7 +28,8 @@ SELECT
        DisplayKey,
        '{' || SelectKey || '}' AS SelectKey,
        Value,
-       CAST(CASE WHEN Type = 'string' THEN Value END AS VARCHAR) AS StringValue,
+       -- Need to string quotes from the JSON string value
+       CAST(CASE WHEN Type = 'string' THEN SUBSTRING(CAST(Value AS VARCHAR), 2, LENGTH(CAST(Value AS VARCHAR)) - 2) END AS VARCHAR) AS StringValue,
        CAST(CASE WHEN Type = 'number' THEN Value END AS DECIMAL) AS NumberValue,
        CAST(CASE WHEN Type = 'boolean' THEN Value END AS BOOLEAN) AS BooleanValue,
        CASE WHEN Type = 'object' THEN Value END AS ObjectValue,

--- a/mothership/resources/queries/mothership/recentJsonMetricValues.sql
+++ b/mothership/resources/queries/mothership/recentJsonMetricValues.sql
@@ -28,7 +28,7 @@ SELECT
        DisplayKey,
        '{' || SelectKey || '}' AS SelectKey,
        Value,
-       -- Need to string quotes from the JSON string value
+       -- Need to strip quotes from the JSON string value
        CAST(CASE WHEN Type = 'string' THEN SUBSTRING(CAST(Value AS VARCHAR), 2, LENGTH(CAST(Value AS VARCHAR)) - 2) END AS VARCHAR) AS StringValue,
        CAST(CASE WHEN Type = 'number' THEN Value END AS DECIMAL) AS NumberValue,
        CAST(CASE WHEN Type = 'boolean' THEN Value END AS BOOLEAN) AS BooleanValue,


### PR DESCRIPTION
#### Rationale
This metric query is returning all string values with quotes around them, because that's how they're captured in JSON.

#### Changes
* Strip the quotes since we don't want them in a typed VARCHAR column