### PR TITLE
Use LabKeyJspWriter for JSP output in production mode

### DIFF
--- a/api/src/org/labkey/api/jsp/JspContext.java
+++ b/api/src/org/labkey/api/jsp/JspContext.java
@@ -16,7 +16,6 @@
 package org.labkey.api.jsp;
 
 import org.apache.jasper.runtime.HttpJspBase;
-import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.view.HttpView;
 
@@ -52,12 +51,11 @@ public abstract class JspContext extends HttpJspBase
     }
 
     /**
-     * This is called by every JSP to get our standard JspWriter. In production mode, this is a pass-through; in dev mode,
-     * it wraps the standard JspWriter with LabKeyJspWriter, an implementation that protects against unsafe output.
+     * This is called by every JSP to get our standard JspWriter, an implementation that protects against unsafe output.
      */
     protected JspWriter getLabKeyJspWriter(JspWriter out)
     {
-        return AppProps.getInstance().isDevMode() ? new LabKeyJspWriter(out) : out;
+        return new LabKeyJspWriter(out);
     }
 
     /**

--- a/api/webapp/WEB-INF/jspWriter.jspf
+++ b/api/webapp/WEB-INF/jspWriter.jspf
@@ -1,6 +1,6 @@
 <%
     // This JSP fragment is injected into every JSP at JSP -> Java translation time (see <jsp-config> element in web.xml).
 
-    // Use our special JspWriter in dev mode to flag unsafe output from JSPs.
+    // Use our special JspWriter to flag unsafe output from JSPs.
     out = getLabKeyJspWriter(out);
 %>


### PR DESCRIPTION
#### Rationale
Increases consistency and allows direct output of `Renderable` from JSPs