### PR TITLE
Improve synchronization around SessionAppender events

### DIFF
--- a/api/src/org/labkey/api/util/SessionAppender.java
+++ b/api/src/org/labkey/api/util/SessionAppender.java
@@ -120,6 +120,9 @@ public class SessionAppender extends AbstractAppender
     }
 
 
+    /**
+     * @return serialization-suitable list of events with eventId, level, message, and timestamp properties
+     */
     public static List<Map<String, Object>> getLoggingEvents(HttpServletRequest request, @Nullable Integer maxEventId)
     {
         AppenderInfo info = _getLoggingForSession(request);

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -7876,32 +7876,17 @@ public class AdminController extends SpringActionController
         @Override
         public ApiResponse execute(Object o, BindException errors)
         {
-            int eventId = 0;
+            Integer eventId = null;
             try
             {
                 String s = getViewContext().getRequest().getParameter("eventId");
                 if (null != s)
                     eventId = Integer.parseInt(s);
             }
-            catch (NumberFormatException x) {}
-            Map<LogEvent, String> events = SessionAppender.getLoggingEvents(getViewContext().getRequest());
-            ArrayList<Map<String, Object>> list = new ArrayList<>(events.size());
-            for (Map.Entry<LogEvent, String> entry : events.entrySet())
-            {
-                if (eventId==0 || eventId<Integer.parseInt(entry.getValue()))
-                {
-                    LogEvent e = entry.getKey();
-                    HashMap<String, Object> m = new HashMap<>();
-                    m.put("eventId", entry.getValue());
-                    m.put("level", e.getLevel().toString());
-                    m.put("message", e.getMessage().getFormattedMessage());
-                    m.put("timestamp", new Date(e.getTimeMillis()));
-                    list.add(m);
-                }
-            }
+            catch (NumberFormatException ignored) {}
             ApiSimpleResponse res = new ApiSimpleResponse();
             res.put("success", true);
-            res.put("events", list);
+            res.put("events", SessionAppender.getLoggingEvents(getViewContext().getRequest(), eventId));
             return res;
         }
     }


### PR DESCRIPTION
#### Rationale
```
java.util.ConcurrentModificationException: null
	at java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:756) ~[?:?]
	at java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:788) ~[?:?]
	at java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:786) ~[?:?]
	at org.labkey.core.admin.AdminController$GetSessionLogEventsAction.execute(AdminController.java:7779) ~[core-22.11.9.jar:?]
	at org.labkey.core.admin.AdminController$GetSessionLogEventsAction.execute(AdminController.java:7753) ~[core-22.11.9.jar:?]
```

#### Changes
* Synchronize while iterating
* Pull serialization into SessionAppender so others don't have to worry about synchronization requirements
* Use Integers instead of Strings