### PR TITLE
Issue 45464: Strict OOXML documents aren't supported, better error

### DIFF
--- a/api/src/org/labkey/api/reader/ExcelFactory.java
+++ b/api/src/org/labkey/api/reader/ExcelFactory.java
@@ -204,7 +204,14 @@ public class ExcelFactory
                 sheetNames.add(ctSheet.getName());
             }
         };
-        return getMetadata(wb, sheetNames);
+        try
+        {
+            return getMetadata(wb, sheetNames);
+        }
+        catch (IllegalArgumentException | POIXMLException e)
+        {
+            throw reportErrorOpeningExcelFile(e);
+        }
     }
 
 
@@ -265,16 +272,18 @@ public class ExcelFactory
         }
         catch (IllegalArgumentException | POIXMLException e)
         {
-            // Issue 45464 - improve error message for .xlsx variant that's unsupported by POI
-            if (e.getMessage() != null && e.getMessage().contains("57699"))
-            {
-                throw new ExcelFormatException("Unable to open file as an Excel document. \"Strict Open XML Spreadsheet\" versions of .xlsx files are not supported.", e);
-            }
-            else
-            {
-                throw new ExcelFormatException("Unable to open file as an Excel document. " + (e.getMessage() == null ? "" : e.getMessage()), e);
-            }
+            throw reportErrorOpeningExcelFile(e);
         }
+    }
+
+    private static ExcelFormatException reportErrorOpeningExcelFile(RuntimeException e)
+    {
+        // Issue 45464 - improve error message for .xlsx variant that's unsupported by POI
+        if (e.getMessage() != null && e.getMessage().contains("57699"))
+        {
+            return new ExcelFormatException("Unable to open file as an Excel document. \"Strict Open XML Spreadsheet\" versions of .xlsx files are not supported.", e);
+        }
+        return new ExcelFormatException("Unable to open file as an Excel document. " + (e.getMessage() == null ? "" : e.getMessage()), e);
     }
 
     /**


### PR DESCRIPTION
#### Rationale
There's a second codepath that may encounter strict OOXML files that needs to do a better job of reporting the problem

#### Changes
* Do the same exception wrapping as the original codepath