### PR TITLE
Add 'one' handler to DataRegion

### DIFF
--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -2567,6 +2567,10 @@ if (!LABKEY.DataRegions) {
         $(this).bind(evt, function() { callback.apply(scope || this, $(arguments).slice(1)); });
     };
 
+    LABKEY.DataRegion.prototype.one = function(evt, callback, scope) {
+        $(this).one(evt, function() { callback.apply(scope || this, $(arguments).slice(1)); });
+    };
+
     LABKEY.DataRegion.prototype._onButtonClick = function(buttonId) {
         var item = this.findButtonById(this.buttonBar.items, buttonId);
         if (item && $.isFunction(item.handler)) {


### PR DESCRIPTION
#### Rationale
This allows DataRegions to use the .[one() jQuery](https://api.jquery.com/one/) event handler, in support of related work linked below.

#### Related Pull Requests
* https://github.com/LabKey/hjfSampleRequests/pull/116

#### Changes
* Add .one handler
