### PR TITLE
Issue 48029: Improve channel-based file copy

### DIFF
--- a/api/src/org/labkey/api/util/FileStream.java
+++ b/api/src/org/labkey/api/util/FileStream.java
@@ -76,39 +76,7 @@ public interface FileStream
         {
             throw new IOException("Destination file [" + dest.getAbsolutePath() + "] already exists and could not be deleted");
         }
-
-        boolean success = false;
-        long expected = s.getSize();
-        long actual = 0;
-        long bytesCopied;
-        try (ReadableByteChannel cIn = s.getInputChannel();
-             FileOutputStream fOut = new FileOutputStream(dest);
-             FileChannel cOut = fOut.getChannel())
-        {
-            LOG.debug("Starting to transfer to " + dest + ", expecting " + (expected == -1 ? "an unknown number" : Long.toString(expected)) + " bytes");
-            do
-            {
-                bytesCopied = cOut.transferFrom(cIn, actual, Long.MAX_VALUE);
-                actual += bytesCopied;
-                if (actual != expected && bytesCopied != 0)
-                {
-                    LOG.debug("Still transferring to " + dest + ", " + actual + " bytes transferred so far");
-                }
-            }
-            while (bytesCopied != 0);
-            success = true;
-        }
-        finally
-        {
-            if (success)
-            {
-                LOG.debug("Finished transferring " + actual + " bytes to " + dest);
-            }
-            else
-            {
-                LOG.debug("Failed during transfer, but successfully copied at least " + actual + " bytes to " + dest);
-            }
-        }
+        FileUtil.copyFile(s.getInputChannel(), s.getSize(), dest);
     }
 
 

--- a/api/src/org/labkey/api/util/FileStream.java
+++ b/api/src/org/labkey/api/util/FileStream.java
@@ -76,7 +76,10 @@ public interface FileStream
         {
             throw new IOException("Destination file [" + dest.getAbsolutePath() + "] already exists and could not be deleted");
         }
-        FileUtil.copyFile(s.getInputChannel(), s.getSize(), dest);
+        try (ReadableByteChannel in = s.getInputChannel())
+        {
+            FileUtil.copyFile(in, s.getSize(), dest);
+        }
     }
 
 


### PR DESCRIPTION
#### Rationale
Channel-based copies aren't guaranteed to copy all bytes in a single call, so we need to loop until we're done.

#### Changes
* Add some logging
* Loop until all bytes have been consumed
* Refactor to allow reuse in WebDav PUT too