### PR TITLE
Make module dependency sorting deterministic based on module name

### DIFF
--- a/api/src/org/labkey/api/module/ModuleDependencySorter.java
+++ b/api/src/org/labkey/api/module/ModuleDependencySorter.java
@@ -44,6 +44,12 @@ public class ModuleDependencySorter
     {
         List<Pair<Module, Set<String>>> dependencies = new ArrayList<>();
         Set<String> moduleNames = new CaseInsensitiveHashSet();
+
+        // Copy the list and sort alphabetically to make the ordering deterministic
+        modules = new ArrayList<>(modules);
+        modules.sort((a, b) -> a.getName().compareToIgnoreCase(b.getName()));
+
+        // Track which dependencies need to be resolved
         for (Module module : modules)
         {
             Pair<Module, Set<String>> dependencyInfo = new Pair<>(module, new CaseInsensitiveHashSet(module.getModuleDependenciesAsSet()));
@@ -51,8 +57,8 @@ public class ModuleDependencySorter
             moduleNames.add(module.getName());
         }
 
+        // Find all missing dependencies
         MultiValuedMap<String, String> missingDependencies = new ArrayListValuedHashMap<>();
-
         for (Pair<Module, Set<String>> dependency : dependencies)
         {
             for (String dependencyName : dependency.getValue())
@@ -75,6 +81,7 @@ public class ModuleDependencySorter
 //  Uncomment this to generate an SVG graph of all module dependencies
 //        graphModuleDependencies(dependencies, "all");
 
+        // Now order based on dependencies
         List<Module> result = new ArrayList<>(modules.size());
         while (!dependencies.isEmpty())
         {


### PR DESCRIPTION
#### Rationale
Module ordering is not deterministic, as it currently relies on the order of the file list, which is OS-specific

#### Changes
* Sort first by module name, and then by module dependencies, to ensure a deterministic order