### PR TITLE
Issue 47289: Export List Archive if the user is an Admin of the folders of the selected Lists, else show a simple error

### DIFF
--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -966,7 +966,8 @@ public class ListController extends SpringActionController
                 // Issue 47289: Export List Archive if the user is an Admin of the folders of the selected Lists, else throw Permission error
                 if (!pair.second.hasPermission(getUser(), DesignListPermission.class))
                 {
-                    throw new UnauthorizedException(String.format("You do not have the permission to export List '%s' from Folder '%s'.", listName, pair.second.getPath()));
+                    errors.reject(ERROR_MSG, String.format("List archive export is only supported for Lists in folders where you are an administrator. Try filtering to select only Lists in the local folder."));
+                    throw new ExportException(new SimpleErrorView(errors, true));
                 }
                 selectedLists.add(pair);
             }


### PR DESCRIPTION
#### Rationale
Issue [47289](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47289): Export List Archive if the user is an Admin of the folders of the selected Lists, else show a simple error

Actual fix was done in https://github.com/LabKey/platform/pull/4270

This PR just changes the type of error and re-words the error message.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1517

#### Changes
* Use simple error message instead of an unauthorized exception.
* Re-word error message.