### PR TITLE
Projects: Selection of data structures to be shown in Projects - Designer UI updates

### DIFF
--- a/api/gwtsrc/org/labkey/api/gwt/client/assay/model/GWTProtocol.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/assay/model/GWTProtocol.java
@@ -75,6 +75,7 @@ public class GWTProtocol implements IsSerializable
     private boolean _qcEnabled;
     private boolean _plateMetadata;
     private String _status;
+    private List<String> _excludedContainerIds;
 
     public GWTProtocol()
     {
@@ -393,5 +394,15 @@ public class GWTProtocol implements IsSerializable
     public void setStatus(String status)
     {
         _status = status;
+    }
+
+    public List<String> getExcludedContainerIds()
+    {
+        return _excludedContainerIds;
+    }
+
+    public void setExcludedContainerIds(List<String> excludedContainerIds)
+    {
+        _excludedContainerIds = excludedContainerIds;
     }
 }

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -284,7 +284,7 @@ public class DataGenerator<T extends DataGenerator.Config>
         _log.info(String.format("Creating Sample Type '%s' with %d fields", sampleTypeName, numFields));
         return service.createSampleType(_container, _user, sampleTypeName,
                 "Generated sample type", props, List.of(), -1, -1, -1, -1, namingPattern, null, null, null,
-                randomIndex(LABEL_COLORS), randomIndex(UNITS), null, null, null);
+                randomIndex(LABEL_COLORS), randomIndex(UNITS));
     }
 
     public void generateSamplesForAllTypes(List<String> dataClassParents) throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException

--- a/api/src/org/labkey/api/exp/api/DataClassDomainKindProperties.java
+++ b/api/src/org/labkey/api/exp/api/DataClassDomainKindProperties.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 public class DataClassDomainKindProperties
@@ -18,6 +19,7 @@ public class DataClassDomainKindProperties
     private String category;
     private boolean _strictFieldValidation = true; // Set as false to skip validation check in ExperimentServiceImpl.createDataClass (used in Rlabkey labkey.domain.createAndLoad)
     private Map<String, String> importAliases;
+    private List<String> excludedContainerIds;
 
     public DataClassDomainKindProperties()
     {}
@@ -165,4 +167,13 @@ public class DataClassDomainKindProperties
         return this.importAliases;
     }
 
+    public List<String> getExcludedContainerIds()
+    {
+        return excludedContainerIds;
+    }
+
+    public void setExcludedContainerIds(List<String> excludedContainerIds)
+    {
+        this.excludedContainerIds = excludedContainerIds;
+    }
 }

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -937,13 +937,15 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     List<QueryViewProvider<ExpRun>> getRunOutputsViewProviders();
 
-    void addDataTypeExclusion(int rowId, DataTypeForExclusion dataType, String excludedContainerId, User user);
-
     @NotNull Map<ExperimentService.DataTypeForExclusion, Set<Integer>> getContainerDataTypeExclusions(@NotNull String excludedContainerId);
 
     Set<String> getDataTypeContainerExclusions(@NotNull DataTypeForExclusion dataType, @NotNull Integer dataTypeRowId);
 
-    void ensureContainerDataTypeExclusions(@Nullable DataTypeForExclusion dataType, @Nullable Collection<Integer> excludedDataTypeRowIds, @Nullable String excludedContainerId, User user);
+    void ensureContainerDataTypeExclusions(@NotNull DataTypeForExclusion dataType, @Nullable Collection<Integer> excludedDataTypeRowIds, @NotNull String excludedContainerId, User user);
+
+    void ensureDataTypeContainerExclusions(@NotNull DataTypeForExclusion dataType, @Nullable Collection<String> excludedContainerIds, @NotNull Integer dataTypeId, User user);
+
+    String getDisabledDataTypeAuditMsg(ExperimentService.DataTypeForExclusion type, List<Integer> ids, boolean isUpdate);
 
     void registerRunInputsViewProvider(QueryViewProvider<ExpRun> provider);
 

--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -511,6 +511,7 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
         String autoLinkCategory = null;
         String category = null;
         Map<String, String> aliases = null;
+        List<String> excludedContainerIds = null;
 
         if (arguments != null)
         {
@@ -530,12 +531,13 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
             autoLinkCategory = StringUtils.trimToNull(arguments.getAutoLinkCategory());
             category = StringUtils.trimToNull(arguments.getCategory());
             aliases = arguments.getImportAliases();
+            excludedContainerIds = arguments.getExcludedContainerIds();
         }
         ExpSampleType st;
         try
         {
             st = SampleTypeService.get().createSampleType(container, user, name, description, properties, indices, idCol1, idCol2, idCol3, parentCol, nameExpression, aliquotNameExpression,
-                    templateInfo, aliases, labelColor, metricUnit, autoLinkTargetContainer, autoLinkCategory, category, domain.getDisabledSystemFields());
+                    templateInfo, aliases, labelColor, metricUnit, autoLinkTargetContainer, autoLinkCategory, category, domain.getDisabledSystemFields(), excludedContainerIds);
         }
         catch (SQLException e)
         {

--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKindProperties.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKindProperties.java
@@ -64,6 +64,7 @@ public class SampleTypeDomainKindProperties implements Cloneable
     private String autoLinkCategory;
     private Integer parentCol;
     private String category;
+    private List<String> excludedContainerIds;
 
     //Ignored on import/save, use Domain.name & Domain.description instead
     private String name;
@@ -226,4 +227,13 @@ public class SampleTypeDomainKindProperties implements Cloneable
         this.category = category;
     }
 
+    public List<String> getExcludedContainerIds()
+    {
+        return excludedContainerIds;
+    }
+
+    public void setExcludedContainerIds(List<String> excludedContainerIds)
+    {
+        this.excludedContainerIds = excludedContainerIds;
+    }
 }

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -104,10 +104,6 @@ public interface SampleTypeService
     ExpSampleType createSampleType(Container container, User user, String name, String description, List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, int idCol1, int idCol2, int idCol3, int parentCol, String nameExpression)
             throws ExperimentException, SQLException;
 
-    @NotNull
-    ExpSampleType createSampleType(Container container, User user, String name, String description, List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, String nameExpression)
-            throws ExperimentException, SQLException;
-
     /**
      * (MAB) todo need a builder interface, or at least  parameter bean
      */
@@ -118,14 +114,13 @@ public interface SampleTypeService
 
     @NotNull
     ExpSampleType createSampleType(Container container, User user, String name, String description, List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, int idCol1, int idCol2, int idCol3, int parentCol,
-                                   String nameExpression, String aliquotNameExpression, @Nullable TemplateInfo templateInfo, @Nullable Map<String, String> importAliases, @Nullable String labelColor, @Nullable String metricUnit,
-                                   @Nullable Container autoLinkTargetContainer, @Nullable String autoLinkCategory, @Nullable String category)
+                                   String nameExpression, String aliquotNameExpression, @Nullable TemplateInfo templateInfo, @Nullable Map<String, String> importAliases, @Nullable String labelColor, @Nullable String metricUnit)
             throws ExperimentException, SQLException;
 
     @NotNull
     ExpSampleType createSampleType(Container c, User u, String name, String description, List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, int idCol1, int idCol2, int idCol3, int parentCol,
                                               String nameExpression, String aliquotNameExpression, @Nullable TemplateInfo templateInfo, @Nullable Map<String, String> importAliases, @Nullable String labelColor, @Nullable String metricUnit,
-                                              @Nullable Container autoLinkTargetContainer, @Nullable String autoLinkCategory, @Nullable String category, @Nullable List<String> disabledSystemField)
+                                              @Nullable Container autoLinkTargetContainer, @Nullable String autoLinkCategory, @Nullable String category, @Nullable List<String> disabledSystemField, @Nullable List<String> excludedContainerIds)
             throws ExperimentException, SQLException;
 
     @NotNull

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -383,7 +383,8 @@ public class AssayDomainServiceImpl extends DomainEditorServiceBase implements A
                         throw new AssayException("Linked Dataset Category name must be shorter than 200 characters.");
 
                     ExpProtocol protocol;
-                    if (assay.getProtocolId() == null)
+                    boolean isNew = assay.getProtocolId() == null;
+                    if (isNew)
                     {
                         // check for existing assay protocol with the given name before creating
                         if (AssayManager.get().getAssayProtocolByName(getContainer(), assay.getName()) != null)
@@ -560,6 +561,9 @@ public class AssayDomainServiceImpl extends DomainEditorServiceBase implements A
                         if (domainErrors.hasErrors())
                             throw domainErrors;
                     }
+
+                    if (assay.getExcludedContainerIds() != null && (!isNew || !assay.getExcludedContainerIds().isEmpty()))
+                        ExperimentService.get().ensureDataTypeContainerExclusions(ExperimentService.DataTypeForExclusion.AssayDesign, assay.getExcludedContainerIds(), protocol.getRowId(), getUser());
 
                     QueryService.get().updateLastModified();
                     transaction.commit();

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8413,7 +8413,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         {
             for (String remove : toRemove)
             {
-                removeDataTypeExclusion(dataTypeId, dataType, remove, user);
+                removeDataTypeExclusion(Collections.singleton(dataTypeId), dataType, remove);
                 addAuditEventForDataTypeContainerUpdate(dataType, remove, user);
             }
         }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -7528,7 +7528,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             DefaultValueService.get().setDefaultValues(domain.getContainer(), defaultValues);
 
             if (options != null && options.getExcludedContainerIds() != null && !options.getExcludedContainerIds().isEmpty())
-                ExperimentService.get().ensureDataTypeContainerExclusions(ExperimentService.DataTypeForExclusion.SampleType, options.getExcludedContainerIds(), impl.getRowId(), u);
+                ExperimentService.get().ensureDataTypeContainerExclusions(DataTypeForExclusion.DataClass, options.getExcludedContainerIds(), impl.getRowId(), u);
 
             tx.addCommitTask(() -> clearDataClassCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
             tx.commit();
@@ -8234,11 +8234,11 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public @NotNull Map<ExperimentService.DataTypeForExclusion, Set<Integer>> getContainerDataTypeExclusions(@NotNull String excludedContainerId)
+    public @NotNull Map<DataTypeForExclusion, Set<Integer>> getContainerDataTypeExclusions(@NotNull String excludedContainerId)
     {
         Map<String, Object>[] exclusions = _getContainerDataTypeExclusions(null, excludedContainerId, null);
 
-        Map<ExperimentService.DataTypeForExclusion, Set<Integer>> typeExclusions = new HashMap<>();
+        Map<DataTypeForExclusion, Set<Integer>> typeExclusions = new HashMap<>();
         for (Map<String, Object> exclusion : exclusions)
         {
             String dataTypeStr = (String) exclusion.get("DataType");

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -7527,6 +7527,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             //TODO do DataClasses actually support default values? The DataClassDomainKind does not override showDefaultValueSettings to return true so it isn't shown in the UI.
             DefaultValueService.get().setDefaultValues(domain.getContainer(), defaultValues);
 
+            if (options != null && options.getExcludedContainerIds() != null && !options.getExcludedContainerIds().isEmpty())
+                ExperimentService.get().ensureDataTypeContainerExclusions(ExperimentService.DataTypeForExclusion.SampleType, options.getExcludedContainerIds(), impl.getRowId(), u);
+
             tx.addCommitTask(() -> clearDataClassCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
             tx.commit();
         }
@@ -7589,6 +7592,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
             if (hasNameChange)
                 addObjectLegacyName(dataClass.getObjectId(), ExperimentServiceImpl.getNamespacePrefix(ExpDataClass.class), oldDataClassName, u);
+
+            if (options != null && options.getExcludedContainerIds() != null)
+                ExperimentService.get().ensureDataTypeContainerExclusions(DataTypeForExclusion.DataClass, options.getExcludedContainerIds(), dataClass.getRowId(), u);
 
             if (!errors.hasErrors())
             {

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8354,7 +8354,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         if (ids != null && (isUpdate || !ids.isEmpty()))
         {
             if (isUpdate && ids.isEmpty())
-                builder.append(type.name()).append( " exclusion has been cleared.");
+                builder.append(type.name()).append( " exclusion has been cleared.\n");
             else
                 builder.append("Excluded ").append(type.name()).append(": ").append(StringUtils.join(ids, ", ")).append(".\n");
         }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1055,6 +1055,9 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             if (hasNameChange)
                 ExperimentService.get().addObjectLegacyName(st.getObjectId(), ExperimentServiceImpl.getNamespacePrefix(ExpSampleType.class), oldSampleTypeName, user);
 
+            if (options != null && options.getExcludedContainerIds() != null)
+                ExperimentService.get().ensureDataTypeContainerExclusions(ExperimentService.DataTypeForExclusion.SampleType, options.getExcludedContainerIds(), st.getRowId(), user);
+
             if (!errors.hasErrors())
             {
                 boolean finalHasMetricUnitChanged = hasMetricUnitChanged;

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -679,36 +679,27 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
     @NotNull
     @Override
-    public ExpSampleTypeImpl createSampleType(Container c, User u, String name, String description, List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, String nameExpression)
-            throws ExperimentException
-    {
-        return createSampleType(c,u,name,description,properties,indices,-1,-1,-1, -1, nameExpression, null);
-    }
-
-    @NotNull
-    @Override
     public ExpSampleTypeImpl createSampleType(Container c, User u, String name, String description, List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, int idCol1, int idCol2, int idCol3, int parentCol,
                                               String nameExpression, @Nullable TemplateInfo templateInfo)
             throws ExperimentException
     {
         return createSampleType(c, u, name, description, properties, indices, idCol1, idCol2, idCol3,
-                parentCol, nameExpression, null, templateInfo, null, null, null, null, null, null);
+                parentCol, nameExpression, null, templateInfo, null, null, null);
     }
 
     @NotNull
     @Override
     public ExpSampleTypeImpl createSampleType(Container c, User u, String name, String description, List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, int idCol1, int idCol2, int idCol3, int parentCol,
-                                              String nameExpression, String aliquotNameExpression, @Nullable TemplateInfo templateInfo, @Nullable Map<String, String> importAliases, @Nullable String labelColor, @Nullable String metricUnit,
-                                              @Nullable Container autoLinkTargetContainer, @Nullable String autoLinkCategory, @Nullable String category) throws ExperimentException
+                                              String nameExpression, String aliquotNameExpression, @Nullable TemplateInfo templateInfo, @Nullable Map<String, String> importAliases, @Nullable String labelColor, @Nullable String metricUnit) throws ExperimentException
     {
-        return createSampleType(c, u, name, description, properties, indices, idCol1, idCol2, idCol3, parentCol, nameExpression, aliquotNameExpression, templateInfo, importAliases, labelColor, metricUnit, autoLinkTargetContainer, autoLinkCategory, category, null);
+        return createSampleType(c, u, name, description, properties, indices, idCol1, idCol2, idCol3, parentCol, nameExpression, aliquotNameExpression, templateInfo, importAliases, labelColor, metricUnit, null, null, null, null, null);
     }
 
     @NotNull
     @Override
     public ExpSampleTypeImpl createSampleType(Container c, User u, String name, String description, List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, int idCol1, int idCol2, int idCol3, int parentCol,
                                               String nameExpression, String aliquotNameExpression, @Nullable TemplateInfo templateInfo, @Nullable Map<String, String> importAliases, @Nullable String labelColor, @Nullable String metricUnit,
-                                              @Nullable Container autoLinkTargetContainer, @Nullable String autoLinkCategory, @Nullable String category, @Nullable List<String> disabledSystemField)
+                                              @Nullable Container autoLinkTargetContainer, @Nullable String autoLinkCategory, @Nullable String category, @Nullable List<String> disabledSystemField, @Nullable List<String> excludedContainerIds)
         throws ExperimentException
     {
         if (name == null)
@@ -891,6 +882,8 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                     domain.save(u);
                     st.save(u);
                     DefaultValueService.get().setDefaultValues(domain.getContainer(), defaultValues);
+                    if (excludedContainerIds != null && !excludedContainerIds.isEmpty())
+                        ExperimentService.get().ensureDataTypeContainerExclusions(ExperimentService.DataTypeForExclusion.SampleType, excludedContainerIds, st.getRowId(), u);
                     transaction.addCommitTask(() -> clearMaterialSourceCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
                     return st;
                 }


### PR DESCRIPTION
#### Rationale
Recent PRs have allowed the app project settings page to exclude certain data types (sample types, data classes, assay designs, and storage) from the UI for that project. This PR introduces the reverse, allowing for a data type field editor / designer to show a panel that allow for project exclusions to be made. The two methods both insert/update the exclusions in the same DB table and add similar audit entries.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1202

#### Changes
- domain kind properties support for posting excludedContainerIds
- saveDomain / saveProtocol updates to call ExperimentService.get().ensureDataTypeContainerExclusions
- refactors in ExperimentService to allow for reuse of helpers to add/remove data type exclusions and add audit entries
