### PR TITLE
TableViewForms must now opt in to old values deserialization

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -1704,12 +1704,6 @@ public class AnnouncementsController extends SpringActionController
             return _stringValues.get("parentid");
         }
 
-        @Override
-        protected boolean deserializeOldValues()
-        {
-            return false;
-        }
-
         AnnouncementModel selectAnnouncement()
         {
             if (null == _selectedAnnouncementModel)

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -23,7 +23,6 @@ import org.apache.commons.beanutils.DynaClass;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -39,6 +38,7 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
@@ -68,7 +68,7 @@ import java.util.Set;
  */
 public class TableViewForm extends ViewForm implements DynaBean, HasBindParameters
 {
-    private static final Logger _log = LogManager.getLogger(TableViewForm.class);
+    private static final Logger _log = LogHelper.getLogger(TableViewForm.class, "Table operation warnings");
 
     protected Map<String, String> _stringValues = new CaseInsensitiveHashMap<>();
     protected Map<String, Object> _values = null;
@@ -763,10 +763,10 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
         return null == getTable() ? null : getTable().getColumn(name);
     }
 
-    // Allow forms to opt out of deserializing old values JSON
+    // Forms must override and return true to opt in to deserializing old values JSON
     protected boolean deserializeOldValues()
     {
-        return true;
+        return false;
     }
 
     @Override

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -37,6 +37,7 @@ import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
@@ -83,6 +84,8 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
 
     public static final String DATA_SUBMIT_NAME = ".dataSubmit";
     public static final String BULK_UPDATE_NAME = ".bulkUpdate";
+    // TODO: Remove in 23.8
+    public static final String EXPERIMENTAL_DESERIALIZE_BEANS = "experimental-deserialize-beans-in-forms";
 
     /**
      * Creates a TableViewForm with no underlying dynaclass.
@@ -763,10 +766,10 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
         return null == getTable() ? null : getTable().getColumn(name);
     }
 
-    // Forms must override and return true to opt in to deserializing old values JSON
+    // Forms can override and return true to opt in to always deserializing old values JSON
     protected boolean deserializeOldValues()
     {
-        return false;
+        return AppProps.getInstance().isExperimentalFeatureEnabled(EXPERIMENTAL_DESERIALIZE_BEANS);
     }
 
     @Override

--- a/api/src/org/labkey/api/query/QueryUpdateForm.java
+++ b/api/src/org/labkey/api/query/QueryUpdateForm.java
@@ -83,4 +83,10 @@ public class QueryUpdateForm extends TableViewForm
     {
         return (_ignorePrefix ? "" : PREFIX) + column.getName();
     }
+
+    @Override
+    protected boolean deserializeOldValues()
+    {
+        return true;
+    }
 }

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -282,6 +282,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.labkey.api.data.TableViewForm.EXPERIMENTAL_DESERIALIZE_BEANS;
 import static org.labkey.api.settings.StashedStartupProperties.homeProjectFolderType;
 import static org.labkey.api.settings.StashedStartupProperties.homeProjectResetPermissions;
 import static org.labkey.api.settings.StashedStartupProperties.homeProjectWebparts;
@@ -1039,6 +1040,10 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_BLOCKER,
                 "Block malicious clients",
                 "Reject requests from clients that appear malicious.  Turn this feature off if you want to run a security scanner.",
+                false);
+        AdminConsole.addExperimentalFeatureFlag(EXPERIMENTAL_DESERIALIZE_BEANS,
+                "Deserialize objects from update forms",
+                "We no longer deserialize objects encoded into update forms. Turn this feature on if the removal of object deserialization is causing specific update operations to fail.",
                 false);
 
         if (null != PropertyService.get())

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentForm.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentForm.java
@@ -36,4 +36,10 @@ public class ExperimentForm extends BeanViewForm<Experiment>
         super(Experiment.class, ExperimentServiceImpl.get().getTinfoExperiment());
         setBean(exp);
     }
+
+    @Override
+    protected boolean deserializeOldValues()
+    {
+        return true;
+    }
 }

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -2209,12 +2209,6 @@ public class IssuesController extends SpringActionController
             return map;
         }
 
-        @Override
-        protected boolean deserializeOldValues()
-        {
-            return false;
-        }
-
         public Issue.action getAction()
         {
             if (getStrings().containsKey("action"))


### PR DESCRIPTION
#### Rationale
We want to eliminate compressed JSON object serialization/deserialization in `TableViewForm`. The related PR eliminated the use of this mechanism for issue, announcement, and visit updates. This PR takes the next step: turning off deserialization for all actions, by default.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4502

#### Changes
* Individual forms can temporarily re-enable de-serialization by overriding `deserializeOldValues()`
* Re-enable de-serialization on QueryUpdateForm - that seems sufficient to appease all the platform tests
* Add an experimental feature to re-enable de-serialization, in case a client deployment discovers failing actions