### PR TITLE
Issue 47799: Adjustment to logic for run deletion when parents are removed

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4807,18 +4807,18 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         if (!runsUsingItems.isEmpty())
         {
             Set<ExpRun> runsToKeep = new HashSet<>();
-            // determine if there are any outputs of this run that are not being deleted. If so, remove the run from the runs to be deleted.
+            // determine if there are any inputs of this run that are not being deleted. If so, we don't want to remove this run.
             runsUsingItems.forEach(run -> {
-                run.getMaterialOutputs().forEach(
+                run.getMaterialInputs().keySet().forEach(
                     sample -> {
                         if (!sampleIds.contains(sample.getRowId()))
-                            runsToKeep.add(sample.getRun());
+                            runsToKeep.add(run);
                     }
                 );
-                run.getDataOutputs().forEach(
+                run.getDataInputs().keySet().forEach(
                     dataObject -> {
                         if (!dataIds.contains(dataObject.getRowId()))
-                            runsToKeep.add(dataObject.getRun());
+                            runsToKeep.add(run);
                     }
                 );
             });
@@ -4862,6 +4862,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         }
     }
 
+    /* Finds the runs where all outputs are also being deleted */
     private Collection<? extends ExpRun> getDeletableSourceRunsFromInputRowId(Collection<Integer> rowIds, TableInfo primaryTableInfo, Collection<Integer> siblingRowIds, TableInfo siblingTableInfo)
     {
         if (rowIds == null || rowIds.isEmpty())

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4797,33 +4797,61 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         List<Integer> dataIds = dataItems == null || dataItems.isEmpty() ? Collections.emptyList() : dataItems.stream().map(RunItem::getRowId).toList();
         Set<Integer> sampleIds = materialItems == null || materialItems.isEmpty() ? Collections.emptySet() : materialItems.stream().map(RunItem::getRowId).collect(Collectors.toSet());
 
-        if (!dataIds.isEmpty())
-            runsUsingItems.addAll(getDeletableSourceRunsFromInputRowId(dataIds, getTinfoData(), sampleIds, getTinfoMaterial()));
-
         if (!sampleIds.isEmpty())
-            // get all the runs that use these samples as inputs
-            runsUsingItems.addAll(getDeletableRunsFromMaterials(ExpMaterialImpl.fromMaterials(materialItems)));
-
-        if (!runsUsingItems.isEmpty())
         {
-            Set<ExpRun> runsToKeep = new HashSet<>();
-            // determine if there are any inputs of this run that are not being deleted. If so, we don't want to remove this run.
-            runsUsingItems.forEach(run -> {
-                run.getMaterialInputs().keySet().forEach(
-                    sample -> {
-                        if (!sampleIds.contains(sample.getRowId()))
-                            runsToKeep.add(run);
-                    }
-                );
-                run.getDataInputs().keySet().forEach(
-                    dataObject -> {
-                        if (!dataIds.contains(dataObject.getRowId()))
-                            runsToKeep.add(run);
-                    }
-                );
-            });
-            runsUsingItems.removeAll(runsToKeep);
+            // get runs where these samples are used as inputs
+            runsUsingItems.addAll(getDerivedRunsFromMaterial(sampleIds));
+            // retain runs if there are other inputs that are not being deleted
+            if (!runsUsingItems.isEmpty())
+            {
+                Set<ExpRun> runsToKeep = new HashSet<>();
+                runsUsingItems.forEach(run -> {
+                    run.getMaterialInputs().keySet().forEach(
+                            sample -> {
+                                if (!sampleIds.contains(sample.getRowId()))
+                                    runsToKeep.add(run);
+                            }
+                    );
+                    run.getDataInputs().keySet().forEach(
+                            dataObject -> {
+                                if (!dataIds.contains(dataObject.getRowId()))
+                                    runsToKeep.add(run);
+                            }
+                    );
+                });
+                runsUsingItems.removeAll(runsToKeep);
+            }
+            // add runs that will no longer have any outputs
+            runsUsingItems.addAll(getDeletableSourceRunsFromInputRowId(sampleIds, getTinfoMaterial(), Collections.emptySet(), getTinfoData()));
+        }
 
+        if (!dataIds.isEmpty())
+        {
+            // get runs where these data objects are used as inputs
+            var dataInputRuns = new ArrayList<ExpRun>(getDerivedRunsFromData(dataIds));
+            // retain runs if there are other inputs that are not being deleted
+            if (!dataInputRuns.isEmpty())
+            {
+                Set<ExpRun> runsToKeep = new HashSet<>();
+                dataInputRuns.forEach(run -> {
+                    run.getMaterialInputs().keySet().forEach(
+                            sample -> {
+                                if (!sampleIds.contains(sample.getRowId()))
+                                    runsToKeep.add(run);
+                            }
+                    );
+                    run.getDataInputs().keySet().forEach(
+                            dataObject -> {
+                                if (!dataIds.contains(dataObject.getRowId()))
+                                    runsToKeep.add(run);
+                            }
+                    );
+                });
+                dataInputRuns.removeAll(runsToKeep);
+            }
+            runsUsingItems.addAll(dataInputRuns);
+            // get runs that will no longer have any outputs
+            runsUsingItems.addAll(getDeletableSourceRunsFromInputRowId(dataIds, getTinfoData(), sampleIds, getTinfoMaterial()));
         }
 
         List<? extends ExpRun> runsToDelete = runsDeletedWithInput(runsUsingItems);
@@ -4945,6 +4973,15 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             return Collections.emptyList();
 
         return ExpRunImpl.fromRuns(getRunsForRunIds(getTargetRunIdsFromMaterialIds(getAppendInClause(materialIds))));
+    }
+
+
+    private Collection<? extends ExpRun> getDerivedRunsFromData(Collection<Integer> rowIds)
+    {
+        if (rowIds == null || rowIds.isEmpty())
+            return Collections.emptyList();
+
+        return ExpRunImpl.fromRuns(getRunsForRunIds(getTargetRunIdsFromDataIds(getAppendInClause(rowIds))));
     }
 
     /**
@@ -5637,6 +5674,26 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
      */
     private SQLFragment getTargetRunIdsFromMaterialIds(SQLFragment materialRowIdSQL)
     {
+        return getTargetRunIdsFromInputRowIds(materialRowIdSQL, getTinfoMaterialInput(), "MaterialID");
+    }
+
+    /**
+     * Generate a query to get the runIds where the supplied set of material rowIds were used as inputs
+     * @param rowIdSQL -- SQL clause generating material rowIds used to limit results
+     * @return Query to retrieve set of runIds from supplied input material ids
+     */
+    private SQLFragment getTargetRunIdsFromDataIds(SQLFragment rowIdSQL)
+    {
+        return getTargetRunIdsFromInputRowIds(rowIdSQL, getTinfoDataInput(), "DataID");
+    }
+
+    /**
+     * Generate a query to get the runIds where the supplied set of material rowIds were used as inputs
+     * @param rowIdSQL -- SQL clause generating rowIds used to limit results
+     * @return Query to retrieve set of runIds from supplied input material ids
+     */
+    private SQLFragment getTargetRunIdsFromInputRowIds(SQLFragment rowIdSQL, TableInfo inputTable, String idColumn)
+    {
         // ex SQL:
         /*
             SELECT pa.RunId
@@ -5651,10 +5708,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
         sql.append("SELECT pa.RunId\n");
         sql.append("FROM ").append(getTinfoProtocolApplication(), "pa").append(",\n\t");
-        sql.append(getTinfoMaterialInput(), "mi").append("\n");
-        sql.append("WHERE mi.TargetApplicationId = pa.RowId ")
-            .append("AND pa.cpastype = ?\n").add(ExperimentRun.name())
-            .append("AND mi.MaterialID ").append(materialRowIdSQL);
+        sql.append(inputTable, "i").append("\n");
+        sql.append("WHERE i.TargetApplicationId = pa.RowId ")
+                .append("AND pa.cpastype = ?\n").add(ExperimentRun.name())
+                .append("AND i.").append(idColumn).append(" ").append(rowIdSQL);
 
         return sql;
     }


### PR DESCRIPTION
#### Rationale
Previous logic that eliminated runs from deletion was incorrect. We need to prevent deletion if there are other *inputs* not *outputs* (the runs with outputs that still exist are not included in the initial list).

#### Related Pull Requests
* #4438 
* https://github.com/LabKey/testAutomation/pull/1531
* https://github.com/LabKey/sampleManagement/pull/1871

#### Changes
* Update logic for run deletion elimination
