### PR TITLE
null check for new method

### DIFF
--- a/api/src/org/labkey/api/data/DisplayColumn.java
+++ b/api/src/org/labkey/api/data/DisplayColumn.java
@@ -551,7 +551,7 @@ public abstract class DisplayColumn extends RenderColumn
         Object value = getDisplayValue(ctx);
         if (null == value)
         {
-            if (this.getColumnInfo().isLookup())
+            if (this.getColumnInfo() != null && this.getColumnInfo().isLookup())
             {
                 value = ctx.get(this.getColumnInfo().getName());
 


### PR DESCRIPTION
#### Rationale
A recent [PR](https://github.com/LabKey/platform/pull/4465) introduced a NPE in certain situations. 

Not every `DisplayColumn` is backed by a `ColumnInfo`, for example: `SpecimenRequestDisplayColumn`. 