### PR TITLE
Issue 47934: Study merge participants UI not handling case differences in dataset name

### DIFF
--- a/study/src/org/labkey/study/view/mergeParticipants.jsp
+++ b/study/src/org/labkey/study/view/mergeParticipants.jsp
@@ -316,8 +316,15 @@
                         table = Object.values(this.tables).find(v => v.label === data.queryName);
                     }
                     if (!table) {
-                        console.error("Dataset: " + tableName + " not found.");
-                        return;
+                        var caseInsensitiveName = Object.keys(this.tables).find(k => k.toLowerCase() === data.queryName.toLowerCase());
+                        if (caseInsensitiveName) {
+                            table = this.tables[caseInsensitiveName];
+                        }
+                    }
+                    if (!table) {
+                        fatalError = true;
+                        updateMergeResults("Error: Dataset " + tableName + " not found.", true);
+                        console.error("Dataset: " + tableName + " not found. Returned queryName: " + data.queryName);
                     }
 
                     gatherIds(table, data.rows, checkTable.oldId, checkTable.newId);


### PR DESCRIPTION
#### Rationale
Merge participants UI first queries study.datasets for the list of datasets then performs selectRows on each dataset. In the selectRows response the dataset is aligned by the dataset name or label in study.datasets and the queryName returned from selectRows. These can have casing differences causing the UI to not handle the dataset.

Needs better error handling when dataset not found instead of just freezing UI.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47934

#### Changes
* Add lowercase matching of query name and dataset name
* Update error message to display in UI
