### PR TITLE
Projects: Selection of data structures to be shown in Projects - Exclude data types on the UI 

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1684,6 +1684,14 @@ public class Container implements Serializable, Comparable<Container>, Securable
         return isFeatureEnabled(ProductFeature.Projects, true);
     }
 
+    public boolean isAppHomeFolder()
+    {
+        if (isProject()) // if it's a project
+            return true;
+
+        return !isProductProjectsEnabled(); // if subfolder, then the folder shouldn't have Projects feature enabled
+    }
+
     /**
      * Returns the subfolder count of the project container, if product projects feature is enabled in project
      */

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -937,7 +937,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     void addDataTypeExclusion(int rowId, DataTypeForExclusion dataType, String excludedContainerId, User user);
 
-    Map<ExperimentService.DataTypeForExclusion, Set<Integer>> getContainerDataTypeExclusions(@NotNull String excludedContainerId);
+    @NotNull Map<ExperimentService.DataTypeForExclusion, Set<Integer>> getContainerDataTypeExclusions(@NotNull String excludedContainerId);
 
     Set<String> getDataTypeContainerExclusions(@NotNull DataTypeForExclusion dataType, @NotNull Integer dataTypeRowId);
 

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -937,7 +937,9 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     void addDataTypeExclusion(int rowId, DataTypeForExclusion dataType, String excludedContainerId, User user);
 
-    Map<String, Object>[] getContainerDataTypeExclusions(@Nullable DataTypeForExclusion dataType, @Nullable String excludedContainerId, @Nullable Integer dataTypeRowId);
+    Map<ExperimentService.DataTypeForExclusion, Set<Integer>> getContainerDataTypeExclusions(@NotNull String excludedContainerId);
+
+    Set<String> getDataTypeContainerExclusions(@NotNull DataTypeForExclusion dataType, @NotNull Integer dataTypeRowId);
 
     void ensureContainerDataTypeExclusions(@Nullable DataTypeForExclusion dataType, @Nullable Collection<Integer> excludedDataTypeRowIds, @Nullable String excludedContainerId, User user);
 

--- a/core/api-src/org/labkey/api/products/MenuItem.java
+++ b/core/api-src/org/labkey/api/products/MenuItem.java
@@ -31,7 +31,9 @@ public class MenuItem
 
     private boolean _fromSharedContainer; // if the item comes from the /Shared container
 
-    public MenuItem(String label, String url, Integer id, String key, Integer orderNum, String productId, boolean hasActiveJob, boolean isSharedContainer)
+    private Boolean _hidden = false; // if the item should be hidden
+
+    public MenuItem(String label, String url, Integer id, String key, Integer orderNum, String productId, boolean hasActiveJob, boolean isSharedContainer, boolean hidden)
     {
         _label = label;
         _id = id;
@@ -41,6 +43,12 @@ public class MenuItem
         _productId = productId;
         _hasActiveJob = hasActiveJob;
         _fromSharedContainer = isSharedContainer;
+        _hidden = hidden;
+    }
+
+    public MenuItem(String label, String url, Integer id, String key, Integer orderNum, String productId, boolean hasActiveJob, boolean isSharedContainer)
+    {
+        this(label, url, id, key, orderNum, productId, hasActiveJob, isSharedContainer, false);
     }
 
     public MenuItem(String label, String url, Integer id, String key, Integer orderNum, String productId, boolean hasActiveJob)
@@ -168,5 +176,14 @@ public class MenuItem
         _hasActiveJob = hasActiveJob;
     }
 
+    public Boolean getHidden()
+    {
+        return _hidden;
+    }
+
+    public void setHidden(Boolean hidden)
+    {
+        _hidden = hidden;
+    }
 
 }

--- a/core/api-src/org/labkey/api/products/ProductMenuProvider.java
+++ b/core/api-src/org/labkey/api/products/ProductMenuProvider.java
@@ -18,6 +18,7 @@ package org.labkey.api.products;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
@@ -26,6 +27,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public abstract class ProductMenuProvider
 {
@@ -64,14 +67,14 @@ public abstract class ProductMenuProvider
     public abstract Collection<String> getSectionNames(@Nullable ViewContext viewContext);
 
     @Nullable
-    public abstract MenuSection getSection(@NotNull ViewContext context, @NotNull String sectionName);
+    public abstract MenuSection getSection(@NotNull ViewContext context, @NotNull String sectionName, Map<ExperimentService.DataTypeForExclusion, Set<Integer>> dataTypeExclusions);
 
     @NotNull
-    public List<MenuSection> getSections(@NotNull ViewContext context, @NotNull Collection<String> sectionNames)
+    public List<MenuSection> getSections(@NotNull ViewContext context, @NotNull Collection<String> sectionNames, Map<ExperimentService.DataTypeForExclusion, Set<Integer>> dataTypeExclusions)
     {
         List<MenuSection> sections = new ArrayList<>();
         sectionNames.forEach((name) -> {
-            MenuSection section = getSection(context, name);
+            MenuSection section = getSection(context, name, dataTypeExclusions);
             if (section != null)
                 sections.add(section);
         });
@@ -80,8 +83,8 @@ public abstract class ProductMenuProvider
     }
 
     @NotNull
-    public List<MenuSection> getSections(@NotNull ViewContext context)
+    public List<MenuSection> getSections(@NotNull ViewContext context, Map<ExperimentService.DataTypeForExclusion, Set<Integer>> dataTypeExclusions)
     {
-        return getSections(context, getSectionNames(context));
+        return getSections(context, getSectionNames(context), dataTypeExclusions);
     }
 }

--- a/core/api-src/org/labkey/api/products/ProductMenuProvider.java
+++ b/core/api-src/org/labkey/api/products/ProductMenuProvider.java
@@ -67,10 +67,10 @@ public abstract class ProductMenuProvider
     public abstract Collection<String> getSectionNames(@Nullable ViewContext viewContext);
 
     @Nullable
-    public abstract MenuSection getSection(@NotNull ViewContext context, @NotNull String sectionName, Map<ExperimentService.DataTypeForExclusion, Set<Integer>> dataTypeExclusions);
+    public abstract MenuSection getSection(@NotNull ViewContext context, @NotNull String sectionName, @NotNull Map<ExperimentService.DataTypeForExclusion, Set<Integer>> dataTypeExclusions);
 
     @NotNull
-    public List<MenuSection> getSections(@NotNull ViewContext context, @NotNull Collection<String> sectionNames, Map<ExperimentService.DataTypeForExclusion, Set<Integer>> dataTypeExclusions)
+    public List<MenuSection> getSections(@NotNull ViewContext context, @NotNull Collection<String> sectionNames, @NotNull Map<ExperimentService.DataTypeForExclusion, Set<Integer>> dataTypeExclusions)
     {
         List<MenuSection> sections = new ArrayList<>();
         sectionNames.forEach((name) -> {
@@ -83,7 +83,7 @@ public abstract class ProductMenuProvider
     }
 
     @NotNull
-    public List<MenuSection> getSections(@NotNull ViewContext context, Map<ExperimentService.DataTypeForExclusion, Set<Integer>> dataTypeExclusions)
+    public List<MenuSection> getSections(@NotNull ViewContext context, @NotNull Map<ExperimentService.DataTypeForExclusion, Set<Integer>> dataTypeExclusions)
     {
         return getSections(context, getSectionNames(context), dataTypeExclusions);
     }

--- a/core/api-src/org/labkey/api/products/ProductRegistry.java
+++ b/core/api-src/org/labkey/api/products/ProductRegistry.java
@@ -143,7 +143,7 @@ public class ProductRegistry
             return Collections.emptyList();
         }
         ProductMenuProvider provider = _productMap.get(productId);
-        List<MenuSection> sections = provider.getSections(context, null);
+        List<MenuSection> sections = provider.getSections(context, Collections.emptyMap());
         // always include the user menu as the last item
         sections.add(new UserInfoMenuSection(context, provider));
         return sections;
@@ -154,7 +154,7 @@ public class ProductRegistry
     {
         if (_sectionMap.containsKey(name))
         {
-            return _sectionMap.get(name).getSection(context, name, null /*used by unit test only*/ );
+            return _sectionMap.get(name).getSection(context, name, Collections.emptyMap() /*used by unit test only*/ );
         }
         else
         {

--- a/core/src/org/labkey/core/CoreContainerListener.java
+++ b/core/src/org/labkey/core/CoreContainerListener.java
@@ -18,6 +18,7 @@ package org.labkey.core;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.AuditTypeEvent;
 import org.labkey.api.audit.provider.ContainerAuditProvider;
@@ -49,7 +50,13 @@ public class CoreContainerListener implements ContainerManager.ContainerListener
     @Override
     public void containerCreated(Container c, User user)
     {
-        String message = c.getContainerNoun(true) + " " + c.getName() + " was created";
+        containerCreated(c, user, null);
+    }
+
+    @Override
+    public void containerCreated(Container c, User user, @Nullable String auditMsg)
+    {
+        String message = auditMsg == null ? c.getContainerNoun(true) + " " + c.getName() + " was created" : auditMsg;
         addAuditEvent(user, c, message);
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8163,7 +8163,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         new SqlExecutor(getExpSchema()).execute(sql);
     }
 
-    @NotNull public Map<String, Object>[] _getContainerDataTypeExclusions(@Nullable DataTypeForExclusion dataType, @Nullable String excludedContainerId, @Nullable Integer dataTypeRowId)
+    @NotNull private Map<String, Object>[] _getContainerDataTypeExclusions(@Nullable DataTypeForExclusion dataType, @Nullable String excludedContainerId, @Nullable Integer dataTypeRowId)
     {
         SQLFragment sql = new SQLFragment("SELECT DataTypeRowId, DataType, ExcludedContainer FROM ")
                 .append(getTinfoDataTypeExclusion())
@@ -8195,7 +8195,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public Map<ExperimentService.DataTypeForExclusion, Set<Integer>> getContainerDataTypeExclusions(@NotNull String excludedContainerId)
+    public @NotNull Map<ExperimentService.DataTypeForExclusion, Set<Integer>> getContainerDataTypeExclusions(@NotNull String excludedContainerId)
     {
         Map<String, Object>[] exclusions = _getContainerDataTypeExclusions(null, excludedContainerId, null);
 
@@ -8223,7 +8223,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
 
-    public Set<Integer> getContainerDataTypeExclusions(DataTypeForExclusion dataType, String excludedContainerId)
+    private Set<Integer> _getContainerDataTypeExclusions(DataTypeForExclusion dataType, String excludedContainerId)
     {
         Set<Integer> excludedRowIds = new HashSet<>();
         Map<String, Object>[] exclusions = _getContainerDataTypeExclusions(dataType, excludedContainerId, null);
@@ -8239,7 +8239,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         if (excludedDataTypeRowIds == null)
             return;
 
-        Set<Integer> previousExclusions = getContainerDataTypeExclusions(dataType, excludedContainerId);
+        Set<Integer> previousExclusions = _getContainerDataTypeExclusions(dataType, excludedContainerId);
         Set<Integer> updatedExclusions = new HashSet<>(excludedDataTypeRowIds);
 
         Set<Integer> toAdd = new HashSet<>(updatedExclusions);


### PR DESCRIPTION
#### Rationale
Server side utils to set/get project level data type exclusions. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1198
- https://github.com/LabKey/labkey-ui-premium/pull/94
- https://github.com/LabKey/platform/pull/4450
- https://github.com/LabKey/inventory/pull/865
- https://github.com/LabKey/sampleManagement/pull/1848
- https://github.com/LabKey/biologics/pull/2148

#### Changes
* modified utils for getContainerDataTypeExclusions and getDataTypeContainerExclusions
* modified audit msg for folder create/update events
