### PR TITLE
Don't recompute RelationColumn.getUniqueName() on the fly.

### DIFF
--- a/query/src/org/labkey/query/sql/QValuesTable.java
+++ b/query/src/org/labkey/query/sql/QValuesTable.java
@@ -219,12 +219,6 @@ public class QValuesTable extends QTable
                 RelationColumn rc = new RelationColumn()
                 {
                     @Override
-                    public String getUniqueName()
-                    {
-                        return super._defaultUniqueName(_QueryRelation.this);
-                    }
-
-                    @Override
                     public Collection<RelationColumn> gatherInvolvedSelectColumns(Collection<RelationColumn> collect)
                     {
                         // VALUES columns don't need any fix-up.  Nothing to do here.

--- a/query/src/org/labkey/query/sql/QueryLookupWrapper.java
+++ b/query/src/org/labkey/query/sql/QueryLookupWrapper.java
@@ -493,7 +493,6 @@ public class QueryLookupWrapper extends AbstractQueryRelation implements QueryRe
         final AbstractQueryRelation _table;
         final FieldKey _key;
         final String _alias;
-        final String _uniqueName;
         ColumnLogging _columnLogging = null;
         PHI _phi;
         
@@ -502,7 +501,6 @@ public class QueryLookupWrapper extends AbstractQueryRelation implements QueryRe
             _table = table;
             _key = key;
             _alias = alias;
-            _uniqueName = super._defaultUniqueName(QueryLookupWrapper.this);
         }
 
         @Override
@@ -515,12 +513,6 @@ public class QueryLookupWrapper extends AbstractQueryRelation implements QueryRe
         AbstractQueryRelation getTable()
         {
             return _table;
-        }
-
-        @Override
-        final public String getUniqueName()
-        {
-            return _uniqueName;
         }
 
         @Override

--- a/query/src/org/labkey/query/sql/QueryPivot.java
+++ b/query/src/org/labkey/query/sql/QueryPivot.java
@@ -623,7 +623,6 @@ public class QueryPivot extends AbstractQueryRelation
         private final @NotNull String _name;
         private final IConstant _c;
 
-        private final String _uniqueName;
 
         public _PivotedAggColumn(FieldKey key, String alias, @NotNull RelationColumn agg, CrosstabMember member, @NotNull String name, IConstant c)
         {
@@ -633,14 +632,8 @@ public class QueryPivot extends AbstractQueryRelation
             _member = member;
             _name = name;
             _c = c;
-            _uniqueName = super._defaultUniqueName(QueryPivot.this);
 
             _query.addUniqueRelationColumn(this);
-        }
-
-        public String getUniqueName()
-        {
-            return _uniqueName;
         }
 
         @Override

--- a/query/src/org/labkey/query/sql/QueryTable.java
+++ b/query/src/org/labkey/query/sql/QueryTable.java
@@ -464,7 +464,6 @@ public class QueryTable extends AbstractQueryRelation implements QueryRelation.C
         ColumnInfo _col;
         final String _alias;
         final TableColumn _parent;
-        final String _uniqueName;
 
         TableColumn(@NotNull FieldKey key, @NotNull ColumnInfo col, @Nullable TableColumn parent)
         {
@@ -476,14 +475,8 @@ public class QueryTable extends AbstractQueryRelation implements QueryRelation.C
             _col = col;
             _alias = _aliasManager.decideAlias(col.getAlias());
             _parent = parent;
-            _uniqueName = super._defaultUniqueName(QueryTable.this);
 
             _query.addUniqueRelationColumn(this);
-        }
-
-        public String getUniqueName()
-        {
-            return _uniqueName;
         }
 
         @Override

--- a/query/src/org/labkey/query/sql/QueryUnion.java
+++ b/query/src/org/labkey/query/sql/QueryUnion.java
@@ -92,6 +92,7 @@ public class QueryUnion extends AbstractQueryRelation implements ColumnResolving
     {
         super(query);
         MemTracker.getInstance().put(this);
+        setAlias("union_" + query.incrementAliasCounter());
     }
 
     QueryUnion(Query query, CommonTableExpressions.QueryTableWith tableWith)
@@ -725,12 +726,6 @@ public class QueryUnion extends AbstractQueryRelation implements ColumnResolving
             _name = new FieldKey(null, name);
             _first = col;
             _ordinal = ordinal;
-        }
-
-        @Override
-        public String getUniqueName()
-        {
-            return super._defaultUniqueName(QueryUnion.this);
         }
 
         private void addSourceColumn(UnionSourceColumn col)


### PR DESCRIPTION
#### Rationale
AbstractQueryRelation._defaultUniqueName() uses get QueryRelation.getAlias() which can change.  Hoever, RelationColumn.getUniqueName() should not change!

Update pattern to always save the generated uniqueName so it will not change.

Issue 48066

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
