### PR TITLE
Project level data type - remove experimental flag

### DIFF
--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1785,6 +1785,10 @@ public class ContainerManager
             // and delete all container-based sequences
             DbSequenceManager.deleteAll(c);
 
+            ExperimentService experimentService = ExperimentService.get();
+            if (experimentService != null)
+                experimentService.removeContainerDataTypeExclusions(c.getId());
+
             // After we've committed the transaction, be sure that we remove this container from the cache
             // See https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=17015
             tx.addCommitTask(() ->

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -939,6 +939,10 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     void addDataTypeExclusion(int rowId, DataTypeForExclusion dataType, String excludedContainerId, User user);
 
+    void removeDataTypeExclusion(Collection<Integer> rowIds, DataTypeForExclusion dataType);
+
+    void removeContainerDataTypeExclusions(String containerId);
+
     @NotNull Map<ExperimentService.DataTypeForExclusion, Set<Integer>> getContainerDataTypeExclusions(@NotNull String excludedContainerId);
 
     Set<String> getDataTypeContainerExclusions(@NotNull DataTypeForExclusion dataType, @NotNull Integer dataTypeRowId);

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -75,7 +75,6 @@ public interface QueryService
     String EXPERIMENTAL_LAST_MODIFIED = "queryMetadataLastModified";
     String EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS = "queryProductAllFolderLookups";
     String EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED = "queryProductProjectDataListingScoped";
-    String EXPERIMENTAL_PRODUCT_PROJECT_DATA_SELECTION = "queryProductProjectDataTypeSelection";
     String PRODUCT_PROJECTS_ENABLED = "isProductProjectsEnabled";
     String PRODUCT_PROJECTS_EXIST = "hasProductProjects";
     String USE_ROW_BY_ROW_UPDATE = "useLegacyUpdateRows";

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8199,10 +8199,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Override
     public void removeDataTypeExclusion(Collection<Integer> rowIds, DataTypeForExclusion dataType)
     {
-        _removeDataTypeExclusion(rowIds, dataType, null);
+        removeDataTypeExclusion(rowIds, dataType, null);
     }
 
-    public void _removeDataTypeExclusion(Collection<Integer> rowIds, DataTypeForExclusion dataType, @Nullable String excludedContainerId)
+    private void removeDataTypeExclusion(Collection<Integer> rowIds, DataTypeForExclusion dataType, @Nullable String excludedContainerId)
     {
         SQLFragment sql = new SQLFragment("DELETE FROM  ")
                 .append(getTinfoDataTypeExclusion())
@@ -8237,7 +8237,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             String excludedContainerId = excludedContainerIdOrPath;
             if (!GUID.isGUID(excludedContainerIdOrPath))
             {
-                Container container = ContainerManager.ensureContainer(excludedContainerIdOrPath);
+                Container container = ContainerManager.getForPath(excludedContainerIdOrPath);
                 if (container != null)
                     excludedContainerId = container.getId();
             }
@@ -8319,7 +8319,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         }
 
         if (!toRemove.isEmpty())
-            _removeDataTypeExclusion(toRemove, dataType, excludedContainerId);
+            removeDataTypeExclusion(toRemove, dataType, excludedContainerId);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8195,7 +8195,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         new SqlExecutor(getExpSchema()).execute(sql);
     }
 
-    @NotNull private Map<String, Object>[] _getContainerDataTypeExclusions(@Nullable DataTypeForExclusion dataType, @Nullable String excludedContainerId, @Nullable Integer dataTypeRowId)
+    @NotNull private Map<String, Object>[] _getContainerDataTypeExclusions(@Nullable DataTypeForExclusion dataType, @Nullable String excludedContainerIdOrPath, @Nullable Integer dataTypeRowId)
     {
         SQLFragment sql = new SQLFragment("SELECT DataTypeRowId, DataType, ExcludedContainer FROM ")
                 .append(getTinfoDataTypeExclusion())
@@ -8208,8 +8208,16 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             and = " AND ";
         }
 
-        if (!StringUtils.isEmpty(excludedContainerId))
+        if (!StringUtils.isEmpty(excludedContainerIdOrPath))
         {
+            String excludedContainerId = excludedContainerIdOrPath;
+            if (!GUID.isGUID(excludedContainerIdOrPath))
+            {
+                Container container = ContainerManager.ensureContainer(excludedContainerIdOrPath);
+                if (container != null)
+                    excludedContainerId = container.getId();
+            }
+
             sql.append(and);
             sql.append("ExcludedContainer = ? ");
             sql.add(excludedContainerId);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -612,6 +612,8 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
             addSampleTypeDeletedAuditEvent(user, c, source, transaction.getAuditId(), auditUserComment);
 
+            ExperimentService.get().removeDataTypeExclusion(Collections.singleton(rowId), ExperimentService.DataTypeForExclusion.SampleType);
+
             transaction.addCommitTask(() -> clearMaterialSourceCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
             transaction.commit();
         }

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -233,8 +233,6 @@ public class QueryModule extends DefaultModule
                 "Allow for lookup fields in product projects to query across all folders within the top-level folder.", false);
         AdminConsole.addExperimentalFeatureFlag(QueryServiceImpl.EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED, "Product projects display project-specific data",
                 "Only list project-specific data within product projects.", false);
-        AdminConsole.addExperimentalFeatureFlag(QueryServiceImpl.EXPERIMENTAL_PRODUCT_PROJECT_DATA_SELECTION, "Selection of data structure to be shown in projects",
-                "Configure which sample types, source types, assay designs and storage locations are relevant for each project.", false);
     }
 
 
@@ -414,7 +412,6 @@ public class QueryModule extends DefaultModule
         json.put(QueryService.PRODUCT_PROJECTS_EXIST, isProductProjectsEnabled && container.hasProductProjects());
         json.put(QueryService.EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS, QueryService.get().isProductProjectsAllFolderScopeEnabled());
         json.put(QueryService.EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED, QueryService.get().isProductProjectsDataListingScopedToProject());
-        json.put(QueryService.EXPERIMENTAL_PRODUCT_PROJECT_DATA_SELECTION, AppProps.getInstance().isExperimentalFeatureEnabled(QueryService.EXPERIMENTAL_PRODUCT_PROJECT_DATA_SELECTION));
 
         return json;
     }


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1200
- https://github.com/LabKey/labkey-ui-premium/pull/97
- https://github.com/LabKey/platform/pull/4467
- https://github.com/LabKey/inventory/pull/869
- https://github.com/LabKey/sampleManagement/pull/1860
- https://github.com/LabKey/biologics/pull/2152

#### Changes
* remove isProductProjectDataTypeSelectionEnabled experimental flag
* allow querying for container data type exclusions by container path
* clean up datatypeexclusion on data type and container delete
