### PR TITLE
Issue 48005: Static Background for Authentication Modal

### DIFF
--- a/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
+++ b/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
@@ -14,20 +14,20 @@ const UNSAVED_ALERT =
     'You have unsaved changes to your authentication configurations. Click "Save and Finish" to apply these changes.';
 
 interface State {
-    error: string;
-    initError: string;
-    loading: boolean;
-    formConfigurations: AuthConfig[];
-    ssoConfigurations: AuthConfig[];
-    secondaryConfigurations: AuthConfig[];
-    primaryProviders: AuthConfigProvider[];
-    secondaryProviders: AuthConfigProvider[];
-    globalSettings: { [key: string]: any };
-    helpLink: string;
+    authCount: number;
     canEdit: boolean;
     dirtinessData: { [key: string]: AuthConfig[] };
     dirty: boolean;
-    authCount: number;
+    error: string;
+    formConfigurations: AuthConfig[];
+    globalSettings: { [key: string]: any };
+    helpLink: string;
+    initError: string;
+    loading: boolean;
+    primaryProviders: AuthConfigProvider[];
+    secondaryConfigurations: AuthConfig[];
+    secondaryProviders: AuthConfigProvider[];
+    ssoConfigurations: AuthConfig[];
 }
 
 export class App extends PureComponent<{}, Partial<State>> {

--- a/core/src/client/components/AuthConfigMasterPanel.tsx
+++ b/core/src/client/components/AuthConfigMasterPanel.tsx
@@ -143,7 +143,7 @@ export default class AuthConfigMasterPanel extends PureComponent<Props, Partial<
         }));
     };
 
-    // Whether a AuthRow modal is open
+    // Whether an AuthRow modal is open
     toggleModalOpen = (modalOpen: boolean): void => {
         this.setState({ modalOpen });
     };

--- a/core/src/client/components/AuthConfigMasterPanel.tsx
+++ b/core/src/client/components/AuthConfigMasterPanel.tsx
@@ -1,11 +1,13 @@
 import React, { PureComponent } from 'react';
 import { Panel, DropdownButton, MenuItem, Tab, Tabs } from 'react-bootstrap';
 import { LabelHelpTip } from '@labkey/components';
+
+import { LOGIN_FORM_TIP_TEXT, SSO_TIP_TEXT } from '../AuthenticationConfiguration/constants';
+
 import DragAndDropPane from './DragAndDropPane';
 import AuthRow from './AuthRow';
 import DynamicConfigurationModal from './DynamicConfigurationModal';
-import { Actions, AuthConfig, AuthConfigProvider } from "./models";
-import {LOGIN_FORM_TIP_TEXT, SSO_TIP_TEXT} from "../AuthenticationConfiguration/constants";
+import { Actions, AuthConfig, AuthConfigProvider } from './models';
 
 interface ViewOnlyAuthConfigRowsProps {
     data: AuthConfig[];
@@ -33,30 +35,22 @@ class ViewOnlyAuthConfigRows extends PureComponent<ViewOnlyAuthConfigRowsProps> 
 }
 
 interface PrimaryTabProps {
-    canEdit: boolean;
     addNewPrimaryDropdown: JSX.Element[];
+    canEdit: boolean;
     primaryTabLoginForm: JSX.Element;
     primaryTabSSO: JSX.Element;
 }
 
 class PrimaryTab extends PureComponent<PrimaryTabProps> {
     render() {
-        const {
-            addNewPrimaryDropdown,
-            primaryTabLoginForm,
-            primaryTabSSO,
-            canEdit
-        } = this.props;
+        const { addNewPrimaryDropdown, primaryTabLoginForm, primaryTabSSO, canEdit } = this.props;
 
-        return(
+        return (
             <>
                 <div className="configurations__auth-tab">
                     {canEdit && (
                         <div className="configurations__dropdown">
-                            <DropdownButton
-                                id="primary-configurations-dropdown"
-                                title="Add New Primary Configuration"
-                            >
+                            <DropdownButton id="primary-configurations-dropdown" title="Add New Primary Configuration">
                                 {addNewPrimaryDropdown}
                             </DropdownButton>
                         </div>
@@ -88,23 +82,20 @@ class PrimaryTab extends PureComponent<PrimaryTabProps> {
 }
 
 interface SecondaryTabProps {
-    canEdit: boolean;
     addNewSecondaryDropdown: JSX.Element[];
+    canEdit: boolean;
     secondaryTabDuo: JSX.Element;
 }
 
 class SecondaryTab extends PureComponent<SecondaryTabProps> {
     render() {
-        const {canEdit, addNewSecondaryDropdown, secondaryTabDuo} = this.props;
+        const { canEdit, addNewSecondaryDropdown, secondaryTabDuo } = this.props;
 
-        return(
+        return (
             <div className="configurations__auth-tab">
                 {canEdit && (
                     <div className="configurations__dropdown">
-                        <DropdownButton
-                            id="secondary-configurations-dropdown"
-                            title="Add New Secondary Configuration"
-                        >
+                        <DropdownButton id="secondary-configurations-dropdown" title="Add New Secondary Configuration">
                             {addNewSecondaryDropdown}
                         </DropdownButton>
                     </div>
@@ -117,21 +108,21 @@ class SecondaryTab extends PureComponent<SecondaryTabProps> {
 }
 
 interface Props {
-    formConfigurations: AuthConfig[];
-    ssoConfigurations: AuthConfig[];
-    secondaryConfigurations: AuthConfig[];
-    primaryProviders: AuthConfigProvider[];
-    secondaryProviders: AuthConfigProvider[];
-    helpLink: string;
-    canEdit: boolean;
     actions: Actions;
+    canEdit: boolean;
+    formConfigurations: AuthConfig[];
+    helpLink: string;
+    primaryProviders: AuthConfigProvider[];
+    secondaryConfigurations: AuthConfig[];
+    secondaryProviders: AuthConfigProvider[];
+    ssoConfigurations: AuthConfig[];
 }
 
 interface State {
-    primaryModalOpen: boolean;
-    secondaryModalOpen: boolean;
     addModalType: string | null;
     modalOpen: boolean;
+    primaryModalOpen: boolean;
+    secondaryModalOpen: boolean;
 }
 
 export default class AuthConfigMasterPanel extends PureComponent<Props, Partial<State>> {
@@ -145,14 +136,14 @@ export default class AuthConfigMasterPanel extends PureComponent<Props, Partial<
         };
     }
 
-    // Whether or not a Create New AuthConfig modal is open
+    // Whether a Create New AuthConfig modal is open
     onToggleModal = (toggled: string): void => {
         this.setState(() => ({
             [toggled]: !this.state[toggled],
         }));
     };
 
-    // Whether or not a AuthRow modal is open
+    // Whether a AuthRow modal is open
     toggleModalOpen = (modalOpen: boolean): void => {
         this.setState({ modalOpen });
     };
@@ -177,109 +168,99 @@ export default class AuthConfigMasterPanel extends PureComponent<Props, Partial<
             secondaryConfigurations,
             canEdit,
             actions,
-            helpLink
+            helpLink,
         } = this.props;
 
-        const {primaryModalOpen, secondaryModalOpen, addModalType} = this.state;
+        const { primaryModalOpen, secondaryModalOpen, addModalType } = this.state;
 
-        const addNewPrimaryDropdown =
-            Object.keys(primaryProviders).map(authOption => (
-                <MenuItem
-                    key={authOption}
-                    onClick={() => this.setState({ primaryModalOpen: true, addModalType: authOption })}>
-                    {authOption} : {primaryProviders[authOption].description}
-                </MenuItem>
-            ));
+        const addNewPrimaryDropdown = Object.keys(primaryProviders).map(authOption => (
+            <MenuItem
+                key={authOption}
+                onClick={() => this.setState({ primaryModalOpen: true, addModalType: authOption })}
+            >
+                {authOption} : {primaryProviders[authOption].description}
+            </MenuItem>
+        ));
 
-        const addNewSecondaryDropdown =
-            Object.keys(secondaryProviders).map(authOption => (
-                <MenuItem
-                    key={authOption}
-                    onClick={() => this.setState({ secondaryModalOpen: true, addModalType: authOption })}>
-                    {authOption} : {secondaryProviders[authOption].description}
-                </MenuItem>
-            ));
+        const addNewSecondaryDropdown = Object.keys(secondaryProviders).map(authOption => (
+            <MenuItem
+                key={authOption}
+                onClick={() => this.setState({ secondaryModalOpen: true, addModalType: authOption })}
+            >
+                {authOption} : {secondaryProviders[authOption].description}
+            </MenuItem>
+        ));
 
         const dbAuth = formConfigurations.slice(-1)[0];
         const isDragDisabled = this.state.modalOpen;
 
-        const primaryTabLoginForm =
-            canEdit ? (
-                <div>
-                    <DragAndDropPane
-                        configType="formConfigurations"
-                        authConfigs={formConfigurations.slice(0, -1)} // Database config is excluded from DragAndDrop
-                        providers={primaryProviders}
-                        isDragDisabled={isDragDisabled}
-                        actions={{...actions, toggleModalOpen: this.toggleModalOpen}}
-                        canEdit={canEdit}
-                    />
-
-                    <AuthRow
-                        draggable={false}
-                        toggleModalOpen={this.toggleModalOpen}
-                        authConfig={dbAuth}
-                        canEdit={canEdit}
-                    />
-                </div>
-            ) : (
-                <ViewOnlyAuthConfigRows data={formConfigurations} providers={primaryProviders} />
-            );
-
-        const primaryTabSSO =
-            canEdit ? (
+        const primaryTabLoginForm = canEdit ? (
+            <div>
                 <DragAndDropPane
-                    configType="ssoConfigurations"
-                    authConfigs={ssoConfigurations}
+                    configType="formConfigurations"
+                    authConfigs={formConfigurations.slice(0, -1)} // Database config is excluded from DragAndDrop
                     providers={primaryProviders}
                     isDragDisabled={isDragDisabled}
-                    actions={{...actions, toggleModalOpen: this.toggleModalOpen}}
+                    actions={{ ...actions, toggleModalOpen: this.toggleModalOpen }}
                     canEdit={canEdit}
                 />
-            ) : (
-                <ViewOnlyAuthConfigRows data={ssoConfigurations} providers={primaryProviders} />
-            );
 
-        const secondaryTabDuo =
-            canEdit ? (
-                <DragAndDropPane
-                    configType="secondaryConfigurations"
-                    authConfigs={secondaryConfigurations}
-                    providers={secondaryProviders}
-                    isDragDisabled={isDragDisabled}
-                    actions={{...actions, toggleModalOpen: this.toggleModalOpen}}
+                <AuthRow
+                    draggable={false}
+                    toggleModalOpen={this.toggleModalOpen}
+                    authConfig={dbAuth}
                     canEdit={canEdit}
                 />
-            ) : (
-                <ViewOnlyAuthConfigRows data={secondaryConfigurations} providers={secondaryProviders} />
-            );
+            </div>
+        ) : (
+            <ViewOnlyAuthConfigRows data={formConfigurations} providers={primaryProviders} />
+        );
 
-        const authConfig = {description: addModalType + ' Configuration', enabled: true, provider: addModalType};
-        const addNewModal = (primaryModalOpen || secondaryModalOpen) &&
-                <DynamicConfigurationModal
-                        authConfig={authConfig}
-                        modalType={
-                            primaryModalOpen
-                                ? primaryProviders[addModalType]
-                                : secondaryProviders[addModalType]
-                        }
-                        configType={this.determineConfigType(addModalType)}
-                        canEdit={canEdit}
-                        title={'New ' + addModalType + ' Configuration'}
-                        updateAuthRowsAfterSave={actions.updateAuthRowsAfterSave}
-                        closeModal={() => {
-                            this.onToggleModal(
-                                primaryModalOpen ? 'primaryModalOpen' : 'secondaryModalOpen'
-                            );
-                            this.toggleModalOpen(false);
-                        }}
-                />;
+        const primaryTabSSO = canEdit ? (
+            <DragAndDropPane
+                configType="ssoConfigurations"
+                authConfigs={ssoConfigurations}
+                providers={primaryProviders}
+                isDragDisabled={isDragDisabled}
+                actions={{ ...actions, toggleModalOpen: this.toggleModalOpen }}
+                canEdit={canEdit}
+            />
+        ) : (
+            <ViewOnlyAuthConfigRows data={ssoConfigurations} providers={primaryProviders} />
+        );
+
+        const secondaryTabDuo = canEdit ? (
+            <DragAndDropPane
+                configType="secondaryConfigurations"
+                authConfigs={secondaryConfigurations}
+                providers={secondaryProviders}
+                isDragDisabled={isDragDisabled}
+                actions={{ ...actions, toggleModalOpen: this.toggleModalOpen }}
+                canEdit={canEdit}
+            />
+        ) : (
+            <ViewOnlyAuthConfigRows data={secondaryConfigurations} providers={secondaryProviders} />
+        );
+
+        const authConfig = { description: addModalType + ' Configuration', enabled: true, provider: addModalType };
+        const addNewModal = (primaryModalOpen || secondaryModalOpen) && (
+            <DynamicConfigurationModal
+                authConfig={authConfig}
+                modalType={primaryModalOpen ? primaryProviders[addModalType] : secondaryProviders[addModalType]}
+                configType={this.determineConfigType(addModalType)}
+                canEdit={canEdit}
+                title={'New ' + addModalType + ' Configuration'}
+                updateAuthRowsAfterSave={actions.updateAuthRowsAfterSave}
+                closeModal={() => {
+                    this.onToggleModal(primaryModalOpen ? 'primaryModalOpen' : 'secondaryModalOpen');
+                    this.toggleModalOpen(false);
+                }}
+            />
+        );
 
         return (
             <Panel>
-                <Panel.Heading>
-                    Configurations
-                </Panel.Heading>
+                <Panel.Heading>Configurations</Panel.Heading>
                 <Panel.Body>
                     <a className="configurations__help-link" href={helpLink}>
                         Get help with authentication

--- a/core/src/client/components/DatabaseConfigurationModal.tsx
+++ b/core/src/client/components/DatabaseConfigurationModal.tsx
@@ -14,16 +14,16 @@ const OPTIONS_MAP = {
 };
 
 interface Props {
-    closeModal: () => void;
     canEdit: boolean;
+    closeModal: () => void;
 }
 
 interface State {
+    currentSettings: DatabasePasswordSettings;
     error: string;
+    helpLink: string;
     initError: string;
     passwordRules: DatabasePasswordRules;
-    currentSettings: DatabasePasswordSettings;
-    helpLink: string;
 }
 
 export default class DatabaseConfigurationModal extends PureComponent<Props, State> {
@@ -44,12 +44,16 @@ export default class DatabaseConfigurationModal extends PureComponent<Props, Sta
             success: Utils.getCallbackWrapper(response => {
                 this.setState({ ...response });
             }),
-            failure: Utils.getCallbackWrapper(error => {
-                console.error('Failed to get login properties', error);
-                this.setState({
-                    initError: resolveErrorMessage(error),
-                });
-            }, undefined, true),
+            failure: Utils.getCallbackWrapper(
+                error => {
+                    console.error('Failed to get login properties', error);
+                    this.setState({
+                        initError: resolveErrorMessage(error),
+                    });
+                },
+                undefined,
+                true
+            ),
         });
     };
 
@@ -76,12 +80,16 @@ export default class DatabaseConfigurationModal extends PureComponent<Props, Sta
             success: Utils.getCallbackWrapper(() => {
                 this.props.closeModal();
             }),
-            failure: Utils.getCallbackWrapper(error => {
-                console.error('Failed to save login properties', error);
-                this.setState({
-                    error: resolveErrorMessage(error),
-                });
-            }, undefined, true),
+            failure: Utils.getCallbackWrapper(
+                error => {
+                    console.error('Failed to save login properties', error);
+                    this.setState({
+                        error: resolveErrorMessage(error),
+                    });
+                },
+                undefined,
+                true
+            ),
         });
     };
 
@@ -93,11 +101,9 @@ export default class DatabaseConfigurationModal extends PureComponent<Props, Sta
         const allowEdit = canEdit && initError === undefined;
 
         return (
-            <Modal show={true} onHide={this.props.closeModal}>
+            <Modal backdrop="static" show={true} onHide={this.props.closeModal}>
                 <Modal.Header closeButton>
-                    <Modal.Title>
-                        Configure Database Authentication
-                    </Modal.Title>
+                    <Modal.Title>Configure Database Authentication</Modal.Title>
                 </Modal.Header>
 
                 <Modal.Body>
@@ -108,18 +114,15 @@ export default class DatabaseConfigurationModal extends PureComponent<Props, Sta
 
                         <span className="database-modal__field">
                             <ButtonGroup onClick={this.handleChange}>
-                                <Button
-                                    value="Weak"
-                                    name="strength"
-                                    active={strength == 'Weak'}
-                                    disabled={!allowEdit}>
+                                <Button value="Weak" name="strength" active={strength == 'Weak'} disabled={!allowEdit}>
                                     Weak
                                 </Button>
                                 <Button
                                     value="Strong"
                                     name="strength"
                                     active={strength == 'Strong'}
-                                    disabled={!allowEdit}>
+                                    disabled={!allowEdit}
+                                >
                                     Strong
                                 </Button>
                             </ButtonGroup>
@@ -132,7 +135,7 @@ export default class DatabaseConfigurationModal extends PureComponent<Props, Sta
                         <div dangerouslySetInnerHTML={{ __html: this.state.passwordRules.Weak }} />
                     </div>
 
-                    <br/>
+                    <br />
 
                     {/* this.state.passwordRules.Strong is safe server-generated HTML */}
                     <div className="bold-text"> Strong </div>
@@ -140,7 +143,7 @@ export default class DatabaseConfigurationModal extends PureComponent<Props, Sta
                         <div dangerouslySetInnerHTML={{ __html: this.state.passwordRules.Strong }} />
                     </div>
 
-                    <br/>
+                    <br />
 
                     <div className="database-modal__field-row">
                         <span>Password Expiration:</span>
@@ -154,11 +157,11 @@ export default class DatabaseConfigurationModal extends PureComponent<Props, Sta
                                     onChange={this.handleChange}
                                     value={expiration}
                                 >
-                                    {Object.keys(OPTIONS_MAP).map((option) =>
+                                    {Object.keys(OPTIONS_MAP).map(option => (
                                         <option value={option} key={option}>
                                             {OPTIONS_MAP[option]}
                                         </option>
-                                    )}
+                                    ))}
                                 </FormControl>
                             ) : (
                                 OPTIONS_MAP[expiration]
@@ -168,7 +171,12 @@ export default class DatabaseConfigurationModal extends PureComponent<Props, Sta
 
                     <div className="database-modal__bottom">
                         <div className="modal__bottom-buttons">
-                            <a target="_blank" href={this.state.helpLink} className="modal__help-link" rel="noopener noreferrer">
+                            <a
+                                target="_blank"
+                                href={this.state.helpLink}
+                                className="modal__help-link"
+                                rel="noopener noreferrer"
+                            >
                                 More about authentication
                             </a>
                             {allowEdit && (

--- a/core/src/client/components/DynamicConfigurationModal.tsx
+++ b/core/src/client/components/DynamicConfigurationModal.tsx
@@ -172,7 +172,7 @@ export default class DynamicConfigurationModal extends PureComponent<Props, Part
         const requiredFieldEmpty = emptyRequiredFields.indexOf('description') !== -1;
 
         return (
-            <Modal show={true} onHide={closeModal}>
+            <Modal backdrop="static" show={true} onHide={closeModal}>
                 <Modal.Header closeButton>
                     <Modal.Title>{modalTitle}</Modal.Title>
                 </Modal.Header>

--- a/core/src/client/components/__snapshots__/DatabaseConfigurationModal.spec.tsx.snap
+++ b/core/src/client/components/__snapshots__/DatabaseConfigurationModal.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`<DatabaseConfigurationModal/> Editable 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
-  backdrop={true}
+  backdrop="static"
   bsClass="modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
@@ -209,7 +209,7 @@ exports[`<DatabaseConfigurationModal/> View-only 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
-  backdrop={true}
+  backdrop="static"
   bsClass="modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}

--- a/core/src/client/components/__snapshots__/DynamicConfigurationModal.spec.tsx.snap
+++ b/core/src/client/components/__snapshots__/DynamicConfigurationModal.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`<DynamicConfigurationModal/> CAS Modal 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
-  backdrop={true}
+  backdrop="static"
   bsClass="modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
@@ -222,7 +222,7 @@ exports[`<DynamicConfigurationModal/> CAS Modal View-only 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
-  backdrop={true}
+  backdrop="static"
   bsClass="modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
@@ -429,7 +429,7 @@ exports[`<DynamicConfigurationModal/> Duo Modal 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
-  backdrop={true}
+  backdrop="static"
   bsClass="modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}
@@ -678,7 +678,7 @@ exports[`<DynamicConfigurationModal/> Duo Modal View-only 1`] = `
 <Modal
   animation={true}
   autoFocus={true}
-  backdrop={true}
+  backdrop="static"
   bsClass="modal"
   dialogComponentClass={[Function]}
   enforceFocus={true}


### PR DESCRIPTION
#### Rationale
It is desired that the Authentication Configuration modals not close when clicking outside their borders.

#### Related Pull Requests
* N/A

#### Changes
* Lint
* Add `backdrop="static"` to the two modals
* Update snapshot tests
