### PR TITLE
updateSerialToBigInt

### DIFF
--- a/audit/resources/schemas/dbscripts/postgresql/audit-23.000-23.001.sql
+++ b/audit/resources/schemas/dbscripts/postgresql/audit-23.000-23.001.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('updateSerialToBigInt');

--- a/audit/src/org/labkey/audit/AuditModule.java
+++ b/audit/src/org/labkey/audit/AuditModule.java
@@ -55,7 +55,7 @@ public class AuditModule extends DefaultModule
     @Override
     public Double getSchemaVersion()
     {
-        return 23.000;
+        return 23.001;
     }
 
     @Override

--- a/audit/src/org/labkey/audit/query/AuditUpgradeCode.java
+++ b/audit/src/org/labkey/audit/query/AuditUpgradeCode.java
@@ -57,4 +57,16 @@ public class AuditUpgradeCode implements UpgradeCode
             }
         });
     }
+
+    // called from audit-23.000-23.001.sql
+    public static void updateSerialToBigInt(ModuleContext context)
+    {
+        DbScope scope = AuditSchema.getInstance().getSchema().getScope();
+        if (scope.getSqlDialect().isPostgreSQL())
+        {
+            var list = new SqlSelector(scope,"SELECT sequencename FROM pg_sequences WHERE schemaname='audit'").getArrayList(String.class);
+            for (var seq : list)
+                new SqlExecutor(scope).execute("ALTER SEQUENCE audit." + seq + " AS bigint MAXVALUE 9223372036854775807");
+        }
+    }
 }


### PR DESCRIPTION
#### Rationale
Update audit sequences to bigint to match the audit rowids.  I believe this affects databases created pre-22.3.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
