### PR TITLE
Issue 48083: Queries from linked schemas don't offer all export options

### DIFF
--- a/query/src/org/labkey/query/LinkedSchemaQueryDefinition.java
+++ b/query/src/org/labkey/query/LinkedSchemaQueryDefinition.java
@@ -376,6 +376,8 @@ public class LinkedSchemaQueryDefinition extends QueryDefinitionImpl
                 action == QueryAction.exportRowsExcel ||
                 action == QueryAction.exportRowsXLSX ||
                 action == QueryAction.exportRowsTsv ||
+                action == QueryAction.excelWebQueryDefinition ||
+                action == QueryAction.exportScript ||
                 action == QueryAction.printRows)
             return QueryService.get().urlDefault(container, action, getSchemaName(), getName());
 


### PR DESCRIPTION
#### Rationale
We're not letting users do script exports or Excel web query downloads for queries exposed via a linked schema

#### Changes
* Add them to the list of allowable export actions