### PR TITLE
ELN: Resolve references via search (bug bash)

### DIFF
--- a/api/src/org/labkey/api/exp/ExperimentProtocolHandler.java
+++ b/api/src/org/labkey/api/exp/ExperimentProtocolHandler.java
@@ -14,15 +14,15 @@ public interface ExperimentProtocolHandler extends Handler<ExpProtocol>
     /**
      * Get a query reference for the protocol type.
      */
-    public @Nullable QueryRowReference getQueryRowReference(ExpProtocol protocol);
+    @Nullable QueryRowReference getQueryRowReference(ExpProtocol protocol);
 
     /**
      * Get a query reference for the run of the protocol type.
      */
-    public @Nullable QueryRowReference getQueryRowReference(ExpProtocol protocol, ExpRun run);
+    @Nullable QueryRowReference getQueryRowReference(ExpProtocol protocol, ExpRun run);
 
     /**
      * Get a query reference for the protocol application of the protocol type.
      */
-    public @Nullable QueryRowReference getQueryRowReference(ExpProtocol protocol, ExpProtocolApplication app);
+    @Nullable QueryRowReference getQueryRowReference(ExpProtocol protocol, ExpProtocolApplication app);
 }

--- a/api/src/org/labkey/api/exp/api/ExpExperiment.java
+++ b/api/src/org/labkey/api/exp/api/ExpExperiment.java
@@ -34,7 +34,7 @@ public interface ExpExperiment extends ExpObject
      * If this experiment is a batch, it only allows runs that are of the same parent protocol.
      * @return the protocol for which this object is a batch. May be null.
      */
-    ExpProtocol getBatchProtocol();
+    @Nullable ExpProtocol getBatchProtocol();
 
     /**
      * If this experiment is a batch, it only allows runs that are of the same parent protocol.
@@ -65,9 +65,9 @@ public interface ExpExperiment extends ExpObject
 
     boolean isHidden();
 
-
     /** Stored in the exp.experimentrun table */
     String getComments();
+
     /** Stored in the exp.experimentrun table */
     void setComments(String comments);
 

--- a/assay/src/org/labkey/assay/AssayBatchDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayBatchDocumentProvider.java
@@ -59,6 +59,7 @@ public class AssayBatchDocumentProvider implements SearchService.DocumentProvide
 
         props.put(SearchService.PROPERTY.identifiersHi.toString(), StringUtils.join(identifiersHi, " "));
         props.put(SearchService.PROPERTY.identifiersMed.toString(), StringUtils.join(identifiersMed, " "));
+        props.put(SearchService.PROPERTY.keywordsLo.toString(), "Batch");
         props.put(SearchService.PROPERTY.categories.toString(), getSearchCategory().getName());
         props.put(SearchService.PROPERTY.title.toString(), "Assay Batch - " + batch.getName());
 

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -85,7 +85,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.labkey.api.assay.DefaultDataTransformer.LEGACY_SESSION_COOKIE_NAME_REPLACEMENT;
 import static org.labkey.api.assay.DefaultDataTransformer.LEGACY_SESSION_ID_REPLACEMENT;
@@ -174,7 +173,7 @@ public class AssayModule extends SpringModule
                 result.addAll(AssayService.get().getAssayProtocols(container)
                     .stream()
                     .map(protocol -> new AssayRunType(protocol, container))
-                    .collect(Collectors.toList()));
+                    .toList());
             }
             return result;
         });

--- a/experiment/src/org/labkey/experiment/api/ExpExperimentImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpExperimentImpl.java
@@ -17,6 +17,9 @@
 package org.labkey.experiment.api;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AssayProtocolSchema;
+import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.assay.AssayService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SQLFragment;
@@ -69,6 +72,27 @@ public class ExpExperimentImpl extends ExpIdentifiableEntityImpl<Experiment> imp
     @Override
     public @Nullable QueryRowReference getQueryRowReference()
     {
+        return getQueryRowReference(null);
+    }
+
+    @Override
+    public @Nullable QueryRowReference getQueryRowReference(@Nullable User user)
+    {
+        // If an ExpExperiment represents an Assay Batch, then resolve the QueryRowReference more specifically
+        // to the Assay Batch.
+        // NK: This could be done via a Handler pattern (similar to ExperimentProtocolHandler) but given
+        // the current narrow use case for Assay Batches I've elected to just resolve them directly here.
+        ExpProtocol protocol = getBatchProtocol();
+        if (protocol != null)
+        {
+            AssayProvider provider = AssayService.get().getProvider(protocol);
+            if (provider != null)
+            {
+                AssayProtocolSchema schema = provider.createProtocolSchema(user, protocol.getContainer(), protocol, null);
+                return new QueryRowReference(protocol.getContainer(), schema.getSchemaPath(), AssayProtocolSchema.BATCHES_TABLE_NAME, FieldKey.fromParts(ExpExperimentTable.Column.RowId.name()), getRowId());
+            }
+        }
+
         return new QueryRowReference(getContainer(), ExpSchema.SCHEMA_EXP, ExpSchema.TableType.RunGroups.name(), FieldKey.fromParts(ExpExperimentTable.Column.RowId.name()), getRowId());
     }
 
@@ -113,7 +137,7 @@ public class ExpExperimentImpl extends ExpIdentifiableEntityImpl<Experiment> imp
     }
 
     @Override
-    public ExpProtocol getBatchProtocol()
+    public @Nullable ExpProtocol getBatchProtocol()
     {
         if (_object.getBatchProtocolId() == null)
         {


### PR DESCRIPTION
#### Rationale
This seeks to make it easier to resolve assay batch query details from search results. When an assay batch is returned in a search result the extended serialized data includes query information about the `ExpExperiment`. This takes it a step further and attempts to resolve assay batch query information for an `ExpExperiment` which is likely more useful/relevant.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/109
- https://github.com/LabKey/platform/pull/4503
- https://github.com/LabKey/biologics/pull/2175
- https://github.com/LabKey/sampleManagement/pull/1887
- https://github.com/LabKey/labbook/pull/503

#### Changes
* Update `ExpExperiment.getQueryRowReference` to resolve assay batch query information.
