### PR TITLE
Preliminary support for PostgreSQL 16

### DIFF
--- a/api/src/org/labkey/api/data/dialect/AbstractDialectRetrievalTestCase.java
+++ b/api/src/org/labkey/api/data/dialect/AbstractDialectRetrievalTestCase.java
@@ -59,7 +59,7 @@ public abstract class AbstractDialectRetrievalTestCase extends Assert
             int majorVersion = i / 10;
             int minorVersion = i % 10;
 
-            String description = databaseName + " version " + majorVersion + "." + minorVersion;
+            String description = "Retrieving dialect for " + databaseName + " version " + majorVersion + "." + minorVersion;
 
             try
             {

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -163,7 +163,8 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
             good("PostgreSQL", 13.0, 14.0, "", connectionUrl, null, PostgreSql_13_Dialect.class);
             good("PostgreSQL", 14.0, 15.0, "", connectionUrl, null, PostgreSql_14_Dialect.class);
             good("PostgreSQL", 15.0, 16.0, "", connectionUrl, null, PostgreSql_15_Dialect.class);
-            good("PostgreSQL", 16.0, 17.0, "", connectionUrl, null, PostgreSql_15_Dialect.class);
+            good("PostgreSQL", 16.0, 17.0, "", connectionUrl, null, PostgreSql_16_Dialect.class);
+            good("PostgreSQL", 17.0, 18.0, "", connectionUrl, null, PostgreSql_16_Dialect.class);
         }
     }
 

--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -21,7 +21,8 @@ public enum PostgreSqlVersion
     POSTGRESQL_13(130, false, true, PostgreSql_13_Dialect::new),
     POSTGRESQL_14(140, false, true, PostgreSql_14_Dialect::new),
     POSTGRESQL_15(150, false, true, PostgreSql_15_Dialect::new),
-    POSTGRESQL_FUTURE(Integer.MAX_VALUE, true, false, PostgreSql_15_Dialect::new);
+    POSTGRESQL_16(160, false, false, PostgreSql_16_Dialect::new),
+    POSTGRESQL_FUTURE(Integer.MAX_VALUE, true, false, PostgreSql_16_Dialect::new);
 
     private final int _version;
     private final boolean _deprecated;
@@ -87,11 +88,12 @@ public enum PostgreSqlVersion
             test(130, POSTGRESQL_13);
             test(140, POSTGRESQL_14);
             test(150, POSTGRESQL_15);
+            test(160, POSTGRESQL_16);
 
             // Future
-            test(160, POSTGRESQL_FUTURE);
             test(170, POSTGRESQL_FUTURE);
             test(180, POSTGRESQL_FUTURE);
+            test(190, POSTGRESQL_FUTURE);
 
             // Bad
             test(83, POSTGRESQL_UNSUPPORTED);

--- a/core/src/org/labkey/core/dialect/PostgreSql_16_Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql_16_Dialect.java
@@ -1,0 +1,18 @@
+package org.labkey.core.dialect;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+public class PostgreSql_16_Dialect extends PostgreSql_15_Dialect
+{
+    @NotNull
+    @Override
+    protected Set<String> getReservedWords()
+    {
+        Set<String> words = super.getReservedWords();
+        words.add("system_user");
+
+        return words;
+    }
+}


### PR DESCRIPTION
#### Rationale
PostgreSQL 16 is in Beta. Add initial support, still listed as "untested."

https://www.postgresql.org/about/news/postgresql-16-beta-1-released-2643/