### PR TITLE
SchemaBrowser: Utilize sub-components for layout

### DIFF
--- a/query/webapp/query/browser/Caches.js
+++ b/query/webapp/query/browser/Caches.js
@@ -155,7 +155,11 @@ Ext4.define('LABKEY.query.browser.cache.QueryDetails', {
                         success.call(scope || this, json);
                     }
                 },
-                failure: failure,
+                failure: function(error) {
+                    if (Ext4.isFunction(failure)) {
+                        failure.call(scope || this, error);
+                    }
+                },
                 scope: this
             });
         }


### PR DESCRIPTION
#### Rationale
This PR seeks to address a race condition in the Schema Browser rendering that could result in ExtJS throwing an error in which the view is unable to recover. This has been reproduced by the crawler at the end of test runs resulting a stack trace:

```
TypeError: itemDom is undefined
  isValidParent (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:35361:26)
  renderItems (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:35346:32)
  renderChildren (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:35844:16)
  invalidate (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:119913:28)
  invalidate (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:119917:28)
  flushInvalidates (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:119756:16)
  run (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:120194:12)
  flushLayouts (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:29278:25)
  updateLayout (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:29312:24)
  updateLayout (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:31188:39)
  onContentChange (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:35416:20)
  updateLayout (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:31183:58)
  resumeLayouts (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:29907:20)
  removeAll (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:38280:12)
  renderQueryDetails (http://localhost:8111/labkey/query/browser/view/QueryDetails.js:777:14)
  setQueryDetails (http://localhost:8111/labkey/query/browser/view/QueryDetails.js:831:14)
  loadQueryDetails/< (http://localhost:8111/labkey/query/browser/view/QueryDetails.js:141:26)
  success (http://localhost:8111/labkey/query/browser/Caches.js:155:33)
```

I was able to reproduce this locally by slowing down the browser requests and then loading multiple views at the same time. In the end, the problem is in our call to `this.removeAll()` which removes our `loading` component. Generally, this isn't a problem, but if it is called at the right time the layout logic fails to load the underlying DOM. I've addressed this by separating `loading` and `error` rendering as well as creating a `content` component where the primary content of a tab within the SchemaBrowser is rendered.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/1528

#### Changes
* Establish constant components with itemId's `loader`, `error` and `content`.
* Use show/hide logic for `loader` and `error` components rather than removing/injecting from/in the layout. In doing so it removes the path that hit the race condition.
