### PR TITLE
Stop serializing old beans into update forms

### DIFF
--- a/announcements/src/org/labkey/announcements/update.jsp
+++ b/announcements/src/org/labkey/announcements/update.jsp
@@ -59,7 +59,6 @@
 <labkey:form method="post" action='<%=baseUrl.setAction(AnnouncementsController.UpdateAction.class)%>' enctype="multipart/form-data" onsubmit="return onSubmit(this);">
 <labkey:input type="hidden" name="rowId" value="<%=ann.getRowId()%>"/>
 <labkey:input type="hidden" name="entityId" value="<%=ann.getEntityId()%>"/>
-<labkey:input type="hidden" name=".oldValues" value="<%=PageFlowUtil.encodeObject(ann)%>"/>
 <%=generateReturnUrlFormField(bean.returnURL)%>
 <table><%
 

--- a/api/src/org/labkey/api/collections/CollectionUtils.java
+++ b/api/src/org/labkey/api/collections/CollectionUtils.java
@@ -144,10 +144,13 @@ public class CollectionUtils
 
     /**
      * Attempts to determine if the provided Set implementation is stable-ordered, i.e., its iteration order matches its
-     * insertion order. Currently, LinkedHashSet, Collections.emptySet(), and Collections.singleton() are considered
-     * stable-ordered; HashSet and TreeSet are not. Sets returned by Set.of() are also not considered stable-ordered;
+     * insertion order. Currently, LinkedHashSet, Collections.singleton(), and Collections.emptySet() are considered
+     * stable-ordered; HashSet and TreeSet are not. Sets returned by Set.of() are also considered not stable-ordered;
      * although they seem to iterate in insertion order in current JVMs, their JavaDoc clearly states that "the
-     * iteration order of set elements is unspecified and is subject to change."
+     * iteration order of set elements is unspecified and is subject to change." Similarly, we used to special case
+     * unstable sets with size 1, allowing them since they obviously iterate in a predicable manner. However, we then
+     * encountered code paths that usually pass a one-element set, but in some circumstances pass a larger set. We now
+     * flag all unstable sets regardless of size. If you want to pass a single value then use Collections.singleton().
      */
     public static boolean isStableOrderedSet(@NotNull Set<?> set)
     {

--- a/api/src/org/labkey/api/data/TableSelector.java
+++ b/api/src/org/labkey/api/data/TableSelector.java
@@ -197,7 +197,7 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
     */
     private static boolean isStableOrdered(Collection<?> collection)
     {
-        return (!(collection instanceof Set set) || CollectionUtils.isStableOrderedSet(set));
+        return (!(collection instanceof Set<?> set) || CollectionUtils.isStableOrderedSet(set));
     }
 
     @NotNull

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -763,6 +763,11 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
         return null == getTable() ? null : getTable().getColumn(name);
     }
 
+    // Allow forms to opt out of deserializing old values JSON
+    protected boolean deserializeOldValues()
+    {
+        return true;
+    }
 
     @Override
     public void setViewContext(@NotNull ViewContext context)
@@ -788,18 +793,23 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
         if (null != StringUtils.trimToNull(pkString) && null != _tinfo)
             setPkVals(pkString);
 
-        try
+        if (deserializeOldValues())
         {
-            String oldVals = request.getParameter(DataRegion.OLD_VALUES_NAME);
-            if (null != StringUtils.trimToNull(oldVals))
+            try
             {
-                String className = getDynaClass().getName();
-                Class beanClass = "className".equals(className) ? Map.class : Class.forName(className);
-                _oldValues = PageFlowUtil.decodeObject(beanClass, oldVals);
-                _isDataLoaded = true;
+                String oldVals = request.getParameter(DataRegion.OLD_VALUES_NAME);
+                if (null != StringUtils.trimToNull(oldVals))
+                {
+                    String className = getDynaClass().getName();
+                    Class beanClass = "className".equals(className) ? Map.class : Class.forName(className);
+                    _oldValues = PageFlowUtil.decodeObject(beanClass, oldVals);
+                    _isDataLoaded = true;
+                }
+            }
+            catch (Exception ignored)
+            {
             }
         }
-        catch (Exception ignored) {}
     }
 
     @Override

--- a/api/src/org/labkey/api/study/TimepointType.java
+++ b/api/src/org/labkey/api/study/TimepointType.java
@@ -21,9 +21,7 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.util.SafeToRenderEnum;
 
 /**
- * List of ways that a study can group events based on their time.
- * User: markigra
- * Date: Oct 31, 2007
+ * List of ways that a study can group events based on their time
  */
 public enum TimepointType implements SafeToRenderEnum
 {

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -933,6 +933,8 @@ public class IssuesController extends SpringActionController
         {
             if (!form.getSkipPost())
             {
+                IssueObject oldIssue = getIssue(form.getIssueId(), false);
+                form.setOldValues(oldIssue);
                 Issue.action action = form.getAction();
                 IssueObject issue = form.getBean();
 

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -2209,6 +2209,12 @@ public class IssuesController extends SpringActionController
             return map;
         }
 
+        @Override
+        protected boolean deserializeOldValues()
+        {
+            return false;
+        }
+
         public Issue.action getAction()
         {
             if (getStrings().containsKey("action"))

--- a/issues/src/org/labkey/issue/view/updateView.jsp
+++ b/issues/src/org/labkey/issue/view/updateView.jsp
@@ -445,7 +445,6 @@
     {%>
         <%= generateReturnUrlFormField(bean.getReturnURL()) %> <%
     }%>
-    <input type="hidden" name=".oldValues" value="<%=PageFlowUtil.encodeObject(bean.getPrevIssue())%>">
     <input type="hidden" name="action" value="<%=h(bean.getAction().name())%>">
     <input type="hidden" name="dirty" value="false">
 </labkey:form>

--- a/study/src/org/labkey/study/controllers/VisitForm.java
+++ b/study/src/org/labkey/study/controllers/VisitForm.java
@@ -15,20 +15,15 @@
  */
 package org.labkey.study.controllers;
 
-import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.DataRegion;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.TimepointType;
 import org.labkey.api.study.Visit;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ViewForm;
 import org.labkey.study.model.StudyManager;
 import org.labkey.study.model.VisitImpl;
 import org.springframework.validation.Errors;
 
-import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
 import java.math.BigDecimal;
 
 /**
@@ -37,6 +32,7 @@ import java.math.BigDecimal;
  */
 public class VisitForm extends ViewForm
 {
+    private int _id;
     private int[] _datasetIds;
     private String[] _datasetStatus;
     private BigDecimal _sequenceNumMin;
@@ -56,7 +52,6 @@ public class VisitForm extends ViewForm
     {
     }
 
-
     public void validate(Errors errors, Study study)
     {
         if (study.getTimepointType() == TimepointType.CONTINUOUS)
@@ -65,19 +60,11 @@ public class VisitForm extends ViewForm
             return;
         }
 
-        HttpServletRequest request = getRequest();
-        String oldValues = request.getParameter(DataRegion.OLD_VALUES_NAME);
+        int rowId = getId();
 
-        if (null != StringUtils.trimToNull(oldValues))
+        if (0 != rowId)
         {
-            try
-            {
-                _visit = PageFlowUtil.decodeObject(VisitImpl.class, oldValues);
-            }
-            catch (IOException x)
-            {
-                throw new RuntimeException(x);
-            }
+            _visit = StudyManager.getInstance().getVisitForRowId(study, rowId).createMutable();
         }
 
         //check for null min/max sequence numbers
@@ -103,12 +90,6 @@ public class VisitForm extends ViewForm
         if (visit.getSequenceNumMin().compareTo(visit.getSequenceNumMax()) > 0)
         {
             errors.reject(null, "The minimum value cannot be greater than the maximum value for the visit range.");
-/*
-                double min = visit.getSequenceNumMax();
-                double max = visit.getSequenceNumMin();
-                visit.setSequenceNumMax(max);
-                visit.setSequenceNumMin(min);
-*/
         }
         setBean(visit);
     }
@@ -119,7 +100,6 @@ public class VisitForm extends ViewForm
         Study visitStudy = StudyManager.getInstance().getStudyForVisits(study);
         return visitStudy.getContainer();
     }
-
 
     public VisitImpl getBean()
     {
@@ -163,6 +143,16 @@ public class VisitForm extends ViewForm
         setLabel(bean.getLabel());
         setCohortId(bean.getCohortId());
         setSequenceNumHandling(bean.getSequenceNumHandling());
+    }
+
+    public int getId()
+    {
+        return _id;
+    }
+
+    public void setId(int id)
+    {
+        _id = id;
     }
 
     public String[] getDatasetStatus()

--- a/study/src/org/labkey/study/view/editVisit.jsp
+++ b/study/src/org/labkey/study/view/editVisit.jsp
@@ -48,7 +48,6 @@
 %>
 <labkey:errors/>
 <labkey:form action="<%=urlFor(VisitSummaryAction.class)%>" method="POST">
-<input type="hidden" name=".oldValues" value="<%=PageFlowUtil.encodeObject(visit)%>">
 <input type="hidden" name="id" value="<%=visit.getRowId()%>">
     <table class="lk-fields-table">
         <tr>


### PR DESCRIPTION
#### Rationale
Serializing beans into update forms is problematic and seems unnecessary. This does away with serialization in issue, announcement, and visit updates.

- Old code path: serialize old bean (via compressed JSON) into the form, deserialize posted JSON old values into a newly constructed bean, overlay newly posted strings onto that bean
- New code path: after post, read old bean from the database, overlay new posted strings onto it

Not yet tackling optimistic concurrency checks, but that shouldn't be difficult to add.