### PR TITLE
Prevent intermittent ServerBootstrap test failure on initial DB connection

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1549,7 +1549,7 @@ public class DbScope
         {
             if (i > 0)
             {
-                LOG.error("Retrying connection to \"" + dsName + "\" at " + props.getUrl() + " in 10 seconds");
+                LOG.warn("Retrying connection to \"" + dsName + "\" at " + props.getUrl() + " in 10 seconds");
 
                 try
                 {
@@ -1557,7 +1557,7 @@ public class DbScope
                 }
                 catch (InterruptedException e)
                 {
-                    LOG.error("ensureDataBase", e);
+                    LOG.warn("ensureDataBase", e);
                 }
             }
 
@@ -1582,8 +1582,8 @@ public class DbScope
                 }
                 else
                 {
-                    LOG.error("Connection to \"" + dsName + "\" at " + props.getUrl() + " failed with the following error:");
-                    LOG.error("Message: " + e.getMessage() + " SQLState: " + e.getSQLState() + " ErrorCode: " + e.getErrorCode(), e);
+                    LOG.warn("Connection to \"" + dsName + "\" at " + props.getUrl() + " failed with the following error:");
+                    LOG.warn("Message: " + e.getMessage() + " SQLState: " + e.getSQLState() + " ErrorCode: " + e.getErrorCode(), e);
                     lastException = e;
                 }
             }


### PR DESCRIPTION
#### Rationale
Sometimes SQLServer isn't quite ready in time for the initial connection attempt. We continue on with a successful retry, but the test fails due to the error message in the log.

https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_Ehr_BvtEhrSqlserver/2449267?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&expandBuildChangesSection=true

#### Changes
* Log the initial connection failures at `WARN`, and the final one at `ERROR`