### PR TITLE
Issue 47941: SQL Server deadlock updating dataset rows

### DIFF
--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -35,6 +35,7 @@ import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.SystemMaintenance;
+import org.labkey.api.view.ViewServlet;
 import org.labkey.api.view.template.Warnings;
 import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.jdbc.BadSqlGrammarException;
@@ -161,6 +162,13 @@ public abstract class SqlDialect
                 sb.append(", SPIDs = ");
                 sb.append(spids);
                 sb.append("\n");
+                ViewServlet.RequestSummary uri = ViewServlet.getRequestSummary(thread);
+                if (null != uri)
+                {
+                    sb.append("\t");
+                    sb.append(uri);
+                    sb.append("\n");
+                }
 
                 for (StackTraceElement stackTraceElement : entry.getValue())
                 {

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -277,9 +277,9 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
             }
 
             _participantVisitResyncRequired = true; // 13717 : Study failing to resync() on dataset insert
-            StudyManager.datasetModified(_dataset, true);
             if (configParameters == null || !Boolean.TRUE.equals(configParameters.get(DatasetUpdateService.Config.SkipResyncStudy)))
             {
+                StudyManager.datasetModified(_dataset, true);
                 resyncStudy(user, container);
             }
         }

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -228,7 +228,7 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
     public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
     {
         int count = _importRowsUsingDIB(user, container, rows, null, context, extraScriptContext);
-        if (count > 0 && Boolean.TRUE != context.getConfigParameterBoolean(Config.SkipResyncStudy))
+        if (count > 0 && !Boolean.TRUE.equals(context.getConfigParameterBoolean(Config.SkipResyncStudy)))
         {
             StudyManager.datasetModified(_dataset, true);
             resyncStudy(user, container, null, null, true);
@@ -278,7 +278,10 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
 
             _participantVisitResyncRequired = true; // 13717 : Study failing to resync() on dataset insert
             StudyManager.datasetModified(_dataset, true);
-            resyncStudy(user, container);
+            if (configParameters == null || !Boolean.TRUE.equals(configParameters.get(DatasetUpdateService.Config.SkipResyncStudy)))
+            {
+                resyncStudy(user, container);
+            }
         }
         return result;
     }


### PR DESCRIPTION
#### Rationale
We're resyncing the study's participant list too frequently. updateRows() calls updateRow() which calls insertRows() with a single row, which is resyncing the study even though the caller is telling it not to, as it will do the same.

This slows down the saveRows() call, and we end up with overlapping executions between the validation-only calls and the actual save attempt.

#### Changes
* Respect the SkipResyncStudy property
* Include URL and duration info when logging other threads with a DB connection after deadlocks