### PR TITLE
Reject subject noun that matches dataset or table name. Resolve study…

### DIFF
--- a/api/src/org/labkey/api/study/StudyService.java
+++ b/api/src/org/labkey/api/study/StudyService.java
@@ -159,9 +159,11 @@ public interface StudyService
 
     String getSubjectGroupMapTableName(Container container);
 
-    boolean isValidSubjectColumnName(Container container, String subjectColumnName);
+    @Nullable String getSubjectColumnNameValidationErrorMessage(Container container, String subjectColumnName);
 
-    boolean isValidSubjectNounSingular(Container container, String subjectNounSingular);
+    @Nullable String getSubjectNounSingularValidationErrorMessage(Container container, String subjectNounSingular);
+
+    @Nullable String getSubjectNounPluralValidationErrorMessage(Container container, String subjectNounSingular);
 
     Dataset.KeyType getDatasetKeyType(Container container, String datasetName);
 

--- a/study/src/org/labkey/study/StudyServiceImpl.java
+++ b/study/src/org/labkey/study/StudyServiceImpl.java
@@ -496,7 +496,7 @@ public class StudyServiceImpl implements StudyService
     @Override
     public String getSubjectColumnNameValidationErrorMessage(Container container, String subjectColumnName)
     {
-        if (subjectColumnName == null || subjectColumnName.length() == 0)
+        if (StringUtils.isBlank(subjectColumnName))
             return "Subject Column Name can't be blank.";
 
         // Disallow standard columns added to all datasets, except "ParticipantId"

--- a/study/src/org/labkey/study/StudyServiceImpl.java
+++ b/study/src/org/labkey/study/StudyServiceImpl.java
@@ -504,7 +504,7 @@ public class StudyServiceImpl implements StudyService
         colNames.remove("ParticipantId");
 
         if (colNames.contains(subjectColumnName))
-            return "\"" + subjectColumnName + "\" is a standard dataset column name";
+            return "Cannot set Subject Column Name to \"" + subjectColumnName + "\" because this is a standard dataset column name.";
 
         Study study = getStudy(container);
 
@@ -519,7 +519,7 @@ public class StudyServiceImpl implements StudyService
                     {
                         if (property.getName().equalsIgnoreCase(subjectColumnName))
                         {
-                            return "Cannot set Subject Column Name to a user-defined dataset field. \"" + subjectColumnName + "\" is already defined in " + dataset.getName() + ".";
+                            return "Cannot set Subject Column Name to a user-defined dataset field. \"" + subjectColumnName + "\" is already defined in dataset \"" + dataset.getName() + "\".";
                         }
                     }
                 }
@@ -590,10 +590,10 @@ public class StudyServiceImpl implements StudyService
                 // Some other table
                 if (null == guidance)
                 {
-                    guidance = quotedTableName + " matches the name of an existing study table.";
+                    guidance = quotedTableName + " is the name of an existing study table.";
                 }
 
-                return "Cannot set Subject Noun Singular to a value " + (getSubjectTableName(subjectNounSingular).equals(tableName) ? "" : "that causes LabKey to create a table ") + " that matches the name of an existing study table or dataset. " + guidance;
+                return "Cannot set Subject Noun Singular to a value " + (getSubjectTableName(subjectNounSingular).equals(tableName) ? "" : "that causes LabKey to create a table ") + "that matches the name of an existing study table or dataset. " + guidance;
             }
         }
 

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -1546,15 +1546,13 @@ public class StudyController extends BaseStudyController
         @Override
         public void validateForm(TableViewForm form, Errors errors)
         {
-            StudyImpl study = getStudyRedirectIfNull();
-
             // Issue 47444 and Issue 47881: Validate that subject noun singular doesn't match the name of an existing
             // study table or dataset
             String subjectNounSingular = form.get("SubjectNounSingular");
             if (null != subjectNounSingular)
             {
                 // Search user ensures we validate against all datasets and tables
-                StudyQuerySchema schema = StudyQuerySchema.createSchema(study, User.getSearchUser());
+                StudyQuerySchema schema = StudyQuerySchema.createSchema(getStudy(), User.getSearchUser());
 
                 // This checks all study tables and dataset names, but not dataset labels (matching a label is tolerated)
                 if (schema.getTableNames().contains(subjectNounSingular))
@@ -1600,7 +1598,7 @@ public class StudyController extends BaseStudyController
             String subjectColName = form.get("SubjectColumnName");
             if (null != subjectColName)
             {
-                for (Dataset dataset : study.getDatasets())
+                for (Dataset dataset : getStudy().getDatasets())
                 {
                     Domain domain = dataset.getDomain();
                     if (null != domain)

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -1545,31 +1545,43 @@ public class StudyController extends BaseStudyController
         @Override
         public void validateForm(TableViewForm form, Errors errors)
         {
-            // Issue 47444 and Issue 47881: Validate that subject noun singular doesn't match the name of an existing
-            // study table or dataset
-            String subjectNounSingular = form.get("SubjectNounSingular");
-            if (null != subjectNounSingular)
+            // Skip validation if Spring binding already has an error for subject noun singular
+            if (errors.getFieldError("SubjectNounSingular") == null)
             {
-                String message = StudyService.get().getSubjectNounSingularValidationErrorMessage(getContainer(), subjectNounSingular);
-                if (message != null)
-                    errors.reject(ERROR_MSG, message);
+                // Issue 47444 and Issue 47881: Validate that subject noun singular doesn't match the name of an existing
+                // study table or dataset
+                String subjectNounSingular = form.get("SubjectNounSingular");
+                if (null != subjectNounSingular)
+                {
+                    String message = StudyService.get().getSubjectNounSingularValidationErrorMessage(getContainer(), subjectNounSingular);
+                    if (message != null)
+                        errors.reject(ERROR_MSG, message);
+                }
             }
 
-            String subjectNounPlural = form.get("SubjectNounPlural");
-            if (null != subjectNounPlural)
+            // Skip validation if Spring binding already has an error for subject noun plural
+            if (errors.getFieldError("SubjectNounPlural") == null)
             {
-                String message = StudyService.get().getSubjectNounPluralValidationErrorMessage(getContainer(), subjectNounPlural);
-                if (message != null)
-                    errors.reject(ERROR_MSG, message);
+                String subjectNounPlural = form.get("SubjectNounPlural");
+                if (null != subjectNounPlural)
+                {
+                    String message = StudyService.get().getSubjectNounPluralValidationErrorMessage(getContainer(), subjectNounPlural);
+                    if (message != null)
+                        errors.reject(ERROR_MSG, message);
+                }
             }
 
-            // Issue 43898: Validate that the subject column name is not a user-defined field in one of the datasets
-            String subjectColName = form.get("SubjectColumnName");
-            if (null != subjectColName)
+            // Skip validation if Spring binding already has an error for subject column name
+            if (errors.getFieldError("SubjectColumnName") == null)
             {
-                String message = StudyService.get().getSubjectColumnNameValidationErrorMessage(getContainer(), subjectColName);
-                if (message != null)
-                    errors.reject(ERROR_MSG, message);
+                // Issue 43898: Validate that the subject column name is not a user-defined field in one of the datasets
+                String subjectColName = form.get("SubjectColumnName");
+                if (null != subjectColName)
+                {
+                    String message = StudyService.get().getSubjectColumnNameValidationErrorMessage(getContainer(), subjectColName);
+                    if (message != null)
+                        errors.reject(ERROR_MSG, message);
+                }
             }
         }
 

--- a/study/src/org/labkey/study/controllers/designer/DesignerController.java
+++ b/study/src/org/labkey/study/controllers/designer/DesignerController.java
@@ -123,8 +123,8 @@ public class DesignerController extends SpringActionController
             return number;
         }
 
-        private String title;
-        private int number;
+        private final String title;
+        private final int number;
 
         public static WizardStep fromNumber(int number)
         {
@@ -582,6 +582,7 @@ public class DesignerController extends SpringActionController
     {
         String folderName = StringUtils.trimToNull(form.getFolderName());
         Container container = getContainer();
+        String message;
         if (null == folderName)
             form.setMessage("Please set a folder name.");
         else if (null == form.getBeginDate())
@@ -591,10 +592,10 @@ public class DesignerController extends SpringActionController
         }
         else if (container.hasChild(folderName) && null != BaseStudyController.getStudy(container.getChild(folderName)))
             form.setMessage(container.getName() + " already has a child named " + folderName + " containing a study.");
-        else if (!StudyService.get().isValidSubjectColumnName(getContainer(), form.getSubjectColumnName()))
-            form.setMessage("\"" + form.getSubjectColumnName() + "\" is not a valid subject column name.");
-        else if (!StudyService.get().isValidSubjectNounSingular(getContainer(), form.getSubjectNounSingular()))
-            form.setMessage("\"" + form.getSubjectNounSingular() + "\" is not a valid subject noun.");
+        else if (null != (message = StudyService.get().getSubjectColumnNameValidationErrorMessage(getContainer(), form.getSubjectColumnName())))
+            form.setMessage(message);
+        else if (null != (message = StudyService.get().getSubjectNounSingularValidationErrorMessage(getContainer(), form.getSubjectNounSingular())))
+            form.setMessage(message);
         else
         {
             GWTStudyDefinition def = getStudyDefinition(form);

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -72,6 +72,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.stream.Collectors;
@@ -535,7 +536,6 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
     private void validateDatasetProperties(DatasetDomainKindProperties datasetProperties, Container container, User user, GWTDomain domain, DatasetDefinition def)
     {
         String name = datasetProperties.getName();
-        String label = datasetProperties.getLabel();
         String keyPropertyName = datasetProperties.getKeyPropertyName();
         Integer datasetId = datasetProperties.getDatasetId();
         boolean isManagedField = datasetProperties.isKeyPropertyManaged();
@@ -557,11 +557,22 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
         if (name.length() > 200)
             throw new IllegalArgumentException("Dataset name must be under 200 characters.");
 
-        // issue 17766: check if dataset or query exist with this name
-        if ((!name.equals(domain.getName()) || def == null) && (null != StudyManager.getInstance().getDatasetDefinitionByName(study, name) || null != QueryService.get().getQueryDef(user, container, "study", name)))
-            throw new IllegalArgumentException("A Dataset or Query already exists with the name \"" + name +"\".");
+        if (!name.equals(domain.getName()) || def == null)
+        {
+            // issue 17766: check if dataset or query exist with this name
+            if (null != StudyManager.getInstance().getDatasetDefinitionByName(study, name) || null != QueryService.get().getQueryDef(user, container, "study", name))
+                throw new IllegalArgumentException("A Dataset or Query already exists with the name \"" + name + "\".");
+
+            StudyQuerySchema schema = StudyQuerySchema.createSchema(StudyManager.getInstance().getStudy(container), User.getSearchUser());
+
+            // Now check standard study tables
+            if (schema.getTableNames().contains(name))
+                throw new IllegalArgumentException("A study table exists with the name \"" + name + "\".");
+        }
 
         // Label related exceptions
+
+        String label = Objects.requireNonNullElse(datasetProperties.getLabel(), name); // Need to verify label uniqueness even if label is unspecified
 
         if ((def == null || !def.getLabel().equals(label)) && null != StudyManager.getInstance().getDatasetDefinitionByLabel(study, label))
             throw new IllegalArgumentException("A Dataset already exists with the label \"" + label +"\".");

--- a/study/src/org/labkey/study/query/StudyQuerySchema.java
+++ b/study/src/org/labkey/study/query/StudyQuerySchema.java
@@ -1022,42 +1022,47 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
     {
         if (getStudy() != null)
         {
-            if ("SpecimenDetail".equalsIgnoreCase(settings.getQueryName()))
+            @Nullable String queryName = settings.getQueryName();
+
+            if ("SpecimenDetail".equalsIgnoreCase(queryName))
             {
                 return SpecimenQueryView.createView(context, settings, SpecimenQueryView.ViewType.VIALS);
             }
 
-            if ("Cohort".equalsIgnoreCase(settings.getQueryName()))
+            if ("Cohort".equalsIgnoreCase(queryName))
             {
                 return new CohortQueryView(context.getUser(), getStudy(), context);
             }
 
-            if ("Location".equalsIgnoreCase(settings.getQueryName()))
+            if ("Location".equalsIgnoreCase(queryName))
             {
                 return new LocationQueryView(this, settings, errors);
             }
 
-            // Call getTable() to ensure consistency with name resolution. Specifically, getTable() resolves datasets
-            // after attempting to resolve all standard tables by name, so dataset labels don't shadow standard tables.
-            // Before this check was added, createView() would resolve dataset labels before table names. See Issue 47444
-            TableInfo table = getTable(settings.getQueryName());
-            if (table instanceof DatasetTable)
+            if (null != queryName)
             {
-                DatasetDefinition dsd = getDatasetDefinitionByQueryName(settings.getQueryName());
-                // Check for permission before deciding to treat the request as a dataset
-                if (dsd != null)
+                // Call getTable() to ensure consistency with name resolution. Specifically, getTable() resolves datasets
+                // after attempting to resolve all standard tables by name, so dataset labels don't shadow standard tables.
+                // Before this check was added, createView() would resolve dataset labels before table names. See Issue 47444
+                TableInfo table = getTable(queryName);
+                if (table instanceof DatasetTable)
                 {
-                    TableInfo t = getDatasetTable(dsd, null);
-                    if (null != t && t.hasPermission(getUser(), ReadPermission.class))
+                    DatasetDefinition dsd = getDatasetDefinitionByQueryName(queryName);
+                    // Check for permission before deciding to treat the request as a dataset
+                    if (dsd != null)
                     {
-                        // Issue 18787: if dataset name and label differ, use the name for the queryName
-                        if (!settings.getQueryName().equals(t.getName()))
-                            settings.setQueryName(t.getName());
+                        TableInfo t = getDatasetTable(dsd, null);
+                        if (null != t && t.hasPermission(getUser(), ReadPermission.class))
+                        {
+                            // Issue 18787: if dataset name and label differ, use the name for the queryName
+                            if (!queryName.equals(t.getName()))
+                                settings.setQueryName(t.getName());
 
-                        if (!(settings instanceof DatasetQuerySettings))
-                            settings = new DatasetQuerySettings(settings);
+                            if (!(settings instanceof DatasetQuerySettings))
+                                settings = new DatasetQuerySettings(settings);
 
-                        return new DatasetQueryView(this, (DatasetQuerySettings) settings, errors);
+                            return new DatasetQueryView(this, (DatasetQuerySettings) settings, errors);
+                        }
                     }
                 }
             }

--- a/study/src/org/labkey/study/query/StudyQuerySchema.java
+++ b/study/src/org/labkey/study/query/StudyQuerySchema.java
@@ -1037,21 +1037,28 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
                 return new LocationQueryView(this, settings, errors);
             }
 
-            DatasetDefinition dsd = getDatasetDefinitionByQueryName(settings.getQueryName());
-            // Check for permission before deciding to treat the request as a dataset
-            if (dsd != null)
+            // Call getTable() to ensure consistency with name resolution. Specifically, getTable() resolves datasets
+            // after attempting to resolve all standard tables by name, so dataset labels don't shadow standard tables.
+            // Before this check was added, createView() would resolve dataset labels before table names. See Issue 47444
+            TableInfo table = getTable(settings.getQueryName());
+            if (table instanceof DatasetTable)
             {
-                TableInfo t = getDatasetTable(dsd, null);
-                if (null != t && t.hasPermission(getUser(), ReadPermission.class))
+                DatasetDefinition dsd = getDatasetDefinitionByQueryName(settings.getQueryName());
+                // Check for permission before deciding to treat the request as a dataset
+                if (dsd != null)
                 {
-                    // Issue 18787: if dataset name and label differ, use the name for the queryName
-                    if (!settings.getQueryName().equals(t.getName()))
-                        settings.setQueryName(t.getName());
+                    TableInfo t = getDatasetTable(dsd, null);
+                    if (null != t && t.hasPermission(getUser(), ReadPermission.class))
+                    {
+                        // Issue 18787: if dataset name and label differ, use the name for the queryName
+                        if (!settings.getQueryName().equals(t.getName()))
+                            settings.setQueryName(t.getName());
 
-                    if (!(settings instanceof DatasetQuerySettings))
-                        settings = new DatasetQuerySettings(settings);
+                        if (!(settings instanceof DatasetQuerySettings))
+                            settings = new DatasetQuerySettings(settings);
 
-                    return new DatasetQueryView(this, (DatasetQuerySettings) settings, errors);
+                        return new DatasetQueryView(this, (DatasetQuerySettings) settings, errors);
+                    }
                 }
             }
         }
@@ -1147,7 +1154,7 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
         return true;
     }
 
-    protected void initSessionParticipantGroup(StudyImpl study, User user)
+    protected void initSessionParticipantGroup(Study study, User user)
     {
         if (study == null)
             return;
@@ -1215,8 +1222,8 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
     public FilteredTable<StudyQuerySchema> getStudyDatasetsUnion(boolean showAll)
     {
         Set<Container> containers = Objects.requireNonNull(getDefaultContainerFilter().getIds()).stream()
-                .map(ContainerManager::getForId).filter(Objects::nonNull)
-                .collect(Collectors.toSet());
+            .map(ContainerManager::getForId).filter(Objects::nonNull)
+            .collect(Collectors.toSet());
         var study = getStudy();
         if (null == study)
             return null;
@@ -1224,10 +1231,10 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
         if (null == datasets || datasets.isEmpty())
             return null;
         List<BaseStudyTable> bst = datasets.stream()
-                .filter(ds -> showAll || ds.isShowByDefault())
-                .map(ds -> (BaseStudyTable)getDatasetTable(ds, null)).filter(Objects::nonNull)
-                .filter(t -> t.hasPermission(getUser(), ReadPermission.class))
-                .collect(Collectors.toList());
+            .filter(ds -> showAll || ds.isShowByDefault())
+            .map(ds -> (BaseStudyTable)getDatasetTable(ds, null)).filter(Objects::nonNull)
+            .filter(t -> t.hasPermission(getUser(), ReadPermission.class))
+            .toList();
 
         if (bst.isEmpty())
             return null;

--- a/study/src/org/labkey/study/view/datasets.jsp
+++ b/study/src/org/labkey/study/view/datasets.jsp
@@ -38,7 +38,7 @@
 <%
     StudyManager manager = StudyManager.getInstance();
     Container container = getContainer();
-    Study study = manager.getStudy(container);
+    StudyImpl study = manager.getStudy(container);
     User user = getUser();
     List<DatasetDefinition> datasets = manager.getDatasetDefinitions(study);
 
@@ -52,7 +52,7 @@
         return;
     }
 
-    StudyQuerySchema sqs = StudyQuerySchema.createSchema((StudyImpl)study, user);
+    StudyQuerySchema sqs = StudyQuerySchema.createSchema(study, user);
 
     List<DatasetDefinition> userDatasets = new ArrayList<>();
     for (DatasetDefinition dataset : datasets)

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
@@ -192,7 +192,7 @@ public class StudyDatasetsTest extends BaseWebDriverTest
         setFormElement(Locator.name("SubjectColumnName"), mySubjectId);
         click(findButton("Submit"));
 
-        waitForText("Cannot set Subject Column Name to a user defined dataset field. " + mySubjectId + " is already defined in " + subjectIdDataset + ".");
+        waitForText("Cannot set Subject Column Name to a user defined dataset field. \"" + mySubjectId + "\" is already defined in \"" + subjectIdDataset + "\".");
         click(findButton("Ok"));
         clickButton("Cancel");
         clickTab("Overview");


### PR DESCRIPTION
… table names before dataset labels.

#### Rationale
* Choosing a subject noun singular that matched a dataset name caused exceptions when attempting to access the dataset. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47881
* The executeQuery action was resolving dataset label before study table names, which is not consistent with other code paths and our rules. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47444
* Attempting to create a dataset with a name that matched an existing study table (e.g., "Participant", "Location", "Cohort", etc.) would display a cryptic error message on save.
* Attempting to create a dataset with a blank label where the name was already used as a label on a different dataset resulted in a constraint violation message.
* Create study and update study properties actions had separate and inconsistent validation.

#### Changes
* Reject a subject noun singular value change when it matches the name of an existing dataset or study table. Also in the unlikely event that a dataset exists with one of the other participant table names: e.g., ParticipantVisit, ParticipantCategory, ParticipantGroup, or ParticipantGroupMap.
* Fix `createView()` to resolve study table names before dataset labels, like `createTable()` does
* Reject dataset names that match standard study table names (e.g., "Participant", "Location", "Cohort", etc.)
* Validate dataset label uniqueness when label is unspecified (and therefore matches name)
* Reconcile create study and manage study property validation for consistency