### PR TITLE
Teach JSONObject how to serialize an HtmlString

### DIFF
--- a/api/src/org/labkey/api/util/HtmlString.java
+++ b/api/src/org/labkey/api/util/HtmlString.java
@@ -19,12 +19,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.json.JSONString;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Objects;
 
-public final class HtmlString implements SafeToRender, DOM.Renderable, Comparable<HtmlString>, Serializable
+public final class HtmlString implements SafeToRender, DOM.Renderable, Comparable<HtmlString>, Serializable, JSONString
 {
     // Helpful constants for convenience (and efficiency)
     public static final HtmlString EMPTY_STRING = HtmlString.of("");
@@ -157,5 +158,11 @@ public final class HtmlString implements SafeToRender, DOM.Renderable, Comparabl
     public int length()
     {
         return _s.length();
+    }
+
+    @Override
+    public String toJSONString()
+    {
+        return _s;
     }
 }


### PR DESCRIPTION
#### Rationale
When encountering an `HtmlString`, the (not so) new `JSONObject` attempted to serialize it as a bean. Having no getters meant the result was an empty JSON object. The previous library would simply call `toString()`. One symptom of the problem:

![image](https://github.com/LabKey/platform/assets/5107383/6e103161-d06b-497f-967b-f64e1e417cff)

There may be other cases where we're hitting this.


