### PR TITLE
47937: Linking Samples to a visit based study ignores "Date" column

### DIFF
--- a/study/src/org/labkey/study/query/AssayDatasetTable.java
+++ b/study/src/org/labkey/study/query/AssayDatasetTable.java
@@ -29,7 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-public class AssayDatasetTable extends DatasetTableImpl
+public class AssayDatasetTable extends LinkedDatasetTable
 {
     /**
      * The assay result LSID column is added to the dataset for assays that support it.

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -194,6 +194,9 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
         String subjectColName = StudyService.get().getSubjectColumnName(dsd.getContainer());
         for (ColumnInfo baseColumn : getRealTable().getColumns())
         {
+            if (!acceptColumn(baseColumn))
+                continue;
+
             String name = baseColumn.getName();
             if (subjectColName.equalsIgnoreCase(name))
             {
@@ -482,6 +485,10 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
         }
     }
 
+    protected boolean acceptColumn(ColumnInfo column)
+    {
+        return true;
+    }
 
     @Override
     public void addContextualRole(Role contextualRole)

--- a/study/src/org/labkey/study/query/LinkedDatasetTable.java
+++ b/study/src/org/labkey/study/query/LinkedDatasetTable.java
@@ -1,0 +1,25 @@
+package org.labkey.study.query;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.study.model.DatasetDefinition;
+
+public class LinkedDatasetTable extends DatasetTableImpl
+{
+    LinkedDatasetTable(@NotNull StudyQuerySchema schema, ContainerFilter cf, @NotNull DatasetDefinition dsd)
+    {
+        super(schema, cf, dsd);
+    }
+
+    @Override
+    protected boolean acceptColumn(ColumnInfo column)
+    {
+        if (getUserSchema().getStudy().getTimepointType().isVisitBased())
+        {
+            // issue : 47937 don't add the date field to linked datasets
+            return (!"date".equalsIgnoreCase(column.getName()));
+        }
+        return true;
+    }
+}

--- a/study/src/org/labkey/study/query/LinkedDatasetTable.java
+++ b/study/src/org/labkey/study/query/LinkedDatasetTable.java
@@ -5,7 +5,7 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.study.model.DatasetDefinition;
 
-public class LinkedDatasetTable extends DatasetTableImpl
+abstract class LinkedDatasetTable extends DatasetTableImpl
 {
     LinkedDatasetTable(@NotNull StudyQuerySchema schema, ContainerFilter cf, @NotNull DatasetDefinition dsd)
     {

--- a/study/src/org/labkey/study/query/SampleDatasetTable.java
+++ b/study/src/org/labkey/study/query/SampleDatasetTable.java
@@ -8,7 +8,6 @@ import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpSampleType;
-import org.labkey.api.exp.query.AbstractExpSchema;
 import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.query.ExprColumn;
@@ -21,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class SampleDatasetTable extends DatasetTableImpl
+public class SampleDatasetTable extends LinkedDatasetTable
 {
     private TableInfo _sampleTable;
     private List<FieldKey> _defaultVisibleColumns = null;


### PR DESCRIPTION
#### Rationale
Creation of a dataset date field in visit based studies interferes joining to either the source assay or sample type. It doesn't seem like that field has a lot of utility for in visit based studies and I considered just dropping it for all datasets. To be conservative I opted for a narrower change which affects only linked datasets. @mbellew I'm happy to do a broader change if you think otherwise. 

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47937)
