### PR TITLE
48015: Pipeline assay import sends multiple emails upon completion

### DIFF
--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -879,7 +879,8 @@ abstract public class PipelineJob extends Job implements Serializable
             getLogger().info("Skipping already completed task '" + factory.getId() + "' at location '" + factory.getExecutionLocation() + "'");
         }
 
-        setActiveTaskStatus(TaskStatus.complete);
+        if (getActiveTaskStatus() != TaskStatus.complete)
+            setActiveTaskStatus(TaskStatus.complete);
     }
 
     public static void logStartStopInfo(String message)


### PR DESCRIPTION
#### Rationale
The `AssayUploadPipelineJob` updates the task status to `TaskStatus.complete` but because of the way it's invoked `PipelineJob.runActiveTask` also updates the task status resulting in the notification getting sent twice. I thought about making the change inside of `setActiveTaskStatus` but I'm not too familiar with this code so let me know if there is a preferred way to handle this.

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48015)