### PR TITLE
endRequest() does not belong in finally {}

### DIFF
--- a/api/src/org/labkey/api/action/ApiQueryResponse.java
+++ b/api/src/org/labkey/api/action/ApiQueryResponse.java
@@ -207,6 +207,7 @@ public class ApiQueryResponse implements ApiResponse
 
                 }
             }
+            writer.endResponse();
         }
         catch (Exception ex)
         {
@@ -214,7 +215,7 @@ public class ApiQueryResponse implements ApiResponse
         }
         finally
         {
-            writer.endResponse();
+            writer.close();
         }
     }
 

--- a/api/src/org/labkey/api/action/ApiResponse.java
+++ b/api/src/org/labkey/api/action/ApiResponse.java
@@ -29,6 +29,7 @@ public interface ApiResponse
      * try
      * {
      *    ... write response ...
+     *     write.endResponse();
      * }
      * catch (Exception x)
      * {
@@ -36,7 +37,7 @@ public interface ApiResponse
      * }
      * finally
      * {
-     *     write.endResponse();
+     *     writer.close();
      * }
      * </pre>
      *


### PR DESCRIPTION
#### Rationale
fix assert in error case caused by endRequest() being in the wrong place.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
