### PR TITLE
Add support for moving ELNs between containers

### DIFF
--- a/announcements/src/org/labkey/announcements/api/AnnouncementServiceImpl.java
+++ b/announcements/src/org/labkey/announcements/api/AnnouncementServiceImpl.java
@@ -215,7 +215,13 @@ public class AnnouncementServiceImpl implements AnnouncementService
         }
         return new AnnouncementImpl(model);
     }
-    
+
+    @Override
+    public int updateContainer(List<String> discussionSrcIds, Container targetContainer, User u)
+    {
+        return AnnouncementManager.updateContainer(discussionSrcIds, targetContainer, u);
+    }
+
     @Override
     public void deleteAnnouncement(Announcement announcement)
     {

--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -701,13 +701,7 @@ public class AnnouncementManager
 
     public static int updateContainer(List<String> discussionSrcIds, Container targetContainer, User user)
     {
-        int numUpdated = 0;
-        try (DbScope.Transaction transaction = _comm.getSchema().getScope().ensureTransaction())
-        {
-            numUpdated = ContainerManager.updateContainer(_comm.getTableInfoAnnouncements(), "discussionSrcIdentifier", discussionSrcIds, targetContainer, user, false);
-            transaction.commit();
-        }
-        return numUpdated;
+        return ContainerManager.updateContainer(_comm.getTableInfoAnnouncements(), "discussionSrcIdentifier", discussionSrcIds, targetContainer, user, false);
     }
 
 

--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -699,6 +699,17 @@ public class AnnouncementManager
         return result;
     }
 
+    public static int updateContainer(List<String> discussionSrcIds, Container targetContainer, User user)
+    {
+        int numUpdated = 0;
+        try (DbScope.Transaction transaction = _comm.getSchema().getScope().ensureTransaction())
+        {
+            numUpdated = ContainerManager.updateContainer(_comm.getTableInfoAnnouncements(), "discussionSrcIdentifier", discussionSrcIds, targetContainer, user, false);
+            transaction.commit();
+        }
+        return numUpdated;
+    }
+
 
     private static void deleteAnnouncement(AnnouncementModel ann)
     {

--- a/api/src/org/labkey/api/announcements/api/AnnouncementService.java
+++ b/api/src/org/labkey/api/announcements/api/AnnouncementService.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
+import org.labkey.api.util.GUID;
 
 import java.util.List;
 
@@ -64,6 +65,9 @@ public interface AnnouncementService
 
     // Update
     Announcement updateAnnouncement(int RowId, Container c, User u, String title, String body);
+
+    // move announcements to the given target container
+    int updateContainer(List<String> discussionSrcIds, Container targetContainer, User u);
 
     // Delete
     void deleteAnnouncement(Announcement announcement);

--- a/api/src/org/labkey/api/attachments/AttachmentDirectory.java
+++ b/api/src/org/labkey/api/attachments/AttachmentDirectory.java
@@ -17,6 +17,7 @@
 package org.labkey.api.attachments;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.Container;
 import org.labkey.api.files.MissingRootDirectoryException;
 import org.labkey.api.security.User;
 
@@ -37,6 +38,7 @@ public interface AttachmentDirectory extends AttachmentParent
     @Deprecated
     File getFileSystemDirectory() throws MissingRootDirectoryException;
     Path getFileSystemDirectoryPath() throws MissingRootDirectoryException;
+    Path getFileSystemDirectoryPath(Container container) throws MissingRootDirectoryException;
 
     void addAttachment(User user, AttachmentFile attachment) throws IOException;
     void deleteAttachment(User user, @Nullable String name);

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -2552,6 +2552,20 @@ public class ContainerManager
         return moveFromProjectToChild || moveFromChildToProject || moveFromChildToSibling;
     }
 
+    public static int updateContainer(TableInfo dataTable, String idField, Collection<?> ids, Container targetContainer, User user, boolean withModified)
+    {
+        SQLFragment dataUpdate = new SQLFragment("UPDATE ").append(dataTable)
+                .append(" SET container = ").appendValue(targetContainer.getEntityId());
+        if (withModified)
+        {
+            dataUpdate.append(", modified = ").appendValue(new Date());
+            dataUpdate.append(", modifiedby = ").appendValue(user.getUserId());
+        }
+        dataUpdate.append(" WHERE ").append(idField);
+        dataTable.getSchema().getSqlDialect().appendInClauseSql(dataUpdate, ids);
+        return new SqlExecutor(dataTable.getSchema()).execute(dataUpdate);
+    }
+
     /**
      * If a container at the given path does not exist create one
      * and set permissions. If the container does exist, permissions

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -836,6 +836,18 @@ public class OntologyManager
     }
 
     /**
+     * Moves the properties of an object from one container to another (used when the object is moving)
+     * @param targetContainer the container to move the properties to
+     * @param user the user doing the move
+     * @param objectLSID the LSID of the object to which the properties are attached
+     * @return number of properties moved
+     */
+    public static int updateContainer(Container targetContainer, User user, @NotNull String objectLSID)
+    {
+        return ContainerManager.updateContainer(getTinfoObject(), "objectURI", List.of(objectLSID), targetContainer, user, false);
+    }
+
+    /**
      * Get ordered list of the PropertyURI in {@link #PropertyOrder}, if present.
      */
     public static List<String> getObjectPropertyOrder(Container c, String objectLSID)

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -1012,7 +1012,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
     int moveExperimentRuns(List<ExpRun> runs, Container targetContainer, User user);
 
     int aliasMapRowContainerUpdate(TableInfo aliasMapTable, List<Integer> dataIds, Container targetContainer);
-    int updateContainer(TableInfo dataTable, String idField, Collection<?> ids, Container targetContainer, User user, boolean withModified);
+
     Map<String, Integer> moveDataClassObjects(Collection<? extends ExpData> dataObjects, @NotNull Container sourceContainer, @NotNull Container targetContainer, @NotNull User user, @Nullable String userComment, @Nullable AuditBehaviorType auditBehavior) throws ExperimentException, BatchValidationException;
 
     class XarExportOptions

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -520,10 +520,10 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
                 for (Attachment att : atts)
                 {
                     filename = att.getName();
-                    if (parent instanceof AttachmentDirectory)
+                    if (parent instanceof AttachmentDirectory parentDir)
                     {
-                        File currentDir = ((AttachmentDirectory)parent).getFileSystemDirectoryPath().toFile();
-                        File newDir = ((AttachmentDirectory) parent).getFileSystemDirectoryPath(newContainer).toFile();
+                        File currentDir = parentDir.getFileSystemDirectoryPath().toFile();
+                        File newDir =  parentDir.getFileSystemDirectoryPath(newContainer).toFile();
                         File src = new File(currentDir, filename);
                         File dest = new File(newDir, filename);
                         if (!src.exists())

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -530,7 +530,6 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
                             throw new FileNotFoundException(src.getAbsolutePath());
                         if (dest.exists())
                             throw new AttachmentService.DuplicateFilenameException(dest.getAbsolutePath());
-
                     }
                     if (ss != null)
                         ss.deleteResource(makeDocId(parent, filename));

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8710,7 +8710,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 TableInfo dataClassTable = schema.getTable(dataClass.getName());
 
                 // update exp.data.container
-                int updateCount = updateContainer(getTinfoData(), "rowId", dataIds, targetContainer, user, true);
+                int updateCount = ContainerManager.updateContainer(getTinfoData(), "rowId", dataIds, targetContainer, user, true);
                 updateCounts.put("sources", updateCounts.get("sources") + updateCount);
 
                 // update for exp.object.container
@@ -8777,20 +8777,6 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     {
         QueryService queryService = QueryService.get();
         queryService.getDefaultAuditHandler().addSummaryAuditEvent(user, container, dataClassTable, QueryService.AuditAction.UPDATE, rowCount, AuditBehaviorType.SUMMARY, auditUserComment);
-    }
-
-    public int updateContainer(TableInfo dataTable, String idField, Collection<?> ids, Container targetContainer, User user, boolean withModified)
-    {
-        SQLFragment dataUpdate = new SQLFragment("UPDATE ").append(dataTable)
-            .append(" SET container = ").appendValue(targetContainer.getEntityId());
-        if (withModified)
-        {
-            dataUpdate.append(", modified = ").appendValue(new Date());
-            dataUpdate.append(", modifiedby = ").appendValue(user.getUserId());
-        }
-        dataUpdate.append(" WHERE ").append(idField);
-        dataTable.getSchema().getSqlDialect().appendInClauseSql(dataUpdate, ids);
-        return new SqlExecutor(dataTable.getSchema()).execute(dataUpdate);
     }
 
     private void moveDataClassObjectAttachments(ExpDataClass dataClass, Collection<ExpData> classObjects, Container targetContainer, User user)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1678,7 +1678,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 List<Integer> sampleIds = typeSamples.stream().map(ExpMaterial::getRowId).toList();
 
                 // update for exp.material.container
-                updateCounts.put("samples", updateCounts.get("samples") + expService.updateContainer(getTinfoMaterial(), "rowid", sampleIds, targetContainer, user, true));
+                updateCounts.put("samples", updateCounts.get("samples") + ContainerManager.updateContainer(getTinfoMaterial(), "rowid", sampleIds, targetContainer, user, true));
 
                 // update for exp.object.container
                 expService.updateExpObjectContainers(getTinfoMaterial(), sampleIds, targetContainer);

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -7885,7 +7885,7 @@ public class ExperimentController extends SpringActionController
         @Override
         public void validateForm(MoveEntitiesForm form, Errors errors)
         {
-            validateTargetContainer(form, errors);
+            _targetContainer = ContainerManager.getMoveTargetContainer(_entityType, getContainer(), getUser(), form.getTargetContainer(), errors);
         }
 
         abstract Map<String, Integer> doMove(MoveEntitiesForm form) throws ExperimentException, BatchValidationException;
@@ -7929,57 +7929,6 @@ public class ExperimentController extends SpringActionController
                 resp.put("error", e.getMessage());
             }
             return resp;
-        }
-
-        private void validateTargetContainer(MoveEntitiesForm form, Errors errors)
-        {
-            if (form.getTargetContainer() == null)
-            {
-                errors.reject(ERROR_GENERIC, "A target container must be specified for the move operation.");
-                return;
-            }
-
-            _targetContainer = getTargetContainer(form);
-            if (_targetContainer == null)
-            {
-                errors.reject(ERROR_GENERIC, "The target container was not found: " + form.getTargetContainer() + ".");
-                return;
-            }
-
-            if (!_targetContainer.hasPermission(getUser(), InsertPermission.class))
-            {
-                errors.reject(ERROR_GENERIC, "You do not have permission to move " + _entityType + " to the target container: " + form.getTargetContainer() + ".");
-                return;
-            }
-
-            if (!isValidTargetContainer(getContainer(), _targetContainer))
-                errors.reject(ERROR_GENERIC, "Invalid target container for the move operation: " + form.getTargetContainer() + ".");
-        }
-
-        private Container getTargetContainer(MoveEntitiesForm form)
-        {
-            Container c = ContainerManager.getForId(form.getTargetContainer());
-            if (c == null)
-                c = ContainerManager.getForPath(form.getTargetContainer());
-
-            return c;
-        }
-
-        // targetContainer must be in the same app project at this time
-        // i.e. child of current project, project of current child, sibling within project
-        private boolean isValidTargetContainer(Container current, Container target)
-        {
-            if (current.isRoot() || target.isRoot())
-                return false;
-
-            if (current.equals(target))
-                return false;
-
-            boolean moveFromProjectToChild = current.isProject() && target.getParent().equals(current);
-            boolean moveFromChildToProject = !current.isProject() && current.getParent().isProject() && current.getParent().equals(target);
-            boolean moveFromChildToSibling = !current.isProject() && current.getParent().isProject() && current.getParent().equals(target.getParent());
-
-            return moveFromProjectToChild || moveFromChildToProject || moveFromChildToSibling;
         }
     }
 

--- a/filecontent/src/org/labkey/filecontent/FileSystemAttachmentParent.java
+++ b/filecontent/src/org/labkey/filecontent/FileSystemAttachmentParent.java
@@ -97,6 +97,12 @@ public class FileSystemAttachmentParent implements AttachmentDirectory
     @Override
     public Path getFileSystemDirectoryPath()
     {
+        return getFileSystemDirectoryPath(c);
+    }
+
+    @Override
+    public Path getFileSystemDirectoryPath(Container container)
+    {
         FileContentService svc = FileContentService.get();
         if (null == svc)
             throw new IllegalStateException("FileContentService not found.");
@@ -106,11 +112,11 @@ public class FileSystemAttachmentParent implements AttachmentDirectory
             Path dir;
             if (null == path)
             {
-                dir = ((FileContentServiceImpl) svc).getMappedDirectory(c, false);
+                dir = ((FileContentServiceImpl) svc).getMappedDirectory(container, false);
             }
             else if (isRelative())
             {
-                Path mappedDir = ((FileContentServiceImpl) svc).getMappedDirectory(c, false);
+                Path mappedDir = ((FileContentServiceImpl) svc).getMappedDirectory(container, false);
                 dir = mappedDir.resolve(path);
             }
             else
@@ -118,7 +124,7 @@ public class FileSystemAttachmentParent implements AttachmentDirectory
                 dir = FileUtil.stringToPath(getContainer(), path, false);       // path not encoded
             }
 
-            if (_contentType != null && !svc.isCloudRoot(c))    // don't need @files in cloud
+            if (_contentType != null && !svc.isCloudRoot(container))    // don't need @files in cloud
             {
                 Path root = dir.resolve(svc.getFolderName(_contentType));
                 if (!Files.exists(root))


### PR DESCRIPTION
#### Rationale
Previous stories have done the work to allow samples and data class objects to be moved to other folders within the application folder structure. This PR and its relatives add support for moving notebooks as well.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/110

#### Changes
* Refactor utility methods used for moving samples and data class objects to make them accessible outside of Experiment
* Add method for moving properties managed by `OntologyManager` from one container to another
* update `moveAttachments` method in AttachmentService to account for attachments that might be stored on disk

