### PR TITLE
Need to handle the new DC method consistently for MV columns.

### DIFF
--- a/api/src/org/labkey/api/data/MVDisplayColumn.java
+++ b/api/src/org/labkey/api/data/MVDisplayColumn.java
@@ -127,6 +127,15 @@ public class MVDisplayColumn extends DataColumn
         }
     }
 
+    @Override
+    public Object getExportCompatibleValue(RenderContext ctx)
+    {
+        if (getMvIndicator(ctx) != null)
+            return getDisplayValue(ctx);
+        else
+            return super.getExportCompatibleValue(ctx);
+    }
+
     @Override @NotNull
     public HtmlString getFormattedHtml(RenderContext ctx)
     {


### PR DESCRIPTION
#### Rationale
A recent [change](https://github.com/LabKey/platform/pull/4465) to export broken lookup values caused a regression in the `AssayMissingValuesTest`. In short MV columns are different from other column types and the newly introduced method : `getExportCompatibleValue` needs to be overridden to be consistent with how we render/export MV columns, because `MVDisplayColumn.getDisplayValue() == null` means something different.
