### PR TITLE
Make use of getContainerFilterForLookups() when applying container filters to QueryForeignKey added via query XML metadata

### DIFF
--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -1100,6 +1100,10 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
             }
             if (!fromSchema.getSchemaName().equals(fk.getFkDbSchema()) || !effectiveTargetContainer.equals(fromSchema.getContainer()))
             {
+                if (lookupContainer == null) {
+                    cf = QueryService.get().getProductContainerFilterForLookups(fromSchema.getContainer(), fromSchema.getUser(), cf);
+                }
+
                 // Let the QueryForeignKey lazily create the schema on demand
                 ret = QueryForeignKey.from(fromSchema, cf)
                         .schema(fk.getFkDbSchema(), effectiveTargetContainer)
@@ -1116,6 +1120,10 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
 
         if (ret == null)
         {
+            if (lookupContainer == null) {
+                cf = QueryService.get().getProductContainerFilterForLookups(fromSchema.getContainer(), fromSchema.getUser(), cf);
+            }
+
             // We can reuse the same schema object
             ret = QueryForeignKey.from(fromSchema, cf)
                     .container(lookupContainer)

--- a/api/src/org/labkey/api/query/PdLookupForeignKey.java
+++ b/api/src/org/labkey/api/query/PdLookupForeignKey.java
@@ -95,7 +95,7 @@ public class PdLookupForeignKey extends AbstractForeignKey
             cf = new ContainerFilter.SimpleContainerFilterWithUser(user, targetContainer);
         else
         {
-            cf = QueryService.get().getProductContainerFilterForLookups(container, user, null);
+            cf = QueryService.get().getProductContainerFilterForLookups(container, user, cf);
 
             if (cf == null)
                 cf = new ContainerFilter.SimpleContainerFilterWithUser(user, container);

--- a/api/src/org/labkey/api/query/PdLookupForeignKey.java
+++ b/api/src/org/labkey/api/query/PdLookupForeignKey.java
@@ -95,12 +95,7 @@ public class PdLookupForeignKey extends AbstractForeignKey
             cf = new ContainerFilter.SimpleContainerFilterWithUser(user, targetContainer);
         else
         {
-            if (QueryService.get().isProductProjectsAllFolderScopeEnabled())
-            {
-                ContainerFilter lookupCf = QueryService.get().getContainerFilterForLookups(container, user);
-                if (lookupCf != null)
-                    cf = lookupCf;
-            }
+            cf = QueryService.get().getProductContainerFilterForLookups(container, user, null);
 
             if (cf == null)
                 cf = new ContainerFilter.SimpleContainerFilterWithUser(user, container);

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -630,6 +630,12 @@ public interface QueryService
     }
 
     /**
+     * Resolves the ContainerFilter to be used for lookups of data in product projects based on the isProductProjectsAllFolderScopeEnabled setting.
+     */
+    @Nullable
+    ContainerFilter getProductContainerFilterForLookups(Container container, User user, ContainerFilter defaultContainerFilter);
+
+    /**
      * Resolves the ContainerFilter to be used for lookups of data in product projects.
      * Defaults to null if product projects are not enabled in container scope.
      */

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3300,6 +3300,18 @@ public class QueryServiceImpl implements QueryService
     }
 
     @Override
+    public @Nullable ContainerFilter getProductContainerFilterForLookups(Container container, User user, ContainerFilter defaultContainerFilter)
+    {
+        if (isProductProjectsAllFolderScopeEnabled())
+        {
+            ContainerFilter lookupCf = getContainerFilterForLookups(container, user);
+            if (lookupCf != null)
+                return lookupCf;
+        }
+        return defaultContainerFilter;
+    }
+
+    @Override
     @Nullable
     public ContainerFilter getContainerFilterForLookups(Container container, User user)
     {


### PR DESCRIPTION
#### Rationale
This was made evident after the implementation of the "Move Registry Items in the LKB app projects" development was completed. If you have a registry item in a project subfolder that references other registry items in that same subfolder and then you move that item to a sibling subfolder, the lookups are broken for those items that were left behind. This is expected behavior, but in the LKB grids and details pages we have an experimental feature that makes these lookups less restrictive (i.e. allow for resolving lookups across any of the in scope containers within the app's projects (home and subfolders). This PR fixes a case that wasn't taking into account this experimental feature container filter change when applying the QueryForeignKey objects for a foreign key being added via query XML metadata.

<img width="1901" alt="Screenshot 2023-05-18 at 4 15 50 PM" src="https://github.com/LabKey/platform/assets/6411206/13c0dd6a-3b0f-4d91-9a35-121dce850d8c">


#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4428

#### Changes
* refactor QueryService.get().getProductContainerFilterForLookups() from PdLookupForeignKey to be reusable
* AbstractTableInfo.initColumnFromXml() to apply getContainerFilterForLookups() on QueryForeignKey
