### PR TITLE
47912: When updating or resolving an issue, fields are changed to default values

### DIFF
--- a/issues/src/org/labkey/issue/model/IssuePage.java
+++ b/issues/src/org/labkey/issue/model/IssuePage.java
@@ -388,7 +388,7 @@ public class IssuePage implements DataRegionSelection.DataSelectionKeyForm
         if (!readOnly)
         {
             // default values don't apply if we are read only
-            row.putAll(_renderContextDefaultValues);
+            _renderContextDefaultValues.forEach(row::putIfAbsent);
         }
         renderContext.setRow(row);
 


### PR DESCRIPTION
#### Rationale
This previous [change](https://github.com/LabKey/platform/pull/4230) resulted in the configured default values overriding any previous set values when updating an issue or viewing an issue's detailed view.

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47912)

#### Changes
- Don't clobber any previously set issue properties with the default values.