### PR TITLE
Fix IssueObject JSON serialization, #48059

### DIFF
--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
+import org.json.JSONString;
 import org.labkey.api.attachments.Attachment;
 import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.compliance.ComplianceFolderSettings;
@@ -63,7 +64,7 @@ import java.util.Set;
  * Represents a user in the LabKey system, typically tied to a specific individual, but see {@link GuestUser} for a
  * catch-all implementation representing anonymous users.
  */
-public class User extends UserPrincipal implements Serializable, Cloneable
+public class User extends UserPrincipal implements Serializable, Cloneable, JSONString
 {
     private String _firstName = null;
     private String _lastName = null;
@@ -675,5 +676,11 @@ public class User extends UserPrincipal implements Serializable, Cloneable
     public void setExpirationDate(Date expirationDate)
     {
         _expirationDate = expirationDate;
+    }
+
+    @Override
+    public String toJSONString()
+    {
+        return String.valueOf(getUserId());
     }
 }

--- a/issues/src/org/labkey/issue/model/IssueObject.java
+++ b/issues/src/org/labkey/issue/model/IssueObject.java
@@ -25,6 +25,7 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.Entity;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.Sort;
+import org.labkey.api.data.Transient;
 import org.labkey.api.issues.Issue;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
@@ -549,6 +550,8 @@ public class IssueObject extends Entity implements Serializable, Cloneable, Issu
         return getNotifyListEmail(getNotifyList(), null);
     }
 
+    @Transient
+    @JSONPropertyIgnore
     @Override
     public List<Pair<User, ValidEmail>> getNotifyListUserEmail()
     {


### PR DESCRIPTION
#### Rationale
`PageFlowUtil.encodeObject()` was throwing when attempting to serialize an `IssueObject` because `JSONObject` was performing very aggressive interrogation of `User` objects returned from `getNotifyListUserEmail()`. This blocked updating of issues that included a notify list. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48059

The main fix is to annotate `User` to JSON serialize as its int user ID. For good measure, we also mark `getNotifyListUserEmail()` with `@Transient` (so BeanUtils skips this method on the top-level issue object) and `@JSONPropertyIgnore` so `JSONObject` skips this method when encountering embedded issues, for example, issues referenced from comments.
