### PR TITLE
Update db consistency check for missing storage column

### DIFF
--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -1253,9 +1253,10 @@ public class StorageProvisionerImpl implements StorageProvisioner
                 }
                 else if (st.prop != null)
                 {
-                    if (st.prop.getPropertyDescriptor().getStorageColumnName() == null)
+                    TableInfo table = DbSchema.get(report.getSchemaName(), DbSchemaType.Provisioned).getTable(report.getTableName());
+                    PropertyDescriptor pd = st.prop.getPropertyDescriptor();
+                    if (st.prop.getPropertyDescriptor().getStorageColumnName() == null && null != table.getColumn(pd.getName()))
                     {
-                        PropertyDescriptor pd = st.prop.getPropertyDescriptor();
                         pd.setStorageColumnName(pd.getName());
                         OntologyManager.updatePropertyDescriptor(pd);
                         continue;
@@ -1263,7 +1264,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
 
                     if (st.colName == null)
                     {
-                        adds.addColumn(st.prop.getPropertyDescriptor());
+                        adds.addColumn(pd);
                     }
                     if (st.mvColName == null && st.prop.isMvEnabled())
                     {
@@ -1429,7 +1430,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
                 status.prop = domainProp;
                 PropertyDescriptor propDescriptor = domainProp.getPropertyDescriptor();
 
-                if (null == propDescriptor.getStorageColumnName())
+                if (null == propDescriptor.getStorageColumnName() && hardColumnNames.contains(domainProp.getName()))
                 {
                     domainReport.addError(String.format("database table %s.%s column '%s' is missing the storage column name.", domainReport.getSchemaName(), domainReport.getTableName(), domainProp.getName()));
                     status.fix = "Add storage column name '" + domainProp.getName() + "' to property descriptor";

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -1253,6 +1253,14 @@ public class StorageProvisionerImpl implements StorageProvisioner
                 }
                 else if (st.prop != null)
                 {
+                    if (st.prop.getPropertyDescriptor().getStorageColumnName() == null)
+                    {
+                        PropertyDescriptor pd = st.prop.getPropertyDescriptor();
+                        pd.setStorageColumnName(pd.getName());
+                        OntologyManager.updatePropertyDescriptor(pd);
+                        continue;
+                    }
+
                     if (st.colName == null)
                     {
                         adds.addColumn(st.prop.getPropertyDescriptor());
@@ -1420,7 +1428,15 @@ public class StorageProvisionerImpl implements StorageProvisioner
                 domainReport.getColumns().add(status);
                 status.prop = domainProp;
                 PropertyDescriptor propDescriptor = domainProp.getPropertyDescriptor();
-                if (hardColumnNames.remove(propDescriptor.getStorageColumnName()))
+
+                if (null == propDescriptor.getStorageColumnName())
+                {
+                    domainReport.addError(String.format("database table %s.%s column '%s' is missing the storage column name.", domainReport.getSchemaName(), domainReport.getTableName(), domainProp.getName()));
+                    status.fix = "Add storage column name '" + domainProp.getName() + "' to property descriptor";
+                    status.hasProblem = true;
+                    hardColumnNames.remove(propDescriptor.getName());
+                }
+                else if (hardColumnNames.remove(propDescriptor.getStorageColumnName()))
                 {
                     status.colName = domainProp.getName();
                 }


### PR DESCRIPTION
#### Rationale
Update the db consistency check to handle the case a property descriptor does not have a storage column name. Throw an error explaining the issue and fix the issue by copying the PD name to the storage column name (instead of deleting and re-adding the field).

Related Reports:
http://localhost:8080/labkey/admin-doCheck.view
http://localhost:8080/labkey/<Container>/experiment-types-repair.view?domainUri=<param>

#### Changes
* Report that the PD is missing storage column name (instead of PD missing column and column missing a PD)
* On fix, add the PD name as the storage column name
