### PR TITLE
ELN: Resolve references via search

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProvider.java
+++ b/api/src/org/labkey/api/assay/AssayProvider.java
@@ -16,7 +16,6 @@
 
 package org.labkey.api.assay;
 
-import org.apache.logging.log4j.Logger;
 import org.fhcrc.cpas.exp.xml.ExperimentRunType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -24,8 +23,6 @@ import org.labkey.api.assay.actions.AssayRunUploadForm;
 import org.labkey.api.assay.pipeline.AssayRunAsyncContext;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Handler;
 import org.labkey.api.exp.Lsid;
@@ -42,7 +39,6 @@ import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.module.Module;
 import org.labkey.api.pipeline.PipelineProvider;
 import org.labkey.api.qc.DataExchangeHandler;
-import org.labkey.api.query.ValidationError;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.study.publish.PublishKey;

--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -67,6 +67,13 @@ public interface AssayService
             return getPermittedContainerIds(user, containers, AssayReadPermission.class);
         }
     };
+    SearchService.SearchCategory ASSAY_BATCH_CATEGORY = new SearchService.SearchCategory("assayBatch", "Assay Batch") {
+        @Override
+        public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
+        {
+            return getPermittedContainerIds(user, containers, AssayReadPermission.class);
+        }
+    };
     SearchService.SearchCategory ASSAY_RUN_CATEGORY = new SearchService.SearchCategory("assayRun", "Assay Run") {
         @Override
         public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
@@ -153,10 +160,8 @@ public interface AssayService
 
     void indexAssay(SearchService.IndexTask task, Container c, ExpProtocol protocol);
     void indexAssays(SearchService.IndexTask task, Container c);
-    void indexAssayRun(SearchService.IndexTask task, int expRunRowId);
-    void indexAssayRuns(SearchService.IndexTask task, Container c);
 
-    void unindexAssays(@NotNull Collection<? extends ExpProtocol> expProtocols);
+    void deindexAssays(@NotNull Collection<? extends ExpProtocol> expProtocols);
 
     /**
      * Creates a run, but does not persist it to the database. Creates the run only, no protocol applications, etc.

--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -34,7 +34,6 @@ import org.labkey.api.exp.query.ExpRunTable;
 import org.labkey.api.query.ValidationError;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
-import org.labkey.api.security.permissions.AssayReadPermission;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.study.assay.ParticipantVisitResolver;
 import org.labkey.api.util.Pair;
@@ -59,28 +58,6 @@ public interface AssayService
 {
     String BATCH_COLUMN_NAME = "Batch";
     String ASSAY_DIR_NAME = "assay";
-
-    SearchService.SearchCategory ASSAY_CATEGORY = new SearchService.SearchCategory("assay", "Study Assay") {
-        @Override
-        public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
-        {
-            return getPermittedContainerIds(user, containers, AssayReadPermission.class);
-        }
-    };
-    SearchService.SearchCategory ASSAY_BATCH_CATEGORY = new SearchService.SearchCategory("assayBatch", "Assay Batch") {
-        @Override
-        public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
-        {
-            return getPermittedContainerIds(user, containers, AssayReadPermission.class);
-        }
-    };
-    SearchService.SearchCategory ASSAY_RUN_CATEGORY = new SearchService.SearchCategory("assayRun", "Assay Run") {
-        @Override
-        public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
-        {
-            return getPermittedContainerIds(user, containers, AssayReadPermission.class);
-        }
-    };
 
     static AssayService get()
     {

--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -34,6 +34,7 @@ import org.labkey.api.exp.query.ExpRunTable;
 import org.labkey.api.query.ValidationError;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.AssayReadPermission;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.study.assay.ParticipantVisitResolver;
 import org.labkey.api.util.Pair;
@@ -58,6 +59,21 @@ public interface AssayService
 {
     String BATCH_COLUMN_NAME = "Batch";
     String ASSAY_DIR_NAME = "assay";
+
+    SearchService.SearchCategory ASSAY_CATEGORY = new SearchService.SearchCategory("assay", "Study Assay") {
+        @Override
+        public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
+        {
+            return getPermittedContainerIds(user, containers, AssayReadPermission.class);
+        }
+    };
+    SearchService.SearchCategory ASSAY_RUN_CATEGORY = new SearchService.SearchCategory("assayRun", "Assay Run") {
+        @Override
+        public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
+        {
+            return getPermittedContainerIds(user, containers, AssayReadPermission.class);
+        }
+    };
 
     static AssayService get()
     {
@@ -137,6 +153,8 @@ public interface AssayService
 
     void indexAssay(SearchService.IndexTask task, Container c, ExpProtocol protocol);
     void indexAssays(SearchService.IndexTask task, Container c);
+    void indexAssayRun(SearchService.IndexTask task, int expRunRowId);
+    void indexAssayRuns(SearchService.IndexTask task, Container c);
 
     void unindexAssays(@NotNull Collection<? extends ExpProtocol> expProtocols);
 

--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -402,7 +402,6 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
             ExperimentService.get().onRunDataCreated(context.getProtocol(), run, container, context.getUser());
 
             int runRowId = run.getRowId();
-            transaction.addCommitTask(() -> indexAssayRun(runRowId), DbScope.CommitTaskOption.POSTCOMMIT);
 
             transaction.commit();
 
@@ -444,15 +443,6 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
         {
             throw new ExperimentException(e);
         }
-    }
-
-    private void indexAssayRun(int expRunRowId)
-    {
-        SearchService ss = SearchService.get();
-        if (ss == null)
-            return;
-
-        AssayService.get().indexAssayRun(ss.defaultTask(), expRunRowId);
     }
 
     private void resolveParticipantVisits(

--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -401,8 +401,6 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
 
             ExperimentService.get().onRunDataCreated(context.getProtocol(), run, container, context.getUser());
 
-            int runRowId = run.getRowId();
-
             transaction.commit();
 
             // Inspect the run properties for a “prov:objectInputs” property that is a list of LSID strings.

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -1985,7 +1985,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         searchIndexColumns.put(column, property);
     }
 
-    public SearchService.PROPERTY getSearchIndexColumns(FieldKey column)
+    public SearchService.PROPERTY getSearchIndexColumn(FieldKey column)
     {
         if (searchIndexColumns == null)
             return null;

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -52,6 +52,7 @@ import org.labkey.api.query.SchemaTreeVisitor;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.query.column.ColumnInfoTransformer;
+import org.labkey.api.search.SearchService;
 import org.labkey.api.security.SecurityLogger;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
@@ -1290,10 +1291,10 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         if (xmlTable.isSetCacheSize())
             _cacheSize = xmlTable.getCacheSize();
 
-        if(xmlTable.getImportMessage() != null)
+        if (xmlTable.getImportMessage() != null)
             setImportMessage(xmlTable.getImportMessage());
 
-        if(xmlTable.getImportTemplates() != null)
+        if (xmlTable.getImportTemplates() != null)
             setImportTemplates(xmlTable.getImportTemplates().getTemplateArray());
 
         // Optimization - only check for wrapped columns based on the "real" set of columns, not columns that are
@@ -1380,7 +1381,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         if (xmlTable.getButtonBarOptions() != null)
             _buttonBarConfig = new ButtonBarConfig(xmlTable.getButtonBarOptions());
 
-        if(xmlTable.getAggregateRowOptions() != null && xmlTable.getAggregateRowOptions().getPosition() != null)
+        if (xmlTable.getAggregateRowOptions() != null && xmlTable.getAggregateRowOptions().getPosition() != null)
         {
             setAggregateRowConfig(xmlTable);
         }
@@ -1501,11 +1502,11 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         _aggregateRowConfig = new AggregateRowConfig(false, false);
 
         PositionTypeEnum.Enum position = xmlTable.getAggregateRowOptions().getPosition();
-        if(position.equals(PositionTypeEnum.BOTH) || position.equals(PositionTypeEnum.TOP))
+        if (position.equals(PositionTypeEnum.BOTH) || position.equals(PositionTypeEnum.TOP))
         {
             _aggregateRowConfig.setAggregateRowFirst(true);
         }
-        if(position.equals(PositionTypeEnum.BOTH) || position.equals(PositionTypeEnum.BOTTOM))
+        if (position.equals(PositionTypeEnum.BOTH) || position.equals(PositionTypeEnum.BOTTOM))
         {
             _aggregateRowConfig.setAggregateRowLast(true);
         }
@@ -1882,14 +1883,14 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         //RenderContext rc = new RenderContext(ctx);
         Map<String, Container> renderCtx = Collections.singletonMap("container", ctx.getContainer());
 
-        if(_importTemplates != null)
+        if (_importTemplates != null)
         {
             for (Pair<String, StringExpression> pair : _importTemplates)
             {
-                if(pair.second instanceof DetailsURL)
-                    templates.add(Pair.of(pair.first, ((DetailsURL)pair.second).copy(ctx.getContainer()).getActionURL().toString()));
-                else if (pair.second instanceof StringExpressionFactory.URLStringExpression)
-                    templates.add(Pair.of(pair.first, pair.second.eval(renderCtx)));
+                if (pair.second instanceof DetailsURL detailsURL)
+                    templates.add(Pair.of(pair.first, detailsURL.copy(ctx.getContainer()).getActionURL().toString()));
+                else if (pair.second instanceof StringExpressionFactory.URLStringExpression expr)
+                    templates.add(Pair.of(pair.first, expr.eval(renderCtx)));
             }
         }
 
@@ -1973,6 +1974,22 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     public boolean supportsInsertOption(QueryUpdateService.InsertOption option)
     {
         return !_disallowedInsertOptions.contains(option);
+    }
+
+    private Map<FieldKey, SearchService.PROPERTY> searchIndexColumns = null;
+
+    public void indexColumn(FieldKey column, SearchService.PROPERTY property)
+    {
+        if (searchIndexColumns == null)
+            searchIndexColumns = new HashMap<>();
+        searchIndexColumns.put(column, property);
+    }
+
+    public SearchService.PROPERTY getSearchIndexColumns(FieldKey column)
+    {
+        if (searchIndexColumns == null)
+            return null;
+        return searchIndexColumns.get(column);
     }
 
     public static class TestCase extends Assert{

--- a/api/src/org/labkey/api/exp/api/ExperimentJSONConverter.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentJSONConverter.java
@@ -675,22 +675,29 @@ public class ExperimentJSONConverter
     @NotNull
     public static JSONObject serializeData(@NotNull ExpData data, @Nullable User user, @NotNull Settings settings)
     {
-        JSONObject jsonObject = serializeExpObject(data, null, settings, user);
-        jsonObject.put(ExperimentJSONConverter.EXP_TYPE, "Data");
-
+        JSONObject jsonObject = null;
         if (settings.isIncludeProperties())
         {
-            final ExpDataClass dc = data.getDataClass(user);
-            if (dc != null)
+            ExpDataClass dataClass = data.getDataClass(user);
+
+            if (dataClass != null)
             {
-                JSONObject dataClassJsonObject = serializeExpObject(dc, null, settings.withIncludeProperties(false), user);
-                if (dc.getCategory() != null)
-                    dataClassJsonObject.put(DATA_CLASS_CATEGORY, dc.getCategory());
+                jsonObject = serializeExpObject(data, dataClass.getDomain().getProperties(), settings, user);
+
+                JSONObject dataClassJsonObject = serializeExpObject(dataClass, null, settings.withIncludeProperties(false), user);
+                if (dataClass.getCategory() != null)
+                    dataClassJsonObject.put(DATA_CLASS_CATEGORY, dataClass.getCategory());
                 jsonObject.put(DATA_CLASS, dataClassJsonObject);
             }
         }
 
+        if (jsonObject == null)
+            jsonObject = serializeExpObject(data, null, settings, user);
+
+        jsonObject.put(CPAS_TYPE, data.getCpasType());
+        jsonObject.put(ExperimentJSONConverter.EXP_TYPE, "Data");
         jsonObject.put(DATA_FILE_URL, data.getDataFileUrl());
+
         File f = data.getFile();
         if (f != null)
         {
@@ -701,8 +708,6 @@ public class ExperimentJSONConverter
                 jsonObject.put(PIPELINE_PATH, pipeRoot.relativePath(f));
             }
         }
-
-        jsonObject.put(CPAS_TYPE, data.getCpasType());
 
         return jsonObject;
     }

--- a/api/src/org/labkey/api/exp/api/ExperimentJSONConverter.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentJSONConverter.java
@@ -194,9 +194,21 @@ public class ExperimentJSONConverter
 
     public static JSONObject serializeRunGroup(ExpExperiment runGroup, Domain domain, @NotNull Settings settings, @Nullable User user)
     {
-        JSONObject jsonObject = serializeExpObject(runGroup, domain != null ? domain.getProperties() : Collections.emptyList(), settings, user);
-        jsonObject.put(COMMENT, runGroup.getComments());
+        JSONObject jsonObject = serializeExpObject(runGroup, domain == null ? null : domain.getProperties(), settings, user);
         jsonObject.put(ExperimentJSONConverter.EXP_TYPE, "Experiment");
+
+        ExpProtocol protocol = runGroup.getBatchProtocol();
+        if (protocol != null)
+        {
+            jsonObject.put(CPAS_TYPE, protocol.getLSID());
+        }
+
+        if (settings.isIncludeProperties())
+        {
+            jsonObject.put(COMMENT, runGroup.getComments());
+            jsonObject.put(PROTOCOL, serializeProtocol(protocol, user));
+        }
+
         return jsonObject;
     }
 
@@ -204,10 +216,17 @@ public class ExperimentJSONConverter
     {
         JSONObject jsonObject = serializeExpObject(run, domain == null ? null : domain.getProperties(), settings, user);
         jsonObject.put(ExperimentJSONConverter.EXP_TYPE, "ExperimentRun");
+
+        ExpProtocol protocol = run.getProtocol();
+        if (protocol != null)
+        {
+            jsonObject.put(CPAS_TYPE, protocol.getLSID());
+        }
+
         if (settings.isIncludeProperties())
         {
             jsonObject.put(COMMENT, run.getComments());
-            jsonObject.put(PROTOCOL, serializeProtocol(run.getProtocol(), user));
+            jsonObject.put(PROTOCOL, serializeProtocol(protocol, user));
         }
 
         if (settings.isIncludeInputsAndOutputs())
@@ -224,7 +243,6 @@ public class ExperimentJSONConverter
                 jsonObject.put(MATERIAL_INPUTS, new JSONArray());
             }
 
-
             // Inputs into the final output step are outputs of the entire run
             ExpProtocolApplication outputApp = run.getOutputProtocolApplication();
             if (outputApp != null)
@@ -239,12 +257,6 @@ public class ExperimentJSONConverter
             }
 
             serializeRunLevelProvenanceProperties(jsonObject, run);
-        }
-
-        ExpProtocol protocol = run.getProtocol();
-        if (protocol != null)
-        {
-            jsonObject.put(CPAS_TYPE, protocol.getLSID());
         }
 
         if (settings.isIncludeRunSteps())

--- a/api/src/org/labkey/api/exp/api/ExperimentListener.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentListener.java
@@ -27,12 +27,32 @@ import java.util.List;
  */
 public interface ExperimentListener
 {
+    /** Called after an experiment is deleted (in-transaction). */
+    default void afterExperimentDeleted(Container c, User user, ExpExperiment experiment)
+    {
+    }
+
+    /** Called after an experiment is saved (post-transaction). */
+    default void afterExperimentSaved(Container c, User user, ExpExperiment experiment)
+    {
+    }
+
     /** Called before deleting a row from exp.experiment */
     default void beforeExperimentDeleted(Container c, User user, ExpExperiment experiment)
     {}
 
     default void beforeProtocolsDeleted(Container c, User user, List<? extends ExpProtocol> protocols)
     { }
+
+    /** Called after an experiment run is deleted (in-transaction). */
+    default void afterRunDelete(ExpProtocol protocol, ExpRun run, User user)
+    {
+    }
+
+    /** Called after an experiment run is saved (post-transaction). */
+    default void afterRunSaved(Container container, User user, ExpProtocol protocol, ExpRun run)
+    {
+    }
 
     // called before the experiment run is created (and saved)
     default void beforeRunCreated(Container container, User user, ExpProtocol protocol, ExpRun run) throws BatchValidationException
@@ -57,5 +77,4 @@ public interface ExperimentListener
     default void beforeMaterialDelete(List<? extends ExpMaterial> materials, Container container, User user) { }
 
     default void afterMaterialCreated(List<? extends ExpMaterial> materials, Container container, User user) { }
-
 }

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -368,6 +368,8 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     ExpExperiment getExpExperiment(String lsid);
 
+    List<? extends ExpExperiment> getExpExperiments(Collection<Integer> rowIds);
+
     List<? extends ExpExperiment> getExperiments(Container container, User user, boolean includeOtherContainers, boolean includeBatches);
 
     ExpProtocol getExpProtocol(int rowid);

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.json.JSONObject;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -144,6 +145,7 @@ public interface SearchService
         categories("searchCategories"),
         ontology("ontology"),
         summary("summary"),
+        jsonData("jsonData"),
         securableResourceId(SecurableResource.class.getName()),
         navtrail(NavTree.class.getName());  // as in NavTree.toJS()
 
@@ -323,6 +325,7 @@ public interface SearchService
         public String url;
         public String navtrail;
         public String identifiers; // identifiersHi
+        public JSONObject jsonData;
         public float score;
 
         public String normalizeHref(Path contextPath)

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -631,6 +631,7 @@ public interface SearchService
     {
         public final List<SearchCategory> categories;
         public final Container container;
+        public final List<String> fields;
         public final Boolean fullResult;
         public final Boolean invertResults;
         public final Integer limit;
@@ -650,11 +651,13 @@ public interface SearchService
             @Nullable Integer offset,
             @Nullable Integer limit,
             @Nullable Boolean invertResults,
-            @Nullable Boolean fullResult
+            @Nullable Boolean fullResult,
+            @Nullable List<String> fields
         )
         {
             this.categories = categories;
             this.container = container;
+            this.fields = fields;
             this.fullResult = fullResult == null || fullResult;
             this.invertResults = invertResults != null && invertResults;
             this.limit = limit == null ? 100 : limit;
@@ -669,6 +672,7 @@ public interface SearchService
         {
             public List<SearchCategory> categories;
             public Container container;
+            public List<String> fields;
             public Boolean fullResult;
             public Boolean invertResults;
             public Integer limit;
@@ -691,6 +695,7 @@ public interface SearchService
             {
                 this(options.queryString, options.user, options.container);
                 this.categories = options.categories;
+                this.fields = options.fields;
                 this.fullResult = options.fullResult;
                 this.invertResults = options.invertResults;
                 this.limit = options.limit;
@@ -701,7 +706,7 @@ public interface SearchService
 
             public SearchOptions build()
             {
-                return new SearchOptions(queryString, user, container, categories, scope, sortField, offset, limit, invertResults, fullResult);
+                return new SearchOptions(queryString, user, container, categories, scope, sortField, offset, limit, invertResults, fullResult, fields);
             }
         }
     }

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -374,12 +374,10 @@ public interface SearchService
 
     WebPartView getSearchView(boolean includeSubfolders, int textBoxWidth, boolean includeHelpLink, boolean isWebpart);
 
-    SearchResult search(String queryString, @Nullable List<SearchCategory> categories, User user, Container current, SearchScope scope, @Nullable String sortField, int offset, int limit) throws IOException;
+    SearchResult search(SearchOptions options) throws IOException;
 
     // return list of uniqueId
-    List<String> searchUniqueIds(String queryString, @Nullable List<SearchCategory> categories, User user, Container current, SearchScope scope, @Nullable String sortField, int offset, int limit, boolean invertResults) throws IOException;
-
-    SearchResult search(String queryString, @Nullable List<SearchCategory> categories, User user, Container current, SearchScope scope, @Nullable String sortField, int offset, int limit, boolean invertResults) throws IOException;
+    List<String> searchUniqueIds(SearchOptions options) throws IOException;
 
     @Nullable SearchHit find(String docId) throws IOException;
 
@@ -626,6 +624,85 @@ public interface SearchService
         public List<FieldKey> getFieldKeys()
         {
             return new ArrayList<>(_fieldKeys);
+        }
+    }
+
+    class SearchOptions
+    {
+        public final List<SearchCategory> categories;
+        public final Container container;
+        public final Boolean fullResult;
+        public final Boolean invertResults;
+        public final Integer limit;
+        public final Integer offset;
+        public final String queryString;
+        public final SearchScope scope;
+        public final String sortField;
+        public final User user;
+
+        private SearchOptions(
+            String queryString,
+            User user,
+            Container container,
+            @Nullable List<SearchCategory> categories,
+            @Nullable SearchScope scope,
+            @Nullable String sortField,
+            @Nullable Integer offset,
+            @Nullable Integer limit,
+            @Nullable Boolean invertResults,
+            @Nullable Boolean fullResult
+        )
+        {
+            this.categories = categories;
+            this.container = container;
+            this.fullResult = fullResult == null || fullResult;
+            this.invertResults = invertResults != null && invertResults;
+            this.limit = limit == null ? 100 : limit;
+            this.offset = offset == null ? 0 : offset;
+            this.queryString = queryString;
+            this.scope = scope == null ? SearchScope.Folder : scope;
+            this.sortField = sortField;
+            this.user = user;
+        }
+
+        public static class Builder
+        {
+            public List<SearchCategory> categories;
+            public Container container;
+            public Boolean fullResult;
+            public Boolean invertResults;
+            public Integer limit;
+            public Integer offset;
+            public String queryString;
+            public SearchScope scope;
+            public String sortField;
+            public User user;
+
+            public Builder() {}
+
+            public Builder(String queryString, User user, Container container)
+            {
+                this.container = container;
+                this.queryString = queryString;
+                this.user = user;
+            }
+
+            public Builder(SearchOptions options)
+            {
+                this(options.queryString, options.user, options.container);
+                this.categories = options.categories;
+                this.fullResult = options.fullResult;
+                this.invertResults = options.invertResults;
+                this.limit = options.limit;
+                this.offset = options.offset;
+                this.scope = options.scope;
+                this.sortField = options.sortField;
+            }
+
+            public SearchOptions build()
+            {
+                return new SearchOptions(queryString, user, container, categories, scope, sortField, offset, limit, invertResults, fullResult);
+            }
         }
     }
 }

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -635,7 +635,6 @@ public interface SearchService
         public final List<SearchCategory> categories;
         public final Container container;
         public final List<String> fields;
-        public final Boolean fullResult;
         public final Boolean invertResults;
         public final Integer limit;
         public final Integer offset;
@@ -654,14 +653,12 @@ public interface SearchService
             @Nullable Integer offset,
             @Nullable Integer limit,
             @Nullable Boolean invertResults,
-            @Nullable Boolean fullResult,
             @Nullable List<String> fields
         )
         {
             this.categories = categories;
             this.container = container;
             this.fields = fields;
-            this.fullResult = fullResult == null || fullResult;
             this.invertResults = invertResults != null && invertResults;
             this.limit = limit == null ? 100 : limit;
             this.offset = offset == null ? 0 : offset;
@@ -676,7 +673,6 @@ public interface SearchService
             public List<SearchCategory> categories;
             public Container container;
             public List<String> fields;
-            public Boolean fullResult;
             public Boolean invertResults;
             public Integer limit;
             public Integer offset;
@@ -699,7 +695,6 @@ public interface SearchService
                 this(options.queryString, options.user, options.container);
                 this.categories = options.categories;
                 this.fields = options.fields;
-                this.fullResult = options.fullResult;
                 this.invertResults = options.invertResults;
                 this.limit = options.limit;
                 this.offset = options.offset;
@@ -709,7 +704,7 @@ public interface SearchService
 
             public SearchOptions build()
             {
-                return new SearchOptions(queryString, user, container, categories, scope, sortField, offset, limit, invertResults, fullResult, fields);
+                return new SearchOptions(queryString, user, container, categories, scope, sortField, offset, limit, invertResults, fields);
             }
         }
     }

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -465,7 +465,9 @@ public interface SearchService
          *if the full-text search is deleted, providers may need to clear
          * any stored lastIndexed values.
          */
-        void indexDeleted() throws SQLException;
+        default void indexDeleted() throws SQLException
+        {
+        }
 
         /**
          * Thrown for a document that is an illegal/invalid state that should not be indexed, but can be safely ignored.

--- a/api/src/org/labkey/api/util/StringUtilsLabKey.java
+++ b/api/src/org/labkey/api/util/StringUtilsLabKey.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.exp.Identifiable;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -54,6 +55,23 @@ public class StringUtilsLabKey
 
     private static final Random RANDOM = new Random();
     private static final int MAX_LONG_LENGTH = String.valueOf(Long.MAX_VALUE).length() - 1;
+
+    public static void append(StringBuilder sb, @Nullable Identifiable identifiable)
+    {
+        if (null != identifiable)
+            append(sb, identifiable.getName());
+    }
+
+    public static void append(StringBuilder sb, @Nullable String value)
+    {
+        if (null != value)
+        {
+            if (sb.length() > 0)
+                sb.append(" ");
+
+            sb.append(value);
+        }
+    }
 
     // Finds the longest common prefix present in all elements of the passed in string collection. In other words,
     // the longest string (prefix) such that, for all s in strings, s.startsWith(prefix). An empty collection returns

--- a/api/src/org/labkey/api/util/StringUtilsLabKey.java
+++ b/api/src/org/labkey/api/util/StringUtilsLabKey.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.data.Container;
 import org.labkey.api.exp.Identifiable;
 
 import java.nio.charset.Charset;
@@ -64,7 +65,7 @@ public class StringUtilsLabKey
 
     public static void append(StringBuilder sb, @Nullable String value)
     {
-        if (null != value)
+        if (!StringUtils.isEmpty(value))
         {
             if (sb.length() > 0)
                 sb.append(" ");
@@ -665,6 +666,47 @@ public class StringUtilsLabKey
             assertEquals("abc\"", unquoteString("abc\""));
             assertEquals("ab\"c", unquoteString("\"ab\"\"c\""));
             assertEquals("WC-1,3", unquoteString("\"WC-1,3\""));
+        }
+
+        @Test
+        public void testAppend()
+        {
+            class TestIdentifiable implements Identifiable
+            {
+                @Override
+                public Container getContainer()
+                {
+                    return null;
+                }
+
+                @Override
+                public String getLSID()
+                {
+                    return null;
+                }
+
+                @Override
+                public String getName()
+                {
+                    return "TestIdentifiable";
+                }
+            }
+
+            StringBuilder sb = new StringBuilder();
+            append(sb, (Identifiable) null);
+            assertEquals("", sb.toString());
+
+            sb = new StringBuilder("first");
+            append(sb, "");
+            assertEquals("first", sb.toString());
+            append(sb, (String) null);
+            assertEquals("first", sb.toString());
+
+            append(sb, "second");
+            assertEquals("first second", sb.toString());
+
+            append(sb, new TestIdentifiable());
+            assertEquals("first second TestIdentifiable", sb.toString());
         }
     }
 }

--- a/assay/src/org/labkey/assay/AssayBatchDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayBatchDocumentProvider.java
@@ -3,7 +3,6 @@ package org.labkey.assay;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.assay.AssayService;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExperimentJSONConverter;
@@ -35,7 +34,7 @@ public class AssayBatchDocumentProvider implements SearchService.DocumentProvide
 
     private static SearchService.SearchCategory getSearchCategory()
     {
-        return AssayService.ASSAY_BATCH_CATEGORY;
+        return AssayManager.get().ASSAY_BATCH_CATEGORY;
     }
 
     private static String getDocumentIdPrefix()

--- a/assay/src/org/labkey/assay/AssayDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayDocumentProvider.java
@@ -25,11 +25,6 @@ public class AssayDocumentProvider implements DocumentProvider
         task.addRunnable(runEnumerate, SearchService.PRIORITY.group);
     }
 
-    @Override
-    public void indexDeleted()
-    {
-    }
-
     public static SearchService.ResourceResolver getSearchResolver()
     {
         return new SearchService.ResourceResolver()

--- a/assay/src/org/labkey/assay/AssayExperimentListener.java
+++ b/assay/src/org/labkey/assay/AssayExperimentListener.java
@@ -1,0 +1,37 @@
+package org.labkey.assay;
+
+import org.labkey.api.data.Container;
+import org.labkey.api.exp.api.ExpExperiment;
+import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.api.ExpRun;
+import org.labkey.api.exp.api.ExperimentListener;
+import org.labkey.api.security.User;
+
+import java.util.List;
+
+public class AssayExperimentListener implements ExperimentListener
+{
+    @Override
+    public void afterExperimentDeleted(Container c, User user, ExpExperiment experiment)
+    {
+        AssayManager.get().deindexAssayBatches(List.of(experiment));
+    }
+
+    @Override
+    public void afterExperimentSaved(Container c, User user, ExpExperiment experiment)
+    {
+        AssayManager.get().indexAssayBatch(experiment.getRowId());
+    }
+
+    @Override
+    public void afterRunDelete(ExpProtocol protocol, ExpRun run, User user)
+    {
+        AssayManager.get().deindexAssayRuns(List.of(run));
+    }
+
+    @Override
+    public void afterRunSaved(Container container, User user, ExpProtocol protocol, ExpRun run)
+    {
+        AssayManager.get().indexAssayRun(run.getRowId());
+    }
+}

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -69,6 +69,7 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationError;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.AssayReadPermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.study.assay.ParticipantVisitResolver;
@@ -120,6 +121,28 @@ import java.util.stream.Collectors;
  */
 public class AssayManager implements AssayService
 {
+    SearchService.SearchCategory ASSAY_CATEGORY = new SearchService.SearchCategory("assay", "Study Assay") {
+        @Override
+        public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
+        {
+            return getPermittedContainerIds(user, containers, AssayReadPermission.class);
+        }
+    };
+    SearchService.SearchCategory ASSAY_BATCH_CATEGORY = new SearchService.SearchCategory("assayBatch", "Assay Batch") {
+        @Override
+        public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
+        {
+            return getPermittedContainerIds(user, containers, AssayReadPermission.class);
+        }
+    };
+    SearchService.SearchCategory ASSAY_RUN_CATEGORY = new SearchService.SearchCategory("assayRun", "Assay Run") {
+        @Override
+        public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
+        {
+            return getPermittedContainerIds(user, containers, AssayReadPermission.class);
+        }
+    };
+
     private static final Cache<Container, List<ExpProtocol>> PROTOCOL_CACHE = CacheManager.getCache(CacheManager.UNLIMITED, TimeUnit.HOURS.toMillis(1), "Assay protocols");
 
     private final List<AssayProvider> _providers = new CopyOnWriteArrayList<>();

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -183,12 +183,12 @@ public class AssayModule extends SpringModule
 
         if (null != ss)
         {
-            ss.addSearchCategory(AssayService.ASSAY_CATEGORY);
-            ss.addSearchCategory(AssayService.ASSAY_BATCH_CATEGORY);
-            ss.addSearchCategory(AssayService.ASSAY_RUN_CATEGORY);
-            ss.addResourceResolver(AssayService.ASSAY_CATEGORY.getName(), AssayDocumentProvider.getSearchResolver());
-            ss.addResourceResolver(AssayService.ASSAY_BATCH_CATEGORY.getName(), AssayBatchDocumentProvider.getResourceResolver());
-            ss.addResourceResolver(AssayService.ASSAY_RUN_CATEGORY.getName(), AssayRunDocumentProvider.getResourceResolver());
+            ss.addSearchCategory(AssayManager.get().ASSAY_CATEGORY);
+            ss.addSearchCategory(AssayManager.get().ASSAY_BATCH_CATEGORY);
+            ss.addSearchCategory(AssayManager.get().ASSAY_RUN_CATEGORY);
+            ss.addResourceResolver(AssayManager.get().ASSAY_CATEGORY.getName(), AssayDocumentProvider.getSearchResolver());
+            ss.addResourceResolver(AssayManager.get().ASSAY_BATCH_CATEGORY.getName(), AssayBatchDocumentProvider.getResourceResolver());
+            ss.addResourceResolver(AssayManager.get().ASSAY_RUN_CATEGORY.getName(), AssayRunDocumentProvider.getResourceResolver());
             ss.addDocumentProvider(new AssayDocumentProvider());
             ss.addDocumentProvider(new AssayBatchDocumentProvider());
             ss.addDocumentProvider(new AssayRunDocumentProvider());

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -183,9 +183,12 @@ public class AssayModule extends SpringModule
 
         if (null != ss)
         {
-            ss.addSearchCategory(AssayManager.ASSAY_CATEGORY);
-            ss.addResourceResolver(AssayManager.ASSAY_CATEGORY.getName(), AssayDocumentProvider.getSearchResolver());
+            ss.addSearchCategory(AssayService.ASSAY_CATEGORY);
+            ss.addSearchCategory(AssayService.ASSAY_RUN_CATEGORY);
+            ss.addResourceResolver(AssayService.ASSAY_CATEGORY.getName(), AssayDocumentProvider.getSearchResolver());
+            ss.addResourceResolver(AssayService.ASSAY_RUN_CATEGORY.getName(), AssayRunDocumentProvider.getResourceResolver());
             ss.addDocumentProvider(new AssayDocumentProvider());
+            ss.addDocumentProvider(new AssayRunDocumentProvider());
         }
 
         // add a container listener so we'll know when our container is deleted:

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -184,10 +184,13 @@ public class AssayModule extends SpringModule
         if (null != ss)
         {
             ss.addSearchCategory(AssayService.ASSAY_CATEGORY);
+            ss.addSearchCategory(AssayService.ASSAY_BATCH_CATEGORY);
             ss.addSearchCategory(AssayService.ASSAY_RUN_CATEGORY);
             ss.addResourceResolver(AssayService.ASSAY_CATEGORY.getName(), AssayDocumentProvider.getSearchResolver());
+            ss.addResourceResolver(AssayService.ASSAY_BATCH_CATEGORY.getName(), AssayBatchDocumentProvider.getResourceResolver());
             ss.addResourceResolver(AssayService.ASSAY_RUN_CATEGORY.getName(), AssayRunDocumentProvider.getResourceResolver());
             ss.addDocumentProvider(new AssayDocumentProvider());
+            ss.addDocumentProvider(new AssayBatchDocumentProvider());
             ss.addDocumentProvider(new AssayRunDocumentProvider());
         }
 
@@ -231,6 +234,8 @@ public class AssayModule extends SpringModule
                 });
             }
         });
+
+        ExperimentService.get().addExperimentListener(new AssayExperimentListener());
     }
 
     @Override

--- a/assay/src/org/labkey/assay/AssayRunDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayRunDocumentProvider.java
@@ -1,0 +1,168 @@
+package org.labkey.assay;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AssayService;
+import org.labkey.api.data.Container;
+import org.labkey.api.exp.Identifiable;
+import org.labkey.api.exp.api.ExpRun;
+import org.labkey.api.exp.api.ExperimentJSONConverter;
+import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.search.SearchService;
+import org.labkey.api.security.User;
+import org.labkey.api.util.Path;
+import org.labkey.api.view.ActionURL;
+import org.labkey.api.webdav.SimpleDocumentResource;
+import org.labkey.api.webdav.WebdavResource;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class AssayRunDocumentProvider implements SearchService.DocumentProvider
+{
+    @Override
+    public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
+    {
+        Runnable runEnumerate = () -> AssayService.get().indexAssayRuns(task, c);
+        task.addRunnable(runEnumerate, SearchService.PRIORITY.group);
+    }
+
+    public static WebdavResource createDocument(@NotNull ExpRun expRun)
+    {
+        Map<String, Object> props = new HashMap<>();
+        Set<String> identifiersHi = new HashSet<>();
+        Set<String> identifiersMed = new HashSet<>();
+        final String documentId = AssayService.ASSAY_RUN_CATEGORY.getName() + ":" + expRun.getRowId();
+
+        identifiersHi.add(expRun.getName());
+        identifiersMed.add(expRun.getLSID());
+
+        props.put(SearchService.PROPERTY.identifiersHi.toString(), StringUtils.join(identifiersHi, " "));
+        props.put(SearchService.PROPERTY.identifiersMed.toString(), StringUtils.join(identifiersMed, " "));
+        props.put(SearchService.PROPERTY.categories.toString(), AssayService.ASSAY_RUN_CATEGORY.getName());
+        props.put(SearchService.PROPERTY.title.toString(), "Assay Run - " + expRun.getName());
+
+        StringBuilder body = new StringBuilder();
+        append(body, expRun.getComments());
+        append(body, expRun.getProtocol());
+
+        ActionURL url = expRun.detailsURL();
+        if (url != null)
+            url.setExtraPath(expRun.getContainer().getId());
+
+        return new SimpleDocumentResource(
+            new Path(documentId),
+            documentId,
+            expRun.getContainer().getId(),
+            "text/plain",
+            body.toString(),
+            url,
+            props
+        );
+    }
+
+    private static void append(StringBuilder sb, @Nullable Identifiable identifiable)
+    {
+        if (null != identifiable)
+            append(sb, identifiable.getName());
+    }
+
+    private static void append(StringBuilder sb, @Nullable String value)
+    {
+        if (null != value)
+        {
+            if (sb.length() > 0)
+                sb.append(" ");
+
+            sb.append(value);
+        }
+    }
+
+    public static SearchService.ResourceResolver getResourceResolver()
+    {
+        return new SearchService.ResourceResolver()
+        {
+            private Integer fromDocumentId(@NotNull String resourceIdentifier)
+            {
+                final String prefix = AssayService.ASSAY_RUN_CATEGORY.getName() + ":";
+
+                if (resourceIdentifier.startsWith(prefix))
+                    resourceIdentifier = resourceIdentifier.substring(prefix.length());
+
+                int expRunId;
+                try
+                {
+                    expRunId = Integer.parseInt(resourceIdentifier);
+                }
+                catch (NumberFormatException e)
+                {
+                    return null;
+                }
+
+                return expRunId;
+            }
+
+            private @Nullable ExpRun getExpRun(@NotNull String resourceIdentifier)
+            {
+                Integer expRunRowId = fromDocumentId(resourceIdentifier);
+                if (expRunRowId == null)
+                    return null;
+
+                return ExperimentService.get().getExpRun(expRunRowId);
+            }
+
+            @Override
+            public WebdavResource resolve(@NotNull String resourceIdentifier)
+            {
+                ExpRun expRun = getExpRun(resourceIdentifier);
+                if (expRun == null)
+                    return null;
+
+                return createDocument(expRun);
+            }
+
+            @Override
+            public Map<String, Object> getCustomSearchJson(User user, @NotNull String resourceIdentifier)
+            {
+                ExpRun expRun = getExpRun(resourceIdentifier);
+                if (expRun == null)
+                    return null;
+
+                return ExperimentJSONConverter.serializeRun(expRun, null, user, ExperimentJSONConverter.DEFAULT_SETTINGS).toMap();
+            }
+
+            @Override
+            public Map<String, Map<String, Object>> getCustomSearchJsonMap(User user, @NotNull Collection<String> resourceIdentifiers)
+            {
+                Set<Integer> expRunRowIds = new HashSet<>();
+                Map<Integer, String> rowIdIdentifierMap = new HashMap<>();
+                for (String resourceIdentifier : resourceIdentifiers)
+                {
+                    Integer expRunRowId = fromDocumentId(resourceIdentifier);
+                    if (expRunRowId != null)
+                    {
+                        expRunRowIds.add(expRunRowId);
+                        rowIdIdentifierMap.put(expRunRowId, resourceIdentifier);
+                    }
+                }
+
+                ExperimentService.get().getExpRuns(expRunRowIds);
+                Map<String, Map<String, Object>> results = new HashMap<>();
+                for (ExpRun expRun : ExperimentService.get().getExpRuns(expRunRowIds))
+                {
+                    results.put(
+                        rowIdIdentifierMap.get(expRun.getRowId()),
+                        ExperimentJSONConverter.serializeRun(expRun, null, user, ExperimentJSONConverter.DEFAULT_SETTINGS).toMap()
+                    );
+                }
+
+                return results;
+            }
+        };
+    }
+}

--- a/assay/src/org/labkey/assay/AssayRunDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayRunDocumentProvider.java
@@ -3,7 +3,6 @@ package org.labkey.assay;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.assay.AssayService;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentJSONConverter;
@@ -35,7 +34,7 @@ public class AssayRunDocumentProvider implements SearchService.DocumentProvider
 
     private static SearchService.SearchCategory getSearchCategory()
     {
-        return AssayService.ASSAY_RUN_CATEGORY;
+        return AssayManager.get().ASSAY_RUN_CATEGORY;
     }
 
     private static String getDocumentIdPrefix()

--- a/core/src/org/labkey/core/search/NoopSearchService.java
+++ b/core/src/org/labkey/core/search/NoopSearchService.java
@@ -265,19 +265,13 @@ public class NoopSearchService implements SearchService
     }
 
     @Override
-    public SearchResult search(String queryString, @Nullable List<SearchCategory> categories, User user, Container current, SearchScope scope, @Nullable String sortField, int offset, int limit, boolean invertResults)
+    public SearchResult search(SearchOptions options)
     {
         return null;
     }
 
     @Override
-    public SearchResult search(String queryString, @Nullable List<SearchCategory> categories, User user, Container current, SearchScope scope, @Nullable String sortField, int offset, int limit)
-    {
-        return null;
-    }
-
-    @Override
-    public List<String> searchUniqueIds(String queryString, @Nullable List<SearchCategory> categories, User user, Container current, SearchScope scope, @Nullable String sortField, int offset, int limit, boolean invertResults) throws IOException
+    public List<String> searchUniqueIds(SearchOptions options)
     {
         return null;
     }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
@@ -391,7 +391,7 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
         Map<String, Object> props = new HashMap<>();
         Set<String> identifiersHi = new HashSet<>();
 
-        // Name is identifier with highest weight
+        // Name is identifier with the highest weight
         identifiersHi.add(getName());
 
         if (isMedia())

--- a/experiment/src/org/labkey/experiment/api/ExpExperimentImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpExperimentImpl.java
@@ -22,7 +22,6 @@ import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.SqlSelector;
-import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -34,7 +34,6 @@ import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.exp.Identifiable;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.OntologyManager;
@@ -51,7 +50,6 @@ import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.qc.DataState;
-import org.labkey.api.qc.DataStateManager;
 import org.labkey.api.qc.SampleStatusService;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryRowReference;
@@ -82,6 +80,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.labkey.api.util.StringUtilsLabKey.append;
 
 public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements ExpMaterial
 {
@@ -517,23 +517,6 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
     }
 
     static final List<Pair<Integer,Long>> updateLastIndexedList = new ArrayList<>();
-
-    private static void append(StringBuilder sb, @Nullable Identifiable identifiable)
-    {
-        if (null != identifiable)
-            append(sb, identifiable.getName());
-    }
-
-    private static void append(StringBuilder sb, @Nullable String value)
-    {
-        if (null != value)
-        {
-            if (sb.length() > 0)
-                sb.append(" ");
-
-            sb.append(value);
-        }
-    }
 
     @Override
     public String getDocumentId()

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1683,10 +1683,11 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
         try
         {
+            // next attempt to resolve by rowId
             Integer rowId = ConvertHelper.convert(sampleName, Integer.class);
 
-            // next attempt to resolve by rowId
-            return materialCache.computeIfAbsent(rowId, (x) -> getExpMaterial(c, user, rowId, sampleType));
+            if (rowId != null)
+                return materialCache.computeIfAbsent(rowId, (x) -> getExpMaterial(c, user, rowId, sampleType));
         }
         catch (ConversionException e1)
         {

--- a/query/src/org/labkey/query/ExternalSchemaDocumentProvider.java
+++ b/query/src/org/labkey/query/ExternalSchemaDocumentProvider.java
@@ -164,10 +164,4 @@ public class ExternalSchemaDocumentProvider implements SearchService.DocumentPro
 
         task.addRunnable(r, SearchService.PRIORITY.group);
     }
-
-
-    @Override
-    public void indexDeleted()
-    {
-    }
 }

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -625,21 +625,11 @@ public class SearchController extends SpringActionController
 
                 arr = new Object[hits.size()];
 
-                int i=0;
+                int i = 0;
                 int batchSize = 1000;
                 Map<String, Map<String, Object>> docDataMap = new HashMap<>();
                 for (int ind = 0; ind < hits.size(); ind++)
                 {
-                    if (ind % batchSize == 0)
-                    {
-                        int batchEnd = Math.min(hits.size(), ind + batchSize);
-                        List<String> docIds = new ArrayList<>();
-                        for (int j = ind; j < batchEnd; j++)
-                            docIds.add(hits.get(j).docid);
-
-                        docDataMap = ss.getCustomSearchJsonMap(getUser(), docIds);
-                    }
-
                     SearchService.SearchHit hit = hits.get(ind);
                     JSONObject o = new JSONObject();
                     String id = StringUtils.isEmpty(hit.docid) ? String.valueOf(i) : hit.docid;
@@ -655,6 +645,18 @@ public class SearchController extends SpringActionController
 
                     if (form.isExperimentalCustomJson())
                     {
+                        o.put("jsonData", hit.jsonData);
+
+                        if (ind % batchSize == 0)
+                        {
+                            int batchEnd = Math.min(hits.size(), ind + batchSize);
+                            List<String> docIds = new ArrayList<>();
+                            for (int j = ind; j < batchEnd; j++)
+                                docIds.add(hits.get(j).docid);
+
+                            docDataMap = ss.getCustomSearchJsonMap(getUser(), docIds);
+                        }
+
                         Map<String, Object> custom = docDataMap.get(hit.docid);
                         if (custom != null)
                             o.put("data", custom);

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -603,10 +603,15 @@ public class SearchController extends SpringActionController
                 SearchResult result;
                 try
                 {
-                    //UNDONE: paging, rowlimit etc
-                    int limit = form.getLimit() < 0 ? 1000 : form.getLimit();
-                    result = ss.search(query, ss.getCategories(form.getCategory()), getUser(), getContainer(), form.getSearchScope(),
-                        form.getSortField(), form.getOffset(), limit, form.isInvertSort());
+                    SearchService.SearchOptions.Builder options = new SearchService.SearchOptions.Builder(query, getUser(), getContainer());
+                    options.categories = ss.getCategories(form.getCategory());
+                    options.invertResults = form.isInvertSort();
+                    options.limit = form.getLimit() < 0 ? 1000 : form.getLimit();
+                    options.offset = form.getOffset();
+                    options.scope = form.getSearchScope();
+                    options.sortField = form.getSortField();
+
+                    result = ss.search(options.build());
                 }
                 catch (Exception x)
                 {
@@ -755,7 +760,15 @@ public class SearchController extends SpringActionController
         @Override
         public SearchResult getSearchResult(String queryString, @Nullable String category, User user, Container currentContainer, SearchScope scope, String sortField, int offset, int limit, boolean invertSort) throws IOException
         {
-            return _ss.search(queryString, _ss.getCategories(category), user, currentContainer, scope, sortField, offset, limit, invertSort);
+            SearchService.SearchOptions.Builder options = new SearchService.SearchOptions.Builder(queryString, user, currentContainer);
+            options.categories = _ss.getCategories(category);
+            options.invertResults = invertSort;
+            options.limit = limit;
+            options.offset = offset;
+            options.scope = scope;
+            options.sortField = sortField;
+
+            return _ss.search(options.build());
         }
 
         @Override

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -605,6 +605,7 @@ public class SearchController extends SpringActionController
                 {
                     SearchService.SearchOptions.Builder options = new SearchService.SearchOptions.Builder(query, getUser(), getContainer());
                     options.categories = ss.getCategories(form.getCategory());
+                    options.fields = form.getFields();
                     options.invertResults = form.isInvertSort();
                     options.limit = form.getLimit() < 0 ? 1000 : form.getLimit();
                     options.offset = form.getOffset();
@@ -915,6 +916,7 @@ public class SearchController extends SpringActionController
         private String _category = null;
         private String _comment = null;
         private int _textBoxWidth = 50; // default size
+        private List<String> _fields;
         private boolean _includeHelpLink = true;
         private boolean _webpart = false;
         private boolean _showAdvanced = false;
@@ -1119,6 +1121,16 @@ public class SearchController extends SpringActionController
         public void setExperimentalCustomJson(boolean experimentalCustomJson)
         {
             _experimentalCustomJson = experimentalCustomJson;
+        }
+
+        public List<String> getFields()
+        {
+            return _fields;
+        }
+
+        public void setFields(List<String> fields)
+        {
+            _fields = fields;
         }
     }
 

--- a/search/src/org/labkey/search/SearchModule.java
+++ b/search/src/org/labkey/search/SearchModule.java
@@ -79,7 +79,7 @@ public class SearchModule extends DefaultModule
     @Override
     public Double getSchemaVersion()
     {
-        return 23.000;
+        return 23.001;
     }
 
     @Override

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -667,6 +667,8 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
 
         if (_resolvers.containsKey(prefix))
             return new Pair<>(prefix, resourceIdentifier.substring(i+1));
+        else if (_resolvers.containsKey(prefix.toLowerCase()))
+            return new Pair<>(prefix.toLowerCase(), resourceIdentifier.substring(i+1));
 
         // Special case to allow customizing docs whose docId does not starting with category.
         // For example, assay design doc id is of "containerId:assays:rowId"

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -667,8 +667,6 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
 
         if (_resolvers.containsKey(prefix))
             return new Pair<>(prefix, resourceIdentifier.substring(i+1));
-        else if (_resolvers.containsKey(prefix.toLowerCase()))
-            return new Pair<>(prefix.toLowerCase(), resourceIdentifier.substring(i+1));
 
         // Special case to allow customizing docs whose docId does not starting with category.
         // For example, assay design doc id is of "containerId:assays:rowId"

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -76,7 +76,6 @@ import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.portal.ProjectUrls;
 import org.labkey.api.resource.Resource;
-import org.labkey.api.search.SearchScope;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.search.SearchUtils;
 import org.labkey.api.search.SearchUtils.HtmlParseException;

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -1457,7 +1457,21 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
 
             try
             {
-                QueryParser queryParser = new MultiFieldQueryParser(standardFields, getAnalyzer(), boosts);
+                String[] customFields = null;
+                if (options.fields != null && !options.fields.isEmpty())
+                {
+                    List<String> customFieldsList = new ArrayList<>();
+                    for (String s : standardFields)
+                    {
+                        if (options.fields.contains(s))
+                            customFieldsList.add(s);
+                    }
+
+                    if (!customFieldsList.isEmpty())
+                        customFields = customFieldsList.toArray(new String[0]);
+                }
+
+                QueryParser queryParser = new MultiFieldQueryParser(customFields != null ? customFields : standardFields, getAnalyzer(), boosts);
                 queryBuilder.add(queryParser.parse(options.queryString), BooleanClause.Occur.MUST);
             }
             catch (ParseException x)

--- a/search/src/org/labkey/search/view/search.jsp
+++ b/search/src/org/labkey/search/view/search.jsp
@@ -254,7 +254,15 @@
 
             if (includeNavigationResults)
             {
-                navResult = SearchService.get().search(queryString, Arrays.asList(SearchService.navigationCategory), user, c, scope, sortField, offset, hitsPerPage, invertSort);
+                SearchService.SearchOptions.Builder options = new SearchService.SearchOptions.Builder(queryString, user, c);
+                options.categories = Arrays.asList(SearchService.navigationCategory);
+                options.invertResults = invertSort;
+                options.limit = hitsPerPage;
+                options.offset = offset;
+                options.scope = scope;
+                options.sortField = sortField;
+
+                navResult = SearchService.get().search(options.build());
                 hasNavResults = navResult != null && navResult.hits.size() > 0;
             }
         }

--- a/study/src/org/labkey/study/assay/ExperimentListenerImpl.java
+++ b/study/src/org/labkey/study/assay/ExperimentListenerImpl.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.study.assay;
 
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
@@ -39,7 +38,6 @@ import org.labkey.api.view.UnauthorizedException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 
 import static java.util.Collections.singleton;


### PR DESCRIPTION
#### Rationale
Extend search functionality in support of the capability to search for ELN references via full-text search. Highlights are:

1. Assay Batches and Assay Runs are now indexed with their own search documents.
1. New search categories for batches and runs.
1. Capability to search on specific search fields (e.g. "identifiersHi", "keywordMed", etc) from the API.
1. Capability to index specific fields on custom domains (still requires indexer implements the indexing in the document).

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/4430
- https://github.com/LabKey/biologics/pull/2141
- https://github.com/LabKey/sampleManagement/pull/1837
- https://github.com/LabKey/labbook/pull/485

#### Changes
* Add search indexing for Assay Batches and Assay Runs. Batches are only indexed if the underlying Batch Domain has fields defined.
* Add search categories for Assay Batches and Assay Runs.
* Add state to `TableInfo` to capture columns to specifically be indexed. See `indexColumn` and `getSearchIndexColumns`.
* Refactor overloaded search methods on `SearchService` to take a `SearchOptions` object that can be built to only specify necessary parameters.
* Add `AssayBatchDocumentProvider` and `AssayRunDocumentProvider` to create search documents for these types.
* Add `SearchService.ResourceResolver`s for Assay Batches and Assay Runs to retrieve tailored search data for these types.
* Add `fields` as a parameter that can be specified on the `search-json.api` to allow requests to fine-tune which search fields are queried.
* Add `ExperimentService.getExpExperiments` to support fetching multiple Assay Batches.
* Bump `SearchModule` schema to invoke full reindex of search indices.