### PR TITLE
Refresh schema warnings after recreating views

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -160,8 +160,6 @@ public class ModuleLoader implements Filter, MemTrackerListener
     public static final String CPAS_DATA_SOURCE = "cpasDataSource";
     public static final Object SCRIPT_RUNNING_LOCK = new Object();
 
-    private static volatile List<String> _missingViews = Collections.emptyList();
-
     private static ModuleLoader _instance = null;
     private static Throwable _startupFailure = null;
     private static boolean _newInstall = false;
@@ -1496,7 +1494,10 @@ public class ModuleLoader implements Filter, MemTrackerListener
                 runScripts(runner, module, SchemaUpdateType.After);
         }
 
-        refreshMissingViews();
+        if (_startupState == StartupState.StartupComplete)
+        {
+            WarningService.get().rerunSchemaCheck();
+        }
     }
 
     // Runs the drop and create scripts in a single module using the standard upgrade script runner
@@ -1770,7 +1771,6 @@ public class ModuleLoader implements Filter, MemTrackerListener
     // performedUpgrade is true if any module required upgrading
     private void afterUpgrade(boolean performedUpgrade, File lockFile)
     {
-        verifyDatabaseViews();
         setUpgradeState(UpgradeState.UpgradeComplete);
 
         if (performedUpgrade)
@@ -1785,38 +1785,6 @@ public class ModuleLoader implements Filter, MemTrackerListener
         lockFile.delete();
 
         verifyRequiredModules();
-    }
-
-    // Register an admin warning that reports if any database views are missing, Issue 40187
-    private void verifyDatabaseViews()
-    {
-        // This is a "dynamic" warning because RecreateViewsAction might correct the problem at runtime
-        WarningService.get().register(new WarningProvider()
-        {
-            @Override
-            public void addDynamicWarnings(@NotNull Warnings warnings, @NotNull ViewContext context, boolean showAllWarnings)
-            {
-                if (context.getUser().hasSiteAdminPermission())
-                {
-                    if (showAllWarnings || !_missingViews.isEmpty())
-                        warnings.add(HtmlStringBuilder.of("The following required database views are not present: " + _missingViews +
-                            ". This is a serious problem that indicates the LabKey database schemas did not upgrade correctly and are in a bad state."));
-                }
-            }
-        });
-        refreshMissingViews();
-    }
-
-    // Determine if any module database views are missing
-    private void refreshMissingViews()
-    {
-        _missingViews = DbSchema.getAllSchemasToTest().stream()
-            .flatMap(s -> s.getTableXmlMap().entrySet().stream()
-                .filter(e -> "VIEW".equalsIgnoreCase(e.getValue().getTableDbType()))
-                .filter(e -> s.getTable(e.getKey()).getTableType() == DatabaseTableType.NOT_IN_DB)
-                .map(e -> s.getName() + "." + e.getValue().getTableName())
-            )
-            .collect(Collectors.toList());
     }
 
     // If the "requiredModules" parameter is present in labkey.xml then fail startup if any specified module is missing.

--- a/core/api-src/org/labkey/api/admin/TableXmlUtils.java
+++ b/core/api-src/org/labkey/api/admin/TableXmlUtils.java
@@ -91,11 +91,8 @@ public class TableXmlUtils
                                               boolean errorOnXmlMiss,
                                               DbSchema schema)
     {
-        boolean bCopyTargetNode;
         TableType[] dbTables;
         TableType[] xmlTables;
-        TableType mt = null;
-        ColumnType mc = null;
         String xmlTableName;
         String xmlTableType;
         String dbTableName;
@@ -146,7 +143,6 @@ public class TableXmlUtils
 
                     if (!xmlTableType.equals("NOT_IN_DB"))
                     {
-                        rlOut.addBlank();
                         rlOut.addError("ERROR: TableName \"").append(xmlTableName).append("\" type \"").append(xmlTableType).append("\" found in XML but not in database.");
                     }
                     continue;
@@ -273,52 +269,52 @@ public class TableXmlUtils
 
                         compareStringProperty(columnType.getDisplayWidth(), xmlCol.getDisplayWidth(), "DisplayWidth", rlTmp, bCaseSensitive, problematicItem);
 
-                        bCopyTargetNode = compareIntegerProperty(
+                        compareIntegerProperty(
                                 (columnType.isSetScale() ? columnType.getScale() : null),
                                 (xmlCol.isSetScale() ? xmlCol.getScale() : null),
                                 "Scale", rlTmp, problematicItem);
 
-                        bCopyTargetNode = compareIntegerProperty(
+                        compareIntegerProperty(
                                 (columnType.isSetPrecision() ? columnType.getPrecision() : null),
                                 (xmlCol.isSetPrecision() ? xmlCol.getPrecision() : null),
                                 "Precision", rlTmp, problematicItem);
 
-                        bCopyTargetNode = compareIntegerProperty(
+                        compareIntegerProperty(
                                 (columnType.isSetInputLength() ? columnType.getInputLength() : null),
                                 (xmlCol.isSetInputLength() ? xmlCol.getInputLength() : null),
                                 "InputLength", rlTmp, problematicItem);
 
-                        bCopyTargetNode = compareIntegerProperty(
+                        compareIntegerProperty(
                                 (columnType.isSetInputRows() ? columnType.getInputRows() : null),
                                 (xmlCol.isSetInputRows() ? xmlCol.getInputRows() : null),
                                 "InputRows", rlTmp, problematicItem);
 
-                        bCopyTargetNode = compareBoolProperty(
+                        compareBoolProperty(
                                 (columnType.isSetNullable() ? columnType.getNullable() : null),
                                 (xmlCol.isSetNullable() ? xmlCol.getNullable() : null),
                                 "Nullable", rlTmp, problematicItem);
 
-                        bCopyTargetNode = compareBoolProperty(
+                        compareBoolProperty(
                                 (columnType.isSetIsAutoInc() ? columnType.getIsAutoInc() : null),
                                 (xmlCol.isSetIsAutoInc() ? xmlCol.getIsAutoInc() : null),
                                 "IsAutoInc", rlTmp, problematicItem);
 
-                        bCopyTargetNode = compareBoolProperty(
+                        compareBoolProperty(
                                 (columnType.isSetIsDisplayColumn() ? columnType.getIsDisplayColumn() : null),
                                 (xmlCol.isSetIsDisplayColumn() ? xmlCol.getIsDisplayColumn() : null),
                                 "IsDisplayColumn", rlTmp, problematicItem);
 
-                        bCopyTargetNode = compareBoolProperty(
+                        compareBoolProperty(
                                 (columnType.isSetIsReadOnly() ? columnType.getIsReadOnly() : null),
                                 (xmlCol.isSetIsReadOnly() ? xmlCol.getIsReadOnly() : null),
                                 "IsReadOnly", rlTmp, problematicItem);
 
-                        bCopyTargetNode = compareBoolProperty(
+                        compareBoolProperty(
                                 (columnType.isSetIsUserEditable() ? columnType.getIsUserEditable() : null),
                                 (xmlCol.isSetIsUserEditable() ? xmlCol.getIsUserEditable() : null),
                                 "IsUserEditable", rlTmp, problematicItem);
 
-                        bCopyTargetNode = compareBoolProperty(
+                        compareBoolProperty(
                                 (columnType.isSetIsKeyField() ? columnType.getIsKeyField() : null),
                                 (xmlCol.isSetIsKeyField() ? xmlCol.getIsKeyField() : null),
                                 "IsKeyField", rlTmp, problematicItem);
@@ -336,7 +332,7 @@ public class TableXmlUtils
                                     , xmlCol.getFk().getFkTable()
                                     , "FkTable", rlTmp, bCaseSensitive, problematicItem);
 
-                            bCopyTargetNode = compareStringProperty((declFk ? columnType.getFk().getFkDbSchema() : null)
+                            compareStringProperty((declFk ? columnType.getFk().getFkDbSchema() : null)
                                     , xmlCol.getFk().getFkDbSchema()
                                     , "FkDbSchema", rlTmp, bCaseSensitive, problematicItem);
                         }
@@ -350,7 +346,6 @@ public class TableXmlUtils
 
                         if (!rlTmp.getResults().isEmpty())
                         {
-                            rlOut.addBlank();
                             rlOut.addInfo(tt.getTableName() + "." + columnType.getColumnName());
                             rlOut.addAll(rlTmp);
                         }
@@ -378,7 +373,6 @@ public class TableXmlUtils
                 if (dbTab.startsWith("_"))
                     continue;
                 idt = mDbTableOrdinals.get(dbTab);
-                TableType tt = dbTables[idt];
                 SiteValidationResult result;
                 if (errorOnXmlMiss)
                     result = rlOut.addError("ERROR: ");

--- a/core/api-src/org/labkey/api/admin/sitevalidation/SiteValidationResultList.java
+++ b/core/api-src/org/labkey/api/admin/sitevalidation/SiteValidationResultList.java
@@ -43,11 +43,6 @@ public class SiteValidationResultList
         return result;
     }
 
-    public SiteValidationResult addBlank()
-    {
-        return addInfo("");
-    }
-
     public SiteValidationResult addInfo(String message)
     {
         return addInfo(message, null);

--- a/core/src/org/labkey/core/admin/ActionsTsvWriter.java
+++ b/core/src/org/labkey/core/admin/ActionsTsvWriter.java
@@ -20,6 +20,7 @@ import org.labkey.api.action.ActionType;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.admin.ActionsHelper;
 import org.labkey.api.data.TSVWriter;
+import org.labkey.api.util.UnexpectedException;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -80,7 +81,7 @@ public class ActionsTsvWriter extends TSVWriter
         }
         catch (Exception e)
         {
-            throw new RuntimeException(e);
+            throw UnexpectedException.wrap(e);
         }
 
         return ret;

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -7830,8 +7830,6 @@ public class AdminController extends SpringActionController
         public boolean handlePost(Object o, BindException errors)
         {
             ModuleLoader.getInstance().recreateViews();
-            // Hopefully we've cleared whatever schema mismatch errors were showing related to DB views
-            ModuleLoader.getInstance().getModule(CoreModule.class).rerunSchemaCheck();
             return true;
         }
 

--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -64,6 +64,7 @@ import static org.labkey.api.view.template.WarningService.SESSION_WARNINGS_BANNE
 
 public class CoreWarningProvider implements WarningProvider
 {
+    /** Schema name -> problem list */
     private final Map<String, List<SiteValidationResult>> _dbSchemaWarnings = new ConcurrentHashMap<>();
 
     public CoreWarningProvider()
@@ -169,7 +170,7 @@ public class CoreWarningProvider implements WarningProvider
             {
                 if (count == 0)
                 {
-                    addStandardWarning(warnings, "One or more database schemas is not as expected. Adjust the module's schema or metadata, or contact LabKey support.", "sqlScripts", "docs for help with upgrade scripts");
+                    addStandardWarning(warnings, (schemaProblems.size() == 1 ? "One database schema is" : (schemaProblems.size() + " database schemas are")) + " not as expected. This indicates there was a serious problem with the upgrade process. Adjust the module's schema or metadata, or contact LabKey support.", "sqlScripts", "docs for help with upgrade scripts");
                 }
                 if (++count <= MAX_SCHEMA_PROBLEMS_TO_SHOW)
                 {


### PR DESCRIPTION
#### Rationale
Recreating the DB views often clears up schema validation errors. Don't make the admin bounce Tomcat to verify.

Also, the action coverage TSV was getting truncated during export

#### Changes
* Queue a schema revalidation after recreating views
* Close the ActionsTsvWriter in a try-with-resources
* Minor cleanup